### PR TITLE
Added Password Toggle Functionality | Fixed one dark mode hover issue as well  in auth pages

### DIFF
--- a/src/components/Auth.tsx
+++ b/src/components/Auth.tsx
@@ -24,6 +24,8 @@ import {
 } from "@/services/authService";
 import { useAuth } from "@/hooks/useAuth";
 import { AuthResponse } from "../types"; // Import AuthResponse type
+import useToggle from "@/hooks/use-toggle";
+import PasswordToggle from "./PasswordToggle";
 
 const Auth = () => {
   const navigate = useNavigate(); // Initialize useNavigate
@@ -37,6 +39,7 @@ const Auth = () => {
   const [fullName, setFullName] = useState("");
   const [passwordError, setPasswordError] = useState<string | null>(null);
   const [loginSettings, setLoginSettings] = useState({ oidc: { enabled: false }, email: { enabled: true } });
+  const { isToggled: showPassword, toggleHandler: passwordToggleHandler } = useToggle();
 
   useEffect(() => {
     const fetchLoginSettings = async () => {
@@ -210,11 +213,11 @@ const Auth = () => {
                     autoComplete="username"
                   />
                 </div>
-                <div className="space-y-2">
+                <div className="space-y-2 relative">
                   <Label htmlFor="signin-password">Password</Label>
                   <Input
                     id="signin-password"
-                    type="password"
+                    type={showPassword ? "text" : "password"}
                     placeholder="Enter your password"
                     value={password}
                     onChange={(e) => {
@@ -227,6 +230,7 @@ const Auth = () => {
                     required
                     autoComplete="current-password"
                   />
+                    <PasswordToggle showPassword = {showPassword} passwordToggleHandler = {passwordToggleHandler} />
                 </div>
                 <div className="text-right text-sm">
                   <a
@@ -239,7 +243,7 @@ const Auth = () => {
                 </div>
                 <Button
                   type="submit"
-                  className="w-full dark:hover:bg-slate-200"
+                  className="w-full"
                   disabled={loading}
                 >
                   {loading ? "Signing in..." : "Sign In"}
@@ -302,11 +306,11 @@ const Auth = () => {
                     autoComplete="username"
                   />
                 </div>
-                <div className="space-y-2">
+                <div className="space-y-2 relative">
                   <Label htmlFor="signup-password">Password</Label>
                   <Input
                     id="signup-password"
-                    type="password"
+                    type={showPassword ? "text" : "password"}
                     placeholder="Create a password"
                     value={password}
                     onChange={(e) => {
@@ -320,6 +324,7 @@ const Auth = () => {
                     required
                     autoComplete="new-password"
                   />
+                    <PasswordToggle showPassword = {showPassword} passwordToggleHandler = {passwordToggleHandler} />
                   {passwordError && (
                     <p className="text-red-500 text-sm">{passwordError}</p>
                   )}

--- a/src/components/PasswordToggle.tsx
+++ b/src/components/PasswordToggle.tsx
@@ -1,0 +1,24 @@
+import { Eye, EyeOff } from "lucide-react";
+import { Toggle } from './ui/toggle';
+
+type PasswordToggleProps = {
+    showPassword: boolean;
+    passwordToggleHandler: () => void;
+}
+
+const PasswordToggle : React.FC<PasswordToggleProps> = ({showPassword, passwordToggleHandler}) => {
+    return (
+        <Toggle
+            variant="outline"
+            size="sm"
+            pressed={showPassword}
+            onPressedChange={passwordToggleHandler}
+            className="absolute right-2 top-11 -translate-y-1/2"
+            aria-label="Toggle password visibility"
+        >
+            {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+        </Toggle>
+    )
+}
+
+export default PasswordToggle

--- a/src/hooks/use-toggle.ts
+++ b/src/hooks/use-toggle.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+
+/**
+ * Custom hook for managing toggle state.
+ * @returns {object} An object containing the toggle state, toggle handler function and state setter function.
+ */
+
+const useToggle = (): {
+  isToggled: boolean;
+  toggleHandler: () => void;
+  setIsToggled: React.Dispatch<React.SetStateAction<boolean>>;
+} => {
+ const [isToggled, setIsToggled] = useState<boolean>(false)
+
+ const toggleHandler = () => {
+    setIsToggled((prev) => !prev)
+ }
+
+  return { isToggled, toggleHandler, setIsToggled }
+}
+
+export default useToggle


### PR DESCRIPTION
The Fixes this PR has

- Added eye off and eye icon to toggle password when the user wants to see the password while typing
- Added one dark mode hover issue fix as well, and it is happening only on the sign-in button 

Now

<img width="657" height="651" alt="image" src="https://github.com/user-attachments/assets/c2d8cf63-93af-4d9c-afb2-43624fceee4d" />

Hover issue fixed and onclicking on toggle button we can see the password now

<img width="555" height="570" alt="image" src="https://github.com/user-attachments/assets/2880945d-2107-45cd-8613-93485490526d" />

Before

No password toggle and hover issue

<img width="546" height="559" alt="image" src="https://github.com/user-attachments/assets/ed72f7a5-9c87-4edf-8fb4-a2caacb56ec5" />

