### PR TITLE
Bugfix/issue105 | water display not persistant

### DIFF
--- a/SparkyFitnessServer/models/preferenceRepository.js
+++ b/SparkyFitnessServer/models/preferenceRepository.js
@@ -14,13 +14,14 @@ async function updateUserPreferences(userId, preferenceData) {
         timezone = COALESCE($7, timezone),
         default_food_data_provider_id = COALESCE($8, default_food_data_provider_id),
         item_display_limit = COALESCE($9, item_display_limit),
+        water_display_unit = COALESCE($10, water_display_unit),
         updated_at = now()
-      WHERE user_id = $10
+      WHERE user_id = $11
       RETURNING *`,
       [
         preferenceData.date_format, preferenceData.default_weight_unit, preferenceData.default_measurement_unit,
         preferenceData.system_prompt, preferenceData.auto_clear_history, preferenceData.logging_level, preferenceData.timezone,
-        preferenceData.default_food_data_provider_id, preferenceData.item_display_limit, userId
+        preferenceData.default_food_data_provider_id, preferenceData.item_display_limit, preferenceData.water_display_unit, userId
       ]
     );
     return result.rows[0];
@@ -62,8 +63,8 @@ async function upsertUserPreferences(preferenceData) {
       `INSERT INTO user_preferences (
         user_id, date_format, default_weight_unit, default_measurement_unit,
         system_prompt, auto_clear_history, logging_level, timezone,
-        default_food_data_provider_id, item_display_limit, created_at, updated_at
-      ) VALUES ($1, COALESCE($2, 'yyyy-MM-dd'), COALESCE($3, 'lbs'), COALESCE($4, 'in'), COALESCE($5, ''), COALESCE($6, 'never'), COALESCE($7, 'INFO'), COALESCE($8, 'UTC'), $9, COALESCE($10, 10), now(), now())
+        default_food_data_provider_id, item_display_limit, water_display_unit, created_at, updated_at
+      ) VALUES ($1, COALESCE($2, 'yyyy-MM-dd'), COALESCE($3, 'lbs'), COALESCE($4, 'in'), COALESCE($5, ''), COALESCE($6, 'never'), COALESCE($7, 'INFO'), COALESCE($8, 'UTC'), $9, COALESCE($10, 10), COALESCE($11, 'ml'), now(), now())
       ON CONFLICT (user_id) DO UPDATE SET
         date_format = COALESCE(EXCLUDED.date_format, user_preferences.date_format),
         default_weight_unit = COALESCE(EXCLUDED.default_weight_unit, user_preferences.default_weight_unit),
@@ -74,12 +75,13 @@ async function upsertUserPreferences(preferenceData) {
         timezone = COALESCE(EXCLUDED.timezone, user_preferences.timezone),
         default_food_data_provider_id = COALESCE(EXCLUDED.default_food_data_provider_id, user_preferences.default_food_data_provider_id),
         item_display_limit = COALESCE(EXCLUDED.item_display_limit, user_preferences.item_display_limit),
+        water_display_unit = COALESCE(EXCLUDED.water_display_unit, user_preferences.water_display_unit),
         updated_at = now()
       RETURNING *`,
       [
         preferenceData.user_id, preferenceData.date_format, preferenceData.default_weight_unit, preferenceData.default_measurement_unit,
         preferenceData.system_prompt, preferenceData.auto_clear_history, preferenceData.logging_level, preferenceData.timezone,
-        preferenceData.default_food_data_provider_id, preferenceData.item_display_limit
+        preferenceData.default_food_data_provider_id, preferenceData.item_display_limit, preferenceData.water_display_unit
       ]
     );
     return result.rows[0];

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -667,7 +667,13 @@ const Settings: React.FC<SettingsProps> = ({ onShowAboutDialog }) => {
                  <SelectItem value="cup">Cups</SelectItem>
                </SelectContent>
              </Select>
+
            </div>
+           <Button onClick={handlePreferencesUpdate} disabled={loading}>
+               <Save className="h-4 w-4 mr-2" />
+               {loading ? 'Saving...' : 'Save Water Display Unit'}
+             </Button>
+        
            <Separator />
            <WaterContainerManager />
         </CardContent>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -656,7 +656,10 @@ const Settings: React.FC<SettingsProps> = ({ onShowAboutDialog }) => {
              <Label htmlFor="water_display_unit">Water Display Unit</Label>
              <Select
                value={water_display_unit}
-               onValueChange={setWaterDisplayUnit}
+               onValueChange={async (value) => {
+                setWaterDisplayUnit(value as "ml" | "oz" | "liter")
+                await handlePreferencesUpdate();
+               }}
              >
                <SelectTrigger>
                  <SelectValue />
@@ -669,11 +672,6 @@ const Settings: React.FC<SettingsProps> = ({ onShowAboutDialog }) => {
              </Select>
 
            </div>
-           <Button onClick={handlePreferencesUpdate} disabled={loading}>
-               <Save className="h-4 w-4 mr-2" />
-               {loading ? 'Saving...' : 'Save Water Display Unit'}
-             </Button>
-        
            <Separator />
            <WaterContainerManager />
         </CardContent>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -656,10 +656,7 @@ const Settings: React.FC<SettingsProps> = ({ onShowAboutDialog }) => {
              <Label htmlFor="water_display_unit">Water Display Unit</Label>
              <Select
                value={water_display_unit}
-               onValueChange={async (value) => {
-                setWaterDisplayUnit(value as "ml" | "oz" | "liter")
-                await handlePreferencesUpdate();
-               }}
+               onValueChange={setWaterDisplayUnit}
              >
                <SelectTrigger>
                  <SelectValue />
@@ -672,6 +669,10 @@ const Settings: React.FC<SettingsProps> = ({ onShowAboutDialog }) => {
              </Select>
 
            </div>
+           <Button onClick={handlePreferencesUpdate} disabled={loading}>
+            <Save className="h-4 w-4 mr-2" />
+            {loading ? 'Saving...' : 'Save Water Display Unit'}
+            </Button>
            <Separator />
            <WaterContainerManager />
         </CardContent>

--- a/src/contexts/PreferencesContext.tsx
+++ b/src/contexts/PreferencesContext.tsx
@@ -147,7 +147,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({ c
 
     try {
       const data = await fetchUserPreferences(user.id);
-
       if (data) {
         debug(loggingLevel, 'PreferencesContext: Preferences data loaded:', data);
         setWeightUnitState(data.default_weight_unit as 'kg' | 'lbs');
@@ -201,7 +200,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({ c
         default_food_data_provider_id: null, // Default to no specific food data provider
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone, // Add default timezone
         item_display_limit: 10,
-        water_display_unit: 'ml', // Set default water display unit
+        water_display_unit: waterDisplayUnit // Set default water display unit
       };
 
 

--- a/src/contexts/WaterContainerContext.tsx
+++ b/src/contexts/WaterContainerContext.tsx
@@ -52,7 +52,7 @@ export const WaterContainerProvider: React.FC<{ children: ReactNode }> = ({ chil
 
   useEffect(() => {
     fetchAndSetActiveContainer();
-  }, []);
+  }, [water_display_unit]);
 
   const refreshContainers = () => {
     fetchAndSetActiveContainer();

--- a/src/contexts/WaterContainerContext.tsx
+++ b/src/contexts/WaterContainerContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { getWaterContainers, setPrimaryWaterContainer, WaterContainer } from '../services/waterContainerService';
 import { useToast } from '../hooks/use-toast';
+import { usePreferences } from './PreferencesContext';
 
 interface WaterContainerContextType {
   activeContainer: WaterContainer | null;
@@ -12,6 +13,7 @@ const WaterContainerContext = createContext<WaterContainerContextType | undefine
 export const WaterContainerProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [activeContainer, setActiveContainer] = useState<WaterContainer | null>(null);
   const { toast } = useToast();
+  const { water_display_unit } = usePreferences();
 
   const fetchAndSetActiveContainer = async () => {
     try {
@@ -37,7 +39,7 @@ export const WaterContainerProvider: React.FC<{ children: ReactNode }> = ({ chil
           user_id: '', // Placeholder, not used for non-persisted default
           name: 'Default Container',
           volume: 2000, // Default to 2000ml
-          unit: 'ml',
+          unit: water_display_unit,
           is_primary: true,
           servings_per_container: 8,
         });


### PR DESCRIPTION
https://github.com/CodeWithCJ/SparkyFitness/issues/105

Now
[screen-capture.webm](https://github.com/user-attachments/assets/772cc465-69e2-472d-8546-2bc0171f1ed8)

Water intake is updating as well when we change the water display unit from settings, and now it is persistent during refresh, logout/login

Before

https://github.com/user-attachments/assets/f6d035aa-ca6c-4239-a398-38572ddce6d4

Water intake was not updating when we change the water display unit from settings, and it was not persistent during refresh, logout/login