### PR TITLE
Bugfix/issue 109: add remaining nutrients to trend data

### DIFF
--- a/SparkyFitnessServer/models/reportRepository.js
+++ b/SparkyFitnessServer/models/reportRepository.js
@@ -94,7 +94,19 @@ async function getMiniNutritionTrends(userId, startDate, endDate) {
          SUM(fv.protein * fe.quantity / fv.serving_size) AS total_protein,
          SUM(fv.carbs * fe.quantity / fv.serving_size) AS total_carbs,
          SUM(fv.fat * fe.quantity / fv.serving_size) AS total_fat,
-         SUM(COALESCE(fv.dietary_fiber, 0) * fe.quantity / fv.serving_size) AS total_dietary_fiber
+         SUM(COALESCE(fv.saturated_fat, 0) * fe.quantity / fv.serving_size) AS total_saturated_fat,
+         SUM(COALESCE(fv.polyunsaturated_fat, 0) * fe.quantity / fv.serving_size) AS total_polyunsaturated_fat,
+         SUM(COALESCE(fv.monounsaturated_fat, 0) * fe.quantity / fv.serving_size) AS total_monounsaturated_fat,
+         SUM(COALESCE(fv.trans_fat, 0) * fe.quantity / fv.serving_size) AS total_trans_fat,
+         SUM(COALESCE(fv.cholesterol, 0) * fe.quantity / fv.serving_size) AS total_cholesterol,
+         SUM(COALESCE(fv.sodium, 0) * fe.quantity / fv.serving_size) AS total_sodium,
+         SUM(COALESCE(fv.potassium, 0) * fe.quantity / fv.serving_size) AS total_potassium,
+         SUM(COALESCE(fv.dietary_fiber, 0) * fe.quantity / fv.serving_size) AS total_dietary_fiber,
+         SUM(COALESCE(fv.sugars, 0) * fe.quantity / fv.serving_size) AS total_sugars,
+         SUM(COALESCE(fv.vitamin_a, 0) * fe.quantity / fv.serving_size) AS total_vitamin_a,
+         SUM(COALESCE(fv.vitamin_c, 0) * fe.quantity / fv.serving_size) AS total_vitamin_c,
+         SUM(COALESCE(fv.calcium, 0) * fe.quantity / fv.serving_size) AS total_calcium,
+         SUM(COALESCE(fv.iron, 0) * fe.quantity / fv.serving_size) AS total_iron
        FROM food_entries fe
        JOIN food_variants fv ON fe.variant_id = fv.id
        WHERE fe.user_id = $1 AND fe.entry_date BETWEEN $2 AND $3

--- a/SparkyFitnessServer/services/reportService.js
+++ b/SparkyFitnessServer/services/reportService.js
@@ -100,7 +100,19 @@ async function getMiniNutritionTrends(authenticatedUserId, targetUserId, startDa
       protein: parseFloat(row.total_protein || 0),
       carbs: parseFloat(row.total_carbs || 0),
       fat: parseFloat(row.total_fat || 0),
-      dietary_fiber: parseFloat(row.total_dietary_fiber || 0),
+      saturated_fat: parseFloat(row.total_saturated_fat) || 0,
+      polyunsaturated_fat: parseFloat(row.total_polyunsaturated_fat) || 0,
+      monounsaturated_fat: parseFloat(row.total_monounsaturated_fat) || 0,
+      trans_fat: parseFloat(row.total_trans_fat) || 0,
+      cholesterol: parseFloat(row.total_cholesterol) || 0,
+      sodium: parseFloat(row.total_sodium) || 0,
+      potassium: parseFloat(row.total_potassium) || 0,
+      dietary_fiber: parseFloat(row.total_dietary_fiber) || 0,
+      sugars: parseFloat(row.total_sugars) || 0,
+      vitamin_a: parseFloat(row.total_vitamin_a) || 0,
+      vitamin_c: parseFloat(row.total_vitamin_c) || 0,
+      calcium: parseFloat(row.total_calcium) || 0,
+      iron: parseFloat(row.total_iron) || 0,
     }));
 
     return formattedResults;


### PR DESCRIPTION
#109 

Fixes missing trend lines for custom nutrient display settings by loading and parsing additional nutrient data.

Before
<img width="827" height="1173" alt="image" src="https://github.com/user-attachments/assets/bd0cef60-5641-49c4-be2b-21c684803348" />

After
<img width="828" height="1174" alt="image" src="https://github.com/user-attachments/assets/80ca64ad-5e0a-4f2d-822c-883d10d4c45e" />
