### PR TITLE
Bugfix/issue 113: filter out quick foods in countFoods

### DIFF
--- a/SparkyFitnessServer/models/foodRepository.js
+++ b/SparkyFitnessServer/models/foodRepository.js
@@ -312,7 +312,7 @@ async function getFoodsWithPagination(searchTerm, foodFilter, authenticatedUserI
 async function countFoods(searchTerm, foodFilter, authenticatedUserId) {
   const client = await pool.connect();
   try {
-    let whereClauses = ['1=1'];
+    let whereClauses = ["is_quick_food = FALSE"];
     const countQueryParams = [];
     let paramIndex = 1;
 


### PR DESCRIPTION
#113 

Fix empty Food Database page by returning the correct count of foods, filtering out quick foods.