### PR TITLE
fix: Dockerfile.frontend updated with new source directory for frontend

### DIFF
--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,13 +1,13 @@
 # Stage 1: Build the React application
 FROM node:20-slim AS builder
-WORKDIR /app
+WORKDIR /app/SparkyFitnessFrontend
 
 # Copy package files and install dependencies
-COPY package.json package-lock.json ./
+COPY SparkyFitnessFrontend/package.json SparkyFitnessFrontend/package-lock.json ./
 RUN npm install
 
 # Copy the rest of the application source code
-COPY . .
+COPY SparkyFitnessFrontend .
 
 # Build the application
 RUN npm run build
@@ -19,7 +19,7 @@ FROM nginx:alpine
 RUN apk add --no-cache bash gettext
 
 # Copy the build output from the builder stage
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --from=builder /app/SparkyFitnessFrontend/dist /usr/share/nginx/html
 
 # Copy the nginx configuration template
 COPY docker/nginx.conf /etc/nginx/templates/default.conf.template


### PR DESCRIPTION
docker/Dockerfile.frontend didn't get updated with Dockerfile.frontend when source files were moved to SparkyFitnessFrontend.

Not totally sure both are still needed, but this gets docker-helper.sh working again.