### PR TITLE
Feature: Streamline common tasks on the diary page by focusing most important input

### DIFF
--- a/SparkyFitnessFrontend/src/components/EditFoodEntryDialog.tsx
+++ b/SparkyFitnessFrontend/src/components/EditFoodEntryDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -197,6 +197,13 @@ const EditFoodEntryDialog = ({ entry, open, onOpenChange, onSave }: EditFoodEntr
   };
 
   const nutrition = calculateNutrition();
+  const focusAndSelect = useCallback(e => {
+    if (e) {
+      e.focus();
+      e.select();
+    }
+  }, []);
+
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -229,6 +236,7 @@ const EditFoodEntryDialog = ({ entry, open, onOpenChange, onSave }: EditFoodEntr
                     step="0.1"
                     min="0.1"
                     value={quantity}
+                    ref={focusAndSelect}
                     onChange={(e) => {
                       debug(loggingLevel, "Quantity changed in edit dialog:", e.target.value);
                       setQuantity(Number(e.target.value));

--- a/SparkyFitnessFrontend/src/components/EditFoodEntryDialog.tsx
+++ b/SparkyFitnessFrontend/src/components/EditFoodEntryDialog.tsx
@@ -126,7 +126,8 @@ const EditFoodEntryDialog = ({ entry, open, onOpenChange, onSave }: EditFoodEntr
 
   if (!entry) return null;
 
-  const handleSave = async () => {
+  const handleSubmit = async (event) => {
+      event.preventDefault();
     debug(loggingLevel, "Handling save food entry.");
     if (!selectedVariant) {
       warn(loggingLevel, "Save called with no selected variant.");
@@ -218,7 +219,7 @@ const EditFoodEntryDialog = ({ entry, open, onOpenChange, onSave }: EditFoodEntr
         {loading ? (
           <div>Loading units...</div>
         ) : (
-          <>
+          <form onSubmit={handleSubmit}>
             <div className="space-y-4">
               <div>
                 <h3 className="text-lg font-semibold mb-2">{entry.foods.name}</h3>
@@ -380,15 +381,15 @@ const EditFoodEntryDialog = ({ entry, open, onOpenChange, onSave }: EditFoodEntr
               )}
 
               <div className="flex justify-end space-x-2 mt-6">
-                <Button variant="outline" onClick={() => onOpenChange(false)}>
+                <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                   Cancel
                 </Button>
-                <Button onClick={handleSave}>
+                <Button type="submit">
                   Save Changes
                 </Button>
               </div>
             </div>
-          </>
+          </form>
         )}
       </DialogContent>
     </Dialog>

--- a/SparkyFitnessFrontend/src/components/EnhancedFoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/EnhancedFoodSearch.tsx
@@ -604,6 +604,7 @@ const EnhancedFoodSearch = ({
         <Input
           placeholder="Search for foods..."
           value={searchTerm}
+          autoFocus
           onChange={(e) => setSearchTerm(e.target.value)}
           onKeyPress={(e) => {
             if (

--- a/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
@@ -1,5 +1,5 @@
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -203,6 +203,12 @@ const FoodUnitSelector = ({ food, open, onOpenChange, onSelect, showUnitSelector
   };
 
   const nutrition = calculateNutrition();
+  const focusAndSelect = useCallback(e => {
+    if (e) {
+      e.focus();
+      e.select();
+    }
+  }, []);
 
   return (
     <Dialog open={open && (showUnitSelector ?? true)} onOpenChange={onOpenChange}>
@@ -227,6 +233,7 @@ const FoodUnitSelector = ({ food, open, onOpenChange, onSelect, showUnitSelector
                   step="0.1"
                   min="0.1"
                   value={quantity}
+                  ref={focusAndSelect}
                   onChange={(e) => {
                     const newQuantity = Number(e.target.value);
                     debug(loggingLevel, "Quantity changed:", newQuantity);

--- a/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
@@ -136,7 +136,8 @@ const FoodUnitSelector = ({ food, open, onOpenChange, onSelect, showUnitSelector
     }
   };
 
-  const handleSubmit = () => {
+  const handleSubmit = (event) => {
+    event.preventDefault();
     debug(loggingLevel, "Handling submit.");
     if (selectedVariant) {
       info(loggingLevel, 'Submitting food selection:', {
@@ -223,6 +224,7 @@ const FoodUnitSelector = ({ food, open, onOpenChange, onSelect, showUnitSelector
         {loading ? (
           <div>Loading units...</div>
         ) : (
+          <form onSubmit={handleSubmit}>
           <div className="space-y-4">
             <div className="grid grid-cols-2 gap-4">
               <div>
@@ -281,14 +283,15 @@ const FoodUnitSelector = ({ food, open, onOpenChange, onSelect, showUnitSelector
             )}
 
             <div className="flex justify-end space-x-2">
-              <Button variant="outline" onClick={() => onOpenChange(false)}>
+              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                 Cancel
               </Button>
-              <Button onClick={handleSubmit} disabled={!selectedVariant}>
+              <Button type="submit" disabled={!selectedVariant}>
                 Add to Meal
               </Button>
             </div>
           </div>
+          </form>
         )}
       </DialogContent>
     </Dialog>


### PR DESCRIPTION
1. After clicking the "Add a new food item" button for a meal, focus will be given to the search box so the user can simply start typing instead of having to separately click the text box or tab over to it.

<img width="747" height="529" alt="image" src="https://github.com/user-attachments/assets/d6f7091c-34ba-4103-81ff-f808ff90dbb0" />


2. After selecting a food from that list, focus will default to the quantity input with the existing value selected so the user can type a new value if desired without having to manually select or delete the existing value. Pressing Enter will add it to the meal.

<img width="752" height="517" alt="image" src="https://github.com/user-attachments/assets/f6371fa2-67d1-4cb7-841e-3998a5bd95b8" />


3. Upon clicking the "Edit entry" button, focus will default to the quantity input with the existing value selected. Pressing Enter will save changes.

<img width="579" height="778" alt="image" src="https://github.com/user-attachments/assets/1fdd6913-a198-4d0a-bdb0-db38c9b17566" />
