### PR TITLE
Parse numeric values from the database

### DIFF
--- a/SparkyFitnessServer/db/connection.js
+++ b/SparkyFitnessServer/db/connection.js
@@ -1,5 +1,8 @@
-const { Pool } = require('pg');
+const { Pool, types } = require('pg');
 const { log } = require('../config/logging'); // Assuming logging.js will be created here
+
+// Parse numeric types
+types.setTypeParser(types.builtins.NUMERIC, value => parseFloat(value));
 
 // Initialize PostgreSQL client globally
 const pool = new Pool({


### PR DESCRIPTION
## Description
This change tells node-postgres to parse numeric values in the database to floats in JavaScript instead of leaving them as strings. Fixes issue #149.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] Changes have been tested locally
- [x] No console errors or warnings
- [ ] Mobile responsiveness verified (for UI changes)

## Screenshots (if applicable)
<img width="1410" height="500" alt="image" src="https://github.com/user-attachments/assets/2382356f-cb43-40f6-8538-4b89f00567d7" />

## Additional Notes
Any additional information or context about the changes.
