### PR TITLE
Fix several background color issues for reports in dark mode

### DIFF
--- a/SparkyFitnessFrontend/src/components/NutritionTrendChart.tsx
+++ b/SparkyFitnessFrontend/src/components/NutritionTrendChart.tsx
@@ -127,6 +127,7 @@ const NutritionTrendChart = ({ selectedDate }: NutritionTrendChartProps) => {
                   const unit = name.includes('calorie') ? ' cal' : 'g';
                   return [`${value}${unit}`, name];
                 }}
+                contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
               />
               <Legend />
               {visibleNutrients.map(nutrientKey => {

--- a/SparkyFitnessFrontend/src/components/Reports.tsx
+++ b/SparkyFitnessFrontend/src/components/Reports.tsx
@@ -603,7 +603,9 @@ const Reports = () => {
                                     return [`${value.toFixed(1)} ${unit}`];
                                   }
                                   return ['N/A'];
-                                }} />
+                                }}
+                                contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
+                                />
                                 <Line type="monotone" dataKey="value" stroke="#8884d8" strokeWidth={2} dot={false} />
                               </LineChart>
                             </ResponsiveContainer>

--- a/SparkyFitnessFrontend/src/components/reports/MeasurementChartsGrid.tsx
+++ b/SparkyFitnessFrontend/src/components/reports/MeasurementChartsGrid.tsx
@@ -62,6 +62,7 @@ const MeasurementChartsGrid = ({ measurementData, showWeightInKg, showMeasuremen
                     <Tooltip
                       labelFormatter={(value) => formatDateForChart(value as string)} // Apply formatter
                       formatter={(value: number) => [`${value.toFixed(1)} ${showWeightInKg ? 'kg' : 'lbs'}`]}
+                      contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
                     />
                     <Line type="monotone" dataKey="weight" stroke="#e74c3c" strokeWidth={2} dot={false} />
                   </LineChart>
@@ -91,6 +92,7 @@ const MeasurementChartsGrid = ({ measurementData, showWeightInKg, showMeasuremen
                     <Tooltip
                       labelFormatter={(value) => formatDateForChart(value as string)} // Apply formatter
                       formatter={(value: number) => [`${value.toFixed(1)} ${showMeasurementsInCm ? 'cm' : 'inches'}`]}
+                      contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
                     />
                     <Line type="monotone" dataKey="neck" stroke="#3498db" strokeWidth={2} dot={false} />
                   </LineChart>
@@ -120,6 +122,7 @@ const MeasurementChartsGrid = ({ measurementData, showWeightInKg, showMeasuremen
                     <Tooltip
                       labelFormatter={(value) => formatDateForChart(value as string)} // Apply formatter
                       formatter={(value: number) => [`${value.toFixed(1)} ${showMeasurementsInCm ? 'cm' : 'inches'}`]}
+                      contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
                     />
                     <Line type="monotone" dataKey="waist" stroke="#e74c3c" strokeWidth={2} dot={false} />
                   </LineChart>
@@ -149,6 +152,7 @@ const MeasurementChartsGrid = ({ measurementData, showWeightInKg, showMeasuremen
                     <Tooltip
                       labelFormatter={(value) => formatDateForChart(value as string)} // Apply formatter
                       formatter={(value: number) => [`${value.toFixed(1)} ${showMeasurementsInCm ? 'cm' : 'inches'}`]}
+                      contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
                     />
                     <Line type="monotone" dataKey="hips" stroke="#f39c12" strokeWidth={2} dot={false} />
                   </LineChart>
@@ -180,6 +184,7 @@ const MeasurementChartsGrid = ({ measurementData, showWeightInKg, showMeasuremen
                   <YAxis />
                   <Tooltip
                     labelFormatter={(value) => formatDateForChart(value as string)} // Apply formatter
+                    contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
                   />
                   <Bar dataKey="steps" fill="#2ecc71" />
                 </BarChart>

--- a/SparkyFitnessFrontend/src/components/reports/NutritionChartsGrid.tsx
+++ b/SparkyFitnessFrontend/src/components/reports/NutritionChartsGrid.tsx
@@ -128,6 +128,7 @@ const NutritionChartsGrid = ({ nutritionData }: NutritionChartsGridProps) => {
                         }
                         return [`${formattedValue} ${chart.unit}`];
                       }}
+                      contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
                     />
                     <Line
                       type="monotone"

--- a/SparkyFitnessFrontend/src/components/reports/ReportsTables.tsx
+++ b/SparkyFitnessFrontend/src/components/reports/ReportsTables.tsx
@@ -238,7 +238,7 @@ const ReportsTables = ({
                   const multiplier = entry.isTotal ? 1 : entry.quantity / (food.serving_size || 100);
 
                   return (
-                    <TableRow key={index} className={entry.isTotal ? "bg-gray-50 font-semibold border-t-2" : ""}>
+                    <TableRow key={index} className={entry.isTotal ? "bg-gray-50 dark:bg-gray-900 font-semibold border-t-2" : ""}>
                       <TableCell>{formatDateInUserTimezone(parseISO(entry.entry_date), dateFormat)}</TableCell>
                       <TableCell className="capitalize">{entry.meal_type}</TableCell>
                       <TableCell className="min-w-[250px]">


### PR DESCRIPTION
The reports page had a few places that used light foreground and background colors in dark mode:
* Recharts' Tooltip defaults the backgroundColor of the tooltip content div to '#fff' (see [here](https://github.com/recharts/recharts/blob/e08883a1f643ff0da77c60bfb6ddba3d4f0fb744/src/component/DefaultTooltipContent.tsx#L137)) this needed to be overridden with an appropriate contentStyle.
* The total table row used a light background color class and needed a dark mode one set as well


Before:
<img width="469" height="289" alt="image" src="https://github.com/user-attachments/assets/f796cea2-bd4c-4ffb-943c-ad37e3c37d95" />

<img width="1374" height="427" alt="image" src="https://github.com/user-attachments/assets/a42ea27e-0e95-4a26-8397-8a87105f3013" />


After:
<img width="471" height="295" alt="image" src="https://github.com/user-attachments/assets/e127452d-f8e0-4725-89aa-c20379f17d89" />

<img width="1380" height="434" alt="image" src="https://github.com/user-attachments/assets/22e120e9-60b3-4627-824c-429b139b71f5" />
