### PR TITLE
Fix wrong unit conversions for Recent Measurements list on Check-In page

### DIFF
--- a/SparkyFitnessFrontend/src/components/CheckIn.tsx
+++ b/SparkyFitnessFrontend/src/components/CheckIn.tsx
@@ -566,10 +566,10 @@ const CheckIn = () => {
                 } else if (measurement.type === 'standard') {
                   // Apply unit conversion for standard measurements if applicable
                   if (measurement.display_name === 'Weight') {
-                    displayValue = convertWeight(measurement.value, measurement.display_unit as 'kg' | 'lbs', displayWeightUnit);
+                    displayValue = convertWeight(measurement.value, 'kg', displayWeightUnit);
                     displayUnit = displayWeightUnit;
                   } else if (['Neck', 'Waist', 'Hips'].includes(measurement.display_name)) {
-                    displayValue = convertMeasurement(measurement.value, measurement.display_unit as 'cm' | 'inches', displayMeasurementUnit);
+                    displayValue = convertMeasurement(measurement.value, 'cm', displayMeasurementUnit);
                     displayUnit = displayMeasurementUnit;
                   }
                 }


### PR DESCRIPTION
The recentMeasurements values are loaded in canonical units, so the conversion here should be from kg/cm to the appropriate display unit.

Before:
<img width="1347" height="1266" alt="image" src="https://github.com/user-attachments/assets/f263faae-5c39-494f-8d84-869ad69bbbae" />

After:
<img width="1352" height="1268" alt="image" src="https://github.com/user-attachments/assets/159456a7-c161-4227-922b-a86cdc130ef2" />
