### PR TITLE
fix: Use entry_hour column instead of extracting hour from UTC timestamp for hourly measurements

### DIFF
--- a/SparkyFitnessServer/models/measurementRepository.js
+++ b/SparkyFitnessServer/models/measurementRepository.js
@@ -407,7 +407,7 @@ async function getCustomMeasurementsByDateRange(userId, categoryId, startDate, e
   const client = await pool.connect();
   try {
     const result = await client.query(
-      'SELECT category_id, entry_date AS date, EXTRACT(HOUR FROM entry_timestamp) AS hour, value, entry_timestamp AS timestamp FROM custom_measurements WHERE user_id = $1 AND category_id = $2 AND entry_date BETWEEN $3 AND $4 ORDER BY entry_date, entry_timestamp',
+      'SELECT category_id, entry_date AS date, entry_hour AS hour, value, entry_timestamp AS timestamp FROM custom_measurements WHERE user_id = $1 AND category_id = $2 AND entry_date BETWEEN $3 AND $4 ORDER BY entry_date, entry_timestamp',
       [userId, categoryId, startDate, endDate]
     );
     return result.rows;

--- a/SparkyFitnessServer/models/reportRepository.js
+++ b/SparkyFitnessServer/models/reportRepository.js
@@ -75,7 +75,7 @@ async function getCustomMeasurementsData(userId, categoryId, startDate, endDate)
   const client = await pool.connect();
   try {
     const result = await client.query(
-       `SELECT category_id, TO_CHAR(entry_date, 'YYYY-MM-DD') AS entry_date, EXTRACT(HOUR FROM entry_timestamp) AS hour, value, entry_timestamp AS timestamp FROM custom_measurements WHERE user_id = $1 AND category_id = $2 AND entry_date BETWEEN $3 AND $4 ORDER BY entry_date, entry_timestamp`,
+       `SELECT category_id, TO_CHAR(entry_date, 'YYYY-MM-DD') AS entry_date, entry_hour AS hour, value, entry_timestamp AS timestamp FROM custom_measurements WHERE user_id = $1 AND category_id = $2 AND entry_date BETWEEN $3 AND $4 ORDER BY entry_date, entry_timestamp`,
       [userId, categoryId, startDate, endDate]
     );
     return result.rows;


### PR DESCRIPTION
##  Issue
Fixes #155 - Hourly custom measurements show UTC time instead of local time on reports page

## Problem
When users create hourly custom measurements, the Reports page displays timestamps in UTC instead of the user's local time. This occurs because the database queries were extracting hours from UTC timestamps instead of using the stored local hour values.

##  Solution
Updated SQL queries in two functions to use the [entry_hour](file://e:\Sparky\SparkyFitness\SparkyFitnessFrontend\src\services\checkInService.ts#L14-L14) column (which stores local hours) instead of extracting hours from [entry_timestamp](file://e:\Sparky\SparkyFitness\SparkyFitnessFrontend\src\services\checkInService.ts#L15-L15) (which is in UTC).

### Files Changed:
- **SparkyFitnessServer/models/reportRepository.js** - Updated [getCustomMeasurementsData()](file://e:\Sparky\SparkyFitness\SparkyFitnessServer\models\reportRepository.js#L73-L84) function
- **SparkyFitnessServer/models/measurementRepository.js** - Updated [getCustomMeasurementsByDateRange()](file://e:\Sparky\SparkyFitness\SparkyFitnessServer\services\measurementService.js#L417-L425) function

### SQL Changes:
```sql
-- BEFORE (Shows UTC time):
EXTRACT(HOUR FROM entry_timestamp) AS hour

-- AFTER (Shows local time):
entry_hour AS hour