### PR TITLE
Fixes #211 use active kcal instead of total

### DIFF
--- a/SparkyFitnessServer/routes/garminRoutes.js
+++ b/SparkyFitnessServer/routes/garminRoutes.js
@@ -74,7 +74,7 @@ router.post('/sync/daily_summary', authenticateToken, async (req, res, next) => 
                 if (summaryData && summaryData.data) {
                     const healthDataArray = [
                         { type: 'step', value: summaryData.data.totalSteps, date: date, timestamp: new Date(date).toISOString() },
-                        { type: 'Active Calories', value: summaryData.data.totalKilocalories, date: date, timestamp: new Date(date).toISOString() },
+                        { type: 'Active Calories', value: summaryData.data.activeKilocalories, date: date, timestamp: new Date(date).toISOString() },
                         { type: 'Floors Climbed', value: summaryData.data.floorsClimbed, date: date, timestamp: new Date(date).toISOString() },
                         { type: 'Distance (km)', value: summaryData.data.totalDistanceMeters ? (summaryData.data.totalDistanceMeters / 1000) : null, date: date, timestamp: new Date(date).toISOString() }
                     ].filter(entry => entry.value !== null && entry.value !== undefined);


### PR DESCRIPTION
## Description
Uses activeKilocalories instead of totalKilocalories when Syncing with Garmin Connect

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing
- [x] Changes have been tested locally
- [x] No console errors or warnings
- [x] Mobile responsiveness verified (for UI changes)