### PR TITLE
Fixes for backup/restore

### DIFF
--- a/SparkyFitnessServer/routes/backupRoutes.js
+++ b/SparkyFitnessServer/routes/backupRoutes.js
@@ -59,7 +59,8 @@ router.post('/restore', authenticate, isAdmin, upload.single('backupFile'), asyn
   try {
     // Move the uploaded file to the designated backup directory for processing
     const finalBackupPath = path.join(BACKUP_DIR, originalFileName);
-    await fs.rename(uploadedFilePath, finalBackupPath);
+    await fs.copyFile(uploadedFilePath, finalBackupPath);
+    await fs.unlink(uploadedFilePath);
     log('info', `Moved uploaded file to: ${finalBackupPath}`);
 
     // Perform restore


### PR DESCRIPTION
Fixes issues in #238 

- wrap pipeline/pgDump promises in Promise.all to avoid contention when awaiting
- split file rename into copyFile/unlink to avoid potential cross-device link not permitted error
- refactor configureSessionMiddleware to only modify sessionMiddleware and not alter the middleware stack
- add indirection layer when use-ing sessionMiddleware so the new version will be called if it is replaced
- ensure performRestore calls configureSessionMiddleware after resetting postgres pool