### PR TITLE
Fix typo in database user environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 # For Docker Compose deployments, SPARKY_FITNESS_DB_HOST will be the service name (e.g., 'sparkyfitness-db').
 # For local development (running Node.js directly), use 'localhost' or '127.0.0.1' if PostgreSQL is on your host.
 SPARKY_FITNESS_DB_NAME=sparkyfitness_db
-SPARKY_FITTY_DB_USER=sparky
+SPARKY_FITNESS_DB_USER=sparky
 SPARKY_FITNESS_DB_PASSWORD=password
 SPARKY_FITNESS_DB_HOST=localhost
 SPARKY_FITNESS_DB_PORT=5432


### PR DESCRIPTION
- There was a typo error in the .env.example file, to fix it  SPARKY_FITTY_DB_USER has been changed to  SPARKY_FITNESS_DB_USER