### PR TITLE
Update android.yml

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,7 +2,7 @@ name: Build Android APK
 
 on:
   push:
-    branches: [ main ]
+#    branches: [ main ]
     tags:
       - 'v*'
   workflow_dispatch:


### PR DESCRIPTION
Pipeline shouldn't execute on every push on main now.
Every release starting with "v" will create a new build as for now. That way, the android app should appear as an asset after every new release. If that's too many android releases, I can change the 'v*' in line 7 to something else, for that every android release would require a different naming scheme than "v.x.x.x" though, otherwise it won't appear under assets.

Sorry for the pipeline run spam though, that was my fault