### PR TITLE
change mobile-navigation icon

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Index.tsx
+++ b/SparkyFitnessFrontend/src/pages/Index.tsx
@@ -30,6 +30,7 @@ import {
   Dumbbell, // Used for Exercises
   Target, // Used for Goals
   Shield,
+  Plus, // Add Plus here for adding checkin / food on mobile navigation
   X, // Add X here for the close icon
 } from "lucide-react";
 import { LucideIcon } from "lucide-react"; // Import LucideIcon
@@ -195,7 +196,7 @@ const Index: React.FC<IndexProps> = ({ onShowAboutDialog }) => {
       mobileTabs.push(
         { value: "home", label: t('nav.diary'), icon: Home },
         { value: "reports", label: t('nav.reports'), icon: BarChart3 },
-        { value: "Add", label: "Add", icon: isAddCompOpen ? X : Activity },
+        { value: "Add", label: "Add", icon: isAddCompOpen ? X : Plus },
         { value: "settings", label: t('nav.settings'), icon: SettingsIcon }
       );
     } else {


### PR DESCRIPTION
Fixes the mobile view from incorrectly using the lucide-home icon to use the lucide-activity icon #317 