### PR TITLE
modify backupSettings to stop constant querying of backup settings

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Admin/BackupSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Admin/BackupSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { api } from '../../services/api'; // Assuming an API service exists
 import { useAuth } from '../../hooks/useAuth'; // Import useAuth hook
@@ -21,7 +21,8 @@ const BackupSettings: React.FC = () => {
   const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 
   // Fetch current backup settings and status from backend
-  const fetchBackupSettings = async () => {
+  useEffect(() => {
+    const fetchBackupSettings = async () => {
     try {
       const response = await api.get('/admin/backup/settings');
       const data = response || {}; // Ensure data is an object even if response is null/undefined
@@ -46,19 +47,17 @@ const BackupSettings: React.FC = () => {
         setLastBackupStatus(data.lastBackupStatus || 'N/A');
       }
       setBackupLocation(data.backupLocation || '/app/SparkyFitnessServer/backup'); // Use fetched or default
-    } catch (error) {
-      toast({
-        title: t('admin.backupSettings.error', 'Error'),
-        description: t('admin.backupSettings.failedToFetchSettings', 'Failed to fetch backup settings.'),
-        variant: 'destructive',
-      });
-      console.error('Error fetching backup settings:', error);
-    }
-  };
-
-  useEffect(() => {
+      } catch (error) {
+        toast({
+          title: t('admin.backupSettings.error', 'Error'),
+          description: t('admin.backupSettings.failedToFetchSettings', 'Failed to fetch backup settings.'),
+          variant: 'destructive',
+        });
+        console.error('Error fetching backup settings:', error);
+      }
+    };
     fetchBackupSettings();
-  }, [fetchBackupSettings, t]);
+  }, [t]);
 
   const handleDayChange = (day: string) => {
     const updatedDays = backupDays.includes(day)


### PR DESCRIPTION
#338 

Move the `fetchBackupSettings` function to be in the useEffect(...) hook in the same manner that it is in the `AuthenticationSettings` page to change the behaviour to only load once.

I used some online references to see if I was solving this in the right way, but I'm not a frontend dev so it might be incorrect, but it lets me change the settings on the local dev build again. It loads the settings once on navigation to the page and then lets me actually modify without overwriting to those cached values constantly.