### PR TITLE
remove missed call to refresh settings on manual backup

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Admin/BackupSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Admin/BackupSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { api } from '../../services/api'; // Assuming an API service exists
 import { useAuth } from '../../hooks/useAuth'; // Import useAuth hook
@@ -21,8 +21,7 @@ const BackupSettings: React.FC = () => {
   const daysOfWeek = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 
   // Fetch current backup settings and status from backend
-  useEffect(() => {
-    const fetchBackupSettings = async () => {
+  const fetchBackupSettings = async () => {
     try {
       const response = await api.get('/admin/backup/settings');
       const data = response || {}; // Ensure data is an object even if response is null/undefined
@@ -47,15 +46,17 @@ const BackupSettings: React.FC = () => {
         setLastBackupStatus(data.lastBackupStatus || 'N/A');
       }
       setBackupLocation(data.backupLocation || '/app/SparkyFitnessServer/backup'); // Use fetched or default
-      } catch (error) {
-        toast({
-          title: t('admin.backupSettings.error', 'Error'),
-          description: t('admin.backupSettings.failedToFetchSettings', 'Failed to fetch backup settings.'),
-          variant: 'destructive',
-        });
-        console.error('Error fetching backup settings:', error);
-      }
-    };
+    } catch (error) {
+      toast({
+        title: t('admin.backupSettings.error', 'Error'),
+        description: t('admin.backupSettings.failedToFetchSettings', 'Failed to fetch backup settings.'),
+        variant: 'destructive',
+      });
+      console.error('Error fetching backup settings:', error);
+    }
+  };
+
+  useEffect(() => {
     fetchBackupSettings();
   }, [t]);
 
@@ -106,6 +107,8 @@ const BackupSettings: React.FC = () => {
         title: t('success', 'Success'),
         description: message,
       });
+      // Re-fetch settings to get the most up-to-date status from the backend
+      await fetchBackupSettings();
     } catch (error: any) {
       const errorMessage = error.response?.data?.error || error.message || t('admin.backupSettings.backupFailed', 'Manual backup failed.');
       console.error('Backup error message:', errorMessage); // Added for debugging


### PR DESCRIPTION
in relation to pull #341, I missed that there was a call to refresh the backup settings upon running a manual backup. Not sure how settings could/would change upon that and if they would affect the manual backup process. Moving it into the useEffect(...) hook in the previous pull makes it obviously unreachable from outside of it.
Seeing as this is just a deletion/removal of two lines I'm sure easy enough to throw into an ongoing change, no need to specifically merge this one.