### PR TITLE
prevent 'custom' settings from auto-balancing other meals #383

### DIFF
--- a/SparkyFitnessFrontend/src/components/MealPercentageManager.tsx
+++ b/SparkyFitnessFrontend/src/components/MealPercentageManager.tsx
@@ -72,6 +72,10 @@ const MealPercentageManager = ({ initialPercentages, onPercentagesChange, totalC
   };
 
   const autoBalance = (currentPercentages: MealPercentages, changedMeal: keyof MealPercentages) => {
+    if (selectedTemplateName === 'Custom') {
+      setPercentages(currentPercentages);
+      return;
+    }
     const lockedTotal = Object.keys(locks).reduce((acc, key) => {
       return locks[key as keyof MealPercentages] && key !== changedMeal ? acc + currentPercentages[key as keyof MealPercentages] : acc;
     }, 0);


### PR DESCRIPTION
Small change to prevent the sliders from auto-balancing when changing the meal target % values but only in 'Custom' mode, in relation to #383. Does not allow you to submit a non-100% goal, as that would be better served by simply lowering the target calories I think and then distributing how you want.