### PR TITLE
return false for excludeIncompleteDay

### DIFF
--- a/SparkyFitnessFrontend/src/utils/chartUtils.ts
+++ b/SparkyFitnessFrontend/src/utils/chartUtils.ts
@@ -159,7 +159,7 @@ export function getChartConfig(dataKey: string) {
   if (vitaminMetrics.includes(dataKey.toLowerCase())) {
     return {
       useSmartScaling: true,
-      excludeIncompleteDay: true,
+      excludeIncompleteDay: false,
       marginPercent: 0.15, // Larger margin for micronutrients
       minRangeThreshold: 0.4
     };


### PR DESCRIPTION
#390 , return false to align vitamin charts with other chart types (include incomplete days)