### PR TITLE
Fix Garmin sync for body composition metrics

### DIFF
--- a/SparkyFitnessServer/integrations/garminconnect/garminMeasurementMapping.js
+++ b/SparkyFitnessServer/integrations/garminconnect/garminMeasurementMapping.js
@@ -3,9 +3,9 @@ const garminMeasurementMapping = {
     'weight': { targetType: 'check_in', field: 'weight', dataType: 'numeric', measurementType: 'kg' },
     'body_fat_percentage': { targetType: 'check_in', field: 'body_fat_percentage', dataType: 'numeric', measurementType: '%' },
     'bmi': { targetType: 'custom', name: 'BMI', dataType: 'numeric', measurementType: 'N/A', frequency: 'Daily' },
-    'body_water_percentage': { targetType: 'check_in', field: 'body_water_percentage', dataType: 'numeric', measurementType: '%' },
+    'body_water_percentage': { targetType: 'custom', name: 'Body Water Percentage', dataType: 'numeric', measurementType: '%', frequency: 'Daily' },
     'bone_mass': { targetType: 'custom', name: 'Bone Mass', dataType: 'numeric', measurementType: 'kg', frequency: 'Daily' },
-    'muscle_mass': { targetType: 'check_in', field: 'muscle_mass_kg', dataType: 'numeric', measurementType: 'kg' },
+    'muscle_mass': { targetType: 'custom', name: 'Muscle Mass', dataType: 'numeric', measurementType: 'kg', frequency: 'Daily' },
     'hydration': { targetType: 'check_in', field: 'water', dataType: 'numeric', measurementType: 'ml' },
 
     // Custom Measurements
@@ -45,7 +45,7 @@ const garminMeasurementMapping = {
     'stress_percentage_low': { targetType: 'custom', name: 'Stress Percentage Low', dataType: 'numeric', measurementType: '%', frequency: 'Daily' },
     'stress_percentage_medium': { targetType: 'custom', name: 'Stress Percentage Medium', dataType: 'numeric', measurementType: '%', frequency: 'Daily' },
     'stress_percentage_high': { targetType: 'custom', name: 'Stress Percentage High', dataType: 'numeric', measurementType: '%', frequency: 'Daily' },
-    'visceral_fat_level': { targetType: 'check_in', field: 'visceral_fat_level', dataType: 'integer', measurementType: 'N/A' },
+    'visceral_fat_level': { targetType: 'custom', name: 'Visceral Fat Level', dataType: 'integer', measurementType: 'N/A', frequency: 'Daily' },
 };
 
 module.exports = garminMeasurementMapping;

--- a/SparkyFitnessServer/services/measurementService.js
+++ b/SparkyFitnessServer/services/measurementService.js
@@ -150,9 +150,6 @@ async function processHealthData(healthDataArray, userId, actingUserId) {
           break;
         case 'weight':
         case 'body_fat_percentage':
-        case 'body_water_percentage':
-        case 'muscle_mass_kg':
-        case 'visceral_fat_level':
           const numericValue = parseFloat(value);
           if (isNaN(numericValue) || numericValue <= 0) {
             errors.push({ error: `Invalid value for ${type}. Must be a positive number.`, entry: dataEntry });


### PR DESCRIPTION
## Summary
My Mi Fit scale syncs body composition metrics (body water percentage, muscle mass, visceral fat level) to Garmin Connect. When syncing Garmin data to SparkyFitness, these metrics failed with database errors because they were mapped as `check_in` table columns that don't exist.

Changed these three metrics to use custom measurements instead (like BMI and Bone Mass already do).

## Changes
- `garminMeasurementMapping.js`: Changed `body_water_percentage`, `muscle_mass`, and `visceral_fat_level` from `check_in` to `custom` type
- `measurementService.js`: Removed these fields from the check-in switch case (they now fall through to custom measurement handling)

## Test plan
- [x] Sync Garmin data with a scale that reports body water, muscle mass, or visceral fat
- [x] Verify no database column errors in logs
- [x] Verify measurements appear in custom measurements