### PR TITLE
Add system theme option to follow OS dark/light mode preference

### DIFF
--- a/SparkyFitnessFrontend/src/components/ThemeToggle.tsx
+++ b/SparkyFitnessFrontend/src/components/ThemeToggle.tsx
@@ -1,10 +1,32 @@
 
-import { Moon, Sun } from "lucide-react";
+import { Moon, Sun, Monitor } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useTheme } from "@/contexts/ThemeContext";
 
 const ThemeToggle = () => {
   const { theme, toggleTheme } = useTheme();
+
+  const getIcon = () => {
+    switch (theme) {
+      case 'light':
+        return <Sun className="h-4 w-4" />;
+      case 'dark':
+        return <Moon className="h-4 w-4" />;
+      case 'system':
+        return <Monitor className="h-4 w-4" />;
+    }
+  };
+
+  const getLabel = () => {
+    switch (theme) {
+      case 'light':
+        return 'Light mode';
+      case 'dark':
+        return 'Dark mode';
+      case 'system':
+        return 'System theme';
+    }
+  };
 
   return (
     <Button
@@ -12,13 +34,10 @@ const ThemeToggle = () => {
       size="sm"
       onClick={toggleTheme}
       className="w-9 h-9 p-0"
+      title={getLabel()}
     >
-      {theme === 'light' ? (
-        <Moon className="h-4 w-4" />
-      ) : (
-        <Sun className="h-4 w-4" />
-      )}
-      <span className="sr-only">Toggle theme</span>
+      {getIcon()}
+      <span className="sr-only">{getLabel()}</span>
     </Button>
   );
 };

--- a/SparkyFitnessFrontend/src/components/reports/SleepAnalyticsCharts.tsx
+++ b/SparkyFitnessFrontend/src/components/reports/SleepAnalyticsCharts.tsx
@@ -16,12 +16,12 @@ interface SleepAnalyticsChartsProps {
 
 const SleepAnalyticsCharts: React.FC<SleepAnalyticsChartsProps> = ({ sleepAnalyticsData, sleepHypnogramData }) => {
     const { formatDateInUserTimezone, dateFormat } = usePreferences();
-    const { theme } = useTheme();
+    const { resolvedTheme } = useTheme();
     const { t } = useTranslation();
-    const tickColor = theme === 'dark' ? '#E0E0E0' : '#333';
-    const gridColor = theme === 'dark' ? '#444' : '#ccc';
-    const tooltipBackgroundColor = theme === 'dark' ? '#333' : '#fff';
-    const tooltipBorderColor = theme === 'dark' ? '#555' : '#ccc';
+    const tickColor = resolvedTheme === 'dark' ? '#E0E0E0' : '#333';
+    const gridColor = resolvedTheme === 'dark' ? '#444' : '#ccc';
+    const tooltipBackgroundColor = resolvedTheme === 'dark' ? '#333' : '#fff';
+    const tooltipBorderColor = resolvedTheme === 'dark' ? '#555' : '#ccc';
 
     const formatTime = (seconds: number) => {
         const hours = Math.floor(seconds / 3600);

--- a/SparkyFitnessFrontend/src/components/reports/SleepStageChart.tsx
+++ b/SparkyFitnessFrontend/src/components/reports/SleepStageChart.tsx
@@ -35,7 +35,7 @@ const stageLabels: { [key: string]: string } = {
 const SleepStageChart: React.FC<SleepStageChartProps> = ({ sleepChartData }) => {
   const { t } = useTranslation();
   const { formatDateInUserTimezone, dateFormat } = usePreferences();
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
 
   if (!sleepChartData || !sleepChartData.segments || sleepChartData.segments.length === 0) {
     return (
@@ -111,7 +111,7 @@ const SleepStageChart: React.FC<SleepStageChartProps> = ({ sleepChartData }) => 
             y1={y1}
             x2={currentEndX}
             y2={y2}
-            stroke={theme === 'dark' ? 'white' : 'black'}
+            stroke={resolvedTheme === 'dark' ? 'white' : 'black'}
             strokeWidth={LINE_WIDTH}
           />
         );
@@ -125,7 +125,7 @@ const SleepStageChart: React.FC<SleepStageChartProps> = ({ sleepChartData }) => 
               y1={y1}
               x2={nextStartX}
               y2={y1}
-              stroke={theme === 'dark' ? 'white' : 'black'}
+              stroke={resolvedTheme === 'dark' ? 'white' : 'black'}
               strokeWidth={LINE_WIDTH}
               strokeDasharray="4 4"
             />
@@ -161,7 +161,7 @@ const SleepStageChart: React.FC<SleepStageChartProps> = ({ sleepChartData }) => 
           x="-10" // Position to the left of the chart
           y={yPos + STAGE_HEIGHT / 2 + 5} // Center vertically
           textAnchor="end"
-          fill={theme === 'dark' ? 'white' : 'black'}
+          fill={resolvedTheme === 'dark' ? 'white' : 'black'}
           fontSize="12"
         >
           {t(`sleepAnalyticsCharts.${stageType === 'light' ? 'core' : stageType}`, stageLabels[stageType])}
@@ -195,7 +195,7 @@ const SleepStageChart: React.FC<SleepStageChartProps> = ({ sleepChartData }) => 
           x={xPos}
           y={CHART_HEIGHT - CHART_PADDING_VERTICAL + 15} // Position below the chart
           textAnchor="middle"
-          fill={theme === 'dark' ? 'white' : 'black'}
+          fill={resolvedTheme === 'dark' ? 'white' : 'black'}
           fontSize="12"
         >
           {timeString}
@@ -250,7 +250,7 @@ const SleepStageChart: React.FC<SleepStageChartProps> = ({ sleepChartData }) => 
                   preserveAspectRatio="xMidYMid meet"
                   style={{ overflow: 'visible' }}
                 >
-                  <rect x="0" y="0" width={SVG_BASE_WIDTH} height={CHART_HEIGHT + 30} fill={theme === 'dark' ? 'black' : 'white'} />
+                  <rect x="0" y="0" width={SVG_BASE_WIDTH} height={CHART_HEIGHT + 30} fill={resolvedTheme === 'dark' ? 'black' : 'white'} />
                   {renderGridAndLabels()}
                   {renderConnectingLines()}
                   {renderSegments()}


### PR DESCRIPTION
## Summary
Added a "system" theme option that automatically follows the operating system's dark/light mode preference. The existing light/dark toggle is preserved, but now cycles through three options instead of two.

## Changes
- **ThemeContext.tsx**: Extended to support `'light' | 'dark' | 'system'` settings with a `resolvedTheme` that reflects the actual applied theme. Listens for OS theme changes in real-time when in system mode.
- **ThemeToggle.tsx**: Updated to show three icons (Sun/Moon/Monitor) and cycle through all three modes.
- **SleepAnalyticsCharts.tsx / SleepStageChart.tsx**: Updated to use `resolvedTheme` instead of `theme` for styling decisions.

## Behavior
- Toggle cycles: Light → Dark → System → Light
- Default for new users is now "System"
- When in System mode, the app responds to OS theme changes immediately
- Existing users with a saved preference (light/dark) are unaffected

## Test plan
- [x] Toggle through all three modes and verify correct icons appear
- [x] Set to System mode, change OS dark/light setting, verify app updates
- [x] Verify sleep charts render correctly in all theme modes
- [x] Refresh page and verify theme preference is preserved