### PR TITLE
Fix AI chatbot bubble visibility when no active AI provider

### DIFF
--- a/SparkyFitnessFrontend/src/components/DraggableChatbotButton.tsx
+++ b/SparkyFitnessFrontend/src/components/DraggableChatbotButton.tsx
@@ -1,40 +1,115 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Button } from "@/components/ui/button";
-import { MessageSquare } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useChatbotVisibility } from '@/contexts/ChatbotVisibilityContext';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { getActiveAiServiceSetting } from '@/services/aiServiceSettingsService';
 import { useAuth } from '@/hooks/useAuth';
 
+const BUTTON_SIZE = 56; // 14 * 4 = 56px (w-14)
+const MINIMIZED_SIZE = 24;
+const EDGE_MARGIN = 16;
+const BOTTOM_NAV_HEIGHT = 80; // Height of bottom navigation bar on mobile
+const STORAGE_KEY = 'chatbot_button_state';
+const MINIMIZE_THRESHOLD = 20; // How close to edge before auto-minimizing on drag
+
+type SnappedEdge = 'left' | 'right';
+
+interface ButtonState {
+  y: number;
+  edge: SnappedEdge;
+  minimized: boolean;
+}
+
 const DraggableChatbotButton: React.FC = () => {
-  const { toggleChat } = useChatbotVisibility();
-  const { user, loading } = useAuth(); // Destructure user and loading from useAuth
-  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const { toggleChat, isChatOpen } = useChatbotVisibility();
+  const { user, loading } = useAuth();
+  const [hasAiProvider, setHasAiProvider] = useState(false);
+  const [buttonState, setButtonState] = useState<ButtonState>({
+    y: 0,
+    edge: 'right',
+    minimized: false,
+  });
   const [isDragging, setIsDragging] = useState(false);
-  const [hasAiProvider, setHasAiProvider] = useState(false); // New state for AI provider check
-  const hasDragged = useRef(false); // New ref to track if a drag occurred
+  const [dragPosition, setDragPosition] = useState({ x: 0, y: 0 });
+  const [hasAppeared, setHasAppeared] = useState(false); // For entrance animation
+  const [isRestoring, setIsRestoring] = useState(false); // For restore from minimized animation
+
+  const hasDragged = useRef(false);
   const dragOffset = useRef({ x: 0, y: 0 });
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
 
-  const STORAGE_KEY = 'chatbot_button_position';
+  // Calculate actual position based on state
+  const getPosition = useCallback(() => {
+    const size = buttonState.minimized ? MINIMIZED_SIZE : BUTTON_SIZE;
+    if (isDragging) {
+      return dragPosition;
+    }
+    return {
+      x: buttonState.edge === 'right'
+        ? window.innerWidth - size - EDGE_MARGIN
+        : EDGE_MARGIN,
+      y: buttonState.y,
+    };
+  }, [buttonState, isDragging, dragPosition]);
 
+  // Initialize position from localStorage or default to bottom-right
   useEffect(() => {
-    // Force a known visible position for debugging
-    setPosition({ x: 50, y: 50 });
-    // Commenting out local storage load for debugging
-    // const savedPosition = localStorage.getItem(STORAGE_KEY);
-    // if (savedPosition) {
-    //   setPosition(JSON.parse(savedPosition));
-    // } else {
-    //   setPosition({ x: window.innerWidth - 100, y: window.innerHeight - 100 });
-    // }
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as ButtonState;
+        // Ensure y is within bounds
+        const maxY = window.innerHeight - BUTTON_SIZE - EDGE_MARGIN;
+        setButtonState({
+          ...parsed,
+          y: Math.min(Math.max(EDGE_MARGIN, parsed.y), maxY),
+        });
+      } catch {
+        setDefaultPosition();
+      }
+    } else {
+      setDefaultPosition();
+    }
   }, []);
 
+  const setDefaultPosition = () => {
+    const bottomOffset = isMobile ? BOTTOM_NAV_HEIGHT : 0;
+    setButtonState({
+      y: window.innerHeight - BUTTON_SIZE - EDGE_MARGIN - bottomOffset,
+      edge: 'right',
+      minimized: false,
+    });
+  };
+
+  // Calculate max Y position (respects bottom nav on mobile)
+  const getMaxY = useCallback((minimized: boolean) => {
+    const size = minimized ? MINIMIZED_SIZE : BUTTON_SIZE;
+    const bottomOffset = isMobile ? BOTTOM_NAV_HEIGHT : 0;
+    return window.innerHeight - size - EDGE_MARGIN - bottomOffset;
+  }, [isMobile]);
+
+  // Handle window resize
+  useEffect(() => {
+    const handleResize = () => {
+      setButtonState((prev: ButtonState) => {
+        const maxY = getMaxY(prev.minimized);
+        return {
+          ...prev,
+          y: Math.min(Math.max(EDGE_MARGIN, prev.y), maxY),
+        };
+      });
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [getMaxY]);
+
+  // AI Provider check
   const checkAiProviders = useCallback(async () => {
-    if (!loading && user?.id) { // Only fetch if not loading and user is available
+    if (!loading && user?.id) {
       try {
         const activeService = await getActiveAiServiceSetting();
-        // Check for null, undefined, or empty object
         const hasActive = activeService !== null &&
                           activeService !== undefined &&
                           Object.keys(activeService).length > 0;
@@ -43,7 +118,7 @@ const DraggableChatbotButton: React.FC = () => {
         console.error("[DraggableChatbotButton] Failed to fetch AI services:", error);
         setHasAiProvider(false);
       }
-    } else if (!loading && !user) { // If loading is false and no user, ensure AI provider is false
+    } else if (!loading && !user) {
       setHasAiProvider(false);
     }
   }, [loading, user?.id]);
@@ -52,192 +127,262 @@ const DraggableChatbotButton: React.FC = () => {
     checkAiProviders();
   }, [checkAiProviders]);
 
-  // Re-check when user returns to the tab (after potentially changing settings)
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
         checkAiProviders();
       }
     };
-
     document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
   }, [checkAiProviders]);
 
-  // Re-check periodically to catch changes made in other tabs or after navigation
   useEffect(() => {
-    const interval = setInterval(checkAiProviders, 5000); // Check every 5 seconds
+    const interval = setInterval(checkAiProviders, 5000);
     return () => clearInterval(interval);
   }, [checkAiProviders]);
 
-  const isMobile = useIsMobile();
+  // Trigger entrance animation after provider check
+  useEffect(() => {
+    if (hasAiProvider && !hasAppeared) {
+      // Small delay to ensure position is set before animating in
+      const timer = setTimeout(() => setHasAppeared(true), 100);
+      return () => clearTimeout(timer);
+    }
+  }, [hasAiProvider, hasAppeared]);
 
+  // Snap to nearest edge (auto-minimize if dragged very close to edge on mobile)
+  const snapToEdge = useCallback((x: number, y: number) => {
+    const centerX = x + BUTTON_SIZE / 2;
+    const screenCenterX = window.innerWidth / 2;
+    const edge: SnappedEdge = centerX > screenCenterX ? 'right' : 'left';
+
+    // Check if dragged very close to edge - auto-minimize on mobile
+    const isNearLeftEdge = x < MINIMIZE_THRESHOLD;
+    const isNearRightEdge = x > window.innerWidth - BUTTON_SIZE - MINIMIZE_THRESHOLD;
+    const shouldMinimize = isMobile && !buttonState.minimized && (isNearLeftEdge || isNearRightEdge);
+
+    const maxY = getMaxY(shouldMinimize || buttonState.minimized);
+    const clampedY = Math.min(Math.max(EDGE_MARGIN, y), maxY);
+
+    const newState: ButtonState = {
+      y: clampedY,
+      edge,
+      minimized: shouldMinimize || buttonState.minimized,
+    };
+
+    setButtonState(newState);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newState));
+  }, [buttonState.minimized, getMaxY, isMobile]);
+
+  // Drag handlers
   const updatePosition = useCallback((clientX: number, clientY: number) => {
     if (!isDragging) return;
 
-    // If mouse moves significantly, it's a drag
-    if (Math.abs(clientX - (position.x + dragOffset.current.x)) > 5 ||
-        Math.abs(clientY - (position.y + dragOffset.current.y)) > 5) {
+    if (Math.abs(clientX - (dragPosition.x + dragOffset.current.x)) > 5 ||
+        Math.abs(clientY - (dragPosition.y + dragOffset.current.y)) > 5) {
       hasDragged.current = true;
     }
 
     let newX = clientX - dragOffset.current.x;
     let newY = clientY - dragOffset.current.y;
 
-    // Constrain to viewport
-    if (buttonRef.current) {
-      const maxX = window.innerWidth - buttonRef.current.offsetWidth;
-      const maxY = window.innerHeight - buttonRef.current.offsetHeight;
+    const size = buttonState.minimized ? MINIMIZED_SIZE : BUTTON_SIZE;
+    const maxX = window.innerWidth - size;
+    const maxY = getMaxY(buttonState.minimized);
 
-      newX = Math.max(0, Math.min(newX, maxX));
-      newY = Math.max(0, Math.min(newY, maxY));
-    }
+    newX = Math.max(0, Math.min(newX, maxX));
+    newY = Math.max(0, Math.min(newY, maxY));
 
-    setPosition({ x: newX, y: newY });
-  }, [isDragging, position]);
+    setDragPosition({ x: newX, y: newY });
+  }, [isDragging, dragPosition, buttonState.minimized, getMaxY]);
 
   const handleInteractionStart = (clientX: number, clientY: number) => {
-    if (buttonRef.current) {
+    if (containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect();
       setIsDragging(true);
-      hasDragged.current = false; // Reset drag flag on interaction start
+      hasDragged.current = false;
       dragOffset.current = {
-        x: clientX - buttonRef.current.getBoundingClientRect().left,
-        y: clientY - buttonRef.current.getBoundingClientRect().top,
+        x: clientX - rect.left,
+        y: clientY - rect.top,
       };
+      setDragPosition({ x: rect.left, y: rect.top });
     }
   };
 
   const handleInteractionEnd = () => {
+    if (isDragging && hasDragged.current) {
+      snapToEdge(dragPosition.x, dragPosition.y);
+    }
     setIsDragging(false);
-    // Save position to local storage
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(position));
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
     handleInteractionStart(e.clientX, e.clientY);
-    e.preventDefault(); // Prevent default drag behavior
+    e.preventDefault();
   };
 
-  const handleMouseMove = (e: MouseEvent) => {
+  const handleMouseMove = useCallback((e: MouseEvent) => {
     updatePosition(e.clientX, e.clientY);
-  };
+  }, [updatePosition]);
 
-  const handleMouseUp = () => {
+  const handleMouseUp = useCallback(() => {
     handleInteractionEnd();
-  };
+  }, [isDragging, hasDragged, dragPosition, snapToEdge]);
 
-  const handleTouchStart = (e: TouchEvent) => {
+  const handleTouchStart = useCallback((e: TouchEvent) => {
     if (e.touches.length === 1) {
       handleInteractionStart(e.touches[0].clientX, e.touches[0].clientY);
-      e.preventDefault(); // Prevent scrolling while dragging
+      e.preventDefault();
     }
-  };
+  }, []);
 
-  const handleTouchMove = (e: TouchEvent) => {
+  const handleTouchMove = useCallback((e: TouchEvent) => {
     if (e.touches.length === 1) {
       updatePosition(e.touches[0].clientX, e.touches[0].clientY);
     }
-  };
+  }, [updatePosition]);
 
-  const handleTouchEnd = () => {
-    // Check if a drag was initiated on the button
+  const handleTouchEnd = useCallback(() => {
     if (isDragging) {
       handleInteractionEnd();
-      // Manually trigger the click handler.
-      // The `onClick` event won't fire on mobile because `e.preventDefault()` is called
-      // in `handleTouchStart` to prevent scrolling during a drag.
-      // We pass a null event because the event object is not used inside handleClick.
-      handleClick(null as any);
-    }
-  };
-
-  const handleClick = (e: React.MouseEvent | React.TouchEvent) => {
-    // Only open chat if no significant drag occurred
-    if (!hasDragged.current) {
-      toggleChat();
-    }
-    hasDragged.current = false; // Reset for next interaction
-  };
-
-  useEffect(() => {
-    const buttonElement = buttonRef.current;
-    if (buttonElement) {
-      if (isMobile) {
-        buttonElement.addEventListener('touchstart', handleTouchStart, { passive: false });
-        window.addEventListener('touchmove', handleTouchMove, { passive: false });
-        window.addEventListener('touchend', handleTouchEnd);
-      } else {
-        window.addEventListener('mousemove', handleMouseMove);
-        window.addEventListener('mouseup', handleMouseUp);
+      if (!hasDragged.current) {
+        handleClick();
       }
     }
+  }, [isDragging, hasDragged, dragPosition, snapToEdge]);
+
+  const handleClick = () => {
+    if (!hasDragged.current) {
+      if (buttonState.minimized) {
+        // Restore from minimized with animation
+        setIsRestoring(true);
+        const newState = { ...buttonState, minimized: false };
+        setButtonState(newState);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(newState));
+        // Reset restoring state after animation
+        setTimeout(() => setIsRestoring(false), 300);
+      } else {
+        toggleChat();
+      }
+    }
+    hasDragged.current = false;
+  };
+
+  const handleMinimize = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const newState = { ...buttonState, minimized: true };
+    setButtonState(newState);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(newState));
+  };
+
+  // Event listeners - attach both mouse and touch events for cross-device support
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return;
+
+    // Touch events on the element
+    element.addEventListener('touchstart', handleTouchStart, { passive: false });
+
+    // Global touch events for drag tracking
+    window.addEventListener('touchmove', handleTouchMove, { passive: false });
+    window.addEventListener('touchend', handleTouchEnd);
+
+    // Global mouse events for drag tracking (mouse down is handled via React props)
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
 
     return () => {
-      if (buttonElement) {
-        if (isMobile) {
-          buttonElement.removeEventListener('touchstart', handleTouchStart);
-          window.removeEventListener('touchmove', handleTouchMove);
-          window.removeEventListener('touchend', handleTouchEnd);
-        } else {
-          window.removeEventListener('mousemove', handleMouseMove);
-          window.removeEventListener('mouseup', handleMouseUp);
-        }
-      }
+      element.removeEventListener('touchstart', handleTouchStart);
+      window.removeEventListener('touchmove', handleTouchMove);
+      window.removeEventListener('touchend', handleTouchEnd);
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
     };
-  }, [isDragging, position, isMobile, updatePosition, handleTouchStart, handleTouchMove, handleTouchEnd]); // Re-run effect if dragging state, position, or mobile state changes
+  }, [handleMouseMove, handleMouseUp, handleTouchStart, handleTouchMove, handleTouchEnd]);
 
   if (!hasAiProvider) {
-    return null; // Do not render the button if no AI provider is set up
+    return null;
   }
 
-  return (
-    <>
-      <Button
-        ref={buttonRef}
-        className="fixed z-50 rounded-full w-14 h-14 shadow-lg hover:shadow-xl transition-all duration-200 bg-gradient-to-r from-blue-500 to-purple-600 hover:from-blue-600 hover:to-purple-700 flex items-center justify-center overflow-hidden"
-        style={{ left: position.x, top: position.y, cursor: isDragging ? 'grabbing' : (isMobile ? 'grab' : 'grab') }}
-        onMouseDown={isMobile ? undefined : handleMouseDown}
-        onClick={handleClick}
-        size="lg"
-      >
-        {/* Cute Robot Head SVG */}
-        {/* Robot Head SVG - Matching provided image */}
-        <svg viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ width: '100%', height: '100%' }}>
-          {/* Head (Circular shape) */}
-          <circle cx="20" cy="20" r="19.8" fill="#E0E0E0"/> {/* Light gray circle, 99% of viewBox */}
-          {/* Eyes */}
-          <g className="robot-eyes">
-            {/* Eye bases (white) */}
-            <circle cx="12" cy="18" r="5" fill="white"/>
-            <circle cx="28" cy="18" r="5" fill="white"/>
-            {/* Pupils (black) - these will blink */}
-            <circle cx="12" cy="18" r="3" fill="black" className="robot-pupil-left"/>
-            <circle cx="28" cy="18" r="3" fill="black" className="robot-pupil-right"/>
-          </g>
-        </svg>
-      </Button>
-      <style>{`
-        @keyframes float {
-          0% { transform: translateY(0px); }
-          50% { transform: translateY(-5px); }
-          100% { transform: translateY(0px); }
-        }
-        .animate-float {
-          animation: float 3s ease-in-out infinite;
-        }
+  const position = getPosition();
+  const size = buttonState.minimized ? MINIMIZED_SIZE : BUTTON_SIZE;
 
-        @keyframes blink {
-          0%, 100% { transform: scaleY(1); }
-          49% { transform: scaleY(1); } /* Hold open */
-          50% { transform: scaleY(0.1); } /* Close quickly */
-          51% { transform: scaleY(1); } /* Open quickly */
-        }
-        .robot-pupil-left, .robot-pupil-right {
-          animation: blink 4s ease-in-out infinite;
-          transform-origin: center;
-        }
-      `}</style>
-    </>
+  // Minimized state - small pill on edge
+  if (buttonState.minimized) {
+    return (
+      <div
+        ref={containerRef}
+        className={`fixed z-50 bg-gradient-to-r from-pink-400 to-pink-500 hover:from-pink-500 hover:to-pink-600
+          transition-all duration-300 cursor-pointer shadow-lg touch-none
+          ${buttonState.edge === 'right' ? 'rounded-l-full' : 'rounded-r-full'}
+          ${hasAppeared ? 'opacity-100' : 'opacity-0'}`}
+        style={{
+          left: buttonState.edge === 'right' ? 'auto' : 0,
+          right: buttonState.edge === 'right' ? 0 : 'auto',
+          top: position.y,
+          width: MINIMIZED_SIZE + 8,
+          height: MINIMIZED_SIZE,
+          padding: '4px',
+        }}
+        onClick={handleClick}
+        onMouseDown={handleMouseDown}
+        role="button"
+        aria-label="Restore AI Chat"
+      >
+        <div className="w-full h-full flex items-center justify-center pointer-events-none">
+          <div className="w-2 h-2 bg-white rounded-full animate-pulse" />
+        </div>
+      </div>
+    );
+  }
+
+  // Full button
+  return (
+    <div
+      ref={containerRef}
+      className={`fixed z-50 touch-none transition-all duration-300 ease-out
+        ${hasAppeared ? 'opacity-100' : 'opacity-0'}`}
+      style={{
+        left: position.x,
+        top: position.y,
+        width: size,
+        height: size,
+        transform: isRestoring ? 'scale(1.15)' : (hasAppeared ? 'scale(1)' : 'scale(0.75)'),
+      }}
+      onMouseDown={handleMouseDown}
+      onClick={handleClick}
+      role="button"
+      aria-label="Open AI Chat"
+    >
+      {/* Minimize button - only on desktop (mobile uses drag-to-edge) */}
+      {!isChatOpen && !isMobile && (
+        <button
+          className={`absolute -top-2 ${buttonState.edge === 'right' ? '-left-2' : '-right-2'}
+            w-6 h-6 bg-gray-600 hover:bg-gray-700 rounded-full
+            flex items-center justify-center
+            opacity-0 hover:opacity-100
+            transition-opacity duration-200
+            shadow-md z-10`}
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            handleMinimize(e);
+          }}
+          onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+          aria-label="Minimize chat button"
+        >
+          <X className="w-4 h-4 text-white" />
+        </button>
+      )}
+
+      <img
+        src="/images/chatbot.gif"
+        alt="AI Chatbot"
+        className={`w-full h-full object-contain drop-shadow-lg pointer-events-none
+          ${isDragging ? 'scale-110' : 'hover:scale-110'} transition-transform duration-200`}
+        draggable={false}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
The AI chatbot bubble remained visible and unresponsive when all AI providers were disabled. Clicking it did nothing because there was no active service to connect to.

## Root Cause
Two issues:
1. The component was calling `getAIServices()` which returns all services (including disabled ones) instead of `getActiveAiServiceSetting()` which only returns active services
2. When no active service exists, the API returns an empty object `{}` rather than `null`. Since `{} !== null` is `true`, the bubble remained visible

## Changes
- **DraggableChatbotButton.tsx**: 
  - Switched from `getAIServices()` to `getActiveAiServiceSetting()`
  - Added check for empty objects: `Object.keys(activeService).length > 0`
  - Added visibility change listener to re-check when returning to the tab
  - Added periodic polling (every 5 seconds) to catch changes without refresh

## Test plan
- [X] Add an AI provider and verify the bubble appears
- [X] Disable the AI provider and verify the bubble disappears within 5 seconds
- [X] Re-enable the AI provider and verify the bubble reappears
- [X] Refresh the page with no active provider and verify bubble is hidden