### PR TITLE
Fix fiber not calculating in meal entries

### DIFF
--- a/SparkyFitnessServer/services/foodEntryService.js
+++ b/SparkyFitnessServer/services/foodEntryService.js
@@ -813,7 +813,7 @@ async function getFoodEntryMealsByDate(authenticatedUserId, targetUserId, select
           carbs: (entry.carbs * entry.quantity) / entry.serving_size,
           fat: (entry.fat * entry.quantity) / entry.serving_size,
           sodium: (entry.sodium * entry.quantity) / entry.serving_size,
-          fiber: (entry.fiber * entry.quantity) / entry.serving_size,
+          fiber: (entry.dietary_fiber * entry.quantity) / entry.serving_size,
           sugars: (entry.sugars * entry.quantity) / entry.serving_size,
           saturated_fat: (entry.saturated_fat * entry.quantity) / entry.serving_size,
           cholesterol: (entry.cholesterol * entry.quantity) / entry.serving_size,


### PR DESCRIPTION
Fixes #452 

## Summary
- Fixed fiber not being calculated from food items into meals in the food diary
- The issue was a field name mismatch: `entry.fiber` was used instead of `entry.dietary_fiber` when mapping individual food entries

## Root Cause
In `getFoodEntryMealsByDate()`, the totals calculation correctly referenced `entry.dietary_fiber` (line 788), but the individual food entry mapping incorrectly referenced `entry.fiber` (line 816), which doesn't exist. This caused `NaN` values that displayed as 0g.

## Changes
- `SparkyFitnessServer/services/foodEntryService.js`: Changed `entry.fiber` to `entry.dietary_fiber` on line 816

## Test plan
- [X] Add a custom food with dietary fiber value
- [X] Create a meal containing that food
- [X] Add the meal to the food diary
- [X] Verify fiber displays correctly in the meal entry
- [X] Verify fiber is included in daily nutrition summary