### PR TITLE
Fix food entry API path in Chatbot_FoodHandler.ts

### DIFF
--- a/SparkyFitnessFrontend/src/services/Chatbot/Chatbot_FoodHandler.ts
+++ b/SparkyFitnessFrontend/src/services/Chatbot/Chatbot_FoodHandler.ts
@@ -129,7 +129,7 @@ export const processFoodInput = async (data: {
       info(userLoggingLevel, 'Inserting food entry...');
       let insertError = null;
       try {
-        await apiCall('/foods/food-entries', {
+        await apiCall('/food-entries', {
           method: 'POST',
           body: {
 food_id: food.id,
@@ -338,7 +338,7 @@ export const addFoodOption = async (optionIndex: number, originalMetadata: any, 
     });
     let entryError = null;
     try {
-      await apiCall('/foods/food-entries', {
+      await apiCall('/food-entries', {
         method: 'POST',
         body: {
           food_id: foodId,


### PR DESCRIPTION
## Summary
  - Fix API path in `Chatbot_FoodHandler.ts` that was causing 404 errors when logging food via the Sparky chatbot
  - Two occurrences of `/foods/food-entries` changed to `/food-entries` (lines 132 and 341)

  ## Context
  This is a follow-up to commit b369a347 ("Fix for editing food entries in food diary") which fixed the same `/foods/food-entries` to `/food-entries` path issue in other service files, but missed the chatbot food handler (or it didn't exist yet).

  ## Test plan
  - [x] Open Sparky chatbot
  - [x] Say "I ate an apple" (or any food not in database)
  - [x] Select one of the AI-generated food options
  - [x] Verify food is added to diary without 404 error