### PR TITLE
Fix missing serving_size in createMealFromDiaryEntries

### DIFF
--- a/SparkyFitnessServer/services/mealService.js
+++ b/SparkyFitnessServer/services/mealService.js
@@ -409,6 +409,8 @@ async function createMealFromDiaryEntries(userId, date, mealType, mealName, desc
       name: mealName || defaultMealName,
       description: description,
       is_public: isPublic,
+      serving_size: 1.0,
+      serving_unit: 'serving',
       foods: mealFoods,
     };
 


### PR DESCRIPTION
Fixes #462

## Summary
  - Fixes `createMealFromDiaryEntries` to include `serving_size` and `serving_unit` fields
  - Resolves NOT NULL constraint violation when converting diary entries to meals

  ## Problem
  The "Convert to Meal" feature was failing with:
  > null value in column "serving_size" of relation "meals" violates not-null constraint

  This occurred because the `createMealFromDiaryEntries` function was added before the meal serving size feature, and wasn't updated when `serving_size` became a required field.

  ## Solution
  Added default values (`serving_size: 1.0`, `serving_unit: 'serving'`) to match the database schema defaults.
