### PR TITLE
Improvement: Hide nutriments sections that are empty

### DIFF
--- a/SparkyFitnessFrontend/src/components/EnhancedCustomFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/components/EnhancedCustomFoodForm.tsx
@@ -951,6 +951,7 @@ const EnhancedCustomFoodForm = ({
                       </div>
 
                       {/* Main Macros: Responsive Grid (1 col on mobile, 2 on sm, 3 on md, 4 on lg) */}
+                      {(["calories", "protein", "carbs", "fat"].some(nutrient => visibleNutrients.includes(nutrient))) && (
                       <div className="mt-4">
                         <h5 className="text-sm font-medium text-gray-700 mb-3">
                           Main Nutrients
@@ -1033,8 +1034,10 @@ const EnhancedCustomFoodForm = ({
                           )}
                         </div>
                       </div>
+                      )}
 
                       {/* Detailed Fat Information: Responsive Grid */}
+                      {(["saturated_fat", "polyunsaturated_fat", "monounsaturated_fat", "trans_fat"].some(nutrient => visibleNutrients.includes(nutrient))) && (
                       <div>
                         <h5 className="text-sm font-medium text-gray-700 mb-3">
                           Fat Breakdown
@@ -1118,8 +1121,10 @@ const EnhancedCustomFoodForm = ({
                           )}
                         </div>
                       </div>
+                      )}
 
                       {/* Minerals and Other Nutrients: Responsive Grid */}
+                      {(["cholesterol", "sodium", "potassium", "dietary_fiber"].some(nutrient => visibleNutrients.includes(nutrient))) && (
                       <div>
                         <h5 className="text-sm font-medium text-gray-700 mb-3">
                           Minerals & Other
@@ -1203,8 +1208,10 @@ const EnhancedCustomFoodForm = ({
                           )}
                         </div>
                       </div>
+                      )}
 
                       {/* Sugars and Vitamins: Responsive Grid */}
+                      {(["sugars", "vitamin_a", "vitamin_c", "calcium"].some(nutrient => visibleNutrients.includes(nutrient))) && (
                       <div>
                         <h5 className="text-sm font-medium text-gray-700 mb-3">
                           Sugars & Vitamins
@@ -1288,6 +1295,7 @@ const EnhancedCustomFoodForm = ({
                           )}
                         </div>
                       </div>
+                      )}
 
                       {/* Last row of nutrients: Responsive Grid */}
                       <div>


### PR DESCRIPTION
The EnhancedCustomFoodForm component now hides sections for nutriments that have no inputs, as otherwise it looks like a label with nothing under it.


## Example when only Calories are selected
### Before

<img width="492" height="399" alt="Screenshot 2026-01-04 105729" src="https://github.com/user-attachments/assets/3b797a55-ec13-4215-b8af-19bf317477af" />

### After

<img width="486" height="320" alt="image" src="https://github.com/user-attachments/assets/c8d614d2-4f44-4822-b5e0-a5e193bf0d45" />


(See https://github.com/CodeWithCJ/SparkyFitness/pull/471 for the glycemic index fix)
