### PR TITLE
fix (garmin): #492 garmin activity minutes off by factor 60

### DIFF
--- a/SparkyFitnessServer/services/garminService.js
+++ b/SparkyFitnessServer/services/garminService.js
@@ -219,7 +219,7 @@ async function processGarminWorkoutSession(userId, sessionData, startDate, endDa
           set_type: setType,
           reps: Math.round(garminSet.repetitionCount || 0),
           weight: weightKg,
-          duration: durationSeconds,
+          duration: Math.round(durationSeconds / 60),
           rest_time: 0, // Default rest time
           notes: garminSet.notes || '',
         };


### PR DESCRIPTION
## Description

Fixes: #492 

The activity minutes are off by factor 60. Minutes are expected but seconds are passed. The division by 60 is missing here.

Before:
<img width="1330" height="442" alt="grafik" src="https://github.com/user-attachments/assets/d839bd67-bc7d-4559-b046-babf57b832ab" />

After:
<img width="1310" height="525" alt="grafik" src="https://github.com/user-attachments/assets/18bae781-669e-46e5-ae36-0f61e50a3b64" />

Connect
![Image 2026-02-06 at 11 07 49](https://github.com/user-attachments/assets/02539e6a-c90a-4f0e-95cd-bb89aae19617)
