### PR TITLE
fix (exercise): #590 incorrect rep count when exercise has no weight/reps

### DIFF
--- a/SparkyFitnessFrontend/src/components/ExerciseEntryDisplay.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseEntryDisplay.tsx
@@ -83,8 +83,8 @@ const ExerciseEntryDisplay: React.FC<ExerciseEntryDisplayProps> = ({
                 {` • Sets: ${String(exerciseEntry.sets.length)}`}
                 {exerciseEntry.sets.map((set, index) => (
                   <span key={index}>
-                    {set.reps && ` • Reps: ${String(set.reps)}`}
-                    {set.weight && ` • Weight: ${convertWeight(set.weight, 'kg', weightUnit).toFixed(1)} ${weightUnit}`}
+                    {Number.isFinite(set.reps) && ` • Reps: ${String(set.reps)}`}
+                    {Number.isFinite(set.weight) && ` • Weight: ${convertWeight(set.weight, 'kg', weightUnit).toFixed(1)} ${weightUnit}`}
                   </span>
                 ))}
               </>


### PR DESCRIPTION
## Description

Fixes: #590 

If the rep or weight count was 0 the check `if(set.reps)` returns false since 0 is interpreted as false. The whole expression is then evaluated as false and the expression returns 0. This lead to the concatenation of zeroes demonstrated by the screenshots in the issue.

By using Number.isFinite() we allow 0 as a value while still checking for undefiend or null.

## Screenshot
It now looks like this:

<img width="1252" height="373" alt="grafik" src="https://github.com/user-attachments/assets/5ab18dfe-427a-4f52-9eec-5956c6734534" />

@CodeWithCJ I think it would be useful to display 'To Failure' (for reps) and 'Bodyweight' (for weight) as options. We could use null or -1 as internal values for this. Alternatively, 0 could serve as the default to represent these states.


