### PR TITLE
fix: default .env download path in docs

### DIFF
--- a/docs/content/1.install/1.docker-compose.md
+++ b/docs/content/1.install/1.docker-compose.md
@@ -15,8 +15,8 @@ Before you begin, ensure you have the following installed:
     Create a new directory for SparkyFitness and navigate into it. Then, download the necessary `docker-compose.yml` and `.env` files.
     ```bash
     mkdir sparkyfitness && cd sparkyfitness
-    curl -o docker-compose.yml https://github.com/CodeWithCJ/SparkyFitness/releases/latest/download/docker-compose.prod.yml
-    curl -o .env https://github.com/CodeWithCJ/SparkyFitness/releases/latest/download/default.env.example
+    curl -o docker-compose.yml https://github.com/CodeWithCJ/SparkyFitness/releases/latest/download/docker-compose.prod.yml    
+    curl -L -o .env https://github.com/CodeWithCJ/SparkyFitness/releases/latest/download/default.env.example
     ```
 
 2.  **Configure Environment Variables**:


### PR DESCRIPTION
The file seems to have been moved in recent releases.