### PR TITLE
Doc: Grant execute permission for functions to sparky_admin

### DIFF
--- a/docs/content/1.install/5.external-database.md
+++ b/docs/content/1.install/5.external-database.md
@@ -50,7 +50,11 @@ CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 -- Performance monitoring
 CREATE EXTENSION IF NOT EXISTS "pg_stat_statements";
+
+-- Grant with grant to functions that extensions add as they are still owned by postgres
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO "sparky_admin" WITH GRANT OPTION;
 ```
+
 
 ## 3. Row Level Security (RLS)
 


### PR DESCRIPTION
For me you were only missing the one line due to extension function ownership. 