### PR TITLE
fix(723): water unit update fails

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Goals/WaterAndExerciseFields.tsx
+++ b/SparkyFitnessFrontend/src/pages/Goals/WaterAndExerciseFields.tsx
@@ -31,8 +31,13 @@ export const WaterAndExerciseFields = <T extends WaterExerciseBase>({
   setState: (newState: T) => void;
 }) => {
   const { t } = useTranslation();
-  const { water_display_unit, setWaterDisplayUnit, energyUnit, convertEnergy } =
-    usePreferences();
+  const {
+    water_display_unit,
+    setWaterDisplayUnit,
+    energyUnit,
+    convertEnergy,
+    saveAllPreferences,
+  } = usePreferences();
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -59,7 +64,10 @@ export const WaterAndExerciseFields = <T extends WaterExerciseBase>({
           />
           <Select
             value={water_display_unit}
-            onValueChange={(v: 'ml' | 'oz' | 'liter') => setWaterDisplayUnit(v)}
+            onValueChange={(v: 'ml' | 'oz' | 'liter') => {
+              saveAllPreferences({ water_display_unit: v });
+              setWaterDisplayUnit(v);
+            }}
           >
             <SelectTrigger className="w-[80px]">
               <SelectValue />

--- a/SparkyFitnessFrontend/src/pages/Settings/SettingsPage.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/SettingsPage.tsx
@@ -129,6 +129,7 @@ const Settings = () => {
     []
   );
   const [localLoggingLevel, setLocalLoggingLevel] = useState(loggingLevel);
+  const [localWaterUnit, setLocalWaterUnit] = useState(water_display_unit);
   const [profileForm, setProfileForm] = useState({
     full_name: '',
     phone: '',
@@ -170,7 +171,8 @@ const Settings = () => {
 
   useEffect(() => {
     setLocalLoggingLevel(loggingLevel);
-  }, [loggingLevel]);
+    setLocalWaterUnit(water_display_unit);
+  }, [loggingLevel, water_display_unit]);
 
   const location = useLocation(); // Hook to get current location
 
@@ -431,12 +433,15 @@ const Settings = () => {
     if (!user) return;
     setLoading(true);
     try {
-      await saveAllPreferences({ loggingLevel: localLoggingLevel }); // Pass the new logging level directly
+      await saveAllPreferences({
+        loggingLevel: localLoggingLevel,
+        water_display_unit: localWaterUnit,
+      }); // Pass the new logging level directly
+      setWaterDisplayUnit(localWaterUnit);
       toast({
         title: 'Success',
         description: 'Preferences updated successfully',
       });
-      window.location.reload();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       console.error('Error updating preferences:', error);
@@ -1109,8 +1114,10 @@ const Settings = () => {
                 )}
               </Label>
               <Select
-                value={water_display_unit}
-                onValueChange={setWaterDisplayUnit}
+                value={localWaterUnit}
+                onValueChange={(unit: 'ml' | 'oz' | 'liter') =>
+                  setLocalWaterUnit(unit)
+                }
               >
                 <SelectTrigger>
                   <SelectValue />
@@ -1128,8 +1135,8 @@ const Settings = () => {
                       'Fluid Ounces (oz)'
                     )}
                   </SelectItem>
-                  <SelectItem value="cup">
-                    {t('settings.waterTracking.cups', 'Cups')}
+                  <SelectItem value="liter">
+                    {t('settings.waterTracking.liters', 'Liters')}
                   </SelectItem>
                 </SelectContent>
               </Select>


### PR DESCRIPTION
## Description

Fixes #723   issue preventing change of the water unit. This was caused by not saving the selected state locally and not calling the update function. The setWaterDisplayUnit is only changing the state locally without saving it to the server. I also removed the window.reload() since it's not needed.