### PR TITLE
fix(713) CSV History Import uses wrong preference field for weight unit conversion 

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Exercises/ExerciseEntryHistoryImportCSV.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/ExerciseEntryHistoryImportCSV.tsx
@@ -132,6 +132,7 @@ const ExerciseEntryHistoryImportCSV = ({
   const { mutateAsync: importAsCsv } = useImportExerciseHistoryMutation();
   const [selectedDateFormat, setSelectedDateFormat] =
     useState<string>(dateFormat);
+  const weightUnitLabel = weightUnit === 'lbs' ? 'lbs' : 'kg';
 
   const dropdownFields = new Set([
     'exercise_force',
@@ -664,10 +665,15 @@ const ExerciseEntryHistoryImportCSV = ({
 
   const getSetDisplay = (sets: GroupedExerciseEntry['sets']) => {
     return sets
-      .map(
-        (set) =>
-          `${set.set_number}: ${set.reps || '-'} reps @ ${set.weight || '-'}kg (${set.set_type})`
-      )
+      .map((set) => {
+        const repsDisplay = set.reps ?? '-';
+        const weightDisplay =
+          set.weight !== undefined && set.weight !== null
+            ? `${set.weight}${weightUnitLabel}`
+            : '-';
+        const setTypeDisplay = set.set_type || '-';
+        return `${set.set_number}: ${repsDisplay} reps @ ${weightDisplay} (${setTypeDisplay})`;
+      })
       .join('; ');
   };
 
@@ -901,7 +907,7 @@ const ExerciseEntryHistoryImportCSV = ({
                   {groupedEntries.map((entry) => (
                     <TableRow key={entry.id}>
                       <TableCell>
-                        {format(entry.entry_date, 'yyyy-MM-dd')}
+                        {format(entry.entry_date, dateFormat)}
                       </TableCell>
                       <TableCell>{entry.exercise_name}</TableCell>
                       <TableCell>{entry.preset_name || '-'}</TableCell>

--- a/SparkyFitnessServer/services/exerciseEntryService.js
+++ b/SparkyFitnessServer/services/exerciseEntryService.js
@@ -53,8 +53,8 @@ async function importExerciseEntriesFromCsv(authenticatedUserId, actingUserId, e
       // 3. Lookup or Create Workout Preset (if preset_name is provided)
       // 3. Convert Distance and Weight based on user preferences and process sets
       const preferences = await preferenceRepository.getUserPreferences(authenticatedUserId);
-      const distanceUnit = preferences?.distance_unit || 'km'; // Default to km
-      const weightUnit = preferences?.weight_unit || 'kg';     // Default to kg
+      const distanceUnit = preferences?.default_distance_unit || preferences?.distance_unit || 'km'; // Default to km
+      const weightUnit = preferences?.default_weight_unit || preferences?.weight_unit || 'kg'; // Default to kg
 
       let distanceInKm = entryGroup.distance;
       if (distanceInKm !== undefined && distanceInKm !== null) {


### PR DESCRIPTION
## Description
Fix the issues #713 that the user preferences is not used on 
- Preview of Entries to Import (Table view) UI fix
- When value from CSV is converted again to user preferences 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Changes have been tested locally

## Screenshots (if applicable)
<img width="3606" height="1904" alt="image" src="https://github.com/user-attachments/assets/26864b10-be04-4afd-988b-a3d99bb04f66" />
<img width="3035" height="799" alt="image" src="https://github.com/user-attachments/assets/2e4cb0d3-6d6c-4f98-b18a-c11005566557" />


## Additional Notes
I also fix the `distance_unit`
