### PR TITLE
fix(foodEntryService): forward meal_type_id to repository in createFoodEntryMeal

### DIFF
--- a/SparkyFitnessServer/services/foodEntryService.js
+++ b/SparkyFitnessServer/services/foodEntryService.js
@@ -568,6 +568,7 @@ async function createFoodEntryMeal(
       {
         user_id: mealData.user_id || authenticatedUserId, // Use target user ID
         meal_template_id: mealData.meal_template_id || null,
+        meal_type_id: mealData.meal_type_id || null,
         meal_type: mealData.meal_type,
         entry_date: mealData.entry_date,
         name: mealData.name,


### PR DESCRIPTION
## Summary

`createFoodEntryMeal` in `foodEntryService.js` receives `meal_type_id` in `mealData` (correctly passed from the route), but drops it when constructing the object sent to `foodEntryMealRepository.createFoodEntryMeal()`.

This forces the repository to always use the string-based fallback lookup:
```js
SELECT id FROM meal_types WHERE LOWER(name) = LOWER($1)
```
…which causes `500` errors when the meal type name doesn't match exactly (e.g. casing differences, custom meal type names).

## Root Cause

`foodEntryMealRoutes.js` correctly destructures and forwards `meal_type_id`:
```js
// route — correct ✅
const { meal_type, meal_type_id, ... } = req.body;
await foodEntryService.createFoodEntryMeal(targetUserId, userId, {
  meal_type,
  meal_type_id,   // <-- passed in
  ...
});
```

`foodEntryService.js` receives it in `mealData` but drops it before calling the repository:
```js
// service — bug ❌
await foodEntryMealRepository.createFoodEntryMeal({
  meal_type: mealData.meal_type,
  // meal_type_id is never forwarded
}, actingUserId);
```

`foodEntryMealRepository.js` already handles `meal_type_id` correctly — it just never receives it:
```js
// repository — already correct ✅
let mealTypeId = foodEntryMealData.meal_type_id;
if (!mealTypeId && foodEntryMealData.meal_type) {
  // string-based fallback
}
```

## Fix

Add `meal_type_id: mealData.meal_type_id || null` to the object passed to the repository:

```js
await foodEntryMealRepository.createFoodEntryMeal({
  user_id: mealData.user_id || authenticatedUserId,
  meal_template_id: mealData.meal_template_id || null,
  meal_type_id: mealData.meal_type_id || null,   // <-- added
  meal_type: mealData.meal_type,
  ...
}, actingUserId);
```

When `meal_type_id` is provided, the repository uses the direct UUID path. When it's absent, the existing string-based fallback still works as before — no behaviour change for existing callers.

## Testing

- Create a food entry meal with a valid `meal_type_id` UUID → should resolve correctly without string lookup
- Create a food entry meal with only `meal_type` string → existing fallback still works
- Create with neither → existing error handling unchanged