### PR TITLE
feat: add percentage and smart exercise calorie earn-back modes

### DIFF
--- a/SparkyFitnessFrontend/src/api/Diary/dailyProgressService.ts
+++ b/SparkyFitnessFrontend/src/api/Diary/dailyProgressService.ts
@@ -6,6 +6,7 @@ export interface Goals {
   carbs: number;
   fat: number;
   water_goal_ml: number;
+  target_exercise_calories_burned?: number;
 }
 
 import type { FoodEntry } from '@/types/food';

--- a/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
@@ -81,7 +81,7 @@ interface PreferencesContextType {
   timezone: string;
   foodDisplayLimit: number;
   itemDisplayLimit: number;
-  calorieGoalAdjustmentMode: 'dynamic' | 'fixed';
+  calorieGoalAdjustmentMode: 'dynamic' | 'fixed' | 'percentage' | 'smart';
   energyUnit: EnergyUnit;
   autoScaleOpenFoodFactsImports: boolean;
   nutrientDisplayPreferences: NutrientPreference[];
@@ -94,6 +94,7 @@ interface PreferencesContextType {
   mineralCalculationAlgorithm: MineralCalculationAlgorithm;
   vitaminCalculationAlgorithm: VitaminCalculationAlgorithm;
   sugarCalculationAlgorithm: SugarCalculationAlgorithm;
+  exerciseCaloriePercentage: number;
   selectedDiet: string;
   setWeightUnit: (unit: 'kg' | 'lbs') => void;
   setMeasurementUnit: (unit: 'cm' | 'inches') => void;
@@ -106,7 +107,10 @@ interface PreferencesContextType {
   setDefaultFoodDataProviderId: (id: string | null) => void;
   setTimezone: (timezone: string) => void;
   setItemDisplayLimit: (limit: number) => void;
-  setCalorieGoalAdjustmentMode: (mode: 'dynamic' | 'fixed') => void;
+  setCalorieGoalAdjustmentMode: (
+    mode: 'dynamic' | 'fixed' | 'percentage' | 'smart'
+  ) => void;
+  setExerciseCaloriePercentage: (percentage: number) => void;
   setEnergyUnit: (unit: EnergyUnit) => void;
   setAutoScaleOpenFoodFactsImports: (enabled: boolean) => void;
   loadNutrientDisplayPreferences: () => Promise<void>;
@@ -190,7 +194,9 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
   const [itemDisplayLimit, setItemDisplayLimitState] = useState<number>(10);
   const [foodDisplayLimit, setFoodDisplayLimitState] = useState<number>(10);
   const [calorieGoalAdjustmentMode, setCalorieGoalAdjustmentModeState] =
-    useState<'dynamic' | 'fixed'>('dynamic');
+    useState<'dynamic' | 'fixed' | 'percentage' | 'smart'>('dynamic');
+  const [exerciseCaloriePercentage, setExerciseCaloriePercentageState] =
+    useState<number>(100);
   const [energyUnit, setEnergyUnitState] = useState<EnergyUnit>('kcal');
   const [autoScaleOpenFoodFactsImports, setAutoScaleOpenFoodFactsImportsState] =
     useState<boolean>(false);
@@ -355,7 +361,12 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         food_display_limit: number;
         water_display_unit: 'ml' | 'oz' | 'liter';
         language: string;
-        calorie_goal_adjustment_mode: 'dynamic' | 'fixed';
+        calorie_goal_adjustment_mode:
+          | 'dynamic'
+          | 'fixed'
+          | 'percentage'
+          | 'smart';
+        exercise_calorie_percentage: number;
         energy_unit: EnergyUnit;
         auto_scale_open_food_facts_imports: boolean;
         bmr_algorithm: BmrAlgorithm;
@@ -449,6 +460,8 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         language: newPrefs?.language ?? language,
         calorie_goal_adjustment_mode:
           newPrefs?.calorieGoalAdjustmentMode ?? calorieGoalAdjustmentMode,
+        exercise_calorie_percentage:
+          newPrefs?.exerciseCaloriePercentage ?? exerciseCaloriePercentage,
         energy_unit: newPrefs?.energyUnit ?? energyUnit,
         auto_scale_open_food_facts_imports:
           newPrefs?.autoScaleOpenFoodFactsImports ??
@@ -497,6 +510,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       waterDisplayUnit,
       language,
       calorieGoalAdjustmentMode,
+      exerciseCaloriePercentage,
       energyUnit,
       autoScaleOpenFoodFactsImports,
       bmrAlgorithm,
@@ -595,6 +609,9 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         setCalorieGoalAdjustmentModeState(
           data.calorie_goal_adjustment_mode || 'dynamic'
         );
+        setExerciseCaloriePercentageState(
+          data.exercise_calorie_percentage ?? 100
+        );
         setEnergyUnitState(data.energy_unit || 'kcal');
         setAutoScaleOpenFoodFactsImportsState(
           data.auto_scale_open_food_facts_imports ?? false
@@ -683,12 +700,16 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
   );
 
   const setCalorieGoalAdjustmentMode = useCallback(
-    (mode: 'dynamic' | 'fixed') => {
+    (mode: 'dynamic' | 'fixed' | 'percentage' | 'smart') => {
       setCalorieGoalAdjustmentModeState(mode);
       saveAllPreferences({ calorieGoalAdjustmentMode: mode });
     },
     [saveAllPreferences]
   );
+
+  const setExerciseCaloriePercentage = useCallback((percentage: number) => {
+    setExerciseCaloriePercentageState(percentage);
+  }, []);
 
   const setDefaultFoodDataProviderId = useCallback((id: string | null) => {
     setDefaultFoodDataProviderIdState(id);
@@ -786,6 +807,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       itemDisplayLimit,
       foodDisplayLimit,
       calorieGoalAdjustmentMode,
+      exerciseCaloriePercentage,
       energyUnit,
       autoScaleOpenFoodFactsImports,
       nutrientDisplayPreferences,
@@ -809,6 +831,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       setTimezone,
       setItemDisplayLimit,
       setCalorieGoalAdjustmentMode,
+      setExerciseCaloriePercentage,
       setEnergyUnit,
       setAutoScaleOpenFoodFactsImports,
       loadNutrientDisplayPreferences,
@@ -845,6 +868,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       itemDisplayLimit,
       foodDisplayLimit,
       calorieGoalAdjustmentMode,
+      exerciseCaloriePercentage,
       energyUnit,
       autoScaleOpenFoodFactsImports,
       nutrientDisplayPreferences,
@@ -868,6 +892,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       setTimezone,
       setItemDisplayLimit,
       setCalorieGoalAdjustmentMode,
+      setExerciseCaloriePercentage,
       setEnergyUnit,
       setAutoScaleOpenFoodFactsImports,
       loadNutrientDisplayPreferences,

--- a/SparkyFitnessFrontend/src/services/preferenceService.ts
+++ b/SparkyFitnessFrontend/src/services/preferenceService.ts
@@ -28,7 +28,8 @@ export interface UserPreferences {
   vitamin_calculation_algorithm: 'RDA_STANDARD' | string;
   sugar_calculation_algorithm: 'WHO_GUIDELINES' | string;
   include_bmr_in_net_calories: boolean;
-  calorie_goal_adjustment_mode: 'dynamic' | 'fixed' | string;
+  calorie_goal_adjustment_mode: 'dynamic' | 'fixed' | 'percentage' | 'smart' | string;
+  exercise_calorie_percentage: number;
   auto_scale_open_food_facts_imports: boolean;
   auto_clear_history: 'never' | string;
   logging_level: 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';

--- a/SparkyFitnessServer/db/migrations/20260226000000_add_exercise_calorie_percentage.sql
+++ b/SparkyFitnessServer/db/migrations/20260226000000_add_exercise_calorie_percentage.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_preferences
+ADD COLUMN IF NOT EXISTS exercise_calorie_percentage INTEGER DEFAULT 100;

--- a/SparkyFitnessServer/models/preferenceRepository.js
+++ b/SparkyFitnessServer/models/preferenceRepository.js
@@ -27,8 +27,9 @@ async function updateUserPreferences(userId, preferenceData) {
         vitamin_calculation_algorithm = COALESCE($20, vitamin_calculation_algorithm),
         sugar_calculation_algorithm = COALESCE($21, sugar_calculation_algorithm),
         auto_scale_open_food_facts_imports = COALESCE($22, auto_scale_open_food_facts_imports),
+        exercise_calorie_percentage = COALESCE($23, exercise_calorie_percentage),
         updated_at = now()
-      WHERE user_id = $23
+      WHERE user_id = $24
       RETURNING *`,
       [
         preferenceData.date_format, preferenceData.default_weight_unit, preferenceData.default_measurement_unit, preferenceData.default_distance_unit,
@@ -38,6 +39,7 @@ async function updateUserPreferences(userId, preferenceData) {
         preferenceData.calorie_goal_adjustment_mode, preferenceData.energy_unit,
         preferenceData.fat_breakdown_algorithm, preferenceData.mineral_calculation_algorithm, preferenceData.vitamin_calculation_algorithm, preferenceData.sugar_calculation_algorithm,
         preferenceData.auto_scale_open_food_facts_imports,
+        preferenceData.exercise_calorie_percentage,
         userId
       ]
     );
@@ -84,7 +86,7 @@ async function upsertUserPreferences(preferenceData) {
        bmr_algorithm, body_fat_algorithm, include_bmr_in_net_calories,
        language, calorie_goal_adjustment_mode, energy_unit,
        fat_breakdown_algorithm, mineral_calculation_algorithm, vitamin_calculation_algorithm, sugar_calculation_algorithm,
-       auto_scale_open_food_facts_imports,
+       auto_scale_open_food_facts_imports, exercise_calorie_percentage,
        created_at, updated_at
      ) VALUES (
        $1, COALESCE($2, 'yyyy-MM-dd'), COALESCE($3, 'lbs'), COALESCE($4, 'in'), COALESCE($5, 'km'),
@@ -93,7 +95,7 @@ async function upsertUserPreferences(preferenceData) {
        COALESCE($13, 'Mifflin-St Jeor'), COALESCE($14, 'U.S. Navy'), COALESCE($15, false),
        COALESCE($16, 'en'), COALESCE($17, 'dynamic'), COALESCE($18, 'kcal'),
        COALESCE($19, 'AHA Guidelines'), COALESCE($20, 'RDA Standard'), COALESCE($21, 'RDA Standard'), COALESCE($22, 'WHO Guidelines'),
-       COALESCE($23, false),
+       COALESCE($23, false), COALESCE($24, 100),
        now(), now()
      )
      ON CONFLICT (user_id) DO UPDATE SET
@@ -119,6 +121,7 @@ async function upsertUserPreferences(preferenceData) {
        vitamin_calculation_algorithm = COALESCE(EXCLUDED.vitamin_calculation_algorithm, user_preferences.vitamin_calculation_algorithm),
        sugar_calculation_algorithm = COALESCE(EXCLUDED.sugar_calculation_algorithm, user_preferences.sugar_calculation_algorithm),
        auto_scale_open_food_facts_imports = COALESCE(EXCLUDED.auto_scale_open_food_facts_imports, user_preferences.auto_scale_open_food_facts_imports),
+       exercise_calorie_percentage = COALESCE(EXCLUDED.exercise_calorie_percentage, user_preferences.exercise_calorie_percentage),
        updated_at = now()
      RETURNING *`,
      [
@@ -128,7 +131,7 @@ async function upsertUserPreferences(preferenceData) {
        preferenceData.bmr_algorithm, preferenceData.body_fat_algorithm, preferenceData.include_bmr_in_net_calories, preferenceData.language,
        preferenceData.calorie_goal_adjustment_mode, preferenceData.energy_unit,
        preferenceData.fat_breakdown_algorithm, preferenceData.mineral_calculation_algorithm, preferenceData.vitamin_calculation_algorithm, preferenceData.sugar_calculation_algorithm,
-       preferenceData.auto_scale_open_food_facts_imports
+       preferenceData.auto_scale_open_food_facts_imports, preferenceData.exercise_calorie_percentage
      ]
     );
     return result.rows[0];

--- a/SparkyFitnessServer/services/DashboardService.js
+++ b/SparkyFitnessServer/services/DashboardService.js
@@ -90,28 +90,42 @@ async function getDashboardStats(userId, date) {
 
     const activeOrStepsToAdd =
       activeCalories > 0 ? activeCalories : stepsCalories;
+    const exerciseCalories = otherCalories + activeOrStepsToAdd;
     const bmrToAdd = includeInNet ? bmr : 0;
-    const totalBurned = otherCalories + activeOrStepsToAdd + bmrToAdd;
+    const totalBurned = exerciseCalories + bmrToAdd;
 
     const netCalories = eatenCalories - totalBurned;
 
     let remaining = 0;
     const adjustmentMode =
-      userPreferences?.calorie_goal_adjustment_mode || "static";
+      userPreferences?.calorie_goal_adjustment_mode || "dynamic";
+    const exerciseCaloriePercentage =
+      userPreferences?.exercise_calorie_percentage ?? 100;
+
     if (adjustmentMode === "dynamic") {
+      // 100% of all burned calories credited
       remaining = goalCalories - netCalories;
+    } else if (adjustmentMode === "percentage") {
+      // Only a percentage of exercise calories are credited (BMR unchanged)
+      const adjustedExerciseBurned = exerciseCalories * (exerciseCaloriePercentage / 100);
+      const adjustedTotalBurned = adjustedExerciseBurned + bmrToAdd;
+      remaining = goalCalories - (eatenCalories - adjustedTotalBurned);
+    } else if (adjustmentMode === "smart") {
+      // Only credits exercise calories ABOVE the target exercise burn goal (MFP-style)
+      const targetExerciseBurned = parseFloat(goals?.target_exercise_calories_burned || 0);
+      const excessExerciseBurned = Math.max(0, exerciseCalories - targetExerciseBurned);
+      const adjustedTotalBurned = excessExerciseBurned + bmrToAdd;
+      remaining = goalCalories - (eatenCalories - adjustedTotalBurned);
     } else {
+      // fixed: no exercise calories credited
       remaining = goalCalories - eatenCalories;
     }
 
+    // effectiveConsumed = goalCalories - remaining (how much of the goal is "used up")
+    const effectiveConsumed = goalCalories - remaining;
     const progress =
       goalCalories > 0
-        ? Math.min(
-            ((adjustmentMode === "dynamic" ? netCalories : eatenCalories) /
-              goalCalories) *
-              100,
-            100,
-          )
+        ? Math.min((effectiveConsumed / goalCalories) * 100, 100)
         : 0;
 
     return {


### PR DESCRIPTION
Adds two new calorie goal adjustment modes beyond the existing dynamic (100%) and fixed (0%) options:

- Percentage mode: earn back a configurable % (0-100) of exercise calories, creating a safety buffer for over-estimated burns
- Smart mode: MFP-style adjustment that only credits calories burned above the user's exercise calorie target in their goals

Changes:
- DB migration adds exercise_calorie_percentage column to user_preferences
- Backend preferenceRepository handles new field in upsert/update queries
- DashboardService applies percentage and smart logic to remaining calc
- Goals interface adds target_exercise_calories_burned for smart mode
- PreferencesContext exposes new field and updated mode type
- CalculationSettings adds radio options and percentage input UI
- DailyProgress applies all four adjustment modes to calorie display

https://claude.ai/code/session_01UufnvyjYiRN6wPCWzHj3WM