### PR TITLE
feat(sparkyfitness): Added Helm Chart to deploy application

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,281 @@
+# Sparkyfitness Helm Chart
+
+A Helm chart for deploying [Sparkyfitness](https://github.com/CodeWithCJ/SparkyFitness) on Kubernetes.
+
+## Components
+
+| Component | Image | Default Port | Optional |
+|-----------|-------|-------------|----------|
+| Server | `codewithcj/sparkyfitness_server` | 3010 | No |
+| Frontend | `codewithcj/sparkyfitness` | 80 | No |
+| Garmin | `codewithcj/sparkyfitness_garmin` | 8000 | Yes |
+| PostgreSQL | `postgres:15-alpine` | 5432 | Yes (bundled) |
+
+## Quick Start
+
+```bash
+helm install sparkyfitness ./chart
+```
+
+This deploys Sparkyfitness with a bundled PostgreSQL instance, auto-generated secrets, and sane defaults. Access via `kubectl port-forward svc/sparkyfitness-frontend 8080:80`.
+
+## Database
+
+### Bundled PostgreSQL (default)
+
+Enabled by default. Credentials are auto-generated on first install and preserved across upgrades.
+
+```yaml
+postgresql:
+  enabled: true
+  auth:
+    database: sparkyfitness
+    username: sparky
+    # password: ""  # auto-generated if empty
+  persistence:
+    size: 8Gi
+```
+
+### External Database
+
+Disable the bundled instance and point to your own:
+
+```yaml
+postgresql:
+  enabled: false
+
+externalDatabase:
+  host: "db.example.com"
+  port: 5432
+  database: "sparkyfitness"
+```
+
+Credentials can be supplied via `externalDatabase.auth.password`, `externalDatabase.auth.existingSecret`, or [External Secrets](#external-secrets-operator).
+
+The application uses a two-user model: a **database owner** (for migrations) and a **limited-privilege app user** (for runtime queries). The owner needs `CREATEROLE` so the app can create the app user on first startup:
+
+```sql
+ALTER USER <owner> CREATEROLE;
+```
+
+The following extensions must be created by a superuser:
+
+```sql
+\c <database>
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE EXTENSION IF NOT EXISTS "pg_stat_statements";
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO "<owner>" WITH GRANT OPTION;
+```
+
+> `pg_stat_statements` requires `shared_preload_libraries = 'pg_stat_statements'` in the PostgreSQL config.
+
+## Secrets
+
+The chart manages five separate Kubernetes Secrets:
+
+| Secret | Keys | Used by |
+|--------|------|---------|
+| `<release>-app` | `api_encryption_key`, `better_auth_secret` | Server |
+| `<release>-appdb` | `username`, `password` | Server (app DB user) |
+| `<release>-postgres` | `username`, `password` | Server (DB owner) |
+| `<release>-oidc` | `client_id`, `client_secret` | Server (if OIDC enabled) |
+| `<release>-smtp` | `username`, `password` | Server (if email enabled) |
+
+Each secret supports three provisioning modes:
+
+1. **Auto-generated** (default) — random values on first install, preserved on upgrade
+2. **Existing secret** — reference a pre-created K8s Secret via `existingSecret`
+3. **External Secrets Operator** — fetched from Vault or other providers
+
+### Existing Secrets
+
+```yaml
+server:
+  secrets:
+    existingSecret: "my-app-secret"       # keys: api_encryption_key, better_auth_secret
+  appDatabase:
+    existingSecret: "my-appdb-secret"     # keys: username, password
+
+externalDatabase:
+  auth:
+    existingSecret: "my-db-owner-secret"  # keys: username, password
+
+config:
+  oidc:
+    secrets:
+      existingSecret: "my-oidc-secret"    # keys: client_id, client_secret
+  email:
+    secrets:
+      existingSecret: "my-smtp-secret"    # keys: username, password
+```
+
+### External Secrets Operator
+
+The chart can create a Vault-backed `SecretStore` and per-type `ExternalSecret` resources:
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStore:
+    name: sparkyfitness
+    vaultPath: sparkyfitness
+    vaultServer: "https://vault.example.com:8200"
+    auth:
+      mountPath: kubernetes
+      role: external-secrets
+  app:
+    enabled: true
+    remoteKey: app_secret
+  smtp:
+    enabled: true
+    remoteKey: smtp
+```
+
+For database credentials, you can use a `ClusterSecretStore` instead of the chart-managed `SecretStore`:
+
+```yaml
+externalSecrets:
+  postgres:
+    enabled: true
+    clusterSecretStore: my-cluster-store
+    remoteKey: db-owner
+  appdb:
+    enabled: true
+    clusterSecretStore: my-cluster-store
+    remoteKey: db-appuser
+```
+
+Key mappings are configurable per secret via the `keys` list:
+
+```yaml
+externalSecrets:
+  postgres:
+    enabled: true
+    remoteKey: my-db
+    keys:
+      - secretKey: username
+        property: db_user       # maps "db_user" in the remote store to "username" in the K8s Secret
+      - secretKey: password
+        property: db_pass
+```
+
+## Networking
+
+### Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: sparkyfitness.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: sparkyfitness-tls
+      hosts:
+        - sparkyfitness.example.com
+```
+
+### Gateway API (HTTPRoute)
+
+```yaml
+httpRoute:
+  enabled: true
+  hostname: sparkyfitness.example.com
+  parentRef:
+    name: my-gateway
+    namespace: gateway-system
+    sectionName: https
+```
+
+### Network Policies
+
+When `networkPolicy.enabled: true`, the chart creates least-privilege policies:
+
+- Frontend accepts traffic from anywhere, can only reach the server
+- Server accepts traffic from frontend, can reach the database, DNS, and optionally Garmin/SMTP/OIDC
+- PostgreSQL only accepts traffic from the server
+- Garmin only accepts traffic from the server, can reach external Garmin APIs
+
+## Features
+
+### OIDC / SSO
+
+```yaml
+config:
+  oidc:
+    enabled: true
+    providerSlug: authentik
+    providerName: "Authentik"
+    issuerUrl: "https://auth.example.com/application/o/sparkyfitness/"
+    secrets:
+      clientId: "..."
+      clientSecret: "..."
+```
+
+### Email Notifications
+
+```yaml
+config:
+  email:
+    enabled: true
+    host: smtp.example.com
+    port: 587
+    from: fitness@example.com
+    secrets:
+      username: "..."
+      password: "..."
+```
+
+### Garmin Connect
+
+```yaml
+config:
+  garmin:
+    enabled: true
+```
+
+Deploys a separate Python microservice that connects to the Garmin API.
+
+## Security Contexts
+
+Each component runs with a security context matching its upstream image:
+
+| Component | UID:GID | Non-Root | Capabilities |
+|-----------|---------|----------|-------------|
+| Server | 1000:1000 | Yes | None (all dropped) |
+| Frontend | root | No | `CHOWN`, `NET_BIND_SERVICE`, `SETGID`, `SETUID` |
+| Garmin | 1:1 | Yes | None (all dropped) |
+| PostgreSQL | 999:999 | Yes | None (all dropped) |
+
+All pods use `seccompProfile: RuntimeDefault` and `allowPrivilegeEscalation: false`.
+
+Security contexts are fully configurable via `<component>.podSecurityContext` and `<component>.containerSecurityContext`.
+
+## ArgoCD
+
+Auto-generated secrets use Helm `lookup` to preserve values across upgrades. Since ArgoCD uses `helm template` (where `lookup` returns nil), secrets will show as changed on every diff. Add this to your Application:
+
+```yaml
+spec:
+  ignoreDifferences:
+    - group: ""
+      kind: Secret
+      jsonPointers:
+        - /data
+```
+
+With `RespectIgnoreDifferences=true` in ArgoCD's resource tracking, this prevents unnecessary sync loops.
+
+## All Values
+
+See [`values.yaml`](values.yaml) for the full reference with comments. The file is organized into sections:
+
+1. **Global** — image registry, pull secrets, storage class, service accounts
+2. **App Configuration** — runtime settings, OIDC, email, Garmin, rate limiting
+3. **Networking** — ingress, HTTPRoute, network policies
+4. **Deployments** — per-component images, resources, security contexts, secrets, persistence
+5. **External Secrets** — ESO integration with per-type secret stores

--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: sparkyfitness
+description: Sparkyfitness fitness tracking application
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/helm/chart/templates/NOTES.txt
+++ b/helm/chart/templates/NOTES.txt
@@ -1,0 +1,59 @@
+
+Sparkyfitness has been deployed!
+
+Components:
+  - Server:   {{ include "sparkyfitness.fullname" . }}-server
+  - Frontend: {{ include "sparkyfitness.fullname" . }}-frontend
+{{- if .Values.config.garmin.enabled }}
+  - Garmin:   {{ include "sparkyfitness.fullname" . }}-garmin
+{{- end }}
+{{- if .Values.postgresql.enabled }}
+  - PostgreSQL: {{ include "sparkyfitness.fullname" . }}-postgresql
+{{- end }}
+
+Frontend URL: {{ include "sparkyfitness.frontendUrl" . }}
+
+{{- if and (not .Values.externalSecrets.enabled) (not .Values.server.secrets.existingSecret) }}
+
+  WARNING: SECRETS STORED AS PLAIN KUBERNETES SECRETS
+
+  Secrets were {{ if .Values.server.secrets.generate }}auto-generated{{ else }}provided via values{{ end }} and stored
+  as plain Kubernetes Secrets. This is suitable for development/testing
+  but NOT recommended for production.
+
+  For production, use one of:
+    - External Secrets Operator: set externalSecrets.enabled=true
+    - Pre-created secrets:
+        server.secrets.existingSecret          (keys: api_encryption_key, better_auth_secret)
+        server.appDatabase.existingSecret      (keys: username, password)
+        config.oidc.secrets.existingSecret      (keys: client_id, client_secret)
+        config.email.secrets.existingSecret     (keys: username, password)
+        postgresql.auth.existingSecret          (keys: username, password)
+{{- end }}
+{{- if not .Values.postgresql.enabled }}
+
+  EXTERNAL DATABASE NOTE:
+  The database owner (externalDatabase.auth.username) must have the CREATEROLE
+  privilege so the application can automatically create the limited-privilege
+  app user ({{ .Values.server.appDatabase.username }}) on first startup:
+
+    ALTER USER <owner> CREATEROLE;
+
+  After successful first startup you may revoke it:
+
+    ALTER USER <owner> NOCREATEROLE;
+
+  Required PostgreSQL extensions and grants (run as superuser):
+
+    \c {{ .Values.externalDatabase.database }}
+
+    -- Standard extensions
+    CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+    CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+    -- Performance monitoring (requires shared_preload_libraries = 'pg_stat_statements')
+    CREATE EXTENSION IF NOT EXISTS "pg_stat_statements";
+
+    -- Grant extension functions to the DB owner so the app can delegate them
+    GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO "<owner>" WITH GRANT OPTION;
+{{- end }}

--- a/helm/chart/templates/_helpers.tpl
+++ b/helm/chart/templates/_helpers.tpl
@@ -1,0 +1,275 @@
+{{/*
+Chart name, truncated to 63 chars.
+*/}}
+{{- define "sparkyfitness.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fully qualified app name, truncated to 63 chars.
+*/}}
+{{- define "sparkyfitness.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "sparkyfitness.labels" -}}
+app.kubernetes.io/name: {{ include "sparkyfitness.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "sparkyfitness.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sparkyfitness.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/* ================================================================== */}}
+{{/* Image helpers                                                      */}}
+{{/* ================================================================== */}}
+
+{{/*
+Build a container image string with optional global.imageRegistry prefix.
+Usage: {{ include "sparkyfitness.image" (dict "image" .Values.server.image "global" .Values.global) }}
+*/}}
+{{- define "sparkyfitness.image" -}}
+{{- $registry := .global.imageRegistry | default "" -}}
+{{- $repo := .image.repository -}}
+{{- $tag := .image.tag | default "latest" -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" $registry $repo $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render global.imagePullSecrets as a YAML list.
+*/}}
+{{- define "sparkyfitness.imagePullSecrets" -}}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.global.imagePullSecrets }}
+  - name: {{ .name }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* ================================================================== */}}
+{{/* Database helpers                                                    */}}
+{{/* ================================================================== */}}
+
+{{- define "sparkyfitness.databaseHost" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- include "sparkyfitness.fullname" . }}-postgresql
+{{- else -}}
+{{- required "externalDatabase.host is required when postgresql.enabled=false" .Values.externalDatabase.host -}}
+{{- end -}}
+{{- end }}
+
+{{- define "sparkyfitness.databasePort" -}}
+{{- if .Values.postgresql.enabled -}}
+5432
+{{- else -}}
+{{- .Values.externalDatabase.port | default 5432 -}}
+{{- end -}}
+{{- end }}
+
+{{- define "sparkyfitness.databaseName" -}}
+{{- if .Values.postgresql.enabled -}}
+{{- .Values.postgresql.auth.database -}}
+{{- else -}}
+{{- required "externalDatabase.database is required when postgresql.enabled=false" .Values.externalDatabase.database -}}
+{{- end -}}
+{{- end }}
+
+{{/* ================================================================== */}}
+{{/* Secret name helpers (per type)                                     */}}
+{{/* ================================================================== */}}
+
+{{/*
+App secret name: existingSecret > chart-managed.
+*/}}
+{{- define "sparkyfitness.appSecretName" -}}
+{{- if .Values.server.secrets.existingSecret -}}
+{{- .Values.server.secrets.existingSecret -}}
+{{- else -}}
+{{- include "sparkyfitness.fullname" . }}-app
+{{- end -}}
+{{- end }}
+
+{{/*
+OIDC secret name: existingSecret > chart-managed.
+*/}}
+{{- define "sparkyfitness.oidcSecretName" -}}
+{{- if .Values.config.oidc.secrets.existingSecret -}}
+{{- .Values.config.oidc.secrets.existingSecret -}}
+{{- else -}}
+{{- include "sparkyfitness.fullname" . }}-oidc
+{{- end -}}
+{{- end }}
+
+{{/*
+SMTP secret name: existingSecret > chart-managed.
+*/}}
+{{- define "sparkyfitness.smtpSecretName" -}}
+{{- if .Values.config.email.secrets.existingSecret -}}
+{{- .Values.config.email.secrets.existingSecret -}}
+{{- else -}}
+{{- include "sparkyfitness.fullname" . }}-smtp
+{{- end -}}
+{{- end }}
+
+{{/*
+App database secret name (limited-privilege user): existingSecret > chart-managed.
+*/}}
+{{- define "sparkyfitness.appDbSecretName" -}}
+{{- if .Values.server.appDatabase.existingSecret -}}
+{{- .Values.server.appDatabase.existingSecret -}}
+{{- else -}}
+{{- include "sparkyfitness.fullname" . }}-appdb
+{{- end -}}
+{{- end }}
+
+{{/*
+Database credentials secret name.
+*/}}
+{{- define "sparkyfitness.databaseSecretName" -}}
+{{- if .Values.postgresql.enabled -}}
+  {{- if .Values.postgresql.auth.existingSecret -}}
+    {{- .Values.postgresql.auth.existingSecret -}}
+  {{- else -}}
+    {{- include "sparkyfitness.fullname" . }}-postgres
+  {{- end -}}
+{{- else -}}
+  {{- if .Values.externalDatabase.auth.existingSecret -}}
+    {{- .Values.externalDatabase.auth.existingSecret -}}
+  {{- else -}}
+    {{- include "sparkyfitness.fullname" . }}-postgres
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/* ================================================================== */}}
+{{/* Secret creation helpers                                            */}}
+{{/* ================================================================== */}}
+
+{{/*
+Whether the chart should create the app secret.
+*/}}
+{{- define "sparkyfitness.createAppSecret" -}}
+{{- if and (not .Values.server.secrets.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.app.enabled)) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Whether the chart should create the app database secret.
+*/}}
+{{- define "sparkyfitness.createAppDbSecret" -}}
+{{- if and (not .Values.server.appDatabase.existingSecret) (not (and .Values.externalSecrets.enabled .Values.externalSecrets.appdb.enabled)) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Whether the chart should create the OIDC secret.
+*/}}
+{{- define "sparkyfitness.createOidcSecret" -}}
+{{- if and .Values.config.oidc.enabled (not .Values.config.oidc.secrets.existingSecret) -}}
+  {{- if not (and .Values.externalSecrets.enabled .Values.externalSecrets.oidc.enabled) -}}
+true
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Whether the chart should create the SMTP secret.
+*/}}
+{{- define "sparkyfitness.createSmtpSecret" -}}
+{{- if and .Values.config.email.enabled (not .Values.config.email.secrets.existingSecret) -}}
+  {{- if not (and .Values.externalSecrets.enabled .Values.externalSecrets.smtp.enabled) -}}
+true
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Whether the chart should create the database credentials secret.
+*/}}
+{{- define "sparkyfitness.createDatabaseSecret" -}}
+{{- if .Values.postgresql.enabled -}}
+  {{- if not .Values.postgresql.auth.existingSecret -}}
+    {{- if not (and .Values.externalSecrets.enabled .Values.externalSecrets.postgres.enabled) -}}
+true
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- if not .Values.externalDatabase.auth.existingSecret -}}
+    {{- if not (and .Values.externalSecrets.enabled .Values.externalSecrets.postgres.enabled) -}}
+true
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/* ================================================================== */}}
+{{/* URL helpers                                                        */}}
+{{/* ================================================================== */}}
+
+{{/*
+Frontend URL — derived from routing config, with manual fallback.
+Priority: httpRoute > ingress > config.frontendUrl > localhost
+*/}}
+{{- define "sparkyfitness.frontendUrl" -}}
+{{- if and .Values.httpRoute.enabled .Values.httpRoute.hostname -}}
+https://{{ .Values.httpRoute.hostname }}
+{{- else if and .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) -}}
+{{- $host := (index .Values.ingress.hosts 0).host -}}
+{{- if .Values.ingress.tls -}}
+https://{{ $host }}
+{{- else -}}
+http://{{ $host }}
+{{- end -}}
+{{- else if .Values.config.frontendUrl -}}
+{{- .Values.config.frontendUrl -}}
+{{- else -}}
+http://localhost:3004
+{{- end -}}
+{{- end }}
+
+{{/* ================================================================== */}}
+{{/* ConfigMap helpers                                                   */}}
+{{/* ================================================================== */}}
+
+{{- define "sparkyfitness.configmapName" -}}
+{{- include "sparkyfitness.fullname" . }}-server-config
+{{- end }}
+
+{{/* ================================================================== */}}
+{{/* StorageClass helper                                                */}}
+{{/* ================================================================== */}}
+
+{{/*
+Effective StorageClass — component-level > global > cluster default.
+Usage: {{ include "sparkyfitness.storageClass" (dict "sc" .Values.postgresql.persistence.storageClass "global" .Values.global) }}
+*/}}
+{{- define "sparkyfitness.storageClass" -}}
+{{- $sc := .sc | default "" -}}
+{{- $globalSc := .global.storageClass | default "" -}}
+{{- if $sc -}}
+{{- $sc -}}
+{{- else if $globalSc -}}
+{{- $globalSc -}}
+{{- end -}}
+{{- end }}

--- a/helm/chart/templates/frontend/deployment.yaml
+++ b/helm/chart/templates/frontend/deployment.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-frontend
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  replicas: {{ .Values.frontend.replicas }}
+  selector:
+    matchLabels:
+      {{- include "sparkyfitness.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  template:
+    metadata:
+      labels:
+        {{- include "sparkyfitness.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: frontend
+    spec:
+      {{- if and .Values.global.serviceAccount.create .Values.frontend.serviceAccount.create }}
+      serviceAccountName: {{ include "sparkyfitness.fullname" . }}-frontend
+      {{- end }}
+      {{- include "sparkyfitness.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.frontend.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: frontend
+          image: {{ include "sparkyfitness.image" (dict "image" .Values.frontend.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.frontend.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.frontend.port }}
+              protocol: TCP
+          env:
+            - name: SPARKY_FITNESS_FRONTEND_URL
+              value: {{ include "sparkyfitness.frontendUrl" . | quote }}
+            - name: SPARKY_FITNESS_SERVER_HOST
+              value: {{ include "sparkyfitness.fullname" . }}-server
+            - name: SPARKY_FITNESS_SERVER_PORT
+              value: {{ .Values.server.port | quote }}
+          {{- with .Values.frontend.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.frontend.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/helm/chart/templates/frontend/service.yaml
+++ b/helm/chart/templates/frontend/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-frontend
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.frontend.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sparkyfitness.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend

--- a/helm/chart/templates/frontend/serviceaccount.yaml
+++ b/helm/chart/templates/frontend/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.serviceAccount.create .Values.frontend.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-frontend
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+  {{- with .Values.frontend.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.frontend.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/helm/chart/templates/garmin/deployment.yaml
+++ b/helm/chart/templates/garmin/deployment.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.config.garmin.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-garmin
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: garmin
+spec:
+  replicas: {{ .Values.garmin.replicas }}
+  selector:
+    matchLabels:
+      {{- include "sparkyfitness.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: garmin
+  template:
+    metadata:
+      labels:
+        {{- include "sparkyfitness.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: garmin
+    spec:
+      {{- if and .Values.global.serviceAccount.create .Values.garmin.serviceAccount.create }}
+      serviceAccountName: {{ include "sparkyfitness.fullname" . }}-garmin
+      {{- end }}
+      {{- include "sparkyfitness.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.garmin.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: garmin
+          image: {{ include "sparkyfitness.image" (dict "image" .Values.garmin.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.garmin.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.garmin.port }}
+              protocol: TCP
+          env:
+            - name: GARMIN_MICROSERVICE_URL
+              value: "http://{{ include "sparkyfitness.fullname" . }}-garmin:{{ .Values.garmin.port }}"
+            - name: GARMIN_SERVICE_PORT
+              value: {{ .Values.garmin.port | quote }}
+            - name: GARMIN_SERVICE_IS_CN
+              value: {{ .Values.config.garmin.isChinaRegion | quote }}
+          {{- with .Values.garmin.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.garmin.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/helm/chart/templates/garmin/service.yaml
+++ b/helm/chart/templates/garmin/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.config.garmin.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-garmin
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: garmin
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.garmin.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sparkyfitness.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: garmin
+{{- end }}

--- a/helm/chart/templates/garmin/serviceaccount.yaml
+++ b/helm/chart/templates/garmin/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.config.garmin.enabled (and .Values.global.serviceAccount.create .Values.garmin.serviceAccount.create) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-garmin
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: garmin
+  {{- with .Values.garmin.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.garmin.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/helm/chart/templates/networking/httproute.yaml
+++ b/helm/chart/templates/networking/httproute.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.httpRoute.parentRef.name }}
+      namespace: {{ .Values.httpRoute.parentRef.namespace }}
+      {{- with .Values.httpRoute.parentRef.sectionName }}
+      sectionName: {{ . }}
+      {{- end }}
+  hostnames:
+    - {{ .Values.httpRoute.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "sparkyfitness.fullname" . }}-frontend
+          port: {{ .Values.frontend.port }}
+{{- end }}

--- a/helm/chart/templates/networking/ingress.yaml
+++ b/helm/chart/templates/networking/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "sparkyfitness.fullname" $ }}-frontend
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/chart/templates/networking/networkpolicy.yaml
+++ b/helm/chart/templates/networking/networkpolicy.yaml
@@ -1,0 +1,159 @@
+{{- if .Values.networkPolicy.enabled }}
+---
+# Frontend: allow ingress from anywhere on HTTP
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-frontend
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: frontend
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "sparkyfitness.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: frontend
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - ports:
+        - port: {{ .Values.frontend.port }}
+  egress:
+    # → server
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "sparkyfitness.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: server
+      ports:
+        - port: {{ .Values.server.port }}
+    # → DNS
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# Server: accept from frontend, egress to DB + DNS
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-server
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "sparkyfitness.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "sparkyfitness.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: frontend
+      ports:
+        - port: {{ .Values.server.port }}
+  egress:
+    {{- if .Values.postgresql.enabled }}
+    # → bundled PostgreSQL
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "sparkyfitness.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: postgresql
+      ports:
+        - port: 5432
+    {{- else }}
+    # → external PostgreSQL (allow all on DB port)
+    - ports:
+        - port: {{ .Values.externalDatabase.port | default 5432 }}
+    {{- end }}
+    {{- if .Values.config.garmin.enabled }}
+    # → Garmin microservice
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "sparkyfitness.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: garmin
+      ports:
+        - port: {{ .Values.garmin.port }}
+    {{- end }}
+    {{- if .Values.config.oidc.enabled }}
+    # → OIDC provider (HTTPS)
+    - ports:
+        - port: 443
+    {{- end }}
+    {{- if .Values.config.email.enabled }}
+    # → SMTP
+    - ports:
+        - port: {{ .Values.config.email.port | default 587 }}
+    {{- end }}
+    # → DNS
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+{{- if .Values.postgresql.enabled }}
+---
+# PostgreSQL: accept from server only
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-postgresql
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "sparkyfitness.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgresql
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "sparkyfitness.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: server
+      ports:
+        - port: 5432
+{{- end }}
+{{- if .Values.config.garmin.enabled }}
+---
+# Garmin: accept from server, egress to Garmin API + DNS
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-garmin
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: garmin
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "sparkyfitness.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: garmin
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "sparkyfitness.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: server
+      ports:
+        - port: {{ .Values.garmin.port }}
+  egress:
+    # → Garmin Connect API (HTTPS)
+    - ports:
+        - port: 443
+    # → DNS
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+{{- end }}
+{{- end }}

--- a/helm/chart/templates/secrets/appdb.yaml
+++ b/helm/chart/templates/secrets/appdb.yaml
@@ -1,0 +1,22 @@
+{{- if include "sparkyfitness.createAppDbSecret" . }}
+{{- $secretName := include "sparkyfitness.appDbSecretName" . -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $existingData := ($existing).data | default dict -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+type: Opaque
+data:
+  username: {{ .Values.server.appDatabase.username | default "sparkyapp" | b64enc }}
+  {{- if .Values.server.appDatabase.password }}
+  password: {{ .Values.server.appDatabase.password | b64enc }}
+  {{- else }}
+  password: {{ get $existingData "password" | default (randAlphaNum 48 | b64enc) }}
+  {{- end }}
+{{- end }}

--- a/helm/chart/templates/secrets/externalsecret-app.yaml
+++ b/helm/chart/templates/secrets/externalsecret-app.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.app.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-app
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStore.name }}
+    kind: SecretStore
+  target:
+    name: {{ include "sparkyfitness.appSecretName" . }}
+    creationPolicy: Owner
+  data:
+    {{- range .Values.externalSecrets.app.keys }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ $.Values.externalSecrets.app.remoteKey }}
+        property: {{ .property }}
+    {{- end }}
+{{- end }}

--- a/helm/chart/templates/secrets/externalsecret-appdb.yaml
+++ b/helm/chart/templates/secrets/externalsecret-appdb.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.appdb.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-appdb
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    {{- if .Values.externalSecrets.appdb.clusterSecretStore }}
+    name: {{ .Values.externalSecrets.appdb.clusterSecretStore }}
+    kind: ClusterSecretStore
+    {{- else }}
+    name: {{ .Values.externalSecrets.secretStore.name }}
+    kind: SecretStore
+    {{- end }}
+  target:
+    name: {{ include "sparkyfitness.appDbSecretName" . }}
+    creationPolicy: Owner
+  data:
+    {{- range .Values.externalSecrets.appdb.keys }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ $.Values.externalSecrets.appdb.remoteKey }}
+        property: {{ .property }}
+    {{- end }}
+{{- end }}

--- a/helm/chart/templates/secrets/externalsecret-oidc.yaml
+++ b/helm/chart/templates/secrets/externalsecret-oidc.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.oidc.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-oidc
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStore.name }}
+    kind: SecretStore
+  target:
+    name: {{ include "sparkyfitness.oidcSecretName" . }}
+    creationPolicy: Owner
+  data:
+    {{- range .Values.externalSecrets.oidc.keys }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ $.Values.externalSecrets.oidc.remoteKey }}
+        property: {{ .property }}
+    {{- end }}
+{{- end }}

--- a/helm/chart/templates/secrets/externalsecret-postgres.yaml
+++ b/helm/chart/templates/secrets/externalsecret-postgres.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.postgres.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-postgres
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    {{- if .Values.externalSecrets.postgres.clusterSecretStore }}
+    name: {{ .Values.externalSecrets.postgres.clusterSecretStore }}
+    kind: ClusterSecretStore
+    {{- else }}
+    name: {{ .Values.externalSecrets.secretStore.name }}
+    kind: SecretStore
+    {{- end }}
+  target:
+    name: {{ include "sparkyfitness.databaseSecretName" . }}
+    creationPolicy: Owner
+  data:
+    {{- range .Values.externalSecrets.postgres.keys }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ $.Values.externalSecrets.postgres.remoteKey }}
+        property: {{ .property }}
+    {{- end }}
+{{- end }}

--- a/helm/chart/templates/secrets/externalsecret-smtp.yaml
+++ b/helm/chart/templates/secrets/externalsecret-smtp.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.externalSecrets.enabled .Values.externalSecrets.smtp.enabled }}
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-smtp
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStore.name }}
+    kind: SecretStore
+  target:
+    name: {{ include "sparkyfitness.smtpSecretName" . }}
+    creationPolicy: Owner
+  data:
+    {{- range .Values.externalSecrets.smtp.keys }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ $.Values.externalSecrets.smtp.remoteKey }}
+        property: {{ .property }}
+    {{- end }}
+{{- end }}

--- a/helm/chart/templates/secrets/oidc.yaml
+++ b/helm/chart/templates/secrets/oidc.yaml
@@ -1,0 +1,16 @@
+{{- if include "sparkyfitness.createOidcSecret" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sparkyfitness.oidcSecretName" . }}
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.config.oidc.secrets.clientId }}
+  client_id: {{ .Values.config.oidc.secrets.clientId | b64enc }}
+  {{- end }}
+  {{- if .Values.config.oidc.secrets.clientSecret }}
+  client_secret: {{ .Values.config.oidc.secrets.clientSecret | b64enc }}
+  {{- end }}
+{{- end }}

--- a/helm/chart/templates/secrets/secretstore.yaml
+++ b/helm/chart/templates/secrets/secretstore.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: {{ .Values.externalSecrets.secretStore.name }}
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+spec:
+  provider:
+    vault:
+      server: {{ .Values.externalSecrets.secretStore.vaultServer | quote }}
+      path: {{ .Values.externalSecrets.secretStore.vaultPath | quote }}
+      version: v2
+      {{- if .Values.externalSecrets.secretStore.caConfigMap.name }}
+      caProvider:
+        type: ConfigMap
+        namespace: {{ .Values.externalSecrets.secretStore.caConfigMap.namespace }}
+        name: {{ .Values.externalSecrets.secretStore.caConfigMap.name }}
+        key: {{ .Values.externalSecrets.secretStore.caConfigMap.key }}
+      {{- end }}
+      auth:
+        kubernetes:
+          mountPath: {{ .Values.externalSecrets.secretStore.auth.mountPath }}
+          role: {{ .Values.externalSecrets.secretStore.auth.role }}
+{{- end }}

--- a/helm/chart/templates/secrets/smtp.yaml
+++ b/helm/chart/templates/secrets/smtp.yaml
@@ -1,0 +1,16 @@
+{{- if include "sparkyfitness.createSmtpSecret" . }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sparkyfitness.smtpSecretName" . }}
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.config.email.secrets.username }}
+  username: {{ .Values.config.email.secrets.username | b64enc }}
+  {{- end }}
+  {{- if .Values.config.email.secrets.password }}
+  password: {{ .Values.config.email.secrets.password | b64enc }}
+  {{- end }}
+{{- end }}

--- a/helm/chart/templates/server/configmap.yaml
+++ b/helm/chart/templates/server/configmap.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "sparkyfitness.configmapName" . }}
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+data:
+  NODE_ENV: {{ .Values.config.nodeEnv | quote }}
+  TZ: {{ .Values.config.timezone | quote }}
+  SPARKY_FITNESS_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  SPARKY_FITNESS_DB_HOST: {{ include "sparkyfitness.databaseHost" . | quote }}
+  SPARKY_FITNESS_DB_PORT: {{ include "sparkyfitness.databasePort" . | quote }}
+  SPARKY_FITNESS_DB_NAME: {{ include "sparkyfitness.databaseName" . | quote }}
+  SPARKY_FITNESS_FRONTEND_URL: {{ include "sparkyfitness.frontendUrl" . | quote }}
+  SPARKY_FITNESS_DISABLE_SIGNUP: {{ .Values.config.disableSignup | quote }}
+  {{- with .Values.config.adminEmail }}
+  SPARKY_FITNESS_ADMIN_EMAIL: {{ . | quote }}
+  {{- end }}
+  ALLOW_PRIVATE_NETWORK_CORS: {{ .Values.config.allowPrivateNetworkCors | quote }}
+  {{- with .Values.config.extraTrustedOrigins }}
+  SPARKY_FITNESS_EXTRA_TRUSTED_ORIGINS: {{ . | quote }}
+  {{- end }}
+  SPARKY_FITNESS_FORCE_EMAIL_LOGIN: {{ .Values.config.forceEmailLogin | quote }}
+  SPARKY_FITNESS_DISABLE_EMAIL_LOGIN: {{ .Values.config.disableEmailLogin | quote }}
+  {{- if .Values.config.email.enabled }}
+  SPARKY_FITNESS_EMAIL_HOST: {{ .Values.config.email.host | quote }}
+  SPARKY_FITNESS_EMAIL_PORT: {{ .Values.config.email.port | quote }}
+  SPARKY_FITNESS_EMAIL_SECURE: {{ .Values.config.email.secure | quote }}
+  SPARKY_FITNESS_EMAIL_FROM: {{ .Values.config.email.from | quote }}
+  {{- end }}
+  {{- if .Values.config.oidc.enabled }}
+  SPARKY_FITNESS_OIDC_AUTH_ENABLED: "true"
+  SPARKY_FITNESS_OIDC_PROVIDER_SLUG: {{ .Values.config.oidc.providerSlug | quote }}
+  SPARKY_FITNESS_OIDC_PROVIDER_NAME: {{ .Values.config.oidc.providerName | quote }}
+  SPARKY_FITNESS_OIDC_ISSUER_URL: {{ .Values.config.oidc.issuerUrl | quote }}
+  SPARKY_FITNESS_OIDC_SCOPE: {{ .Values.config.oidc.scope | quote }}
+  {{- with .Values.config.oidc.domain }}
+  SPARKY_FITNESS_OIDC_DOMAIN: {{ . | quote }}
+  {{- end }}
+  SPARKY_FITNESS_OIDC_AUTO_REGISTER: {{ .Values.config.oidc.autoRegister | quote }}
+  SPARKY_FITNESS_OIDC_AUTO_REDIRECT: {{ .Values.config.oidc.autoRedirect | quote }}
+  {{- with .Values.config.oidc.logoUrl }}
+  SPARKY_FITNESS_OIDC_LOGO_URL: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.oidc.adminGroup }}
+  SPARKY_FITNESS_OIDC_ADMIN_GROUP: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.oidc.tokenAuthMethod }}
+  SPARKY_FITNESS_OIDC_TOKEN_AUTH_METHOD: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.oidc.idTokenSignedAlg }}
+  SPARKY_FITNESS_OIDC_ID_TOKEN_SIGNED_ALG: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.oidc.userinfoSignedAlg }}
+  SPARKY_FITNESS_OIDC_USERINFO_SIGNED_ALG: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.oidc.timeout }}
+  SPARKY_FITNESS_OIDC_TIMEOUT: {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.config.garmin.enabled }}
+  GARMIN_MICROSERVICE_URL: "http://{{ include "sparkyfitness.fullname" . }}-garmin:{{ .Values.garmin.port }}"
+  GARMIN_SERVICE_IS_CN: {{ .Values.config.garmin.isChinaRegion | quote }}
+  {{- end }}
+  {{- with .Values.config.rateLimiting.windowMs }}
+  SPARKY_FITNESS_API_KEY_RATELIMIT_WINDOW_MS: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.rateLimiting.maxRequests }}
+  SPARKY_FITNESS_API_KEY_RATELIMIT_MAX_REQUESTS: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.developer.fitbitDataSource }}
+  SPARKY_FITNESS_FITBIT_DATA_SOURCE: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.developer.withingsDataSource }}
+  SPARKY_FITNESS_WITHINGS_DATA_SOURCE: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.developer.garminDataSource }}
+  SPARKY_FITNESS_GARMIN_DATA_SOURCE: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.developer.polarDataSource }}
+  SPARKY_FITNESS_POLAR_DATA_SOURCE: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.config.developer.hevyDataSource }}
+  SPARKY_FITNESS_HEVY_DATA_SOURCE: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.config.developer.saveMockData }}
+  SPARKY_FITNESS_SAVE_MOCK_DATA: "true"
+  {{- end }}

--- a/helm/chart/templates/server/deployment.yaml
+++ b/helm/chart/templates/server/deployment.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-server
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  replicas: {{ .Values.server.replicas }}
+  selector:
+    matchLabels:
+      {{- include "sparkyfitness.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/server/configmap.yaml") . | sha256sum }}
+      labels:
+        {{- include "sparkyfitness.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
+    spec:
+      {{- if and .Values.global.serviceAccount.create .Values.server.serviceAccount.create }}
+      serviceAccountName: {{ include "sparkyfitness.fullname" . }}-server
+      {{- end }}
+      {{- include "sparkyfitness.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.server.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: server
+          image: {{ include "sparkyfitness.image" (dict "image" .Values.server.image "global" .Values.global) }}
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.port }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "sparkyfitness.configmapName" . }}
+          env:
+            # --- App secrets ---
+            - name: SPARKY_FITNESS_API_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.appSecretName" . }}
+                  key: api_encryption_key
+            - name: BETTER_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.appSecretName" . }}
+                  key: better_auth_secret
+            # --- App database credentials (limited-privilege user) ---
+            - name: SPARKY_FITNESS_APP_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.appDbSecretName" . }}
+                  key: username
+            - name: SPARKY_FITNESS_APP_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.appDbSecretName" . }}
+                  key: password
+            # --- Database credentials (owner) ---
+            - name: SPARKY_FITNESS_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.databaseSecretName" . }}
+                  key: username
+            - name: SPARKY_FITNESS_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.databaseSecretName" . }}
+                  key: password
+            {{- if .Values.config.oidc.enabled }}
+            # --- OIDC credentials ---
+            - name: SPARKY_FITNESS_OIDC_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.oidcSecretName" . }}
+                  key: client_id
+            - name: SPARKY_FITNESS_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.oidcSecretName" . }}
+                  key: client_secret
+            {{- end }}
+            {{- if .Values.config.email.enabled }}
+            # --- SMTP credentials ---
+            - name: SPARKY_FITNESS_EMAIL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.smtpSecretName" . }}
+                  key: username
+            - name: SPARKY_FITNESS_EMAIL_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.smtpSecretName" . }}
+                  key: password
+            {{- end }}
+            {{- range $k, $v := .Values.server.extraEnv }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+          {{- with .Values.server.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: backup
+              mountPath: /app/SparkyFitnessServer/backup
+            - name: uploads
+              mountPath: /app/SparkyFitnessServer/uploads
+            - name: temp-uploads
+              mountPath: /app/SparkyFitnessServer/temp_uploads
+      volumes:
+        - name: backup
+          persistentVolumeClaim:
+            claimName: {{ include "sparkyfitness.fullname" . }}-server-backup
+        - name: uploads
+          persistentVolumeClaim:
+            claimName: {{ include "sparkyfitness.fullname" . }}-server-uploads
+        - name: temp-uploads
+          emptyDir: {}

--- a/helm/chart/templates/server/pvc-backup.yaml
+++ b/helm/chart/templates/server/pvc-backup.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-server-backup
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  accessModes:
+    - {{ .Values.server.persistence.backup.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.server.persistence.backup.size }}
+  {{- with .Values.global.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}

--- a/helm/chart/templates/server/pvc-uploads.yaml
+++ b/helm/chart/templates/server/pvc-uploads.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-server-uploads
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  accessModes:
+    - {{ .Values.server.persistence.uploads.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.server.persistence.uploads.size }}
+  {{- with .Values.global.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}

--- a/helm/chart/templates/server/secret.yaml
+++ b/helm/chart/templates/server/secret.yaml
@@ -1,0 +1,26 @@
+{{- if include "sparkyfitness.createAppSecret" . }}
+{{- $secretName := include "sparkyfitness.appSecretName" . -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $existingData := ($existing).data | default dict -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+type: Opaque
+data:
+  {{- if .Values.server.secrets.apiEncryptionKey }}
+  api_encryption_key: {{ .Values.server.secrets.apiEncryptionKey | b64enc }}
+  {{- else if .Values.server.secrets.generate }}
+  api_encryption_key: {{ get $existingData "api_encryption_key" | default (randAlphaNum 64 | b64enc) }}
+  {{- end }}
+  {{- if .Values.server.secrets.betterAuthSecret }}
+  better_auth_secret: {{ .Values.server.secrets.betterAuthSecret | b64enc }}
+  {{- else if .Values.server.secrets.generate }}
+  better_auth_secret: {{ get $existingData "better_auth_secret" | default (randAlphaNum 64 | b64enc) }}
+  {{- end }}
+{{- end }}

--- a/helm/chart/templates/server/service.yaml
+++ b/helm/chart/templates/server/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-server
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.server.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sparkyfitness.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server

--- a/helm/chart/templates/server/serviceaccount.yaml
+++ b/helm/chart/templates/server/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.global.serviceAccount.create .Values.server.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-server
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  {{- with .Values.server.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.server.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -1,0 +1,347 @@
+# =============================================================================
+# Sparkyfitness Helm Chart — values.yaml
+# Community-ready defaults: bundled PostgreSQL, no external dependencies.
+# =============================================================================
+
+# ========================== 1. GLOBAL ========================================
+
+global:
+  # -- Container image registry prefix (e.g. "registry.example.com")
+  imageRegistry: ""
+  # -- Global image pull secrets, e.g. [{name: "regcred"}]
+  imagePullSecrets: []
+  # -- Default StorageClass for all PVCs (overridable per component)
+  storageClass: ""
+  # -- Master toggle: create ServiceAccounts for all services
+  serviceAccount:
+    create: true
+
+# ========================== 2. APP CONFIGURATION =============================
+# Feature toggles, non-secret runtime settings.
+
+config:
+  # -- Node.js environment mode
+  nodeEnv: "production"
+  # -- Server timezone (TZ database name)
+  timezone: "Etc/UTC"
+  # -- Log level (debug, info, warn, error)
+  logLevel: "info"
+  # -- Public URL of the frontend (fallback only — httpRoute/ingress always take priority).
+  frontendUrl: ""
+
+  # -- Disable new user registrations
+  disableSignup: false
+  # -- Email of the auto-admin user (leave empty to skip)
+  adminEmail: ""
+
+  # -- Allow CORS from private network ranges (only for self-hosted/private networks)
+  allowPrivateNetworkCors: false
+  # -- Extra trusted origins, comma-separated (e.g. "http://192.168.1.5:8080")
+  extraTrustedOrigins: ""
+
+  # -- Force email/password login to be enabled (fail-safe against OIDC lockout)
+  forceEmailLogin: true
+  # -- Hide email/password login on login page (overridden by forceEmailLogin)
+  disableEmailLogin: false
+
+  # -- OIDC authentication (OpenID Connect SSO)
+  oidc:
+    enabled: false
+    providerSlug: ""
+    providerName: ""
+    issuerUrl: ""
+    scope: "openid email profile"
+    domain: ""
+    autoRegister: true
+    autoRedirect: false
+    logoUrl: ""
+    adminGroup: ""
+    # -- Advanced (leave empty for app defaults)
+    tokenAuthMethod: ""
+    idTokenSignedAlg: ""
+    userinfoSignedAlg: ""
+    timeout: ""
+    # -- OIDC credentials
+    secrets:
+      clientId: ""
+      clientSecret: ""
+      # -- Use an existing K8s Secret (keys: client_id, client_secret)
+      existingSecret: ""
+
+  # -- Email / SMTP notifications
+  email:
+    enabled: false
+    host: ""
+    port: 587
+    secure: false
+    from: ""
+    # -- SMTP credentials
+    secrets:
+      username: ""
+      password: ""
+      # -- Use an existing K8s Secret (keys: username, password)
+      existingSecret: ""
+
+  # -- Garmin Connect integration
+  garmin:
+    enabled: false
+    isChinaRegion: false
+
+  # -- API key rate limiting (leave empty for app defaults: 100 req / 60s)
+  rateLimiting:
+    windowMs: ""
+    maxRequests: ""
+
+  # -- Developer / mock data sources (for development only)
+  developer:
+    fitbitDataSource: ""
+    withingsDataSource: ""
+    garminDataSource: ""
+    polarDataSource: ""
+    hevyDataSource: ""
+    saveMockData: false
+
+# ========================== 3. NETWORKING ====================================
+
+networkPolicy:
+  enabled: false
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: sparkyfitness.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+httpRoute:
+  enabled: false
+  hostname: ""
+  parentRef:
+    name: ""
+    namespace: ""
+    sectionName: ""
+
+# ========================== 4. DEPLOYMENTS / STATEFULSETS ====================
+
+# -- Server (Node.js backend API — node:20-slim, UID 1000)
+server:
+  image:
+    repository: codewithcj/sparkyfitness_server
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  port: 3010
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  podSecurityContext:
+    runAsNonRoot: true
+    fsGroup: 1000
+    fsGroupChangePolicy: OnRootMismatch
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: [ALL]
+  # -- Application secrets (encryption keys, auth tokens)
+  secrets:
+    # -- Auto-generate random secrets on first install (set false to require explicit values)
+    generate: true
+    # -- 64-character hex API encryption key
+    apiEncryptionKey: ""
+    # -- Better Auth secret key
+    betterAuthSecret: ""
+    # -- Use an existing K8s Secret (keys: api_encryption_key, better_auth_secret)
+    existingSecret: ""
+  # -- Application database credentials (limited-privilege user for runtime queries)
+  appDatabase:
+    # -- Username for the limited-privilege app DB user
+    username: "sparkyapp"
+    # -- Password (auto-generated if empty)
+    password: ""
+    # -- Use an existing K8s Secret (keys: username, password)
+    existingSecret: ""
+  persistence:
+    backup:
+      size: 5Gi
+      accessMode: ReadWriteOnce
+    uploads:
+      size: 10Gi
+      accessMode: ReadWriteOnce
+  # -- Extra environment variables injected into the server container
+  extraEnv: {}
+  serviceAccount:
+    create: true
+    automountServiceAccountToken: false
+    annotations: {}
+
+# -- Frontend (nginx:alpine, runs as root for port 80)
+frontend:
+  image:
+    repository: codewithcj/sparkyfitness
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  port: 80
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  podSecurityContext:
+    runAsNonRoot: false
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: [ALL]
+      add: [CHOWN, NET_BIND_SERVICE, SETGID, SETUID]
+  serviceAccount:
+    create: true
+    automountServiceAccountToken: false
+    annotations: {}
+
+# -- Garmin microservice (python, USER daemon UID 1)
+# Only deployed when config.garmin.enabled=true
+garmin:
+  image:
+    repository: codewithcj/sparkyfitness_garmin
+    tag: "latest"
+    pullPolicy: IfNotPresent
+  replicas: 1
+  port: 8000
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  podSecurityContext:
+    runAsNonRoot: true
+    fsGroup: 1
+    seccompProfile:
+      type: RuntimeDefault
+  containerSecurityContext:
+    runAsUser: 1
+    runAsGroup: 1
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: [ALL]
+  serviceAccount:
+    create: true
+    automountServiceAccountToken: false
+    annotations: {}
+
+# -- Bundled PostgreSQL (postgres:15-alpine, UID 999)
+# Set enabled=false and configure externalDatabase to use an existing instance.
+postgresql:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "15-alpine"
+    pullPolicy: IfNotPresent
+  auth:
+    database: sparkyfitness
+    username: sparky
+    password: ""
+    # -- Use an existing K8s Secret (keys: username, password)
+    existingSecret: ""
+  persistence:
+    enabled: true
+    size: 8Gi
+    accessMode: ReadWriteOnce
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# -- External database (used when postgresql.enabled=false)
+externalDatabase:
+  host: ""
+  port: 5432
+  database: ""
+  auth:
+    username: ""
+    password: ""
+    existingSecret: ""
+
+# ========================== 5. EXTERNAL SECRETS (Advanced) ===================
+# When enabled, secrets are fetched from an external provider (e.g. Vault) via ESO.
+
+externalSecrets:
+  enabled: false
+  secretStore:
+    name: sparkyfitness
+    vaultPath: sparkyfitness
+    vaultServer: ""
+    caConfigMap:
+      namespace: ""
+      name: ""
+      key: ""
+    auth:
+      mountPath: kubernetes
+      role: external-secrets
+  app:
+    enabled: false
+    remoteKey: app_secret
+    keys:
+      - secretKey: api_encryption_key
+        property: api_encryption_key
+      - secretKey: better_auth_secret
+        property: better_auth_secret
+  appdb:
+    enabled: false
+    clusterSecretStore: ""
+    remoteKey: appdb
+    keys:
+      - secretKey: username
+        property: username
+      - secretKey: password
+        property: password
+  postgres:
+    enabled: false
+    clusterSecretStore: ""
+    remoteKey: ""
+    keys:
+      - secretKey: username
+        property: username
+      - secretKey: password
+        property: password
+  oidc:
+    enabled: false
+    remoteKey: oidc
+    keys:
+      - secretKey: client_id
+        property: client_id
+      - secretKey: client_secret
+        property: client_secret
+  smtp:
+    enabled: false
+    remoteKey: smtp
+    keys:
+      - secretKey: username
+        property: username
+      - secretKey: password
+        property: password


### PR DESCRIPTION
Description

Add a community-ready Helm chart for deploying Sparkyfitness on Kubernetes.

The chart packages all components (server, frontend, garmin microservice, optional bundled PostgreSQL) and supports three secret management strategies: auto-generated secrets for development, pre-created existing secrets, and External Secrets Operator integration..

Key features:
- Bundled PostgreSQL or external database support
- Per-component security contexts matching upstream image UIDs
- Per-component ServiceAccounts with token mounting disabled by default
- Gateway API (HTTPRoute) and classic Ingress support
- NetworkPolicy with least-privilege rules per component
- ESO integration with configurable SecretStore/ClusterSecretStore per secret type
- OIDC, SMTP, and Garmin toggles with separate secrets each
- ArgoCD-compatible (ignoreDifferences guidance for auto-generated secrets)
- NOTES.txt with post-install guidance for external database setup