### PR TITLE
fix(lint): no unsafe function types

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Exercises/AddWorkoutPlanDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/AddWorkoutPlanDialog.tsx
@@ -104,12 +104,17 @@ const SortableSetItem = React.memo(
     set: WorkoutPresetSet;
     assignmentIndex: number;
     setIndex: number;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleSetChangeInPlan: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleDuplicateSetInPlan: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleRemoveSetInPlan: Function;
+    handleSetChangeInPlan: (
+      assignmentIndex: number,
+      setIndex: number,
+      field: keyof WorkoutPresetSet,
+      value: WorkoutPresetSet[keyof WorkoutPresetSet]
+    ) => void;
+    handleDuplicateSetInPlan: (
+      assignmentIndex: number,
+      setIndex: number
+    ) => void;
+    handleRemoveSetInPlan: (assignmentIndex: number, setIndex: number) => void;
     weightUnit: string;
   }) => {
     const { attributes, listeners, setNodeRef, transform, transition } =
@@ -313,18 +318,20 @@ const SortableAssignmentItem = React.memo(
     assignment: WorkoutPlanAssignment;
     originalIndex: number;
     workoutPresets: WorkoutPreset[];
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleCopyAssignment: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleRemoveAssignment: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleSetChangeInPlan: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleDuplicateSetInPlan: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleRemoveSetInPlan: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleAddSetInPlan: Function;
+    handleCopyAssignment: (assignment: WorkoutPlanAssignment) => void;
+    handleRemoveAssignment: (index: number) => void;
+    handleSetChangeInPlan: (
+      assignmentIndex: number,
+      setIndex: number,
+      field: keyof WorkoutPresetSet,
+      value: WorkoutPresetSet[keyof WorkoutPresetSet]
+    ) => void;
+    handleDuplicateSetInPlan: (
+      assignmentIndex: number,
+      setIndex: number
+    ) => void;
+    handleRemoveSetInPlan: (assignmentIndex: number, setIndex: number) => void;
+    handleAddSetInPlan: (assignmentIndex: number) => void;
     weightUnit: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     t: any;

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetForm.tsx
@@ -83,12 +83,14 @@ const SortableSetItem = React.memo(
     set: WorkoutPresetSet;
     exerciseIndex: number;
     setIndex: number;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    onSetChange: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    onDuplicateSet: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    onRemoveSet: Function;
+    onSetChange: (
+      exerciseIndex: number,
+      setIndex: number,
+      field: keyof WorkoutPresetSet,
+      value: WorkoutPresetSet[keyof WorkoutPresetSet]
+    ) => void;
+    onDuplicateSet: (exerciseIndex: number, setIndex: number) => void;
+    onRemoveSet: (exerciseIndex: number, setIndex: number) => void;
     weightUnit: string;
   }) => {
     const { attributes, listeners, setNodeRef, transform, transition } =
@@ -305,16 +307,16 @@ const SortableExerciseItem = React.memo(
   }: {
     ex: WorkoutPresetExercise;
     exerciseIndex: number;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleRemoveExercise: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleSetChange: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleDuplicateSet: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleRemoveSet: Function;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    handleAddSet: Function;
+    handleRemoveExercise: (index: number) => void;
+    handleSetChange: (
+      exerciseIndex: number,
+      setIndex: number,
+      field: keyof WorkoutPresetSet,
+      value: WorkoutPresetSet[keyof WorkoutPresetSet]
+    ) => void;
+    handleDuplicateSet: (exerciseIndex: number, setIndex: number) => void;
+    handleRemoveSet: (exerciseIndex: number, setIndex: number) => void;
+    handleAddSet: (exerciseIndex: number) => void;
     weightUnit: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     t: any;


### PR DESCRIPTION
## Description

Fixes all (17) no-unsafe-function-type errors from eslint. The function code prevents checks from typescript and autocomplete. Reasons for fixing all eslint errors are outlined in #795.

## Related Issue

PR type [ ] Issue [x] New Feature [ ] Documentation
Linked Issue: #795

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

