### PR TITLE
fix(lint): only-export-components

### DIFF
--- a/SparkyFitnessFrontend/eslint.config.js
+++ b/SparkyFitnessFrontend/eslint.config.js
@@ -81,6 +81,7 @@ export default tseslint.config(
   {
     files: ['src/hooks/**/*.{ts,tsx}'],
     rules: {
+      'react-refresh/only-export-components': 'off',
       'no-restricted-imports': [
         'error',
         {
@@ -118,6 +119,12 @@ export default tseslint.config(
   },
   {
     files: ['src/components/ui/**/*.{ts,tsx}'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
+  {
+    files: ['src/contexts/**/*.{ts,tsx}'],
     rules: {
       'react-refresh/only-export-components': 'off',
     },

--- a/SparkyFitnessFrontend/src/contexts/ActiveUserContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/ActiveUserContext.tsx
@@ -21,7 +21,6 @@ const ActiveUserContext = createContext<ActiveUserContextType | undefined>(
   undefined
 );
 
-// eslint-disable-next-line  react-refresh/only-export-components
 export const useActiveUser = () => {
   const context = useContext(ActiveUserContext);
   if (context === undefined) {

--- a/SparkyFitnessFrontend/src/contexts/ChatbotVisibilityContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/ChatbotVisibilityContext.tsx
@@ -12,7 +12,6 @@ const ChatbotVisibilityContext = createContext<
   ChatbotVisibilityContextType | undefined
 >(undefined);
 
-// eslint-disable-next-line react-refresh/only-export-components
 export const useChatbotVisibility = () => {
   const context = useContext(ChatbotVisibilityContext);
   if (!context) {

--- a/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
@@ -140,7 +140,6 @@ const PreferencesContext = createContext<PreferencesContextType | undefined>(
   undefined
 );
 
-// eslint-disable-next-line react-refresh/only-export-components
 export const usePreferences = () => {
   const context = useContext(PreferencesContext);
   if (!context) {

--- a/SparkyFitnessFrontend/src/contexts/ThemeContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/ThemeContext.tsx
@@ -15,7 +15,6 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
-// eslint-disable-next-line react-refresh/only-export-components
 export const useTheme = () => {
   const context = useContext(ThemeContext);
   if (!context) {

--- a/SparkyFitnessFrontend/src/contexts/WaterContainerContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/WaterContainerContext.tsx
@@ -74,7 +74,6 @@ export const WaterContainerProvider: React.FC<{ children: ReactNode }> = ({
   );
 };
 
-// eslint-disable-next-line react-refresh/only-export-components
 export const useWaterContainer = () => {
   const context = useContext(WaterContainerContext);
   if (context === undefined) {

--- a/SparkyFitnessFrontend/src/hooks/useAuth.tsx
+++ b/SparkyFitnessFrontend/src/hooks/useAuth.tsx
@@ -236,7 +236,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
-// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (context === undefined) {

--- a/SparkyFitnessFrontend/src/pages/Reports/BodyBatteryGauge.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/BodyBatteryGauge.tsx
@@ -155,6 +155,4 @@ const BodyBatteryGauge: React.FC<BodyBatteryGaugeProps> = ({
   );
 };
 
-// eslint-disable-next-line react-refresh/only-export-components
-export { getBodyBatteryStatusInfo };
 export default BodyBatteryGauge;

--- a/SparkyFitnessFrontend/src/pages/Reports/SpO2Gauge.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SpO2Gauge.tsx
@@ -120,6 +120,4 @@ const SpO2Gauge = ({ value, size = 160, strokeWidth = 12 }: SpO2GaugeProps) => {
   );
 };
 
-// eslint-disable-next-line react-refresh/only-export-components
-export { getSpO2StatusInfo };
 export default SpO2Gauge;


### PR DESCRIPTION
## Description

Fixes 2 only-export-components warnings from eslint. These were re-exports and not necessary. I also defined exemptions for /hooks and /context since the rule is not needed there. It's acceptable for the app to reload in development when changing a context.

## Related Issue

PR type [ ] Issue [x] New Feature [ ] Documentation
Linked Issue: #795

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

