### PR TITLE
feat: remember last selected camera for barcode scanning

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/BarcodeScanner.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/BarcodeScanner.tsx
@@ -70,7 +70,14 @@ const BarcodeScanner: React.FC<BarcodeScannerProps> = ({
   }, [selectedEngine]);
   // Camera Selection
   const [cameras, setCameras] = useState<MediaDeviceInfo[]>([]);
-  const [selectedCameraId, setSelectedCameraId] = useState<string>('');
+  const [selectedCameraId, setSelectedCameraId] = useState<string>(() => {
+    try {
+      const stored = localStorage.getItem('barcodeCameraId');
+      return stored || '';
+    } catch {
+      return '';
+    }
+  });
 
   // Scanning State
   const [scanLine, setScanLine] = useState(false);
@@ -294,6 +301,15 @@ const BarcodeScanner: React.FC<BarcodeScannerProps> = ({
     []
   );
 
+  const handleCameraChange = (id: string) => {
+    setSelectedCameraId(id);
+    try {
+      localStorage.setItem('barcodeCameraId', id);
+    } catch (e) {
+      console.error('Failed to save camera selection to localStorage', e);
+    }
+  };
+
   const handleEngineChange = (newEngine: string) => {
     setSelectedEngine(newEngine);
     try {
@@ -323,10 +339,7 @@ const BarcodeScanner: React.FC<BarcodeScannerProps> = ({
           </Select>
 
           {cameras.length > 0 && (
-            <Select
-              value={selectedCameraId}
-              onValueChange={setSelectedCameraId}
-            >
+            <Select value={selectedCameraId} onValueChange={handleCameraChange}>
               <SelectTrigger className="w-full max-w-[150px] bg-black/60 text-white border-gray-600 h-8 text-xs">
                 <Camera className="w-3 h-3 mr-2" />
                 <SelectValue placeholder="Camera" />


### PR DESCRIPTION
## Description

Saves the selected camera in localstorage just like the scanner engine. This improves usage on smartphones with multiple cameras.

## Related Issue

PR type [ ] Issue [ ] New Feature [x] Documentation
Linked Issue: #786

## Checklist

Please check all that apply:

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [x] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).
