### PR TITLE
fix(lint): remove first batch of explicit anys

### DIFF
--- a/SparkyFitnessFrontend/src/api/Chatbot/Chatbot_ExerciseHandler.ts
+++ b/SparkyFitnessFrontend/src/api/Chatbot/Chatbot_ExerciseHandler.ts
@@ -47,8 +47,7 @@ export const processExerciseInput = async (
           method: 'GET',
         }
       );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
       searchError = err; // Assign error to searchError
       error(
         userLoggingLevel,
@@ -96,8 +95,7 @@ export const processExerciseInput = async (
           body: formData,
           isFormData: true,
         });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (err: any) {
+      } catch (err: unknown) {
         error(
           userLoggingLevel,
           '❌ [Nutrition Coach] Error creating exercise:',
@@ -131,8 +129,7 @@ export const processExerciseInput = async (
             : undefined,
         },
       });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
       error(
         userLoggingLevel,
         '❌ [Nutrition Coach] Error adding exercise entry:',

--- a/SparkyFitnessFrontend/src/api/Chatbot/Chatbot_FoodHandler.ts
+++ b/SparkyFitnessFrontend/src/api/Chatbot/Chatbot_FoodHandler.ts
@@ -107,8 +107,7 @@ export const processFoodInput = async (
           method: 'GET',
         }
       );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
       error(
         userLoggingLevel,
         '❌ [Nutrition Coach] Error searching for exact food match:',
@@ -136,8 +135,7 @@ export const processFoodInput = async (
             method: 'GET',
           }
         );
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (err: any) {
+      } catch (err: unknown) {
         error(
           userLoggingLevel,
           '❌ [Nutrition Coach] Error searching for broad food match:',
@@ -197,8 +195,7 @@ export const processFoodInput = async (
             variant_id: food.default_variant.id, // Populate variant_id
           },
         });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (err: any) {
+      } catch (err: unknown) {
         error(
           userLoggingLevel,
           '❌ [Nutrition Coach] Error adding food entry:',
@@ -301,8 +298,7 @@ export const addFoodOption = async (
           method: 'GET',
         }
       );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
       error(
         userLoggingLevel,
         `[${transactionId}] Error fetching existing food:`,
@@ -340,8 +336,7 @@ export const addFoodOption = async (
               method: 'GET',
             }
           );
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (err: any) {
+        } catch (err: unknown) {
           error(
             userLoggingLevel,
             `[${transactionId}] Error fetching existing variant:`,
@@ -396,8 +391,7 @@ export const addFoodOption = async (
                 iron: selectedOption.iron,
               },
             });
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } catch (err: any) {
+          } catch (err: unknown) {
             error(
               userLoggingLevel,
               `[${transactionId}] Error creating food variant:`,
@@ -447,8 +441,7 @@ export const addFoodOption = async (
             is_custom: true,
           },
         });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (err: any) {
+      } catch (err: unknown) {
         error(userLoggingLevel, `[${transactionId}] Error creating food:`, err);
         return {
           action: 'none',
@@ -485,8 +478,7 @@ export const addFoodOption = async (
           variant_id: variantId,
         },
       });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
       error(
         userLoggingLevel,
         `[${transactionId}] Error creating food entry:`,

--- a/SparkyFitnessFrontend/src/api/Chatbot/Chatbot_MeasurementHandler.ts
+++ b/SparkyFitnessFrontend/src/api/Chatbot/Chatbot_MeasurementHandler.ts
@@ -7,6 +7,7 @@ import {
   type UserLoggingLevel,
 } from '@/utils/logging';
 import { apiCall } from '@/api/api';
+import { getErrorMessage } from '@/utils/api';
 
 // Function to upsert check-in measurements
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -34,11 +35,11 @@ const searchCustomCategory = async (name: string) => {
       }
     );
     return data;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
+  } catch (err: unknown) {
+    const message = getErrorMessage(err);
     // If it's a 404, it means no category is found, which is a valid scenario.
     // We return null in this case, and the calling function will handle it.
-    if (err.message && err.message.includes('404')) {
+    if (message && message.includes('404')) {
       return null;
     }
     console.error('Error searching custom category:', err);
@@ -131,8 +132,7 @@ export const processMeasurementInput = async (
         let upsertError = null;
         try {
           await upsertCheckInMeasurement(updateData);
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (err: any) {
+        } catch (err: unknown) {
           upsertError = err;
         }
 
@@ -160,8 +160,7 @@ export const processMeasurementInput = async (
         let categorySearchError: any = null;
         try {
           existingCategory = await searchCustomCategory(customMeasurementName);
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (err: any) {
+        } catch (err: unknown) {
           categorySearchError = err;
         }
 
@@ -198,8 +197,7 @@ export const processMeasurementInput = async (
               frequency: 'Daily',
               measurement_type: 'numeric',
             });
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } catch (err: any) {
+          } catch (err: unknown) {
             categoryCreateError = err;
           }
 
@@ -236,8 +234,7 @@ export const processMeasurementInput = async (
             value: valueToLog,
             entry_timestamp: new Date().toISOString(),
           });
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (err: any) {
+        } catch (err: unknown) {
           customEntryError = err;
         }
 

--- a/SparkyFitnessFrontend/src/api/Chatbot/sparkyChatService.ts
+++ b/SparkyFitnessFrontend/src/api/Chatbot/sparkyChatService.ts
@@ -17,6 +17,7 @@ import { processWaterInput } from '@/api/Chatbot/Chatbot_WaterHandler';
 import { CoachResponse, FoodOption, Message } from '@/types/Chatbot_types';
 import { processChatInput } from '@/utils/Chatbot_utils';
 import { AIService } from '@/types/settings';
+import { getErrorMessage } from '@/utils/api';
 
 export interface UserPreferences {
   auto_clear_history: 'never' | '7days' | 'all';
@@ -408,10 +409,10 @@ const getAIResponse = async (
       action: 'advice',
       response: response.content,
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
+  } catch (err: unknown) {
+    const message = getErrorMessage(err);
     error(userLoggingLevel, `[${transactionId}] Error in getAIResponse:`, err);
-    if (err.message && err.message.includes('503')) {
+    if (message && message.includes('503')) {
       return {
         action: 'none',
         response:
@@ -421,7 +422,7 @@ const getAIResponse = async (
     return {
       action: 'none',
       response:
-        err.message ||
+        message ||
         'An unexpected error occurred while trying to get an AI response.',
     };
   }
@@ -520,8 +521,7 @@ const callAIForFoodOptions = async (
       );
       return [];
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
+  } catch (err: unknown) {
     error(userLoggingLevel, 'Error in callAIForFoodOptions:', err);
     return [];
   }

--- a/SparkyFitnessFrontend/src/api/CheckIn/moodService.ts
+++ b/SparkyFitnessFrontend/src/api/CheckIn/moodService.ts
@@ -1,5 +1,6 @@
 import { api } from '@/api/api';
 import type { MoodEntry } from '@/types/mood';
+import { getErrorMessage } from '@/utils/api';
 import { debug, info, error } from '@/utils/logging';
 import { getUserLoggingLevel } from '@/utils/userPreferences';
 
@@ -71,9 +72,9 @@ export const getMoodEntryByDate = async (
     });
     debug(userLoggingLevel, 'Response from getMoodEntryByDate API:', response);
     return response;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
-    if (err.message && err.message.includes('404')) {
+  } catch (err: unknown) {
+    const message = getErrorMessage(err);
+    if (message && message.includes('404')) {
       info(getUserLoggingLevel(), `No mood entry found for date ${entryDate}.`);
       return null;
     }

--- a/SparkyFitnessFrontend/src/api/Diary/dailyProgressService.ts
+++ b/SparkyFitnessFrontend/src/api/Diary/dailyProgressService.ts
@@ -5,6 +5,7 @@ import type { GroupedExerciseEntry } from '@/types/exercises';
 import { loadGoals } from '@/api/Goals/goals';
 import { loadFoodEntries } from '@/api/Diary/foodEntryService';
 import { loadExistingCheckInMeasurements } from '@/api/CheckIn/checkInService';
+import { getErrorMessage } from '@/utils/api';
 
 export { getExerciseEntriesForDate } from '../Exercises/exerciseEntryService';
 
@@ -25,9 +26,9 @@ export const getCheckInMeasurementsForDate = async (
   try {
     const measurement = await loadExistingCheckInMeasurements(date);
     return measurement || null;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    if (error.message.includes('404')) {
+  } catch (error: unknown) {
+    const message = getErrorMessage(error);
+    if (message.includes('404')) {
       return null;
     }
     throw error;

--- a/SparkyFitnessFrontend/src/api/Settings/aiServiceSettingsService.ts
+++ b/SparkyFitnessFrontend/src/api/Settings/aiServiceSettingsService.ts
@@ -1,5 +1,6 @@
 import { apiCall } from '@/api/api';
 import { AIService, UserPreferencesChat } from '@/types/settings';
+import { getErrorMessage } from '@/utils/api';
 
 export const getAIServices = async (): Promise<AIService[]> => {
   try {
@@ -8,11 +9,11 @@ export const getAIServices = async (): Promise<AIService[]> => {
       suppress404Toast: true, // Suppress toast for 404
     });
     return services || []; // Return empty array if 404 (no services found)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
+  } catch (err: unknown) {
+    const message = getErrorMessage(err);
     // If it's a 404, it means no services are found, which is a valid scenario.
     // We return an empty array in this case, and the calling function will handle it.
-    if (err.message && err.message.includes('404')) {
+    if (message && message.includes('404')) {
       return [];
     }
     throw err;
@@ -26,11 +27,11 @@ export const getPreferences = async (): Promise<UserPreferencesChat> => {
       suppress404Toast: true, // Suppress toast for 404
     });
     return preferences;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
+  } catch (err: unknown) {
+    const message = getErrorMessage(err);
     // If it's a 404, it means no preferences are found, which is a valid scenario.
     // We return null in this case, and the calling function will handle it.
-    if (err.message && err.message.includes('404')) {
+    if (message && message.includes('404')) {
       return null;
     }
     throw err;
@@ -45,9 +46,9 @@ export const getActiveAiServiceSetting =
         suppress404Toast: true, // Suppress toast for 404
       });
       return setting;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
-      if (err.message && err.message.includes('404')) {
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
+      if (message && message.includes('404')) {
         return null;
       }
       throw err;
@@ -112,9 +113,9 @@ export const getGlobalAIServices = async (): Promise<AIService[]> => {
       suppress404Toast: true,
     });
     return services || [];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
-    if (err.message && err.message.includes('404')) {
+  } catch (err: unknown) {
+    const message = getErrorMessage(err);
+    if (message && message.includes('404')) {
       return [];
     }
     throw err;

--- a/SparkyFitnessFrontend/src/api/api.ts
+++ b/SparkyFitnessFrontend/src/api/api.ts
@@ -175,8 +175,7 @@ export async function apiCall(
     );
     //console.log(`API Call: Returning JSON response for ${url}:`, jsonResponse); // Added console.log
     return jsonResponse;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (err: any) {
+  } catch (err: unknown) {
     const errorMessage = err instanceof Error ? err.message : String(err);
     logging.error(userLoggingLevel, 'API call network error:', err); // Log the raw error object for better debugging
     toast({

--- a/SparkyFitnessFrontend/src/components/OidcCallback.tsx
+++ b/SparkyFitnessFrontend/src/components/OidcCallback.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { authClient } from '../lib/auth-client';
 import { useAuth } from '../hooks/useAuth';
+import { getErrorMessage } from '@/utils/api';
 
 const OidcCallback: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
@@ -45,11 +46,10 @@ const OidcCallback: React.FC = () => {
         } else {
           setError('No active session found after OIDC redirect.');
         }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (err: any) {
+      } catch (err: unknown) {
+        const message = getErrorMessage(err);
         setError(
-          err.message ||
-            'An unexpected error occurred during OIDC verification.'
+          message || 'An unexpected error occurred during OIDC verification.'
         );
       }
     };

--- a/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
@@ -27,6 +27,7 @@ import {
   useCreateWaterContainerMutation,
   useSetPrimaryWaterContainerMutation,
 } from '@/hooks/Settings/useWaterContainers';
+import { getErrorMessage } from '@/utils/api';
 
 // Function to fetch user preferences from the backend
 
@@ -229,9 +230,9 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
     try {
       const data = await queryClient.fetchQuery(preferencesOptions.user());
       return data;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
-      if (err.message && err.message.includes('404')) {
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
+      if (message && message.includes('404')) {
         return null;
       }
       console.error('Error fetching user preferences:', err);
@@ -500,8 +501,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
     try {
       const data = await queryClient.fetchQuery(preferencesOptions.nutrients());
       setNutrientDisplayPreferences(data);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Error fetching nutrient display preferences:', err);
     }
   }, [user, queryClient]);

--- a/SparkyFitnessFrontend/src/pages/Admin/OidcSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Admin/OidcSettings.tsx
@@ -90,8 +90,7 @@ const OidcSettings: React.FC = () => {
           'OIDC provider deleted successfully.'
         ),
       });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch {
       toast({
         title: t('admin.oidcSettings.error', 'Error'),
         description: t(
@@ -173,8 +172,7 @@ const OidcSettings: React.FC = () => {
       }
 
       setIsDialogOpen(false);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch {
       toast({
         title: t('admin.oidcSettings.error', 'Error'),
         description: t(

--- a/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
@@ -33,6 +33,7 @@ import {
 import { MagicLinkRequestDialog } from './MagicLinkRequestDialog';
 import { useQueryClient } from '@tanstack/react-query';
 import { AuthResponse } from '@/types/auth';
+import { getErrorMessage } from '@/utils/api';
 
 const Auth = () => {
   const navigate = useNavigate();
@@ -166,10 +167,8 @@ const Auth = () => {
                 },
               },
             });
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          } catch (err: any) {
-            // Silently fail for autofill, especially for AbortError
-            if (err.name === 'AbortError') {
+          } catch (err: unknown) {
+            if (err instanceof Error && err.name === 'AbortError') {
               debug(loggingLevel, 'Auth: Passkey autofill aborted.');
             } else {
               debug(
@@ -318,12 +317,12 @@ const Auth = () => {
               data.fullName
             );
           }
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (err: any) {
+        } catch (err: unknown) {
+          const message = getErrorMessage(err);
           error(loggingLevel, 'Auth: Magic link login failed:', err);
           toast({
             title: 'Error',
-            description: err.message || 'Magic link is invalid or has expired.',
+            description: message || 'Magic link is invalid or has expired.',
             variant: 'destructive',
           });
           window.location.replace('/'); // Force a full page reload to clear state
@@ -437,8 +436,7 @@ const Auth = () => {
         true,
         data.fullName
       );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
       error(loggingLevel, 'Auth: Sign in failed:', err);
     }
 
@@ -456,13 +454,13 @@ const Auth = () => {
       info(loggingLevel, 'Auth: Passkey sign-in successful.');
       toast({ title: 'Success', description: 'Logged in with Passkey!' });
       navigate('/');
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
       error(loggingLevel, 'Auth: Passkey sign-in failed:', err);
       toast({
         title: 'Passkey Error',
         description:
-          err.message ||
+          message ||
           'Failed to sign in with Passkey. Ensure your device supports it.',
         variant: 'destructive',
       });

--- a/SparkyFitnessFrontend/src/pages/Auth/ForgotPassword.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/ForgotPassword.tsx
@@ -12,6 +12,7 @@ import { Label } from '@/components/ui/label';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { debug, info } from '@/utils/logging';
 import { useRequestPasswordResetMutation } from '@/hooks/Auth/useAuth';
+import { getErrorMessage } from '@/utils/api';
 
 const ForgotPassword = () => {
   const { loggingLevel } = usePreferences();
@@ -34,9 +35,9 @@ const ForgotPassword = () => {
       setMessage(
         'If an account with that email exists, a password reset link has been sent.'
       );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
-      setMessage(err.message || 'An unexpected error occurred.');
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
+      setMessage(message || 'An unexpected error occurred.');
     } finally {
       setLoading(false);
     }

--- a/SparkyFitnessFrontend/src/pages/Auth/MfaChallenge.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/MfaChallenge.tsx
@@ -16,6 +16,7 @@ import { Mail, QrCode, KeyRound, Loader2 } from 'lucide-react';
 import { authClient } from '@/lib/auth-client';
 import { toast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
+import { getErrorMessage } from '@/utils/api';
 
 interface MfaChallengeProps {
   userId: string;
@@ -85,16 +86,15 @@ const MfaChallenge: React.FC<MfaChallengeProps> = ({
       } else if (error) {
         throw error;
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
       toast({
         title: t(
           'mfaChallenge.error.verificationFailed',
           'Verification Failed'
         ),
         description:
-          err.message ||
-          t('mfaChallenge.error.totpInvalid', 'Invalid TOTP code.'),
+          message || t('mfaChallenge.error.totpInvalid', 'Invalid TOTP code.'),
         variant: 'destructive',
       });
     } finally {
@@ -113,11 +113,11 @@ const MfaChallenge: React.FC<MfaChallengeProps> = ({
         title: 'Code Sent',
         description: 'A verification code has been sent to your email.',
       });
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
       toast({
         title: 'Error',
-        description: err.message || 'Failed to send code.',
+        description: message || 'Failed to send code.',
         variant: 'destructive',
       });
     } finally {
@@ -147,11 +147,11 @@ const MfaChallenge: React.FC<MfaChallengeProps> = ({
       } else if (error) {
         throw error;
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
       toast({
         title: 'Error',
-        description: err.message || 'Invalid email code.',
+        description: message || 'Invalid email code.',
         variant: 'destructive',
       });
     } finally {
@@ -181,15 +181,15 @@ const MfaChallenge: React.FC<MfaChallengeProps> = ({
       } else if (error) {
         throw error;
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
       toast({
         title: t(
           'mfaChallenge.error.verificationFailed',
           'Verification Failed'
         ),
         description:
-          err.message ||
+          message ||
           t('mfaChallenge.error.recoveryCodeInvalid', 'Invalid recovery code.'),
         variant: 'destructive',
       });

--- a/SparkyFitnessFrontend/src/pages/Auth/ResetPassword.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/ResetPassword.tsx
@@ -16,6 +16,7 @@ import { debug, info } from '@/utils/logging';
 import useToggle from '@/hooks/use-toggle';
 import PasswordToggle from '@/components/PasswordToggle';
 import { useResetPasswordMutation } from '@/hooks/Auth/useAuth';
+import { getErrorMessage } from '@/utils/api';
 
 const ResetPassword = () => {
   const navigate = useNavigate();
@@ -96,9 +97,9 @@ const ResetPassword = () => {
         'Your password has been reset successfully. You can now sign in with your new password.'
       );
       navigate('/'); // Redirect to root
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (err: any) {
-      setMessage(err.message || 'An unexpected error occurred.');
+    } catch (err: unknown) {
+      const message = getErrorMessage(err);
+      setMessage(message || 'An unexpected error occurred.');
     } finally {
       setLoading(false);
     }

--- a/SparkyFitnessFrontend/src/pages/Exercises/ExerciseEntryHistoryImportCSV.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/ExerciseEntryHistoryImportCSV.tsx
@@ -32,6 +32,7 @@ import {
 import { useImportExerciseHistoryMutation } from '@/hooks/Exercises/useExercises';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { HistoryImportEntry } from '@/types/exercises';
+import { isObject } from '@/utils/api';
 
 // Define the shape of a single row from the CSV
 interface CsvRow {
@@ -424,24 +425,28 @@ const ExerciseEntryHistoryImportCSV = ({
 
       await importAsCsv(entries);
       onImportComplete();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      const errorMessage = error.details?.failedEntries
-        ? t(
-            'exercise.importHistoryCSV.partialImportError',
-            'Some entries failed to import: {{details}}',
-            {
-              details: error.details.failedEntries
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .map((e: any) => e.entry.exercise_name + ' - ' + e.reason)
-                .join(', '),
-            }
+    } catch (error: unknown) {
+      let errorMessage = t('exercise.importHistoryCSV.importError');
+
+      if (
+        isObject(error) &&
+        isObject(error.details) &&
+        Array.isArray(error.details.failedEntries)
+      ) {
+        const details = error.details.failedEntries
+          .map(
+            (e: { entry: { exercise_name: string }; reason: string }) =>
+              `${e.entry.exercise_name} - ${e.reason}`
           )
-        : error.message ||
-          t(
-            'exercise.importHistoryCSV.importError',
-            'Failed to import historical exercise entries. Please try again.'
-          );
+          .join(', ');
+
+        errorMessage = t('exercise.importHistoryCSV.partialImportError', {
+          details,
+        });
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
+      }
+
       toast({
         title: t('common.error', 'Error'),
         description: errorMessage,

--- a/SparkyFitnessFrontend/src/pages/Integrations/FitbitCallback.tsx
+++ b/SparkyFitnessFrontend/src/pages/Integrations/FitbitCallback.tsx
@@ -36,8 +36,7 @@ const FitbitCallback = () => {
       try {
         await linkFitbitAccount({ code, state });
         setMessage('Fitbit account successfully linked!');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
+      } catch (error: unknown) {
         console.error('Error processing Fitbit callback:', error);
         setMessage('Error linking Fitbit account.');
       } finally {

--- a/SparkyFitnessFrontend/src/pages/Integrations/PolarCallback.tsx
+++ b/SparkyFitnessFrontend/src/pages/Integrations/PolarCallback.tsx
@@ -32,8 +32,7 @@ const PolarCallback = () => {
       try {
         await linkPolarAccount({ code, state });
         setMessage('Polar account successfully linked!');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
+      } catch (error: unknown) {
         console.error('Error processing Polar callback:', error);
         setMessage('Error linking Polar account.');
       } finally {

--- a/SparkyFitnessFrontend/src/pages/Integrations/StravaCallback.tsx
+++ b/SparkyFitnessFrontend/src/pages/Integrations/StravaCallback.tsx
@@ -32,8 +32,7 @@ const StravaCallback = () => {
       try {
         await linkStravaAccount({ code, state });
         setMessage('Strava account successfully linked!');
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
+      } catch (error: unknown) {
         console.error('Error processing Strava callback:', error);
         setMessage('Error linking Strava account.');
       } finally {

--- a/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
@@ -107,8 +107,7 @@ const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
       } else if (data && defaultFoodDataProviderId === data.id) {
         setDefaultFoodDataProviderId(null);
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error updating external data provider:', error);
     }
   };

--- a/SparkyFitnessFrontend/src/pages/Settings/MFASettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/MFASettings.tsx
@@ -15,6 +15,7 @@ import {
   useSyncTotpMutation,
   useToggleEmailMfaMutation,
 } from '@/hooks/Settings/useProfile';
+import { getErrorMessage } from '@/utils/api';
 
 const MFASettings = () => {
   const { t } = useTranslation();
@@ -102,12 +103,12 @@ const MFASettings = () => {
       setShowPasswordPrompt(false);
       setConfirmPassword(''); // Clear password after use
       setPendingAction(null);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = getErrorMessage(error);
       log(loggingLevel, 'ERROR', 'MFA Action Error:', error);
       toast({
         title: 'Error',
-        description: error.message || 'Failed to perform action',
+        description: message || 'Failed to perform action',
         variant: 'destructive',
       });
     } finally {
@@ -127,12 +128,12 @@ const MFASettings = () => {
       await refetch();
       setOtpAuthUrl(null); // Clear OTP URL after successful verification
       setTotpCode(''); // Clear TOTP code after successful verification
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = getErrorMessage(error);
       log(loggingLevel, 'ERROR', 'Error verifying TOTP:', error);
       toast({
         title: 'Error',
-        description: `Failed to verify TOTP: ${error.message}`,
+        description: `Failed to verify TOTP: ${message}`,
         variant: 'destructive',
       });
     } finally {
@@ -146,11 +147,11 @@ const MFASettings = () => {
       await toggleEmailMfa(true);
       toast({ title: 'Success', description: 'Email MFA enabled!' });
       await refetch();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = getErrorMessage(error);
       toast({
         title: 'Error',
-        description: error.message || 'Failed to enable Email MFA',
+        description: message || 'Failed to enable Email MFA',
         variant: 'destructive',
       });
     } finally {
@@ -164,11 +165,11 @@ const MFASettings = () => {
       await toggleEmailMfa(false);
       toast({ title: 'Success', description: 'Email MFA disabled.' });
       await refetch();
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const message = getErrorMessage(error);
       toast({
         title: 'Error',
-        description: error.message || 'Failed to disable Email MFA',
+        description: message || 'Failed to disable Email MFA',
         variant: 'destructive',
       });
     } finally {

--- a/SparkyFitnessFrontend/src/pages/Settings/NutrientDisplaySettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/NutrientDisplaySettings.tsx
@@ -11,6 +11,7 @@ import {
   useResetNutrientPreferenceMutation,
   useUpdateNutrientPreferenceMutation,
 } from '@/hooks/Settings/useNutrientPreferences';
+import { getErrorMessage } from '@/utils/api';
 
 const baseNutrients = [
   'calories',
@@ -90,11 +91,11 @@ const NutrientDisplaySettings: React.FC = () => {
           platform: pref.platform,
           visibleNutrients: pref.visible_nutrients,
         });
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
+      } catch (error: unknown) {
+        const message = getErrorMessage(error);
         toast({
           title: 'Error',
-          description: `Failed to save ${pref.view_group} (${pref.platform}) preferences: ${error.message}`,
+          description: `Failed to save ${pref.view_group} (${pref.platform}) preferences: ${message}`,
           variant: 'destructive',
         });
       }
@@ -222,11 +223,11 @@ const NutrientDisplaySettings: React.FC = () => {
             defaultPreference.visible_nutrients
           );
         }
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } catch (error: any) {
+      } catch (error: unknown) {
+        const message = getErrorMessage(error);
         toast({
           title: 'Error',
-          description: `Failed to reset ${viewGroup} (${pform}) preferences: ${error.message}`,
+          description: `Failed to reset ${viewGroup} (${pform}) preferences: ${message}`,
           variant: 'destructive',
         });
       }

--- a/SparkyFitnessFrontend/src/utils/api.ts
+++ b/SparkyFitnessFrontend/src/utils/api.ts
@@ -67,3 +67,21 @@ export const del = async <T>(url: string): Promise<T> => {
   }
   return response.json() as Promise<T>;
 };
+
+export const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'message' in error &&
+    typeof (error as Record<string, unknown>).message === 'string'
+  ) {
+    return (error as { message: string }).message;
+  }
+
+  return String(error);
+};
+
+export const isObject = (val: unknown): val is Record<string, unknown> =>
+  typeof val === 'object' && val !== null;


### PR DESCRIPTION
## Description

Removes 52 explicit anys from the code. I focused on the error types only. If the types don't match they could lead to crashes of the app when an error is thrown. I added a helper function to extract the messages.

## Related Issue

PR type [ ] Issue [x] New Feature [ ] Documentation
Linked Issue: #795 

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).
