### PR TITLE
feat: implement localized food search and barcode lookup for OpenFoodFacts

### DIFF
--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.js
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.js
@@ -17,9 +17,9 @@ const OFF_FIELDS = [
   "nutriments",
 ];
 
-async function searchOpenFoodFacts(query, page = 1) {
+async function searchOpenFoodFacts(query, page = 1, language = "en") {
   try {
-    const searchUrl = `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=20&page=${page}&fields=${OFF_FIELDS.join(",")}`;
+    const searchUrl = `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=20&page=${page}&fields=${OFF_FIELDS.join(",")}&lc=${language}`;
     const response = await fetch(searchUrl, {
       method: "GET",
       headers: OFF_HEADERS,
@@ -53,10 +53,11 @@ async function searchOpenFoodFacts(query, page = 1) {
 async function searchOpenFoodFactsByBarcodeFields(
   barcode,
   fields = OFF_FIELDS,
+  language = "en",
 ) {
   try {
     const fieldsParam = fields.join(",");
-    const searchUrl = `https://world.openfoodfacts.org/api/v2/product/${barcode}.json?fields=${fieldsParam}`;
+    const searchUrl = `https://world.openfoodfacts.org/api/v2/product/${barcode}.json?fields=${fieldsParam}&lc=${language}`;
     const response = await fetch(searchUrl, {
       method: "GET",
       headers: OFF_HEADERS,

--- a/SparkyFitnessServer/routes/foodIntegrationRoutes.js
+++ b/SparkyFitnessServer/routes/foodIntegrationRoutes.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const { authenticate } = require("../middleware/authMiddleware");
+const preferenceService = require("../services/preferenceService");
 const checkPermissionMiddleware = require('../middleware/checkPermissionMiddleware');
 const foodService = require("../services/foodService");
 const { log } = require("../config/logging");
@@ -371,7 +372,9 @@ router.get(
     }
     const page = Math.max(1, parseInt(req.query.page, 10) || 1);
     try {
-      const data = await searchOpenFoodFacts(query, page);
+      const userPrefs = await preferenceService.getUserPreferences(req.userId, req.userId);
+      const language = userPrefs?.language || "en";
+      const data = await searchOpenFoodFacts(query, page, language);
       res.json(data);
     } catch (error) {
       next(error);
@@ -408,7 +411,9 @@ router.get(
       return res.status(400).json({ error: "Missing barcode" });
     }
     try {
-      const data = await searchOpenFoodFactsByBarcodeFields(barcode);
+      const userPrefs = await preferenceService.getUserPreferences(req.userId, req.userId);
+      const language = userPrefs?.language || "en";
+      const data = await searchOpenFoodFactsByBarcodeFields(barcode, undefined, language);
       res.json(data);
     } catch (error) {
       next(error);

--- a/SparkyFitnessServer/routes/v2/foodRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/foodRoutes.ts
@@ -9,6 +9,7 @@ const { log } = require("../../config/logging");
 const checkPermissionMiddleware = require("../../middleware/checkPermissionMiddleware");
 const foodCoreService = require("../../services/foodCoreService");
 const externalProviderService = require("../../services/externalProviderService");
+const preferenceService = require("../../services/preferenceService");
 const {
   searchOpenFoodFacts,
   searchOpenFoodFactsByBarcodeFields,
@@ -176,6 +177,8 @@ const searchHandler: RequestHandler<{ providerType: string }> = async (req, res,
 
   try {
     const credentials = await resolveProviderCredentials(req.userId, providerId, providerType);
+    const userPrefs = await preferenceService.getUserPreferences(req.userId, req.userId);
+    const language = userPrefs?.language || "en";
 
     let foods: unknown[] = [];
     let pagination = EMPTY_PAGINATION(page, pageSize);
@@ -183,7 +186,7 @@ const searchHandler: RequestHandler<{ providerType: string }> = async (req, res,
     switch (providerType) {
       case "openfoodfacts": {
         const autoScale = (req.query.autoScale as string ?? 'true') !== 'false';
-        const result = await searchOpenFoodFacts(query, page);
+        const result = await searchOpenFoodFacts(query, page, language);
         const products = (result.products || []).filter(
           (p: Record<string, unknown>) => p.product_name,
         );
@@ -284,12 +287,14 @@ const detailHandler: RequestHandler<{
 
   try {
     const credentials = await resolveProviderCredentials(req.userId, providerId, providerType);
+    const userPrefs = await preferenceService.getUserPreferences(req.userId, req.userId);
+    const language = userPrefs?.language || "en";
 
     let food: unknown = null;
 
     switch (providerType) {
       case "openfoodfacts": {
-        const data = await searchOpenFoodFactsByBarcodeFields(externalId);
+        const data = await searchOpenFoodFactsByBarcodeFields(externalId, undefined, language);
         if (data.status === 1 && data.product) {
           food = mapOpenFoodFactsProduct(data.product);
         }

--- a/SparkyFitnessServer/services/foodCoreService.js
+++ b/SparkyFitnessServer/services/foodCoreService.js
@@ -831,7 +831,16 @@ async function lookupBarcode(barcode, userId, providerId) {
     // Fall back to OpenFoodFacts
     let offData;
     try {
-      offData = await searchOpenFoodFactsByBarcodeFields(barcode);
+      const userPreferences = await preferenceService.getUserPreferences(
+        userId,
+        userId,
+      );
+      const language = userPreferences?.language || "en";
+      offData = await searchOpenFoodFactsByBarcodeFields(
+        barcode,
+        undefined,
+        language,
+      );
     } catch (error) {
       log("warn", `OpenFoodFacts lookup failed for barcode ${barcode}:`, error);
       return { source: "not_found", food: null };

--- a/SparkyFitnessServer/tests/barcodeLookup.test.js
+++ b/SparkyFitnessServer/tests/barcodeLookup.test.js
@@ -605,8 +605,36 @@ describe("lookupBarcode", () => {
 
   // --- USDA provider path tests ---
 
-  it("should return USDA result when providerId is given and USDA matches", async () => {
+  it("should pass the user's language preference to OpenFoodFacts", async () => {
+    const barcode = "9876543210123";
     foodRepository.findFoodByBarcode.mockResolvedValue(null);
+    preferenceService.getUserPreferences.mockResolvedValue({
+      language: "fr",
+    });
+    searchOpenFoodFactsByBarcodeFields.mockResolvedValue({
+      status: 1,
+      product: {
+        product_name: "Produit Français",
+        code: barcode,
+      },
+    });
+
+    const result = await lookupBarcode(barcode, TEST_USER_ID);
+
+    expect(preferenceService.getUserPreferences).toHaveBeenCalledWith(
+      TEST_USER_ID,
+      TEST_USER_ID,
+    );
+    expect(searchOpenFoodFactsByBarcodeFields).toHaveBeenCalledWith(
+      barcode,
+      undefined,
+      "fr",
+    );
+    expect(result.source).toBe("openfoodfacts");
+    expect(result.food.name).toBe("Produit Français");
+  });
+
+  it("should return USDA result when providerId is given and USDA matches", async () => {    foodRepository.findFoodByBarcode.mockResolvedValue(null);
     externalProviderService.getExternalDataProviderDetails.mockResolvedValue(
       makeUsdaProvider(),
     );

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.js
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.js
@@ -1,0 +1,72 @@
+const {
+  searchOpenFoodFacts,
+  searchOpenFoodFactsByBarcodeFields,
+} = require("../integrations/openfoodfacts/openFoodFactsService");
+
+global.fetch = jest.fn();
+
+describe("openFoodFactsService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("searchOpenFoodFacts", () => {
+    it("should append the lc parameter with the specified language to the search URL", async () => {
+      fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ products: [], count: 0 }),
+      });
+
+      await searchOpenFoodFacts("pizza", 1, "fr");
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("&lc=fr"),
+        expect.any(Object),
+      );
+    });
+
+    it("should default to language 'en' when not specified", async () => {
+      fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ products: [], count: 0 }),
+      });
+
+      await searchOpenFoodFacts("pizza", 1);
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("&lc=en"),
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("searchOpenFoodFactsByBarcodeFields", () => {
+    it("should append the lc parameter with the specified language to the product URL", async () => {
+      fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 1, product: {} }),
+      });
+
+      await searchOpenFoodFactsByBarcodeFields("12345678", undefined, "it");
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("&lc=it"),
+        expect.any(Object),
+      );
+    });
+
+    it("should default to language 'en' when not specified", async () => {
+      fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 1, product: {} }),
+      });
+
+      await searchOpenFoodFactsByBarcodeFields("12345678");
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining("&lc=en"),
+        expect.any(Object),
+      );
+    });
+  });
+});

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict XMPoZfhXx6XolCQ8XUXABdlRy833TlKTMbiOHW15an1W9JHKJsCk1zPAT9ZyU3V
+\restrict hmnn8vTKiwqbmCWCTgcN8xKnPFVCnYvDAyIZZpP9YBoOEbxYqNaVfbMLbgrqgcG
 
 -- Dumped from database version 15.15
 -- Dumped by pg_dump version 18.0
@@ -2447,7 +2447,8 @@ CREATE TABLE public.water_intake (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     water_ml numeric(10,3),
     created_by_user_id uuid,
-    updated_by_user_id uuid
+    updated_by_user_id uuid,
+    source character varying(50) DEFAULT 'manual'::character varying NOT NULL
 );
 
 
@@ -3312,6 +3313,14 @@ ALTER TABLE ONLY public.user_water_containers
 
 ALTER TABLE ONLY public.verification
     ADD CONSTRAINT verification_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: water_intake water_intake_user_date_source_unique; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.water_intake
+    ADD CONSTRAINT water_intake_user_date_source_unique UNIQUE (user_id, entry_date, source);
 
 
 --
@@ -4584,7 +4593,7 @@ ALTER TABLE ONLY public.water_intake
 --
 
 ALTER TABLE ONLY public.water_intake
-    ADD CONSTRAINT water_intake_updated_by_user_id_fkey FOREIGN KEY (updated_by_user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+    ADD CONSTRAINT water_intake_updated_by_user_id_fkey FOREIGN KEY (updated_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
 
 
 --
@@ -7207,5 +7216,5 @@ ALTER DEFAULT PRIVILEGES FOR ROLE sparky IN SCHEMA public GRANT SELECT,INSERT,DE
 -- PostgreSQL database dump complete
 --
 
-\unrestrict XMPoZfhXx6XolCQ8XUXABdlRy833TlKTMbiOHW15an1W9JHKJsCk1zPAT9ZyU3V
+\unrestrict hmnn8vTKiwqbmCWCTgcN8xKnPFVCnYvDAyIZZpP9YBoOEbxYqNaVfbMLbgrqgcG
 


### PR DESCRIPTION

This PR integrates user language preferences into the OpenFoodFacts (OFF) food search and barcode lookup workflows. Previously, the OFF integration was hardcoded to a global context, often returning results
  in English regardless of the user's settings.

  Key Changes
   * API Integration: Updated the openFoodFactsService to support the lc (language code) parameter in all outgoing API requests to world.openfoodfacts.org.
   * User Preference Integration: Modified the backend services and routes to retrieve the language field from user_preferences (stored in the database) and pass it through to the OFF integration.
   * Route Updates:
       * Updated v2/foodRoutes.ts (Search and Details) to provide localized results.
       * Updated foodIntegrationRoutes.js (v1) for backward compatibility.
   * Core Logic: Updated foodCoreService.js to ensure barcode scanning automatically uses the user's preferred language when falling back to OpenFoodFacts.

  Verification Results
   * Manual Testing: Verified via the UI that searching for "gelato" with an Italian profile correctly prioritizes Italian product names (e.g., "Triplo Cioccolato").
   * Automated Testing:
       * Updated barcodeLookup.test.js to verify language parameter propagation.
       * Created openFoodFactsService.test.js to ensure correct URL construction (appending &lc=...). * All 56 tests passed successfully.

## Description

Provide a brief summary of your changes.

## Related Issue

PR type [ ] Issue [x] New Feature [ ] Documentation
Linked Issue: #

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before

[Insert screenshot/GIF here]

### After

[Insert screenshot/GIF here]
