### PR TITLE
fix(auth): add missing image column to user table for OIDC profile sync

### DIFF
--- a/SparkyFitnessServer/auth.js
+++ b/SparkyFitnessServer/auth.js
@@ -372,6 +372,7 @@ const auth = betterAuth({
             await ensureUserInitialization(
               user.id,
               user.name || user.email.split("@")[0],
+              user.image,
             );
 
             // Also initialize default nutrient preferences

--- a/SparkyFitnessServer/db/migrations/20260314175000_add_image_to_user_table.sql
+++ b/SparkyFitnessServer/db/migrations/20260314175000_add_image_to_user_table.sql
@@ -1,0 +1,6 @@
+-- Add missing image column to user table for Better Auth OIDC integration
+-- This column is required for syncing profile pictures from SSO providers
+
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS "image" TEXT;
+
+COMMENT ON COLUMN "user"."image" IS 'Profile image URL synced from Better Auth / OIDC providers';

--- a/SparkyFitnessServer/models/userRepository.js
+++ b/SparkyFitnessServer/models/userRepository.js
@@ -8,8 +8,8 @@ async function createUser(userId, email, hashedPassword, full_name) {
 
     // Insert into "user"
     await client.query(
-      'INSERT INTO "user" (id, email, name, created_at, updated_at) VALUES ($1, $2, $3, now(), now())',
-      [userId, email, full_name]
+      'INSERT INTO "user" (id, email, name, image, created_at, updated_at) VALUES ($1, $2, $3, $4, now(), now())',
+      [userId, email, full_name, null]
     );
 
     // Insert into "account" for email/password
@@ -216,9 +216,9 @@ async function createOidcUser(userId, email, fullName, providerId, oidcSub) {
 
     // Insert into "user"
     const userResult = await client.query(
-      `INSERT INTO "user" (id, email, created_at, updated_at)
-             VALUES ($1, $2, now(), now()) RETURNING id`,
-      [userId, email]
+      `INSERT INTO "user" (id, email, image, created_at, updated_at)
+             VALUES ($1, $2, $3, now(), now()) RETURNING id`,
+      [userId, email, null]
     );
     const newUserId = userResult.rows[0].id;
 
@@ -480,16 +480,15 @@ async function isOidcUser(userId) {
   }
 }
 
-async function ensureUserInitialization(userId, fullName, existingClient = null) {
+async function ensureUserInitialization(userId, fullName, avatarUrl = null, existingClient = null) {
   const client = existingClient || await getSystemClient();
   try {
     if (!existingClient) await client.query('BEGIN');
 
-    // Ensure profile exists
     await client.query(
-      'INSERT INTO profiles (id, full_name, created_at, updated_at) ' +
-      'SELECT $1, $2, now(), now() WHERE NOT EXISTS (SELECT 1 FROM profiles WHERE id = $1)',
-      [userId, fullName]
+      'INSERT INTO profiles (id, full_name, avatar_url, created_at, updated_at) ' +
+      'SELECT $1, $2, $3, now(), now() WHERE NOT EXISTS (SELECT 1 FROM profiles WHERE id = $1)',
+      [userId, fullName, avatarUrl]
     );
 
     // Ensure user_goals exists (the base goal with NULL date)


### PR DESCRIPTION

## Description

Provide a brief summary of your changes.

Adds the missing `image` column to the `user` table required by `Better Auth` for OIDC/SSO registrations.

**Changes:**
- **Database**: New migration to add the `image` column to the `user` table.
- **Sync**: Updated [userRepository.js](cci:7://file:///c:/SparkyApps/SparkyFitness/SparkyFitnessServer/models/userRepository.js:0:0-0:0) and [auth.js](cci:7://file:///c:/SparkyApps/SparkyFitness/SparkyFitnessServer/auth.js:0:0-0:0) to pre-fill the SparkyFitness profile photo from the SSO provider during sign-up.
- **Fix**: Resolves registration errors where the backend was looking for a non-existent image field.
- **Safety**: Existing manual profile uploads are preserved and will not be overwritten by subsequent logins.


## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: # https://github.com/CodeWithCJ/SparkyFitness/discussions/858

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [ ] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before

[Insert screenshot/GIF here]

### After

[Insert screenshot/GIF here]
