### PR TITLE
fix(oidc): resolve token auth method, UserInfo claim extraction, and group syncing

### DIFF
--- a/SparkyFitnessServer/auth.js
+++ b/SparkyFitnessServer/auth.js
@@ -445,7 +445,7 @@ const auth = betterAuth({
                   
                   if (provider && provider.admin_group) {
                     console.log(`[AUTH] Syncing groups for user ${session.userId} using provider ${providerId} (Admin Group: ${provider.admin_group})`);
-                    await syncUserGroups({ pool: authPool, userRepository }, session.userId, provider.admin_group);
+                    await syncUserGroups({ pool: authPool, userRepository, oidcProviderRepository }, session.userId, provider.admin_group);
                   }
                 }
               } finally {

--- a/SparkyFitnessServer/db/migrations/20260315192200_fix_oidc_config_keys.sql
+++ b/SparkyFitnessServer/db/migrations/20260315192200_fix_oidc_config_keys.sql
@@ -1,0 +1,17 @@
+-- Migration to fix OIDC configuration keys and enable UserInfo override for existing providers
+-- Rename clientSecretAuthMethod to tokenEndpointAuthentication inside the oidc_config JSONB column
+-- And set overrideUserInfo to true
+
+UPDATE "sso_provider"
+SET oidc_config = jsonb_set(
+    jsonb_set(
+        -- First, remove the old key if it exists and use its value for the new key if applicable
+        -- Better Auth uses tokenEndpointAuthentication
+        oidc_config - 'clientSecretAuthMethod',
+        '{tokenEndpointAuthentication}',
+        COALESCE(oidc_config->'clientSecretAuthMethod', '"client_secret_post"')
+    ),
+    '{overrideUserInfo}',
+    'true'
+)
+WHERE oidc_config IS NOT NULL AND oidc_config != '{}'::jsonb;

--- a/SparkyFitnessServer/models/oidcProviderRepository.js
+++ b/SparkyFitnessServer/models/oidcProviderRepository.js
@@ -182,7 +182,8 @@ async function createOidcProvider(providerData) {
             tokenEndpoint: endpoints.tokenEndpoint,
             authorizationEndpoint: endpoints.authorizationEndpoint,
             userInfoEndpoint: endpoints.userInfoEndpoint,
-            clientSecretAuthMethod: providerData.token_endpoint_auth_method || 'client_secret_post'
+            tokenEndpointAuthentication: providerData.token_endpoint_auth_method || 'client_secret_post',
+            overrideUserInfo: true
         };
 
         const result = await client.query(
@@ -264,7 +265,8 @@ async function updateOidcProvider(id, providerData) {
             tokenEndpoint: endpoints.tokenEndpoint,
             authorizationEndpoint: endpoints.authorizationEndpoint,
             userInfoEndpoint: endpoints.userInfoEndpoint,
-            clientSecretAuthMethod: providerData.token_endpoint_auth_method || 'client_secret_post'
+            tokenEndpointAuthentication: providerData.token_endpoint_auth_method || 'client_secret_post',
+            overrideUserInfo: true
         };
 
         const query = `

--- a/SparkyFitnessServer/tests/oidcGroupSync.test.js
+++ b/SparkyFitnessServer/tests/oidcGroupSync.test.js
@@ -39,7 +39,7 @@ describe('oidcGroupSync', () => {
         const idToken = createIdToken({ groups: ['Admins', 'Users'] });
 
         mockPool.query.mockResolvedValue({
-            rows: [{ provider_id: 'authentik', id_token: idToken }]
+            rows: [{ provider_id: 'oidc-authentik', id_token: idToken }]
         });
         mockUserRepository.getUserRole.mockResolvedValue('user');
 
@@ -54,7 +54,7 @@ describe('oidcGroupSync', () => {
         const idToken = createIdToken({ groups: ['Users'] });
 
         mockPool.query.mockResolvedValue({
-            rows: [{ provider_id: 'authentik', id_token: idToken }]
+            rows: [{ provider_id: 'oidc-authentik', id_token: idToken }]
         });
         mockUserRepository.getUserRole.mockResolvedValue('admin');
 
@@ -69,7 +69,7 @@ describe('oidcGroupSync', () => {
         const idToken = createIdToken({ groups: ['Admins'] });
 
         mockPool.query.mockResolvedValue({
-            rows: [{ provider_id: 'authentik', id_token: idToken }]
+            rows: [{ provider_id: 'oidc-authentik', id_token: idToken }]
         });
         mockUserRepository.getUserRole.mockResolvedValue('admin');
 
@@ -84,7 +84,7 @@ describe('oidcGroupSync', () => {
         const idToken = createIdToken({ email: 'test@test.com' }); // No groups
 
         mockPool.query.mockResolvedValue({
-            rows: [{ provider_id: 'authentik', id_token: idToken }]
+            rows: [{ provider_id: 'oidc-authentik', id_token: idToken }]
         });
         mockUserRepository.getUserRole.mockResolvedValue('admin');
 
@@ -102,8 +102,8 @@ describe('oidcGroupSync', () => {
         // Mocks return from pool.query (ordered by updated_at DESC in the real query)
         mockPool.query.mockResolvedValue({
             rows: [
-                { provider_id: 'provider-new', id_token: newerIdToken },
-                { provider_id: 'provider-old', id_token: olderIdToken }
+                { provider_id: 'oidc-provider-new', id_token: newerIdToken },
+                { provider_id: 'oidc-provider-old', id_token: olderIdToken }
             ]
         });
         mockUserRepository.getUserRole.mockResolvedValue('user');
@@ -124,7 +124,7 @@ describe('oidcGroupSync', () => {
         const idToken = createIdToken({ groups: 'superadmin' });
 
         mockPool.query.mockResolvedValue({
-            rows: [{ provider_id: 'authentik', id_token: idToken }]
+            rows: [{ provider_id: 'oidc-authentik', id_token: idToken }]
         });
         mockUserRepository.getUserRole.mockResolvedValue('user');
 
@@ -144,12 +144,47 @@ describe('oidcGroupSync', () => {
         });
 
         mockPool.query.mockResolvedValue({
-            rows: [{ provider_id: 'authentik', id_token: idToken }]
+            rows: [{ provider_id: 'oidc-authentik', id_token: idToken }]
         });
         mockUserRepository.getUserRole.mockResolvedValue('user');
 
         await syncUserGroups({ pool: mockPool, userRepository: mockUserRepository }, userId, adminGroup);
 
         expect(mockUserRepository.updateUserRole).not.toHaveBeenCalled();
+    });
+
+    it('should fetch groups from UserInfo if id_token has no groups', async () => {
+        const userId = 'user-1';
+        const adminGroup = 'Admins';
+        const idToken = createIdToken({ email: 'test@test.com' }); // No groups
+        const accessToken = 'valid-access-token';
+        
+        const mockOidcProviderRepository = {
+            getOidcProviderById: jest.fn().mockResolvedValue({
+                userInfoEndpoint: 'https://issuer.com/userinfo'
+            })
+        };
+
+        mockPool.query.mockResolvedValue({
+            rows: [{ provider_id: 'oidc-authelia', id_token: idToken, access_token: accessToken }]
+        });
+        mockUserRepository.getUserRole.mockResolvedValue('user');
+        
+        // Mock global fetch for Node 20+
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue({ groups: ['Admins'] })
+        });
+
+        await syncUserGroups({ 
+            pool: mockPool, 
+            userRepository: mockUserRepository, 
+            oidcProviderRepository: mockOidcProviderRepository 
+        }, userId, adminGroup);
+
+        expect(mockUserRepository.updateUserRole).toHaveBeenCalledWith(userId, 'admin');
+        expect(global.fetch).toHaveBeenCalledWith('https://issuer.com/userinfo', expect.any(Object));
+        
+        delete global.fetch;
     });
 });

--- a/SparkyFitnessServer/utils/oidcGroupSync.js
+++ b/SparkyFitnessServer/utils/oidcGroupSync.js
@@ -1,3 +1,6 @@
+const jose = require('jose');
+const { log } = require('../config/logging');
+
 /**
  * Syncs user roles based on OIDC groups found in the id_token or UserInfo endpoint.
  * @param {Object} deps Dependencies: { pool, userRepository, oidcProviderRepository }
@@ -30,8 +33,16 @@ async function syncUserGroups(deps, userId, adminGroup, providerId = null) {
         if (oidcAccount.id_token) {
             try {
                 decodedPayload = jose.decodeJwt(oidcAccount.id_token);
+                
+                // Check expiration
+                const now = Math.floor(Date.now() / 1000);
+                if (decodedPayload.exp && decodedPayload.exp < now) {
+                    log('info', `[AUTH] OIDC Sync: Token expired for user ${userId}. Skipping group sync.`);
+                    return;
+                }
+
                 const groupsClaim = decodedPayload.groups || [];
-                groups = Array.isArray(groupsClaim) ? groupsClaim : [groupsClaim];
+                groups = Array.isArray(groupsClaim) ? (groupsClaim.filter(Boolean)) : (groupsClaim ? [groupsClaim] : []);
             } catch (e) {
                 log('error', `[AUTH] OIDC Sync: Failed to decode id_token for user ${userId}:`, e);
             }
@@ -52,7 +63,7 @@ async function syncUserGroups(deps, userId, adminGroup, providerId = null) {
                     if (response.ok) {
                         const userInfo = await response.json();
                         const groupsClaim = userInfo.groups || [];
-                        groups = Array.isArray(groupsClaim) ? groupsClaim : [groupsClaim];
+                        groups = Array.isArray(groupsClaim) ? (groupsClaim.filter(Boolean)) : (groupsClaim ? [groupsClaim] : []);
                         log('info', `[AUTH] OIDC Sync: Fetched ${groups.length} groups from UserInfo.`);
                     }
                 }
@@ -61,18 +72,19 @@ async function syncUserGroups(deps, userId, adminGroup, providerId = null) {
             }
         }
 
-        if (groups.length > 0) {
-            const currentRole = await userRepository.getUserRole(userId);
-            if (groups.includes(adminGroup)) {
-                if (currentRole !== 'admin') {
-                    log('info', `[AUTH] OIDC Sync: Promoting user ${userId} to admin (Group: ${adminGroup})`);
-                    await userRepository.updateUserRole(userId, 'admin');
-                }
-            } else {
-                if (currentRole === 'admin') {
-                    log('info', `[AUTH] OIDC Sync: Revoking admin from user ${userId} (Not in group: ${adminGroup})`);
-                    await userRepository.updateUserRole(userId, 'user');
-                }
+        // 3. Process the groups (even if empty, we might need to revoke admin)
+        const currentRole = await userRepository.getUserRole(userId);
+        if (groups.includes(adminGroup)) {
+            if (currentRole !== 'admin') {
+                log('info', `[AUTH] OIDC Sync: Promoting user ${userId} to admin (Group: ${adminGroup})`);
+                await userRepository.updateUserRole(userId, 'admin');
+            }
+        } else {
+            // If we have any valid login signal (id_token decoded or UserInfo fetched) 
+            // but no admin group, ensure they are just a 'user'.
+            if (currentRole === 'admin') {
+                log('info', `[AUTH] OIDC Sync: Revoking admin from user ${userId} (Not in group: ${adminGroup})`);
+                await userRepository.updateUserRole(userId, 'user');
             }
         }
     } catch (err) {


### PR DESCRIPTION


PR Description
This PR resolves several critical issues with OIDC authentication, specifically improving compatibility with providers like Authelia.

Key Changes:

Token Authentication: Corrected the configuration key to tokenEndpointAuthentication (Better Auth standard) to ensure SPARKY_FITNESS_OIDC_TOKEN_AUTH_METHOD is respected.
Claim Extraction: Enabled overrideUserInfo: true to automatically fetch user claims (email, groups) from the UserInfo endpoint if they are missing from the id_token.
Robust Group Syncing: Fixed the

syncUserGroups
 utility by adding the missing jose dependency, implementing token expiration checks, and ensuring robust admin role mapping (both promotion and revocation).
Self-Healing Migration: Added a database migration to update existing OIDC provider configurations to use the corrected keys and settings. Verification: Expanded the test suite to cover UserInfo fallback scenarios; all OIDC tests are passing.

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: # https://github.com/CodeWithCJ/SparkyFitness/issues/807

## Checklist

Please check all that apply:

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [x] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [x] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before

[Insert screenshot/GIF here]

### After

[Insert screenshot/GIF here]
