### PR TITLE
fix: resolve global sync for Garmin

### DIFF
--- a/SparkyFitnessFrontend/src/hooks/Integrations/useSyncAll.ts
+++ b/SparkyFitnessFrontend/src/hooks/Integrations/useSyncAll.ts
@@ -26,7 +26,9 @@ export const useSyncAllMutation = () => {
           (MANUAL_SYNC_PROVIDERS as readonly string[]).includes(
             p.provider_type
           ) &&
-          (p.provider_type === 'hevy' || p.has_token)
+          (p.provider_type === 'hevy' ||
+            p.provider_type === 'garmin' ||
+            p.has_token)
       );
 
       if (activeSyncProviders.length === 0) {


### PR DESCRIPTION

## Description

Provide a brief summary of your changes.
Updated useSyncAll.ts  to properly account for Garmin's tokenless OAuth 1.0 linking state. The Global Sync button will no longer fail with a NO_PROVIDERS error when Garmin is the only active integration.


## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: # https://github.com/CodeWithCJ/SparkyFitness/issues/931

## Checklist

Please check all that apply:

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before

[Insert screenshot/GIF here]

### After

[Insert screenshot/GIF here]
