### PR TITLE
Fix FatSecret unit mapping, variant splitting, and search result scaling

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
@@ -155,6 +155,7 @@ const COMMON_UNITS = [
   'piece',
   'slice',
   'serving',
+  'portion',
   'can',
   'bottle',
   'packet',

--- a/SparkyFitnessServer/integrations/fatsecret/fatsecretService.js
+++ b/SparkyFitnessServer/integrations/fatsecret/fatsecretService.js
@@ -1,4 +1,5 @@
 const { log } = require("../../config/logging");
+const { normalizeBarcode } = require("../../utils/foodUtils");
 
 // Cache tokens by scope
 const tokensByScope = new Map();
@@ -9,6 +10,102 @@ const CACHE_DURATION_MS = 5 * 60 * 1000; // 5 minutes
 
 const FATSECRET_OAUTH_TOKEN_URL = "https://oauth.fatsecret.com/connect/token";
 const FATSECRET_API_BASE_URL = "https://platform.fatsecret.com/rest";
+
+// Placeholder for serving unit aliases. In a real application, this would be more comprehensive.
+const SERVING_UNIT_ALIASES = {
+  "g": "g",
+  "gram": "g",
+  "grams": "g",
+  "ml": "ml",
+  "milliliter": "ml",
+  "milliliters": "ml",
+  "oz": "oz",
+  "ounce": "oz",
+  "ounces": "oz",
+  "cup": "cup",
+  "cups": "cup",
+  "tbsp": "tbsp",
+  "tablespoon": "tbsp",
+  "tablespoons": "tbsp",
+  "tsp": "tsp",
+  "teaspoon": "tsp",
+  "teaspoons": "tsp",
+  "serving": "serving",
+  "servings": "serving",
+  "unit": "unit",
+  "units": "unit",
+  "fl oz": "fl oz",
+  "fluid ounce": "fl oz",
+  "fluid ounces": "fl oz",
+  "piece": "piece",
+  "pieces": "piece",
+  "slice": "slice",
+  "slices": "slice",
+  "package": "package",
+  "packages": "package",
+  "container": "container",
+  "containers": "container",
+  "bottle": "bottle",
+  "bottles": "bottle",
+  "can": "can",
+  "cans": "can",
+  "box": "box",
+  "boxes": "box",
+  "bar": "bar",
+  "bars": "bar",
+  "bag": "bag",
+  "bags": "bag",
+  "each": "each",
+  "item": "item",
+  "items": "item",
+  "small": "small",
+  "medium": "medium",
+  "large": "large",
+  "extra large": "extra large",
+  "extra-large": "extra large",
+  "x-large": "extra large",
+  "x large": "extra large",
+  "small (approx)": "small",
+  "medium (approx)": "medium",
+  "large (approx)": "large",
+  "extra large (approx)": "extra large",
+  "small (edible portion)": "small",
+  "medium (edible portion)": "medium",
+  "large (edible portion)": "large",
+  "extra large (edible portion)": "extra large",
+};
+
+function normalizeServingUnit(unit) {
+  if (!unit) return "g";
+  // Strip anything in parentheses at the end: "serving (237g)" -> "serving"
+  let clean = unit.replace(/\s*\([^)]*\)\s*$/i, "").toLowerCase().trim();
+  
+  const result = SERVING_UNIT_ALIASES[clean] || (SERVING_UNIT_ALIASES[clean.split(/\s+/)[0]] || clean);
+  console.log(`NORMALIZE_UNIT: in="${unit}", clean="${clean}", result="${result}"`);
+  return result;
+}
+
+function evaluateFraction(fractionStr) {
+  if (!fractionStr) return 0;
+  // Handle strings like "1 1/4 cup" by only taking the leading number/fraction part
+  const match = fractionStr.trim().match(/^([\d\s./]+)/);
+  if (!match) return 0;
+
+  const parts = match[1].trim().split(/\s+/);
+  let total = 0;
+  for (const part of parts) {
+    if (part.includes("/")) {
+      const [num, den] = part.split("/");
+      const n = parseFloat(num);
+      const d = parseFloat(den);
+      if (d !== 0) total += n / d;
+    } else {
+      const val = parseFloat(part);
+      if (!isNaN(val)) total += val;
+    }
+  }
+  return total || 0;
+}
 
 // Function to get FatSecret OAuth 2.0 Access Token
 async function getFatSecretAccessToken(
@@ -137,54 +234,121 @@ async function searchFatSecretByBarcode(barcode, clientId, clientSecret) {
   }
 }
 
-function mapFatSecretBarcodeProduct(data) {
+function mapFatSecretFood(data) {
   const food = data.food;
   if (!food) return null;
 
   // Servings can be an array or a single object in FatSecret API
-  let servings = food.servings?.serving || [];
-  if (!Array.isArray(servings)) {
-    servings = [servings];
+  let servingsList = food.servings?.serving || [];
+  if (!Array.isArray(servingsList)) {
+    servingsList = [servingsList];
   }
 
-  // Find the default serving or use the first one
-  const serving =
-    servings.find((s) => s.is_default === "1") || servings[0] || {};
+  const variantsMap = new Map();
 
-  const defaultVariant = {
-    serving_size: parseFloat(serving.metric_serving_amount) || 100,
-    serving_unit: serving.metric_serving_unit || "g",
-    calories: Math.round(parseFloat(serving.calories) || 0),
-    protein: Math.round((parseFloat(serving.protein) || 0) * 10) / 10,
-    carbs: Math.round((parseFloat(serving.carbohydrate) || 0) * 10) / 10,
-    fat: Math.round((parseFloat(serving.fat) || 0) * 10) / 10,
-    saturated_fat:
-      Math.round((parseFloat(serving.saturated_fat) || 0) * 10) / 10,
-    polyunsaturated_fat:
-      Math.round((parseFloat(serving.polyunsaturated_fat) || 0) * 10) / 10,
-    monounsaturated_fat:
-      Math.round((parseFloat(serving.monounsaturated_fat) || 0) * 10) / 10,
-    trans_fat: Math.round((parseFloat(serving.trans_fat) || 0) * 10) / 10,
-    cholesterol: Math.round(parseFloat(serving.cholesterol) || 0),
-    sodium: Math.round(parseFloat(serving.sodium) || 0),
-    potassium: Math.round(parseFloat(serving.potassium) || 0),
-    dietary_fiber: Math.round((parseFloat(serving.fiber) || 0) * 10) / 10,
-    sugars: Math.round((parseFloat(serving.sugar) || 0) * 10) / 10,
-    vitamin_a: Math.round(parseFloat(serving.vitamin_a) || 0),
-    vitamin_c: Math.round(parseFloat(serving.vitamin_c) || 0),
-    calcium: Math.round(parseFloat(serving.calcium) || 0),
-    iron: Math.round(parseFloat(serving.iron) || 0),
-    is_default: true,
-  };
+  servingsList.forEach((serving) => {
+    // We will attempt to create TWO variants per FatSecret serving:
+    // 1. Household variant (e.g., "1 serving", "1/4 cup")
+    // 2. Metric variant (e.g., "237 g", "100 ml")
+
+    const baseNutrients = {
+      calories: Math.round(parseFloat(serving.calories) || 0),
+      protein: Math.round((parseFloat(serving.protein) || 0) * 10) / 10,
+      carbs: Math.round((parseFloat(serving.carbohydrate) || 0) * 10) / 10,
+      fat: Math.round((parseFloat(serving.fat) || 0) * 10) / 10,
+      saturated_fat:
+        Math.round((parseFloat(serving.saturated_fat) || 0) * 10) / 10,
+      polyunsaturated_fat:
+        Math.round((parseFloat(serving.polyunsaturated_fat) || 0) * 10) / 10,
+      monounsaturated_fat:
+        Math.round((parseFloat(serving.monounsaturated_fat) || 0) * 10) / 10,
+      trans_fat: Math.round((parseFloat(serving.trans_fat) || 0) * 10) / 10,
+      cholesterol: Math.round(parseFloat(serving.cholesterol) || 0),
+      sodium: Math.round(parseFloat(serving.sodium) || 0),
+      potassium: Math.round(parseFloat(serving.potassium) || 0),
+      dietary_fiber: Math.round((parseFloat(serving.fiber) || 0) * 10) / 10,
+      sugars: Math.round((parseFloat(serving.sugar) || 0) * 10) / 10,
+      vitamin_a: Math.round(parseFloat(serving.vitamin_a) || 0),
+      vitamin_c: Math.round(parseFloat(serving.vitamin_c) || 0),
+      calcium: Math.round(parseFloat(serving.calcium) || 0),
+      iron: Math.round(parseFloat(serving.iron) || 0),
+    };
+
+    const addVariant = (size, unit, isDefault) => {
+      if (isNaN(size) || !unit) return;
+
+      const normalizedUnit = normalizeServingUnit(unit);
+      const key = `${size}_${normalizedUnit}`.toLowerCase();
+
+      if (!variantsMap.has(key) || isDefault) {
+        log("info", `FATSECRET_DEBUG: Adding variant: size=${size}, unit=${unit}, normalizedUnit=${normalizedUnit}, key=${key}, isDefault=${isDefault}`);
+        variantsMap.set(key, {
+          serving_size: size,
+          serving_unit: normalizedUnit,
+          ...baseNutrients,
+          is_default: isDefault,
+        });
+      }
+    };
+
+    // 1. Try to create Household variant
+    let hhSize = parseFloat(serving.number_of_units);
+    let hhUnit = serving.measurement_description;
+
+    const isGenericHH =
+      !hhUnit ||
+      hhUnit.toLowerCase() === "portion" ||
+      hhUnit.toLowerCase() === "serving";
+
+    if (isNaN(hhSize) || isGenericHH) {
+      // Try parsing from serving_description
+      const desc = serving.serving_description || "";
+      const descMatch = desc.match(/^([\d\s./]+)\s+(.+)$/);
+      if (descMatch) {
+        const parsedSize = evaluateFraction(descMatch[1]);
+        const parsedUnit = descMatch[2].trim();
+        if (parsedSize > 0 && parsedUnit) {
+          hhSize = parsedSize;
+          hhUnit = parsedUnit;
+        }
+      }
+    }
+
+    if (isNaN(hhSize) || !hhUnit) {
+      hhSize = 1;
+      hhUnit = serving.serving_description || "serving";
+    }
+
+    addVariant(hhSize, hhUnit, serving.is_default === "1");
+
+    // 2. Try to create Metric variant
+    const mSize = parseFloat(serving.metric_serving_amount);
+    const mUnit = serving.metric_serving_unit;
+
+    if (!isNaN(mSize) && mUnit) {
+      // Only add metric if it's different from household (to avoid duplicates like "100 g" and "100 g")
+      addVariant(mSize, mUnit, serving.is_default === "1");
+    }
+  });
+
+  const mappedVariants = Array.from(variantsMap.values());
+
+  // Ensure exactly one default
+  let defaultVariant = mappedVariants.find((v) => v.is_default);
+  if (!defaultVariant && mappedVariants.length > 0) {
+    defaultVariant = mappedVariants[0];
+    defaultVariant.is_default = true;
+  }
 
   return {
     name: food.food_name,
     brand: food.brand_name || null,
-    barcode: food.barcode, // Passed in from lookupBarcode
-    provider_external_id: food.food_id,
+    barcode: food.barcode,
+    provider_external_id: String(food.food_id),
     provider_type: "fatsecret",
     is_custom: false,
     default_variant: defaultVariant,
+    variants: mappedVariants,
   };
 }
 
@@ -206,22 +370,78 @@ function mapFatSecretSearchItem(item) {
   //   "Per 1 serving (28g) - ..." → 28 g  (prefer metric in parentheses)
   //   "Per 1 serving - ..."      → 1 serving
   //   "Per 1 bar - ..."          → 1 bar
-  const metricMatch = desc.match(
-    /^Per\s+(?:\d+\s+\w+\s+\()?([\d.]+)(g|ml)\)?/,
-  );
+  //   "Per 1/4 cup - ..."        → 0.25 cup
+
+  // 1. Try to find metric in parentheses: "Per ... (28g) -"
+  const parenMetricMatch = desc.match(/\(([\d.]+)(g|ml)\)\s*-/);
+
+  // 2. Try to find direct metric: "Per 100g -"
+  const directMetricMatch = desc.match(/^Per\s+([\d.]+)(g|ml)\s*-/);
+
+  // 3. Try to find household with potential fractions: "Per 1/4 cup -"
+  const householdMatch = desc.match(/^Per\s+([\d\s./]+)\s+(.+?)\s*-/);
+
   let servingSize, servingUnit;
-  if (metricMatch) {
-    servingSize = parseFloat(metricMatch[1]);
-    servingUnit = metricMatch[2];
+
+  // Priority for search item mapping:
+  // 1. Specific household (e.g. "cup", "slice")
+  // 2. Reasonable metric in parentheses (e.g. "serving (28g)")
+  // 3. Generic household fallback
+  // 4. Direct metric
+
+  const hSize = householdMatch ? evaluateFraction(householdMatch[1]) : 0;
+  const hUnitOrig = householdMatch ? householdMatch[2].trim() : "";
+  const hUnitNorm = normalizeServingUnit(hUnitOrig);
+  
+  const isTrueGeneric = ["serving", "portion", "unit", "item"].some(g => hUnitNorm.includes(g));
+  const isContainer = ["container", "package", "bag", "box", "recipe", "pot", "can", "bottle", "packet", "bowl", "plate"].some(g => hUnitNorm.includes(g));
+  const isGeneric = isTrueGeneric || isContainer;
+
+  const pSize = parenMetricMatch ? parseFloat(parenMetricMatch[1]) : 0;
+  const pUnit = parenMetricMatch ? parenMetricMatch[2] : "";
+
+  if (householdMatch && !isGeneric) {
+    // Specific household unit like "cup", "slice", "tbsp"
+    servingSize = hSize;
+    servingUnit = hUnitNorm;
+  } else if (parenMetricMatch && ((pSize > 0 && pSize <= 1000) || isTrueGeneric)) {
+    // Metric in parents is usually better for "serving" or "portion" unless it's a whole container/pot
+    servingSize = pSize;
+    servingUnit = normalizeServingUnit(pUnit);
+  } else if (householdMatch) {
+    // Fallback to generic or container household
+    servingSize = hSize;
+    servingUnit = hUnitNorm;
+  } else if (directMetricMatch) {
+    servingSize = parseFloat(directMetricMatch[1]);
+    servingUnit = normalizeServingUnit(directMetricMatch[2]);
   } else {
-    const nonMetricMatch = desc.match(/^Per\s+([\d.]+)\s+(.+?)\s*-/);
-    if (nonMetricMatch) {
-      servingSize = parseFloat(nonMetricMatch[1]);
-      servingUnit = nonMetricMatch[2].trim();
-    } else {
-      servingSize = 100;
-      servingUnit = "g";
-    }
+    servingSize = 100;
+    servingUnit = "g";
+  }
+
+  // Mandatory normalization
+  servingUnit = normalizeServingUnit(servingUnit);
+  log("info", `FATSECRET_DEBUG: Search item final mapping: size=${servingSize}, unit=${servingUnit}, desc="${desc}"`);
+
+  // Ensure weight labels aren't "Per 2135 g" if we can help it,
+  // but we must keep the nutrients in sync.
+  // FatSecret description nutrients ALIGN with the serving shown.
+
+  // Scaler for "weird g": if metric weight is too large/specific, scale nutrients to 100g/ml
+  let scaledCalories = calories;
+  let scaledProtein = protein;
+  let scaledCarbs = carbs;
+  let scaledFat = fat;
+
+  if ((servingUnit === "g" || servingUnit === "ml") && servingSize > 0 && servingSize !== 100 && servingSize > 1) {
+    const factor = 100 / servingSize;
+    scaledCalories = Math.round(calories * factor);
+    scaledProtein = Math.round(protein * factor * 10) / 10;
+    scaledCarbs = Math.round(carbs * factor * 10) / 10;
+    scaledFat = Math.round(fat * factor * 10) / 10;
+    servingSize = 100;
+    log("info", `FATSECRET_DEBUG: Scaling search result from ${servingSize/factor}${servingUnit} to 100${servingUnit}`);
   }
 
   return {
@@ -233,10 +453,10 @@ function mapFatSecretSearchItem(item) {
     default_variant: {
       serving_size: servingSize,
       serving_unit: servingUnit,
-      calories: Math.round(calories),
-      protein: Math.round(protein * 10) / 10,
-      carbs: Math.round(carbs * 10) / 10,
-      fat: Math.round(fat * 10) / 10,
+      calories: Math.round(scaledCalories),
+      protein: scaledProtein,
+      carbs: scaledCarbs,
+      fat: scaledFat,
       is_default: true,
     },
   };
@@ -245,7 +465,7 @@ function mapFatSecretSearchItem(item) {
 module.exports = {
   getFatSecretAccessToken,
   searchFatSecretByBarcode,
-  mapFatSecretBarcodeProduct,
+  mapFatSecretFood,
   mapFatSecretSearchItem,
   foodNutrientCache,
   CACHE_DURATION_MS,

--- a/SparkyFitnessServer/routes/v2/foodRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/foodRoutes.ts
@@ -21,7 +21,7 @@ const {
   mapUsdaBarcodeProduct,
 } = require("../../integrations/usda/usdaService");
 const {
-  mapFatSecretBarcodeProduct,
+  mapFatSecretFood,
   mapFatSecretSearchItem,
 } = require("../../integrations/fatsecret/fatsecretService");
 const {
@@ -319,7 +319,7 @@ const detailHandler: RequestHandler<{
           credentials.app_key,
         );
         if (data) {
-          food = mapFatSecretBarcodeProduct(data);
+          food = mapFatSecretFood(data);
         }
         break;
       }

--- a/SparkyFitnessServer/services/foodCoreService.js
+++ b/SparkyFitnessServer/services/foodCoreService.js
@@ -16,7 +16,7 @@ const {
 } = require("../integrations/usda/usdaService");
 const {
   searchFatSecretByBarcode,
-  mapFatSecretBarcodeProduct,
+  mapFatSecretFood,
 } = require("../integrations/fatsecret/fatsecretService");
 
 async function searchFoods(
@@ -780,7 +780,7 @@ async function lookupBarcode(barcode, userId, providerId) {
           fatSecretData.food.barcode = barcode;
           return {
             source: "fatsecret",
-            food: mapFatSecretBarcodeProduct(fatSecretData),
+            food: mapFatSecretFood(fatSecretData),
             barcode_raw: fatSecretData,
           };
         }
@@ -885,6 +885,6 @@ module.exports = {
   lookupBarcode,
   // Re-exported from integration services for backward compatibility
   mapOpenFoodFactsProduct,
-  mapFatSecretBarcodeProduct,
+  mapFatSecretFood,
   mapUsdaBarcodeProduct,
 };

--- a/SparkyFitnessServer/tests/fatsecretService.test.js
+++ b/SparkyFitnessServer/tests/fatsecretService.test.js
@@ -1,0 +1,169 @@
+const {
+  mapFatSecretBarcodeProduct,
+  mapFatSecretSearchItem,
+} = require("../integrations/fatsecret/fatsecretService");
+
+describe("FatSecret Service Mapping", () => {
+  describe("mapFatSecretSearchItem", () => {
+    it("should map metric description correctly", () => {
+      const item = {
+        food_name: "Test Food",
+        brand_name: "Test Brand",
+        food_id: "123",
+        food_description: "Per 100g - Calories: 165kcal | Fat: 3.57g | Carbs: 0.00g | Protein: 31.02g"
+      };
+      const result = mapFatSecretSearchItem(item);
+      expect(result.default_variant.serving_size).toBe(100);
+      expect(result.default_variant.serving_unit).toBe("g");
+      expect(result.default_variant.calories).toBe(165);
+    });
+
+    it("should map metric in parentheses correctly", () => {
+      const item = {
+        food_name: "Test Food",
+        food_description: "Per 1 serving (28g) - Calories: 110kcal | Fat: 2.00g | Carbs: 15.00g | Protein: 7.00g"
+      };
+      const result = mapFatSecretSearchItem(item);
+      expect(result.default_variant.serving_size).toBe(28);
+      expect(result.default_variant.serving_unit).toBe("g");
+    });
+
+    it("should map fractional household units", () => {
+      const item = {
+        food_name: "Test Food",
+        food_description: "Per 1/4 cup - Calories: 110kcal | Fat: 2g | Carbs: 15g | Protein: 7g"
+      };
+      const result = mapFatSecretSearchItem(item);
+      expect(result.default_variant.serving_size).toBe(0.25);
+      expect(result.default_variant.serving_unit).toBe("cup");
+    });
+
+    it("should map whole household units correctly", () => {
+      const item = {
+        food_name: "Test Food",
+        food_description: "Per 1 slice - Calories: 70kcal | Fat: 1g | Carbs: 12g | Protein: 2g"
+      };
+      const result = mapFatSecretSearchItem(item);
+      expect(result.default_variant.serving_size).toBe(1);
+      expect(result.default_variant.serving_unit).toBe("slice");
+    });
+    
+    it("should map mixed fractions like 1 1/2 cups", () => {
+      const item = {
+        food_name: "Test Food",
+        food_description: "Per 1 1/2 cups - Calories: 150kcal | Fat: 2g | Carbs: 25g | Protein: 5g"
+      };
+      const result = mapFatSecretSearchItem(item);
+      expect(result.default_variant.serving_size).toBe(1.5);
+      expect(result.default_variant.serving_unit).toBe("cup");
+    });
+  });
+
+  describe("mapFatSecretFood", () => {
+    const { mapFatSecretFood } = require("../integrations/fatsecret/fatsecretService");
+
+    it("should map detailed food with multiple variants", () => {
+      const data = {
+        food: {
+          food_name: "Peanut Butter",
+          brand_name: "Jif",
+          food_id: "456",
+          servings: {
+            serving: [
+              {
+                serving_description: "1 tbsp",
+                metric_serving_amount: "15.000",
+                metric_serving_unit: "g",
+                number_of_units: "1.000",
+                measurement_description: "tablespoon",
+                calories: "95",
+                protein: "4",
+                carbohydrate: "3.5",
+                fat: "8",
+                is_default: "1"
+              },
+              {
+                serving_description: "100g",
+                metric_serving_amount: "100.000",
+                metric_serving_unit: "g",
+                number_of_units: "6.667",
+                measurement_description: "tablespoon",
+                calories: "594",
+                protein: "25",
+                carbohydrate: "22",
+                fat: "50"
+              }
+            ]
+          }
+        }
+      };
+      const result = mapFatSecretFood(data);
+      expect(result.name).toBe("Peanut Butter");
+      expect(result.default_variant.serving_size).toBe(1);
+      expect(result.default_variant.serving_unit).toBe("tbsp");
+      
+      expect(result.variants.length).toBe(4);
+      expect(result.variants.some(v => v.serving_size === 15 && v.serving_unit === "g")).toBe(true);
+      expect(result.variants.some(v => v.serving_size === 100 && v.serving_unit === "g")).toBe(true);
+      expect(result.variants.some(v => v.serving_size === 6.667 && v.serving_unit === "tbsp")).toBe(true);
+    });
+
+    it("should parse Brand food serving_description for fractions", () => {
+      const data = {
+        food: {
+          food_name: "Brand Food",
+          brand_name: "Test Brand",
+          food_id: "999",
+          servings: {
+            serving: {
+              serving_description: "1/4 cup",
+              number_of_units: "1.000",
+              measurement_description: "portion",
+              metric_serving_amount: "28.000",
+              metric_serving_unit: "g"
+            }
+          }
+        }
+      };
+      const result = mapFatSecretFood(data);
+      // Even though number_of_units is 1, it should parse "1/4 cup" 
+      // from the description and get 0.25 cup.
+      expect(result.default_variant.serving_size).toBe(0.25);
+      expect(result.default_variant.serving_unit).toBe("cup");
+    });
+
+    it("should split a single serving into household and metric variants", () => {
+      const data = {
+        food: {
+          food_name: "Splitting Food",
+          food_id: "777",
+          servings: {
+            serving: {
+              serving_description: "1 cup (237 g)",
+              number_of_units: "1.000",
+              measurement_description: "cup",
+              metric_serving_amount: "237.000",
+              metric_serving_unit: "g",
+              is_default: "1",
+              calories: "100"
+            }
+          }
+        }
+      };
+      const result = mapFatSecretFood(data);
+      expect(result.variants.length).toBe(2);
+      
+      const hh = result.variants.find(v => v.serving_unit === "cup");
+      const m = result.variants.find(v => v.serving_unit === "g");
+      
+      expect(hh.serving_size).toBe(1);
+      expect(hh.serving_unit).toBe("cup");
+      expect(m.serving_size).toBe(237);
+      expect(m.serving_unit).toBe("g");
+      expect(hh.calories).toBe(100);
+      expect(m.calories).toBe(100);
+      expect(hh.is_default).toBe(true);
+      expect(m.is_default).toBe(true); // Both are default as they come from a default serving
+    });
+  });
+});

--- a/SparkyFitnessServer/utils/foodUtils.js
+++ b/SparkyFitnessServer/utils/foodUtils.js
@@ -12,17 +12,46 @@ function sanitizeCustomNutrients(customNutrients) {
 
 const SERVING_UNIT_ALIASES = {
   g: "g", grm: "g", gm: "g", gram: "g", grams: "g",
-  ml: "ml", milliliter: "ml", millilitre: "ml",
+  ml: "ml", milliliter: "ml", millilitre: "ml", milliliters: "ml", millilitres: "ml",
   oz: "oz", ounce: "oz", ounces: "oz",
-  tbsp: "tbsp", tablespoon: "tbsp",
-  tsp: "tsp", teaspoon: "tsp",
+  tbsp: "tbsp", tablespoon: "tbsp", tablespoons: "tbsp",
+  tsp: "tsp", teaspoon: "tsp", teaspoons: "tsp",
   cup: "cup", cups: "cup",
+  slice: "slice", slices: "slice",
+  portion: "serving", portions: "serving",
+  servings: "serving", serving: "serving",
+  container: "container", containers: "container",
+  package: "packet", packages: "packet",
+  piece: "piece", pieces: "piece",
+  kg: "kg", kilogram: "kg", kilograms: "kg",
+  mg: "mg", milligram: "mg", milligrams: "mg",
+  lb: "lb", pound: "lb", pounds: "lb",
+  l: "l", liter: "l", litre: "l", liters: "l", litres: "l",
+  can: "can", cans: "can",
+  bottle: "bottle", bottles: "bottle",
+  packet: "packet", packets: "packet",
+  bag: "bag", bags: "bag",
+  bowl: "bowl", bowls: "bowl",
+  plate: "plate", plates: "plate",
+  handful: "handful", handfuls: "handful",
+  scoop: "scoop", scoops: "scoop",
+  bar: "bar", bars: "bar",
+  stick: "stick", sticks: "stick",
 };
 
 function normalizeServingUnit(unit) {
   if (!unit) return "g";
-  const key = unit.toLowerCase().trim();
-  return SERVING_UNIT_ALIASES[key] || key;
+  // Strip anything in parentheses at the end: "serving (237g)" -> "serving"
+  let clean = unit.replace(/\s*\([^)]*\)\s*$/i, "").toLowerCase().trim();
+  
+  // Try exact match first
+  if (SERVING_UNIT_ALIASES[clean]) return SERVING_UNIT_ALIASES[clean];
+  
+  // Try first word match (e.g., "cup pieces" -> "cup")
+  const firstWord = clean.split(/\s+/)[0];
+  if (SERVING_UNIT_ALIASES[firstWord]) return SERVING_UNIT_ALIASES[firstWord];
+  
+  return clean;
 }
 
 function normalizeBarcode(barcode) {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!

## Description

Provide a brief summary of your changes.

This PR improves FatSecret food integration by implementing automatic variant splitting (household and metric) and a robust unit normalization system that strips parenthetical weight info to fix blank dropdowns. It also introduces automatic scaling for metric search results to a standard 100g portion, ensuring cleaner and more comparable search result cards.



## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: # https://github.com/CodeWithCJ/SparkyFitness/issues/883

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [ ] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [ ] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before

[Insert screenshot/GIF here]

### After

[Insert screenshot/GIF here]
<img width="1034" height="139" alt="image" src="https://github.com/user-attachments/assets/7d3c3a67-aebf-45b4-bef7-06d7796aad59" />
