### PR TITLE
Fix Garmin sync: heart rate field name, distance double-conversion, and multi-user error isolation

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Reports/ActivityReportVisualizer.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/ActivityReportVisualizer.tsx
@@ -131,7 +131,7 @@ const ActivityReportVisualizer = ({
     activityData.activity.activity.distance > 0
   ) {
     totalActivityDistanceForDisplay = convertDistance(
-      activityData.activity.activity.distance / 1000,
+      activityData.activity.activity.distance,
       'km',
       distanceUnit
     );

--- a/SparkyFitnessServer/SparkyFitnessServer.js
+++ b/SparkyFitnessServer/SparkyFitnessServer.js
@@ -449,11 +449,18 @@ const scheduleGarminSyncs = async () => {
       await externalProviderRepository.getProvidersByType("garmin");
     for (const provider of providers) {
       if (provider.is_active && provider.sync_frequency === "hourly") {
-        await garminService.syncGarminData(provider.user_id, "scheduled");
-        await externalProviderRepository.updateProviderLastSync(
-          provider.id,
-          new Date(),
-        );
+        try {
+          await garminService.syncGarminData(provider.user_id, "scheduled");
+          await externalProviderRepository.updateProviderLastSync(
+            provider.id,
+            new Date(),
+          );
+        } catch (error) {
+          console.error(
+            `[CRON] Garmin sync failed for user ${provider.user_id}:`,
+            error,
+          );
+        }
       }
     }
   });

--- a/SparkyFitnessServer/services/garminService.js
+++ b/SparkyFitnessServer/services/garminService.js
@@ -451,7 +451,7 @@ async function processGarminSimpleActivity(userId, activityData) {
     entry_date: entryDate,
     notes: `Garmin Activity: ${activity.activityName} (${activity.activityType?.typeKey})`,
     distance: activity.distance,
-    avg_heart_rate: activity.averageHeartRateInBeatsPerMinute || null,
+    avg_heart_rate: activity.averageHR || activity.averageHeartRateInBeatsPerMinute || null,
   };
 
   const newEntry = await exerciseEntryRepository.createExerciseEntry(userId, exerciseEntryData, userId, 'garmin');


### PR DESCRIPTION
## Summary

- **Heart rate always null** (`garminService.js`): `processGarminSimpleActivity` was reading `activity.averageHeartRateInBeatsPerMinute` but the Garmin API returns `averageHR`. Changed to read `averageHR` first with the old name as a fallback.
- **Distance shows ~0** (`ActivityReportVisualizer.tsx`): The fallback distance branch divided by 1000 treating the value as meters, but the Python microservice already converts meters → km before sending. Removed the erroneous `/ 1000`.
- **One failing user blocks all others** (`SparkyFitnessServer.js`): The Garmin scheduled sync loop had no per-user `try/catch`, so an error for User A would abort User B's sync entirely. Wrapped each iteration in `try/catch` to match the pattern already used by Withings and Strava.

## Test plan
- [ ] Trigger a Garmin sync for an activity with GPS distance — verify distance displays correctly in the Activity Report
- [ ] Trigger a Garmin sync for an activity with heart rate data — verify avg heart rate is populated on the exercise entry
- [ ] Simulate a sync failure for one user (e.g. revoke token) and confirm the other user's scheduled sync still completes

WARNING made with claude code.
