### PR TITLE
fix: validate garth token dump structure before accessing OAuth2Token at index [1]

### DIFF
--- a/SparkyFitnessServer/integrations/garminconnect/garminConnectService.js
+++ b/SparkyFitnessServer/integrations/garminconnect/garminConnectService.js
@@ -44,7 +44,14 @@ async function handleGarminTokens(userId, tokensB64) {
         // The Python microservice returns the full garth.dumps() output directly.
         const garthDump = tokensB64;
         const parsedGarthDump = JSON.parse(Buffer.from(garthDump, 'base64').toString('utf8'));
-        // The actual tokens are typically in the second element of the array returned by garth.dumps()
+        // garth.dumps() always returns a 2-element JSON array: [OAuth1Token, OAuth2Token].
+        // OAuth2Token (index 1) contains access_token, refresh_token, expires_at, etc.
+        if (!Array.isArray(parsedGarthDump) || parsedGarthDump.length < 2 || !parsedGarthDump[1]) {
+            throw new Error(
+                `Unexpected garth dump structure: expected a 2-element array [OAuth1Token, OAuth2Token], ` +
+                `received ${Array.isArray(parsedGarthDump) ? `array of length ${parsedGarthDump.length}` : typeof parsedGarthDump}`
+            );
+        }
         const tokens = parsedGarthDump[1];
         log('debug', `handleGarminTokens: Parsed Garth Dump:`, parsedGarthDump);
         log('debug', `handleGarminTokens: Extracted Tokens:`, tokens);


### PR DESCRIPTION
## Description

`garth.dumps()` returns a base64-encoded 2-element JSON array:
- `[0]` — `OAuth1Token` (SSO credentials)
- `[1]` — `OAuth2Token` (access_token, refresh_token, expires_at, …)

The code accessed `parsedGarthDump[1]` with no guard. Any unexpected
structure — truncated array, non-array response, future garth version
change — would silently produce `undefined` and cause a cryptic
downstream error (e.g. `Cannot read properties of undefined` when
reading `tokens.access_token`).

**Fix:** Added a guard before the index access that checks:
1. The parsed value is an array
2. It has at least 2 elements
3. The second element is truthy

If any check fails, a descriptive error is thrown explaining exactly
what was expected vs what was received, making debugging straightforward.

**Verified with simulated inputs:**
| Input | Result |
|---|---|
| Valid 2-element garth dump | ✅ Tokens extracted correctly |
| Empty array `[]` | ❌ Descriptive error thrown |
| Only 1 element (OAuth1 only) | ❌ Descriptive error thrown |
| Second element is `null` | ❌ Descriptive error thrown |
| Plain object instead of array | ❌ Descriptive error thrown |
| Corrupted base64 | ❌ JSON parse error caught by outer try-catch |

## Checklist

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code and I agree to the License terms.
