### PR TITLE
Fix(953): entry update not using newest variant

### DIFF
--- a/SparkyFitnessServer/services/foodEntryService.js
+++ b/SparkyFitnessServer/services/foodEntryService.js
@@ -108,9 +108,7 @@ async function updateFoodEntry(
 
     let newSnapshotData;
 
-    const variantChanged = entryData.variant_id && entryData.variant_id !== existingEntry.variant_id;
-
-    if (foodIdToUse && variantChanged) {
+    if (foodIdToUse) {
       // Variant changed — rebuild snapshot from the new food/variant
       const food = await foodRepository.getFoodById(
         foodIdToUse,


### PR DESCRIPTION
## Description

Updating a food entry didn't use the newest variant. Always using the variant from the request is safer.

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: #953

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).
