### PR TITLE
Fix creating totp

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Settings/MFASettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/MFASettings.tsx
@@ -10,7 +10,8 @@ import { authClient } from '@/lib/auth-client';
 import { toast } from '@/hooks/use-toast';
 import { log } from '@/utils/logging';
 import { usePreferences } from '@/contexts/PreferencesContext';
-import QRCode from 'react-qr-code';
+// @ts-expect-error workaround for import error
+import { QRCode } from 'react-qr-code';
 import {
   useSyncTotpMutation,
   useToggleEmailMfaMutation,

--- a/SparkyFitnessServer/auth.js
+++ b/SparkyFitnessServer/auth.js
@@ -101,7 +101,7 @@ const apiKeyPlugin = require("@better-auth/api-key").apiKey({
 
 const auth = betterAuth({
   database: authPool,
-  secret: Buffer.from(process.env.BETTER_AUTH_SECRET, "base64"),
+  secret: Buffer.from(process.env.BETTER_AUTH_SECRET, "base64").toString(),
 
   // Base URL configuration - MUST use public frontend URL for OIDC to work
   baseURL:


### PR DESCRIPTION
## Description

Better auth changed some things in version 1.5.5 which led to the error described in the issue. converting the secret to a string fixes the problems. This was done internally before. Additionally the QRCode import without brackets leads to an error. I think vite became stricter. 

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: #967

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

