### PR TITLE
fix: replace N/A with actual totals in laps table Cumulative columns

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Reports/ActivityReportLapTable.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/ActivityReportLapTable.tsx
@@ -431,13 +431,17 @@ const ActivityReportLapTable: React.FC<LapTableProps> = ({
               <td className="py-2 px-4 text-center">
                 {formatTime(totalDurSec)}
               </td>
-              <td className="py-2 px-4 text-center">{NA}</td>
+              <td className="py-2 px-4 text-center">
+                {formatTime(totalDurSec)}
+              </td>
               {showDistanceCols && (
                 <>
                   <td className="py-2 px-4 text-center">
                     {totalDist.toFixed(2)}
                   </td>
-                  <td className="py-2 px-4 text-center">{NA}</td>
+                  <td className="py-2 px-4 text-center">
+                    {totalDist.toFixed(2)}
+                  </td>
                 </>
               )}
               {showPaceCols && (


### PR DESCRIPTION
## Description

The **Cumulative Time** and **Cumulative Distance** columns in the Laps table
Totals row were hardcoded to display `N/A`. They now show the actual totals:
total elapsed duration (formatted as `mm:ss`) and total distance (in km),
matching the values already shown in the other total cells.

`SparkyFitnessFrontend/src/pages/Reports/ActivityReportLapTable.tsx` — replaced
two hardcoded `{NA}` values in the `<tfoot>` Totals row with
`{formatTime(totalDurSec)}` and `{totalDist.toFixed(2)}`.

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation

Linked Issue: N/A

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code (phishing, malware, etc.) and I agree to the [License terms](LICENSE).

