### PR TITLE
Fix #988 USDA missing calories

### DIFF
--- a/SparkyFitnessServer/integrations/usda/usdaService.js
+++ b/SparkyFitnessServer/integrations/usda/usdaService.js
@@ -97,7 +97,7 @@ function mapUsdaBarcodeProduct(food) {
     serving_size: servingSize,
     serving_unit: normalizeServingUnit(food.servingSizeUnit),
     calories: Math.round(
-      (nutrients[1008] || nutrients[2048] || nutrients[2047] || 0) * scale,
+      (nutrients[1008] ?? nutrients[2048] ?? nutrients[2047] ?? 0) * scale,
     ),
     protein: Math.round((nutrients[1003] || 0) * scale * 10) / 10,
     carbs: Math.round((nutrients[1005] || 0) * scale * 10) / 10,

--- a/SparkyFitnessServer/tests/barcodeLookup.test.js
+++ b/SparkyFitnessServer/tests/barcodeLookup.test.js
@@ -498,6 +498,19 @@ describe("mapUsdaBarcodeProduct", () => {
     expect(result.default_variant.calories).toBe(120);
   });
 
+  it("should preserve explicit zero from 1008 and not fall through to Atwater", () => {
+    const usdaFood = makeUsdaFood({
+      servingSize: 100,
+      foodNutrients: [
+        { nutrientId: 1008, value: 0 },
+        { nutrientId: 2048, value: 125 },
+        { nutrientId: 2047, value: 119 },
+      ],
+    });
+    const result = mapUsdaBarcodeProduct(usdaFood);
+    expect(result.default_variant.calories).toBe(0);
+  });
+
   it("should normalize a 12-digit gtinUpc to 13 digits", () => {
     const usdaFood = makeUsdaFood({ gtinUpc: "094395000172" });
     const result = mapUsdaBarcodeProduct(usdaFood);


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!

## Description

USDA uses different nutrient IDs for energy from foundation foods. These changes make it so it calories are not found, it tries to fall back on the Energy fields. It still returns 0 if none are found.

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: #988

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [x] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [x] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before

[Insert screenshot/GIF here]

### After

[Insert screenshot/GIF here]
