### PR TITLE
fix: show Body Battery Current value in gauge instead of always showi…

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Reports/BodyBatteryCard.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/BodyBatteryCard.tsx
@@ -118,7 +118,7 @@ const BodyBatteryCard: React.FC<BodyBatteryCardProps> = ({
       ? transformedData[transformedData.length - 1]
       : null;
 
-  // Use at_wake if available, otherwise highest
+  // Use current value if available, otherwise fall back to at_wake, then highest
   const gaugeValue =
     latestData?.current ?? latestData?.at_wake ?? latestData?.highest ?? 0;
   const chargedValue = latestData?.charged ?? 0;


### PR DESCRIPTION
## Description

The Body Battery gauge always showed 100 because `Body Battery Current` was
never read from the data. The component fell back to `Body Battery Highest`,
which is typically 100 after overnight charging.

**Root cause:** `BodyBatteryCard.tsx` had no `case` for `'Body Battery Current'`
in the switch statement, and the `BodyBatteryDay` interface had no `current`
field — so the value was silently discarded even though it is correctly synced
from Garmin.

**Fix (`SparkyFitnessFrontend/src/pages/Reports/BodyBatteryCard.tsx`):**
- Added `current: number | null` to the `BodyBatteryDay` interface
- Added `case 'Body Battery Current':` to the switch statement
- Changed gauge priority to `current ?? at_wake ?? highest ?? 0`

No backend changes needed — the data is already synced and stored correctly.

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation

Linked Issue: N/A

## Checklist

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [x] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code (phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before
Gauge always showed **100** (fell back to Body Battery Highest, which is 100 after overnight charging).
<img width="1414" height="477" alt="Schermafbeelding 2026-03-26 080535" src="https://github.com/user-attachments/assets/22f8e11e-b28d-45a4-b6d7-502ee2d8ede5" />


### After
Gauge shows the actual **Body Battery Current** value from Garmin (e.g. 44 mid-day), falling back to At Wake, then Highest only if Current is unavailable.
<img width="1424" height="453" alt="Schermafbeelding 2026-03-26 082234" src="https://github.com/user-attachments/assets/b484c5c4-d245-41ba-8a81-136db77f7ee8" />
