### PR TITLE
Better Auth MFA Sync Fix

### DIFF
--- a/SparkyFitnessServer/auth.js
+++ b/SparkyFitnessServer/auth.js
@@ -7,6 +7,7 @@ const bcrypt = require('bcrypt');
 const { v4: uuidv4 } = require('uuid');
 const { syncUserGroups } = require('./utils/oidcGroupSync');
 const userRepository = require('./models/userRepository');
+const { resolveTwoFactorDisableUserUpdate } = require('./utils/twoFactorState');
 const {
   sendPasswordResetEmail,
   sendMagicLinkEmail,
@@ -387,6 +388,25 @@ const auth = betterAuth({
             );
             // We don't throw here to avoid blocking the signup, but we log the failure
           }
+        },
+      },
+      update: {
+        before: async (user, ctx) => {
+          const data = await resolveTwoFactorDisableUserUpdate(
+            user,
+            ctx,
+            userRepository.findUserById
+          );
+
+          if (!data) {
+            return;
+          }
+
+          log(
+            'info',
+            '[AUTH] Preserving email MFA while Better Auth disables TOTP.'
+          );
+          return { data };
         },
       },
     },

--- a/SparkyFitnessServer/tests/twoFactorState.test.js
+++ b/SparkyFitnessServer/tests/twoFactorState.test.js
@@ -1,0 +1,70 @@
+const {
+  resolveTwoFactorDisableUserUpdate,
+} = require('../utils/twoFactorState');
+
+describe('resolveTwoFactorDisableUserUpdate', () => {
+  it('preserves the global MFA flag when disabling TOTP and email MFA remains enabled', async () => {
+    const findUserById = jest.fn().mockResolvedValue({
+      id: 'user-123',
+      mfa_email_enabled: true,
+    });
+
+    const result = await resolveTwoFactorDisableUserUpdate(
+      { twoFactorEnabled: false },
+      {
+        path: '/two-factor/disable',
+        context: {
+          session: {
+            user: { id: 'user-123' },
+          },
+        },
+      },
+      findUserById
+    );
+
+    expect(findUserById).toHaveBeenCalledWith('user-123');
+    expect(result).toEqual({ twoFactorEnabled: true });
+  });
+
+  it('does not change the update when email MFA is not enabled', async () => {
+    const findUserById = jest.fn().mockResolvedValue({
+      id: 'user-123',
+      mfa_email_enabled: false,
+    });
+
+    const result = await resolveTwoFactorDisableUserUpdate(
+      { twoFactorEnabled: false },
+      {
+        path: '/two-factor/disable',
+        context: {
+          session: {
+            user: { id: 'user-123' },
+          },
+        },
+      },
+      findUserById
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('ignores unrelated user updates', async () => {
+    const findUserById = jest.fn();
+
+    const result = await resolveTwoFactorDisableUserUpdate(
+      { twoFactorEnabled: false },
+      {
+        path: '/update-user',
+        context: {
+          session: {
+            user: { id: 'user-123' },
+          },
+        },
+      },
+      findUserById
+    );
+
+    expect(findUserById).not.toHaveBeenCalled();
+    expect(result).toBeNull();
+  });
+});

--- a/SparkyFitnessServer/utils/twoFactorState.js
+++ b/SparkyFitnessServer/utils/twoFactorState.js
@@ -1,0 +1,51 @@
+function getRequestPath(ctx) {
+  if (typeof ctx?.path === 'string' && ctx.path.length > 0) {
+    return ctx.path;
+  }
+
+  const requestUrl = ctx?.request?.url;
+  if (typeof requestUrl !== 'string' || requestUrl.length === 0) {
+    return '';
+  }
+
+  try {
+    return new URL(requestUrl).pathname;
+  } catch {
+    return '';
+  }
+}
+
+function getSessionUserId(ctx) {
+  return (
+    ctx?.context?.session?.user?.id ||
+    ctx?.context?.session?.session?.userId ||
+    null
+  );
+}
+
+async function resolveTwoFactorDisableUserUpdate(data, ctx, findUserById) {
+  if (data?.twoFactorEnabled !== false) {
+    return null;
+  }
+
+  const requestPath = getRequestPath(ctx);
+  if (!requestPath.includes('/two-factor/disable')) {
+    return null;
+  }
+
+  const userId = getSessionUserId(ctx);
+  if (!userId) {
+    return null;
+  }
+
+  const user = await findUserById(userId);
+  if (!user?.mfa_email_enabled) {
+    return null;
+  }
+
+  return { twoFactorEnabled: true };
+}
+
+module.exports = {
+  resolveTwoFactorDisableUserUpdate,
+};


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!

## Description

This fixes a bug I just introduced that will arise when the user has both email and totp MFA enabled. It keeps the MFA states in sync with better auth hooks.

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: #

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [x] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before

[Insert screenshot/GIF here]

### After

[Insert screenshot/GIF here]
