### PR TITLE
fix: convert Fitbit height from inches to cm when heightUnit is en_US, do not convert raw_data weight.

### DIFF
--- a/SparkyFitnessServer/integrations/fitbit/fitbitDataProcessor.js
+++ b/SparkyFitnessServer/integrations/fitbit/fitbitDataProcessor.js
@@ -60,7 +60,7 @@ async function processFitbitProfile(
   
   if (heightUnit === "en_US") {
       height = parseFloat((height * IN_TO_CM).toFixed(2));
-
+  }
   const syncDate = date || todayInZone(timezone);
   await measurementRepository.upsertCheckInMeasurements(
     userId,


### PR DESCRIPTION


> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!

## Description

I've found that when syncing with fitbit, my height comes down in inches, not cm, and that the weight raw_data is already in kg. This means that the conversion is problematic and incorrect.

The changes I made:

1. convert the height to cm if the height unit is 'en_US'
2. remove the conversion on the weight entries since they appear to come from the raw weight data.

Because this is happening on entry, it is not simply a display issue, but is causing issues with all calculations.

There was a comment in the height section of the code:
```
// Fitbit Profile API height is typically returned in Centimeters by default.  
// We will treat it as CM to avoid double-conversion issues.
```

I do not know if my data is different than what was originally coded against. My understanding of the fit bit api is that it should send the data out in the units set by the fit bit account preferences.

What I found, however, is that it is sending it out the same regardless of that setting:

```
./fitbit_raw_metric.json:          "height": 66.92913385826772,
./fitbit_raw_metric.json:          "heightUnit": "METRIC",
./fitbit_raw_metric.json:          "weight": 220.9,
./fitbit_raw_metric.json:          "weightUnit": "METRIC"
./fitbit_raw_metric.json:    "raw_weight": {
./fitbit_raw_metric.json:        "weight": [
./fitbit_raw_metric.json:            "weight": 99.2
./fitbit_raw_metric.json:            "weight": 100.2
./fitbit_raw_enus.json:          "height": 66.92913385826772,
./fitbit_raw_enus.json:          "heightUnit": "en_US",
./fitbit_raw_enus.json:          "weight": 220.9,
./fitbit_raw_enus.json:          "weightUnit": "en_US"
./fitbit_raw_enus.json:    "raw_weight": {
./fitbit_raw_enus.json:        "weight": [
./fitbit_raw_enus.json:            "weight": 99.2
./fitbit_raw_enus.json:            "weight": 100.2
```
so I'm not entirely sure if this will break for others or even how to code against that. 

## Related Issue

PR type [x ] Issue [ ] New Feature [ ] Documentation
Linked Issue: discord chat with CodeWithCJ

## Checklist

Please check all that apply:

- [ ?] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- -chatted CodeWithCJ and mentioned possibly doing a PR but didn't hear back.
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x ] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x ] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before

<img width="1627" height="410" alt="image" src="https://github.com/user-attachments/assets/c21b0c3d-0270-4165-b9ba-f47255cc1b35" />

### After

<img width="1641" height="386" alt="image" src="https://github.com/user-attachments/assets/249bac1a-d263-4ced-92c9-8164993d2549" />

