### PR TITLE
fix(helm): make frontend Service type/port/annotations configurable via values

### DIFF
--- a/helm/chart/templates/frontend/service.yaml
+++ b/helm/chart/templates/frontend/service.yaml
@@ -5,10 +5,14 @@ metadata:
   labels:
     {{- include "sparkyfitness.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
+  {{- if .Values.frontend.service.annotations }}
+  annotations:
+    {{- toYaml .Values.frontend.service.annotations | nindent 4 }}
+  {{- end }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.frontend.service.type | default "ClusterIP" }}
   ports:
-    - port: {{ .Values.frontend.port }}
+    - port: {{ .Values.frontend.service.port | default .Values.frontend.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -263,6 +263,9 @@ frontend:
     capabilities:
       drop: [ALL]
       add: [CHOWN, NET_BIND_SERVICE, SETGID, SETUID]
+  service:
+    type: ClusterIP
+    annotations: {}
   # -- Extra environment variables injected into the frontend container (key: value)
   extraEnv: {}
   # -- Extra envFrom sources (configMapRef, secretRef) for the frontend container


### PR DESCRIPTION
## Description

This changes the default hardcoded deployment of the frontend service type from a ClusterIP to configurable value (ClusterIP still being the default). This also allows to configure the annotations via the values.

## Related Issue

PR type [ ] Issue [x] New Feature [ ] Documentation

Linked Issue: None, this is something I noticed when installing it, the fix is relatively straightforward so I just went ahead with submitting a fix.

## Checklist

Please check all that apply:

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).
