### PR TITLE
fix(1046): meal goals missing from diary

### DIFF
--- a/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
+++ b/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
@@ -537,8 +537,10 @@ export const getMealData = (
       : [];
 
   const combinedEntries: (FoodEntry | FoodEntryMeal)[] = [...entries, ...meals];
+  const mealKey = mealType.toLowerCase();
+  const percentageKey = `${mealKey}_percentage` as keyof Goals;
 
-  const percentage = goals?.meal_percentages?.[mealType.toLowerCase()] ?? 0;
+  const percentage = (goals?.[percentageKey] as number) ?? 0;
 
   let displayName = mealType;
   if (mealType.toLowerCase() === 'breakfast')


### PR DESCRIPTION
## Description

The code tried to access a nested object which doesn't exist anymore. This lead to missing display of goal calories per meal

## Related Issue

PR type [ ] Issue [ ] New Feature [ ] Documentation
Linked Issue: #

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).
