### PR TITLE
fix(1047): zod validation error for exercise details

### DIFF
--- a/SparkyFitnessFrontend/src/api/Exercises/exerciseEntryService.ts
+++ b/SparkyFitnessFrontend/src/api/Exercises/exerciseEntryService.ts
@@ -209,7 +209,27 @@ export const fetchExerciseDetails = async (
   const response = await apiCall(`/exercises/${exerciseId}`, {
     method: 'GET',
   });
-  return exerciseSnapshotResponseSchema.parse(response);
+
+  const parsedResponse = { ...response };
+  const arrayFields = [
+    'images',
+    'primary_muscles',
+    'secondary_muscles',
+    'equipment',
+    'instructions',
+  ];
+
+  arrayFields.forEach((field) => {
+    if (typeof parsedResponse[field] === 'string') {
+      try {
+        parsedResponse[field] = JSON.parse(parsedResponse[field]);
+      } catch {
+        parsedResponse[field] = [];
+      }
+    }
+  });
+
+  return exerciseSnapshotResponseSchema.parse(parsedResponse);
 };
 
 export const getActivityDetails = async (


### PR DESCRIPTION
## Description

Updating an exercise lead to a zod error because the backend returns array inside strings like equipment: "[a,b,c] instead of just a normal array. Because the route will be rewritten anyway I decided to adjust the parsing to accept the current response.

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: #1047 

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).