### PR TITLE
fix(1065): converting units onChange leads to weird behavior

### DIFF
--- a/SparkyFitnessFrontend/src/components/ui/UnitInput.tsx
+++ b/SparkyFitnessFrontend/src/components/ui/UnitInput.tsx
@@ -89,7 +89,9 @@ export const UnitInput: React.FC<UnitInputProps> = ({
     let converted = num;
     if (unit === 'lbs') converted = lbsToKg(num);
     if (unit === 'inches') converted = inchesToCm(num);
-    onChange(converted);
+    if (converted !== metricValue) {
+      onChange(converted);
+    }
   };
 
   const handleSplitChange = (v1: string, v2: string) => {
@@ -103,7 +105,9 @@ export const UnitInput: React.FC<UnitInputProps> = ({
     let converted = 0;
     if (unit === 'st_lbs') converted = stonesLbsToKg(n1, n2);
     else if (unit === 'ft_in') converted = feetInchesToCm(n1, n2);
-    onChange(converted);
+    if (converted !== metricValue) {
+      onChange(converted);
+    }
   };
 
   // Render two inputs for st_lbs or ft_in


### PR DESCRIPTION
## Description

The checkin inputs converted the input from inches to feet + inches on every keystroke. This lead to numbers disappearing and weird behavior. Now the conversion only happens when you leave the fields, which is what is expected from a user.

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: #1065

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [ ] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).