### PR TITLE
App Health Connect Sleep Stage Fix, Exercise Entry Distance

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/healthDataApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthDataApi.test.ts
@@ -645,6 +645,54 @@ describe('healthDataApi', () => {
         expect(body).toHaveLength(CHUNK_SIZE + 500);
       });
 
+      test('preserves staged sleep session payloads inside session chunks', async () => {
+        mockGetActiveServerConfig.mockResolvedValue(testConfig);
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ success: true }),
+        });
+
+        const stageEvents = [
+          {
+            stage_type: 'deep',
+            start_time: '2024-01-15T22:00:00.000Z',
+            end_time: '2024-01-15T23:00:00.000Z',
+            duration_in_seconds: 3600,
+          },
+          {
+            stage_type: 'awake',
+            start_time: '2024-01-15T23:00:00.000Z',
+            end_time: '2024-01-15T23:15:00.000Z',
+            duration_in_seconds: 900,
+          },
+        ];
+        const data = [
+          {
+            type: 'SleepSession',
+            source: 'Health Connect',
+            timestamp: '2024-01-15T22:00:00.000Z',
+            entry_date: '2024-01-15',
+            bedtime: '2024-01-15T22:00:00.000Z',
+            wake_time: '2024-01-16T06:00:00.000Z',
+            duration_in_seconds: 28800,
+            time_asleep_in_seconds: 27900,
+            deep_sleep_seconds: 3600,
+            light_sleep_seconds: 22500,
+            rem_sleep_seconds: 1800,
+            awake_sleep_seconds: 900,
+            stage_events: stageEvents,
+          },
+        ] as HealthDataPayload;
+
+        await syncHealthData(data);
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+        expect(body[0].type).toBe('SleepSession');
+        expect(body[0].source).toBe('Health Connect');
+        expect(body[0].stage_events).toEqual(stageEvents);
+      });
+
       test('reports partial success when a chunk fails', async () => {
         mockGetActiveServerConfig.mockResolvedValue(testConfig);
 

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/dataTransformation.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/dataTransformation.test.ts
@@ -274,6 +274,164 @@ describe('transformHealthRecords', () => {
 
       expect(result).toHaveLength(0);
     });
+
+    test('processes sleep stages into duration breakdowns', () => {
+      const records = [
+        {
+          startTime: '2024-01-15T22:00:00Z',
+          endTime: '2024-01-16T06:00:00Z',
+          stages: [
+            { startTime: '2024-01-15T22:00:00Z', endTime: '2024-01-15T22:30:00Z', stage: 4 },  // LIGHT - 30min
+            { startTime: '2024-01-15T22:30:00Z', endTime: '2024-01-15T23:30:00Z', stage: 5 },  // DEEP - 60min
+            { startTime: '2024-01-15T23:30:00Z', endTime: '2024-01-16T00:00:00Z', stage: 6 },  // REM - 30min
+            { startTime: '2024-01-16T00:00:00Z', endTime: '2024-01-16T00:15:00Z', stage: 1 },  // AWAKE - 15min
+            { startTime: '2024-01-16T00:15:00Z', endTime: '2024-01-16T06:00:00Z', stage: 4 },  // LIGHT - 5h45m
+          ],
+        },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'SleepSession', unit: '', type: 'sleep' }) as AggregatedSleepSession[];
+
+      expect(result).toHaveLength(1);
+      expect(result[0].stage_events).toEqual([
+        {
+          stage_type: 'light',
+          start_time: '2024-01-15T22:00:00.000Z',
+          end_time: '2024-01-15T22:30:00.000Z',
+          duration_in_seconds: 1800,
+        },
+        {
+          stage_type: 'deep',
+          start_time: '2024-01-15T22:30:00.000Z',
+          end_time: '2024-01-15T23:30:00.000Z',
+          duration_in_seconds: 3600,
+        },
+        {
+          stage_type: 'rem',
+          start_time: '2024-01-15T23:30:00.000Z',
+          end_time: '2024-01-16T00:00:00.000Z',
+          duration_in_seconds: 1800,
+        },
+        {
+          stage_type: 'awake',
+          start_time: '2024-01-16T00:00:00.000Z',
+          end_time: '2024-01-16T00:15:00.000Z',
+          duration_in_seconds: 900,
+        },
+        {
+          stage_type: 'light',
+          start_time: '2024-01-16T00:15:00.000Z',
+          end_time: '2024-01-16T06:00:00.000Z',
+          duration_in_seconds: 20700,
+        },
+      ]);
+      expect(result[0].deep_sleep_seconds).toBe(3600);     // 60min
+      expect(result[0].light_sleep_seconds).toBe(22500);   // 30min + 5h45m
+      expect(result[0].rem_sleep_seconds).toBe(1800);      // 30min
+      expect(result[0].awake_sleep_seconds).toBe(900);     // 15min
+      expect(result[0].time_asleep_in_seconds).toBe(27900); // total minus awake
+      expect(result[0].duration_in_seconds).toBe(28800);    // full 8 hours
+    });
+
+    test('maps generic sleeping and out-of-bed stages into duration totals', () => {
+      const records = [
+        {
+          startTime: '2024-01-15T22:00:00Z',
+          endTime: '2024-01-16T01:00:00Z',
+          stages: [
+            { startTime: '2024-01-15T22:00:00Z', endTime: '2024-01-15T23:00:00Z', stage: 1 },  // AWAKE
+            { startTime: '2024-01-15T23:00:00Z', endTime: '2024-01-16T00:00:00Z', stage: 2 },  // SLEEPING (generic)
+            { startTime: '2024-01-16T00:00:00Z', endTime: '2024-01-16T01:00:00Z', stage: 3 },  // OUT_OF_BED
+          ],
+        },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'SleepSession', unit: '', type: 'sleep' }) as AggregatedSleepSession[];
+
+      expect(result[0].stage_events).toEqual([
+        {
+          stage_type: 'awake',
+          start_time: '2024-01-15T22:00:00.000Z',
+          end_time: '2024-01-15T23:00:00.000Z',
+          duration_in_seconds: 3600,
+        },
+        {
+          stage_type: 'light',
+          start_time: '2024-01-15T23:00:00.000Z',
+          end_time: '2024-01-16T00:00:00.000Z',
+          duration_in_seconds: 3600,
+        },
+        {
+          stage_type: 'awake',
+          start_time: '2024-01-16T00:00:00.000Z',
+          end_time: '2024-01-16T01:00:00.000Z',
+          duration_in_seconds: 3600,
+        },
+      ]);
+      expect(result[0].light_sleep_seconds).toBe(3600); // SLEEPING → light
+      expect(result[0].awake_sleep_seconds).toBe(7200); // AWAKE + OUT_OF_BED
+      expect(result[0].time_asleep_in_seconds).toBe(3600);
+    });
+
+    test('falls back to full duration as light sleep when no stages present', () => {
+      const records = [
+        {
+          startTime: '2024-01-15T22:00:00Z',
+          endTime: '2024-01-16T06:00:00Z',
+        },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'SleepSession', unit: '', type: 'sleep' }) as AggregatedSleepSession[];
+
+      expect(result[0].stage_events).toHaveLength(0);
+      expect(result[0].light_sleep_seconds).toBe(28800);
+      expect(result[0].deep_sleep_seconds).toBe(0);
+      expect(result[0].rem_sleep_seconds).toBe(0);
+      expect(result[0].awake_sleep_seconds).toBe(0);
+      expect(result[0].time_asleep_in_seconds).toBe(28800);
+    });
+
+    test('skips stage entries with invalid timestamps', () => {
+      const records = [
+        {
+          startTime: '2024-01-15T22:00:00Z',
+          endTime: '2024-01-16T06:00:00Z',
+          stages: [
+            { startTime: '2024-01-15T22:00:00Z', endTime: '2024-01-15T23:00:00Z', stage: 5 },  // valid DEEP
+            { startTime: 'invalid', endTime: '2024-01-16T01:00:00Z', stage: 4 },                // invalid
+          ],
+        },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'SleepSession', unit: '', type: 'sleep' }) as AggregatedSleepSession[];
+
+      expect(result[0].stage_events).toEqual([
+        {
+          stage_type: 'deep',
+          start_time: '2024-01-15T22:00:00.000Z',
+          end_time: '2024-01-15T23:00:00.000Z',
+          duration_in_seconds: 3600,
+        },
+      ]);
+      expect(result[0].deep_sleep_seconds).toBe(3600);
+      expect(result[0].time_asleep_in_seconds).toBe(3600);
+    });
+
+    test('falls back to full duration when all stages are unknown', () => {
+      const records = [
+        {
+          startTime: '2024-01-15T22:00:00Z',
+          endTime: '2024-01-16T06:00:00Z',
+          stages: [
+            { startTime: '2024-01-15T22:00:00Z', endTime: '2024-01-16T06:00:00Z', stage: 0 },
+          ],
+        },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'SleepSession', unit: '', type: 'sleep' }) as AggregatedSleepSession[];
+
+      expect(result[0].stage_events).toHaveLength(0);
+      expect(result[0].light_sleep_seconds).toBe(28800);
+      expect(result[0].deep_sleep_seconds).toBe(0);
+      expect(result[0].rem_sleep_seconds).toBe(0);
+      expect(result[0].awake_sleep_seconds).toBe(0);
+      expect(result[0].time_asleep_in_seconds).toBe(28800);
+    });
   });
 
   describe('ExerciseSession records', () => {

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/dataTransformation.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/dataTransformation.test.ts
@@ -590,7 +590,7 @@ describe('transformHealthRecords', () => {
       expect(result[0].caloriesBurned).toBe(0);
     });
 
-    test('extracts distance from distance.inMeters', () => {
+    test('converts distance from distance.inMeters to kilometers', () => {
       const records = [
         {
           startTime: '2024-01-15T08:00:00Z',
@@ -602,7 +602,7 @@ describe('transformHealthRecords', () => {
       const result = transformHealthRecords(records, { recordType: 'ExerciseSession', unit: '', type: 'exercise' }) as TransformedExerciseSession[];
 
       expect(result).toHaveLength(1);
-      expect(result[0].distance).toBe(5000.75);
+      expect(result[0].distance).toBe(5);
     });
 
     test('defaults distance to 0 when distance is missing', () => {
@@ -656,14 +656,14 @@ describe('transformHealthRecords', () => {
           endTime: '2024-01-15T09:00:00Z',
           exerciseType: 8,
           energy: { inKilocalories: 350.5678 },
-          distance: { inMeters: 5000.1234 },
+          distance: { inMeters: 5234.1234 },
         },
       ];
       const result = transformHealthRecords(records, { recordType: 'ExerciseSession', unit: '', type: 'exercise' }) as TransformedExerciseSession[];
 
       expect(result).toHaveLength(1);
       expect(result[0].caloriesBurned).toBe(350.57);
-      expect(result[0].distance).toBe(5000.12);
+      expect(result[0].distance).toBe(5.23);
     });
 
     test('extracts both caloriesBurned and distance from complete wearable record', () => {
@@ -687,7 +687,7 @@ describe('transformHealthRecords', () => {
         title: 'Morning Run',
         duration: 3600,
         caloriesBurned: 450,
-        distance: 7500,
+        distance: 7.5,
         notes: 'Great pace today',
       });
     });
@@ -722,7 +722,7 @@ describe('transformHealthRecords', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].caloriesBurned).toBe(-50);
-      expect(result[0].distance).toBe(-100);
+      expect(result[0].distance).toBe(-0.1);
     });
 
     test('includes sets array with duration in minutes', () => {

--- a/SparkyFitnessMobile/__tests__/services/healthkit/dataTransformation.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthkit/dataTransformation.test.ts
@@ -341,7 +341,7 @@ describe('transformHealthRecords', () => {
       expect((result[0] as TransformedExerciseSession).duration).toBe(1800);
     });
 
-    test('extracts calories and distance from record', () => {
+    test('extracts calories and converts distance to kilometers from record', () => {
       const records = [
         {
           startTime: '2024-01-15T08:00:00Z',
@@ -356,7 +356,7 @@ describe('transformHealthRecords', () => {
 
       const exerciseResult = result[0] as TransformedExerciseSession;
       expect(exerciseResult.caloriesBurned).toBe(500);
-      expect(exerciseResult.distance).toBe(5000);
+      expect(exerciseResult.distance).toBe(5);
       expect(exerciseResult.type).toBe('ExerciseSession');
       expect(exerciseResult.source).toBe('HealthKit');
     });

--- a/SparkyFitnessMobile/src/services/api/healthDataApi.ts
+++ b/SparkyFitnessMobile/src/services/api/healthDataApi.ts
@@ -3,15 +3,45 @@ import { addLog } from '../LogService';
 import { normalizeUrl } from './apiClient';
 import { getAuthHeaders, notifySessionExpired } from './authService';
 import { ensureTimezoneBootstrapped } from './preferencesApi';
+import type { SleepStageEvent } from '../../types/mobileHealthData';
 
-export interface HealthDataPayloadItem {
+interface BaseHealthDataPayloadItem {
   type: string;
-  date: string;  // YYYY-MM-DD format
-  value: number;
+  source?: string;
+  timestamp?: string;
+  date?: string;
+  entry_date?: string;
+  value?: number;
   /** IANA timezone when available (best source for HealthKit) */
   record_timezone?: string | null;
   /** Fixed UTC offset in minutes (best fallback for Health Connect) */
   record_utc_offset_minutes?: number | null;
+}
+
+export interface HealthDataPayloadItem extends BaseHealthDataPayloadItem {
+  bedtime?: string;
+  wake_time?: string;
+  duration_in_seconds?: number;
+  time_asleep_in_seconds?: number;
+  sleep_score?: number;
+  deep_sleep_seconds?: number;
+  light_sleep_seconds?: number;
+  rem_sleep_seconds?: number;
+  awake_sleep_seconds?: number;
+  stage_events?: SleepStageEvent[];
+  activityType?: string;
+  title?: string;
+  startTime?: string;
+  endTime?: string;
+  duration?: number;
+  caloriesBurned?: number;
+  distance?: number;
+  notes?: string;
+  raw_data?: unknown;
+  sets?: unknown[];
+  source_id?: string;
+  unit?: string;
+  [key: string]: unknown;
 }
 
 export type HealthDataPayload = HealthDataPayloadItem[];

--- a/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
@@ -6,6 +6,7 @@ import {
   TransformedExerciseSession,
   AggregatedSleepSession,
   RecordTimezoneMetadata,
+  SleepStageType,
   HEALTH_CONNECT_SOURCE,
 } from '../../types/healthRecords';
 import { toLocalDateString } from '../../utils/dateUtils';
@@ -462,6 +463,25 @@ const EXERCISE_MAP: Record<number, string> = {
   83: 'Yoga',
 } as const;
 
+// Health Connect SleepStageType constants from react-native-health-connect.
+// We skip UNKNOWN values so they do not distort asleep-time totals downstream.
+const mapHealthConnectSleepStage = (stage: number): SleepStageType | null => {
+  switch (stage) {
+    case 1: return 'awake';
+    case 2: return 'light';   // SLEEPING (generic) → light
+    case 3: return 'awake';   // OUT_OF_BED → awake
+    case 4: return 'light';
+    case 5: return 'deep';
+    case 6: return 'rem';
+    case 0:
+      addLog('[HealthConnect] Skipping UNKNOWN sleep stage value', 'WARNING');
+      return null;
+    default:
+      addLog(`[HealthConnect] Skipping unsupported sleep stage value: ${stage}`, 'WARNING');
+      return null;
+  }
+};
+
 const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
   HeartRate: (rec, _record, metricConfig, output) => {
     const samples = rec.samples as { beatsPerMinute: number }[] | undefined;
@@ -518,6 +538,48 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
     const durationInSeconds = (end - start) / 1000;
     const recordDate = toLocalDateString(rec.endTime as string);
 
+    const stages = rec.stages as { startTime: string; endTime: string; stage: number }[] | undefined;
+
+    let deepSeconds = 0;
+    let lightSeconds = 0;
+    let remSeconds = 0;
+    let awakeSeconds = 0;
+    let hasRecognizedStages = false;
+    const stageEvents: AggregatedSleepSession['stage_events'] = [];
+
+    if (stages && stages.length > 0) {
+      for (const stage of stages) {
+        const stageStart = new Date(stage.startTime).getTime();
+        const stageEnd = new Date(stage.endTime).getTime();
+        if (isNaN(stageStart) || isNaN(stageEnd)) continue;
+
+        const stageDuration = (stageEnd - stageStart) / 1000;
+        if (stageDuration <= 0) continue;
+
+        const stageType = mapHealthConnectSleepStage(stage.stage);
+        if (!stageType) continue;
+
+        hasRecognizedStages = true;
+        stageEvents.push({
+          stage_type: stageType,
+          start_time: new Date(stageStart).toISOString(),
+          end_time: new Date(stageEnd).toISOString(),
+          duration_in_seconds: stageDuration,
+        });
+
+        switch (stageType) {
+          case 'deep': deepSeconds += stageDuration; break;
+          case 'light': lightSeconds += stageDuration; break;
+          case 'rem': remSeconds += stageDuration; break;
+          case 'awake': awakeSeconds += stageDuration; break;
+        }
+      }
+    }
+
+    const timeAsleep = hasRecognizedStages
+      ? deepSeconds + lightSeconds + remSeconds
+      : durationInSeconds;
+
     const sleepSession: AggregatedSleepSession = {
       type: 'SleepSession',
       source: HEALTH_CONNECT_SOURCE,
@@ -526,13 +588,13 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
       bedtime: rec.startTime as string,
       wake_time: rec.endTime as string,
       duration_in_seconds: durationInSeconds,
-      time_asleep_in_seconds: durationInSeconds,
-      stage_events: [],
+      time_asleep_in_seconds: timeAsleep,
+      stage_events: stageEvents,
       sleep_score: 0,
-      deep_sleep_seconds: 0,
-      light_sleep_seconds: durationInSeconds,
-      rem_sleep_seconds: 0,
-      awake_sleep_seconds: 0,
+      deep_sleep_seconds: deepSeconds,
+      light_sleep_seconds: hasRecognizedStages ? lightSeconds : durationInSeconds,
+      rem_sleep_seconds: remSeconds,
+      awake_sleep_seconds: awakeSeconds,
       ...extractTimezoneMetadata(rec, true),
     };
     output.push(sleepSession);

--- a/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
@@ -624,11 +624,12 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
       caloriesBurned = energy.inCalories / 1000;
     }
 
-    // Extract distance
-    let distance = 0;
+    // Exercise entries store distance in kilometers, but Health Connect
+    // returns aggregate session distance in meters.
+    let distanceKm = 0;
     const distanceObj = rec.distance as Record<string, number> | undefined;
     if (distanceObj?.inMeters != null && !isNaN(distanceObj.inMeters)) {
-      distance = distanceObj.inMeters;
+      distanceKm = distanceObj.inMeters / 1000;
     }
 
     const metadata = rec.metadata as { id?: string } | undefined;
@@ -645,7 +646,7 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
       activityType: activityTypeName,
       title: title,
       caloriesBurned: parseFloat(caloriesBurned.toFixed(2)),
-      distance: parseFloat(distance.toFixed(2)),
+      distance: parseFloat(distanceKm.toFixed(2)),
       notes: rec.notes as string | undefined,
       raw_data: record,
       sets: [{ set_number: 1, set_type: 'Working Set', duration: Math.round(durationInSeconds / 60) }],

--- a/SparkyFitnessMobile/src/services/healthkit/dataTransformation.ts
+++ b/SparkyFitnessMobile/src/services/healthkit/dataTransformation.ts
@@ -357,6 +357,7 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
     const timezone: RecordTimezoneMetadata = Object.keys(tzMeta).length > 0
       ? tzMeta
       : { record_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone };
+    const totalDistanceMeters = typeof rec.totalDistance === 'number' ? rec.totalDistance : 0;
 
     const exerciseSession: TransformedExerciseSession = {
       type: 'ExerciseSession',
@@ -370,7 +371,7 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
       activityType: activityTypeName,
       title: activityTypeName,
       caloriesBurned: rec.totalEnergyBurned as number || 0,
-      distance: rec.totalDistance as number || 0,
+      distance: parseFloat((totalDistanceMeters / 1000).toFixed(2)),
       notes: 'Source: HealthKit',
       raw_data: record,
       sets: [{ set_number: 1, set_type: 'Working Set', duration: Math.round(durationInSeconds / 60) }],

--- a/SparkyFitnessMobile/src/types/healthRecords.ts
+++ b/SparkyFitnessMobile/src/types/healthRecords.ts
@@ -151,6 +151,7 @@ export interface TransformedExerciseSession extends RecordTimezoneMetadata {
   activityType: string;
   title: string;
   caloriesBurned?: number;
+  /** Stored in kilometers to match exercise entry API/storage. */
   distance?: number;
   notes?: string;
   raw_data?: unknown;

--- a/SparkyFitnessServer/services/measurementService.js
+++ b/SparkyFitnessServer/services/measurementService.js
@@ -268,6 +268,67 @@ function resolveHealthEntryDate(entry, fallbackTimezone) {
   };
 }
 
+const HEALTH_CONNECT_SLEEP_SOURCES = new Set([
+  'Health Connect',
+  'HealthConnect',
+]);
+const VALID_SLEEP_STAGE_TYPES = new Set([
+  'awake',
+  'rem',
+  'light',
+  'deep',
+  'in_bed',
+  'unknown',
+]);
+
+function isHealthConnectSleepSource(source) {
+  return typeof source === 'string' && HEALTH_CONNECT_SLEEP_SOURCES.has(source);
+}
+
+function sanitizeHealthConnectSleepStageEvents(stageEvents) {
+  if (!Array.isArray(stageEvents)) {
+    return [];
+  }
+
+  return stageEvents.reduce((sanitized, stageEvent) => {
+    if (!stageEvent || typeof stageEvent !== 'object') {
+      return sanitized;
+    }
+
+    const stageType =
+      typeof stageEvent.stage_type === 'string'
+        ? stageEvent.stage_type.toLowerCase()
+        : null;
+    if (!stageType || !VALID_SLEEP_STAGE_TYPES.has(stageType)) {
+      return sanitized;
+    }
+
+    const startTime = new Date(stageEvent.start_time);
+    const endTime = new Date(stageEvent.end_time);
+    if (isNaN(startTime.getTime()) || isNaN(endTime.getTime())) {
+      return sanitized;
+    }
+
+    let durationInSeconds = Number(stageEvent.duration_in_seconds);
+    if (!Number.isFinite(durationInSeconds) || durationInSeconds <= 0) {
+      durationInSeconds = (endTime.getTime() - startTime.getTime()) / 1000;
+    }
+    durationInSeconds = Math.round(durationInSeconds);
+
+    if (durationInSeconds <= 0) {
+      return sanitized;
+    }
+
+    sanitized.push({
+      stage_type: stageType,
+      start_time: startTime.toISOString(),
+      end_time: endTime.toISOString(),
+      duration_in_seconds: durationInSeconds,
+    });
+    return sanitized;
+  }, []);
+}
+
 async function processHealthData(healthDataArray, userId, actingUserId) {
   const tz = await loadUserTimezone(userId);
   const processedResults = [];
@@ -491,6 +552,10 @@ async function processHealthData(healthDataArray, userId, actingUserId) {
           break;
         case 'SleepSession':
           try {
+            const stageEvents = isHealthConnectSleepSource(source)
+              ? sanitizeHealthConnectSleepStageEvents(dataEntry.stage_events)
+              : dataEntry.stage_events || [];
+
             // Map the dataEntry fields to what processSleepEntry expects
             const sleepEntryData = {
               entry_date: parsedDate,
@@ -510,7 +575,7 @@ async function processHealthData(healthDataArray, userId, actingUserId) {
                 Number(dataEntry.time_asleep_in_seconds) || 0,
               sleep_score: Number(dataEntry.sleep_score) || 0,
               source: source,
-              stage_events: dataEntry.stage_events || [],
+              stage_events: stageEvents,
               deep_sleep_seconds: Number(dataEntry.deep_sleep_seconds) || 0,
               light_sleep_seconds: Number(dataEntry.light_sleep_seconds) || 0,
               rem_sleep_seconds: Number(dataEntry.rem_sleep_seconds) || 0,

--- a/SparkyFitnessServer/tests/measurementService.healthConnectSleepStages.test.js
+++ b/SparkyFitnessServer/tests/measurementService.healthConnectSleepStages.test.js
@@ -1,0 +1,230 @@
+jest.mock('../models/measurementRepository');
+jest.mock('../models/userRepository');
+jest.mock('../models/exerciseRepository');
+jest.mock('../models/exerciseEntry');
+jest.mock('../models/sleepRepository');
+jest.mock('../models/waterContainerRepository');
+jest.mock('../models/activityDetailsRepository');
+jest.mock('../utils/timezoneLoader', () => ({
+  loadUserTimezone: jest.fn(),
+}));
+jest.mock('../config/logging', () => ({
+  log: jest.fn(),
+}));
+
+const measurementService = require('../services/measurementService');
+const sleepRepository = require('../models/sleepRepository');
+const userRepository = require('../models/userRepository');
+const exerciseEntryDb = require('../models/exerciseEntry');
+const { loadUserTimezone } = require('../utils/timezoneLoader');
+
+describe('processHealthData Health Connect sleep stages', () => {
+  const userId = 'user-hc-sleep';
+  const actingUserId = 'user-hc-sleep';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    loadUserTimezone.mockResolvedValue('UTC');
+    userRepository.getUserProfile = jest.fn().mockResolvedValue(null);
+    sleepRepository.deleteSleepEntriesByEntrySourceAndDate = jest
+      .fn()
+      .mockResolvedValue(undefined);
+    sleepRepository.upsertSleepEntry = jest
+      .fn()
+      .mockResolvedValue({ id: 'sleep-entry-1' });
+    sleepRepository.upsertSleepStageEvent = jest
+      .fn()
+      .mockResolvedValue({ id: 'sleep-stage-1' });
+    exerciseEntryDb.deleteExerciseEntriesByEntrySourceAndDate = jest
+      .fn()
+      .mockResolvedValue(undefined);
+  });
+
+  it('sanitizes staged Health Connect sleep events before generic sleep processing', async () => {
+    const healthData = [
+      {
+        type: 'SleepSession',
+        source: 'Health Connect',
+        timestamp: '2024-01-15T22:00:00Z',
+        bedtime: '2024-01-15T22:00:00Z',
+        wake_time: '2024-01-16T06:00:00Z',
+        duration_in_seconds: 28800,
+        time_asleep_in_seconds: 1,
+        sleep_score: 0,
+        deep_sleep_seconds: 3600,
+        light_sleep_seconds: 22500,
+        rem_sleep_seconds: 1800,
+        awake_sleep_seconds: 900,
+        record_utc_offset_minutes: -300,
+        stage_events: [
+          {
+            stage_type: 'light',
+            start_time: '2024-01-15T22:00:00Z',
+            end_time: '2024-01-15T22:30:00Z',
+            duration_in_seconds: 1800,
+          },
+          {
+            stage_type: 'deep',
+            start_time: '2024-01-15T22:30:00Z',
+            end_time: '2024-01-15T23:30:00Z',
+            duration_in_seconds: 3600,
+          },
+          {
+            stage_type: 'unsupported',
+            start_time: '2024-01-15T23:30:00Z',
+            end_time: '2024-01-16T00:00:00Z',
+            duration_in_seconds: 1800,
+          },
+          {
+            stage_type: 'rem',
+            start_time: '2024-01-15T23:30:00Z',
+            end_time: '2024-01-16T00:00:00Z',
+            duration_in_seconds: 1800,
+          },
+          {
+            stage_type: 'awake',
+            start_time: '2024-01-16T00:00:00Z',
+            end_time: '2024-01-16T00:15:00Z',
+            duration_in_seconds: 900,
+          },
+          {
+            stage_type: 'light',
+            start_time: '2024-01-16T00:15:00Z',
+            end_time: '2024-01-16T06:00:00Z',
+            duration_in_seconds: 20700,
+          },
+          {
+            stage_type: 'light',
+            start_time: 'invalid',
+            end_time: '2024-01-16T06:30:00Z',
+            duration_in_seconds: 1800,
+          },
+        ],
+      },
+    ];
+
+    await measurementService.processHealthData(
+      healthData,
+      userId,
+      actingUserId
+    );
+
+    expect(
+      sleepRepository.deleteSleepEntriesByEntrySourceAndDate
+    ).toHaveBeenCalledWith(
+      userId,
+      'Health Connect',
+      '2024-01-16',
+      '2024-01-16'
+    );
+    expect(
+      exerciseEntryDb.deleteExerciseEntriesByEntrySourceAndDate
+    ).toHaveBeenCalledWith(
+      userId,
+      '2024-01-16',
+      '2024-01-16',
+      'Health Connect'
+    );
+    expect(sleepRepository.upsertSleepEntry).toHaveBeenCalledWith(
+      userId,
+      actingUserId,
+      expect.objectContaining({
+        entry_date: '2024-01-16',
+        source: 'Health Connect',
+        time_asleep_in_seconds: 27900,
+        deep_sleep_seconds: 3600,
+        light_sleep_seconds: 22500,
+        rem_sleep_seconds: 1800,
+        awake_sleep_seconds: 900,
+      })
+    );
+    expect(
+      sleepRepository.upsertSleepStageEvent.mock.calls.map((call) => call[2])
+    ).toEqual([
+      {
+        stage_type: 'light',
+        start_time: '2024-01-15T22:00:00.000Z',
+        end_time: '2024-01-15T22:30:00.000Z',
+        duration_in_seconds: 1800,
+      },
+      {
+        stage_type: 'deep',
+        start_time: '2024-01-15T22:30:00.000Z',
+        end_time: '2024-01-15T23:30:00.000Z',
+        duration_in_seconds: 3600,
+      },
+      {
+        stage_type: 'rem',
+        start_time: '2024-01-15T23:30:00.000Z',
+        end_time: '2024-01-16T00:00:00.000Z',
+        duration_in_seconds: 1800,
+      },
+      {
+        stage_type: 'awake',
+        start_time: '2024-01-16T00:00:00.000Z',
+        end_time: '2024-01-16T00:15:00.000Z',
+        duration_in_seconds: 900,
+      },
+      {
+        stage_type: 'light',
+        start_time: '2024-01-16T00:15:00.000Z',
+        end_time: '2024-01-16T06:00:00.000Z',
+        duration_in_seconds: 20700,
+      },
+    ]);
+  });
+
+  it('accepts the legacy HealthConnect source spelling for staged sleep payloads', async () => {
+    const healthData = [
+      {
+        type: 'SleepSession',
+        source: 'HealthConnect',
+        timestamp: '2024-01-15T22:00:00Z',
+        bedtime: '2024-01-15T22:00:00Z',
+        wake_time: '2024-01-16T00:00:00Z',
+        duration_in_seconds: 7200,
+        time_asleep_in_seconds: 0,
+        deep_sleep_seconds: 3600,
+        light_sleep_seconds: 0,
+        rem_sleep_seconds: 0,
+        awake_sleep_seconds: 0,
+        stage_events: [
+          {
+            stage_type: 'deep',
+            start_time: '2024-01-15T22:00:00Z',
+            end_time: '2024-01-15T23:00:00Z',
+            duration_in_seconds: 3600,
+          },
+          {
+            stage_type: 'nope',
+            start_time: '2024-01-15T23:00:00Z',
+            end_time: '2024-01-16T00:00:00Z',
+            duration_in_seconds: 3600,
+          },
+        ],
+      },
+    ];
+
+    await measurementService.processHealthData(
+      healthData,
+      userId,
+      actingUserId
+    );
+
+    expect(sleepRepository.upsertSleepEntry).toHaveBeenCalledWith(
+      userId,
+      actingUserId,
+      expect.objectContaining({
+        source: 'HealthConnect',
+        time_asleep_in_seconds: 3600,
+      })
+    );
+    expect(sleepRepository.upsertSleepStageEvent).toHaveBeenCalledTimes(1);
+    expect(sleepRepository.upsertSleepStageEvent.mock.calls[0][2]).toEqual({
+      stage_type: 'deep',
+      start_time: '2024-01-15T22:00:00.000Z',
+      end_time: '2024-01-15T23:00:00.000Z',
+      duration_in_seconds: 3600,
+    });
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!

## Description

Fix for sleep stages not syncing correctly for Health Connect. 
Fixed mobile app using the wrong units for exercises, resulting in distance being off by 1000
These changes don't touch any other integration code.

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: #1034

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [x] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before

[Insert screenshot/GIF here]

### After

[Insert screenshot/GIF here]
