### PR TITLE
Fix Date Shift from UTC Conversion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ pnpm test
 ### Date, Day Strings, and Timezones
 
 - Prefer the shared helpers in `shared/src/utils/timezone.ts`, exported through `@workspace/shared`, for day-string and timezone-aware date logic.
-- Use `isDayString`, `addDays`, `compareDays`, `dayToPickerDate`, and `pickerDateToDay` for `YYYY-MM-DD` calendar-day strings.
+- Use `isDayString`, `addDays`, `compareDays`, `dayToPickerDate`, and `localDateToDay` for `YYYY-MM-DD` calendar-day strings.
 - Use `todayInZone`, `instantToDay`, `instantHourMinute`, `dayToUtcRange`, and `dayRangeToUtcRange` when a user's timezone matters.
 - On the server, load the user's timezone with `SparkyFitnessServer/utils/timezoneLoader.js` before deriving "today", bucketing timestamps by day, or building day-based query ranges.
 - Avoid ad hoc UTC date extraction such as `toISOString().split('T')[0]` for user-facing or business-logic dates. That pattern silently shifts dates near timezone boundaries and is not a substitute for timezone-aware day handling.

--- a/SparkyFitnessMobile/CLAUDE.md
+++ b/SparkyFitnessMobile/CLAUDE.md
@@ -126,7 +126,7 @@ Monorepo package at `../shared/` providing Zod schemas, TypeScript types, consta
 - **Exercise/workout types**: `ExerciseSessionResponse` (discriminated union: `IndividualSessionResponse | PresetSessionResponse`), `ExerciseHistoryResponse`, `CreatePresetSessionRequest`, `ExerciseEntryResponse`, `ExerciseEntrySetResponse`, `ActivityDetailResponse`, `Pagination`
 - **API schemas**: `dailySummaryResponseSchema`/`DailySummaryResponse` (aggregates goals + food entries + exercise sessions + water intake), `dailyGoalsResponseSchema`, `foodEntryResponseSchema`, `exerciseSessionResponseSchema`
 - **Constants**: `MEASUREMENT_PRECISION`/`getPrecision()` for decimal formatting, `CALORIE_CALCULATION_CONSTANTS`/`ACTIVITY_MULTIPLIERS` for step/calorie math
-- **Timezone utilities** (`shared/src/utils/timezone.ts`): `isDayString`, `addDays`, `compareDays`, `dayToPickerDate`, `pickerDateToDay` for day-string operations; `isValidTimeZone`, `todayInZone`, `instantToDay`, `userHourMinute`, `instantHourMinute`, `dayToUtcRange`, `dayRangeToUtcRange` for timezone-aware conversions
+- **Timezone utilities** (`shared/src/utils/timezone.ts`): `isDayString`, `addDays`, `compareDays`, `dayToPickerDate`, `localDateToDay` for day-string operations; `isValidTimeZone`, `todayInZone`, `instantToDay`, `userHourMinute`, `instantHourMinute`, `dayToUtcRange`, `dayRangeToUtcRange` for timezone-aware conversions
 
 ### Workout & Exercise Architecture
 

--- a/SparkyFitnessServer/integrations/fitbit/fitbitDataProcessor.js
+++ b/SparkyFitnessServer/integrations/fitbit/fitbitDataProcessor.js
@@ -6,7 +6,7 @@ const exerciseRepository = require('../../models/exercise');
 const activityDetailsRepository = require('../../models/activityDetailsRepository');
 const sleepRepository = require('../../models/sleepRepository');
 const { log } = require('../../config/logging');
-const { todayInZone } = require('@workspace/shared');
+const { localDateToDay, todayInZone } = require('@workspace/shared');
 
 // Conversion factors for en-US to Metric
 const LBS_TO_KG = 0.453592;
@@ -236,7 +236,6 @@ async function processFitbitTemperature(
     let tempVariation = entry.value.nightlyRelative;
 
     if (tempVariation !== undefined) {
-      
       await upsertCustomMeasurementLogic(userId, createdByUserId, {
         categoryName: 'Skin Temperature Variation',
         value: tempVariation,
@@ -393,7 +392,6 @@ async function processFitbitCoreTemperature(
     let temp = entry.value;
 
     if (temp !== undefined) {
-      
       await upsertCustomMeasurementLogic(userId, createdByUserId, {
         categoryName: 'Core Temperature',
         value: temp,
@@ -602,7 +600,7 @@ async function processFitbitActivities(
     }
 
     let distanceKm = activity.distance;
-    
+
     const entryData = {
       exercise_id: exercise.id,
       entry_date: entryDate,
@@ -663,7 +661,7 @@ async function processFitbitActivities(
         let dateKey = m.entry_date;
         // Handle different possible types for entry_date (Date object or string)
         if (dateKey instanceof Date) {
-          dateKey = dateKey.toISOString().split('T')[0];
+          dateKey = localDateToDay(dateKey);
         } else if (typeof dateKey === 'string' && dateKey.includes('T')) {
           dateKey = dateKey.split('T')[0];
         }

--- a/SparkyFitnessServer/models/exerciseTemplate.js
+++ b/SparkyFitnessServer/models/exerciseTemplate.js
@@ -3,7 +3,12 @@ const format = require('pg-format');
 const { log } = require('../config/logging');
 const workoutPresetRepository = require('./workoutPresetRepository');
 const { getExerciseById } = require('./exercise');
-const { addDays, compareDays, dayOfWeek } = require('@workspace/shared');
+const {
+  addDays,
+  compareDays,
+  dayOfWeek,
+  localDateToDay,
+} = require('@workspace/shared');
 
 async function createExerciseEntriesFromTemplate(templateId, userId, today) {
   log(
@@ -66,12 +71,12 @@ async function createExerciseEntriesFromTemplate(templateId, userId, today) {
     const startDay =
       typeof template.start_date === 'string'
         ? template.start_date.slice(0, 10)
-        : template.start_date.toISOString().slice(0, 10);
+        : localDateToDay(template.start_date);
     // If end_date is not provided, default to one year from start_date
     const endDay = template.end_date
       ? typeof template.end_date === 'string'
         ? template.end_date.slice(0, 10)
-        : template.end_date.toISOString().slice(0, 10)
+        : localDateToDay(template.end_date)
       : addDays(startDay, 365);
 
     log(

--- a/SparkyFitnessServer/models/foodTemplate.js
+++ b/SparkyFitnessServer/models/foodTemplate.js
@@ -3,7 +3,12 @@ const { log } = require('../config/logging');
 const format = require('pg-format');
 const foodEntryDb = require('./foodEntry');
 const foodEntryMealRepository = require('./foodEntryMealRepository');
-const { addDays, compareDays, dayOfWeek } = require('@workspace/shared');
+const {
+  addDays,
+  compareDays,
+  dayOfWeek,
+  localDateToDay,
+} = require('@workspace/shared');
 
 async function deleteFoodEntriesByMealPlanId(mealPlanId, userId) {
   const client = await getClient(userId); // User-specific operation
@@ -128,12 +133,12 @@ async function createFoodEntriesFromTemplate(templateId, userId, today) {
     const startDay =
       typeof start_date === 'string'
         ? start_date.slice(0, 10)
-        : start_date.toISOString().slice(0, 10);
+        : localDateToDay(start_date);
     // If end_date is not provided, default to one year from start_date
     const endDay = end_date
       ? typeof end_date === 'string'
         ? end_date.slice(0, 10)
-        : end_date.toISOString().slice(0, 10)
+        : localDateToDay(end_date)
       : addDays(startDay, 365);
 
     // Start from today if template start_date is in the past
@@ -224,7 +229,7 @@ async function createFoodEntriesFromTemplate(templateId, userId, today) {
       const dateStr =
         typeof entry.entry_date === 'string'
           ? entry.entry_date.slice(0, 10)
-          : entry.entry_date.toISOString().slice(0, 10);
+          : localDateToDay(entry.entry_date);
       const key = `${entry.food_id || entry.meal_id}-${entry.meal_type_id}-${dateStr}-${entry.variant_id}`;
       existingFoodEntries.add(key);
     });

--- a/SparkyFitnessServer/services/exerciseEntryHistoryService.ts
+++ b/SparkyFitnessServer/services/exerciseEntryHistoryService.ts
@@ -1,4 +1,5 @@
 import {
+  localDateToDay,
   presetSessionResponseSchema,
   type PresetSessionResponse,
   type ActivityDetailResponse,
@@ -14,7 +15,7 @@ const { log } = require('../config/logging');
 /** Convert a pg date value to a YYYY-MM-DD string, or return null. */
 function _dateToString(value: unknown): string | null {
   if (value == null) return null;
-  if (value instanceof Date) return value.toISOString().split('T')[0];
+  if (value instanceof Date) return localDateToDay(value);
   return String(value);
 }
 

--- a/SparkyFitnessServer/services/reportService.js
+++ b/SparkyFitnessServer/services/reportService.js
@@ -432,9 +432,8 @@ function calculateMuscleGroupRecovery(exerciseEntries) {
       ? JSON.parse(entry.exercises.primary_muscles || '[]')
       : [];
     muscles.forEach((muscle) => {
-      const entryDate = new Date(entry.entry_date);
-      if (!recoveryData[muscle] || entryDate > new Date(recoveryData[muscle])) {
-        recoveryData[muscle] = entryDate.toISOString().split('T')[0];
+      if (!recoveryData[muscle] || entry.entry_date > recoveryData[muscle]) {
+        recoveryData[muscle] = entry.entry_date;
       }
     });
   });
@@ -501,7 +500,7 @@ function calculatePrProgression(exerciseEntries) {
           reps > lastPr.maxReps
         ) {
           progression[entry.exercise_name].push({
-            date: new Date(entry.entry_date).toISOString().split('T')[0],
+            date: entry.entry_date,
             oneRM: oneRM,
             maxWeight: weight,
             maxReps: reps,
@@ -593,7 +592,7 @@ async function getExerciseDashboardData(
     const muscleGroupVolume = {}; // Stores total volume per muscle group
 
     exerciseEntries.forEach((entry) => {
-      totalWorkouts.add(new Date(entry.entry_date).toISOString().split('T')[0]); // Add unique dates
+      totalWorkouts.add(entry.entry_date); // Add unique dates
 
       if (entry.sets && entry.sets.length > 0) {
         entry.sets.forEach((set) => {
@@ -613,7 +612,7 @@ async function getExerciseDashboardData(
           ) {
             prData[entry.exercise_name] = {
               oneRM,
-              date: new Date(entry.entry_date).toISOString().split('T')[0],
+              date: entry.entry_date,
               weight,
               reps,
             };
@@ -632,7 +631,7 @@ async function getExerciseDashboardData(
               bestSetRepRange[entry.exercise_name][repRange] = {
                 weight,
                 reps,
-                date: new Date(entry.entry_date).toISOString().split('T')[0],
+                date: entry.entry_date,
               };
             }
           }

--- a/SparkyFitnessServer/services/sleepScienceService.js
+++ b/SparkyFitnessServer/services/sleepScienceService.js
@@ -4,6 +4,7 @@ const { loadUserTimezone } = require('../utils/timezoneLoader');
 const {
   instantHourMinute,
   dayOfWeek,
+  localDateToDay,
   userHourMinute,
 } = require('@workspace/shared');
 
@@ -184,9 +185,7 @@ function classifyDaysAutomatically(history, timezone = 'UTC') {
     if (wakeHour === null) continue;
 
     const dateStr =
-      typeof entry.date === 'string'
-        ? entry.date
-        : entry.date.toISOString().slice(0, 10);
+      typeof entry.date === 'string' ? entry.date : localDateToDay(entry.date);
     const dow = dayOfWeek(dateStr);
 
     if (!dayBuckets.has(dow)) dayBuckets.set(dow, []);
@@ -251,9 +250,7 @@ async function calculateBaseline(userId, windowDays = 90, timezone = 'UTC') {
     if (tst === null || tst < 3 || tst > 14) continue;
 
     const dateStr =
-      typeof entry.date === 'string'
-        ? entry.date
-        : entry.date.toISOString().slice(0, 10);
+      typeof entry.date === 'string' ? entry.date : localDateToDay(entry.date);
     const dow = dayOfWeek(dateStr);
     const dayType = dayClassification.get(dow) || 'workday';
 
@@ -360,9 +357,7 @@ async function calculateBaseline(userId, windowDays = 90, timezone = 'UTC') {
 
   // Determine data range
   const dates = history
-    .map((e) =>
-      typeof e.date === 'string' ? e.date : e.date.toISOString().slice(0, 10)
-    )
+    .map((e) => (typeof e.date === 'string' ? e.date : localDateToDay(e.date)))
     .sort();
   const dataStartDate = dates[0] || null;
   const dataEndDate = dates[dates.length - 1] || null;
@@ -446,9 +441,7 @@ function getDayOfWeekStats(history, classification, timezone = 'UTC') {
     if (wakeHour === null) continue;
 
     const dateStr =
-      typeof entry.date === 'string'
-        ? entry.date
-        : entry.date.toISOString().slice(0, 10);
+      typeof entry.date === 'string' ? entry.date : localDateToDay(entry.date);
     const dow = dayOfWeek(dateStr);
 
     if (!buckets.has(dow)) buckets.set(dow, []);
@@ -862,9 +855,7 @@ async function checkDataSufficiency(userId) {
   let freedayCount = 0;
   for (const entry of entriesWithTimestamps) {
     const dateStr =
-      typeof entry.date === 'string'
-        ? entry.date
-        : entry.date.toISOString().slice(0, 10);
+      typeof entry.date === 'string' ? entry.date : localDateToDay(entry.date);
     const dow = dayOfWeek(dateStr);
     if (dow === 0 || dow === 6) {
       freedayCount++;

--- a/SparkyFitnessServer/tests/dateShifting.test.js
+++ b/SparkyFitnessServer/tests/dateShifting.test.js
@@ -1,0 +1,167 @@
+/**
+ * Tests for date-shifting bugs caused by .toISOString().split('T')[0]
+ * on Date objects created by the pg driver for DATE columns.
+ *
+ * pg parses DATE columns via `new Date(year, month-1, day)` (local midnight).
+ * On a non-UTC server, .toISOString() converts to UTC and the date can shift.
+ *
+ * Run with: TZ=Pacific/Auckland npx jest --testPathPatterns=dateShifting
+ * to verify the fix holds on non-UTC servers.
+ */
+
+const { localDateToDay } = require('@workspace/shared');
+
+// Simulate how pg creates a Date from a DATE column value like '2024-06-15'
+function simulatePgDate(dateStr) {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y, m - 1, d); // local midnight — this is what pg does
+}
+
+// ---------------------------------------------------------------------------
+// Core: localDateToDay is safe regardless of server TZ
+// ---------------------------------------------------------------------------
+describe('pg DATE → string round-trip with localDateToDay', () => {
+  const dates = ['2024-01-01', '2024-06-15', '2024-12-31', '2025-03-10'];
+
+  it.each(dates)('%s: localDateToDay preserves the date', (dateStr) => {
+    const pgDate = simulatePgDate(dateStr);
+    expect(localDateToDay(pgDate)).toBe(dateStr);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reportService patterns — entry.entry_date from pg as Date
+// ---------------------------------------------------------------------------
+describe('reportService: exercise report date conversions (TO_CHAR strings)', () => {
+  // reportRepository returns entry_date as TO_CHAR(..., 'YYYY-MM-DD') strings,
+  // so these should be used directly — no Date conversion needed.
+
+  it('muscle group recovery: uses string entry_date directly', () => {
+    const entry = { entry_date: '2024-06-15' };
+    const recoveryData = {};
+    const muscle = 'chest';
+    if (!recoveryData[muscle] || entry.entry_date > recoveryData[muscle]) {
+      recoveryData[muscle] = entry.entry_date;
+    }
+    expect(recoveryData[muscle]).toBe('2024-06-15');
+  });
+
+  it('unique workout day counting with string dates', () => {
+    const entries = [
+      { entry_date: '2024-06-15' },
+      { entry_date: '2024-06-15' },
+      { entry_date: '2024-06-16' },
+    ];
+
+    const days = new Set();
+    entries.forEach((entry) => {
+      days.add(entry.entry_date);
+    });
+
+    expect([...days].sort()).toEqual(['2024-06-15', '2024-06-16']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exerciseEntryHistoryService — _dateToString (line 17)
+// ---------------------------------------------------------------------------
+describe('exerciseEntryHistoryService: _dateToString', () => {
+  function _dateToString(value) {
+    if (value == null) return null;
+    if (value instanceof Date) return localDateToDay(value);
+    return String(value);
+  }
+
+  it('preserves date for Date objects', () => {
+    const pgDate = simulatePgDate('2024-06-15');
+    expect(_dateToString(pgDate)).toBe('2024-06-15');
+  });
+
+  it('passes through strings unchanged', () => {
+    expect(_dateToString('2024-06-15')).toBe('2024-06-15');
+  });
+
+  it('returns null for null', () => {
+    expect(_dateToString(null)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sleepScienceService — entry.date conversion
+// ---------------------------------------------------------------------------
+describe('sleepScienceService: date conversion', () => {
+  function sleepDateToString(entry) {
+    return typeof entry.date === 'string'
+      ? entry.date
+      : localDateToDay(entry.date);
+  }
+
+  it('string dates pass through correctly', () => {
+    expect(sleepDateToString({ date: '2024-06-15' })).toBe('2024-06-15');
+  });
+
+  it('Date objects preserve the date', () => {
+    const pgDate = simulatePgDate('2024-06-15');
+    expect(sleepDateToString({ date: pgDate })).toBe('2024-06-15');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// foodTemplate / exerciseTemplate — start_date, end_date from pg
+// ---------------------------------------------------------------------------
+describe('template date conversions (foodTemplate/exerciseTemplate)', () => {
+  function templateDateToString(dateValue) {
+    return typeof dateValue === 'string'
+      ? dateValue.slice(0, 10)
+      : localDateToDay(dateValue);
+  }
+
+  it('string dates work correctly', () => {
+    expect(templateDateToString('2024-06-15')).toBe('2024-06-15');
+  });
+
+  it('Date objects from pg preserve the date', () => {
+    const pgDate = simulatePgDate('2024-06-15');
+    expect(templateDateToString(pgDate)).toBe('2024-06-15');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fitbitDataProcessor — entry_date normalization
+// ---------------------------------------------------------------------------
+describe('fitbitDataProcessor: entry_date normalization', () => {
+  it('Date objects preserve the date', () => {
+    let dateKey = simulatePgDate('2024-06-15');
+    if (dateKey instanceof Date) {
+      dateKey = localDateToDay(dateKey);
+    }
+    expect(dateKey).toBe('2024-06-15');
+  });
+
+  it('string dates with T are split correctly', () => {
+    let dateKey = '2024-06-15T00:00:00';
+    if (typeof dateKey === 'string' && dateKey.includes('T')) {
+      dateKey = dateKey.split('T')[0];
+    }
+    expect(dateKey).toBe('2024-06-15');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// foodEntryService — Date.UTC path (should always be safe)
+// ---------------------------------------------------------------------------
+describe('foodEntryService: Date.UTC prior day calculation', () => {
+  it('correctly computes prior day using Date.UTC', () => {
+    const targetDate = '2024-06-15';
+    const [yearStr, monthStr, dayStr] = targetDate.split('-');
+    const year = parseInt(yearStr, 10);
+    const month = parseInt(monthStr, 10);
+    const day = parseInt(dayStr, 10);
+
+    const priorDay = new Date(Date.UTC(year, month - 1, day));
+    priorDay.setUTCDate(priorDay.getUTCDate() - 1);
+    const sourceDate = priorDay.toISOString().split('T')[0];
+
+    expect(sourceDate).toBe('2024-06-14'); // one day before — correct
+  });
+});

--- a/SparkyFitnessServer/tests/timezone.test.js
+++ b/SparkyFitnessServer/tests/timezone.test.js
@@ -4,7 +4,7 @@ const {
   addDays,
   compareDays,
   dayToPickerDate,
-  pickerDateToDay,
+  localDateToDay,
   isValidTimeZone,
   todayInZone,
   instantToDay,
@@ -91,16 +91,16 @@ describe('compareDays', () => {
 });
 
 // ---------------------------------------------------------------------------
-// dayToPickerDate / pickerDateToDay
+// dayToPickerDate / localDateToDay
 // ---------------------------------------------------------------------------
-describe('dayToPickerDate / pickerDateToDay', () => {
+describe('dayToPickerDate / localDateToDay', () => {
   it('round-trips through picker date', () => {
     const day = '2024-06-15';
     const pickerDate = dayToPickerDate(day);
     expect(pickerDate.getFullYear()).toBe(2024);
     expect(pickerDate.getMonth()).toBe(5); // 0-indexed
     expect(pickerDate.getDate()).toBe(15);
-    expect(pickerDateToDay(pickerDate)).toBe(day);
+    expect(localDateToDay(pickerDate)).toBe(day);
   });
 });
 

--- a/SparkyFitnessServer/utils/dateHelpers.js
+++ b/SparkyFitnessServer/utils/dateHelpers.js
@@ -1,4 +1,8 @@
-const { todayInZone, isValidTimeZone } = require('@workspace/shared');
+const {
+  todayInZone,
+  isValidTimeZone,
+  localDateToDay,
+} = require('@workspace/shared');
 
 /**
  * Calculate a user's age from their date of birth, respecting their timezone.
@@ -15,8 +19,7 @@ function userAge(dob, timezone = 'UTC') {
   const todayMonth = parseInt(today.slice(5, 7), 10);
   const todayDay = parseInt(today.slice(8, 10), 10);
 
-  const dobStr =
-    typeof dob === 'string' ? dob : new Date(dob).toISOString().slice(0, 10);
+  const dobStr = typeof dob === 'string' ? dob : localDateToDay(new Date(dob));
   const dobYear = parseInt(dobStr.slice(0, 4), 10);
   const dobMonth = parseInt(dobStr.slice(5, 7), 10);
   const dobDay = parseInt(dobStr.slice(8, 10), 10);

--- a/shared/src/utils/timezone.ts
+++ b/shared/src/utils/timezone.ts
@@ -60,8 +60,8 @@ export function dayToPickerDate(day: string): Date {
   return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
 }
 
-/** Convert a local Date (from a date picker) to a YYYY-MM-DD string using local getters. */
-export function pickerDateToDay(date: Date): string {
+/** Convert a local Date to a YYYY-MM-DD string using local getters. */
+export function localDateToDay(date: Date): string {
   const y = date.getFullYear();
   const m = date.getMonth() + 1;
   const d = date.getDate();


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!

## Description

Some areas of the server were using date strings from the database and `new Date(dbDate).toISOString().slice(0,10)` or `new Date(dbDate).toISOString().split('T')[0]` which converts the datetime to UTC. If this is done late in the day it can cause a date shift:

Today at 9pm -> convert to UTC -> drop timezone data = tomorrow in a string

This PR renames and the uses the shared package helper that correctly handles this situation. I also added a bunch of tests to test for date shifts in problem areas.

## Related Issue

PR type [x] Issue [ ] New Feature [ ] Documentation
Linked Issue: #

## Checklist

Please check all that apply:

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers
- [x] **Tests**: I have included automated tests for my changes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached "Before" vs "After" screenshots below.
- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` (especially for Frontend).
- [ ] **Translations**: I have only updated the English (`en`) translation file (if applicable).
- [x] **Architecture**: My code follows the existing architecture standards.
- [ ] **Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code(phishing, malware, etc.) and I agree to the [License terms](LICENSE).

## Screenshots (if applicable)

### Before

[Insert screenshot/GIF here]

### After

[Insert screenshot/GIF here]
