### PR TITLE
fix: include source in exercise_snapshot for v2 by-date endpoint

### DIFF
--- a/SparkyFitnessServer/services/exerciseEntryHistoryService.ts
+++ b/SparkyFitnessServer/services/exerciseEntryHistoryService.ts
@@ -116,6 +116,7 @@ function _buildExerciseEntryWithSnapshot(
       id: entryData.exercise_id as string,
       name: exercise_name as string,
       category: (category as string) ?? null,
+      source: (source as string) ?? null,
       images: _parseJsonArray(images),
       primary_muscles: _parseJsonArray(primary_muscles),
       secondary_muscles: _parseJsonArray(secondary_muscles),


### PR DESCRIPTION
## Summary
- The v2 `_buildExerciseEntryWithSnapshot` function omits `source` from the `exercise_snapshot` object
- The frontend checks `exercise_snapshot.source` to decide whether to prepend `/uploads/exercises/` to image paths
- Without `source` in the snapshot, it's `undefined` (falsy), so the frontend uses raw image filenames as URLs, resulting in 404s for all exercise images in the diary view

## Test plan
- [ ] Navigate to the diary page with exercise entries that have images from FreeExerciseDB
- [ ] Verify exercise images load correctly (no broken image icons)
- [ ] Verify the image URLs include the `/uploads/exercises/` prefix