### PR TITLE
Fix Search for Existing Local Barcode Zod Error

### DIFF
--- a/SparkyFitnessMobile/CLAUDE.md
+++ b/SparkyFitnessMobile/CLAUDE.md
@@ -209,6 +209,8 @@ Tests in `__tests__/` mirror source structure (`hooks/`, `services/`). Mocks in 
 
 When writing or modifying tests, run the FULL test suite (not just new tests) to catch mock pollution and regressions in existing tests. Never introduce global mocks without checking for side effects on other test files.
 
+When fixing a bug that could have been caught by a test, write a regression test that reproduces the bug and verifies the fix.
+
 ### Testing Android Code on macOS
 
 Jest loads `.ios.ts` by default. Use explicit require for Android:

--- a/SparkyFitnessServer/routes/v2/foodRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/foodRoutes.ts
@@ -113,6 +113,81 @@ const EMPTY_PAGINATION = (page: number, pageSize: number) => ({
   hasMore: false,
 });
 
+function nullToUndefined<T>(value: T | null | undefined): T | undefined {
+  return value === null ? undefined : value;
+}
+
+function normalizeFoodVariantForResponse(variant: unknown): unknown {
+  if (!variant || typeof variant !== 'object' || Array.isArray(variant)) {
+    return variant;
+  }
+
+  const record = variant as Record<string, unknown>;
+
+  return {
+    ...record,
+    id: nullToUndefined(record.id as string | null | undefined),
+    saturated_fat: nullToUndefined(
+      record.saturated_fat as number | null | undefined
+    ),
+    polyunsaturated_fat: nullToUndefined(
+      record.polyunsaturated_fat as number | null | undefined
+    ),
+    monounsaturated_fat: nullToUndefined(
+      record.monounsaturated_fat as number | null | undefined
+    ),
+    trans_fat: nullToUndefined(record.trans_fat as number | null | undefined),
+    cholesterol: nullToUndefined(
+      record.cholesterol as number | null | undefined
+    ),
+    sodium: nullToUndefined(record.sodium as number | null | undefined),
+    potassium: nullToUndefined(record.potassium as number | null | undefined),
+    dietary_fiber: nullToUndefined(
+      record.dietary_fiber as number | null | undefined
+    ),
+    sugars: nullToUndefined(record.sugars as number | null | undefined),
+    vitamin_a: nullToUndefined(record.vitamin_a as number | null | undefined),
+    vitamin_c: nullToUndefined(record.vitamin_c as number | null | undefined),
+    calcium: nullToUndefined(record.calcium as number | null | undefined),
+    iron: nullToUndefined(record.iron as number | null | undefined),
+    glycemic_index: nullToUndefined(
+      record.glycemic_index as string | null | undefined
+    ),
+    custom_nutrients: nullToUndefined(
+      record.custom_nutrients as
+        | Record<string, string | number>
+        | null
+        | undefined
+    ),
+  };
+}
+
+function normalizeFoodForResponse(food: unknown): unknown {
+  if (!food || typeof food !== 'object' || Array.isArray(food)) {
+    return food;
+  }
+
+  const record = food as Record<string, unknown>;
+
+  return {
+    ...record,
+    id: nullToUndefined(record.id as string | null | undefined),
+    barcode: nullToUndefined(record.barcode as string | null | undefined),
+    provider_external_id: nullToUndefined(
+      record.provider_external_id as string | null | undefined
+    ),
+    provider_type: nullToUndefined(
+      record.provider_type as string | null | undefined
+    ),
+    default_variant: normalizeFoodVariantForResponse(record.default_variant),
+    variants: Array.isArray(record.variants)
+      ? record.variants.map((variant) =>
+          normalizeFoodVariantForResponse(variant)
+        )
+      : nullToUndefined(record.variants as unknown[] | null | undefined),
+  };
+}
+
 // --- Barcode endpoint ---
 
 const barcodeHandler: RequestHandler<{ barcode: string }> = async (
@@ -142,8 +217,13 @@ const barcodeHandler: RequestHandler<{ barcode: string }> = async (
       result.food.barcode = barcode;
     }
 
+    const normalizedResult = {
+      ...result,
+      food: result.food ? normalizeFoodForResponse(result.food) : null,
+    };
+
     // Validate and strip unknown keys (e.g. barcode_raw)
-    const response = BarcodeResponseSchema.parse(result);
+    const response = BarcodeResponseSchema.parse(normalizedResult);
     res.status(200).json(response);
   } catch (error: unknown) {
     if (error instanceof Error && error.name === 'ZodError') {
@@ -280,7 +360,11 @@ const searchHandler: RequestHandler<{ providerType: string }> = async (
       }
     }
 
-    const response = SearchResponseSchema.parse({ foods, pagination });
+    const normalizedFoods = foods.map((food) => normalizeFoodForResponse(food));
+    const response = SearchResponseSchema.parse({
+      foods: normalizedFoods,
+      pagination,
+    });
     res.status(200).json(response);
   } catch (error: unknown) {
     if (error instanceof Error && error.name === 'ZodError') {
@@ -406,7 +490,7 @@ const detailHandler: RequestHandler<{
       return;
     }
 
-    const response = NormalizedFoodSchema.parse(food);
+    const response = NormalizedFoodSchema.parse(normalizeFoodForResponse(food));
     res.status(200).json(response);
   } catch (error: unknown) {
     if (error instanceof Error && error.name === 'ZodError') {

--- a/SparkyFitnessServer/tests/foodRoutesV2.test.js
+++ b/SparkyFitnessServer/tests/foodRoutesV2.test.js
@@ -1,0 +1,133 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../middleware/checkPermissionMiddleware', () =>
+  jest.fn(() => (req, res, next) => next())
+);
+jest.mock('../services/foodCoreService', () => ({
+  lookupBarcode: jest.fn(),
+}));
+jest.mock('../services/externalProviderService', () => ({
+  getExternalDataProviderDetails: jest.fn(),
+}));
+jest.mock('../services/preferenceService', () => ({
+  getUserPreferences: jest.fn(),
+}));
+jest.mock('../config/logging', () => ({ log: jest.fn() }));
+jest.mock('../integrations/openfoodfacts/openFoodFactsService', () => ({
+  searchOpenFoodFacts: jest.fn(),
+  searchOpenFoodFactsByBarcodeFields: jest.fn(),
+  mapOpenFoodFactsProduct: jest.fn(),
+}));
+jest.mock('../integrations/usda/usdaService', () => ({
+  searchUsdaFoods: jest.fn(),
+  getUsdaFoodDetails: jest.fn(),
+  mapUsdaBarcodeProduct: jest.fn(),
+}));
+jest.mock('../integrations/fatsecret/fatsecretService', () => ({
+  mapFatSecretFood: jest.fn(),
+  mapFatSecretSearchItem: jest.fn(),
+}));
+jest.mock('../services/foodIntegrationService', () => ({
+  searchFatSecretFoods: jest.fn(),
+  getFatSecretNutrients: jest.fn(),
+  searchMealieFoods: jest.fn(),
+  getMealieFoodDetails: jest.fn(),
+  searchTandoorFoods: jest.fn(),
+  getTandoorFoodDetails: jest.fn(),
+}));
+
+const foodCoreService = require('../services/foodCoreService');
+const foodRoutesV2 = require('../routes/v2/foodRoutes.ts');
+
+const app = express();
+app.use(express.json());
+app.use((req, res, next) => {
+  req.userId = 'user-123';
+  req.authenticatedUserId = 'user-123';
+  next();
+});
+app.use('/v2/foods', foodRoutesV2);
+app.use((err, req, res, _next) => {
+  res.status(err.status || 500).json({ error: err.message });
+});
+
+describe('GET /v2/foods/barcode/:barcode', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a local barcode hit when optional fields are null', async () => {
+    const barcode = '012345678901';
+
+    foodCoreService.lookupBarcode.mockResolvedValue({
+      source: 'local',
+      food: {
+        id: 'food-abc-123',
+        name: 'Manual Granola',
+        brand: null,
+        barcode: null,
+        provider_external_id: null,
+        provider_type: null,
+        is_custom: true,
+        default_variant: {
+          id: 'variant-xyz-789',
+          serving_size: 100,
+          serving_unit: 'g',
+          calories: 420,
+          protein: 12,
+          carbs: 61,
+          fat: 14,
+          saturated_fat: null,
+          polyunsaturated_fat: null,
+          monounsaturated_fat: null,
+          trans_fat: null,
+          cholesterol: null,
+          sodium: null,
+          potassium: null,
+          dietary_fiber: null,
+          sugars: null,
+          vitamin_a: null,
+          vitamin_c: null,
+          calcium: null,
+          iron: null,
+          is_default: true,
+          glycemic_index: null,
+          custom_nutrients: null,
+        },
+        variants: null,
+      },
+    });
+
+    const res = await request(app).get(`/v2/foods/barcode/${barcode}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      source: 'local',
+      food: {
+        id: 'food-abc-123',
+        name: 'Manual Granola',
+        brand: null,
+        barcode,
+        is_custom: true,
+        default_variant: {
+          id: 'variant-xyz-789',
+          serving_size: 100,
+          serving_unit: 'g',
+          calories: 420,
+          protein: 12,
+          carbs: 61,
+          fat: 14,
+          is_default: true,
+        },
+      },
+    });
+    expect(res.body.food).not.toHaveProperty('provider_external_id');
+    expect(res.body.food).not.toHaveProperty('provider_type');
+    expect(res.body.food).not.toHaveProperty('variants');
+    expect(res.body.food.default_variant).not.toHaveProperty('saturated_fat');
+    expect(res.body.food.default_variant).not.toHaveProperty(
+      'custom_nutrients'
+    );
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

Fixes looking up a barcode that was already saved returning an error.

**How did you implement the solution?**
(Brief technical approach.)

Now normalize the food response before zod validation so it does not error. Applied to barcode, search, and detail for consistency.

Linked Issue: #

## How to Test

1. Scan item - Not found
2. Manually enter nutrition but leave 1+ fields blank
3. Scan again
4. Get the same food back

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
