### PR TITLE
Feat: Optional Only Food Facts Authentication

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Settings/EditProviderForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/EditProviderForm.tsx
@@ -84,6 +84,48 @@ export const EditProviderForm = ({
           </Select>
         </div>
       </div>
+      {editData.provider_type === 'openfoodfacts' && (
+        <>
+          <div>
+            <Label>Open Food Facts Username (Optional)</Label>
+            <Input
+              type="text"
+              value={editData.app_id || ''}
+              onChange={(e) =>
+                setEditData((prev) => ({
+                  ...prev,
+                  app_id: e.target.value,
+                }))
+              }
+              placeholder="(leave blank to keep existing)"
+              autoComplete="username"
+            />
+          </div>
+          <div>
+            <Label>Open Food Facts Password (Optional)</Label>
+            <Input
+              type="password"
+              value={editData.app_key || ''}
+              onChange={(e) =>
+                setEditData((prev) => ({
+                  ...prev,
+                  app_key: e.target.value,
+                }))
+              }
+              placeholder="•••••••• (leave blank to keep existing)"
+              autoComplete="current-password"
+            />
+          </div>
+          <p className="text-sm text-muted-foreground col-span-2">
+            Username and password for Open Food Facts are optional. If you have
+            an account, adding these credentials allows Sparky to make
+            authenticated requests, which can help reduce rate limiting during
+            busy periods. If you want to keep the existing credentials, simply
+            leave the fields blank. Note that credentials cannot be combined
+            with publicly sharing this provider row.
+          </p>
+        </>
+      )}
       {(editData.provider_type === 'mealie' ||
         editData.provider_type === 'tandoor' ||
         editData.provider_type === 'free-exercise-db') && (

--- a/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
@@ -37,14 +37,24 @@ const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
     const providerUpdateData: Partial<ExternalDataProvider> = {
       provider_name: editData.provider_name,
       provider_type: editData.provider_type,
+      // OFF: GET /external-providers does not return decrypted app_id/app_key,
+      // and startEditing seeds app_key to '' (we never echo passwords back to
+      // the DOM). For both fields we cannot distinguish "untouched" from
+      // "user cleared", so blank means "leave existing". To remove stored OFF
+      // credentials, users must delete and re-add the provider.
       app_id:
         editData.provider_type === 'mealie' ||
         editData.provider_type === 'tandoor' ||
         editData.provider_type === 'free-exercise-db' ||
         editData.provider_type === 'wger'
           ? null
-          : editData.app_id || null,
-      app_key: editData.app_key || null,
+          : editData.provider_type === 'openfoodfacts'
+            ? editData.app_id || undefined
+            : editData.app_id || null,
+      app_key:
+        editData.provider_type === 'openfoodfacts'
+          ? editData.app_key || undefined
+          : editData.app_key || null,
       is_active: editData.is_active,
       base_url:
         editData.provider_type === 'mealie' ||
@@ -99,6 +109,7 @@ const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
         data: providerUpdateData,
       });
       setEditData({});
+      setEditingProvider(null);
       if (
         data &&
         data.is_active &&

--- a/SparkyFitnessFrontend/src/pages/Settings/ProviderSpecificFields.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ProviderSpecificFields.tsx
@@ -115,6 +115,49 @@ export const ProviderSpecificFields = ({
         </div>
       )}
 
+      {provider.provider_type === 'openfoodfacts' && (
+        <>
+          <div>
+            <Label htmlFor="add-openfoodfacts-username">
+              Open Food Facts Username (Optional)
+            </Label>
+            <Input
+              id="add-openfoodfacts-username"
+              type="text"
+              value={provider.app_id || ''}
+              onChange={(e) =>
+                setProvider((prev) => ({ ...prev, app_id: e.target.value }))
+              }
+              placeholder="Enter Open Food Facts username"
+              autoComplete="username"
+            />
+          </div>
+          <div>
+            <Label htmlFor="add-openfoodfacts-password">
+              Open Food Facts Password (Optional)
+            </Label>
+            <Input
+              id="add-openfoodfacts-password"
+              type="password"
+              value={provider.app_key || ''}
+              onChange={(e) =>
+                setProvider((prev) => ({ ...prev, app_key: e.target.value }))
+              }
+              placeholder="Enter Open Food Facts password"
+              autoComplete="current-password"
+            />
+          </div>
+          <p className="text-sm text-muted-foreground col-span-2">
+            Username and password for Open Food Facts are optional. If you have
+            an account, adding these credentials allows Sparky to make
+            authenticated requests, which can help reduce rate limiting during
+            busy periods. If you want to keep the existing credentials, simply
+            leave the fields blank. Note that credentials cannot be combined
+            with publicly sharing this provider row.
+          </p>
+        </>
+      )}
+
       {provider.provider_type === 'garmin' && (
         <>
           <div>

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsAuth.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsAuth.ts
@@ -1,0 +1,223 @@
+const { log } = require('../../config/logging');
+const pkg = require('../../package.json');
+
+interface SessionCacheEntry {
+  session: string | null;
+  expiresAt: number;
+}
+
+interface OpenFoodFactsProviderDetails {
+  provider_type?: string;
+  app_id?: string | null;
+  app_key?: string | null;
+}
+
+// Per-process in-memory cache of OFF session cookies. Keyed by
+// `${authenticatedUserId}:${providerId}` so a cached cookie for user A can
+// never be served to user B. Not persisted — each server process keeps its
+// own cache, which is acceptable at our traffic profile.
+const sessionCache = new Map<string, SessionCacheEntry>();
+// Coalesce concurrent logins for the same cache key into a single in-flight
+// promise, so a burst of requests after TTL expiry only triggers one login
+// against OFF rather than a stampede.
+const inFlightLogins = new Map<string, Promise<string | null>>();
+
+const POSITIVE_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
+const NEGATIVE_TTL_MS = 30 * 1000; // 30 seconds
+const LOGIN_URL = 'https://world.openfoodfacts.org/cgi/session.pl';
+const USER_AGENT = `${pkg.name}/${pkg.version} (https://github.com/CodeWithCJ/SparkyFitness)`;
+
+function cacheKey(userId: string, providerId: string): string {
+  return `${userId}:${providerId}`;
+}
+
+function getCachedEntry(key: string): SessionCacheEntry | null {
+  const entry = sessionCache.get(key);
+  if (!entry) return null;
+  if (entry.expiresAt <= Date.now()) {
+    sessionCache.delete(key);
+    return null;
+  }
+  return entry;
+}
+
+function parseSessionCookie(response: Response): string | null {
+  // Node 20+ supports Headers.getSetCookie() which returns all Set-Cookie
+  // headers as an array — the single-value .get('set-cookie') folds them
+  // into one comma-joined string that can't be parsed reliably.
+  let setCookies: string[] = [];
+  const headers = response.headers as Headers & {
+    getSetCookie?: () => string[];
+    raw?: () => Record<string, string[]>;
+  };
+  if (headers && typeof headers.getSetCookie === 'function') {
+    setCookies = headers.getSetCookie();
+  } else if (headers && typeof headers.raw === 'function') {
+    setCookies = headers.raw()['set-cookie'] || [];
+  }
+  for (const cookieStr of setCookies) {
+    const match = /(?:^|;\s*)session=([^;]+)/.exec(cookieStr);
+    if (match && match[1]) {
+      return match[1];
+    }
+  }
+  return null;
+}
+
+async function loginToOpenFoodFacts(
+  userId: string,
+  password: string
+): Promise<string | null> {
+  const body = new URLSearchParams({
+    user_id: userId,
+    password,
+    '.submit': 'Sign-in',
+  }).toString();
+
+  log('info', `OpenFoodFacts: attempting login for user_id="${userId}"`);
+  const response = await fetch(LOGIN_URL, {
+    method: 'POST',
+    headers: {
+      'User-Agent': USER_AGENT,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+    redirect: 'manual',
+  });
+
+  const session = parseSessionCookie(response);
+  if (!session) {
+    log(
+      'info',
+      `OpenFoodFacts: login returned no session cookie for ${userId}`
+    );
+    return null;
+  }
+
+  // OFF returns 200 with an HTML page containing an error marker when the
+  // credentials are wrong but still sets a cookie; guard against that.
+  try {
+    const text = await response.text();
+    if (/Incorrect user name or password/i.test(text)) {
+      log('info', `OpenFoodFacts: login rejected for ${userId}`);
+      return null;
+    }
+  } catch {
+    // Body read failures are non-fatal — trust the cookie we already parsed.
+  }
+
+  return session;
+}
+
+async function getOpenFoodFactsSessionCookie(
+  authenticatedUserId: string,
+  providerId: string
+): Promise<string | null> {
+  if (!authenticatedUserId || !providerId) {
+    return null;
+  }
+  const key = cacheKey(authenticatedUserId, providerId);
+
+  const cached = getCachedEntry(key);
+  if (cached) {
+    return cached.session;
+  }
+
+  const existing = inFlightLogins.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  // Lazy-require to avoid a circular dependency:
+  //   externalProviderService → openFoodFactsAuth (invalidate hook)
+  //   openFoodFactsAuth → externalProviderService (cred fetch)
+  const externalProviderService = require('../../services/externalProviderService');
+
+  const loginPromise: Promise<string | null> = (async () => {
+    let providerDetails: OpenFoodFactsProviderDetails | null;
+    try {
+      providerDetails =
+        await externalProviderService.getExternalDataProviderDetails(
+          authenticatedUserId,
+          providerId
+        );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log(
+        'debug',
+        `OpenFoodFacts: provider lookup rejected for user ${authenticatedUserId}, provider ${providerId}: ${message}`
+      );
+      sessionCache.set(key, {
+        session: null,
+        expiresAt: Date.now() + NEGATIVE_TTL_MS,
+      });
+      return null;
+    }
+
+    if (
+      !providerDetails ||
+      providerDetails.provider_type !== 'openfoodfacts' ||
+      !providerDetails.app_id ||
+      !providerDetails.app_key
+    ) {
+      sessionCache.set(key, {
+        session: null,
+        expiresAt: Date.now() + NEGATIVE_TTL_MS,
+      });
+      return null;
+    }
+
+    let session: string | null = null;
+    try {
+      session = await loginToOpenFoodFacts(
+        providerDetails.app_id,
+        providerDetails.app_key
+      );
+    } catch (error) {
+      log('warn', `OpenFoodFacts login threw for ${key}:`, error);
+    }
+
+    if (!session) {
+      sessionCache.set(key, {
+        session: null,
+        expiresAt: Date.now() + NEGATIVE_TTL_MS,
+      });
+      return null;
+    }
+
+    sessionCache.set(key, {
+      session,
+      expiresAt: Date.now() + POSITIVE_TTL_MS,
+    });
+    return session;
+  })();
+
+  inFlightLogins.set(key, loginPromise);
+  try {
+    return await loginPromise;
+  } finally {
+    inFlightLogins.delete(key);
+  }
+}
+
+function invalidateOpenFoodFactsSession(
+  authenticatedUserId: string,
+  providerId: string
+): void {
+  if (!authenticatedUserId || !providerId) return;
+  sessionCache.delete(cacheKey(authenticatedUserId, providerId));
+}
+
+// Exposed for tests only — lets a test reset cache state between cases
+// without digging into the module internals.
+function __resetForTests(): void {
+  sessionCache.clear();
+  inFlightLogins.clear();
+}
+
+module.exports = {
+  getOpenFoodFactsSessionCookie,
+  invalidateOpenFoodFactsSession,
+  loginToOpenFoodFacts,
+  __resetForTests,
+};

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.js
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.js
@@ -1,6 +1,10 @@
 const { log } = require('../../config/logging');
 const { name, version } = require('../../package.json');
 const { normalizeBarcode } = require('../../utils/foodUtils');
+const {
+  getOpenFoodFactsSessionCookie,
+  invalidateOpenFoodFactsSession,
+} = require('./openFoodFactsAuth');
 
 const USER_AGENT = `${name}/${version} (https://github.com/CodeWithCJ/SparkyFitness)`;
 
@@ -18,7 +22,54 @@ const OFF_FIELDS = [
   'nutriments',
 ];
 
-async function searchOpenFoodFacts(query, page = 1, language = 'en') {
+// Wraps fetch with optional session-cookie authentication for OFF endpoints.
+// On 429/5xx with an attached cookie, invalidates the session and retries once
+// without the cookie. OFF returns 200 on stale cookies (no 401 signal), so we
+// don't try to distinguish that case — we only retry on the observable
+// failure mode (rate limiting).
+async function fetchOpenFoodFacts(
+  url,
+  { authenticatedUserId, providerId } = {}
+) {
+  const baseHeaders = { ...OFF_HEADERS };
+  let sessionCookie = null;
+
+  if (authenticatedUserId && providerId) {
+    try {
+      sessionCookie = await getOpenFoodFactsSessionCookie(
+        authenticatedUserId,
+        providerId
+      );
+    } catch (error) {
+      log('debug', 'OpenFoodFacts: session cookie lookup failed:', error);
+    }
+  }
+
+  const headers = sessionCookie
+    ? { ...baseHeaders, Cookie: `session=${sessionCookie}` }
+    : baseHeaders;
+
+  const response = await fetch(url, { method: 'GET', headers });
+
+  if (sessionCookie && (response.status === 429 || response.status >= 500)) {
+    log(
+      'warn',
+      `OpenFoodFacts: ${response.status} with session cookie — invalidating and retrying unauthenticated`
+    );
+    invalidateOpenFoodFactsSession(authenticatedUserId, providerId);
+    return fetch(url, { method: 'GET', headers: baseHeaders });
+  }
+
+  return response;
+}
+
+async function searchOpenFoodFacts(
+  query,
+  page = 1,
+  language = 'en',
+  authenticatedUserId,
+  providerId
+) {
   try {
     const fieldSet = new Set(OFF_FIELDS);
     if (language !== 'en') {
@@ -27,9 +78,9 @@ async function searchOpenFoodFacts(query, page = 1, language = 'en') {
     const fields = [...fieldSet];
 
     const searchUrl = `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=20&page=${page}&fields=${fields.join(',')}&lc=${language}`;
-    const response = await fetch(searchUrl, {
-      method: 'GET',
-      headers: OFF_HEADERS,
+    const response = await fetchOpenFoodFacts(searchUrl, {
+      authenticatedUserId,
+      providerId,
     });
     if (!response.ok) {
       const errorText = await response.text();
@@ -60,7 +111,9 @@ async function searchOpenFoodFacts(query, page = 1, language = 'en') {
 async function searchOpenFoodFactsByBarcodeFields(
   barcode,
   fields = OFF_FIELDS,
-  language = 'en'
+  language = 'en',
+  authenticatedUserId,
+  providerId
 ) {
   try {
     const fieldSet = new Set(fields);
@@ -70,9 +123,9 @@ async function searchOpenFoodFactsByBarcodeFields(
     const finalFields = [...fieldSet];
     const fieldsParam = finalFields.join(',');
     const searchUrl = `https://world.openfoodfacts.org/api/v2/product/${barcode}.json?fields=${fieldsParam}&lc=${language}`;
-    const response = await fetch(searchUrl, {
-      method: 'GET',
-      headers: OFF_HEADERS,
+    const response = await fetchOpenFoodFacts(searchUrl, {
+      authenticatedUserId,
+      providerId,
     });
     if (!response.ok) {
       if (response.status === 404) {

--- a/SparkyFitnessServer/models/externalProviderRepository.js
+++ b/SparkyFitnessServer/models/externalProviderRepository.js
@@ -199,6 +199,16 @@ async function createExternalDataProvider(providerData) {
   }
 }
 
+// Note on OFF convention: the `app_id` / `app_key` columns (encrypted per-row)
+// double as OFF username / password for providers of type `openfoodfacts`. For
+// other providers they are API credential fields. Callers must honor the
+// mutual-exclusion rule between populated OFF credentials and
+// `shared_with_public` — see externalProviderService.
+//
+// updateExternalDataProvider: passing `updateData.app_id === null` (and
+// similarly `app_key === null`) is an explicit request to CLEAR the stored
+// credential — all three encrypted columns are nulled out. Passing
+// `undefined` leaves them unchanged (COALESCE semantics).
 async function updateExternalDataProvider(id, userId, updateData) {
   const client = await getClient(userId); // User-specific operation
   try {
@@ -208,18 +218,24 @@ async function updateExternalDataProvider(id, userId, updateData) {
     let encryptedAppKey = updateData.encrypted_app_key || null;
     let appKeyIv = updateData.app_key_iv || null;
     let appKeyTag = updateData.app_key_tag || null;
+    let clearAppId = false;
+    let clearAppKey = false;
 
     const encryptedGarthDump = updateData.encrypted_garth_dump || null;
     const garthDumpIv = updateData.garth_dump_iv || null;
     const garthDumpTag = updateData.garth_dump_tag || null;
 
-    if (updateData.app_id !== undefined) {
+    if (updateData.app_id === null) {
+      clearAppId = true;
+    } else if (updateData.app_id !== undefined) {
       const encryptedId = await encrypt(updateData.app_id, ENCRYPTION_KEY);
       encryptedAppId = encryptedId.encryptedText;
       appIdIv = encryptedId.iv;
       appIdTag = encryptedId.tag;
     }
-    if (updateData.app_key !== undefined) {
+    if (updateData.app_key === null) {
+      clearAppKey = true;
+    } else if (updateData.app_key !== undefined) {
       const encryptedKey = await encrypt(updateData.app_key, ENCRYPTION_KEY);
       encryptedAppKey = encryptedKey.encryptedText;
       appKeyIv = encryptedKey.iv;
@@ -233,12 +249,12 @@ async function updateExternalDataProvider(id, userId, updateData) {
         is_active = COALESCE($3, is_active),
         base_url = COALESCE($4, base_url),
         shared_with_public = COALESCE($5, shared_with_public),
-        encrypted_app_id = COALESCE($6, encrypted_app_id),
-        app_id_iv = COALESCE($7, app_id_iv),
-        app_id_tag = COALESCE($8, app_id_tag),
-        encrypted_app_key = COALESCE($9, encrypted_app_key),
-        app_key_iv = COALESCE($10, app_key_iv),
-        app_key_tag = COALESCE($11, app_key_tag),
+        encrypted_app_id = CASE WHEN $19 THEN NULL ELSE COALESCE($6, encrypted_app_id) END,
+        app_id_iv = CASE WHEN $19 THEN NULL ELSE COALESCE($7, app_id_iv) END,
+        app_id_tag = CASE WHEN $19 THEN NULL ELSE COALESCE($8, app_id_tag) END,
+        encrypted_app_key = CASE WHEN $20 THEN NULL ELSE COALESCE($9, encrypted_app_key) END,
+        app_key_iv = CASE WHEN $20 THEN NULL ELSE COALESCE($10, app_key_iv) END,
+        app_key_tag = CASE WHEN $20 THEN NULL ELSE COALESCE($11, app_key_tag) END,
         encrypted_garth_dump = COALESCE($12, encrypted_garth_dump),
         garth_dump_iv = COALESCE($13, garth_dump_iv),
         garth_dump_tag = COALESCE($14, garth_dump_tag),
@@ -267,6 +283,8 @@ async function updateExternalDataProvider(id, userId, updateData) {
         updateData.external_user_id,
         id,
         updateData.sync_frequency,
+        clearAppId,
+        clearAppKey,
       ]
     );
     return result.rows[0];

--- a/SparkyFitnessServer/routes/foodIntegrationRoutes.js
+++ b/SparkyFitnessServer/routes/foodIntegrationRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { authenticate } = require('../middleware/authMiddleware');
 const preferenceService = require('../services/preferenceService');
+const externalProviderService = require('../services/externalProviderService');
 const checkPermissionMiddleware = require('../middleware/checkPermissionMiddleware');
 const foodService = require('../services/foodService');
 const { log } = require('../config/logging');
@@ -381,7 +382,18 @@ router.get('/openfoodfacts/search', authenticate, async (req, res, next) => {
       req.userId
     );
     const language = userPrefs?.language || 'en';
-    const data = await searchOpenFoodFacts(query, page, language);
+    const providerId =
+      req.headers['x-provider-id'] ||
+      (await externalProviderService.getActiveOpenFoodFactsProviderId(
+        req.userId
+      ));
+    const data = await searchOpenFoodFacts(
+      query,
+      page,
+      language,
+      providerId ? req.userId : undefined,
+      providerId || undefined
+    );
     res.json(data);
   } catch (error) {
     next(error);
@@ -422,10 +434,17 @@ router.get(
         req.userId
       );
       const language = userPrefs?.language || 'en';
+      const providerId =
+        req.headers['x-provider-id'] ||
+        (await externalProviderService.getActiveOpenFoodFactsProviderId(
+          req.userId
+        ));
       const data = await searchOpenFoodFactsByBarcodeFields(
         barcode,
         undefined,
-        language
+        language,
+        providerId ? req.userId : undefined,
+        providerId || undefined
       );
       res.json(data);
     } catch (error) {

--- a/SparkyFitnessServer/routes/v2/foodRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/foodRoutes.ts
@@ -58,6 +58,39 @@ interface ProviderCredentials {
   is_active?: boolean;
 }
 
+// Resolve an OFF providerId for session-cookie auth. Unlike other providers,
+// OFF does not need credentials to function — this just opts into the
+// authenticated request path when the user has configured an OFF account.
+// Returns the provided id (validated for ownership) or the user's first
+// credentialed OFF provider, or null.
+async function resolveOpenFoodFactsProviderId(
+  userId: string,
+  providerId: string | undefined
+): Promise<string | null> {
+  if (providerId) {
+    try {
+      const details =
+        await externalProviderService.getExternalDataProviderDetails(
+          userId,
+          providerId
+        );
+      if (
+        details &&
+        details.is_active &&
+        details.provider_type === 'openfoodfacts' &&
+        details.app_id &&
+        details.app_key
+      ) {
+        return providerId;
+      }
+    } catch (error) {
+      log('debug', 'v2 OFF providerId validation failed:', error);
+    }
+    return null;
+  }
+  return externalProviderService.getActiveOpenFoodFactsProviderId(userId);
+}
+
 async function resolveProviderCredentials(
   userId: string,
   providerId: string | undefined,
@@ -282,7 +315,17 @@ const searchHandler: RequestHandler<{ providerType: string }> = async (
       case 'openfoodfacts': {
         const autoScale =
           ((req.query.autoScale as string) ?? 'true') !== 'false';
-        const result = await searchOpenFoodFacts(query, page, language);
+        const offProviderId = await resolveOpenFoodFactsProviderId(
+          req.userId,
+          providerId
+        );
+        const result = await searchOpenFoodFacts(
+          query,
+          page,
+          language,
+          offProviderId ? req.userId : undefined,
+          offProviderId || undefined
+        );
         const products = (result.products || []).filter(
           (p: Record<string, any>) =>
             p.product_name || p[`product_name_${language}`] || p.product_name_en
@@ -415,10 +458,16 @@ const detailHandler: RequestHandler<{
 
     switch (providerType) {
       case 'openfoodfacts': {
+        const offProviderId = await resolveOpenFoodFactsProviderId(
+          req.userId,
+          providerId
+        );
         const data = await searchOpenFoodFactsByBarcodeFields(
           externalId,
           undefined,
-          language
+          language,
+          offProviderId ? req.userId : undefined,
+          offProviderId || undefined
         );
         if (data.status === 1 && data.product) {
           food = mapOpenFoodFactsProduct(data.product, { language });

--- a/SparkyFitnessServer/services/externalProviderService.js
+++ b/SparkyFitnessServer/services/externalProviderService.js
@@ -1,12 +1,45 @@
 const externalProviderRepository = require('../models/externalProviderRepository');
 const { log } = require('../config/logging');
+const {
+  invalidateOpenFoodFactsSession,
+} = require('../integrations/openfoodfacts/openFoodFactsAuth');
+
+// Build a 400-tagged Error for user-input validation failures so the
+// centralized errorHandler surfaces them as client errors instead of the
+// default 500 Internal Server Error.
+function badRequest(message) {
+  const err = new Error(message);
+  err.statusCode = 400;
+  return err;
+}
+
+// Strip decrypted credentials and their encrypted backing columns from any
+// provider row the viewer does not own. Prevents family / public sharing from
+// leaking OFF passwords (or any other per-row `app_id`/`app_key`).
+function redactCredentialsForNonOwner(provider, authenticatedUserId) {
+  if (provider.user_id === authenticatedUserId) {
+    return provider;
+  }
+  const {
+    app_id: _appId,
+    app_key: _appKey,
+    encrypted_app_id: _eAppId,
+    app_id_iv: _iAppId,
+    app_id_tag: _tAppId,
+    encrypted_app_key: _eAppKey,
+    app_key_iv: _iAppKey,
+    app_key_tag: _tAppKey,
+    ...rest
+  } = provider;
+  return rest;
+}
 
 async function getExternalDataProviders(userId) {
   try {
     const providers =
       await externalProviderRepository.getExternalDataProviders(userId);
     const providersWithVisibility = providers.map((p) => ({
-      ...p,
+      ...redactCredentialsForNonOwner(p, userId),
       visibility:
         p.user_id === userId
           ? 'private'
@@ -50,7 +83,7 @@ async function getExternalDataProvidersForUser(
         : providers.filter((p) => !p.is_strictly_private);
 
     const providersWithVisibility = filteredProviders.map((p) => ({
-      ...p,
+      ...redactCredentialsForNonOwner(p, authenticatedUserId),
       visibility:
         p.user_id === authenticatedUserId
           ? 'private'
@@ -76,8 +109,34 @@ async function getExternalDataProvidersForUser(
 async function createExternalDataProvider(authenticatedUserId, providerData) {
   try {
     providerData.user_id = authenticatedUserId;
+    if (providerData.provider_type === 'openfoodfacts') {
+      // OFF authenticated access requires a username/password pair. Reject
+      // half-configured credentials so the settings page can't land in a
+      // silently-misconfigured state where every OFF request still runs
+      // unauthenticated.
+      if (!!providerData.app_id !== !!providerData.app_key) {
+        throw badRequest(
+          'Open Food Facts credentials must include both a username and a password.'
+        );
+      }
+      if (
+        providerData.shared_with_public === true &&
+        (providerData.app_id || providerData.app_key)
+      ) {
+        throw badRequest(
+          'Open Food Facts credentials cannot be stored on a provider row that is shared publicly. Remove credentials or disable public sharing first.'
+        );
+      }
+    }
     const newProvider =
       await externalProviderRepository.createExternalDataProvider(providerData);
+    if (
+      providerData.provider_type === 'openfoodfacts' &&
+      newProvider &&
+      newProvider.id
+    ) {
+      invalidateOpenFoodFactsSession(authenticatedUserId, newProvider.id);
+    }
     return newProvider;
   } catch (error) {
     log(
@@ -105,19 +164,67 @@ async function updateExternalDataProvider(
         'Forbidden: You do not have permission to update this external data provider.'
       );
     }
+    // Fetch current provider once — used for several guards and to know whether
+    // we need to invalidate the OFF session cache after the update.
+    const existingProvider =
+      await externalProviderRepository.getExternalDataProviderById(providerId);
+
     // Only allow owner to set shared_with_public
     if (updateData.shared_with_public === true) {
-      // Fetch current provider to check name
-      const provider =
-        await externalProviderRepository.getExternalDataProviderById(
-          providerId
-        );
-      if (provider && provider.is_strictly_private) {
+      if (existingProvider && existingProvider.is_strictly_private) {
         throw new Error(
-          `Forbidden: ${provider.provider_name} connection is strictly private and cannot be shared publicly.`
+          `Forbidden: ${existingProvider.provider_name} connection is strictly private and cannot be shared publicly.`
         );
       }
     }
+
+    // Mutual exclusion: an OFF row cannot simultaneously be shared publicly
+    // and hold credentials. Check both directions to cover TOCTOU.
+    const isOpenFoodFacts =
+      existingProvider?.provider_type === 'openfoodfacts' ||
+      updateData.provider_type === 'openfoodfacts';
+    if (isOpenFoodFacts) {
+      const nextSharedWithPublic =
+        updateData.shared_with_public !== undefined
+          ? updateData.shared_with_public
+          : existingProvider?.shared_with_public;
+
+      // Resolve post-update credential state:
+      //   - explicit null means "clear"
+      //   - undefined means "leave as-is"
+      //   - any other value means "populated"
+      const resolveField = (nextVal, currentVal) => {
+        if (nextVal === null) return null;
+        if (nextVal === undefined) return currentVal;
+        return nextVal;
+      };
+      const nextAppId = resolveField(
+        updateData.app_id,
+        existingProvider?.app_id
+      );
+      const nextAppKey = resolveField(
+        updateData.app_key,
+        existingProvider?.app_key
+      );
+      const willHaveCredentials = !!(nextAppId || nextAppKey);
+
+      // Reject half-configured credentials: OFF authenticated access needs
+      // both username and password, so any post-update state with exactly one
+      // field populated is silently broken (every OFF request would still run
+      // unauthenticated).
+      if (!!nextAppId !== !!nextAppKey) {
+        throw badRequest(
+          'Open Food Facts credentials must include both a username and a password.'
+        );
+      }
+
+      if (nextSharedWithPublic === true && willHaveCredentials) {
+        throw badRequest(
+          'Open Food Facts credentials cannot be stored on a provider row that is shared publicly. Remove credentials or disable public sharing first.'
+        );
+      }
+    }
+
     const updatedProvider =
       await externalProviderRepository.updateExternalDataProvider(
         providerId,
@@ -128,6 +235,9 @@ async function updateExternalDataProvider(
       throw new Error(
         'External data provider not found or not authorized to update.'
       );
+    }
+    if (isOpenFoodFacts) {
+      invalidateOpenFoodFactsSession(authenticatedUserId, providerId);
     }
     return updatedProvider;
   } catch (error) {
@@ -186,6 +296,7 @@ async function deleteExternalDataProvider(authenticatedUserId, providerId) {
         'External data provider not found or not authorized to delete.'
       );
     }
+    invalidateOpenFoodFactsSession(authenticatedUserId, providerId);
     return true;
   } catch (error) {
     log(
@@ -197,6 +308,35 @@ async function deleteExternalDataProvider(authenticatedUserId, providerId) {
   }
 }
 
+// Returns the id of the first active OFF provider owned by the user that has
+// populated encrypted credentials, or null. The seeded default OFF row has no
+// credentials — this filter ensures we don't add pointless session lookups for
+// users who never configured a username/password.
+async function getActiveOpenFoodFactsProviderId(userId) {
+  try {
+    const providers =
+      await externalProviderRepository.getExternalDataProvidersByUserId(
+        userId,
+        userId
+      );
+    const match = providers.find(
+      (p) =>
+        p.provider_type === 'openfoodfacts' &&
+        p.is_active &&
+        p.app_id &&
+        p.app_key
+    );
+    return match ? match.id : null;
+  } catch (error) {
+    log(
+      'warn',
+      `getActiveOpenFoodFactsProviderId failed for user ${userId}:`,
+      error
+    );
+    return null;
+  }
+}
+
 module.exports = {
   getExternalDataProviders,
   getExternalDataProvidersForUser,
@@ -204,4 +344,5 @@ module.exports = {
   updateExternalDataProvider,
   getExternalDataProviderDetails,
   deleteExternalDataProvider,
+  getActiveOpenFoodFactsProviderId,
 };

--- a/SparkyFitnessServer/services/foodCoreService.js
+++ b/SparkyFitnessServer/services/foodCoreService.js
@@ -836,7 +836,9 @@ async function lookupBarcode(barcode, userId, providerId) {
         const offData = await searchOpenFoodFactsByBarcodeFields(
           barcode,
           undefined,
-          language
+          language,
+          userId,
+          provider.id
         );
         if (offData?.status === 1 && offData.product) {
           const food = mapOpenFoodFactsProduct(offData.product, {
@@ -865,11 +867,33 @@ async function lookupBarcode(barcode, userId, providerId) {
       !triedOpenFoodFacts &&
       userPreferences?.barcode_fallback_open_food_facts !== false
     ) {
+      // Only look up a credentialed OFF provider when none is already
+      // resolved. Avoids an extra DB round-trip on every OFF barcode lookup
+      // for users without configured credentials.
+      let offProviderId = null;
+      if (provider?.provider_type === 'openfoodfacts') {
+        offProviderId = provider.id;
+      } else {
+        try {
+          offProviderId =
+            await externalProviderService.getActiveOpenFoodFactsProviderId(
+              userId
+            );
+        } catch (fallbackError) {
+          log(
+            'debug',
+            'OpenFoodFacts fallback provider resolution failed:',
+            fallbackError
+          );
+        }
+      }
       try {
         const offData = await searchOpenFoodFactsByBarcodeFields(
           barcode,
           undefined,
-          language
+          language,
+          offProviderId ? userId : undefined,
+          offProviderId || undefined
         );
         if (offData?.status === 1 && offData.product) {
           const food = mapOpenFoodFactsProduct(offData.product, {

--- a/SparkyFitnessServer/tests/barcodeLookup.test.js
+++ b/SparkyFitnessServer/tests/barcodeLookup.test.js
@@ -628,7 +628,9 @@ describe('lookupBarcode', () => {
     expect(searchOpenFoodFactsByBarcodeFields).toHaveBeenCalledWith(
       barcode,
       undefined,
-      'fr'
+      'fr',
+      undefined,
+      undefined
     );
     expect(result.source).toBe('openfoodfacts');
     expect(result.food.name).toBe('Produit Français');
@@ -848,6 +850,74 @@ describe('lookupBarcode', () => {
       2,
       '094395000172',
       'test-usda-api-key'
+    );
+  });
+
+  it('passes (userId, provider.id) to OFF when OFF is the configured primary provider', async () => {
+    const offProvider = {
+      id: 'prov-off-1',
+      provider_type: 'openfoodfacts',
+      is_active: true,
+    };
+    foodRepository.findFoodByBarcode.mockResolvedValue(null);
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue(
+      offProvider
+    );
+    searchOpenFoodFactsByBarcodeFields.mockResolvedValue(makeOffResponse());
+
+    const result = await lookupBarcode(
+      '3017620422003',
+      TEST_USER_ID,
+      'prov-off-1'
+    );
+
+    expect(result.source).toBe('openfoodfacts');
+    expect(searchOpenFoodFactsByBarcodeFields).toHaveBeenCalledWith(
+      '3017620422003',
+      undefined,
+      'en',
+      TEST_USER_ID,
+      'prov-off-1'
+    );
+  });
+
+  it('uses getActiveOpenFoodFactsProviderId in the OFF fallback branch', async () => {
+    foodRepository.findFoodByBarcode.mockResolvedValue(null);
+    externalProviderService.getActiveOpenFoodFactsProviderId.mockResolvedValue(
+      'prov-off-2'
+    );
+    searchOpenFoodFactsByBarcodeFields.mockResolvedValue(makeOffResponse());
+
+    const result = await lookupBarcode('3017620422003', TEST_USER_ID);
+
+    expect(result.source).toBe('openfoodfacts');
+    expect(
+      externalProviderService.getActiveOpenFoodFactsProviderId
+    ).toHaveBeenCalledWith(TEST_USER_ID);
+    expect(searchOpenFoodFactsByBarcodeFields).toHaveBeenCalledWith(
+      '3017620422003',
+      undefined,
+      'en',
+      TEST_USER_ID,
+      'prov-off-2'
+    );
+  });
+
+  it('OFF fallback omits user/providerId when no credentialed OFF provider exists', async () => {
+    foodRepository.findFoodByBarcode.mockResolvedValue(null);
+    externalProviderService.getActiveOpenFoodFactsProviderId.mockResolvedValue(
+      null
+    );
+    searchOpenFoodFactsByBarcodeFields.mockResolvedValue(makeOffResponse());
+
+    await lookupBarcode('3017620422003', TEST_USER_ID);
+
+    expect(searchOpenFoodFactsByBarcodeFields).toHaveBeenCalledWith(
+      '3017620422003',
+      undefined,
+      'en',
+      undefined,
+      undefined
     );
   });
 

--- a/SparkyFitnessServer/tests/externalProviderService.test.js
+++ b/SparkyFitnessServer/tests/externalProviderService.test.js
@@ -1,0 +1,401 @@
+jest.mock('../models/externalProviderRepository');
+jest.mock('../integrations/openfoodfacts/openFoodFactsAuth', () => ({
+  invalidateOpenFoodFactsSession: jest.fn(),
+}));
+jest.mock('../config/logging', () => ({ log: jest.fn() }));
+
+const externalProviderRepository = require('../models/externalProviderRepository');
+const externalProviderService = require('../services/externalProviderService');
+const {
+  invalidateOpenFoodFactsSession,
+} = require('../integrations/openfoodfacts/openFoodFactsAuth');
+
+const OWNER = 'owner-1';
+const VIEWER = 'viewer-2';
+const PROVIDER_ID = 'prov-off-1';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getExternalDataProvidersForUser - non-owner credential redaction', () => {
+  it('strips app_id/app_key and encrypted_* columns when viewer is not owner', async () => {
+    externalProviderRepository.getExternalDataProvidersByUserId.mockResolvedValue(
+      [
+        {
+          id: PROVIDER_ID,
+          user_id: OWNER,
+          provider_type: 'openfoodfacts',
+          shared_with_public: true,
+          is_active: true,
+          is_strictly_private: false,
+          app_id: 'username',
+          app_key: 'secretpw',
+          encrypted_app_id: 'cipher',
+          app_id_iv: 'iv',
+          app_id_tag: 'tag',
+          encrypted_app_key: 'cipher2',
+          app_key_iv: 'iv2',
+          app_key_tag: 'tag2',
+        },
+      ]
+    );
+
+    const result =
+      await externalProviderService.getExternalDataProvidersForUser(
+        VIEWER,
+        OWNER
+      );
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.app_id).toBeUndefined();
+    expect(row.app_key).toBeUndefined();
+    expect(row.encrypted_app_id).toBeUndefined();
+    expect(row.app_id_iv).toBeUndefined();
+    expect(row.app_id_tag).toBeUndefined();
+    expect(row.encrypted_app_key).toBeUndefined();
+    expect(row.app_key_iv).toBeUndefined();
+    expect(row.app_key_tag).toBeUndefined();
+    expect(row.visibility).toBe('public');
+    expect(row.is_active).toBe(true);
+  });
+
+  it('preserves credentials when viewer is the owner', async () => {
+    externalProviderRepository.getExternalDataProvidersByUserId.mockResolvedValue(
+      [
+        {
+          id: PROVIDER_ID,
+          user_id: OWNER,
+          provider_type: 'openfoodfacts',
+          shared_with_public: false,
+          is_active: true,
+          is_strictly_private: false,
+          app_id: 'username',
+          app_key: 'secretpw',
+        },
+      ]
+    );
+
+    const result =
+      await externalProviderService.getExternalDataProvidersForUser(
+        OWNER,
+        OWNER
+      );
+
+    expect(result[0].app_id).toBe('username');
+    expect(result[0].app_key).toBe('secretpw');
+    expect(result[0].visibility).toBe('private');
+  });
+});
+
+describe('createExternalDataProvider - mutual exclusion', () => {
+  // Expect a rejection whose error message matches `pattern` AND carries
+  // statusCode=400 so the centralized errorHandler will surface it as a
+  // client validation failure rather than 500 Internal Server Error.
+  const expectBadRequest = async (promise, pattern) => {
+    await expect(promise).rejects.toThrow(pattern);
+    await expect(promise).rejects.toMatchObject({ statusCode: 400 });
+  };
+
+  it('rejects shared_with_public=true on an OFF row carrying credentials', async () => {
+    await expectBadRequest(
+      externalProviderService.createExternalDataProvider(OWNER, {
+        provider_type: 'openfoodfacts',
+        provider_name: 'OFF',
+        shared_with_public: true,
+        app_id: 'me',
+        app_key: 'pw',
+      }),
+      /cannot be stored on a provider row that is shared/
+    );
+    expect(
+      externalProviderRepository.createExternalDataProvider
+    ).not.toHaveBeenCalled();
+  });
+
+  it('rejects an OFF row with only app_id populated', async () => {
+    await expectBadRequest(
+      externalProviderService.createExternalDataProvider(OWNER, {
+        provider_type: 'openfoodfacts',
+        provider_name: 'OFF',
+        app_id: 'me',
+      }),
+      /must include both a username and a password/
+    );
+    expect(
+      externalProviderRepository.createExternalDataProvider
+    ).not.toHaveBeenCalled();
+  });
+
+  it('rejects an OFF row with only app_key populated', async () => {
+    await expectBadRequest(
+      externalProviderService.createExternalDataProvider(OWNER, {
+        provider_type: 'openfoodfacts',
+        provider_name: 'OFF',
+        app_key: 'pw',
+      }),
+      /must include both a username and a password/
+    );
+    expect(
+      externalProviderRepository.createExternalDataProvider
+    ).not.toHaveBeenCalled();
+  });
+
+  it('allows public sharing of an OFF row without credentials', async () => {
+    externalProviderRepository.createExternalDataProvider.mockResolvedValue({
+      id: PROVIDER_ID,
+    });
+    await externalProviderService.createExternalDataProvider(OWNER, {
+      provider_type: 'openfoodfacts',
+      provider_name: 'OFF',
+      shared_with_public: true,
+    });
+    expect(
+      externalProviderRepository.createExternalDataProvider
+    ).toHaveBeenCalled();
+    expect(invalidateOpenFoodFactsSession).toHaveBeenCalledWith(
+      OWNER,
+      PROVIDER_ID
+    );
+  });
+});
+
+describe('updateExternalDataProvider - mutual exclusion + invalidation', () => {
+  // Expect a rejection whose error message matches `pattern` AND carries
+  // statusCode=400 so the centralized errorHandler will surface it as a
+  // client validation failure rather than 500 Internal Server Error.
+  const expectBadRequest = async (promise, pattern) => {
+    await expect(promise).rejects.toThrow(pattern);
+    await expect(promise).rejects.toMatchObject({ statusCode: 400 });
+  };
+
+  beforeEach(() => {
+    externalProviderRepository.checkExternalDataProviderOwnership.mockResolvedValue(
+      true
+    );
+    externalProviderRepository.updateExternalDataProvider.mockResolvedValue({
+      id: PROVIDER_ID,
+    });
+  });
+
+  it('rejects setting credentials on a row that is currently shared_with_public', async () => {
+    externalProviderRepository.getExternalDataProviderById.mockResolvedValue({
+      id: PROVIDER_ID,
+      provider_type: 'openfoodfacts',
+      shared_with_public: true,
+      app_id: null,
+      app_key: null,
+    });
+
+    await expectBadRequest(
+      externalProviderService.updateExternalDataProvider(OWNER, PROVIDER_ID, {
+        app_id: 'me',
+        app_key: 'pw',
+      }),
+      /cannot be stored on a provider row that is shared/
+    );
+  });
+
+  it('rejects flipping shared_with_public=true on a row that already has credentials', async () => {
+    externalProviderRepository.getExternalDataProviderById.mockResolvedValue({
+      id: PROVIDER_ID,
+      provider_type: 'openfoodfacts',
+      shared_with_public: false,
+      app_id: 'me',
+      app_key: 'pw',
+    });
+
+    await expectBadRequest(
+      externalProviderService.updateExternalDataProvider(OWNER, PROVIDER_ID, {
+        shared_with_public: true,
+      }),
+      /cannot be stored on a provider row that is shared/
+    );
+  });
+
+  it('allows setting credentials on a private OFF row and invalidates the session', async () => {
+    externalProviderRepository.getExternalDataProviderById.mockResolvedValue({
+      id: PROVIDER_ID,
+      provider_type: 'openfoodfacts',
+      shared_with_public: false,
+      app_id: null,
+      app_key: null,
+    });
+
+    await externalProviderService.updateExternalDataProvider(
+      OWNER,
+      PROVIDER_ID,
+      { app_id: 'me', app_key: 'pw' }
+    );
+
+    expect(
+      externalProviderRepository.updateExternalDataProvider
+    ).toHaveBeenCalled();
+    expect(invalidateOpenFoodFactsSession).toHaveBeenCalledWith(
+      OWNER,
+      PROVIDER_ID
+    );
+  });
+
+  it('rejects an update that would leave only app_id populated', async () => {
+    externalProviderRepository.getExternalDataProviderById.mockResolvedValue({
+      id: PROVIDER_ID,
+      provider_type: 'openfoodfacts',
+      shared_with_public: false,
+      app_id: null,
+      app_key: null,
+    });
+
+    await expectBadRequest(
+      externalProviderService.updateExternalDataProvider(OWNER, PROVIDER_ID, {
+        app_id: 'me',
+      }),
+      /must include both a username and a password/
+    );
+    expect(
+      externalProviderRepository.updateExternalDataProvider
+    ).not.toHaveBeenCalled();
+  });
+
+  it('rejects clearing only app_key on a row that already has both', async () => {
+    externalProviderRepository.getExternalDataProviderById.mockResolvedValue({
+      id: PROVIDER_ID,
+      provider_type: 'openfoodfacts',
+      shared_with_public: false,
+      app_id: 'me',
+      app_key: 'pw',
+    });
+
+    await expectBadRequest(
+      externalProviderService.updateExternalDataProvider(OWNER, PROVIDER_ID, {
+        app_key: null,
+      }),
+      /must include both a username and a password/
+    );
+    expect(
+      externalProviderRepository.updateExternalDataProvider
+    ).not.toHaveBeenCalled();
+  });
+
+  it('allows clearing credentials via explicit null on a public OFF row', async () => {
+    externalProviderRepository.getExternalDataProviderById.mockResolvedValue({
+      id: PROVIDER_ID,
+      provider_type: 'openfoodfacts',
+      shared_with_public: true,
+      app_id: 'me',
+      app_key: 'pw',
+    });
+
+    await externalProviderService.updateExternalDataProvider(
+      OWNER,
+      PROVIDER_ID,
+      { app_id: null, app_key: null }
+    );
+
+    expect(
+      externalProviderRepository.updateExternalDataProvider
+    ).toHaveBeenCalledWith(
+      PROVIDER_ID,
+      OWNER,
+      expect.objectContaining({ app_id: null, app_key: null })
+    );
+  });
+
+  it('does not invalidate OFF session for non-OFF providers', async () => {
+    externalProviderRepository.getExternalDataProviderById.mockResolvedValue({
+      id: PROVIDER_ID,
+      provider_type: 'usda',
+      shared_with_public: false,
+    });
+
+    await externalProviderService.updateExternalDataProvider(
+      OWNER,
+      PROVIDER_ID,
+      { app_key: 'new-api-key' }
+    );
+
+    expect(invalidateOpenFoodFactsSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteExternalDataProvider', () => {
+  it('invalidates the OFF session cache after deletion', async () => {
+    externalProviderRepository.checkExternalDataProviderOwnership.mockResolvedValue(
+      true
+    );
+    externalProviderRepository.deleteExternalDataProvider.mockResolvedValue(
+      true
+    );
+
+    await externalProviderService.deleteExternalDataProvider(
+      OWNER,
+      PROVIDER_ID
+    );
+
+    expect(invalidateOpenFoodFactsSession).toHaveBeenCalledWith(
+      OWNER,
+      PROVIDER_ID
+    );
+  });
+});
+
+describe('getActiveOpenFoodFactsProviderId', () => {
+  it('returns the id of the first active OFF provider with credentials', async () => {
+    externalProviderRepository.getExternalDataProvidersByUserId.mockResolvedValue(
+      [
+        {
+          id: 'p1',
+          provider_type: 'openfoodfacts',
+          is_active: true,
+          app_id: null,
+          app_key: null,
+        },
+        {
+          id: 'p2',
+          provider_type: 'openfoodfacts',
+          is_active: true,
+          app_id: 'me',
+          app_key: 'pw',
+        },
+      ]
+    );
+    const id =
+      await externalProviderService.getActiveOpenFoodFactsProviderId(OWNER);
+    expect(id).toBe('p2');
+  });
+
+  it('returns null when no credentialed OFF provider exists', async () => {
+    externalProviderRepository.getExternalDataProvidersByUserId.mockResolvedValue(
+      [
+        {
+          id: 'p1',
+          provider_type: 'openfoodfacts',
+          is_active: true,
+          app_id: null,
+          app_key: null,
+        },
+      ]
+    );
+    const id =
+      await externalProviderService.getActiveOpenFoodFactsProviderId(OWNER);
+    expect(id).toBe(null);
+  });
+
+  it('skips inactive providers', async () => {
+    externalProviderRepository.getExternalDataProvidersByUserId.mockResolvedValue(
+      [
+        {
+          id: 'p1',
+          provider_type: 'openfoodfacts',
+          is_active: false,
+          app_id: 'me',
+          app_key: 'pw',
+        },
+      ]
+    );
+    const id =
+      await externalProviderService.getActiveOpenFoodFactsProviderId(OWNER);
+    expect(id).toBe(null);
+  });
+});

--- a/SparkyFitnessServer/tests/openFoodFactsAuth.test.js
+++ b/SparkyFitnessServer/tests/openFoodFactsAuth.test.js
@@ -1,0 +1,162 @@
+jest.mock('../services/externalProviderService');
+jest.mock('../config/logging', () => ({ log: jest.fn() }));
+
+const externalProviderService = require('../services/externalProviderService');
+const {
+  getOpenFoodFactsSessionCookie,
+  invalidateOpenFoodFactsSession,
+  __resetForTests,
+} = require('../integrations/openfoodfacts/openFoodFactsAuth');
+
+global.fetch = jest.fn();
+
+const USER_ID = 'user-A';
+const PROVIDER_ID = 'prov-1';
+const OTHER_PROVIDER_ID = 'prov-2';
+
+function makeOffLoginResponse({ session = 'abc123', body = '' } = {}) {
+  return {
+    headers: {
+      getSetCookie: () => [
+        `session=${session}; Path=/; HttpOnly`,
+        'other=foo; Path=/',
+      ],
+    },
+    text: jest.fn().mockResolvedValue(body),
+  };
+}
+
+function makeOffLoginRejectedResponse() {
+  return {
+    headers: { getSetCookie: () => [] },
+    text: jest.fn().mockResolvedValue(''),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __resetForTests();
+});
+
+describe('getOpenFoodFactsSessionCookie', () => {
+  it('caches the session after a successful login', async () => {
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue({
+      provider_type: 'openfoodfacts',
+      app_id: 'me',
+      app_key: 'pw',
+    });
+    fetch.mockResolvedValue(makeOffLoginResponse({ session: 'XYZ' }));
+
+    const first = await getOpenFoodFactsSessionCookie(USER_ID, PROVIDER_ID);
+    const second = await getOpenFoodFactsSessionCookie(USER_ID, PROVIDER_ID);
+
+    expect(first).toBe('XYZ');
+    expect(second).toBe('XYZ');
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(
+      externalProviderService.getExternalDataProviderDetails
+    ).toHaveBeenCalledWith(USER_ID, PROVIDER_ID);
+  });
+
+  it('negative-caches when login returns no session cookie', async () => {
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue({
+      provider_type: 'openfoodfacts',
+      app_id: 'me',
+      app_key: 'pw',
+    });
+    fetch.mockResolvedValue(makeOffLoginRejectedResponse());
+
+    const result = await getOpenFoodFactsSessionCookie(USER_ID, PROVIDER_ID);
+
+    expect(result).toBe(null);
+  });
+
+  it('returns null without throwing when ownership check rejects', async () => {
+    externalProviderService.getExternalDataProviderDetails.mockRejectedValue(
+      new Error('Forbidden: not owner')
+    );
+
+    const result = await getOpenFoodFactsSessionCookie(
+      USER_ID,
+      OTHER_PROVIDER_ID
+    );
+
+    expect(result).toBe(null);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('coalesces concurrent logins for the same key into one fetch', async () => {
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue({
+      provider_type: 'openfoodfacts',
+      app_id: 'me',
+      app_key: 'pw',
+    });
+    let resolveFetch;
+    fetch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+
+    const p1 = getOpenFoodFactsSessionCookie(USER_ID, PROVIDER_ID);
+    const p2 = getOpenFoodFactsSessionCookie(USER_ID, PROVIDER_ID);
+
+    resolveFetch(makeOffLoginResponse({ session: 'COALESCED' }));
+
+    const [a, b] = await Promise.all([p1, p2]);
+    expect(a).toBe('COALESCED');
+    expect(b).toBe('COALESCED');
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips login when provider has no credentials', async () => {
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue({
+      provider_type: 'openfoodfacts',
+      app_id: null,
+      app_key: null,
+    });
+
+    const result = await getOpenFoodFactsSessionCookie(USER_ID, PROVIDER_ID);
+
+    expect(result).toBe(null);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('treats a login HTML page with the error marker as failure', async () => {
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue({
+      provider_type: 'openfoodfacts',
+      app_id: 'me',
+      app_key: 'wrong',
+    });
+    fetch.mockResolvedValue(
+      makeOffLoginResponse({
+        session: 'leftover',
+        body: '<p>Incorrect user name or password</p>',
+      })
+    );
+
+    const result = await getOpenFoodFactsSessionCookie(USER_ID, PROVIDER_ID);
+    expect(result).toBe(null);
+  });
+});
+
+describe('invalidateOpenFoodFactsSession', () => {
+  it('drops a cached entry so the next call re-logs in', async () => {
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue({
+      provider_type: 'openfoodfacts',
+      app_id: 'me',
+      app_key: 'pw',
+    });
+    fetch
+      .mockResolvedValueOnce(makeOffLoginResponse({ session: 'one' }))
+      .mockResolvedValueOnce(makeOffLoginResponse({ session: 'two' }));
+
+    const a = await getOpenFoodFactsSessionCookie(USER_ID, PROVIDER_ID);
+    invalidateOpenFoodFactsSession(USER_ID, PROVIDER_ID);
+    const b = await getOpenFoodFactsSessionCookie(USER_ID, PROVIDER_ID);
+
+    expect(a).toBe('one');
+    expect(b).toBe('two');
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.js
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.js
@@ -1,13 +1,23 @@
+jest.mock('../integrations/openfoodfacts/openFoodFactsAuth', () => ({
+  getOpenFoodFactsSessionCookie: jest.fn(),
+  invalidateOpenFoodFactsSession: jest.fn(),
+}));
+
 const {
   searchOpenFoodFacts,
   searchOpenFoodFactsByBarcodeFields,
 } = require('../integrations/openfoodfacts/openFoodFactsService');
+const {
+  getOpenFoodFactsSessionCookie,
+  invalidateOpenFoodFactsSession,
+} = require('../integrations/openfoodfacts/openFoodFactsAuth');
 
 global.fetch = jest.fn();
 
 describe('openFoodFactsService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    getOpenFoodFactsSessionCookie.mockResolvedValue(null);
   });
 
   describe('searchOpenFoodFacts', () => {
@@ -67,6 +77,112 @@ describe('openFoodFactsService', () => {
         expect.stringContaining('&lc=en'),
         expect.any(Object)
       );
+    });
+  });
+
+  describe('authenticated request path', () => {
+    it('attaches a session cookie when providerId+userId are supplied', async () => {
+      getOpenFoodFactsSessionCookie.mockResolvedValue('SESS_TOKEN');
+      fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 1, product: {} }),
+      });
+
+      await searchOpenFoodFactsByBarcodeFields(
+        '12345678',
+        undefined,
+        'en',
+        'user-A',
+        'prov-1'
+      );
+
+      expect(getOpenFoodFactsSessionCookie).toHaveBeenCalledWith(
+        'user-A',
+        'prov-1'
+      );
+      const callArgs = fetch.mock.calls[0];
+      expect(callArgs[1].headers).toMatchObject({
+        Cookie: 'session=SESS_TOKEN',
+      });
+    });
+
+    it('does not attach a cookie when no providerId is supplied', async () => {
+      fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 1, product: {} }),
+      });
+
+      await searchOpenFoodFactsByBarcodeFields('12345678');
+
+      expect(getOpenFoodFactsSessionCookie).not.toHaveBeenCalled();
+      const headers = fetch.mock.calls[0][1].headers;
+      expect(headers.Cookie).toBeUndefined();
+    });
+
+    it('on 429 with cookie, invalidates and retries unauthenticated once', async () => {
+      getOpenFoodFactsSessionCookie.mockResolvedValue('SESS_TOKEN');
+      fetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 429,
+          text: () => Promise.resolve('rate limited'),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ status: 1, product: {} }),
+        });
+
+      const result = await searchOpenFoodFactsByBarcodeFields(
+        '12345678',
+        undefined,
+        'en',
+        'user-A',
+        'prov-1'
+      );
+
+      expect(result).toEqual({ status: 1, product: {} });
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(invalidateOpenFoodFactsSession).toHaveBeenCalledWith(
+        'user-A',
+        'prov-1'
+      );
+      // First call had cookie, second call did not
+      expect(fetch.mock.calls[0][1].headers.Cookie).toBe('session=SESS_TOKEN');
+      expect(fetch.mock.calls[1][1].headers.Cookie).toBeUndefined();
+    });
+
+    it('on 503 with cookie, retries unauthenticated and returns final response', async () => {
+      getOpenFoodFactsSessionCookie.mockResolvedValue('SESS_TOKEN');
+      fetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          text: () => Promise.resolve('unavailable'),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ products: [], count: 0 }),
+        });
+
+      await searchOpenFoodFacts('pizza', 1, 'en', 'user-A', 'prov-1');
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(invalidateOpenFoodFactsSession).toHaveBeenCalled();
+    });
+
+    it('does not retry on 429 when no cookie was attached', async () => {
+      fetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: () => Promise.resolve('rate limited'),
+      });
+
+      await expect(
+        searchOpenFoodFactsByBarcodeFields('12345678')
+      ).rejects.toThrow('OpenFoodFacts API error');
+      expect(fetch).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

This PR adds optional authentication to open food facts requests. This can help users bypass errors during busy times. Note: this is not documented in their API but it seems to work (hard to verify)

Linked Issue: #1079

## How to Test

1. Add OFF credentials
2. Search
3. Hopefully no more error

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="1327" height="425" alt="off userpw" src="https://github.com/user-attachments/assets/d89a6393-8add-4611-a46d-c4fc68e1b35f" />


### After

<img width="1327" height="425" alt="off userpw" src="https://github.com/user-attachments/assets/60e125ec-103c-4f15-bfea-9df0f9d5c290" />


</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
