### PR TITLE
App: Added sync on open option

### DIFF
--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -55,7 +55,7 @@ import {
   isSyncClaimed,
   isForegroundAutoSyncWindowOpen,
   setForegroundAutoSyncWindowOpen,
-  shouldRunColdStartAutoSync,
+  shouldRunForegroundResumeAutoSync,
   recordAutoSyncTime,
 } from './src/services/autoSyncCoordinator';
 import { initializeTheme } from './src/services/themeService';
@@ -414,7 +414,6 @@ function AppContent() {
       if (!syncOnOpen) return;
       const config = await getActiveServerConfig();
       if (!config) return;
-      if (!(await shouldRunColdStartAutoSync(config.id))) return;
 
       setForegroundAutoSyncWindowState(true);
       const coordRelease = tryClaimAutoSync();
@@ -468,7 +467,7 @@ function AppContent() {
 
         const syncOnOpen = await loadSyncOnOpenEnabled();
         if (!syncOnOpen) return;
-        if (!(await shouldRunColdStartAutoSync(config.id))) return;
+        if (!(await shouldRunForegroundResumeAutoSync(config.id))) return;
 
         setForegroundAutoSyncWindowState(true);
         const coordRelease = tryClaimAutoSync();

--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -1,6 +1,6 @@
 import './global.css'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { StatusBar, Platform, Alert } from 'react-native';
+import { StatusBar, Platform, Alert, AppState } from 'react-native';
 import * as SplashScreen from 'expo-splash-screen';
 import {
   NavigationContainer,
@@ -40,11 +40,24 @@ import OnboardingScreen from './src/screens/OnboardingScreen';
 import ReauthModal from './src/components/ReauthModal';
 import ServerConfigModal from './src/components/ServerConfigModal';
 import { useAuth } from './src/hooks/useAuth';
-import { loadBackgroundSyncEnabled, loadTimeRange, getActiveServerConfig } from './src/services/storage';
+import {
+  loadBackgroundSyncEnabled,
+  loadTimeRange,
+  getActiveServerConfig,
+  loadSyncOnOpenEnabled,
+} from './src/services/storage';
 import type { TimeRange } from './src/services/storage';
 import { initHealthConnect, loadHealthPreference , startObservers, stopObservers } from './src/services/healthConnectService';
 import { HEALTH_METRICS } from './src/HealthMetrics';
 import { configureBackgroundSync, performBackgroundSync } from './src/services/backgroundSyncService';
+import {
+  tryClaimAutoSync,
+  isSyncClaimed,
+  isForegroundAutoSyncWindowOpen,
+  setForegroundAutoSyncWindowOpen,
+  shouldRunColdStartAutoSync,
+  recordAutoSyncTime,
+} from './src/services/autoSyncCoordinator';
 import { initializeTheme } from './src/services/themeService';
 import { loadActiveDraft, clearDraft } from './src/services/workoutDraftService';
 import { initLogService } from './src/services/LogService';
@@ -115,6 +128,13 @@ function AppContent() {
 
   const addSheetRef = useRef<AddSheetRef>(null);
   const navigationRef = useRef<NavigationProp<TabParamList> | null>(null);
+  const foregroundAutoSyncWindowRef = useRef(false);
+  const backgroundEnteredAtRef = useRef<number | null>(null);
+  const wasInBackgroundRef = useRef(false);
+  const setForegroundAutoSyncWindowState = useCallback((isOpen: boolean) => {
+    foregroundAutoSyncWindowRef.current = isOpen;
+    setForegroundAutoSyncWindowOpen(isOpen);
+  }, []);
 
   const [primary, chrome, chromeBorder, bgPrimary, textPrimary] = useCSSVariable([
     '--color-accent-primary',
@@ -246,7 +266,7 @@ function AppContent() {
   const syncMutation = useSyncHealthData();
 
   const handleSyncHealthData = useCallback(async () => {
-    if (syncMutation.isPending) return;
+    if (syncMutation.isPending || isSyncClaimed()) return;
 
     const initialized = await initHealthConnect();
     if (!initialized) {
@@ -265,6 +285,46 @@ function AppContent() {
 
     syncMutation.mutate({ timeRange, healthMetricStates });
   }, [syncMutation]);
+
+  const triggerAutoSync = useCallback(async (configId: string, release: () => void) => {
+    let committed = false;
+    try {
+      if (syncMutation.isPending) return;
+
+      const initialized = await initHealthConnect();
+      if (!initialized) return;
+
+      const loadedTimeRange = await loadTimeRange();
+      const timeRange: TimeRange = loadedTimeRange ?? '3d';
+      const healthMetricStates: Record<string, boolean> = {};
+      for (const metric of HEALTH_METRICS) {
+        const enabled = await loadHealthPreference<boolean>(metric.preferenceKey);
+        healthMetricStates[metric.stateKey] = enabled === true;
+      }
+
+      committed = true;
+      syncMutation.mutate({
+        timeRange,
+        healthMetricStates,
+      }, {
+        onSuccess: () => {
+          void recordAutoSyncTime(configId);
+        },
+        onSettled: () => {
+          release();
+        },
+      });
+    } catch (error) {
+      console.error('[App] Auto sync on open failed:', error);
+    } finally {
+      if (!committed) release();
+    }
+  }, [syncMutation]);
+
+  const triggerAutoSyncRef = useRef(triggerAutoSync);
+  useEffect(() => {
+    triggerAutoSyncRef.current = triggerAutoSync;
+  }, [triggerAutoSync]);
 
   useEffect(() => {
     let cancelled = false;
@@ -308,9 +368,26 @@ function AppContent() {
         if (!enabled || cancelled) return;
 
         startObservers(() => {
-          performBackgroundSync('healthkit-observer').catch(error => {
-            console.error('[App] Observer-triggered sync failed:', error);
-          });
+          // Yield only during a deliberate foreground auto-sync window (cold-start or
+          // foreground-return). Outside that narrow window, let background delivery fire normally.
+          if (
+            AppState.currentState === 'active' &&
+            foregroundAutoSyncWindowRef.current &&
+            isForegroundAutoSyncWindowOpen()
+          ) {
+            return;
+          }
+
+          const release = tryClaimAutoSync();
+          if (!release) return;
+
+          performBackgroundSync('healthkit-observer')
+            .catch(error => {
+              console.error('[App] Observer-triggered sync failed:', error);
+            })
+            .finally(() => {
+              release();
+            });
         });
       } catch (error) {
         console.error('[App] Failed to configure HealthKit observers:', error);
@@ -327,7 +404,98 @@ function AppContent() {
         stopObservers();
       }
     };
-  }, []);
+  }, [setForegroundAutoSyncWindowState]);
+
+  useEffect(() => {
+    if (initialRoute !== 'Tabs') return;
+
+    const triggerColdStartSync = async () => {
+      const syncOnOpen = await loadSyncOnOpenEnabled();
+      if (!syncOnOpen) return;
+      const config = await getActiveServerConfig();
+      if (!config) return;
+      if (!(await shouldRunColdStartAutoSync(config.id))) return;
+
+      setForegroundAutoSyncWindowState(true);
+      const coordRelease = tryClaimAutoSync();
+      if (!coordRelease) {
+        setForegroundAutoSyncWindowState(false);
+        return;
+      }
+
+      const cleanup = () => {
+        setForegroundAutoSyncWindowState(false);
+        coordRelease();
+      };
+      const watchdog = setTimeout(cleanup, 90_000);
+      const safeCleanup = () => {
+        clearTimeout(watchdog);
+        cleanup();
+      };
+
+      await triggerAutoSyncRef.current(config.id, safeCleanup);
+    };
+
+    triggerColdStartSync().catch(error => {
+      setForegroundAutoSyncWindowState(false);
+      console.error('[App] Cold-start sync on open failed:', error);
+    });
+  }, [initialRoute, setForegroundAutoSyncWindowState]);
+
+  useEffect(() => {
+    const FOREGROUND_SYNC_MIN_AWAY_MS = 5 * 60 * 1000;
+
+    const subscription = AppState.addEventListener('change', async (nextAppState) => {
+      try {
+        if (nextAppState === 'background') {
+          backgroundEnteredAtRef.current = Date.now();
+          wasInBackgroundRef.current = true;
+          return;
+        }
+
+        if (nextAppState !== 'active') return;
+        if (!wasInBackgroundRef.current) return;
+
+        const enteredAt = backgroundEnteredAtRef.current;
+        wasInBackgroundRef.current = false;
+        backgroundEnteredAtRef.current = null;
+
+        const timeAway = enteredAt !== null ? Date.now() - enteredAt : Infinity;
+        if (timeAway < FOREGROUND_SYNC_MIN_AWAY_MS) return;
+
+        const config = await getActiveServerConfig();
+        if (!config) return;
+
+        const syncOnOpen = await loadSyncOnOpenEnabled();
+        if (!syncOnOpen) return;
+        if (!(await shouldRunColdStartAutoSync(config.id))) return;
+
+        setForegroundAutoSyncWindowState(true);
+        const coordRelease = tryClaimAutoSync();
+        if (!coordRelease) {
+          setForegroundAutoSyncWindowState(false);
+          return;
+        }
+
+        const cleanup = () => {
+          setForegroundAutoSyncWindowState(false);
+          coordRelease();
+        };
+        const watchdog = setTimeout(cleanup, 90_000);
+        const safeCleanup = () => {
+          clearTimeout(watchdog);
+          cleanup();
+        };
+
+        await triggerAutoSyncRef.current(config.id, safeCleanup);
+      } catch (error) {
+        setForegroundAutoSyncWindowState(false);
+        console.error('[App] Foreground-return sync on open failed:', error);
+      }
+    });
+
+    return () => subscription.remove();
+  }, [setForegroundAutoSyncWindowState]);
 
   if (!initialRoute) return null;
 

--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -76,6 +76,7 @@ SplashScreen.preventAutoHideAsync();
 const Tab = createBottomTabNavigator<TabParamList>();
 const Stack = createStackNavigator<RootStackParamList>();
 const EmptyScreen = () => null;
+const AUTO_SYNC_WATCHDOG_MS = 90_000;
 
 // Tab screens — no Go Back (tab bar provides navigation)
 const SafeDashboard = withErrorBoundary(DashboardScreen, 'Dashboard');
@@ -297,10 +298,12 @@ function AppContent() {
       const loadedTimeRange = await loadTimeRange();
       const timeRange: TimeRange = loadedTimeRange ?? '3d';
       const healthMetricStates: Record<string, boolean> = {};
-      for (const metric of HEALTH_METRICS) {
-        const enabled = await loadHealthPreference<boolean>(metric.preferenceKey);
-        healthMetricStates[metric.stateKey] = enabled === true;
-      }
+      await Promise.all(
+        HEALTH_METRICS.map(async (metric) => {
+          const enabled = await loadHealthPreference<boolean>(metric.preferenceKey);
+          healthMetricStates[metric.stateKey] = enabled === true;
+        }),
+      );
 
       committed = true;
       syncMutation.mutate({
@@ -426,7 +429,7 @@ function AppContent() {
         setForegroundAutoSyncWindowState(false);
         coordRelease();
       };
-      const watchdog = setTimeout(cleanup, 90_000);
+      const watchdog = setTimeout(cleanup, AUTO_SYNC_WATCHDOG_MS);
       const safeCleanup = () => {
         clearTimeout(watchdog);
         cleanup();
@@ -480,7 +483,7 @@ function AppContent() {
           setForegroundAutoSyncWindowState(false);
           coordRelease();
         };
-        const watchdog = setTimeout(cleanup, 90_000);
+        const watchdog = setTimeout(cleanup, AUTO_SYNC_WATCHDOG_MS);
         const safeCleanup = () => {
           clearTimeout(watchdog);
           cleanup();

--- a/SparkyFitnessMobile/src/components/SyncOnOpen.tsx
+++ b/SparkyFitnessMobile/src/components/SyncOnOpen.tsx
@@ -26,7 +26,7 @@ const SyncOnOpen: React.FC<SyncOnOpenProps> = ({ isEnabled, onToggle }) => {
         />
       </View>
       <Text className="text-[13px] text-text-muted leading-4.5 mt-1">
-        When enabled, health data will sync automatically each time you open the app. Syncs again only after 5 minutes away.
+        When enabled, health data will sync automatically when you open the app.
       </Text>
     </View>
   );

--- a/SparkyFitnessMobile/src/components/SyncOnOpen.tsx
+++ b/SparkyFitnessMobile/src/components/SyncOnOpen.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { View, Text, Switch } from 'react-native';
+import { useCSSVariable } from 'uniwind';
+
+interface SyncOnOpenProps {
+  isEnabled: boolean;
+  onToggle: (enabled: boolean) => void;
+}
+
+const SyncOnOpen: React.FC<SyncOnOpenProps> = ({ isEnabled, onToggle }) => {
+  const [formEnabled, formDisabled] = useCSSVariable([
+    '--color-form-enabled',
+    '--color-form-disabled',
+  ]) as [string, string];
+
+  return (
+    <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
+      <Text className="text-lg font-bold mb-3 text-text-primary">Sync on Open</Text>
+      <View className="flex-row justify-between items-center">
+        <Text className="text-base text-text-primary">Sync when app opens</Text>
+        <Switch
+          onValueChange={onToggle}
+          value={isEnabled}
+          trackColor={{ false: formDisabled, true: formEnabled }}
+          thumbColor="#FFFFFF"
+        />
+      </View>
+      <Text className="text-[13px] text-text-muted leading-4.5 mt-1">
+        When enabled, health data will sync automatically each time you open the app. Syncs again only after 5 minutes away.
+      </Text>
+    </View>
+  );
+};
+
+export default SyncOnOpen;

--- a/SparkyFitnessMobile/src/screens/SyncScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SyncScreen.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { View, Text, Image, ScrollView, Platform, Alert, ActivityIndicator } from 'react-native';
+import { View, Text, Image, ScrollView, Platform, Alert, ActivityIndicator, AppState } from 'react-native';
 import Button from '../components/ui/Button';
 import Icon from '../components/Icon';
 import SyncFrequency from '../components/SyncFrequency';
+import SyncOnOpen from '../components/SyncOnOpen';
 import HealthDataSync from '../components/HealthDataSync';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
@@ -24,7 +25,20 @@ import {
   stopObservers,
 } from '../services/healthConnectService';
 import { configureBackgroundSync, stopBackgroundSync, performBackgroundSync } from '../services/backgroundSyncService';
-import { saveTimeRange, loadTimeRange, loadLastSyncedTime, loadBackgroundSyncEnabled, saveBackgroundSyncEnabled } from '../services/storage';
+import {
+  tryClaimAutoSync,
+  isForegroundAutoSyncWindowOpen,
+  isSyncClaimed,
+} from '../services/autoSyncCoordinator';
+import {
+  saveTimeRange,
+  loadTimeRange,
+  loadLastSyncedTime,
+  loadBackgroundSyncEnabled,
+  saveBackgroundSyncEnabled,
+  saveSyncOnOpenEnabled,
+  loadSyncOnOpenEnabled,
+} from '../services/storage';
 import type { TimeRange } from '../services/storage';
 import { addLog } from '../services/LogService';
 import { HEALTH_METRICS } from '../HealthMetrics';
@@ -58,6 +72,7 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
   const accentPrimary = useCSSVariable('--color-accent-primary') as string | undefined;
   const [healthMetricStates, setHealthMetricStates] = useState<HealthMetricStates>({});
   const [isBackgroundSyncEnabled, setIsBackgroundSyncEnabled] = useState<boolean>(false);
+  const [isSyncOnOpenEnabled, setIsSyncOnOpenEnabled] = useState<boolean>(false);
   const [lastSyncedTime, setLastSyncedTime] = useState<string | null>(null);
   const [lastSyncedTimeLoaded, setLastSyncedTimeLoaded] = useState<boolean>(false);
   const [isHealthConnectInitialized, setIsHealthConnectInitialized] = useState<boolean>(false);
@@ -108,6 +123,9 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
 
     const bgSyncEnabled = await loadBackgroundSyncEnabled();
     setIsBackgroundSyncEnabled(bgSyncEnabled);
+
+    const syncOnOpen = await loadSyncOnOpenEnabled();
+    setIsSyncOnOpenEnabled(syncOnOpen);
 
     const loadedSyncTime = await loadLastSyncedTime();
     setLastSyncedTime(loadedSyncTime);
@@ -164,9 +182,24 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
       await configureBackgroundSync();
       if (Platform.OS === 'ios') {
         startObservers(() => {
-          performBackgroundSync('healthkit-observer').catch(error => {
-            console.error('[SyncScreen] Observer-triggered sync failed:', error);
-          });
+          if (
+            AppState.currentState === 'active' &&
+            Platform.OS === 'ios' &&
+            isForegroundAutoSyncWindowOpen()
+          ) {
+            return;
+          }
+
+          const release = tryClaimAutoSync();
+          if (!release) return;
+
+          performBackgroundSync('healthkit-observer')
+            .catch(error => {
+              console.error('[SyncScreen] Observer-triggered sync failed:', error);
+            })
+            .finally(() => {
+              release();
+            });
         });
       }
     } else {
@@ -175,6 +208,11 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
         stopObservers();
       }
     }
+  };
+
+  const handleToggleSyncOnOpen = async (newValue: boolean): Promise<void> => {
+    setIsSyncOnOpenEnabled(newValue);
+    await saveSyncOnOpenEnabled(newValue);
   };
 
   const handleToggleHealthMetric = async (
@@ -297,7 +335,7 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
   };
 
   const handleSync = (): void => {
-    if (syncMutation.isPending) return;
+    if (syncMutation.isPending || isSyncClaimed()) return;
     syncMutation.mutate({ timeRange: selectedTimeRange, healthMetricStates });
   };
 
@@ -347,7 +385,7 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
           variant="primary"
           className="flex-row items-center mb-2"
           onPress={handleSync}
-          disabled={syncMutation.isPending || !isHealthConnectInitialized}
+          disabled={syncMutation.isPending || isSyncClaimed() || !isHealthConnectInitialized}
         >
           <Image
             source={require('../../assets/icons/sync_now_alt.png')}
@@ -400,6 +438,7 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
           isEnabled={isBackgroundSyncEnabled}
           onToggle={handleToggleBackgroundSync}
         />
+        <SyncOnOpen isEnabled={isSyncOnOpenEnabled} onToggle={handleToggleSyncOnOpen} />
 
         <HealthDataSync
           healthMetricStates={healthMetricStates}

--- a/SparkyFitnessMobile/src/screens/SyncScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SyncScreen.tsx
@@ -184,7 +184,6 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
         startObservers(() => {
           if (
             AppState.currentState === 'active' &&
-            Platform.OS === 'ios' &&
             isForegroundAutoSyncWindowOpen()
           ) {
             return;

--- a/SparkyFitnessMobile/src/services/autoSyncCoordinator.ts
+++ b/SparkyFitnessMobile/src/services/autoSyncCoordinator.ts
@@ -1,0 +1,60 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * In-memory lock shared by the observer-triggered background sync and the
+ * sync-on-open foreground sync. Prevents both paths from starting in the
+ * same app-open window.
+ *
+ * Returns a release function if the claim is granted; null if already claimed.
+ * The caller MUST call release() when done (on success, error, or early return).
+ * The release function is idempotent - safe to call more than once.
+ */
+let claimed = false;
+let foregroundAutoSyncWindowOpen = false;
+const AUTO_SYNC_COOLDOWN_MS = 5 * 60 * 1000;
+
+const autoSyncKeyForConfig = (configId: string): string => `@AutoSync:lastAutoSyncAt:${configId}`;
+
+export const tryClaimAutoSync = (): (() => void) | null => {
+  if (claimed) return null;
+  claimed = true;
+
+  let released = false;
+  return () => {
+    if (!released) {
+      released = true;
+      claimed = false;
+    }
+  };
+};
+
+export const isSyncClaimed = (): boolean => claimed;
+
+export const setForegroundAutoSyncWindowOpen = (isOpen: boolean): void => {
+  foregroundAutoSyncWindowOpen = isOpen;
+};
+
+export const isForegroundAutoSyncWindowOpen = (): boolean => foregroundAutoSyncWindowOpen;
+
+export const shouldRunColdStartAutoSync = async (configId: string): Promise<boolean> => {
+  try {
+    const value = await AsyncStorage.getItem(autoSyncKeyForConfig(configId));
+    if (!value) return true;
+
+    const lastAutoSyncAt = Number.parseInt(value, 10);
+    if (Number.isNaN(lastAutoSyncAt)) return true;
+
+    return Date.now() - lastAutoSyncAt >= AUTO_SYNC_COOLDOWN_MS;
+  } catch (error) {
+    console.error('[AutoSyncCoordinator] Failed to load auto-sync cooldown:', error);
+    return true;
+  }
+};
+
+export const recordAutoSyncTime = async (configId: string): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(autoSyncKeyForConfig(configId), Date.now().toString());
+  } catch (error) {
+    console.error('[AutoSyncCoordinator] Failed to record auto-sync time:', error);
+  }
+};

--- a/SparkyFitnessMobile/src/services/autoSyncCoordinator.ts
+++ b/SparkyFitnessMobile/src/services/autoSyncCoordinator.ts
@@ -36,7 +36,7 @@ export const setForegroundAutoSyncWindowOpen = (isOpen: boolean): void => {
 
 export const isForegroundAutoSyncWindowOpen = (): boolean => foregroundAutoSyncWindowOpen;
 
-export const shouldRunColdStartAutoSync = async (configId: string): Promise<boolean> => {
+export const shouldRunForegroundResumeAutoSync = async (configId: string): Promise<boolean> => {
   try {
     const value = await AsyncStorage.getItem(autoSyncKeyForConfig(configId));
     if (!value) return true;

--- a/SparkyFitnessMobile/src/services/storage.ts
+++ b/SparkyFitnessMobile/src/services/storage.ts
@@ -32,6 +32,7 @@ const ACTIVE_SERVER_CONFIG_ID_KEY = 'activeServerConfigId';
 const TIME_RANGE_KEY = 'timeRange';
 const LAST_SYNCED_TIME_KEY = 'lastSyncedTime';
 const BACKGROUND_SYNC_ENABLED_KEY = 'backgroundSyncEnabled';
+const SYNC_ON_OPEN_ENABLED_KEY = 'syncOnOpenEnabled';
 
 const secureStoreKey = (configId: string) => `apiKey_${configId}`;
 const sessionTokenSecureStoreKey = (configId: string) => `sessionToken_${configId}`;
@@ -298,6 +299,25 @@ export const loadBackgroundSyncEnabled = async (): Promise<boolean> => {
     return JSON.parse(value) as boolean;
   } catch (error) {
     console.error('Failed to load background sync enabled preference.', error);
+    return false;
+  }
+};
+
+export const saveSyncOnOpenEnabled = async (enabled: boolean): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(SYNC_ON_OPEN_ENABLED_KEY, JSON.stringify(enabled));
+  } catch (error) {
+    console.error('Failed to save sync on open preference.', error);
+  }
+};
+
+export const loadSyncOnOpenEnabled = async (): Promise<boolean> => {
+  try {
+    const value = await AsyncStorage.getItem(SYNC_ON_OPEN_ENABLED_KEY);
+    if (value === null) return false;
+    return JSON.parse(value) as boolean;
+  } catch (error) {
+    console.error('Failed to load sync on open preference.', error);
     return false;
   }
 };


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Added the option to sync on open. This was kind of implemented before but was more of a bug and didn't work properly.

**How did you implement the solution?**
Implemented a new `sync on open` preference in mobile storage and surfaced it on `SyncScreen` with a dedicated `SyncOnOpen` toggle component. In `App.tsx`, I added app-lifecycle handling that triggers an automatic health sync when the app cold-starts with an active server config and the setting enabled, plus a foreground-return path that re-syncs only after the app has been in the background for at least 5 minutes.


Linked Issue: #

## How to Test

1. Open the app
2. enable "sync on open"
3. Close app and open it up

## PR Type

- [x] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

To prevent overlapping syncs, I added `autoSyncCoordinator.ts`, which manages an in-memory claim/lock and a foreground auto-sync window shared between manual sync, auto-sync-on-open, and iOS observer-triggered background syncs. I also updated the observer callbacks and manual sync buttons to respect that coordination, and recorded auto-sync timestamps so resume-based auto-syncs can enforce the cooldown without affecting true cold starts.


I was able to fully test on an iOS device and it worked, tested it on an android simulator and it seemed to work. Hard to fully test android without a physical device though.
