### PR TITLE
Add unit 'whole'

### DIFF
--- a/SparkyFitnessFrontend/src/constants/foodForm.ts
+++ b/SparkyFitnessFrontend/src/constants/foodForm.ts
@@ -42,6 +42,7 @@ export const UNIT_GROUPS = [
       'scoop',
       'bar',
       'stick',
+      'whole',
     ],
   },
 ];

--- a/SparkyFitnessFrontend/src/pages/Foods/FoodImportFromCSV.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/FoodImportFromCSV.tsx
@@ -76,6 +76,7 @@ const servingUnitOptions = [
   'scoop',
   'bar',
   'stick',
+  'whole',
 ];
 
 const ImportFromCSV = ({ onSave }: ImportFromCSVProps) => {

--- a/SparkyFitnessFrontend/src/utils/servingSizeConversions.ts
+++ b/SparkyFitnessFrontend/src/utils/servingSizeConversions.ts
@@ -62,6 +62,7 @@ export const SERVING_UNIT_GROUP: StandardUnitGroup = {
     'scoop',
     'bar',
     'stick',
+    'whole',
   ],
 };
 
@@ -100,6 +101,7 @@ export const ALL_CONVERSION_UNITS: string[] = [
   'scoop',
   'bar',
   'stick',
+  'whole',
 ];
 
 /** Returns the measurement category for a unit, or null if not a standard unit */

--- a/SparkyFitnessMobile/src/components/FoodForm.tsx
+++ b/SparkyFitnessMobile/src/components/FoodForm.tsx
@@ -39,7 +39,7 @@ export interface FoodFormProps {
 
 const SERVING_UNIT_OPTIONS = [
   'serving', 'g', 'oz', 'cup', 'piece', 'slice', 'scoop', 'tbsp', 'tsp',
-  'bowl', 'plate', 'handful', 'bar', 'stick', 'can', 'bottle', 'packet', 'bag',
+  'bowl', 'plate', 'handful', 'bar', 'stick', 'can', 'bottle', 'packet', 'bag', 'whole',
   'ml', 'l', 'kg', 'lb', 'mg',
 ].map((u) => ({ label: u, value: u }));
 

--- a/SparkyFitnessServer/utils/foodUtils.ts
+++ b/SparkyFitnessServer/utils/foodUtils.ts
@@ -79,6 +79,7 @@ const SERVING_UNIT_ALIASES = {
   bars: 'bar',
   stick: 'stick',
   sticks: 'stick',
+  whole: 'whole',
 };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function normalizeServingUnit(unit: any) {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)
There is no unit for whole foods. This is useful particularly for fruits and vegetables (e.g. 1 whole apple, 3 whole oranges).

**How did you implement the solution?**
(Brief technical approach.)
Added the additional unit in all the relevant places in the code base.

Linked Issue: #

## How to Test

1. Navigate to Foods and Add New Food.
2. Complete the details for a new food and confirm the unit 'whole' is selectable from the options.
3. Add new food to a meal.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After
<img width="2561" height="1819" alt="Screenshot 2026-04-14 at 1 27 51 PM" src="https://github.com/user-attachments/assets/0ffd9a3b-ec1e-43d9-af8a-8f785fff9be1" />
<img width="2561" height="1819" alt="Screenshot 2026-04-14 at 1 28 03 PM" src="https://github.com/user-attachments/assets/4fc58e92-c127-4f0b-bd66-54aa02f15397" />
<img width="2561" height="1819" alt="Screenshot 2026-04-14 at 1 28 15 PM" src="https://github.com/user-attachments/assets/f08eae46-2885-4bbc-83d3-40e2b99117aa" />


</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
