### PR TITLE
fix: white input arrows in dark mode 

### DIFF
--- a/SparkyFitnessFrontend/src/components/Onboarding/NutrientGoals.tsx
+++ b/SparkyFitnessFrontend/src/components/Onboarding/NutrientGoals.tsx
@@ -84,7 +84,7 @@ export const NutrientGoals = ({
                         prev ? { ...prev, carbs: Number(e.target.value) } : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">g</span>
                 </div>
@@ -119,7 +119,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">g</span>
                 </div>
@@ -152,7 +152,7 @@ export const NutrientGoals = ({
                         prev ? { ...prev, fat: Number(e.target.value) } : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">g</span>
                 </div>
@@ -175,7 +175,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">g</span>
                 </div>
@@ -209,7 +209,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">g</span>
                 </div>
@@ -232,7 +232,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">g</span>
                 </div>
@@ -258,7 +258,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">g</span>
                 </div>
@@ -284,7 +284,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">g</span>
                 </div>
@@ -318,7 +318,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">mg</span>
                 </div>
@@ -341,7 +341,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">mg</span>
                 </div>
@@ -364,7 +364,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">mg</span>
                 </div>
@@ -387,7 +387,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">mg</span>
                 </div>
@@ -408,7 +408,7 @@ export const NutrientGoals = ({
                         prev ? { ...prev, iron: Number(e.target.value) } : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">mg</span>
                 </div>
@@ -442,7 +442,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">g</span>
                 </div>
@@ -465,7 +465,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">µg</span>
                 </div>
@@ -488,7 +488,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">mg</span>
                 </div>
@@ -527,7 +527,7 @@ export const NutrientGoals = ({
                               : null
                           )
                         }
-                        className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                        className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                       />
                       <span className="text-sm">{cn.unit}</span>
                     </div>
@@ -608,7 +608,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">min</span>
                 </div>
@@ -635,7 +635,7 @@ export const NutrientGoals = ({
                           : null
                       )
                     }
-                    className="w-16 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
+                    className="w-20 text-right bg-transparent border-gray-700 text-white h-8 text-sm"
                   />
                   <span className="text-sm">kcal</span>
                 </div>

--- a/SparkyFitnessFrontend/src/components/ui/input.tsx
+++ b/SparkyFitnessFrontend/src/components/ui/input.tsx
@@ -1,19 +1,70 @@
 import * as React from 'react';
-
 import { cn } from '@/lib/utils';
+import { ChevronUp, ChevronDown } from 'lucide-react';
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
   ({ className, type, ...props }, ref) => {
-    return (
+    const innerRef = React.useRef<HTMLInputElement>(null);
+
+    React.useImperativeHandle(ref, () => innerRef.current!);
+
+    const handleStep = (direction: 'up' | 'down') => {
+      const input = innerRef.current;
+      if (!input || input.disabled || input.readOnly) return;
+      if (direction === 'up') {
+        input.stepUp();
+      } else {
+        input.stepDown();
+      }
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+
+    const inputElement = (
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          'dark:[color-scheme:dark]',
+          type === 'number' && [
+            '[appearance:textfield]',
+            '[&::-webkit-outer-spin-button]:appearance-none',
+            '[&::-webkit-inner-spin-button]:appearance-none',
+            'pr-6',
+          ],
           className
         )}
-        ref={ref}
+        ref={innerRef}
         {...props}
       />
+    );
+
+    if (type !== 'number') return inputElement;
+
+    return (
+      <div className="relative group/input w-full">
+        {inputElement}
+        <div className="absolute right-0 top-0 flex flex-col w-5 h-full border-l bg-muted/5 opacity-0 group-hover/input:opacity-100 transition-opacity z-10">
+          <button
+            type="button"
+            tabIndex={-1}
+            disabled={props.disabled || props.readOnly}
+            className="flex flex-1 items-center justify-center hover:bg-accent hover:text-accent-foreground transition-colors border-b"
+            onClick={() => handleStep('up')}
+          >
+            <ChevronUp className="h-2.5 w-2.5" />
+          </button>
+          <button
+            type="button"
+            tabIndex={-1}
+            disabled={props.disabled || props.readOnly}
+            className="flex flex-1 items-center justify-center hover:bg-accent hover:text-accent-foreground transition-colors"
+            onClick={() => handleStep('down')}
+          >
+            <ChevronDown className="h-2.5 w-2.5" />
+          </button>
+        </div>
+      </div>
     );
   }
 );


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Input arrows looked like trash before with dark mode.

**How did you implement the solution?**
Only show them when hovering and make them transparent.

Linked Issue: #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="1216" height="723" alt="image" src="https://github.com/user-attachments/assets/02daa5c4-4a3c-4cfe-adbe-b90b0c2b8606" />

### After

<img width="1216" height="723" alt="image" src="https://github.com/user-attachments/assets/a2444ff0-f745-4e7f-9198-c2325086aac6" />


<img width="1240" height="862" alt="image" src="https://github.com/user-attachments/assets/2633f4cf-0729-4708-a1d1-a2c78f46b246" />

</details>

