### PR TITLE
fix: loading exercise progress data, feat: textarea for description

### DIFF
--- a/SparkyFitnessFrontend/src/components/MealBuilder.tsx
+++ b/SparkyFitnessFrontend/src/components/MealBuilder.tsx
@@ -36,6 +36,7 @@ import {
   useCreateFoodEntryMealMutation,
   useUpdateFoodEntryMealMutation,
 } from '@/hooks/Diary/useFoodEntries';
+import { Textarea } from './ui/textarea';
 
 interface MealBuilderProps {
   mealId?: string; // Optional: if editing an existing meal template
@@ -571,7 +572,7 @@ const MealBuilder: React.FC<MealBuilderProps> = ({
         <Label htmlFor="mealDescription">
           {t('mealBuilder.mealDescription', 'Description (Optional)')}
         </Label>
-        <Input
+        <Textarea
           id="mealDescription"
           value={mealDescription}
           onChange={(e) => setMealDescription(e.target.value)}

--- a/SparkyFitnessFrontend/src/components/MealBuilder.tsx
+++ b/SparkyFitnessFrontend/src/components/MealBuilder.tsx
@@ -36,7 +36,7 @@ import {
   useCreateFoodEntryMealMutation,
   useUpdateFoodEntryMealMutation,
 } from '@/hooks/Diary/useFoodEntries';
-import { Textarea } from './ui/textarea';
+import { Textarea } from '@/components/ui/textarea';
 
 interface MealBuilderProps {
   mealId?: string; // Optional: if editing an existing meal template

--- a/shared/src/schemas/api/ExerciseEntries.api.zod.ts
+++ b/shared/src/schemas/api/ExerciseEntries.api.zod.ts
@@ -213,7 +213,7 @@ export const exerciseProgressResponseSchema = z.object({
   image_url: z.string().nullable(),
   distance: z.number().nullable(),
   avg_heart_rate: z.number().nullable(),
-  provider_name: z.string(),
+  provider_name: z.string().nullable(),
   sets: z.array(exerciseEntrySetRequestSchema),
 });
 


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
1. The description of meals was an input and not a textarea like in the rest of the app
2. Exercise progress failed to load for specific providers since the provider name can be null

**How did you implement the solution?**
1. Change input to TextArea
2. Make provder_name nullable

Linked Issue: #1130, #1134 

## How to Test

1. Check out this branch and run `...`
3. Navigate to...
4. Verify that...

## PR Type

- [x] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

Closes #1130 
Closes #1134 