### PR TITLE
Auto-reload stale frontend chunks after app updates

### DIFF
--- a/SparkyFitnessFrontend/src/App.tsx
+++ b/SparkyFitnessFrontend/src/App.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { useState, useEffect, lazy, Suspense } from 'react';
+import { useState, useEffect, Suspense } from 'react';
 import {
   PreferencesProvider,
   usePreferences,
@@ -36,33 +36,48 @@ import {
 } from './pages/Errors/ErrorComponents';
 import { error as logError } from '@/utils/logging';
 import { getUserLoggingLevel } from '@/utils/userPreferences.ts';
-const Auth = lazy(() => import('@/pages/Auth/Auth'));
-const ForgotPassword = lazy(() => import('@/pages/Auth/ForgotPassword'));
-const ResetPassword = lazy(() => import('@/pages/Auth/ResetPassword'));
-const Index = lazy(() => import('@/pages/Index'));
-const Diary = lazy(() => import('@/pages/Diary/Diary'));
-const CheckIn = lazy(() => import('./pages/CheckIn/CheckIn'));
-const FoodDatabaseManager = lazy(() => import('./pages/Foods/Foods'));
-const Reports = lazy(() => import('./pages/Reports/Reports'));
-const ExerciseDatabaseManager = lazy(
+import { lazyWithChunkRecovery } from '@/utils/chunkRecovery';
+const Auth = lazyWithChunkRecovery(() => import('@/pages/Auth/Auth'));
+const ForgotPassword = lazyWithChunkRecovery(
+  () => import('@/pages/Auth/ForgotPassword')
+);
+const ResetPassword = lazyWithChunkRecovery(
+  () => import('@/pages/Auth/ResetPassword')
+);
+const Index = lazyWithChunkRecovery(() => import('@/pages/Index'));
+const Diary = lazyWithChunkRecovery(() => import('@/pages/Diary/Diary'));
+const CheckIn = lazyWithChunkRecovery(() => import('./pages/CheckIn/CheckIn'));
+const FoodDatabaseManager = lazyWithChunkRecovery(
+  () => import('./pages/Foods/Foods')
+);
+const Reports = lazyWithChunkRecovery(() => import('./pages/Reports/Reports'));
+const ExerciseDatabaseManager = lazyWithChunkRecovery(
   () => import('./pages/Exercises/Exercises')
 );
-const GoalsSettings = lazy(() => import('./pages/Goals/Goals'));
-const Settings = lazy(() => import('./pages/Settings/SettingsPage'));
-const AdminPage = lazy(() => import('./pages/Admin/Admin'));
-const UserManagement = lazy(() => import('@/pages/Admin/UserManagement'));
-const AuthenticationSettings = lazy(
+const GoalsSettings = lazyWithChunkRecovery(
+  () => import('./pages/Goals/Goals')
+);
+const Settings = lazyWithChunkRecovery(
+  () => import('./pages/Settings/SettingsPage')
+);
+const AdminPage = lazyWithChunkRecovery(() => import('./pages/Admin/Admin'));
+const UserManagement = lazyWithChunkRecovery(
+  () => import('@/pages/Admin/UserManagement')
+);
+const AuthenticationSettings = lazyWithChunkRecovery(
   () => import('@/pages/Admin/AuthenticationSettings')
 );
-const NotFound = lazy(() => import('@/pages/Errors/NotFound'));
-const WithingsCallback = lazy(
+const NotFound = lazyWithChunkRecovery(() => import('@/pages/Errors/NotFound'));
+const WithingsCallback = lazyWithChunkRecovery(
   () => import('@/pages/Integrations/WithingsCallback')
 );
-const FitbitCallback = lazy(
+const FitbitCallback = lazyWithChunkRecovery(
   () => import('@/pages/Integrations/FitbitCallback')
 );
-const PolarCallback = lazy(() => import('@/pages/Integrations/PolarCallback'));
-const StravaCallback = lazy(
+const PolarCallback = lazyWithChunkRecovery(
+  () => import('@/pages/Integrations/PolarCallback')
+);
+const StravaCallback = lazyWithChunkRecovery(
   () => import('@/pages/Integrations/StravaCallback')
 );
 

--- a/SparkyFitnessFrontend/src/components/FoodSearch/BarcodeScannerDialog.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/BarcodeScannerDialog.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from 'react';
+import { Suspense } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -16,8 +16,11 @@ import {
 import { useTranslation } from 'react-i18next';
 import { DataProvider } from '@/types/settings.ts';
 import { Database } from 'lucide-react';
+import { lazyWithChunkRecovery } from '@/utils/chunkRecovery';
 
-const BarcodeScanner = lazy(() => import('./BarcodeScanner.tsx'));
+const BarcodeScanner = lazyWithChunkRecovery(
+  () => import('./BarcodeScanner.tsx')
+);
 
 interface BarcodeScannerDialogProps {
   isOpen: boolean;

--- a/SparkyFitnessFrontend/src/pages/Errors/ErrorComponents.tsx
+++ b/SparkyFitnessFrontend/src/pages/Errors/ErrorComponents.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import {
   isRouteErrorResponse,
   useRouteError,
@@ -16,18 +16,25 @@ const UPDATE_TITLE = 'Updating SparkyFitness...';
 const UPDATE_MESSAGE = 'Loading the latest version.';
 
 const useChunkRecoveryReload = (routeError: unknown) => {
-  const shouldAttemptRecovery =
+  const canAttemptRecovery =
     isStaleChunkLoadError(routeError) && canAttemptChunkRecoveryReload();
+  const [isUpdatingApp, setIsUpdatingApp] = useState(canAttemptRecovery);
 
   useEffect(() => {
-    if (!shouldAttemptRecovery) {
+    setIsUpdatingApp(canAttemptRecovery);
+  }, [canAttemptRecovery]);
+
+  useEffect(() => {
+    if (!canAttemptRecovery) {
       return;
     }
 
-    triggerChunkRecoveryReload();
-  }, [shouldAttemptRecovery]);
+    if (!triggerChunkRecoveryReload()) {
+      setIsUpdatingApp(false);
+    }
+  }, [canAttemptRecovery]);
 
-  return shouldAttemptRecovery;
+  return isUpdatingApp;
 };
 
 export const RootErrorBoundary = () => {

--- a/SparkyFitnessFrontend/src/pages/Errors/ErrorComponents.tsx
+++ b/SparkyFitnessFrontend/src/pages/Errors/ErrorComponents.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import {
   isRouteErrorResponse,
   useRouteError,
@@ -5,10 +6,47 @@ import {
 } from 'react-router-dom';
 import { Home, RefreshCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  canAttemptChunkRecoveryReload,
+  isStaleChunkLoadError,
+  triggerChunkRecoveryReload,
+} from '@/utils/chunkRecovery';
+
+const UPDATE_TITLE = 'Updating SparkyFitness...';
+const UPDATE_MESSAGE = 'Loading the latest version.';
+
+const useChunkRecoveryReload = (routeError: unknown) => {
+  const shouldAttemptRecovery =
+    isStaleChunkLoadError(routeError) && canAttemptChunkRecoveryReload();
+
+  useEffect(() => {
+    if (!shouldAttemptRecovery) {
+      return;
+    }
+
+    triggerChunkRecoveryReload();
+  }, [shouldAttemptRecovery]);
+
+  return shouldAttemptRecovery;
+};
 
 export const RootErrorBoundary = () => {
   const error = useRouteError();
   const navigate = useNavigate();
+  const isUpdatingApp = useChunkRecoveryReload(error);
+
+  if (isUpdatingApp) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background p-4 text-center">
+        <div className="max-w-md">
+          <h1 className="text-4xl font-bold mb-4 text-foreground">
+            {UPDATE_TITLE}
+          </h1>
+          <p className="text-xl text-muted-foreground">{UPDATE_MESSAGE}</p>
+        </div>
+      </div>
+    );
+  }
 
   let title = 'Unknown Error';
   let message = 'An unexpected error occurred.';
@@ -41,6 +79,20 @@ export const RootErrorBoundary = () => {
 export const RouteErrorBoundary = () => {
   const error = useRouteError();
   const navigate = useNavigate();
+  const isUpdatingApp = useChunkRecoveryReload(error);
+
+  if (isUpdatingApp) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[50vh] bg-background p-6 text-center rounded-lg border border-border mt-4">
+        <div className="max-w-md">
+          <h2 className="text-2xl font-bold mb-3 text-foreground">
+            {UPDATE_TITLE}
+          </h2>
+          <p className="text-muted-foreground">{UPDATE_MESSAGE}</p>
+        </div>
+      </div>
+    );
+  }
 
   let title = 'Something went wrong';
   let message = 'We are having trouble loading this section.';

--- a/SparkyFitnessFrontend/src/tests/components/ErrorComponents.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/ErrorComponents.test.tsx
@@ -89,6 +89,31 @@ describe('ErrorComponents', () => {
     nowSpy.mockRestore();
   });
 
+  it('falls back to the manual recovery UI if storage blocks the reload guard', async () => {
+    const setItemSpy = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+      });
+
+    mockUseRouteError.mockReturnValue(
+      new TypeError('Failed to fetch dynamically imported module')
+    );
+
+    render(<RouteErrorBoundary />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Reload Page')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText('Updating SparkyFitness...')
+    ).not.toBeInTheDocument();
+    expect(mockReload).not.toHaveBeenCalled();
+
+    setItemSpy.mockRestore();
+  });
+
   it('keeps unrelated root errors on the normal fallback UI', () => {
     mockUseRouteError.mockReturnValue(new Error('Unexpected failure'));
 

--- a/SparkyFitnessFrontend/src/tests/components/ErrorComponents.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/ErrorComponents.test.tsx
@@ -1,0 +1,101 @@
+import type React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  RouteErrorBoundary,
+  RootErrorBoundary,
+} from '@/pages/Errors/ErrorComponents';
+import {
+  chunkRecoveryRuntime,
+  triggerChunkRecoveryReload,
+} from '@/utils/chunkRecovery';
+
+const mockNavigate = jest.fn();
+const mockUseRouteError = jest.fn();
+const mockReload = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useRouteError: () => mockUseRouteError(),
+  };
+});
+
+jest.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+describe('ErrorComponents', () => {
+  beforeAll(() => {
+    jest
+      .spyOn(chunkRecoveryRuntime, 'reloadWindowLocation')
+      .mockImplementation(mockReload);
+  });
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    mockNavigate.mockClear();
+    mockReload.mockClear();
+    mockUseRouteError.mockReset();
+    jest.restoreAllMocks();
+    jest
+      .spyOn(chunkRecoveryRuntime, 'reloadWindowLocation')
+      .mockImplementation(mockReload);
+  });
+
+  it('auto-reloads once for stale route chunk errors', async () => {
+    mockUseRouteError.mockReturnValue(
+      new TypeError('Failed to fetch dynamically imported module')
+    );
+
+    render(<RouteErrorBoundary />);
+
+    expect(screen.getByText('Updating SparkyFitness...')).toBeInTheDocument();
+    expect(screen.queryByText('Reload Page')).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockReload).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('falls back to the existing manual actions after a recent reload attempt', () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(5_000);
+
+    triggerChunkRecoveryReload();
+    mockReload.mockClear();
+
+    mockUseRouteError.mockReturnValue(
+      new TypeError('Failed to fetch dynamically imported module')
+    );
+
+    render(<RouteErrorBoundary />);
+
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(
+      screen.getByText('Failed to fetch dynamically imported module')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Reload Page')).toBeInTheDocument();
+    expect(screen.getByText('Return to Home')).toBeInTheDocument();
+    expect(mockReload).not.toHaveBeenCalled();
+
+    nowSpy.mockRestore();
+  });
+
+  it('keeps unrelated root errors on the normal fallback UI', () => {
+    mockUseRouteError.mockReturnValue(new Error('Unexpected failure'));
+
+    render(<RootErrorBoundary />);
+
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText('Unexpected failure')).toBeInTheDocument();
+    expect(mockReload).not.toHaveBeenCalled();
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/utils/chunkRecovery.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/chunkRecovery.test.ts
@@ -1,0 +1,56 @@
+import {
+  CHUNK_RECOVERY_TTL_MS,
+  chunkRecoveryRuntime,
+  isStaleChunkLoadError,
+  triggerChunkRecoveryReload,
+} from '@/utils/chunkRecovery';
+
+const mockReload = jest.fn();
+
+describe('chunkRecovery', () => {
+  beforeAll(() => {
+    jest
+      .spyOn(chunkRecoveryRuntime, 'reloadWindowLocation')
+      .mockImplementation(mockReload);
+  });
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    mockReload.mockClear();
+    jest.restoreAllMocks();
+    jest
+      .spyOn(chunkRecoveryRuntime, 'reloadWindowLocation')
+      .mockImplementation(mockReload);
+  });
+
+  it.each([
+    new TypeError('Failed to fetch dynamically imported module'),
+    new Error('Importing a module script failed.'),
+    Object.assign(new Error('Chunk failed to load'), {
+      name: 'ChunkLoadError',
+    }),
+  ])('detects stale chunk load failures', (error) => {
+    expect(isStaleChunkLoadError(error)).toBe(true);
+  });
+
+  it('ignores unrelated errors', () => {
+    expect(isStaleChunkLoadError(new Error('Something else broke'))).toBe(
+      false
+    );
+  });
+
+  it('only reloads once per url within the ttl window', () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000);
+
+    expect(triggerChunkRecoveryReload()).toBe(true);
+    expect(mockReload).toHaveBeenCalledTimes(1);
+
+    expect(triggerChunkRecoveryReload()).toBe(false);
+    expect(mockReload).toHaveBeenCalledTimes(1);
+
+    nowSpy.mockReturnValue(1_000 + CHUNK_RECOVERY_TTL_MS + 1);
+
+    expect(triggerChunkRecoveryReload()).toBe(true);
+    expect(mockReload).toHaveBeenCalledTimes(2);
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/utils/chunkRecovery.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/chunkRecovery.test.ts
@@ -53,4 +53,17 @@ describe('chunkRecovery', () => {
     expect(triggerChunkRecoveryReload()).toBe(true);
     expect(mockReload).toHaveBeenCalledTimes(2);
   });
+
+  it('does not reload if persisting the guard fails', () => {
+    const setItemSpy = jest
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+      });
+
+    expect(triggerChunkRecoveryReload()).toBe(false);
+    expect(mockReload).not.toHaveBeenCalled();
+
+    setItemSpy.mockRestore();
+  });
 });

--- a/SparkyFitnessFrontend/src/utils/chunkRecovery.ts
+++ b/SparkyFitnessFrontend/src/utils/chunkRecovery.ts
@@ -1,0 +1,168 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from 'react';
+
+const CHUNK_RECOVERY_STORAGE_PREFIX = 'sparkyfitness:chunk-recovery';
+const NEVER_RESOLVING_IMPORT = new Promise<never>(() => {});
+const STALE_CHUNK_ERROR_PATTERNS = [
+  /Failed to fetch dynamically imported module/i,
+  /Importing a module script failed/i,
+];
+
+export const CHUNK_RECOVERY_TTL_MS = 30_000;
+export const chunkRecoveryRuntime = {
+  reloadWindowLocation: () => window.location.reload(),
+};
+
+// React's lazy component inference needs a permissive component constraint here
+// so each wrapped component keeps its own prop type.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type LazyComponentModule<T extends ComponentType<any>> = {
+  default: T;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type LazyImporter<T extends ComponentType<any>> = () => Promise<
+  LazyComponentModule<T>
+>;
+
+const canUseWindow = () => typeof window !== 'undefined';
+
+const getSessionStorage = (): Storage | null => {
+  if (!canUseWindow()) {
+    return null;
+  }
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+};
+
+const getCurrentUrlKey = () => {
+  if (!canUseWindow()) {
+    return '';
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+};
+
+const getGuardKey = (urlKey: string) =>
+  `${CHUNK_RECOVERY_STORAGE_PREFIX}:${urlKey}`;
+
+const getErrorValue = (error: unknown, key: 'name' | 'message') => {
+  if (error instanceof Error) {
+    return error[key];
+  }
+
+  if (typeof error === 'string') {
+    return key === 'message' ? error : '';
+  }
+
+  if (
+    error &&
+    typeof error === 'object' &&
+    key in error &&
+    typeof (error as Record<string, unknown>)[key] === 'string'
+  ) {
+    return String((error as Record<string, unknown>)[key]);
+  }
+
+  return '';
+};
+
+export const isStaleChunkLoadError = (error: unknown) => {
+  const name = getErrorValue(error, 'name');
+  const message = getErrorValue(error, 'message');
+
+  if (name === 'ChunkLoadError') {
+    return true;
+  }
+
+  return STALE_CHUNK_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+};
+
+export const hasRecentChunkRecoveryReload = (
+  urlKey = getCurrentUrlKey(),
+  now = Date.now()
+) => {
+  const storage = getSessionStorage();
+
+  if (!storage || !urlKey) {
+    return false;
+  }
+
+  const guardKey = getGuardKey(urlKey);
+  const storedAttempt = storage.getItem(guardKey);
+
+  if (!storedAttempt) {
+    return false;
+  }
+
+  try {
+    const parsedAttempt = JSON.parse(storedAttempt) as { timestamp?: number };
+
+    if (typeof parsedAttempt.timestamp !== 'number') {
+      storage.removeItem(guardKey);
+      return false;
+    }
+
+    if (now - parsedAttempt.timestamp <= CHUNK_RECOVERY_TTL_MS) {
+      return true;
+    }
+
+    storage.removeItem(guardKey);
+    return false;
+  } catch {
+    storage.removeItem(guardKey);
+    return false;
+  }
+};
+
+export const canAttemptChunkRecoveryReload = (
+  urlKey = getCurrentUrlKey(),
+  now = Date.now()
+) => {
+  const storage = getSessionStorage();
+
+  if (!storage || !urlKey) {
+    return false;
+  }
+
+  return !hasRecentChunkRecoveryReload(urlKey, now);
+};
+
+export const triggerChunkRecoveryReload = (
+  urlKey = getCurrentUrlKey(),
+  now = Date.now()
+) => {
+  const storage = getSessionStorage();
+
+  if (!storage || !urlKey || hasRecentChunkRecoveryReload(urlKey, now)) {
+    return false;
+  }
+
+  try {
+    storage.setItem(getGuardKey(urlKey), JSON.stringify({ timestamp: now }));
+  } catch {
+    return false;
+  }
+
+  chunkRecoveryRuntime.reloadWindowLocation();
+  return true;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const lazyWithChunkRecovery = <T extends ComponentType<any>>(
+  importer: LazyImporter<T>
+): LazyExoticComponent<T> =>
+  lazy(async () => {
+    try {
+      return await importer();
+    } catch (error) {
+      if (isStaleChunkLoadError(error) && triggerChunkRecoveryReload()) {
+        return NEVER_RESOLVING_IMPORT as Promise<LazyComponentModule<T>>;
+      }
+
+      throw error;
+    }
+  });

--- a/SparkyFitnessFrontend/src/utils/chunkRecovery.ts
+++ b/SparkyFitnessFrontend/src/utils/chunkRecovery.ts
@@ -92,13 +92,13 @@ export const hasRecentChunkRecoveryReload = (
   }
 
   const guardKey = getGuardKey(urlKey);
-  const storedAttempt = storage.getItem(guardKey);
-
-  if (!storedAttempt) {
-    return false;
-  }
-
   try {
+    const storedAttempt = storage.getItem(guardKey);
+
+    if (!storedAttempt) {
+      return false;
+    }
+
     const parsedAttempt = JSON.parse(storedAttempt) as { timestamp?: number };
 
     if (typeof parsedAttempt.timestamp !== 'number') {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
After updating SparkyFitness, some users could run into an error when opening certain pages before the app had fully refreshed to the new version. Reloading the page fixed it, but it made updates cause errors.

**How did you implement the solution?**
I added frontend stale-chunk recovery logic that detects failed dynamic imports caused by post-deploy chunk mismatches and automatically reloads the app once. I also wrapped the lazy-loaded route/component imports with a shared recovery helper and updated the error boundaries to show a temporary updating state before falling back to the existing manual recovery UI.

Linked Issue: #

## How to Test

1. Check out this branch, go to `SparkyFitnessFrontend/`, and run `pnpm run typecheck` plus `pnpm exec jest src/tests/utils/chunkRecovery.test.ts src/tests/components/ErrorComponents.test.tsx --runInBand`
2. Open SparkyFitness, keep an older tab open, then simulate a frontend update and navigate to a lazy-loaded page like `Foods`
3. Verify that the app automatically reloads instead of staying on the dynamic import error screen.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
