### PR TITLE
fix(helm): Invalid encryption key generation

### DIFF
--- a/helm/chart/templates/server/secret.yaml
+++ b/helm/chart/templates/server/secret.yaml
@@ -16,7 +16,7 @@ data:
   {{- if .Values.server.secrets.apiEncryptionKey }}
   api_encryption_key: {{ .Values.server.secrets.apiEncryptionKey | b64enc }}
   {{- else if .Values.server.secrets.generate }}
-  api_encryption_key: {{ get $existingData "api_encryption_key" | default (randAlphaNum 64 | b64enc) }}
+  api_encryption_key: {{ get $existingData "api_encryption_key" | default (randAlphaNum 64 | sha256sum | b64enc) }}
   {{- end }}
   {{- if .Values.server.secrets.betterAuthSecret }}
   better_auth_secret: {{ .Values.server.secrets.betterAuthSecret | b64enc }}


### PR DESCRIPTION

## Description

**What problem does this PR solve?**

The chart uses randAlphaNum 64 to generate the API encryption key, this is invalid since the actual key needs to be a 64 char hex

**How did you implement the solution?**

Pipe the random string into sha256sum

## How to Test

`helm template helm/chart/ -s templates/server/secret.yaml`

Verify that the base64 output decodes to a 32 byte hex string

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).