### PR TITLE
feat(849): reorder food providers

### DIFF
--- a/SparkyFitnessFrontend/src/hooks/Settings/useExternalProviderSettings.ts
+++ b/SparkyFitnessFrontend/src/hooks/Settings/useExternalProviderSettings.ts
@@ -1,3 +1,4 @@
+import { exerciseSearchKeys } from '@/api/keys/exercises';
 import { externalProviderKeys } from '@/api/keys/settings';
 import {
   createExternalProvider,
@@ -95,6 +96,9 @@ export const useUpdateExternalProviderMutation = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: externalProviderKeys.all,
+      });
+      queryClient.invalidateQueries({
+        queryKey: exerciseSearchKeys.providers,
       });
     },
     meta: {

--- a/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearch.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearch.tsx
@@ -62,6 +62,7 @@ const ExerciseSearch = ({
     disableTabs,
     initialSearchSource,
   });
+
   const renderExerciseList = (
     list: Exercise[],
     type: 'internal' | 'external',

--- a/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
@@ -1,22 +1,93 @@
-import { Database } from 'lucide-react';
+import { Database, GripVertical } from 'lucide-react';
 import type { ExternalDataProvider } from './ExternalProviderSettings';
 import {
   useExternalProviders,
   useUpdateExternalProviderMutation,
 } from '@/hooks/Settings/useExternalProviderSettings';
 import { usePreferences } from '@/contexts/PreferencesContext';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { EditProviderForm } from './EditProviderForm';
 import { ProviderCard } from './ProviderCard';
+
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 interface ExternalProviderListProps {
   showAddForm: boolean;
 }
 
+interface SortableProviderRowProps {
+  id: string;
+  children: React.ReactNode;
+  disabled?: boolean;
+}
+
+const SortableProviderRow = ({
+  id,
+  children,
+  disabled = false,
+}: SortableProviderRowProps) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    id,
+    disabled,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.7 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="border rounded-lg p-4 bg-background"
+    >
+      <div className="flex items-start gap-3">
+        <button
+          type="button"
+          aria-label="Drag to reorder provider"
+          className="mt-1 text-muted-foreground hover:text-foreground cursor-grab active:cursor-grabbing disabled:opacity-40"
+          {...attributes}
+          {...listeners}
+          disabled={disabled}
+        >
+          <GripVertical className="h-4 w-4" />
+        </button>
+        <div className="min-w-0 flex-1">{children}</div>
+      </div>
+    </div>
+  );
+};
+
 const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
   const [editData, setEditData] = useState<Partial<ExternalDataProvider>>({});
+
   const { user } = useAuth();
   const {
     defaultFoodDataProviderId,
@@ -25,6 +96,7 @@ const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
     setDefaultBarcodeProviderId,
     saveAllPreferences,
   } = usePreferences();
+
   const { data: providers = [], isLoading: providersLoading } =
     useExternalProviders(user?.activeUserId);
 
@@ -32,6 +104,35 @@ const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
     useUpdateExternalProviderMutation();
 
   const loading = providersLoading || updatePending;
+
+  const [optimisticProviders, setOptimisticProviders] = useState<
+    ExternalDataProvider[] | null
+  >(null);
+
+  const sortedProviders = useMemo(() => {
+    return [...providers].sort((a, b) => {
+      const aOrder = a.sort_order;
+      const bOrder = b.sort_order;
+
+      if (aOrder != null && bOrder != null) return aOrder - bOrder;
+      if (aOrder != null) return -1;
+      if (bOrder != null) return 1;
+
+      return a.provider_name.localeCompare(b.provider_name);
+    });
+  }, [providers]);
+
+  const displayProviders = optimisticProviders ?? sortedProviders;
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const providerIds = useMemo(
+    () => displayProviders.map((p) => p.id),
+    [displayProviders]
+  );
 
   const handleUpdateProvider = async (providerId: string) => {
     const providerUpdateData: Partial<ExternalDataProvider> = {
@@ -108,8 +209,10 @@ const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
         id: providerId,
         data: providerUpdateData,
       });
+
       setEditData({});
       setEditingProvider(null);
+
       if (
         data &&
         data.is_active &&
@@ -124,6 +227,7 @@ const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
       } else if (data && defaultFoodDataProviderId === data.id) {
         setDefaultFoodDataProviderId(null);
       }
+
       if (data && !data.is_active && defaultBarcodeProviderId === data.id) {
         setDefaultBarcodeProviderId(null);
         saveAllPreferences({ defaultBarcodeProviderId: null });
@@ -132,6 +236,37 @@ const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
       console.error('Error updating external data provider:', error);
     }
   };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    // Prevent reorder while editing for cleaner UX
+    if (editingProvider) return;
+
+    const oldIndex = displayProviders.findIndex((p) => p.id === active.id);
+    const newIndex = displayProviders.findIndex((p) => p.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+
+    const next = arrayMove(displayProviders, oldIndex, newIndex);
+    setOptimisticProviders(next); // optimistic
+
+    // Optional persistence if your backend supports sort_order
+    try {
+      await Promise.all(
+        next.map((provider, index) =>
+          updateExternalProvider({
+            id: provider.id,
+            data: { sort_order: index } as Partial<ExternalDataProvider>,
+          })
+        )
+      );
+    } catch (error) {
+      console.error('Failed to persist provider order:', error);
+      setOptimisticProviders(null); // rollback
+    }
+  };
+
   const startEditing = (provider: ExternalDataProvider) => {
     setEditingProvider(provider.id);
     setEditData({
@@ -161,7 +296,7 @@ const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
     setEditData({});
   };
 
-  if (providers.length === 0 && !showAddForm) {
+  if (displayProviders.length === 0 && !showAddForm) {
     return (
       <div className="text-center py-8 text-muted-foreground">
         <Database className="h-12 w-12 mx-auto mb-4 opacity-50" />
@@ -172,31 +307,45 @@ const ExternalProviderList = ({ showAddForm }: ExternalProviderListProps) => {
       </div>
     );
   }
+
   return (
-    <div className="space-y-4">
-      {providers.map((provider) => (
-        <div key={provider.id} className="border rounded-lg p-4">
-          {editingProvider === provider.id ? (
-            // Edit Mode
-            <EditProviderForm
-              provider={provider}
-              editData={editData}
-              setEditData={setEditData}
-              onSubmit={handleUpdateProvider}
-              onCancel={cancelEditing}
-              loading={loading}
-            />
-          ) : (
-            // View Mode
-            <ProviderCard
-              provider={provider}
-              isLoading={loading}
-              startEditing={startEditing}
-            />
-          )}
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={providerIds}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="space-y-4">
+          {displayProviders.map((provider) => (
+            <SortableProviderRow
+              key={provider.id}
+              id={provider.id}
+              disabled={loading || editingProvider !== null}
+            >
+              {editingProvider === provider.id ? (
+                <EditProviderForm
+                  provider={provider}
+                  editData={editData}
+                  setEditData={setEditData}
+                  onSubmit={handleUpdateProvider}
+                  onCancel={cancelEditing}
+                  loading={loading}
+                />
+              ) : (
+                <ProviderCard
+                  provider={provider}
+                  isLoading={loading}
+                  startEditing={startEditing}
+                />
+              )}
+            </SortableProviderRow>
+          ))}
         </div>
-      ))}
-    </div>
+      </SortableContext>
+    </DndContext>
   );
 };
 

--- a/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderSettings.tsx
@@ -61,6 +61,7 @@ export interface ExternalDataProvider {
   strava_last_sync_at?: string | null;
   strava_token_expires?: string | null;
   is_strictly_private?: boolean | null;
+  sort_order?: number;
 }
 
 const BARCODE_PROVIDER_TYPES = ['openfoodfacts', 'usda', 'fatsecret'];

--- a/SparkyFitnessServer/db/migrations/20260426120000_provider_sort_order.sql
+++ b/SparkyFitnessServer/db/migrations/20260426120000_provider_sort_order.sql
@@ -1,0 +1,22 @@
+ALTER TABLE public.external_data_providers
+ADD COLUMN IF NOT EXISTS sort_order integer;
+
+COMMENT ON COLUMN public.external_data_providers.sort_order IS
+'Manual display order for provider selection UI (lower value appears first).';
+
+-- Backfill existing rows so each user gets a stable order.
+-- Orders by created_at, then id for deterministic results.
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY user_id
+      ORDER BY created_at ASC, id ASC
+    ) - 1 AS new_sort_order
+  FROM public.external_data_providers
+)
+UPDATE public.external_data_providers edp
+SET sort_order = ranked.new_sort_order
+FROM ranked
+WHERE edp.id = ranked.id
+  AND edp.sort_order IS NULL;

--- a/SparkyFitnessServer/models/externalProviderRepository.ts
+++ b/SparkyFitnessServer/models/externalProviderRepository.ts
@@ -7,11 +7,11 @@ async function getExternalDataProviders(userId: any) {
   try {
     const result = await client.query(
       `SELECT edp.id, edp.user_id, edp.provider_name, edp.provider_type, edp.is_active, edp.base_url, 
-              edp.shared_with_public, edp.encrypted_access_token, edp.sync_frequency,
+              edp.shared_with_public, edp.encrypted_access_token, edp.sync_frequency, edp.sort_order,
               ept.is_strictly_private
        FROM external_data_providers edp
        LEFT JOIN external_provider_types ept ON edp.provider_type = ept.id
-       ORDER BY edp.created_at DESC`,
+       ORDER BY edp.sort_order ASC NULLS LAST, edp.created_at DESC`,
       []
     );
     // log('debug', `getExternalDataProviders: Raw query results for user ${userId}:`, result.rows);
@@ -272,6 +272,7 @@ async function updateExternalDataProvider(
         token_expires_at = COALESCE($15, token_expires_at),
         external_user_id = COALESCE($16, external_user_id),
         sync_frequency = COALESCE($18, sync_frequency),
+        sort_order = COALESCE($21, sort_order),
         updated_at = now()
       WHERE id = $17
       RETURNING *`,
@@ -296,6 +297,7 @@ async function updateExternalDataProvider(
         updateData.sync_frequency,
         clearAppId,
         clearAppKey,
+        updateData.sort_order,
       ]
     );
     return result.rows[0];


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The providers were ordered by date of creation. Having multiple providers makes it annoying on small screens.

**How did you implement the solution?**
Add a new attribute sort_order and a dnd for the provider list. Existing providers get a sort order according to the date of creation to have backwards compatibility.

Linked Issue: #849 

## How to Test

1. Reorder providers
2. Verify the order is different

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>
<img width="1201" height="1239" alt="image" src="https://github.com/user-attachments/assets/a8c94f67-257d-4d25-bc59-62adcebf3939" />

</details>

 Closes #849

Can also be closed:

Closes #833