### PR TITLE
feat(946): hide sign up when sign up is disabled

### DIFF
--- a/SparkyFitnessFrontend/src/api/Auth/auth.ts
+++ b/SparkyFitnessFrontend/src/api/Auth/auth.ts
@@ -169,6 +169,7 @@ export const getLoginSettings = async (): Promise<LoginSettings> => {
     return {
       email: { enabled: true },
       oidc: { enabled: false, providers: [] },
+      signup_disabled: false,
     };
   }
 };

--- a/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
@@ -424,27 +424,33 @@ const Auth = () => {
               )}
               {loginSettings?.email.enabled ? (
                 <Tabs defaultValue="signin" className="w-full">
-                  <TabsList className="h-10 grid w-full grid-cols-2">
-                    <TabsTrigger
-                      value="signin"
-                      onClick={() => {
-                        setFormError(null);
-                        debug(loggingLevel, 'Auth: Switched to Sign In tab.');
-                      }}
-                    >
-                      Sign In
-                    </TabsTrigger>
-                    <TabsTrigger
-                      value="signup"
-                      onClick={() => {
-                        setFormError(null);
-                        debug(loggingLevel, 'Auth: Switched to Sign Up tab.');
-                      }}
-                    >
-                      Sign Up
-                    </TabsTrigger>
-                  </TabsList>
-
+                  {!loginSettings?.signup_disabled && (
+                    <TabsList className="h-10 grid w-full grid-cols-2">
+                      <TabsTrigger
+                        value="signin"
+                        onClick={() => {
+                          setFormError(null);
+                          debug(loggingLevel, 'Auth: Switched to Sign In tab.');
+                        }}
+                      >
+                        Sign In
+                      </TabsTrigger>
+                      <TabsTrigger
+                        value="signup"
+                        onClick={() => {
+                          setFormError(null);
+                          debug(loggingLevel, 'Auth: Switched to Sign Up tab.');
+                        }}
+                      >
+                        Sign Up
+                      </TabsTrigger>
+                    </TabsList>
+                  )}
+                  {loginSettings?.signup_disabled && (
+                    <p className="text-center text-xs text-muted-foreground">
+                      Registration is currently disabled.
+                    </p>
+                  )}
                   <TabsContent value="signin">
                     <form onSubmit={handleSignIn} className="space-y-4">
                       <div className="space-y-2">
@@ -559,81 +565,85 @@ const Auth = () => {
                     )}
                   </TabsContent>
 
-                  <TabsContent value="signup">
-                    <form onSubmit={handleSignUp} className="space-y-4">
-                      <div className="space-y-2">
-                        <Label htmlFor="signup-name">Full Name</Label>
-                        <Input
-                          id="signup-name"
-                          type="text"
-                          placeholder="Enter your full name"
-                          value={fullName}
-                          onChange={(e) => {
-                            debug(
-                              loggingLevel,
-                              'Auth: Sign Up full name input changed.'
-                            );
-                            setFullName(e.target.value);
-                          }}
-                          autoComplete="name"
-                          required
-                        />
-                      </div>
-                      <div className="space-y-2">
-                        <Label htmlFor="signup-email">Email</Label>
-                        <Input
-                          id="signup-email"
-                          type="email"
-                          placeholder="Enter your email"
-                          value={email}
-                          onChange={(e) => {
-                            debug(
-                              loggingLevel,
-                              'Auth: Sign Up email input changed.'
-                            );
-                            setEmail(e.target.value);
-                          }}
-                          required
-                          autoComplete="username"
-                        />
-                      </div>
-                      <div className="space-y-2 relative">
-                        <Label htmlFor="signup-password">Password</Label>
-                        <Input
-                          id="signup-password"
-                          type={showPassword ? 'text' : 'password'}
-                          placeholder="Create a password"
-                          value={password}
-                          onChange={(e) => {
-                            debug(
-                              loggingLevel,
-                              'Auth: Sign Up password input changed.'
-                            );
-                            setPassword(e.target.value);
-                            setPasswordError(validatePassword(e.target.value));
-                          }}
-                          required
-                          autoComplete="new-password"
-                        />
-                        <PasswordToggle
-                          showPassword={showPassword}
-                          passwordToggleHandler={passwordToggleHandler}
-                        />
-                        {passwordError && (
-                          <p className="text-red-500 text-sm">
-                            {passwordError}
-                          </p>
-                        )}
-                      </div>
-                      <Button
-                        type="submit"
-                        className="w-full"
-                        disabled={loading || !!passwordError}
-                      >
-                        {loading ? 'Creating account...' : 'Sign Up'}
-                      </Button>
-                    </form>
-                  </TabsContent>
+                  {!loginSettings?.signup_disabled && (
+                    <TabsContent value="signup">
+                      <form onSubmit={handleSignUp} className="space-y-4">
+                        <div className="space-y-2">
+                          <Label htmlFor="signup-name">Full Name</Label>
+                          <Input
+                            id="signup-name"
+                            type="text"
+                            placeholder="Enter your full name"
+                            value={fullName}
+                            onChange={(e) => {
+                              debug(
+                                loggingLevel,
+                                'Auth: Sign Up full name input changed.'
+                              );
+                              setFullName(e.target.value);
+                            }}
+                            autoComplete="name"
+                            required
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label htmlFor="signup-email">Email</Label>
+                          <Input
+                            id="signup-email"
+                            type="email"
+                            placeholder="Enter your email"
+                            value={email}
+                            onChange={(e) => {
+                              debug(
+                                loggingLevel,
+                                'Auth: Sign Up email input changed.'
+                              );
+                              setEmail(e.target.value);
+                            }}
+                            required
+                            autoComplete="username"
+                          />
+                        </div>
+                        <div className="space-y-2 relative">
+                          <Label htmlFor="signup-password">Password</Label>
+                          <Input
+                            id="signup-password"
+                            type={showPassword ? 'text' : 'password'}
+                            placeholder="Create a password"
+                            value={password}
+                            onChange={(e) => {
+                              debug(
+                                loggingLevel,
+                                'Auth: Sign Up password input changed.'
+                              );
+                              setPassword(e.target.value);
+                              setPasswordError(
+                                validatePassword(e.target.value)
+                              );
+                            }}
+                            required
+                            autoComplete="new-password"
+                          />
+                          <PasswordToggle
+                            showPassword={showPassword}
+                            passwordToggleHandler={passwordToggleHandler}
+                          />
+                          {passwordError && (
+                            <p className="text-red-500 text-sm">
+                              {passwordError}
+                            </p>
+                          )}
+                        </div>
+                        <Button
+                          type="submit"
+                          className="w-full"
+                          disabled={loading || !!passwordError}
+                        >
+                          {loading ? 'Creating account...' : 'Sign Up'}
+                        </Button>
+                      </form>
+                    </TabsContent>
+                  )}
                 </Tabs>
               ) : (
                 <div>

--- a/SparkyFitnessFrontend/src/types/auth.ts
+++ b/SparkyFitnessFrontend/src/types/auth.ts
@@ -26,6 +26,7 @@ export interface LoginSettings {
     auto_redirect?: boolean;
   };
   warning?: string | null;
+  signup_disabled: boolean;
 }
 
 export interface AccessibleUser {

--- a/SparkyFitnessServer/routes/auth/authCoreRoutes.ts
+++ b/SparkyFitnessServer/routes/auth/authCoreRoutes.ts
@@ -78,6 +78,7 @@ router.get('/settings', async (req, res) => {
     // Environment overrides are now handled within globalSettingsRepository.getGlobalSettings()
     const oidcAutoRedirectEnv =
       process.env.SPARKY_FITNESS_OIDC_AUTO_REDIRECT === 'true';
+    const signupDisabled = process.env.SPARKY_FITNESS_DISABLE_SIGNUP === 'true';
     const emailEnabled = globalSettings.enable_email_password_login;
     const oidcEnabled = globalSettings.is_oidc_active;
     const activeProviders = providers
@@ -104,6 +105,7 @@ router.get('/settings', async (req, res) => {
         providers: activeProviders,
         auto_redirect: oidcAutoRedirectEnv,
       },
+      signup_disabled: signupDisabled,
     });
   } catch (error) {
     // @ts-expect-error TS(2571): Object is of type 'unknown'.


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The env variable only disables it server side but the sign up tab still shows in the frontend.

**How did you implement the solution?**
Hide the tabs when sign up is disabled.

Linked Issue: #946

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="562" height="733" alt="image" src="https://github.com/user-attachments/assets/00c5989f-d9f7-4719-a0a6-433a66f2a44a" />


</details>

Closes #946 
