### PR TITLE
feat(781): meal calorie distribution for custom meals

### DIFF
--- a/SparkyFitnessFrontend/src/api/Diary/foodEntryService.ts
+++ b/SparkyFitnessFrontend/src/api/Diary/foodEntryService.ts
@@ -2,7 +2,8 @@ import { apiCall } from '../api';
 import type { MealFood } from '@/types/meal';
 import type { FoodEntryMeal } from '@/types/meal';
 import type { FoodEntry } from '@/types/food';
-import { DayData, FoodEntryUpdateData, Goals } from '@/types/diary';
+import { DayData, FoodEntryUpdateData } from '@/types/diary';
+import { ExpandedGoals } from '@/types/goals';
 
 export interface FoodEntryCreateData {
   user_id?: string;
@@ -69,7 +70,7 @@ export const loadFoodEntries = async (date: string): Promise<FoodEntry[]> => {
   return response;
 };
 
-export const loadDiaryGoals = async (date: string): Promise<Goals> => {
+export const loadDiaryGoals = async (date: string): Promise<ExpandedGoals> => {
   // Adjust return type as needed
   const response = await apiCall(`/goals/by-date/${date}`, {
     method: 'GET',

--- a/SparkyFitnessFrontend/src/api/Goals/goals.ts
+++ b/SparkyFitnessFrontend/src/api/Goals/goals.ts
@@ -149,6 +149,7 @@ export const loadGoals = async (
       lunch_percentage: 25,
       dinner_percentage: 25,
       snacks_percentage: 25,
+      custom_meal_percentages: {},
     }
   );
 };
@@ -194,6 +195,7 @@ export const saveGoals = async (
       p_lunch_percentage: goals.lunch_percentage,
       p_dinner_percentage: goals.dinner_percentage,
       p_snacks_percentage: goals.snacks_percentage,
+      custom_meal_percentages: goals.custom_meal_percentages,
       custom_nutrients,
     },
   });

--- a/SparkyFitnessFrontend/src/components/MealPercentageManager.tsx
+++ b/SparkyFitnessFrontend/src/components/MealPercentageManager.tsx
@@ -14,12 +14,7 @@ import {
 import { Lock, Unlock } from 'lucide-react';
 import { usePreferences } from '@/contexts/PreferencesContext';
 
-export interface MealPercentages {
-  breakfast: number;
-  lunch: number;
-  dinner: number;
-  snacks: number;
-}
+export type MealPercentages = Record<string, number>;
 
 interface MealPercentageManagerProps {
   initialPercentages: MealPercentages;
@@ -53,33 +48,22 @@ const MealPercentageManager = ({
 }: MealPercentageManagerProps) => {
   const { t } = useTranslation();
   const { energyUnit, convertEnergy } = usePreferences();
-  const [percentages, setPercentages] =
-    useState<MealPercentages>(initialPercentages);
-  const [locks, setLocks] = useState({
-    breakfast: false,
-    lunch: false,
-    dinner: false,
-    snacks: false,
-  });
+
+  const [locks, setLocks] = useState<Record<string, boolean>>({});
+
   const selectedTemplateName = useMemo(() => {
-    const matchingTemplate = distributionTemplates.find(
-      (t) => JSON.stringify(t.values) === JSON.stringify(percentages)
-    );
+    const matchingTemplate = distributionTemplates.find((tpl) => {
+      const tplKeys = Object.keys(tpl.values);
+      const curKeys = Object.keys(initialPercentages);
+      if (tplKeys.length !== curKeys.length) return false;
+      const keysMatch = tplKeys.every((k) => curKeys.includes(k));
+      return (
+        keysMatch &&
+        JSON.stringify(tpl.values) === JSON.stringify(initialPercentages)
+      );
+    });
     return matchingTemplate ? matchingTemplate.name : 'Custom';
-  }, [percentages]);
-
-  const [prevInitial, setPrevInitial] =
-    useState<MealPercentages>(initialPercentages);
-
-  if (
-    initialPercentages.breakfast !== prevInitial.breakfast ||
-    initialPercentages.lunch !== prevInitial.lunch ||
-    initialPercentages.dinner !== prevInitial.dinner ||
-    initialPercentages.snacks !== prevInitial.snacks
-  ) {
-    setPrevInitial(initialPercentages);
-    setPercentages(initialPercentages);
-  }
+  }, [initialPercentages]);
 
   const getEnergyUnitString = (unit: 'kcal' | 'kJ'): string => {
     return unit === 'kcal'
@@ -87,178 +71,81 @@ const MealPercentageManager = ({
       : t('common.kJUnit', 'kJ');
   };
 
-  // Calculate calories for a given percentage
   const calculateCalories = (percentage: number): number => {
-    // totalCalories is assumed to be in kcal
     const caloriesInKcal = (percentage / 100) * totalCalories;
-    return Math.round(convertEnergy(caloriesInKcal, 'kcal', energyUnit)); // Return converted value for display
+    return Math.round(convertEnergy(caloriesInKcal, 'kcal', energyUnit));
   };
 
   const handleTemplateChange = useCallback(
     (templateName: string) => {
       if (templateName === 'Custom') return;
       const template = distributionTemplates.find(
-        (t) => t.name === templateName
+        (tpl) => tpl.name === templateName
       );
       if (template) {
-        const newValues = template.values;
-        setPercentages(newValues);
-        setLocks({
-          breakfast: false,
-          lunch: false,
-          dinner: false,
-          snacks: false,
-        });
+        const newValues = { ...template.values };
+        setLocks({}); // Clear locks when applying a new template
         onPercentagesChange(newValues);
       }
     },
     [onPercentagesChange]
   );
 
-  const normalizePercentages = useCallback(
-    (
-      currentPercentages: MealPercentages,
-      changedMeal: keyof MealPercentages | undefined,
-      currentLocks: typeof locks
-    ): MealPercentages => {
-      const total = Object.values(currentPercentages).reduce(
-        (sum, p) => sum + p,
-        0
-      );
-      if (Math.round(total) !== 100) {
-        const diff = 100 - total;
-        const unlockedMeals = Object.keys(currentLocks).filter(
-          (key) =>
-            !currentLocks[key as keyof MealPercentages] && key !== changedMeal
-        ) as (keyof MealPercentages)[];
-        if (unlockedMeals.length > 0) {
-          const adjustment = diff / unlockedMeals.length;
-          unlockedMeals.forEach((m) => {
-            currentPercentages[m] += adjustment;
-          });
-        }
-      }
-      // Round to nearest integer and ensure sum is exactly 100
-      let roundedTotal = 0;
-      const finalPercentages = { ...currentPercentages };
-      (Object.keys(finalPercentages) as (keyof MealPercentages)[]).forEach(
-        (m) => {
-          finalPercentages[m] = Math.round(finalPercentages[m]);
-          roundedTotal += finalPercentages[m];
-        }
-      );
-
-      // Adjust for rounding errors
-      let roundingDiff = 100 - roundedTotal;
-      const unlockedMeals = Object.keys(currentLocks).filter(
-        (key) =>
-          !currentLocks[key as keyof MealPercentages] && key !== changedMeal
-      ) as (keyof MealPercentages)[];
-      if (unlockedMeals.length > 0) {
-        let i = 0;
-        while (roundingDiff !== 0) {
-          const mealToAdjust = unlockedMeals[i % unlockedMeals.length];
-          const adjustment = Math.sign(roundingDiff);
-          if (mealToAdjust) {
-            finalPercentages[mealToAdjust] += adjustment;
-          }
-          roundingDiff -= adjustment;
-          i++;
-        }
-      }
-
-      return finalPercentages;
-    },
-    []
-  );
-
-  const autoBalance = useCallback(
-    (
-      currentPercentages: MealPercentages,
-      changedMeal: keyof MealPercentages,
-      currentLocks: typeof locks,
-      currentTemplate: string
-    ): MealPercentages => {
-      if (currentTemplate === 'Custom') {
-        return currentPercentages;
-      }
-      const lockedTotal = Object.keys(currentLocks).reduce((acc, key) => {
-        return currentLocks[key as keyof MealPercentages] && key !== changedMeal
-          ? acc + currentPercentages[key as keyof MealPercentages]
-          : acc;
-      }, 0);
-
-      const unlockedMeals = Object.keys(currentLocks).filter(
-        (key) =>
-          !currentLocks[key as keyof MealPercentages] && key !== changedMeal
-      ) as (keyof MealPercentages)[];
-      const changedValue = currentPercentages[changedMeal];
-      const remainingToDistribute = 100 - lockedTotal - changedValue;
-
-      if (unlockedMeals.length > 0) {
-        const perMealShare = remainingToDistribute / unlockedMeals.length;
-        unlockedMeals.forEach((m) => {
-          currentPercentages[m] = perMealShare;
-        });
-      }
-
-      return normalizePercentages(
-        currentPercentages,
-        changedMeal,
-        currentLocks
-      );
-    },
-    [normalizePercentages]
-  );
-
   const handleSliderChange = useCallback(
-    (meal: keyof MealPercentages, value: number) => {
-      setPercentages((prev) => {
-        const newPercentages = { ...prev, [meal]: value };
-
-        onPercentagesChange(newPercentages);
-        return autoBalance(newPercentages, meal, locks, selectedTemplateName);
-      });
+    (meal: string, value: number) => {
+      // Create a new object with the updated value and send it straight to the parent
+      const newPercentages = { ...initialPercentages, [meal]: value };
+      onPercentagesChange(newPercentages);
     },
-    [locks, selectedTemplateName, autoBalance, onPercentagesChange]
+    [initialPercentages, onPercentagesChange]
   );
 
-  const handleLockToggle = useCallback((meal: keyof MealPercentages) => {
+  const handleLockToggle = useCallback((meal: string) => {
     setLocks((prevLocks) => ({ ...prevLocks, [meal]: !prevLocks[meal] }));
   }, []);
 
   const distributeRemaining = useCallback(() => {
     const lockedTotal = Object.keys(locks).reduce((acc, key) => {
-      return locks[key as keyof MealPercentages]
-        ? acc + percentages[key as keyof MealPercentages]
-        : acc;
+      return locks[key] ? acc + (initialPercentages[key] ?? 0) : acc;
     }, 0);
 
-    const unlockedMeals = Object.keys(locks).filter(
-      (key) => !locks[key as keyof MealPercentages]
-    ) as (keyof MealPercentages)[];
-    const remainingToDistribute = 100 - lockedTotal;
+    const unlockedMeals = Object.keys(initialPercentages).filter(
+      (key) => !locks[key]
+    );
+    let remainingToDistribute = 100 - lockedTotal;
 
     if (unlockedMeals.length > 0) {
-      const perMealShare = remainingToDistribute / unlockedMeals.length;
-      const newPercentages = { ...percentages };
-      unlockedMeals.forEach((m) => {
-        newPercentages[m] = perMealShare;
-      });
-      const finalPercentages = normalizePercentages(
-        newPercentages,
-        undefined,
-        locks
-      );
-      setPercentages(finalPercentages);
-      onPercentagesChange(finalPercentages);
-    }
-  }, [percentages, locks, onPercentagesChange, normalizePercentages]);
+      const newPercentages = { ...initialPercentages };
 
-  const totalPercentage = Object.values(percentages).reduce(
-    (sum, p) => sum + Number(p),
+      unlockedMeals.forEach((m, index) => {
+        if (index === unlockedMeals.length - 1) {
+          // Give the exact remainder to the last unlocked meal to prevent rounding drift
+          newPercentages[m] = Math.max(0, remainingToDistribute);
+        } else {
+          // Divide evenly and round
+          const share = Math.round((100 - lockedTotal) / unlockedMeals.length);
+          newPercentages[m] = Math.max(0, share);
+          remainingToDistribute -= share;
+        }
+      });
+
+      onPercentagesChange(newPercentages);
+    }
+  }, [initialPercentages, locks, onPercentagesChange]);
+
+  const totalPercentage = Object.values(initialPercentages).reduce(
+    (sum, p) => sum + Number(p ?? 0),
     0
   );
+
+  const hasCustomMeals = useMemo(() => {
+    const templateKeys = Object.keys(distributionTemplates[0]?.values ?? {});
+    const currentKeys = Object.keys(initialPercentages);
+    return (
+      currentKeys.length !== templateKeys.length ||
+      !currentKeys.every((k) => templateKeys.includes(k))
+    );
+  }, [initialPercentages]);
 
   return (
     <div className="space-y-6">
@@ -266,6 +153,7 @@ const MealPercentageManager = ({
         <Select
           onValueChange={handleTemplateChange}
           value={selectedTemplateName}
+          disabled={hasCustomMeals}
         >
           <SelectTrigger>
             <SelectValue
@@ -278,11 +166,12 @@ const MealPercentageManager = ({
                 {t('goals.mealDistribution.custom')}
               </SelectItem>
             )}
-            {distributionTemplates.map((template) => (
-              <SelectItem key={template.name} value={template.name}>
-                {template.name}
-              </SelectItem>
-            ))}
+            {!hasCustomMeals &&
+              distributionTemplates.map((template) => (
+                <SelectItem key={template.name} value={template.name}>
+                  {template.name}
+                </SelectItem>
+              ))}
           </SelectContent>
         </Select>
         <Button
@@ -294,11 +183,13 @@ const MealPercentageManager = ({
         </Button>
       </div>
 
-      {(Object.keys(percentages) as Array<keyof MealPercentages>).map(
-        (meal) => (
+      {Object.keys(initialPercentages).map((meal) => {
+        const mealPercentage = initialPercentages[meal] ?? 0;
+
+        return (
           <div key={meal} className="space-y-2">
             <Label htmlFor={meal} className="capitalize font-semibold">
-              {t(`common.${meal}`)} ({calculateCalories(percentages[meal])}{' '}
+              {t(`common.${meal}`, meal)} ({calculateCalories(mealPercentage)}{' '}
               {getEnergyUnitString(energyUnit)})
             </Label>
             <div className="flex items-center gap-4">
@@ -318,7 +209,7 @@ const MealPercentageManager = ({
                 min={0}
                 max={100}
                 step={1}
-                value={[percentages[meal]]}
+                value={[mealPercentage]}
                 onValueChange={([value]) =>
                   handleSliderChange(meal, value || 0)
                 }
@@ -327,7 +218,7 @@ const MealPercentageManager = ({
               <div className="flex items-center gap-2">
                 <Input
                   type="number"
-                  value={percentages[meal]}
+                  value={mealPercentage}
                   onChange={(e) =>
                     handleSliderChange(meal, parseInt(e.target.value, 10) || 0)
                   }
@@ -338,11 +229,13 @@ const MealPercentageManager = ({
               </div>
             </div>
           </div>
-        )
-      )}
+        );
+      })}
 
       <div
-        className={`text-right font-semibold ${totalPercentage === 100 ? 'text-green-600' : 'text-red-600'}`}
+        className={`text-right font-semibold ${
+          totalPercentage === 100 ? 'text-green-600' : 'text-red-600'
+        }`}
       >
         {t('goals.mealDistribution.total')}: {totalPercentage}%
         {totalPercentage !== 100 && (

--- a/SparkyFitnessFrontend/src/components/Onboarding/NutrientGoals.tsx
+++ b/SparkyFitnessFrontend/src/components/Onboarding/NutrientGoals.tsx
@@ -1,6 +1,5 @@
 import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableRow } from '@/components/ui/table';
-import MealPercentageManager from '@/components/MealPercentageManager';
 import {
   convertMlToSelectedUnit,
   convertSelectedUnitToMl,
@@ -8,6 +7,8 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useCustomNutrients } from '@/hooks/Foods/useCustomNutrients';
 import { ExpandedGoals } from '@/types/goals';
+import { MealPercentages } from '@/types/meal';
+import MealPercentageManager from '../MealPercentageManager';
 
 export interface NutrientGoalsProps {
   convertEnergy: (
@@ -16,12 +17,7 @@ export interface NutrientGoalsProps {
     toUnit: 'kcal' | 'kJ'
   ) => number;
   editedPlan: ExpandedGoals | null;
-  handlePercentagesChange: (newPercentages: {
-    breakfast: number;
-    lunch: number;
-    dinner: number;
-    snacks: number;
-  }) => void;
+  handlePercentagesChange: (newPercentages: MealPercentages) => void;
   localEnergyUnit: 'kcal' | 'kJ';
   localWaterUnit: 'ml' | 'oz' | 'liter';
   memoizedInitialPercentages: {

--- a/SparkyFitnessFrontend/src/components/Onboarding/PersonalPlan.tsx
+++ b/SparkyFitnessFrontend/src/components/Onboarding/PersonalPlan.tsx
@@ -26,6 +26,7 @@ import { createInitialPlan } from '@/utils/onboarding';
 import { useUpdateProfileMutation } from '@/hooks/Settings/useProfile';
 import { useAuth } from '@/hooks/useAuth';
 import { OnboardingData } from '@/types/onboarding';
+import { MealPercentages } from '@/types/meal';
 
 interface PersonalPlanProps {
   formData: OnboardingData;
@@ -327,20 +328,15 @@ const PersonalPlan = ({
     ]
   );
 
-  const handlePercentagesChange = (newPercentages: {
-    breakfast: number;
-    lunch: number;
-    dinner: number;
-    snacks: number;
-  }) => {
+  const handlePercentagesChange = (newPercentages: MealPercentages) => {
     setEditedPlan((prev) =>
       prev
         ? {
             ...prev,
-            breakfast_percentage: newPercentages.breakfast,
-            lunch_percentage: newPercentages.lunch,
-            dinner_percentage: newPercentages.dinner,
-            snacks_percentage: newPercentages.snacks,
+            breakfast_percentage: newPercentages['breakfast'] ?? 0,
+            lunch_percentage: newPercentages['lunch'] ?? 0,
+            dinner_percentage: newPercentages['dinner'] ?? 0,
+            snacks_percentage: newPercentages['snacks'] ?? 0,
           }
         : null
     );

--- a/SparkyFitnessFrontend/src/pages/Diary/DiaryTopControls.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/DiaryTopControls.tsx
@@ -14,7 +14,6 @@ import type { UserCustomNutrient } from '@/types/customNutrient';
 import EditGoalsForToday from '@/pages/Goals/EditGoalsForToday';
 import { useMemo } from 'react';
 import { DEFAULT_GOALS } from '@/constants/goals';
-import { Goals } from '@/types/diary';
 import { Button } from '@/components/ui/button';
 import { ClipboardCopy, History } from 'lucide-react';
 import {
@@ -23,6 +22,7 @@ import {
 } from '@/hooks/Diary/useFoodEntries';
 import CopyFoodEntryDialog from './CopyFoodEntryDialog';
 import { useState } from 'react';
+import { ExpandedGoals } from '@/types/goals';
 
 export interface DayTotals {
   calories: number; // Stored internally as kcal
@@ -36,7 +36,7 @@ export interface DayTotals {
 interface DiaryTopControlsProps {
   selectedDate: string;
   dayTotals?: DayTotals;
-  goals: Goals;
+  goals: ExpandedGoals;
   energyUnit: 'kcal' | 'kJ';
   convertEnergy: (
     value: number,
@@ -145,7 +145,7 @@ const DiaryTopControls = ({
                   (dayTotals[nutrient as keyof DayTotals] as number) ??
                   dayTotals.custom_nutrients?.[nutrient] ??
                   0;
-                const rawGoal = goals[nutrient as keyof Goals];
+                const rawGoal = goals[nutrient as keyof ExpandedGoals];
                 const goal =
                   typeof rawGoal === 'number'
                     ? rawGoal

--- a/SparkyFitnessFrontend/src/pages/Goals/DailyGoals.tsx
+++ b/SparkyFitnessFrontend/src/pages/Goals/DailyGoals.tsx
@@ -15,6 +15,9 @@ import { useCallback, useMemo } from 'react';
 import { ExpandedGoals } from '@/types/goals';
 import { WaterAndExerciseFields } from './WaterAndExerciseFields';
 import { useCustomNutrients } from '@/hooks/Foods/useCustomNutrients';
+import { useMealTypes } from '@/hooks/Diary/useMealTypes';
+import { buildGoalsPayload, getMealPercentage } from '@/utils/goals';
+
 interface DailyGoalsProps {
   goals: ExpandedGoals;
   setGoals: React.Dispatch<React.SetStateAction<ExpandedGoals>>;
@@ -32,52 +35,50 @@ export const DailyGoals = ({
   const { t } = useTranslation();
   const { user } = useAuth();
   const { data: customNutrients } = useCustomNutrients();
+  const { data: mealTypes = [] } = useMealTypes();
 
-  const memoizedGoalsPercentages = useMemo(
-    () => ({
-      breakfast: goals.breakfast_percentage,
-      lunch: goals.lunch_percentage,
-      dinner: goals.dinner_percentage,
-      snacks: goals.snacks_percentage,
-    }),
-    [
-      goals.breakfast_percentage,
-      goals.lunch_percentage,
-      goals.dinner_percentage,
-      goals.snacks_percentage,
-    ]
+  const visibleMeals = useMemo(
+    () => mealTypes.filter((m) => m.is_visible),
+    [mealTypes]
   );
+
+  const memoizedGoalsPercentages = useMemo(() => {
+    const percentages: Record<string, number> = {};
+    visibleMeals.forEach((meal) => {
+      percentages[meal.name.toLowerCase()] = getMealPercentage(
+        meal.name,
+        goals
+      );
+    });
+    return percentages;
+  }, [goals, visibleMeals]);
+
   const { mutateAsync: saveGoalsService, isPending: saving } =
     useSaveGoalsMutation();
+
   const handleSaveGoals = async () => {
     if (!user) return;
-
     await saveGoalsService({ date: today, goals, cascade: true });
   };
 
   const handleGoalsPercentagesChange = useCallback(
-    (newPercentages: {
-      breakfast: number;
-      lunch: number;
-      dinner: number;
-      snacks: number;
-    }) => {
+    (newPercentages: Record<string, number>) => {
       setGoals((prevGoals) => ({
         ...prevGoals,
-        breakfast_percentage: newPercentages.breakfast,
-        lunch_percentage: newPercentages.lunch,
-        dinner_percentage: newPercentages.dinner,
-        snacks_percentage: newPercentages.snacks,
+        ...buildGoalsPayload(newPercentages, prevGoals),
       }));
     },
     [setGoals]
   );
-  const isTotalPercentageValid =
-    goals.breakfast_percentage +
-      goals.lunch_percentage +
-      goals.dinner_percentage +
-      goals.snacks_percentage ===
-    100;
+
+  const isTotalPercentageValid = useMemo(() => {
+    const total = visibleMeals.reduce(
+      (sum, meal) => sum + getMealPercentage(meal.name, goals),
+      0
+    );
+    return Math.round(total) === 100;
+  }, [goals, visibleMeals]);
+
   return (
     <>
       <Card>
@@ -97,7 +98,6 @@ export const DailyGoals = ({
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {/* Primary Macros */}
             {visibleNutrients.includes('calories') && (
               <div className="space-y-1.5">
                 <Label htmlFor="calories">
@@ -131,7 +131,6 @@ export const DailyGoals = ({
                 customNutrients={customNutrients}
               />
             ))}
-            {/* Custom Nutrients */}
             {customNutrients?.map((cn) => {
               return (
                 <NutrientInput

--- a/SparkyFitnessFrontend/src/pages/Goals/EditGoalsForToday.tsx
+++ b/SparkyFitnessFrontend/src/pages/Goals/EditGoalsForToday.tsx
@@ -35,6 +35,8 @@ import { WaterAndExerciseFields } from '@/pages/Goals/WaterAndExerciseFields';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { useCustomNutrients } from '@/hooks/Foods/useCustomNutrients';
 import type { UserCustomNutrient } from '@/types/customNutrient';
+import { useMealTypes } from '@/hooks/Diary/useMealTypes';
+import { buildGoalsPayload, getMealPercentage } from '@/utils/goals';
 
 interface EditGoalsProps {
   selectedDate: string;
@@ -87,6 +89,7 @@ const EditGoalsForm = ({
   );
 
   const { data: goalPresets = [] } = useGoalPresets();
+  const { data: mealTypes = [] } = useMealTypes();
 
   const goalPreferences = nutrientDisplayPreferences.find(
     (p) => p.view_group === 'goal' && p.platform === platform
@@ -122,12 +125,29 @@ const EditGoalsForm = ({
 
   const isMacroValid = Math.round(currentMacroTotal) === 100;
 
-  const isTotalPercentageValid =
-    goals.breakfast_percentage +
-      goals.lunch_percentage +
-      goals.dinner_percentage +
-      goals.snacks_percentage ===
-    100;
+  const visibleMeals = useMemo(
+    () => mealTypes.filter((m) => m.is_visible),
+    [mealTypes]
+  );
+
+  const memoizedGoalsPercentages = useMemo(() => {
+    const percentages: Record<string, number> = {};
+    visibleMeals.forEach((meal) => {
+      percentages[meal.name.toLowerCase()] = getMealPercentage(
+        meal.name,
+        goals
+      );
+    });
+    return percentages;
+  }, [goals, visibleMeals]);
+
+  const isTotalPercentageValid = useMemo(() => {
+    const total = visibleMeals.reduce(
+      (sum, meal) => sum + getMealPercentage(meal.name, goals),
+      0
+    );
+    return Math.round(total) === 100;
+  }, [goals, visibleMeals]);
   const handleApplyPreset = (presetId: string) => {
     const preset = goalPresets.find((p) => p.id === presetId);
     if (preset) {
@@ -308,20 +328,12 @@ const EditGoalsForm = ({
       <div className="space-y-4">
         <h3 className="text-sm font-semibold">Meal Distribution</h3>
         <MealPercentageManager
-          initialPercentages={{
-            breakfast: goals.breakfast_percentage,
-            lunch: goals.lunch_percentage,
-            dinner: goals.dinner_percentage,
-            snacks: goals.snacks_percentage,
-          }}
+          initialPercentages={memoizedGoalsPercentages}
           totalCalories={goals.calories}
           onPercentagesChange={(p) =>
             setGoals((prev) => ({
               ...prev,
-              breakfast_percentage: p.breakfast,
-              lunch_percentage: p.lunch,
-              dinner_percentage: p.dinner,
-              snacks_percentage: p.snacks,
+              ...buildGoalsPayload(p, prev),
             }))
           }
         />

--- a/SparkyFitnessFrontend/src/pages/Goals/GoalPresetDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Goals/GoalPresetDialog.tsx
@@ -27,6 +27,8 @@ import {
 import { useMemo, useState } from 'react';
 import { useCustomNutrients } from '@/hooks/Foods/useCustomNutrients';
 import { GoalPreset } from '@/types/goals';
+import { getMealPercentage, buildGoalsPayload } from '@/utils/goals';
+import { useMealTypes } from '@/hooks/Diary/useMealTypes';
 
 interface GoalPresetDialogProps {
   open: boolean;
@@ -54,6 +56,8 @@ export const GoalPresetDialog = ({
   const { t } = useTranslation();
   const { user } = useAuth();
   const { data: customNutrients } = useCustomNutrients();
+  const { data: mealTypes = [] } = useMealTypes();
+
   const [formData, setFormData] = useState<GoalPreset | null>(() => {
     if (!preset) {
       return { ...DEFAULT_GOALS, preset_name: '', id: undefined } as GoalPreset;
@@ -75,15 +79,22 @@ export const GoalPresetDialog = ({
 
   const presetSaving = createSaving || updateSaving;
 
+  const visibleMeals = useMemo(
+    () => mealTypes.filter((m) => m.is_visible),
+    [mealTypes]
+  );
+
   const mealPercentages = useMemo(() => {
-    if (!formData) return { breakfast: 25, lunch: 25, dinner: 25, snacks: 25 };
-    return {
-      breakfast: formData.breakfast_percentage ?? 25,
-      lunch: formData.lunch_percentage ?? 25,
-      dinner: formData.dinner_percentage ?? 25,
-      snacks: formData.snacks_percentage ?? 25,
-    };
-  }, [formData]);
+    if (!formData) return {};
+    const percentages: Record<string, number> = {};
+    visibleMeals.forEach((meal) => {
+      percentages[meal.name.toLowerCase()] = getMealPercentage(
+        meal.name,
+        formData
+      );
+    });
+    return percentages;
+  }, [formData, visibleMeals]);
 
   const handleSave = async () => {
     if (!formData || !user) return;
@@ -112,6 +123,7 @@ export const GoalPresetDialog = ({
       console.error('Failed to save preset', error);
     }
   };
+
   const currentMacroTotal = useMemo(() => {
     if (!formData || macroInputType === 'grams') return 0;
     return (
@@ -121,13 +133,14 @@ export const GoalPresetDialog = ({
     );
   }, [formData, macroInputType]);
 
-  const isTotalPercentageValid = formData
-    ? formData.breakfast_percentage +
-        formData.lunch_percentage +
-        formData.dinner_percentage +
-        formData.snacks_percentage ===
-      100
-    : false;
+  const isTotalPercentageValid = useMemo(() => {
+    if (!formData) return false;
+    const total = visibleMeals.reduce(
+      (sum, meal) => sum + getMealPercentage(meal.name, formData),
+      0
+    );
+    return Math.round(total) === 100;
+  }, [formData, visibleMeals]);
 
   if (!formData) return null;
   return (
@@ -310,10 +323,7 @@ export const GoalPresetDialog = ({
                 onPercentagesChange={(p) =>
                   setFormData({
                     ...formData,
-                    breakfast_percentage: p.breakfast,
-                    lunch_percentage: p.lunch,
-                    dinner_percentage: p.dinner,
-                    snacks_percentage: p.snacks,
+                    ...buildGoalsPayload(p, formData),
                   })
                 }
               />

--- a/SparkyFitnessFrontend/src/types/diary.ts
+++ b/SparkyFitnessFrontend/src/types/diary.ts
@@ -1,16 +1,5 @@
 import { WorkoutPresetSet } from './workout';
 
-export interface Goals {
-  calories: number;
-  protein: number;
-  carbs: number;
-  fat: number;
-  water_goal_ml: number;
-  dietary_fiber?: number;
-  custom_nutrients?: Record<string, number>;
-  meal_percentages?: Record<string, number>;
-}
-
 export interface ExerciseEntry {
   id: string;
   exercise_id: string;

--- a/SparkyFitnessFrontend/src/types/goals.ts
+++ b/SparkyFitnessFrontend/src/types/goals.ts
@@ -26,6 +26,8 @@ export interface ExpandedGoals {
   lunch_percentage: number;
   dinner_percentage: number;
   snacks_percentage: number;
+  custom_meal_percentages?: Record<string, number>;
+  custom_nutrients?: Record<string, number>;
   [key: string]: number | string | Record<string, number> | null | undefined;
 }
 export interface GoalPreset {
@@ -59,6 +61,7 @@ export interface GoalPreset {
   lunch_percentage: number;
   dinner_percentage: number;
   snacks_percentage: number;
+  custom_meal_percentages?: Record<string, number>;
   custom_nutrients?: Record<string, number>;
   [key: string]: number | string | Record<string, number> | null | undefined;
 }

--- a/SparkyFitnessFrontend/src/types/meal.ts
+++ b/SparkyFitnessFrontend/src/types/meal.ts
@@ -165,3 +165,4 @@ export interface MealTotals {
 }
 
 export type MealFilter = 'all' | 'mine' | 'family' | 'public' | 'needs-review';
+export type MealPercentages = Record<string, number>;

--- a/SparkyFitnessFrontend/src/utils/goals.ts
+++ b/SparkyFitnessFrontend/src/utils/goals.ts
@@ -1,0 +1,39 @@
+import { ExpandedGoals } from '@/types/goals';
+
+export const getMealPercentage = (
+  mealName: string,
+  goals?: ExpandedGoals
+): number => {
+  if (!goals) return 0;
+
+  const key = mealName.toLowerCase();
+
+  if (goals.custom_meal_percentages && key in goals.custom_meal_percentages) {
+    return goals.custom_meal_percentages[key] ?? 0;
+  }
+
+  const legacyKey = `${key}_percentage` as keyof ExpandedGoals;
+  return (goals[legacyKey] as number) ?? 0;
+};
+
+export const buildGoalsPayload = (
+  sliderValues: Record<string, number>,
+  currentGoals: ExpandedGoals
+): Partial<ExpandedGoals> => {
+  const payload: Partial<ExpandedGoals> = {
+    custom_meal_percentages: { ...currentGoals.custom_meal_percentages },
+  };
+  const defaultMeals = ['breakfast', 'lunch', 'dinner', 'snacks'];
+
+  for (const [mealName, percentage] of Object.entries(sliderValues)) {
+    const key = mealName.toLowerCase();
+
+    if (defaultMeals.includes(key)) {
+      payload[`${key}_percentage` as keyof ExpandedGoals] = percentage;
+    } else {
+      payload.custom_meal_percentages![key] = percentage;
+    }
+  }
+
+  return payload;
+};

--- a/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
+++ b/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
@@ -1,10 +1,11 @@
 import { getDietTemplate } from '@/constants/dietTemplates';
 import { EMPTY_MEAL_TOTALS } from '@/constants/nutrients';
 import i18n from '@/i18n';
-import { Goals } from '@/types/diary';
 import type { FoodEntry, FoodVariant } from '@/types/food';
 import { FoodEntryMeal, MealTotals } from '@/types/meal';
 import { CALORIE_CALCULATION_CONSTANTS } from '@workspace/shared';
+import { getMealPercentage } from './goals';
+import { ExpandedGoals } from '@/types/goals';
 
 // Utility functions for nutrition calculations
 
@@ -515,7 +516,7 @@ export const getMealData = (
   mealType: string,
   foodEntries: FoodEntry[],
   foodEntryMeals: FoodEntryMeal[],
-  goals: Goals
+  goals: ExpandedGoals
 ): {
   name: string;
   type: string;
@@ -526,7 +527,6 @@ export const getMealData = (
     return { name: '', type: '', targetCalories: 0, entries: [] };
   }
 
-  // Filter both standalone food entries and food entry meals
   const entries =
     foodEntries.length !== 0
       ? foodEntries.filter((entry) => entry.meal_type === mealType)
@@ -537,20 +537,11 @@ export const getMealData = (
       : [];
 
   const combinedEntries: (FoodEntry | FoodEntryMeal)[] = [...entries, ...meals];
-  const mealKey = mealType.toLowerCase();
-  const percentageKey = `${mealKey}_percentage` as keyof Goals;
 
-  const percentage = (goals?.[percentageKey] as number) ?? 0;
+  const percentage = getMealPercentage(mealType, goals);
 
-  let displayName = mealType;
-  if (mealType.toLowerCase() === 'breakfast')
-    displayName = i18n.t('common.breakfast', 'Breakfast');
-  else if (mealType.toLowerCase() === 'lunch')
-    displayName = i18n.t('common.lunch', 'Lunch');
-  else if (mealType.toLowerCase() === 'dinner')
-    displayName = i18n.t('common.dinner', 'Dinner');
-  else if (mealType.toLowerCase() === 'snacks')
-    displayName = i18n.t('common.snacks', 'Snacks');
+  const i18nKey = `common.${mealType.toLowerCase()}`;
+  const displayName = i18n.exists(i18nKey) ? i18n.t(i18nKey) : mealType;
 
   return {
     name: displayName,

--- a/SparkyFitnessServer/db/migrations/20260426120001_custom_meal_percentages.sql
+++ b/SparkyFitnessServer/db/migrations/20260426120001_custom_meal_percentages.sql
@@ -1,0 +1,11 @@
+ALTER TABLE user_goals
+ADD COLUMN IF NOT EXISTS custom_meal_percentages JSONB DEFAULT '{}'::jsonb;
+
+ALTER TABLE user_goals
+DROP CONSTRAINT IF EXISTS chk_meal_percentages_sum;
+
+ALTER TABLE goal_presets
+ADD COLUMN IF NOT EXISTS custom_meal_percentages JSONB DEFAULT '{}'::jsonb;
+
+ALTER TABLE goal_presets
+DROP CONSTRAINT IF EXISTS chk_meal_percentages_sum;

--- a/SparkyFitnessServer/models/goalPresetRepository.ts
+++ b/SparkyFitnessServer/models/goalPresetRepository.ts
@@ -21,9 +21,9 @@ async function createGoalPreset(presetData: any) {
         target_exercise_calories_burned, target_exercise_duration_minutes,
         protein_percentage, carbs_percentage, fat_percentage,
         breakfast_percentage, lunch_percentage, dinner_percentage, snacks_percentage,
-        custom_nutrients
+        custom_nutrients, custom_meal_percentages
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31)
       RETURNING *`,
       [
         presetData.user_id,
@@ -56,6 +56,7 @@ async function createGoalPreset(presetData: any) {
         presetData.dinner_percentage,
         presetData.snacks_percentage,
         presetData.custom_nutrients || {},
+        presetData.custom_meal_percentages || {},
       ]
     );
     return result.rows[0];
@@ -110,9 +111,9 @@ async function updateGoalPreset(presetId: any, presetData: any) {
         target_exercise_calories_burned = $20, target_exercise_duration_minutes = $21,
         protein_percentage = $22, carbs_percentage = $23, fat_percentage = $24,
         breakfast_percentage = $25, lunch_percentage = $26, dinner_percentage = $27, snacks_percentage = $28,
-        custom_nutrients = $29,
+        custom_nutrients = $29, custom_meal_percentages = $30,
         updated_at = now()
-      WHERE id = $30 AND user_id = $31
+      WHERE id = $31 AND user_id = $32
       RETURNING *`,
       [
         presetData.preset_name,
@@ -144,6 +145,7 @@ async function updateGoalPreset(presetId: any, presetData: any) {
         presetData.dinner_percentage,
         presetData.snacks_percentage,
         presetData.custom_nutrients || {},
+        presetData.custom_meal_percentages || {},
         presetId,
         presetData.user_id,
       ]

--- a/SparkyFitnessServer/models/goalRepository.ts
+++ b/SparkyFitnessServer/models/goalRepository.ts
@@ -11,7 +11,7 @@ async function getGoalByDate(userId: any, selectedDate: any) {
                target_exercise_calories_burned, target_exercise_duration_minutes,
                protein_percentage, carbs_percentage, fat_percentage,
                breakfast_percentage, lunch_percentage, dinner_percentage, snacks_percentage,
-               custom_nutrients
+               custom_meal_percentages, custom_nutrients
         FROM user_goals
         WHERE user_id = $1 AND goal_date = $2
         ORDER BY updated_at DESC, created_at DESC -- Prioritize most recently updated/created
@@ -35,7 +35,7 @@ async function getMostRecentGoalBeforeDate(userId: any, selectedDate: any) {
                target_exercise_calories_burned, target_exercise_duration_minutes,
                protein_percentage, carbs_percentage, fat_percentage,
                breakfast_percentage, lunch_percentage, dinner_percentage, snacks_percentage,
-               custom_nutrients
+               custom_meal_percentages, custom_nutrients
        FROM user_goals
        WHERE user_id = $1 AND (goal_date < $2 OR goal_date IS NULL)
        ORDER BY goal_date DESC NULLS LAST
@@ -60,9 +60,9 @@ async function upsertGoal(goalData: any) {
         target_exercise_calories_burned, target_exercise_duration_minutes,
         protein_percentage, carbs_percentage, fat_percentage,
         breakfast_percentage, lunch_percentage, dinner_percentage, snacks_percentage,
-        custom_nutrients, created_at, updated_at
+        custom_meal_percentages, custom_nutrients, created_at, updated_at
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33)
       ON CONFLICT (user_id, COALESCE(goal_date, '1900-01-01'::date))
       DO UPDATE SET
         calories = EXCLUDED.calories,
@@ -92,6 +92,7 @@ async function upsertGoal(goalData: any) {
         lunch_percentage = EXCLUDED.lunch_percentage,
         dinner_percentage = EXCLUDED.dinner_percentage,
         snacks_percentage = EXCLUDED.snacks_percentage,
+        custom_meal_percentages = EXCLUDED.custom_meal_percentages,
         custom_nutrients = EXCLUDED.custom_nutrients,
         updated_at = now()
       RETURNING *`,
@@ -125,6 +126,7 @@ async function upsertGoal(goalData: any) {
         goalData.lunch_percentage,
         goalData.dinner_percentage,
         goalData.snacks_percentage,
+        goalData.custom_meal_percentages || {},
         goalData.custom_nutrients || {},
         new Date(), // for created_at
         new Date(), // for updated_at

--- a/SparkyFitnessServer/services/goalPresetService.ts
+++ b/SparkyFitnessServer/services/goalPresetService.ts
@@ -3,10 +3,11 @@ import { log } from '../config/logging.js';
 // Convert water_goal_ml to the correct repository field name
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function mapWaterGoalMlToDb(presetData: any) {
-  const { water_goal_ml, ...rest } = presetData;
+  const { water_goal_ml, custom_meal_percentages, ...rest } = presetData;
   return {
     ...rest,
     water_goal: water_goal_ml,
+    custom_meal_percentages: custom_meal_percentages || {},
   };
 }
 // Convert water_goal repository field name to water_goal_ml

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -201,6 +201,7 @@ async function manageGoalTimeline(authenticatedUserId: any, goalData: any) {
       p_lunch_percentage,
       p_dinner_percentage,
       p_snacks_percentage,
+      custom_meal_percentages,
       custom_nutrients,
     } = goalData;
     log(
@@ -317,6 +318,7 @@ async function manageGoalTimeline(authenticatedUserId: any, goalData: any) {
       lunch_percentage: cleanNumber(p_lunch_percentage, true),
       dinner_percentage: cleanNumber(p_dinner_percentage, true),
       snacks_percentage: cleanNumber(p_snacks_percentage, true),
+      custom_meal_percentages: custom_meal_percentages || {},
       custom_nutrients: filteredCustomNutrients,
     };
     // If cascade is false, or if editing a past date, only update that specific date


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Calorie distribution didn't work for custom meals. Also hiding a meal didn't remove it from the distribution.

**How did you implement the solution?**
I added a new attribute that holds the new percentages. To guarantee backwards compatibility for mobile I didnt't change the values for the standard types, but they should be moved into the json in the future. I removed the database constraints that percentages must add up to 100 because that doesn't work for json entries and the frontend prevents it from saving anyways.

Linked Issue: #781 

## How to Test

1. Create custom meal
2. Change distribution for custom meal for goals, goals for today and goal preset.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="1248" height="972" alt="image" src="https://github.com/user-attachments/assets/8c68009c-ba47-4a5a-86b7-1dec63205fc7" />

</details>

Closes #781
