### PR TITLE
fix: food unit conversion behavior for compatible and incompatible variants

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
@@ -34,7 +34,7 @@ const CustomFoodForm = ({
     loading,
     showSyncConfirmation,
     setShowSyncConfirmation,
-    loadedVariants,
+    conversionBaseVariants,
     updateField,
     addVariant,
     duplicateVariant,
@@ -129,7 +129,7 @@ const CustomFoodForm = ({
                     convertEnergy={convertEnergy}
                     customNutrients={customNutrients}
                     baseServingUnit={
-                      loadedVariants[index]?.serving_unit ??
+                      conversionBaseVariants[index]?.serving_unit ??
                       variant.serving_unit
                     }
                     onUpdate={updateVariant}

--- a/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
@@ -31,7 +31,7 @@ interface VariantCardProps {
     to: 'kcal' | 'kJ'
   ) => number;
   customNutrients?: UserCustomNutrient[];
-  baseServingUnit: string; // loadedVariantsRef.current[index]?.serving_unit ?? variant.serving_unit
+  baseServingUnit: string; // trusted conversion base for compatibility checkmarks
   onUpdate: (
     index: number,
     field: string,

--- a/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
@@ -26,8 +26,10 @@ import {
   foodVariantsOptions,
   useCreateFoodVariantMutation,
 } from '@/hooks/Foods/useFoodVariants';
-import { getConversionFactor } from '@/utils/servingSizeConversions';
-import { useUnitConversion } from '@/hooks/Foods/useUnitConversion';
+import {
+  canAutoConvertToUnit,
+  useUnitConversion,
+} from '@/hooks/Foods/useUnitConversion';
 
 interface FoodUnitSelectorProps {
   food: Food;
@@ -375,11 +377,11 @@ const FoodUnitSelector = ({
                         <>
                           <SelectSeparator />
                           {convertibleUnits.map((u) => {
-                            const compatible =
-                              getConversionFactor(
-                                selectedVariant?.serving_unit || '',
-                                u
-                              ) !== null;
+                            const compatible = canAutoConvertToUnit(
+                              variants,
+                              selectedVariant,
+                              u
+                            );
                             return (
                               <SelectItem key={u} value={u}>
                                 <span className="flex items-center gap-1.5">
@@ -427,7 +429,7 @@ const FoodUnitSelector = ({
                         type="number"
                         step="0.01"
                         min="0.01"
-                        placeholder="e.g. 14.2"
+                        placeholder="e.g. 1"
                         value={conversionFactor}
                         onChange={(e) => {
                           const val = e.target.value;
@@ -474,7 +476,7 @@ const FoodUnitSelector = ({
                         type="number"
                         step="0.01"
                         min="0.01"
-                        placeholder="e.g. 14.2"
+                        placeholder="e.g. 1"
                         value={conversionFactor}
                         onChange={(e) => {
                           const val = e.target.value;

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
@@ -356,6 +356,14 @@ export function useCustomFoodForm({
             if (!isNaN(old))
               newVariant[nutrient] = Number((old * factor).toFixed(4));
           }
+          if (currentVariant.custom_nutrients) {
+            const scaled = { ...newVariant.custom_nutrients };
+            Object.keys(currentVariant.custom_nutrients).forEach((name) => {
+              const old = Number(currentVariant.custom_nutrients?.[name]);
+              if (!isNaN(old)) scaled[name] = Number((old * factor).toFixed(4));
+            });
+            newVariant.custom_nutrients = scaled;
+          }
           updatedManualUnitConversionPending[index] = false;
         } else if (factor === null && !bothServing) {
           newVariant = zeroOutVariantNutrition(newVariant);

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
@@ -37,6 +37,29 @@ interface UseCustomFoodFormProps {
   onSave: (foodData: Food) => void;
 }
 
+function buildManualConversionToast(baseUnit: string, targetUnit: string) {
+  return {
+    title: 'Manual conversion required',
+    description: `"${baseUnit}" and "${targetUnit}" are incompatible unit types. Please update the serving size and nutrition values manually.`,
+  } as const;
+}
+
+function zeroOutVariantNutrition(variant: FormFoodVariant): FormFoodVariant {
+  const zeroedVariant = { ...variant };
+
+  for (const nutrient of nutrientFields) {
+    zeroedVariant[nutrient] = 0;
+  }
+
+  if (variant.custom_nutrients) {
+    zeroedVariant.custom_nutrients = Object.fromEntries(
+      Object.keys(variant.custom_nutrients).map((name) => [name, 0])
+    );
+  }
+
+  return zeroedVariant;
+}
+
 export function useCustomFoodForm({
   food,
   initialVariants,
@@ -60,6 +83,8 @@ export function useCustomFoodForm({
     []
   );
   const [loadedVariants, setLoadedVariants] = useState<FormFoodVariant[]>([]);
+  const [manualUnitConversionPending, setManualUnitConversionPending] =
+    useState<boolean[]>([]);
   const [variantErrors, setVariantErrors] = useState<string[]>([]);
   const [showSyncConfirmation, setShowSyncConfirmation] = useState(false);
   const [syncFoodId, setSyncFoodId] = useState<string | null>(null);
@@ -76,6 +101,7 @@ export function useCustomFoodForm({
     setVariants([defaultVariant]);
     setOriginalVariants(snapshot);
     setLoadedVariants(snapshot);
+    setManualUnitConversionPending([false]);
     setVariantErrors(['']);
   }, [customNutrients]);
 
@@ -115,6 +141,7 @@ export function useCustomFoodForm({
       setVariants(loaded);
       setOriginalVariants(snapshot);
       setLoadedVariants(snapshot);
+      setManualUnitConversionPending(new Array(loaded.length).fill(false));
     } catch (err) {
       console.error('Error loading variants:', err);
       const fallback = createDefaultFormVariant(customNutrients);
@@ -122,6 +149,7 @@ export function useCustomFoodForm({
       setVariants([fallback]);
       setOriginalVariants(snapshot);
       setLoadedVariants(snapshot);
+      setManualUnitConversionPending([false]);
     }
   }, [food?.default_variant, food?.id, queryClient, customNutrients]);
 
@@ -145,6 +173,7 @@ export function useCustomFoodForm({
         setVariants(mapped);
         setOriginalVariants(snapshot);
         setLoadedVariants(snapshot);
+        setManualUnitConversionPending(new Array(mapped.length).fill(false));
         setVariantErrors(new Array(food.variants.length).fill(null));
       } else {
         loadExistingVariants();
@@ -156,6 +185,7 @@ export function useCustomFoodForm({
       setVariants(mapped);
       setOriginalVariants(snapshot);
       setLoadedVariants(snapshot);
+      setManualUnitConversionPending(new Array(mapped.length).fill(false));
       setVariantErrors(new Array(initialVariants.length).fill(null));
     } else {
       resetForm();
@@ -178,11 +208,16 @@ export function useCustomFoodForm({
     setVariants((prev) => [...prev, newVariant]);
     setOriginalVariants((prev) => [...prev, clone]);
     setLoadedVariants((prev) => [...prev, clone]);
+    setManualUnitConversionPending((prev) => [...prev, false]);
     setVariantErrors((prev) => [...prev, '']);
   };
 
   const duplicateVariant = (index: number) => {
     const src = variants[index];
+    const sourceOriginalVariant = originalVariants[index];
+    const sourceLoadedVariant = loadedVariants[index];
+    const sourceRequiresManualConversion =
+      manualUnitConversionPending[index] ?? false;
     if (!src) {
       error(
         loggingLevel,
@@ -197,10 +232,21 @@ export function useCustomFoodForm({
       is_default: false,
       is_locked: false,
     };
-    const clone = deepClone(newVariant);
+    const originalClone = deepClone(
+      sourceRequiresManualConversion ? sourceOriginalVariant || src : newVariant
+    );
+    const loadedClone = deepClone(
+      sourceRequiresManualConversion
+        ? sourceLoadedVariant || sourceOriginalVariant || src
+        : newVariant
+    );
     setVariants((prev) => [...prev, newVariant]);
-    setOriginalVariants((prev) => [...prev, clone]);
-    setLoadedVariants((prev) => [...prev, clone]);
+    setOriginalVariants((prev) => [...prev, originalClone]);
+    setLoadedVariants((prev) => [...prev, loadedClone]);
+    setManualUnitConversionPending((prev) => [
+      ...prev,
+      sourceRequiresManualConversion,
+    ]);
     setVariantErrors((prev) => [...prev, '']);
   };
 
@@ -215,6 +261,11 @@ export function useCustomFoodForm({
       return;
     }
     setVariants((prev) => prev.filter((_, i) => i !== index));
+    setOriginalVariants((prev) => prev.filter((_, i) => i !== index));
+    setLoadedVariants((prev) => prev.filter((_, i) => i !== index));
+    setManualUnitConversionPending((prev) =>
+      prev.filter((_, i) => i !== index)
+    );
     setVariantErrors((prev) => prev.filter((_, i) => i !== index));
   };
 
@@ -225,6 +276,7 @@ export function useCustomFoodForm({
   ) => {
     const updatedVariants = [...variants];
     const updatedOriginalVariants = [...originalVariants];
+    const updatedManualUnitConversionPending = [...manualUnitConversionPending];
     const currentVariant = updatedVariants[index];
     if (!currentVariant) {
       error(loggingLevel, 'Could not find variant to update at index:', index);
@@ -277,26 +329,40 @@ export function useCustomFoodForm({
       const oldUnit = currentVariant.serving_unit;
       const newUnit = String(value);
       const loadedVariant = loadedVariants[index];
+      const trustedBaseUnit =
+        updatedOriginalVariants[index]?.serving_unit ??
+        loadedVariant?.serving_unit ??
+        oldUnit;
+      const manualConversionPendingForVariant =
+        updatedManualUnitConversionPending[index] ?? false;
 
       if (loadedVariant && newUnit === loadedVariant.serving_unit) {
-        for (const nutrient of nutrientFields)
+        for (const nutrient of nutrientFields) {
           newVariant[nutrient] = loadedVariant[nutrient];
+        }
+        newVariant.custom_nutrients = deepClone(loadedVariant.custom_nutrients);
+        updatedManualUnitConversionPending[index] = false;
       } else {
         const factor = getConversionFactor(oldUnit, newUnit);
         const bothServing =
           getUnitCategory(oldUnit) === null &&
           getUnitCategory(newUnit) === null;
-        if (factor !== null && factor !== 1) {
+        if (manualConversionPendingForVariant) {
+          toast(buildManualConversionToast(trustedBaseUnit, newUnit));
+          updatedManualUnitConversionPending[index] = true;
+        } else if (factor !== null && factor !== 1) {
           for (const nutrient of nutrientFields) {
             const old = Number(currentVariant[nutrient]);
             if (!isNaN(old))
               newVariant[nutrient] = Number((old * factor).toFixed(4));
           }
+          updatedManualUnitConversionPending[index] = false;
         } else if (factor === null && !bothServing) {
-          toast({
-            title: 'Manual conversion required',
-            description: `"${oldUnit}" and "${newUnit}" are incompatible unit types. Please update the serving size and nutrition values manually.`,
-          });
+          newVariant = zeroOutVariantNutrition(newVariant);
+          toast(buildManualConversionToast(trustedBaseUnit, newUnit));
+          updatedManualUnitConversionPending[index] = true;
+        } else {
+          updatedManualUnitConversionPending[index] = false;
         }
       }
     }
@@ -309,7 +375,11 @@ export function useCustomFoodForm({
     }
 
     // Proportional scaling for locked variants
-    if (field === 'serving_size' && newVariant.is_locked) {
+    if (
+      field === 'serving_size' &&
+      newVariant.is_locked &&
+      !(updatedManualUnitConversionPending[index] ?? false)
+    ) {
       const originalVariant = updatedOriginalVariants[index];
       if (!originalVariant) {
         error(loggingLevel, 'Could not find original variant at index:', index);
@@ -333,12 +403,18 @@ export function useCustomFoodForm({
       }
     } else {
       // Update scaling baseline for any non-scaling change
-      updatedOriginalVariants[index] = deepClone(newVariant);
-      setOriginalVariants(updatedOriginalVariants);
+      if (
+        field !== 'serving_unit' ||
+        !(updatedManualUnitConversionPending[index] ?? false)
+      ) {
+        updatedOriginalVariants[index] = deepClone(newVariant);
+        setOriginalVariants(updatedOriginalVariants);
+      }
     }
 
     updatedVariants[index] = newVariant;
     setVariants(updatedVariants);
+    setManualUnitConversionPending(updatedManualUnitConversionPending);
   };
 
   const updateField = (field: string, value: string | boolean) => {
@@ -438,6 +514,7 @@ export function useCustomFoodForm({
     showSyncConfirmation,
     setShowSyncConfirmation,
     loadedVariants,
+    conversionBaseVariants: originalVariants,
     platform,
     // Handlers
     updateField,

--- a/SparkyFitnessFrontend/src/hooks/Foods/useUnitConversion.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useUnitConversion.ts
@@ -34,6 +34,50 @@ export interface UseUnitConversionResult {
   resetConversionState: () => void;
 }
 
+interface ResolvedAutoConversion {
+  baseVariant: FoodVariant;
+  factor: number;
+}
+
+function getManualConversionBaseVariant(
+  variants: FoodVariant[],
+  selectedVariant: FoodVariant | null
+): FoodVariant | null {
+  return selectedVariant || variants[0] || null;
+}
+
+export function resolveAutoConversionSource(
+  variants: FoodVariant[],
+  selectedVariant: FoodVariant | null,
+  targetUnit: string
+): ResolvedAutoConversion | null {
+  const candidateVariants = selectedVariant
+    ? [selectedVariant, ...variants]
+    : variants;
+
+  for (const variant of candidateVariants) {
+    const factor = getConversionFactor(variant.serving_unit, targetUnit);
+    if (factor !== null) {
+      return {
+        baseVariant: variant,
+        factor,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function canAutoConvertToUnit(
+  variants: FoodVariant[],
+  selectedVariant: FoodVariant | null,
+  targetUnit: string
+): boolean {
+  return (
+    resolveAutoConversionSource(variants, selectedVariant, targetUnit) !== null
+  );
+}
+
 export function useUnitConversion({
   variants,
   selectedVariant,
@@ -41,7 +85,7 @@ export function useUnitConversion({
 }: UseUnitConversionOptions): UseUnitConversionResult {
   const [pendingUnit, setPendingUnit] = useState('');
   const [pendingUnitIsCustom, setPendingUnitIsCustom] = useState(false);
-  const [conversionFactor, setConversionFactor] = useState<number | ''>(1);
+  const [conversionFactor, setConversionFactor] = useState<number | ''>('');
   const [autoConversionFactor, setAutoConversionFactor] = useState<
     number | null
   >(null);
@@ -70,9 +114,11 @@ export function useUnitConversion({
       autoConversionFactor !== null
         ? autoConversionFactor
         : typeof conversionFactor === 'number'
-          ? conversionFactor
-          : 0;
-    if (!base || effectiveFactor <= 0 || !pendingUnit.trim()) return null;
+          ? conversionFactor > 0
+            ? conversionFactor
+            : null
+          : null;
+    if (!base || effectiveFactor === null || !pendingUnit.trim()) return null;
     const ratio = effectiveFactor / base.serving_size;
     return {
       serving_size: 1,
@@ -115,7 +161,7 @@ export function useUnitConversion({
         setPendingUnitIsCustom(true);
         setPendingUnit('');
         setAutoConversionFactor(null);
-        setConversionFactor(1);
+        setConversionFactor('');
         setConversionError('');
         return;
       }
@@ -125,19 +171,29 @@ export function useUnitConversion({
         onVariantSelect(value, variant);
         setPendingUnit('');
         setPendingUnitIsCustom(false);
+        setConversionFactor('');
         setAutoConversionFactor(null);
         setConversionBaseVariant(null);
+        setConversionError('');
         return;
       }
 
       // Standard unit for conversion
-      const base = selectedVariant || variants[0] || null;
-      setConversionBaseVariant(base);
+      const manualBase = getManualConversionBaseVariant(
+        variants,
+        selectedVariant
+      );
+      const autoConversion = resolveAutoConversionSource(
+        variants,
+        selectedVariant,
+        value
+      );
+
       setPendingUnit(value);
       setPendingUnitIsCustom(false);
-      const auto = base ? getConversionFactor(base.serving_unit, value) : null;
-      setAutoConversionFactor(auto);
-      if (auto === null) setConversionFactor(1);
+      setConversionFactor('');
+      setConversionBaseVariant(autoConversion?.baseVariant || manualBase);
+      setAutoConversionFactor(autoConversion?.factor ?? null);
       setConversionError('');
     },
     [selectedVariant, variants, onVariantSelect]
@@ -146,14 +202,16 @@ export function useUnitConversion({
   const cancelConversion = useCallback(() => {
     setPendingUnit('');
     setPendingUnitIsCustom(false);
+    setConversionFactor('');
     setAutoConversionFactor(null);
+    setConversionBaseVariant(null);
     setConversionError('');
   }, []);
 
   const resetConversionState = useCallback(() => {
     setPendingUnit('');
     setPendingUnitIsCustom(false);
-    setConversionFactor(1);
+    setConversionFactor('');
     setAutoConversionFactor(null);
     setConversionBaseVariant(null);
     setConversionError('');

--- a/SparkyFitnessFrontend/src/pages/Diary/EditFoodEntryDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/EditFoodEntryDialog.tsx
@@ -352,7 +352,7 @@ const EditFoodEntryDialog = ({
                         type="number"
                         step="0.01"
                         min="0.01"
-                        placeholder="e.g. 14.2"
+                        placeholder="e.g. 1"
                         value={conversionFactor}
                         onChange={(e) => {
                           const val = e.target.value;
@@ -399,7 +399,7 @@ const EditFoodEntryDialog = ({
                         type="number"
                         step="0.01"
                         min="0.01"
-                        placeholder="e.g. 14.2"
+                        placeholder="e.g. 1"
                         value={conversionFactor}
                         onChange={(e) => {
                           const val = e.target.value;

--- a/SparkyFitnessFrontend/src/tests/components/EditFoodEntryDialog.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/EditFoodEntryDialog.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import EditFoodEntryDialog from '@/pages/Diary/EditFoodEntryDialog';
+import type { FoodEntry } from '@/types/food';
+import type { MealTypeDefinition } from '@/types/diary';
+
+const mockUpdateFoodEntry = jest.fn();
+const mockCreateVariant = jest.fn();
+
+jest.mock('@/contexts/PreferencesContext', () => ({
+  usePreferences: () => ({
+    loggingLevel: 'DEBUG',
+    energyUnit: 'kcal' as const,
+    convertEnergy: (value: number) => value,
+  }),
+}));
+
+jest.mock('@/utils/logging', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('@/hooks/Foods/useCustomNutrients', () => ({
+  useCustomNutrients: () => ({
+    data: [],
+  }),
+}));
+
+jest.mock('@/hooks/Foods/useFoods', () => ({
+  useFoodView: () => ({
+    data: {
+      id: 'food-1',
+      name: 'Cornstarch',
+      is_custom: true,
+      default_variant: {
+        id: 'default-variant',
+        serving_size: 10,
+        serving_unit: 'g',
+        calories: 10,
+        protein: 1,
+        carbs: 1,
+        fat: 1,
+      },
+    },
+    isLoading: false,
+  }),
+}));
+
+jest.mock('@/hooks/Foods/useFoodVariants', () => ({
+  useFoodVariants: () => ({
+    data: [],
+    isLoading: false,
+  }),
+  useCreateFoodVariantMutation: () => ({
+    isPending: false,
+    mutateAsync: mockCreateVariant,
+  }),
+}));
+
+jest.mock('@/hooks/Diary/useFoodEntries', () => ({
+  useUpdateFoodEntryMutation: () => ({
+    mutateAsync: mockUpdateFoodEntry,
+  }),
+}));
+
+jest.mock('@/pages/Diary/NutrientsGrid', () => ({
+  NutrientGrid: () => <div data-testid="nutrient-grid" />,
+}));
+
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock('@/components/ui/select', () => {
+  const SelectContext = React.createContext<(value: string) => void>(() => {});
+
+  return {
+    Select: ({
+      children,
+      onValueChange,
+    }: {
+      children: React.ReactNode;
+      onValueChange?: (value: string) => void;
+    }) => (
+      <SelectContext.Provider value={onValueChange ?? (() => {})}>
+        {children}
+      </SelectContext.Provider>
+    ),
+    SelectContent: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectItem: ({
+      children,
+      value,
+    }: {
+      children: React.ReactNode;
+      value: string;
+    }) => {
+      const onValueChange = React.useContext(SelectContext);
+
+      return (
+        <button
+          type="button"
+          data-value={value}
+          onClick={() => onValueChange(value)}
+        >
+          {children}
+        </button>
+      );
+    },
+    SelectSeparator: () => <div data-testid="select-separator" />,
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectValue: () => <span />,
+  };
+});
+
+const mealTypes: MealTypeDefinition[] = [
+  {
+    id: 'meal-1',
+    name: 'Breakfast',
+    sort_order: 1,
+    user_id: null,
+  },
+];
+
+const entry: FoodEntry = {
+  id: 'entry-1',
+  food_id: 'food-1',
+  meal_type: 'Breakfast',
+  meal_type_id: 'meal-1',
+  quantity: 1,
+  unit: 'g',
+  variant_id: 'default-variant',
+  food_name: 'Cornstarch',
+  entry_date: '2026-04-18',
+};
+
+describe('EditFoodEntryDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the manual warning, hides preview, and disables save for unresolved incompatible units', async () => {
+    render(
+      <EditFoodEntryDialog
+        entry={entry}
+        open={true}
+        onOpenChange={jest.fn()}
+        availableMealTypes={mealTypes}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Cornstarch')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^tsp$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/These units can/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByPlaceholderText(/e\.g\. 1/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('nutrient-grid')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Save Changes/i })
+    ).toBeDisabled();
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/components/FoodUnitSelector.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/FoodUnitSelector.test.tsx
@@ -1,0 +1,242 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FoodUnitSelector from '@/components/FoodUnitSelector';
+import type { Food, FoodVariant } from '@/types/food';
+
+const mockFetchQuery = jest.fn();
+const mockMutateAsync = jest.fn();
+const mockQueryClient = {
+  fetchQuery: mockFetchQuery,
+};
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => mockQueryClient,
+}));
+
+jest.mock('@/contexts/PreferencesContext', () => ({
+  usePreferences: () => ({
+    loggingLevel: 'DEBUG',
+    energyUnit: 'kcal' as const,
+    convertEnergy: (value: number) => value,
+  }),
+}));
+
+jest.mock('@/utils/logging', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('@/hooks/Foods/useFoodVariants', () => ({
+  foodVariantsOptions: (foodId: string) => ({
+    queryKey: ['food-variants', foodId],
+  }),
+  useCreateFoodVariantMutation: () => ({
+    isPending: false,
+    mutateAsync: mockMutateAsync,
+  }),
+}));
+
+jest.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock('@/components/ui/select', () => {
+  const SelectContext = React.createContext<(value: string) => void>(() => {});
+
+  return {
+    Select: ({
+      children,
+      onValueChange,
+    }: {
+      children: React.ReactNode;
+      onValueChange?: (value: string) => void;
+    }) => (
+      <SelectContext.Provider value={onValueChange ?? (() => {})}>
+        {children}
+      </SelectContext.Provider>
+    ),
+    SelectContent: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectItem: ({
+      children,
+      value,
+    }: {
+      children: React.ReactNode;
+      value: string;
+    }) => {
+      const onValueChange = React.useContext(SelectContext);
+
+      return (
+        <button
+          type="button"
+          data-value={value}
+          onClick={() => onValueChange(value)}
+        >
+          {children}
+        </button>
+      );
+    },
+    SelectSeparator: () => <div data-testid="select-separator" />,
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectValue: () => <span />,
+  };
+});
+
+jest.mock('lucide-react', () => {
+  const actual = jest.requireActual('lucide-react');
+
+  return {
+    ...actual,
+    Check: ({ className }: { className?: string }) => (
+      <svg data-testid="check-icon" className={className} />
+    ),
+  };
+});
+
+const createVariant = (overrides: Partial<FoodVariant>): FoodVariant => ({
+  id: 'variant-id',
+  serving_size: 1,
+  serving_unit: 'g',
+  calories: 10,
+  protein: 1,
+  carbs: 1,
+  fat: 1,
+  custom_nutrients: {},
+  ...overrides,
+});
+
+const createFood = (defaultVariant: FoodVariant): Food => ({
+  id: 'food-1',
+  name: 'Cornstarch',
+  is_custom: true,
+  default_variant: defaultVariant,
+});
+
+describe('FoodUnitSelector', () => {
+  const renderSelector = async (food: Food) => {
+    render(
+      <FoodUnitSelector
+        food={food}
+        open={true}
+        onOpenChange={jest.fn()}
+        onSelect={jest.fn()}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockFetchQuery).toHaveBeenCalled();
+      expect(
+        screen.getByRole('button', { name: /^tsp$/i })
+      ).toBeInTheDocument();
+    });
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the manual warning, hides preview, and disables save for unresolved incompatible units', async () => {
+    const food = createFood(
+      createVariant({
+        id: 'default-variant',
+        serving_size: 10,
+        serving_unit: 'g',
+      })
+    );
+
+    mockFetchQuery.mockResolvedValue([]);
+
+    await renderSelector(food);
+
+    fireEvent.click(screen.getByRole('button', { name: /^tsp$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/These units can/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByPlaceholderText(/e\.g\. 1/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Nutrition for .* tsp:/i)
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add to Meal/i })).toBeDisabled();
+  });
+
+  it('does not derive another incompatible unit before the first manual unit is saved', async () => {
+    const food = createFood(
+      createVariant({
+        id: 'default-variant',
+        serving_size: 10,
+        serving_unit: 'g',
+      })
+    );
+
+    mockFetchQuery.mockResolvedValue([]);
+
+    await renderSelector(food);
+
+    fireEvent.click(screen.getByRole('button', { name: /^tsp$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^tbsp$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/1 tbsp = \? g/i)).toHaveValue(null);
+    });
+
+    expect(
+      screen.queryByText(/Nutrition for .* tbsp:/i)
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add to Meal/i })).toBeDisabled();
+  });
+
+  it('uses a saved compatible variant immediately after reopen-style loading', async () => {
+    const food = createFood(
+      createVariant({
+        id: 'default-variant',
+        serving_size: 10,
+        serving_unit: 'g',
+      })
+    );
+
+    mockFetchQuery.mockResolvedValue([
+      createVariant({
+        id: 'tbsp-variant',
+        serving_size: 1,
+        serving_unit: 'tbsp',
+        calories: 30,
+      }),
+    ]);
+
+    await renderSelector(food);
+
+    const tspItem = screen.getByRole('button', { name: /^tsp$/i });
+
+    expect(tspItem.querySelector('svg.text-green-500')).not.toBeNull();
+
+    fireEvent.click(tspItem);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Nutrition for .* tsp:/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/These units can/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add to Meal/i })).toBeEnabled();
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/hooks/useFoodForm.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useFoodForm.test.tsx
@@ -1,0 +1,199 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useCustomFoodForm } from '@/hooks/Foods/useFoodForm';
+import { getConversionFactor } from '@/utils/servingSizeConversions';
+import type { FoodVariant } from '@/types/food';
+
+const mockToast = jest.fn();
+const mockFetchQuery = jest.fn();
+const mockCustomNutrients: [] = [];
+const mockQueryClient = {
+  fetchQuery: mockFetchQuery,
+};
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { id: 'user-1' },
+  }),
+}));
+
+jest.mock('@/contexts/PreferencesContext', () => ({
+  usePreferences: () => ({
+    energyUnit: 'kcal' as const,
+    convertEnergy: (value: number) => value,
+    loggingLevel: 'ERROR',
+    autoScaleOnlineImports: false,
+  }),
+}));
+
+jest.mock('@/hooks/use-mobile', () => ({
+  useIsMobile: () => false,
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  toast: (...args: unknown[]) => mockToast(...args),
+}));
+
+jest.mock('@/hooks/Foods/useFoods', () => ({
+  useUpdateFoodEntriesSnapshotMutation: () => ({
+    mutateAsync: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/Foods/useCustomNutrients', () => ({
+  useCustomNutrients: () => ({
+    data: mockCustomNutrients,
+  }),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => mockQueryClient,
+}));
+
+jest.mock('@/hooks/Foods/useFoodVariants', () => ({
+  foodVariantsOptions: () => ({
+    queryKey: ['food-variants'],
+  }),
+  useSaveFoodMutation: () => ({
+    mutateAsync: jest.fn(),
+  }),
+}));
+
+const createVariant = (overrides: Partial<FoodVariant> = {}): FoodVariant => ({
+  id: 'variant-1',
+  serving_size: 10,
+  serving_unit: 'g',
+  calories: 100,
+  protein: 10,
+  carbs: 20,
+  fat: 5,
+  saturated_fat: 1,
+  polyunsaturated_fat: 0,
+  monounsaturated_fat: 0,
+  trans_fat: 0,
+  cholesterol: 0,
+  sodium: 0,
+  potassium: 0,
+  dietary_fiber: 0,
+  sugars: 0,
+  vitamin_a: 0,
+  vitamin_c: 0,
+  calcium: 0,
+  iron: 0,
+  custom_nutrients: {},
+  ...overrides,
+});
+
+describe('useCustomFoodForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('zeros nutrition and keeps manual mode after an incompatible unit change', async () => {
+    const initialVariants = [createVariant()];
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        initialVariants,
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.serving_unit).toBe('g');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'tsp');
+    });
+
+    expect(result.current.variants[0]?.serving_unit).toBe('tsp');
+    expect(result.current.variants[0]?.calories).toBe(0);
+    expect(result.current.variants[0]?.protein).toBe(0);
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Manual conversion required',
+        description:
+          '"g" and "tsp" are incompatible unit types. Please update the serving size and nutrition values manually.',
+      })
+    );
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'tbsp');
+    });
+
+    expect(result.current.variants[0]?.serving_unit).toBe('tbsp');
+    expect(result.current.variants[0]?.calories).toBe(0);
+    expect(result.current.variants[0]?.protein).toBe(0);
+    expect(mockToast).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        title: 'Manual conversion required',
+        description:
+          '"g" and "tbsp" are incompatible unit types. Please update the serving size and nutrition values manually.',
+      })
+    );
+  });
+
+  it('keeps the original compatibility base when duplicating a manual-only variant', async () => {
+    const initialVariants = [createVariant()];
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        initialVariants,
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.serving_unit).toBe('g');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'tsp');
+    });
+
+    act(() => {
+      result.current.duplicateVariant(0);
+    });
+
+    expect(result.current.variants[1]?.serving_unit).toBe('tsp');
+    expect(result.current.conversionBaseVariants[1]?.serving_unit).toBe('g');
+  });
+
+  it('allows automatic conversion again after reverting to the loaded unit', async () => {
+    const baseVariant = createVariant();
+    const initialVariants = [baseVariant];
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        initialVariants,
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.serving_unit).toBe('g');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'tsp');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'g');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'oz');
+    });
+
+    expect(result.current.variants[0]?.serving_unit).toBe('oz');
+    expect(Number(result.current.variants[0]?.calories)).toBeCloseTo(
+      baseVariant.calories * (getConversionFactor('g', 'oz') ?? 0),
+      4
+    );
+    expect(Number(result.current.variants[0]?.protein)).toBeCloseTo(
+      baseVariant.protein * (getConversionFactor('g', 'oz') ?? 0),
+      4
+    );
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/hooks/useFoodForm.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useFoodForm.test.tsx
@@ -196,4 +196,45 @@ describe('useCustomFoodForm', () => {
       4
     );
   });
+
+  it('scales custom nutrients during compatible automatic unit conversion', async () => {
+    const baseVariant = createVariant({
+      custom_nutrients: {
+        caffeine: 25,
+        taurine: 12.5,
+      },
+    });
+    const initialVariants = [baseVariant];
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        initialVariants,
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.serving_unit).toBe('g');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'oz');
+    });
+
+    const conversionFactor = getConversionFactor('g', 'oz') ?? 0;
+
+    expect(result.current.variants[0]?.serving_unit).toBe('oz');
+    expect(
+      Number(result.current.variants[0]?.custom_nutrients?.['caffeine'])
+    ).toBeCloseTo(
+      Number(baseVariant.custom_nutrients?.['caffeine']) * conversionFactor,
+      4
+    );
+    expect(
+      Number(result.current.variants[0]?.custom_nutrients?.['taurine'])
+    ).toBeCloseTo(
+      Number(baseVariant.custom_nutrients?.['taurine']) * conversionFactor,
+      4
+    );
+  });
 });

--- a/SparkyFitnessFrontend/src/tests/hooks/useUnitConversion.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useUnitConversion.test.tsx
@@ -1,0 +1,227 @@
+import { act, renderHook } from '@testing-library/react';
+import { useUnitConversion } from '@/hooks/Foods/useUnitConversion';
+import { getConversionFactor } from '@/utils/servingSizeConversions';
+import type { FoodVariant } from '@/types/food';
+
+const createVariant = (overrides: Partial<FoodVariant>): FoodVariant => ({
+  id: 'variant-id',
+  serving_size: 1,
+  serving_unit: 'g',
+  calories: 10,
+  protein: 1,
+  carbs: 1,
+  fat: 1,
+  custom_nutrients: {},
+  ...overrides,
+});
+
+describe('useUnitConversion', () => {
+  const onVariantSelect = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('falls back to a compatible saved variant when the selected unit is incompatible', () => {
+    const gramsVariant = createVariant({
+      id: 'grams',
+      serving_size: 10,
+      serving_unit: 'g',
+    });
+    const tbspVariant = createVariant({
+      id: 'tbsp',
+      serving_size: 1,
+      serving_unit: 'tbsp',
+    });
+
+    const { result } = renderHook(() =>
+      useUnitConversion({
+        variants: [gramsVariant, tbspVariant],
+        selectedVariant: gramsVariant,
+        onVariantSelect,
+      })
+    );
+
+    act(() => {
+      result.current.handleUnitChange('tsp');
+    });
+
+    expect(result.current.conversionBaseVariant).toBe(tbspVariant);
+    expect(result.current.autoConversionFactor).toBeCloseTo(
+      getConversionFactor('tbsp', 'tsp') ?? 0,
+      5
+    );
+    expect(result.current.pendingUnit).toBe('tsp');
+  });
+
+  it('uses the first compatible saved variant for other compatible volume targets', () => {
+    const gramsVariant = createVariant({
+      id: 'grams',
+      serving_size: 10,
+      serving_unit: 'g',
+    });
+    const tbspVariant = createVariant({
+      id: 'tbsp',
+      serving_size: 1,
+      serving_unit: 'tbsp',
+    });
+
+    const { result } = renderHook(() =>
+      useUnitConversion({
+        variants: [gramsVariant, tbspVariant],
+        selectedVariant: gramsVariant,
+        onVariantSelect,
+      })
+    );
+
+    act(() => {
+      result.current.handleUnitChange('ml');
+    });
+
+    expect(result.current.conversionBaseVariant).toBe(tbspVariant);
+    expect(result.current.autoConversionFactor).toBeCloseTo(
+      getConversionFactor('tbsp', 'ml') ?? 0,
+      5
+    );
+  });
+
+  it('keeps the manual conversion flow when no compatible saved variant exists', () => {
+    const gramsVariant = createVariant({
+      id: 'grams',
+      serving_size: 10,
+      serving_unit: 'g',
+    });
+    const pieceVariant = createVariant({
+      id: 'piece',
+      serving_size: 1,
+      serving_unit: 'piece',
+    });
+
+    const { result } = renderHook(() =>
+      useUnitConversion({
+        variants: [gramsVariant, pieceVariant],
+        selectedVariant: gramsVariant,
+        onVariantSelect,
+      })
+    );
+
+    act(() => {
+      result.current.handleUnitChange('tsp');
+    });
+
+    expect(result.current.conversionBaseVariant).toBe(gramsVariant);
+    expect(result.current.autoConversionFactor).toBeNull();
+    expect(result.current.conversionFactor).toBe('');
+    expect(result.current.buildConvertedVariant()).toBeNull();
+    expect(result.current.pendingUnit).toBe('tsp');
+  });
+
+  it('enables manual conversion only for the exact pending unit and clears it on unit switch', () => {
+    const gramsVariant = createVariant({
+      id: 'grams',
+      serving_size: 10,
+      serving_unit: 'g',
+      calories: 50,
+    });
+
+    const { result } = renderHook(() =>
+      useUnitConversion({
+        variants: [gramsVariant],
+        selectedVariant: gramsVariant,
+        onVariantSelect,
+      })
+    );
+
+    act(() => {
+      result.current.handleUnitChange('tsp');
+    });
+
+    expect(result.current.buildConvertedVariant()).toBeNull();
+
+    act(() => {
+      result.current.setConversionFactor(4.2);
+    });
+
+    expect(result.current.buildConvertedVariant()).toMatchObject({
+      serving_unit: 'tsp',
+      serving_size: 1,
+    });
+
+    act(() => {
+      result.current.handleUnitChange('tbsp');
+    });
+
+    expect(result.current.pendingUnit).toBe('tbsp');
+    expect(result.current.conversionFactor).toBe('');
+    expect(result.current.autoConversionFactor).toBeNull();
+    expect(result.current.buildConvertedVariant()).toBeNull();
+  });
+
+  it('keeps the selected compatible variant ahead of fallback variants', () => {
+    const gramsVariant = createVariant({
+      id: 'grams',
+      serving_size: 10,
+      serving_unit: 'g',
+    });
+    const cupVariant = createVariant({
+      id: 'cup',
+      serving_size: 1,
+      serving_unit: 'cup',
+    });
+    const tbspVariant = createVariant({
+      id: 'tbsp',
+      serving_size: 1,
+      serving_unit: 'tbsp',
+    });
+
+    const { result } = renderHook(() =>
+      useUnitConversion({
+        variants: [gramsVariant, cupVariant, tbspVariant],
+        selectedVariant: tbspVariant,
+        onVariantSelect,
+      })
+    );
+
+    act(() => {
+      result.current.handleUnitChange('tsp');
+    });
+
+    expect(result.current.conversionBaseVariant).toBe(tbspVariant);
+    expect(result.current.autoConversionFactor).toBeCloseTo(
+      getConversionFactor('tbsp', 'tsp') ?? 0,
+      5
+    );
+  });
+
+  it('requires a positive factor before building a custom unit variant', () => {
+    const gramsVariant = createVariant({
+      id: 'grams',
+      serving_size: 10,
+      serving_unit: 'g',
+    });
+
+    const { result } = renderHook(() =>
+      useUnitConversion({
+        variants: [gramsVariant],
+        selectedVariant: gramsVariant,
+        onVariantSelect,
+      })
+    );
+
+    act(() => {
+      result.current.handleUnitChange('__custom__');
+      result.current.setPendingUnit('scoop');
+    });
+
+    expect(result.current.buildConvertedVariant()).toBeNull();
+
+    act(() => {
+      result.current.setConversionFactor(15);
+    });
+
+    expect(result.current.buildConvertedVariant()).toMatchObject({
+      serving_unit: 'scoop',
+      serving_size: 1,
+    });
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
This fixes incorrect food unit conversion behavior in the food editor and diary. Compatible saved variants now auto-convert correctly, while incompatible unit changes no longer create misleading nutrition values.

**How did you implement the solution?**
I updated the shared unit-conversion logic to search all saved variants for a compatible conversion source, while still preferring the currently selected variant. Also incompatible unit changes stay manual-only, zero out nutrition until the user updates.

Linked Issue: #1111 

## How to Test

1. Add `Argo` cornstarch from Open Food Facts, then edit the food so it has both `10 g` and `1 tbsp`, with `10 g` still as the default unit.
2. Add that food to a meal and open the unit selector while `g` is selected.
3. Change the unit from `g` to `tsp` and verify it auto-converts immediately instead of showing the manual conversion warning.
4. Confirm `tsp` already has the green checkmark and you do not need to switch to `tbsp` first to make `tsp` work.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="941" height="796" alt="Screenshot 2026-04-18 152254" src="https://github.com/user-attachments/assets/45ffc0d5-808c-4b55-b2f7-5f5a5c80ccc4" />

### After

<img width="885" height="776" alt="Screenshot 2026-04-18 152127" src="https://github.com/user-attachments/assets/5700a86d-57e2-4dfc-8b9b-afa049087cd7" />


</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
