### PR TITLE
feat(566): reorder nutrients

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
@@ -17,7 +17,7 @@ import { useCustomFoodForm } from '@/hooks/Foods/useFoodForm';
 interface CustomFoodFormProps {
   onSave: (foodData: Food) => void;
   food?: Food;
-  initialVariants?: FoodVariant[]; // New prop for pre-populating variants
+  initialVariants?: FoodVariant[];
   visibleNutrients?: string[];
 }
 
@@ -68,7 +68,6 @@ const CustomFoodForm = ({
         </CardHeader>
         <CardContent>
           <form onSubmit={handleSubmit} className="space-y-6">
-            {/* Basic Info: grid-cols-1 on mobile, sm:grid-cols-2 on small screens and up */}
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <Label htmlFor="name">Food Name *</Label>
@@ -89,7 +88,6 @@ const CustomFoodForm = ({
               </div>
             </div>
 
-            {/* Quick Add Checkbox (already good, flex handles it) */}
             <div className="flex items-center space-x-2 pt-2">
               <Checkbox
                 id="is_quick_food"
@@ -103,7 +101,6 @@ const CustomFoodForm = ({
               </Label>
             </div>
 
-            {/* Unit Variants with Individual Nutrition */}
             <div className="space-y-4">
               <div className="flex items-center justify-between">
                 <h3 className="text-lg font-semibold">Unit Variants</h3>
@@ -124,7 +121,7 @@ const CustomFoodForm = ({
                     index={index}
                     variant={variant}
                     variantError={variantErrors[index] ?? ''}
-                    visibleNutrients={visibleNutrients}
+                    visibleNutrients={visibleNutrients} // Passing the ordered array here
                     energyUnit={energyUnit}
                     convertEnergy={convertEnergy}
                     customNutrients={customNutrients}

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -469,9 +469,15 @@ const EnhancedFoodSearch = ({
       (p) => p.view_group === 'quick_info' && p.platform === 'desktop'
     );
 
-  const visibleNutrients = quickInfoPreferences
-    ? quickInfoPreferences.visible_nutrients
-    : DEFAULT_NUTRIENTS;
+  const visibleNutrients = useMemo(() => {
+    const base = quickInfoPreferences
+      ? quickInfoPreferences.visible_nutrients
+      : DEFAULT_NUTRIENTS;
+
+    const allKeys = [...base, ...(customNutrients?.map((cn) => cn.name) || [])];
+
+    return Array.from(new Set(allKeys));
+  }, [quickInfoPreferences, customNutrients]);
 
   const nutrientConfig = {
     visibleNutrients,

--- a/SparkyFitnessFrontend/src/components/FoodSearch/NutrientFormGrid.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/NutrientFormGrid.tsx
@@ -7,71 +7,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { CENTRAL_NUTRIENT_CONFIG } from '@/constants/nutrients';
 import { UserCustomNutrient } from '@/types/customNutrient';
 import type { GlycemicIndex, NumericFoodVariantKeys } from '@/types/food';
 import type { FormFoodVariant } from '@/utils/foodForm';
-
-interface NutrientFieldConfig {
-  key: NumericFoodVariantKeys;
-  label: string;
-  unit: string;
-  step?: string;
-}
-
-interface NutrientSection {
-  title: string;
-  fields: NutrientFieldConfig[];
-}
-
-const NUTRIENT_SECTIONS: NutrientSection[] = [
-  {
-    title: 'Main Nutrients',
-    fields: [
-      // calories is handled separately (energy unit conversion) — excluded here
-      { key: 'protein', label: 'Protein', unit: 'g', step: '0.1' },
-      { key: 'carbs', label: 'Carbs', unit: 'g', step: '0.1' },
-      { key: 'fat', label: 'Fat', unit: 'g', step: '0.1' },
-    ],
-  },
-  {
-    title: 'Fat Breakdown',
-    fields: [
-      { key: 'saturated_fat', label: 'Saturated Fat', unit: 'g', step: '0.1' },
-      {
-        key: 'polyunsaturated_fat',
-        label: 'Polyunsaturated Fat',
-        unit: 'g',
-        step: '0.1',
-      },
-      {
-        key: 'monounsaturated_fat',
-        label: 'Monounsaturated Fat',
-        unit: 'g',
-        step: '0.1',
-      },
-      { key: 'trans_fat', label: 'Trans Fat', unit: 'g', step: '0.1' },
-    ],
-  },
-  {
-    title: 'Minerals & Other',
-    fields: [
-      { key: 'cholesterol', label: 'Cholesterol', unit: 'mg', step: '0.1' },
-      { key: 'sodium', label: 'Sodium', unit: 'mg', step: '0.1' },
-      { key: 'potassium', label: 'Potassium', unit: 'mg', step: '0.1' },
-      { key: 'dietary_fiber', label: 'Dietary Fiber', unit: 'g', step: '0.1' },
-    ],
-  },
-  {
-    title: 'Sugars & Vitamins',
-    fields: [
-      { key: 'sugars', label: 'Sugars', unit: 'g', step: '0.1' },
-      { key: 'vitamin_a', label: 'Vitamin A', unit: 'μg', step: '0.1' },
-      { key: 'vitamin_c', label: 'Vitamin C', unit: 'mg', step: '0.1' },
-      { key: 'calcium', label: 'Calcium', unit: 'mg', step: '0.1' },
-      { key: 'iron', label: 'Iron', unit: 'mg', step: '0.1' },
-    ],
-  },
-];
+import { useTranslation } from 'react-i18next';
 
 const GLYCEMIC_INDEX_OPTIONS: { value: GlycemicIndex; label: string }[] = [
   { value: 'None', label: 'None' },
@@ -144,114 +84,97 @@ export function NutrientGrid({
   customNutrients,
   onUpdate,
 }: NutrientGridProps) {
+  const { t } = useTranslation();
   const isLocked = variant.is_locked ?? false;
-  const visible = new Set(visibleNutrients);
-
   const update = (field: string) => (val: string) =>
     onUpdate(variantIndex, field, val);
 
   return (
-    <div className="space-y-4">
-      {/* Glycemic Index */}
-      {visible.has('glycemic_index') && (
-        <div>
-          <Label htmlFor={gridId(variantIndex, 'glycemic_index')}>
-            Glycemic Index (GI)
-          </Label>
-          <Select
-            value={variant.glycemic_index ?? 'None'}
-            onValueChange={(val: GlycemicIndex) =>
-              onUpdate(variantIndex, 'glycemic_index', val)
-            }
-          >
-            <SelectTrigger
-              id={gridId(variantIndex, 'glycemic_index')}
-              className="w-45"
-            >
-              <SelectValue placeholder="Select GI" />
-            </SelectTrigger>
-            <SelectContent>
-              {GLYCEMIC_INDEX_OPTIONS.map(({ value, label }) => (
-                <SelectItem key={value} value={value}>
-                  {label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      )}
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+      {visibleNutrients.map((key) => {
+        // --- Glycemic Index ---
+        if (key === 'glycemic_index') {
+          return (
+            <div key="glycemic_index">
+              <Label htmlFor={gridId(variantIndex, 'glycemic_index')}>
+                Glycemic Index (GI)
+              </Label>
+              <Select
+                value={variant.glycemic_index ?? 'None'}
+                onValueChange={(val: GlycemicIndex) =>
+                  onUpdate(variantIndex, 'glycemic_index', val)
+                }
+              >
+                <SelectTrigger
+                  id={gridId(variantIndex, 'glycemic_index')}
+                  disabled={isLocked}
+                >
+                  <SelectValue placeholder="Select GI" />
+                </SelectTrigger>
+                <SelectContent>
+                  {GLYCEMIC_INDEX_OPTIONS.map(({ value, label }) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          );
+        }
 
-      {/* Standard sections */}
-      {NUTRIENT_SECTIONS.map((section) => {
-        const visibleFields = section.fields.filter((f) => visible.has(f.key));
-        const isMainNutrients = section.title === 'Main Nutrients';
-        const showCalories = isMainNutrients && visible.has('calories');
-        if (!showCalories && visibleFields.length === 0) return null;
+        // --- Calories ---
+        if (key === 'calories') {
+          return (
+            <NutrientInput
+              key="calories"
+              id={gridId(variantIndex, 'calories')}
+              label={`Calories (${energyUnit})`}
+              value={
+                variant.calories === ''
+                  ? ''
+                  : Math.round(
+                      convertEnergy(variant.calories || 0, 'kcal', energyUnit)
+                    )
+              }
+              step="1"
+              disabled={isLocked}
+              onChange={update('calories')}
+            />
+          );
+        }
+
+        // --- Standard Nutrients ---
+        const cfg = CENTRAL_NUTRIENT_CONFIG[key];
+        if (cfg) {
+          return (
+            <NutrientInput
+              key={key}
+              id={gridId(variantIndex, key)}
+              label={`${t(cfg.label, { defaultValue: cfg.defaultLabel })} (${cfg.unit})`}
+              value={variant[key as NumericFoodVariantKeys] ?? ''}
+              step={cfg.decimals === 0 ? '1' : '0.1'}
+              disabled={isLocked}
+              onChange={update(key)}
+            />
+          );
+        }
+
+        // --- Custom Nutrients ---
+        const cn = customNutrients?.find((n) => n.name === key);
+        if (!cn) return null;
 
         return (
-          <div key={section.title}>
-            <h5 className="text-sm font-medium text-gray-700 mb-3">
-              {section.title}
-            </h5>
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-              {showCalories && (
-                <NutrientInput
-                  id={gridId(variantIndex, 'calories')}
-                  label={`Calories (${energyUnit})`}
-                  value={
-                    variant.calories === ''
-                      ? ''
-                      : Math.round(
-                          convertEnergy(
-                            variant.calories || 0,
-                            'kcal',
-                            energyUnit
-                          )
-                        )
-                  }
-                  step="1"
-                  disabled={isLocked}
-                  onChange={update('calories')}
-                />
-              )}
-              {visibleFields.map(({ key, label, unit, step }) => (
-                <NutrientInput
-                  key={key}
-                  id={gridId(variantIndex, key)}
-                  label={`${label} (${unit})`}
-                  value={variant[key] ?? ''}
-                  step={step}
-                  disabled={isLocked}
-                  onChange={update(key)}
-                />
-              ))}
-            </div>
-          </div>
+          <NutrientInput
+            key={key}
+            id={gridId(variantIndex, key)}
+            label={`${cn.name} (${cn.unit})`}
+            value={variant.custom_nutrients?.[cn.name] ?? ''}
+            disabled={isLocked}
+            onChange={update(cn.name)}
+          />
         );
       })}
-
-      {/* Custom nutrients */}
-      {customNutrients && customNutrients.some((n) => visible.has(n.name)) && (
-        <div>
-          <h5 className="text-sm font-medium text-gray-700 mb-3">
-            Custom Nutrients
-          </h5>
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            {customNutrients
-              .filter((n) => visible.has(n.name))
-              .map((nutrient) => (
-                <NutrientInput
-                  key={nutrient.id}
-                  id={gridId(variantIndex, nutrient.name)}
-                  label={`${nutrient.name} (${nutrient.unit})`}
-                  value={variant.custom_nutrients?.[nutrient.name] ?? ''}
-                  disabled={isLocked}
-                  onChange={update(nutrient.name)}
-                />
-              ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
@@ -31,7 +31,7 @@ interface VariantCardProps {
     to: 'kcal' | 'kJ'
   ) => number;
   customNutrients?: UserCustomNutrient[];
-  baseServingUnit: string; // trusted conversion base for compatibility checkmarks
+  baseServingUnit: string;
   onUpdate: (
     index: number,
     field: string,
@@ -56,9 +56,8 @@ export function VariantCard({
 }: VariantCardProps) {
   return (
     <Card key={index} className="p-4">
-      {/* ── Header row: serving size / unit / checkboxes / actions ── */}
       <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 flex-wrap mb-4">
-        {/* Serving size + unit select */}
+        {/* Unit Select and Serving Size Inputs go here (omitted for brevity, same as your original) */}
         <div className="flex items-end gap-2">
           <div className="flex flex-col">
             <Label htmlFor={`serving-size-${index}`}>Serving Size</Label>
@@ -109,12 +108,11 @@ export function VariantCard({
           </div>
         </div>
 
-        {/* Validation error */}
         {variantError && (
           <p className="text-red-500 text-sm mt-1">{variantError}</p>
         )}
 
-        {/* Default / Auto-Scale checkboxes */}
+        {/* Default / Auto-Scale Checkboxes */}
         <div className="flex items-center gap-4 flex-wrap">
           <div className="flex items-center space-x-2">
             <input
@@ -143,7 +141,7 @@ export function VariantCard({
           </div>
         </div>
 
-        {/* Duplicate / Remove actions */}
+        {/* Action Buttons */}
         <div className="flex items-center gap-2 ml-auto sm:ml-0">
           <Button
             type="button"
@@ -168,10 +166,11 @@ export function VariantCard({
         </div>
       </div>
 
-      {/* ── Nutrition section ── */}
       <h4 className="text-md font-medium mb-2">
         Nutrition per {variant.serving_size} {variant.serving_unit}
       </h4>
+
+      {/* Pass the array straight through */}
       <NutrientGrid
         variantIndex={index}
         variant={variant}

--- a/SparkyFitnessFrontend/src/pages/Diary/EditFoodEntryDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/EditFoodEntryDialog.tsx
@@ -31,6 +31,8 @@ import { calculateNutrition } from '@/utils/nutritionCalculations';
 import { NutrientGrid } from './NutrientsGrid';
 import { useUnitConversion } from '@/hooks/Foods/useUnitConversion';
 import { FoodEntryUpdateData, MealTypeDefinition } from '@/types/diary';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { DEFAULT_NUTRIENTS } from '@/constants/nutrients';
 
 interface EditFoodEntryDialogProps {
   entry: FoodEntry | null;
@@ -45,7 +47,14 @@ const EditFoodEntryDialog = ({
   onOpenChange,
   availableMealTypes,
 }: EditFoodEntryDialogProps) => {
-  const { loggingLevel, energyUnit, convertEnergy } = usePreferences();
+  const {
+    loggingLevel,
+    energyUnit,
+    convertEnergy,
+    nutrientDisplayPreferences,
+  } = usePreferences();
+  const isMobile = useIsMobile();
+  const platform = isMobile ? 'mobile' : 'desktop';
 
   const [quantity, setQuantity] = useState<number>(entry?.quantity || 1);
   const [selectedVariantId, setSelectedVariantId] = useState<string | null>(
@@ -150,6 +159,24 @@ const EditFoodEntryDialog = ({
       setSelectedVariantId(variantId);
     },
   });
+
+  const quickInfoPreferences =
+    nutrientDisplayPreferences.find(
+      (p) => p.view_group === 'food_database' && p.platform === platform
+    ) ||
+    nutrientDisplayPreferences.find(
+      (p) => p.view_group === 'food_database' && p.platform === 'desktop'
+    );
+
+  const visibleNutrients = useMemo(() => {
+    const base = quickInfoPreferences
+      ? quickInfoPreferences.visible_nutrients
+      : DEFAULT_NUTRIENTS;
+
+    const allKeys = [...base, ...(customNutrients?.map((cn) => cn.name) || [])];
+
+    return Array.from(new Set(allKeys));
+  }, [quickInfoPreferences, customNutrients]);
 
   if (!entry) return null;
 
@@ -432,6 +459,7 @@ const EditFoodEntryDialog = ({
                     customNutrients={customNutrients}
                     energyUnit={energyUnit}
                     convertEnergy={convertEnergy}
+                    visibleNutrients={visibleNutrients}
                   />
                 </div>
               )}

--- a/SparkyFitnessFrontend/src/pages/Diary/NutrientsGrid.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/NutrientsGrid.tsx
@@ -18,6 +18,7 @@ interface NutrientGridProps {
     to: 'kcal' | 'kJ'
   ) => number;
   baseVariant: FoodVariant | null | undefined;
+  visibleNutrients: string[];
 }
 
 export const NutrientGrid = ({
@@ -26,124 +27,74 @@ export const NutrientGrid = ({
   energyUnit,
   convertEnergy,
   baseVariant,
+  visibleNutrients,
 }: NutrientGridProps) => {
   const getEnergyUnitString = (unit: 'kcal' | 'kJ'): string => {
     return unit === 'kcal' ? 'kcal' : 'kJ';
   };
   const { t } = useTranslation();
 
-  const renderNutrientBlock = (
-    keys: Array<keyof CalculatedNutrition>,
-    customNutrientList: UserCustomNutrient[]
-  ) => {
-    return keys.map((key) => {
-      const meta = getNutrientMetadata(key as string, customNutrientList);
-      if (key === 'custom_nutrients') return null;
-
-      const value = nutrition[key] as number;
-
-      return (
-        <div key={key}>
-          <Label className="text-sm">
-            {t(meta.label, { defaultValue: meta.defaultLabel })} ({meta.unit})
-          </Label>
-          <div className="text-lg font-medium">
-            {formatNutrientValue(key as string, value, customNutrientList)}
-          </div>
-        </div>
-      );
-    });
-  };
-
   return (
     <div className="space-y-4">
-      <div>
-        <h4 className="font-medium mb-3">Macronutrients</h4>
-        <div className="grid grid-cols-4 gap-4">
-          <div>
-            <Label className="text-sm">
-              Calories ({getEnergyUnitString(energyUnit)})
-            </Label>
-            <div className="text-lg font-medium">
-              {Math.round(
-                convertEnergy(nutrition.calories, 'kcal', energyUnit)
-              )}
-            </div>
-          </div>
-          {renderNutrientBlock(['protein', 'carbs', 'fat'], customNutrients)}
-        </div>
-      </div>
-
-      <div>
-        <h4 className="font-medium mb-3">Fat Breakdown</h4>
-        <div className="grid grid-cols-4 gap-4">
-          {renderNutrientBlock(
-            [
-              'saturated_fat',
-              'polyunsaturated_fat',
-              'monounsaturated_fat',
-              'trans_fat',
-            ],
-            customNutrients
-          )}
-        </div>
-      </div>
-
-      <div>
-        <h4 className="font-medium mb-3">Minerals & Other Nutrients</h4>
-        <div className="grid grid-cols-4 gap-4">
-          {renderNutrientBlock(
-            ['cholesterol', 'sodium', 'potassium', 'dietary_fiber'],
-            customNutrients
-          )}
-        </div>
-      </div>
-
-      <div>
-        <h4 className="font-medium mb-3">Sugars & Vitamins</h4>
-        <div className="grid grid-cols-4 gap-4">
-          {renderNutrientBlock(
-            ['sugars', 'vitamin_a', 'vitamin_c', 'calcium'],
-            customNutrients
-          )}
-        </div>
-      </div>
-
-      <div>
-        <div className="grid grid-cols-1 gap-4">
-          {renderNutrientBlock(['iron'], customNutrients)}
-        </div>
-      </div>
-
-      {customNutrients.length > 0 && nutrition.custom_nutrients && (
-        <div>
-          <h4 className="font-medium mb-3">Custom Nutrients</h4>
-          <div className="grid grid-cols-4 gap-4">
-            {customNutrients.map((nutrient) => (
-              <div key={nutrient.id}>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+        {visibleNutrients.map((key) => {
+          if (key === 'calories') {
+            return (
+              <div key="calories">
                 <Label className="text-sm">
-                  {nutrient.name} ({nutrient.unit})
+                  Calories ({getEnergyUnitString(energyUnit)})
                 </Label>
                 <div className="text-lg font-medium">
-                  {formatNutrientValue(
-                    nutrient.name,
-                    nutrition.custom_nutrients[nutrient.name] || 0,
-                    customNutrients
+                  {Math.round(
+                    convertEnergy(nutrition.calories, 'kcal', energyUnit)
                   )}
                 </div>
               </div>
-            ))}
-          </div>
-        </div>
-      )}
+            );
+          }
+
+          const customNutrient = customNutrients.find((cn) => cn.name === key);
+          if (customNutrient) {
+            const value = nutrition.custom_nutrients?.[key] || 0;
+            return (
+              <div key={key}>
+                <Label className="text-sm">
+                  {customNutrient.name} ({customNutrient.unit})
+                </Label>
+                <div className="text-lg font-medium">
+                  {formatNutrientValue(key, value, customNutrients)}
+                </div>
+              </div>
+            );
+          }
+
+          if (key in nutrition && key !== 'custom_nutrients') {
+            const meta = getNutrientMetadata(key, customNutrients);
+            const value = nutrition[key as keyof CalculatedNutrition] as number;
+            return (
+              <div key={key}>
+                <Label className="text-sm">
+                  {t(meta.label, { defaultValue: meta.defaultLabel })} (
+                  {meta.unit})
+                </Label>
+                <div className="text-lg font-medium">
+                  {formatNutrientValue(key, value, customNutrients)}
+                </div>
+              </div>
+            );
+          }
+
+          return null;
+        })}
+      </div>
 
       {baseVariant && (
-        <div className="bg-muted p-4 rounded-lg">
+        <div className="bg-muted p-4 rounded-lg mt-4">
           <h4 className="font-medium mb-2">
             Base Values (per {baseVariant.serving_size}{' '}
             {baseVariant.serving_unit}):
           </h4>
-          <div className="grid grid-cols-4 gap-4 text-sm">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
             <div>
               {Math.round(
                 convertEnergy(baseVariant.calories || 0, 'kcal', energyUnit)

--- a/SparkyFitnessFrontend/src/pages/Goals/DailyGoals.tsx
+++ b/SparkyFitnessFrontend/src/pages/Goals/DailyGoals.tsx
@@ -98,44 +98,46 @@ export const DailyGoals = ({
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {visibleNutrients.includes('calories') && (
-              <div className="space-y-1.5">
-                <Label htmlFor="calories">
-                  {t(
-                    'nutrition.calories',
-                    `Calories (${getEnergyUnitString(energyUnit)})`
-                  )}
-                </Label>
-                <NumericInput
-                  id="calories"
-                  step={1}
-                  value={Math.round(
-                    convertEnergy(goals.calories, 'kcal', energyUnit)
-                  )}
-                  onValueChange={(val) =>
-                    setGoals({
-                      ...goals,
-                      calories: convertEnergy(val ?? 0, energyUnit, 'kcal'),
-                    })
-                  }
-                />
-              </div>
-            )}
-            {NUTRIENT_CONFIG.map((f) => (
-              <NutrientInput
-                key={f.id}
-                nutrientId={f.id}
-                state={goals}
-                setState={setGoals}
-                visibleNutrients={visibleNutrients}
-                customNutrients={customNutrients}
-              />
-            ))}
-            {customNutrients?.map((cn) => {
+            {/* Loop directly over the ordered array from settings */}
+            {visibleNutrients.map((key) => {
+              // 1. Handle Calories Explicitly
+              if (key === 'calories') {
+                return (
+                  <div key="calories" className="space-y-1.5">
+                    <Label htmlFor="calories">
+                      {t(
+                        'nutrition.calories',
+                        `Calories (${getEnergyUnitString(energyUnit)})`
+                      )}
+                    </Label>
+                    <NumericInput
+                      id="calories"
+                      step={1}
+                      value={Math.round(
+                        convertEnergy(goals.calories, 'kcal', energyUnit)
+                      )}
+                      onValueChange={(val) =>
+                        setGoals({
+                          ...goals,
+                          calories: convertEnergy(val ?? 0, energyUnit, 'kcal'),
+                        })
+                      }
+                    />
+                  </div>
+                );
+              }
+
+              // 2. Validate standard or custom nutrient
+              const isStandard = NUTRIENT_CONFIG.some((n) => n.id === key);
+              const isCustom = customNutrients?.some((cn) => cn.name === key);
+
+              if (!isStandard && !isCustom) return null;
+
+              // 3. Render nutrient input
               return (
                 <NutrientInput
-                  key={cn.id}
-                  nutrientId={cn.name}
+                  key={key}
+                  nutrientId={key}
                   state={goals}
                   setState={setGoals}
                   visibleNutrients={visibleNutrients}

--- a/SparkyFitnessFrontend/src/pages/Goals/GoalsContent.tsx
+++ b/SparkyFitnessFrontend/src/pages/Goals/GoalsContent.tsx
@@ -121,18 +121,22 @@ export const GoalsContent = ({
       ? goalPreferences.visible_nutrients
       : Object.keys(DEFAULT_GOALS);
 
-    // In the goal editor, we should ensure the newly fixed fats are always visible
-    // if they are in DEFAULT_GOALS, even if the user hasn't toggled them yet.
     const mustInclude = [
       'saturated_fat',
       'polyunsaturated_fat',
       'monounsaturated_fat',
       'trans_fat',
     ];
-    const merged = Array.from(new Set([...base, ...mustInclude]));
 
-    // Also include custom nutrients in the visibility list so they aren't filtered out by NutrientInput
-    return [...merged, ...customNutrients.map((cn) => cn.name)];
+    // Combine arrays but use Set to deduplicate while preserving the FIRST occurrence.
+    // This means `base` order is kept perfectly intact. Missing required or custom nutrients get added to the end.
+    const allKeys = [
+      ...base,
+      ...mustInclude,
+      ...customNutrients.map((cn) => cn.name),
+    ];
+
+    return Array.from(new Set(allKeys));
   }, [goalPreferences, customNutrients]);
 
   return (

--- a/SparkyFitnessFrontend/src/pages/Reports/NutritionChartsGrid.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/NutritionChartsGrid.tsx
@@ -122,11 +122,16 @@ const NutritionChartsGrid = ({
     return charts;
   }, [t, energyUnit, customNutrients]);
 
-  const visibleCharts = reportChartPreferences
-    ? allNutritionCharts.filter((chart) =>
-        reportChartPreferences.visible_nutrients.includes(chart.key)
-      )
-    : allNutritionCharts;
+  const visibleCharts = useMemo(() => {
+    if (reportChartPreferences && reportChartPreferences.visible_nutrients) {
+      return reportChartPreferences.visible_nutrients
+        .map((key) => allNutritionCharts.find((chart) => chart.key === key))
+        .filter(
+          (chart): chart is NonNullable<typeof chart> => chart !== undefined
+        );
+    }
+    return allNutritionCharts;
+  }, [reportChartPreferences, allNutritionCharts]);
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 min-w-0">

--- a/SparkyFitnessFrontend/src/pages/Settings/NutrientDisplaySettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/NutrientDisplaySettings.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
@@ -12,6 +12,24 @@ import {
   useUpdateNutrientPreferenceMutation,
 } from '@/hooks/Settings/useNutrientPreferences';
 import { getErrorMessage } from '@/utils/api';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  rectSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { GripVertical } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { CENTRAL_NUTRIENT_CONFIG } from '@/constants/nutrients';
 
 const baseNutrients = [
   'calories',
@@ -49,10 +67,133 @@ interface NutrientPreference {
   visible_nutrients: string[];
 }
 
-const NutrientDisplaySettings: React.FC = () => {
-  const { nutrientDisplayPreferences, loadNutrientDisplayPreferences } =
-    usePreferences();
-  const [preferences, setPreferences] = useState<NutrientPreference[]>([]);
+function buildOrderedList(
+  visibleNutrients: string[],
+  allNutrients: string[]
+): string[] {
+  const visibleSet = new Set(visibleNutrients);
+  const rest = allNutrients.filter((n) => !visibleSet.has(n));
+  return [...visibleNutrients, ...rest];
+}
+
+interface SortableNutrientRowProps {
+  nutrient: string;
+  isVisible: boolean;
+  onToggle: (nutrient: string, checked: boolean) => void;
+}
+
+function SortableNutrientRow({
+  nutrient,
+  isVisible,
+  onToggle,
+}: SortableNutrientRowProps) {
+  const { t } = useTranslation();
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: nutrient });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  const getNutrientLabel = (key: string) => {
+    const config = CENTRAL_NUTRIENT_CONFIG[key];
+    if (config) {
+      return t(config.label, { defaultValue: config.defaultLabel });
+    }
+    return key;
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-2 py-1.5 px-2 rounded-md hover:bg-muted/50 group"
+    >
+      <button
+        type="button"
+        className="cursor-grab text-muted-foreground opacity-40 group-hover:opacity-100 transition-opacity touch-none"
+        {...attributes}
+        {...listeners}
+        aria-label={`Drag to reorder ${nutrient}`}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <Checkbox
+        id={`row-${nutrient}`}
+        checked={isVisible}
+        onCheckedChange={(checked) => onToggle(nutrient, !!checked)}
+      />
+      <Label
+        htmlFor={`row-${nutrient}`}
+        className="capitalize cursor-pointer select-none"
+      >
+        {getNutrientLabel(nutrient)}
+      </Label>
+    </div>
+  );
+}
+
+function buildInitialOrder(
+  preferences: NutrientPreference[],
+  allNutrients: string[]
+) {
+  const initialOrder: Record<string, Record<string, string[]>> = {};
+  for (const group of viewGroups) {
+    const groupOrders: Record<'desktop' | 'mobile', string[]> = {
+      desktop: [],
+      mobile: [],
+    };
+
+    for (const platform of ['desktop', 'mobile'] as const) {
+      const pref = preferences.find(
+        (p) => p.view_group === group.id && p.platform === platform
+      );
+      groupOrders[platform] = buildOrderedList(
+        pref?.visible_nutrients ?? [],
+        allNutrients
+      );
+    }
+
+    initialOrder[group.id] = groupOrders;
+  }
+  return initialOrder;
+}
+
+interface NutrientDisplaySettingsInnerProps {
+  initialPreferences: NutrientPreference[];
+  customNutrients: { name: string }[];
+  updatePreference: (variables: {
+    viewGroup: string;
+    platform: 'desktop' | 'mobile';
+    visibleNutrients: string[];
+  }) => Promise<unknown>;
+  resetPreference: (variables: {
+    viewGroup: string;
+    platform: 'desktop' | 'mobile';
+  }) => Promise<{ visible_nutrients?: string[] }>;
+  loadNutrientDisplayPreferences: () => void;
+}
+
+const NutrientDisplaySettingsInner: React.FC<
+  NutrientDisplaySettingsInnerProps
+> = ({
+  initialPreferences,
+  customNutrients,
+  updatePreference,
+  resetPreference,
+  loadNutrientDisplayPreferences,
+}) => {
+  const allNutrients = useMemo(
+    () => [...baseNutrients, ...customNutrients.map((n) => n.name)],
+    [customNutrients]
+  );
+
+  const [preferences, setPreferences] =
+    useState<NutrientPreference[]>(initialPreferences);
+  const [nutrientOrder, setNutrientOrder] = useState<
+    Record<string, Record<string, string[]>>
+  >(() => buildInitialOrder(initialPreferences, allNutrients));
   const [syncState, setSyncState] = useState<Record<string, boolean>>({});
   const [activePlatformTab, setActivePlatformTab] = useState<
     'desktop' | 'mobile'
@@ -60,22 +201,45 @@ const NutrientDisplaySettings: React.FC = () => {
   const [activeViewGroupTab, setActiveViewGroupTab] =
     useState<string>('summary');
 
-  const { data: customNutrients = [] } = useCustomNutrients();
-  const { mutateAsync: updatePreference } =
-    useUpdateNutrientPreferenceMutation();
-  const { mutateAsync: resetPreference } = useResetNutrientPreferenceMutation();
-  const allNutrients = [
-    ...baseNutrients,
-    ...customNutrients.map((n) => n.name),
-  ];
+  const getVisibleNutrients = useCallback(
+    (viewGroup: string, platform: string): string[] => {
+      const pref = preferences.find(
+        (p) => p.view_group === viewGroup && p.platform === platform
+      );
+      return pref?.visible_nutrients ?? [];
+    },
+    [preferences]
+  );
 
-  useEffect(() => {
-    setPreferences(nutrientDisplayPreferences);
-  }, [nutrientDisplayPreferences]);
+  const updatePreferences = useCallback(
+    (
+      viewGroup: string,
+      platform: 'desktop' | 'mobile',
+      newNutrients: string[]
+    ) => {
+      setPreferences((prev) => {
+        const next = [...prev];
+        const idx = next.findIndex(
+          (p) => p.view_group === viewGroup && p.platform === platform
+        );
+        if (idx > -1) {
+          next[idx] = { ...next[idx]!, visible_nutrients: newNutrients };
+        } else {
+          next.push({
+            view_group: viewGroup,
+            platform,
+            visible_nutrients: newNutrients,
+          });
+        }
+        return next;
+      });
+    },
+    []
+  );
 
   const savePreferences = useCallback(async () => {
     const changedPreferences = preferences.filter((p) => {
-      const originalPref = nutrientDisplayPreferences.find(
+      const originalPref = initialPreferences.find(
         (op) => op.view_group === p.view_group && op.platform === p.platform
       );
       return (
@@ -103,7 +267,7 @@ const NutrientDisplaySettings: React.FC = () => {
     }
     loadNutrientDisplayPreferences();
   }, [
-    nutrientDisplayPreferences,
+    initialPreferences,
     preferences,
     loadNutrientDisplayPreferences,
     updatePreference,
@@ -111,45 +275,12 @@ const NutrientDisplaySettings: React.FC = () => {
 
   useEffect(() => {
     const handler = setTimeout(() => {
-      if (
-        JSON.stringify(preferences) !==
-        JSON.stringify(nutrientDisplayPreferences)
-      ) {
+      if (JSON.stringify(preferences) !== JSON.stringify(initialPreferences)) {
         savePreferences();
       }
     }, 1000);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [preferences, nutrientDisplayPreferences, savePreferences]);
-
-  const updatePreferences = (
-    viewGroup: string,
-    platform: 'desktop' | 'mobile',
-    newNutrients: string[]
-  ) => {
-    setPreferences((prev) => {
-      const newPrefs = [...prev];
-      const prefIndex = newPrefs.findIndex(
-        (p) => p.view_group === viewGroup && p.platform === platform
-      );
-      const newPrefsAtIndex = newPrefs[prefIndex];
-      if (prefIndex > -1 && newPrefsAtIndex) {
-        newPrefs[prefIndex] = {
-          ...newPrefsAtIndex,
-          visible_nutrients: newNutrients,
-        };
-      } else {
-        newPrefs.push({
-          view_group: viewGroup,
-          platform,
-          visible_nutrients: newNutrients,
-        });
-      }
-      return newPrefs;
-    });
-  };
+    return () => clearTimeout(handler);
+  }, [preferences, initialPreferences, savePreferences]);
 
   const handleCheckboxChange = (
     viewGroup: string,
@@ -163,17 +294,48 @@ const NutrientDisplaySettings: React.FC = () => {
       : [platform];
 
     platformsToUpdate.forEach((pform) => {
-      const pref = preferences.find(
-        (p) => p.view_group === viewGroup && p.platform === pform
-      );
-      const currentNutrients = pref ? pref.visible_nutrients : [];
-      let newNutrients: string[];
-      if (checked) {
-        newNutrients = [...currentNutrients, nutrient];
-      } else {
-        newNutrients = currentNutrients.filter((n) => n !== nutrient);
-      }
-      updatePreferences(viewGroup, pform, newNutrients);
+      const order =
+        nutrientOrder[viewGroup]?.[pform] ??
+        buildOrderedList(getVisibleNutrients(viewGroup, pform), allNutrients);
+      const currentVisible = getVisibleNutrients(viewGroup, pform);
+      const newVisible = checked
+        ? order.filter((n) => n === nutrient || currentVisible.includes(n))
+        : currentVisible.filter((n) => n !== nutrient);
+      updatePreferences(viewGroup, pform, newVisible);
+    });
+  };
+
+  const handleDragEnd = (
+    event: DragEndEvent,
+    viewGroup: string,
+    platform: 'desktop' | 'mobile'
+  ) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const isSynced = syncState[viewGroup] || false;
+    const platformsToUpdate: ('desktop' | 'mobile')[] = isSynced
+      ? ['desktop', 'mobile']
+      : [platform];
+
+    platformsToUpdate.forEach((pform) => {
+      const currentOrder =
+        nutrientOrder[viewGroup]?.[pform] ??
+        buildOrderedList(getVisibleNutrients(viewGroup, pform), allNutrients);
+      const oldIndex = currentOrder.indexOf(active.id as string);
+      const newIndex = currentOrder.indexOf(over.id as string);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const newOrder = arrayMove(currentOrder, oldIndex, newIndex);
+
+      setNutrientOrder((prev) => ({
+        ...prev,
+        [viewGroup]: { ...(prev[viewGroup] ?? {}), [pform]: newOrder },
+      }));
+
+      const currentVisible = new Set(getVisibleNutrients(viewGroup, pform));
+      const newVisible = newOrder.filter((n) => currentVisible.has(n));
+      updatePreferences(viewGroup, pform, newVisible);
     });
   };
 
@@ -185,9 +347,12 @@ const NutrientDisplaySettings: React.FC = () => {
     const platformsToUpdate: ('desktop' | 'mobile')[] = isSynced
       ? ['desktop', 'mobile']
       : [platform];
-    platformsToUpdate.forEach((pform) =>
-      updatePreferences(viewGroup, pform, allNutrients)
-    );
+    platformsToUpdate.forEach((pform) => {
+      const order =
+        nutrientOrder[viewGroup]?.[pform] ??
+        buildOrderedList(getVisibleNutrients(viewGroup, pform), allNutrients);
+      updatePreferences(viewGroup, pform, order);
+    });
   };
 
   const handleClearAll = (
@@ -218,12 +383,22 @@ const NutrientDisplaySettings: React.FC = () => {
           viewGroup,
           platform: pform,
         });
-        if (defaultPreference && defaultPreference.visible_nutrients) {
+        if (defaultPreference?.visible_nutrients) {
           updatePreferences(
             viewGroup,
             pform,
             defaultPreference.visible_nutrients
           );
+          setNutrientOrder((prev) => ({
+            ...prev,
+            [viewGroup]: {
+              ...(prev[viewGroup] ?? {}),
+              [pform]: buildOrderedList(
+                defaultPreference.visible_nutrients ?? [],
+                allNutrients
+              ),
+            },
+          }));
         }
       } catch (error: unknown) {
         const message = getErrorMessage(error);
@@ -259,8 +434,20 @@ const NutrientDisplaySettings: React.FC = () => {
           sourcePref.visible_nutrients
         );
       }
+      const sourceOrder = nutrientOrder[viewGroup]?.[platform];
+      if (sourceOrder) {
+        setNutrientOrder((prev) => ({
+          ...prev,
+          [viewGroup]: {
+            ...(prev[viewGroup] ?? {}),
+            [targetPlatform]: sourceOrder,
+          },
+        }));
+      }
     }
   };
+
+  const sensors = useSensors(useSensor(PointerSensor));
 
   return (
     <div className="space-y-4">
@@ -270,132 +457,154 @@ const NutrientDisplaySettings: React.FC = () => {
           setActivePlatformTab(value as 'desktop' | 'mobile')
         }
       >
-        <TabsList className="h-10 ">
+        <TabsList className="h-10">
           <TabsTrigger value="desktop">Desktop</TabsTrigger>
           <TabsTrigger value="mobile">Mobile</TabsTrigger>
         </TabsList>
-        {['desktop', 'mobile'].map((platform) => (
+
+        {(['desktop', 'mobile'] as const).map((platform) => (
           <TabsContent key={platform} value={platform}>
             <Tabs
               value={activeViewGroupTab}
               onValueChange={setActiveViewGroupTab}
             >
-              <TabsList className="h-10 ">
+              <TabsList className="h-10">
                 {viewGroups.map((group) => (
                   <TabsTrigger key={group.id} value={group.id}>
                     {group.name}
                   </TabsTrigger>
                 ))}
               </TabsList>
-              {viewGroups.map((group) => (
-                <TabsContent key={group.id} value={group.id}>
-                  <p className="text-sm text-muted-foreground mb-4">
-                    {group.id === 'summary'
-                      ? 'Controls the Nutrition Summary and 14-Day Trends on the Diary page.'
-                      : group.id === 'quick_info'
-                        ? 'Controls nutrients shown for individual food entries, meal totals, food search results, and the food database.'
-                        : group.id === 'food_database'
-                          ? 'Controls nutrients shown when editing foods in your database.'
-                          : group.id === 'goal'
-                            ? 'Controls nutrients shown when setting or editing your goals.'
-                            : group.id === 'report_tabular'
-                              ? 'Controls nutrient columns in the Reports table view.'
-                              : 'Controls which nutrients are available for charts in the Reports section.'}
-                  </p>
-                  <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 mt-4">
-                    {allNutrients.map((nutrient) => {
-                      const preference = preferences.find(
-                        (p) =>
-                          p.view_group === group.id && p.platform === platform
-                      );
-                      const isChecked =
-                        preference?.visible_nutrients.includes(nutrient) ||
-                        false;
-                      return (
-                        <div
-                          key={nutrient}
-                          className="flex items-center space-x-2"
-                        >
-                          <Checkbox
-                            id={`${group.id}-${platform}-${nutrient}`}
-                            checked={isChecked}
-                            onCheckedChange={(checked) =>
-                              handleCheckboxChange(
-                                group.id,
-                                platform as 'desktop' | 'mobile',
-                                nutrient,
-                                !!checked
-                              )
-                            }
-                          />
-                          <Label
-                            htmlFor={`${group.id}-${platform}-${nutrient}`}
-                            className="capitalize cursor-pointer"
-                          >
-                            {nutrient.replace(/_/g, ' ')}
-                          </Label>
-                        </div>
-                      );
-                    })}
-                  </div>
-                  <div className="flex items-center gap-4 mt-6 pt-4 border-t">
-                    <div className="flex items-center space-x-2">
-                      <Checkbox
-                        id={`sync-${group.id}-${platform}`}
-                        checked={syncState[group.id] || false}
-                        onCheckedChange={() =>
-                          handleSyncToggle(
-                            group.id,
-                            platform as 'desktop' | 'mobile'
-                          )
-                        }
-                      />
-                      <Label
-                        className="cursor-pointer"
-                        htmlFor={`sync-${group.id}-${platform}`}
+
+              {viewGroups.map((group) => {
+                const visibleSet = new Set(
+                  getVisibleNutrients(group.id, platform)
+                );
+                const orderedList =
+                  nutrientOrder[group.id]?.[platform] ??
+                  buildOrderedList(
+                    getVisibleNutrients(group.id, platform),
+                    allNutrients
+                  );
+
+                return (
+                  <TabsContent key={group.id} value={group.id}>
+                    <p className="text-sm text-muted-foreground mb-1">
+                      {group.id === 'summary'
+                        ? 'Controls the Nutrition Summary and 14-Day Trends on the Diary page.'
+                        : group.id === 'quick_info'
+                          ? 'Controls nutrients shown for individual food entries, meal totals, food search results, and the food database.'
+                          : group.id === 'food_database'
+                            ? 'Controls nutrients shown when editing foods in your database.'
+                            : group.id === 'goal'
+                              ? 'Controls nutrients shown when setting or editing your goals.'
+                              : group.id === 'report_tabular'
+                                ? 'Controls nutrient columns in the Reports table view.'
+                                : 'Controls which nutrients are available for charts in the Reports section.'}
+                    </p>
+
+                    <DndContext
+                      sensors={sensors}
+                      collisionDetection={closestCenter}
+                      onDragEnd={(e) => handleDragEnd(e, group.id, platform)}
+                    >
+                      <SortableContext
+                        items={orderedList}
+                        strategy={rectSortingStrategy}
                       >
-                        Sync with{' '}
-                        {platform === 'desktop' ? 'Mobile' : 'Desktop'}
-                      </Label>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-6 gap-y-0.5">
+                          {orderedList.map((nutrient) => (
+                            <SortableNutrientRow
+                              key={nutrient}
+                              nutrient={nutrient}
+                              isVisible={visibleSet.has(nutrient)}
+                              onToggle={(n, checked) =>
+                                handleCheckboxChange(
+                                  group.id,
+                                  platform,
+                                  n,
+                                  checked
+                                )
+                              }
+                            />
+                          ))}
+                        </div>
+                      </SortableContext>
+                    </DndContext>
+
+                    <div className="flex items-center gap-4 mt-6 pt-4 border-t flex-wrap">
+                      <div className="flex items-center space-x-2">
+                        <Checkbox
+                          id={`sync-${group.id}-${platform}`}
+                          checked={syncState[group.id] || false}
+                          onCheckedChange={() =>
+                            handleSyncToggle(group.id, platform)
+                          }
+                        />
+                        <Label
+                          className="cursor-pointer"
+                          htmlFor={`sync-${group.id}-${platform}`}
+                        >
+                          Sync with{' '}
+                          {platform === 'desktop' ? 'Mobile' : 'Desktop'}
+                        </Label>
+                      </div>
+                      <Button
+                        variant="outline"
+                        onClick={() => handleSelectAll(group.id, platform)}
+                      >
+                        Select All
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() => handleClearAll(group.id, platform)}
+                      >
+                        Clear All
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() => handleReset(group.id, platform)}
+                      >
+                        Reset to Default
+                      </Button>
                     </div>
-                    <Button
-                      variant="outline"
-                      onClick={() =>
-                        handleSelectAll(
-                          group.id,
-                          platform as 'desktop' | 'mobile'
-                        )
-                      }
-                    >
-                      Select All
-                    </Button>
-                    <Button
-                      variant="outline"
-                      onClick={() =>
-                        handleClearAll(
-                          group.id,
-                          platform as 'desktop' | 'mobile'
-                        )
-                      }
-                    >
-                      Clear All
-                    </Button>
-                    <Button
-                      variant="outline"
-                      onClick={() =>
-                        handleReset(group.id, platform as 'desktop' | 'mobile')
-                      }
-                    >
-                      Reset to Default
-                    </Button>
-                  </div>
-                </TabsContent>
-              ))}
+                  </TabsContent>
+                );
+              })}
             </Tabs>
           </TabsContent>
         ))}
       </Tabs>
     </div>
+  );
+};
+
+const NutrientDisplaySettings = () => {
+  const { nutrientDisplayPreferences, loadNutrientDisplayPreferences } =
+    usePreferences();
+  const { data: customNutrients = [], isSuccess } = useCustomNutrients();
+  const { mutateAsync: updatePreference } =
+    useUpdateNutrientPreferenceMutation();
+  const { mutateAsync: resetPreference } = useResetNutrientPreferenceMutation();
+
+  const isDataLoaded = nutrientDisplayPreferences.length > 0 || isSuccess;
+
+  if (!isDataLoaded) {
+    return null;
+  }
+
+  const componentKey =
+    nutrientDisplayPreferences.length > 0 ? 'loaded' : 'default';
+
+  return (
+    <NutrientDisplaySettingsInner
+      key={componentKey}
+      initialPreferences={nutrientDisplayPreferences}
+      customNutrients={customNutrients}
+      updatePreference={updatePreference}
+      resetPreference={resetPreference}
+      loadNutrientDisplayPreferences={loadNutrientDisplayPreferences}
+    />
   );
 };
 

--- a/SparkyFitnessFrontend/src/tests/components/EditFoodEntryDialog.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/EditFoodEntryDialog.test.tsx
@@ -13,6 +13,7 @@ jest.mock('@/contexts/PreferencesContext', () => ({
     loggingLevel: 'DEBUG',
     energyUnit: 'kcal' as const,
     convertEnergy: (value: number) => value,
+    nutrientDisplayPreferences: [],
   }),
 }));
 
@@ -20,6 +21,7 @@ jest.mock('@/utils/logging', () => ({
   info: jest.fn(),
   warn: jest.fn(),
   error: jest.fn(),
+  debug: jest.fn(),
 }));
 
 jest.mock('@/hooks/Foods/useCustomNutrients', () => ({


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Nutrition labels have different orders depending on the country. It's annoying to jump back and forth when entering nutrients.

**How did you implement the solution?**
Since we already save alot of information about the nutrient in the settings, I made it dnd and changed the components to respect the order of the saved preferences. This means no backend or database changes were needed. It works for every area that uses the nutrients like goals, reports and the diary. The Edit Food Entry now only shows the nutrients that are shown in the food database.

Linked Issue: Closes #566

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots



| Settings | Food Search | Custom Food |
| :---: | :---: | :---: |
| <img width="250" alt="Settings" src="https://github.com/user-attachments/assets/0636ac54-fdf6-4171-98f7-b414071d2615" /> | <img width="250" alt="Food Search" src="https://github.com/user-attachments/assets/67e0816c-51d5-4011-b4c1-fca547364813" /> | <img width="250" alt="Custom Food" src="https://github.com/user-attachments/assets/9bdc5d7d-4601-4ae5-a6da-177d5865ecb1" /> |

| Diary | Goals | Reports |
| :---: | :---: | :---: |
| <img width="250" alt="Diary" src="https://github.com/user-attachments/assets/800ee8d5-4148-45aa-8ff5-94ba9031cce2" /> | <img width="250" alt="Goals" src="https://github.com/user-attachments/assets/9fc5873f-b1ca-4515-a700-627d94c7ffdc" /> | <img width="250" alt="Reports" src="https://github.com/user-attachments/assets/c364c95a-1ee1-4b1a-97f7-af55a2c056bb" /> |