### PR TITLE
fix(1151, 1045): wger serch doesn't respect language and endpoints are deprecated

### DIFF
--- a/SparkyFitnessFrontend/src/api/Exercises/exerciseSearchService.ts
+++ b/SparkyFitnessFrontend/src/api/Exercises/exerciseSearchService.ts
@@ -31,6 +31,7 @@ interface ExternalExerciseSearchParams {
   query: string;
   providerId: string;
   providerType: string;
+  language?: string;
   equipmentFilter?: string;
   muscleGroupFilter?: string;
   limit?: number;
@@ -39,6 +40,7 @@ export const searchExternalExercises = async (
   query: string,
   providerId: string,
   providerType: string,
+  language: string = 'en',
   equipmentFilter: string[] = [],
   muscleGroupFilter: string[] = [],
   limit?: number
@@ -47,6 +49,7 @@ export const searchExternalExercises = async (
     query: query,
     providerId: providerId,
     providerType: providerType,
+    language: language,
   };
 
   if (equipmentFilter.length > 0) {
@@ -67,11 +70,12 @@ export const searchExternalExercises = async (
 };
 
 export const addExternalExerciseToUserExercises = async (
-  wgerExerciseId: string
+  wgerExerciseId: string,
+  language?: string
 ): Promise<Exercise> => {
   return apiCall(`/exercises/add-external`, {
     method: 'POST',
-    body: JSON.stringify({ wgerExerciseId }),
+    body: JSON.stringify({ wgerExerciseId, language }),
   });
 };
 

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useExerciseSearch.ts
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useExerciseSearch.ts
@@ -36,6 +36,7 @@ export const externalSearchOptions = (
   pType: string | null,
   eq: string[],
   mus: string[],
+  language?: string,
   limit?: number
 ) => ({
   queryKey: exerciseSearchKeys.search.external(
@@ -46,7 +47,8 @@ export const externalSearchOptions = (
     mus,
     limit
   ),
-  queryFn: () => searchExternalExercises(query, pId!, pType!, eq, mus, limit),
+  queryFn: () =>
+    searchExternalExercises(query, pId!, pType!, language, eq, mus, limit),
   enabled:
     !!pId &&
     !!pType &&
@@ -96,12 +98,14 @@ export const useAddExerciseMutation = () => {
     mutationFn: async ({
       exercise,
       type,
+      language,
     }: {
       exercise: Exercise;
       type: string;
+      language?: string;
     }) => {
       if (type === 'wger')
-        return addExternalExerciseToUserExercises(exercise.id);
+        return addExternalExerciseToUserExercises(exercise.id, language);
       if (type === 'nutritionix') return addNutritionixExercise(exercise);
       if (type === 'free-exercise-db')
         return addFreeExerciseDBExercise(exercise.id);

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useExerciseSearchHook.ts
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useExerciseSearchHook.ts
@@ -30,7 +30,7 @@ export function useExerciseSearchHook({
 }: ExerciseSearchProps) {
   const { user } = useAuth();
 
-  const { loggingLevel, itemDisplayLimit } = usePreferences();
+  const { loggingLevel, itemDisplayLimit, language } = usePreferences();
   const [searchTerm, setSearchTerm] = useState('');
   const [exercises, setExercises] = useState<Exercise[]>([]);
   const [recentExercises, setRecentExercises] = useState<Exercise[]>([]);
@@ -116,6 +116,7 @@ export function useExerciseSearchHook({
               selectedProviderType,
               equipmentFilter,
               muscleGroupFilter,
+              language,
               itemDisplayLimit
             )
           );
@@ -137,6 +138,7 @@ export function useExerciseSearchHook({
       selectedProviderId,
       user?.id,
       selectedProviderType,
+      language,
     ]
   );
 
@@ -146,7 +148,11 @@ export function useExerciseSearchHook({
     if (!selectedProviderType) return;
     setLoading(true);
     try {
-      return await addExercise({ exercise, type: selectedProviderType });
+      return await addExercise({
+        exercise,
+        type: selectedProviderType,
+        language,
+      });
     } catch (err) {
       return undefined;
     } finally {

--- a/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearch.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearch.tsx
@@ -94,11 +94,12 @@ const ExerciseSearch = ({
       <div className="mt-4 space-y-4">
         {searchSource === 'external' && (
           <Select
-            value={selectedProviderId || ''}
+            value={selectedProviderId ? String(selectedProviderId) : ''}
             onValueChange={(value) => {
               setSelectedProviderId(value);
               setSelectedProviderType(
-                providers.find((p) => p.id === value)?.provider_type || null
+                providers.find((p) => String(p.id) === value)?.provider_type ||
+                  null
               );
             }}
           >
@@ -107,7 +108,7 @@ const ExerciseSearch = ({
             </SelectTrigger>
             <SelectContent>
               {providers.map((p) => (
-                <SelectItem key={p.id} value={p.id}>
+                <SelectItem key={p.id} value={String(p.id)}>
                   {p.provider_name}
                 </SelectItem>
               ))}

--- a/SparkyFitnessServer/constants/wger.ts
+++ b/SparkyFitnessServer/constants/wger.ts
@@ -1,0 +1,7 @@
+export const WGER_LANGUAGE_MAP: Record<string, number> = {
+  de: 1,
+  en: 2,
+  es: 4,
+  fr: 10,
+  it: 13,
+};

--- a/SparkyFitnessServer/integrations/wger/wgerService.ts
+++ b/SparkyFitnessServer/integrations/wger/wgerService.ts
@@ -6,237 +6,236 @@ import {
   forceMap,
   mechanicMap,
 } from './wgerNameMapping.js';
+import { WGER_LANGUAGE_MAP } from 'constants/wger.ts';
+import {
+  WgerExerciseTranslation,
+  WgerPaginatedResponse,
+  WgerExerciseInfo,
+  WgerMuscle,
+  WgerEquipment,
+} from 'types/wger.ts';
+
 const WGER_API_BASE_URL = 'https://wger.de/api/v2';
-const WGER_CACHE_DURATION_SECONDS = 3600; // Cache for 1 hour
+const WGER_CACHE_DURATION_SECONDS = 3600;
 const wgerCache = new NodeCache({ stdTTL: WGER_CACHE_DURATION_SECONDS });
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function callWgerApi(endpoint: any, params = {}) {
-  // Create a stable query string for caching by sorting keys
-  const sortedKeys = Object.keys(params).sort();
-  const sortedParams = {};
-  for (const key of sortedKeys) {
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    sortedParams[key] = params[key];
+
+async function callWgerApi<T>(
+  endpoint: string,
+  params: Record<string, string | number | number[] | string[]> = {}
+): Promise<T | null> {
+  const queryParts: string[] = [];
+
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        queryParts.push(`${encodeURIComponent(key)}=${encodeURIComponent(v)}`);
+      }
+    } else {
+      queryParts.push(
+        `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+      );
+    }
   }
-  const queryString = new URLSearchParams(sortedParams).toString();
-  const url = `${WGER_API_BASE_URL}${endpoint}/?${queryString}`;
-  const cacheKey = `${endpoint}?${queryString}`;
-  // Check cache first
-  const cachedData = wgerCache.get(cacheKey);
-  if (cachedData) {
-    log('info', `Returning cached data for Wger API: ${url}`);
-    return cachedData;
-  }
+
+  const queryString = queryParts.join('&');
+  const normalizedEndpoint = endpoint.endsWith('/') ? endpoint : `${endpoint}/`;
+  const url = `${WGER_API_BASE_URL}${normalizedEndpoint}${queryString ? `?${queryString}` : ''}`;
+
+  const cachedData = wgerCache.get<T>(url);
+  if (cachedData !== undefined) return cachedData;
+
   try {
-    log('info', `Calling Wger API: ${url}`);
     const response = await fetch(url, {
       method: 'GET',
-      headers: {
-        Accept: 'application/json',
-      },
+      headers: { Accept: 'application/json' },
     });
+
     if (!response.ok) {
-      // For 404, we can expect this if an exercise doesn't exist, so we don't want to throw an error.
-      if (response.status === 404) {
-        log(
-          'warn',
-          `Wger API returned 404 for ${endpoint}, resource not found.`
-        );
-        return null; // Indicate that the resource was not found
-      }
-      const errorText = await response.text();
-      log(
-        'error',
-        `Wger API error for ${endpoint}: ${response.status} - ${errorText}`
-      );
-      throw new Error(`Wger API error: ${response.status} - ${errorText}`);
+      if (response.status === 404) return null;
+      throw new Error(`Wger API error: ${response.status}`);
     }
-    const data = await response.json();
-    wgerCache.set(cacheKey, data); // Cache the response
+
+    const data = (await response.json()) as T;
+    wgerCache.set(url, data);
     return data;
   } catch (error) {
     log('error', `Error calling Wger API ${endpoint}:`, error);
     throw error;
   }
 }
-async function searchWgerExercises(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  query: any,
-  muscleIds = [],
-  equipmentIds = [],
-  language = 'en',
-  limit = 20,
-  offset = 0
-) {
-  const hasQuery = query && query.trim().length > 0;
-  const muscleIdList = Array.isArray(muscleIds)
-    ? muscleIds
-    : muscleIds
-      ? // @ts-expect-error TS(2339): Property 'split' does not exist on type 'never'.
-        muscleIds.split(',')
-      : [];
-  const equipmentIdList = Array.isArray(equipmentIds)
-    ? equipmentIds
-    : equipmentIds
-      ? // @ts-expect-error TS(2339): Property 'split' does not exist on type 'never'.
-        equipmentIds.split(',')
-      : [];
-  const hasFilters = muscleIdList.length > 0 || equipmentIdList.length > 0;
-  const exerciseSet = new Map();
-  if (hasQuery && !hasFilters) {
-    const params = { term: query, language: language };
-    const data = await callWgerApi('/exercise/search', params);
-    if (data && data.suggestions) {
-      for (const s of data.suggestions) {
-        exerciseSet.set(s.data.base_id, { id: s.data.base_id, name: s.value });
-      }
-    }
-  } else {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const filterPromises: any = [];
-    // Create API calls for each muscle and equipment ID
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    muscleIdList.forEach((id: any) => {
-      filterPromises.push(
-        callWgerApi('/exercise', { language, muscles: id, limit: 100 })
-      );
-    });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    equipmentIdList.forEach((id: any) => {
-      filterPromises.push(
-        callWgerApi('/exercise', { language, equipment: id, limit: 100 })
-      );
-    });
-    const results = await Promise.all(filterPromises);
-    results.forEach((data) => {
-      if (data && data.results) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        data.results.forEach((exercise: any) => {
-          exerciseSet.set(exercise.id, exercise);
-        });
-      }
-    });
-  }
-  const exercises = Array.from(exerciseSet.values());
-  const detailedExercises = await Promise.all(
-    exercises.map(async (exercise) => {
-      const details = await getWgerExerciseDetails(exercise.id);
-      if (!details) return null;
-      const englishTranslation = details.translations?.find(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (t: any) => t.language === 2
-      );
-      const anyTranslation = details.translations?.[0];
-      const exerciseName =
-        englishTranslation?.name || details.name || anyTranslation?.name;
-      const description =
-        englishTranslation?.description || anyTranslation?.description || '';
-      const images = details.images
-        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          details.images.map((img: any) => img.image)
-        : [];
-      return {
-        ...exercise,
-        ...details,
-        name: exerciseName || `Exercise ID: ${details.id}`,
-        force: details.force?.name
-          ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-            forceMap[details.force.name.toLowerCase()]
-          : null,
-        mechanic: details.mechanic?.name
-          ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-            mechanicMap[details.mechanic.name.toLowerCase()]
-          : null,
-        instructions: description,
-        images: images,
-      };
-    })
+
+function extractWgerText(
+  translations: WgerExerciseTranslation[],
+  targetLangCode: string = 'en'
+): { exerciseName: string; description: string } {
+  const targetLangId = WGER_LANGUAGE_MAP[targetLangCode] ?? 2;
+
+  const targetTranslation = translations.find(
+    (t) => t.language === targetLangId
   );
-  const validExercises = detailedExercises.filter((d) => d !== null);
+  const englishTranslation = translations.find((t) => t.language === 2);
+  const fallbackTranslation = translations[0];
+
+  const exerciseName =
+    targetTranslation?.name ??
+    englishTranslation?.name ??
+    fallbackTranslation?.name ??
+    'Unknown';
+
+  const description =
+    targetTranslation?.description ??
+    englishTranslation?.description ??
+    fallbackTranslation?.description ??
+    '';
+
+  return { exerciseName, description };
+}
+
+async function searchWgerExercises(
+  query: string,
+  muscleIds: number[] = [],
+  equipmentIds: number[] = [],
+  language: string = 'en',
+  limit: number = 20,
+  offset: number = 0
+) {
+  const params: Record<string, string | number | number[]> = {
+    language__code: language,
+    limit: 50,
+    offset: 0,
+  };
+
+  if (query.trim().length > 0) {
+    params.name__search = query.trim();
+  }
+
+  if (muscleIds.length > 0) {
+    params.muscles = muscleIds;
+  }
+
+  if (equipmentIds.length > 0) {
+    params.equipment = equipmentIds;
+  }
+
+  const data = await callWgerApi<WgerPaginatedResponse<WgerExerciseInfo>>(
+    '/exerciseinfo',
+    params
+  );
+  const results = data?.results ?? [];
+
+  const exercises = results.map((details) => {
+    const { exerciseName, description } = extractWgerText(
+      details.translations,
+      language
+    );
+
+    return {
+      ...details,
+      id: details.id.toString(),
+      name: exerciseName,
+      force: details.force?.name
+        ? (forceMap[
+            details.force.name.toLowerCase() as keyof typeof forceMap
+          ] ?? null)
+        : null,
+      mechanic: details.mechanic?.name
+        ? (mechanicMap[
+            details.mechanic.name.toLowerCase() as keyof typeof mechanicMap
+          ] ?? null)
+        : null,
+      instructions: description,
+      images: details.images.map((img) => img.image),
+    };
+  });
+
   return {
-    exercises: validExercises.slice(offset, offset + limit),
-    totalCount: validExercises.length,
+    exercises: exercises.slice(offset, offset + limit),
+    totalCount: exercises.length,
   };
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getWgerExerciseDetails(exerciseId: any) {
-  // Use /exerciseinfo/ endpoint for detailed information
-  const data = await callWgerApi(`/exerciseinfo/${exerciseId}`);
-  // If data is null (which callWgerApi returns for a 404), we just return it.
-  return data;
+
+async function getWgerExerciseDetails(
+  exerciseId: number | string
+): Promise<WgerExerciseInfo | null> {
+  return callWgerApi<WgerExerciseInfo>(`/exerciseinfo/${exerciseId}`);
 }
-async function getWgerMuscleIdMap() {
+
+async function getWgerMuscleIdMap(): Promise<
+  Partial<Record<string, number[]>>
+> {
   const cacheKey = 'wger-muscle-id-map';
-  let idMap = wgerCache.get(cacheKey);
-  if (idMap) {
-    return idMap;
-  }
-  const wgerMusclesData = await callWgerApi('/muscle');
-  const wgerMuscles = wgerMusclesData.results;
-  idMap = {};
-  for (const ourName in muscleNameMap) {
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    const wgerNames = Array.isArray(muscleNameMap[ourName])
-      ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        muscleNameMap[ourName]
-      : // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        [muscleNameMap[ourName]];
+  const cached = wgerCache.get<Partial<Record<string, number[]>>>(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const data = await callWgerApi<WgerPaginatedResponse<WgerMuscle>>('/muscle');
+  const wgerMuscles = data?.results ?? [];
+
+  const idMap: Partial<Record<string, number[]>> = {};
+
+  for (const ourName of Object.keys(muscleNameMap)) {
+    const rawValue = muscleNameMap[ourName as keyof typeof muscleNameMap] as
+      | string
+      | string[];
+    const wgerNames = Array.isArray(rawValue) ? rawValue : [rawValue];
+
     const ids = wgerNames
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .map((wgerName: any) => {
-        const wgerMuscle = wgerMuscles.find(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (m: any) =>
-            m.name.toLowerCase() === wgerName.toLowerCase() ||
-            (m.name_en && m.name_en.toLowerCase() === wgerName.toLowerCase())
-        );
-        return wgerMuscle ? wgerMuscle.id : null;
-      })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .filter((id: any) => id !== null);
+      .map(
+        (wgerName) =>
+          wgerMuscles.find(
+            (m) =>
+              m.name.toLowerCase() === wgerName.toLowerCase() ||
+              m.name_en.toLowerCase() === wgerName.toLowerCase()
+          )?.id ?? null
+      )
+      .filter((id): id is number => id !== null);
+
     if (ids.length > 0) {
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
       idMap[ourName] = ids;
     }
   }
+
   wgerCache.set(cacheKey, idMap);
   return idMap;
 }
-async function getWgerEquipmentIdMap() {
+
+async function getWgerEquipmentIdMap(): Promise<
+  Partial<Record<string, number[]>>
+> {
   const cacheKey = 'wger-equipment-id-map';
-  let idMap = wgerCache.get(cacheKey);
-  if (idMap) {
-    return idMap;
-  }
-  const wgerEquipmentData = await callWgerApi('/equipment');
-  const wgerEquipment = wgerEquipmentData.results;
-  idMap = {};
-  for (const ourName in equipmentNameMap) {
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    const wgerNames = Array.isArray(equipmentNameMap[ourName])
-      ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        equipmentNameMap[ourName]
-      : // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        [equipmentNameMap[ourName]];
+  const cached = wgerCache.get<Partial<Record<string, number[]>>>(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const data =
+    await callWgerApi<WgerPaginatedResponse<WgerEquipment>>('/equipment');
+  const wgerEquipment = data?.results ?? [];
+
+  const idMap: Partial<Record<string, number[]>> = {};
+
+  for (const ourName of Object.keys(equipmentNameMap)) {
+    const wgerNames = Array.isArray(
+      equipmentNameMap[ourName as keyof typeof equipmentNameMap]
+    )
+      ? (equipmentNameMap[ourName as keyof typeof equipmentNameMap] as string[])
+      : [equipmentNameMap[ourName as keyof typeof equipmentNameMap] as string];
+
     const ids = wgerNames
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .map((wgerName: any) => {
-        const wgerEquip = wgerEquipment.find(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (e: any) => e.name.toLowerCase() === wgerName.toLowerCase()
-        );
-        return wgerEquip ? wgerEquip.id : null;
-      })
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .filter((id: any) => id !== null);
+      .map(
+        (wgerName) =>
+          wgerEquipment.find(
+            (e) => e.name.toLowerCase() === wgerName.toLowerCase()
+          )?.id ?? null
+      )
+      .filter((id): id is number => id !== null);
+
     if (ids.length > 0) {
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
       idMap[ourName] = ids;
     }
   }
+
   wgerCache.set(cacheKey, idMap);
   return idMap;
 }
+
 export { searchWgerExercises };
 export { getWgerExerciseDetails };
 export { getWgerMuscleIdMap };
@@ -246,4 +245,5 @@ export default {
   getWgerExerciseDetails,
   getWgerMuscleIdMap,
   getWgerEquipmentIdMap,
+  extractWgerText,
 };

--- a/SparkyFitnessServer/routes/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/exerciseRoutes.ts
@@ -7,6 +7,7 @@ import wgerService from '../integrations/wger/wgerService.js';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
+import { ExternalProviderType } from 'types/externalProvider.ts';
 const router = express.Router();
 // Setup Multer for file uploads
 const storage = multer.diskStorage({
@@ -432,38 +433,41 @@ router.get('/search', authenticate, async (req, res, next) => {
  *       500:
  *         description: Server error.
  */
+function queryString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
 router.get('/search-external', authenticate, async (req, res, next) => {
-  const {
-    query,
-    providerId,
-    providerType,
-    equipmentFilter,
-    muscleGroupFilter,
-  } = req.query;
+  const query = queryString(req.query.query);
+  const providerId = queryString(req.query.providerId);
+  const providerType = queryString(req.query.providerType);
+  const equipmentFilter = queryString(req.query.equipmentFilter);
+  const muscleGroupFilter = queryString(req.query.muscleGroupFilter);
+  const languageParam = queryString(req.query.language) ?? 'en';
+
+  const page = Math.max(
+    1,
+    parseInt(queryString(req.query.page) ?? '', 10) || 1
+  );
+  const rawSize =
+    parseInt(queryString(req.query.pageSize) ?? '', 10) ||
+    parseInt(queryString(req.query.limit) ?? '', 10) ||
+    20;
+  const pageSize = Math.min(100, Math.max(1, rawSize));
   const paginated =
     req.query.page !== undefined || req.query.pageSize !== undefined;
-  // @ts-expect-error TS(2345): Argument of type 'string | ParsedQs | (string | Pa... Remove this comment to see the full error message
-  const page = Math.max(1, parseInt(req.query.page, 10) || 1);
-  const rawSize =
-    // @ts-expect-error TS(2345): Argument of type 'string | ParsedQs | (string | Pa... Remove this comment to see the full error message
-    parseInt(req.query.pageSize, 10) || parseInt(req.query.limit, 10) || 20;
-  const pageSize = Math.min(100, Math.max(1, rawSize));
-  const equipmentFilterArray =
-    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
-    equipmentFilter && equipmentFilter.length > 0
-      ? // @ts-expect-error TS(2339): Property 'split' does not exist on type 'string | ... Remove this comment to see the full error message
-        equipmentFilter.split(',')
-      : [];
-  const muscleGroupFilterArray =
-    // @ts-expect-error TS(2532): Object is possibly 'undefined'.
-    muscleGroupFilter && muscleGroupFilter.length > 0
-      ? // @ts-expect-error TS(2339): Property 'split' does not exist on type 'string | ... Remove this comment to see the full error message
-        muscleGroupFilter.split(',')
-      : [];
-  // @ts-expect-error TS(2339): Property 'trim' does not exist on type 'string | P... Remove this comment to see the full error message
+
+  const equipmentFilterArray = equipmentFilter
+    ? equipmentFilter.split(',')
+    : [];
+  const muscleGroupFilterArray = muscleGroupFilter
+    ? muscleGroupFilter.split(',')
+    : [];
+
   const hasQuery = query && query.trim().length > 0;
   const hasFilters =
     equipmentFilterArray.length > 0 || muscleGroupFilterArray.length > 0;
+
   if (!hasQuery && !hasFilters) {
     return res
       .status(400)
@@ -474,14 +478,16 @@ router.get('/search-external', authenticate, async (req, res, next) => {
       error: 'Provider ID and Type are required for external search.',
     });
   }
+
   try {
     const result = await exerciseService.searchExternalExercises(
       req.userId,
-      query,
+      query ?? '',
       providerId,
-      providerType,
+      providerType as ExternalProviderType,
       equipmentFilterArray,
       muscleGroupFilterArray,
+      languageParam,
       page,
       pageSize
     );
@@ -584,11 +590,9 @@ router.get('/wger-filters', authenticate, async (req, res, next) => {
     const wgerEquipment = await wgerService.getWgerEquipmentIdMap();
     const ourMuscles = await exerciseService.getAvailableMuscleGroups();
     const ourEquipment = await exerciseService.getAvailableEquipment();
-    // @ts-expect-error TS(2769): No overload matches this call.
     const uniqueMuscles = Object.keys(wgerMuscles).filter(
       (m) => !ourMuscles.includes(m)
     );
-    // @ts-expect-error TS(2769): No overload matches this call.
     const uniqueEquipment = Object.keys(wgerEquipment).filter(
       (e) => !ourEquipment.includes(e)
     );
@@ -676,7 +680,7 @@ router.get('/names', authenticate, async (req, res, next) => {
  *         description: Server error.
  */
 router.post('/add-external', authenticate, async (req, res, next) => {
-  const { wgerExerciseId } = req.body;
+  const { wgerExerciseId, language } = req.body;
   if (!wgerExerciseId) {
     return res.status(400).json({ error: 'Wger exercise ID is required.' });
   }
@@ -684,7 +688,8 @@ router.post('/add-external', authenticate, async (req, res, next) => {
     const newExercise =
       await exerciseService.addExternalExerciseToUserExercises(
         req.userId,
-        wgerExerciseId
+        wgerExerciseId,
+        language || 'en'
       );
     res.status(201).json(newExercise);
   } catch (error) {

--- a/SparkyFitnessServer/services/exerciseService.ts
+++ b/SparkyFitnessServer/services/exerciseService.ts
@@ -10,7 +10,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { log } from '../config/logging.js';
 import wgerService from '../integrations/wger/wgerService.js';
 import nutritionixService from '../integrations/nutritionix/nutritionixService.js';
-import measurementRepository from '../models/measurementRepository.js';
 import { downloadImage } from '../utils/imageDownloader.js';
 import calorieCalculationService from './CalorieCalculationService.js';
 import fs from 'fs';
@@ -23,13 +22,13 @@ import {
   getGroupedExerciseSessionByIdWithClient,
 } from './exerciseEntryHistoryService.js';
 import {
-  levelMap,
   forceMap,
   mechanicMap,
   createReverseMap,
   muscleNameMap,
   equipmentNameMap,
 } from '../integrations/wger/wgerNameMapping.js';
+import { ExternalProviderType } from 'types/externalProvider.ts';
 async function getExercisesWithPagination(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   authenticatedUserId: any,
@@ -766,19 +765,32 @@ async function upsertExerciseEntryData(
     throw error;
   }
 }
+
+interface FreeExerciseDBResult {
+  totalCount: number;
+  exercises: {
+    id: string;
+    name: string;
+    category: string;
+    description: string;
+    force: string | null;
+    level: string | null;
+    mechanic: string | null;
+    equipment: string | string[];
+    primaryMuscles: string | string[];
+    secondaryMuscles: string | string[];
+    instructions: string | string[];
+    images: string[];
+  }[];
+}
 async function searchExternalExercises(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authenticatedUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  query: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  providerId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  providerType: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  equipmentFilter: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  muscleGroupFilter: any,
+  _authenticatedUserId: string,
+  query: string,
+  providerId: string,
+  providerType: ExternalProviderType,
+  equipmentFilter: string[],
+  muscleGroupFilter: string[],
+  language: string,
   page = 1,
   pageSize = 20
 ) {
@@ -789,139 +801,107 @@ async function searchExternalExercises(
     'info',
     `[exerciseService] searchExternalExercises called with: query='${query}', providerType='${providerType}', equipmentFilter='${equipmentFilter}', muscleGroupFilter='${muscleGroupFilter}', page=${page}, pageSize=${pageSize}`
   );
+
   const emptyResponse = {
     items: [],
     pagination: { page, pageSize, totalCount: 0, hasMore: false },
   };
+
   try {
-    let items = [];
+    let items: unknown[] = [];
     let totalCount = 0;
     const offset = (page - 1) * pageSize;
-    const latestMeasurement =
-      await measurementRepository.getLatestMeasurement(authenticatedUserId);
-    const userWeightKg =
-      latestMeasurement && latestMeasurement.weight
-        ? latestMeasurement.weight
-        : 70; // Default to 70kg
+
     const hasFilters =
       equipmentFilter.length > 0 || muscleGroupFilter.length > 0;
     const hasQuery = query.trim().length > 0;
-    // If there's no search query but filters are present, and the provider doesn't support filters,
-    // return an empty result to avoid returning a large, unfiltered list.
-    if (!hasQuery && hasFilters) {
-      if (providerType === 'nutritionix') {
-        log(
-          'warn',
-          `External search for provider ${providerType} received filters but no search query. Filters are not supported for this provider without a search query. Returning empty results.`
-        );
-        return emptyResponse;
-      }
+
+    if (!hasQuery && hasFilters && providerType === 'nutritionix') {
+      log(
+        'warn',
+        `External search for provider ${providerType} received filters but no search query. Returning empty results.`
+      );
+      return emptyResponse;
     }
+
     if (providerType === 'wger') {
       const muscleIdMap = await wgerService.getWgerMuscleIdMap();
       const equipmentIdMap = await wgerService.getWgerEquipmentIdMap();
-      const muscleIds = muscleGroupFilter
-        // @ts-expect-error TS(2571): Object is of type 'unknown'.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .flatMap((name: any) => muscleIdMap[name] || [])
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .filter((id: any) => id);
-      const equipmentIds = equipmentFilter
-        // @ts-expect-error TS(2571): Object is of type 'unknown'.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .flatMap((name: any) => equipmentIdMap[name] || [])
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .filter((id: any) => id);
+
+      const muscleIds = muscleGroupFilter.flatMap(
+        (name) => muscleIdMap[name] ?? []
+      );
+      const equipmentIds = equipmentFilter.flatMap(
+        (name) => equipmentIdMap[name] ?? []
+      );
+
       const wgerResult = await wgerService.searchWgerExercises(
         query,
         muscleIds,
         equipmentIds,
-        'en',
+        language ?? 'en',
         pageSize,
         offset
       );
+
       totalCount = wgerResult.totalCount;
-      items = wgerResult.exercises.map((exercise) => {
-        let caloriesPerHour = 0;
-        if (exercise.met && exercise.met > 0) {
-          caloriesPerHour = Math.round(
-            ((exercise.met * 3.5 * userWeightKg) / 200) * 60
-          );
-        }
-        return {
-          id: exercise.id.toString(),
-          name: exercise.name,
-          category: exercise.category
-            ? exercise.category.name
-            : 'Uncategorized',
-          calories_per_hour: caloriesPerHour,
-          source: 'wger',
-          description: exercise.description || exercise.name,
-          force: exercise.force,
-          mechanic: exercise.mechanic,
-          instructions: exercise.instructions,
-          images: exercise.images,
-        };
-      });
+      items = wgerResult.exercises.map((exercise) => ({
+        id: exercise.id.toString(),
+        name: exercise.name,
+        category: exercise.category?.name ?? 'Uncategorized',
+        calories_per_hour: 0,
+        source: 'wger',
+        description: exercise.instructions || exercise.name,
+        force: exercise.force,
+        mechanic: exercise.mechanic,
+        instructions: exercise.instructions,
+        images: exercise.images,
+      }));
     } else if (providerType === 'nutritionix') {
-      // For Nutritionix, we are not using user demographics for now, as per user feedback.
       const nutritionixSearchResults =
         await nutritionixService.searchNutritionixExercises(query, providerId);
       totalCount = nutritionixSearchResults.length;
       items = nutritionixSearchResults.slice(offset, offset + pageSize);
     } else if (providerType === 'free-exercise-db') {
-      const freeExerciseDBResult = await freeExerciseDBService.searchExercises(
+      const freeExerciseDBResult = (await freeExerciseDBService.searchExercises(
         query,
-        equipmentFilter,
-        muscleGroupFilter,
+        equipmentFilter as never[],
+        muscleGroupFilter as never[],
         pageSize,
         offset
-      );
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
+      )) as FreeExerciseDBResult;
       totalCount = freeExerciseDBResult.totalCount;
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      items = freeExerciseDBResult.exercises.map((exercise: any) => ({
+      items = freeExerciseDBResult.exercises.map((exercise) => ({
         id: exercise.id,
         name: exercise.name,
         category: exercise.category,
-
-        // Will be calculated when added to user's exercises
         calories_per_hour: 0,
-
         description: exercise.description,
         source: 'free-exercise-db',
         force: exercise.force,
         level: exercise.level,
         mechanic: exercise.mechanic,
-
         equipment: Array.isArray(exercise.equipment)
           ? exercise.equipment
           : exercise.equipment
             ? [exercise.equipment]
             : [],
-
         primary_muscles: Array.isArray(exercise.primaryMuscles)
           ? exercise.primaryMuscles
           : exercise.primaryMuscles
             ? [exercise.primaryMuscles]
             : [],
-
         secondary_muscles: Array.isArray(exercise.secondaryMuscles)
           ? exercise.secondaryMuscles
           : exercise.secondaryMuscles
             ? [exercise.secondaryMuscles]
             : [],
-
         instructions: Array.isArray(exercise.instructions)
           ? exercise.instructions
           : exercise.instructions
             ? [exercise.instructions]
             : [],
-
-        // Convert to full URLs for search results
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        images: exercise.images.map((img: any) =>
+        images: exercise.images.map((img: string) =>
           freeExerciseDBService.getExerciseImageUrl(img)
         ),
       }));
@@ -930,6 +910,7 @@ async function searchExternalExercises(
         `Unsupported external exercise provider: ${providerType}`
       );
     }
+
     return {
       items,
       pagination: {
@@ -948,11 +929,11 @@ async function searchExternalExercises(
     throw error;
   }
 }
+
 async function addExternalExerciseToUserExercises(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authenticatedUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  wgerExerciseId: any
+  authenticatedUserId: string,
+  wgerExerciseId: string | number,
+  language: string = 'en'
 ) {
   try {
     const wgerExerciseDetails =
@@ -960,119 +941,92 @@ async function addExternalExerciseToUserExercises(
     if (!wgerExerciseDetails) {
       throw new Error('Wger exercise not found.');
     }
+
     log(
       'info',
       `Raw wger exercise data for exercise ID ${wgerExerciseId}: ${JSON.stringify(wgerExerciseDetails, null, 2)}`
     );
-    // Calculate calories_per_hour
-    let caloriesPerHour = 0; // Default value if MET is not available or calculation fails
-    if (wgerExerciseDetails.met && wgerExerciseDetails.met > 0) {
-      let userWeightKg = 70; // Default to 70kg if user weight not found
-      const latestMeasurement =
-        await measurementRepository.getLatestMeasurement(authenticatedUserId);
-      if (latestMeasurement && latestMeasurement.weight) {
-        userWeightKg = latestMeasurement.weight;
-      }
-      // Formula: METs * 3.5 * body weight in kg / 200 = calories burned per minute
-      // To get calories per hour: (METs * 3.5 * body weight in kg) / 200 * 60
-      caloriesPerHour =
-        ((wgerExerciseDetails.met * 3.5 * userWeightKg) / 200) * 60;
-      caloriesPerHour = Math.round(caloriesPerHour); // Round to nearest whole number
-    } else {
-      caloriesPerHour =
-        // @ts-expect-error TS(2554): Expected 3 arguments, but got 2.
-        await calorieCalculationService.estimateCaloriesBurnedPerHour(
-          wgerExerciseDetails,
-          authenticatedUserId
-        );
-    }
-    // Use the name from translations if available, otherwise fallback to description or ID
-    const exerciseName =
-      wgerExerciseDetails.translations &&
-      wgerExerciseDetails.translations.length > 0 &&
-      wgerExerciseDetails.translations[0].name
-        ? wgerExerciseDetails.translations[0].name
-        : wgerExerciseDetails.description || `Wger Exercise ${wgerExerciseId}`;
-    const wgerLevelName = wgerExerciseDetails.level?.name || 'Intermediate';
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    const mappedLevel = levelMap[wgerLevelName] || 'intermediate';
+
+    let caloriesPerHour = 0;
+
+    // met and level are not in the wger /exerciseinfo schema, so we always fall back
+    caloriesPerHour =
+      await calorieCalculationService.estimateCaloriesBurnedPerHour(
+        wgerExerciseDetails,
+        authenticatedUserId,
+        [{ reps: 10, weight: 0 }]
+      );
+
+    const { exerciseName, description: rawDescription } =
+      wgerService.extractWgerText(wgerExerciseDetails.translations, language);
+
     const reverseMuscleMap = createReverseMap(muscleNameMap);
     const reverseEquipmentMap = createReverseMap(equipmentNameMap);
-    const wgerForceName = wgerExerciseDetails.force?.name || null;
-    const mappedForce = wgerForceName
-      ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        forceMap[wgerForceName.toLowerCase()]
+
+    const mappedForce = wgerExerciseDetails.force?.name
+      ? (forceMap[
+          wgerExerciseDetails.force.name.toLowerCase() as keyof typeof forceMap
+        ] ?? null)
       : null;
-    const wgerMechanicName = wgerExerciseDetails.mechanic?.name || null;
-    const mappedMechanic = wgerMechanicName
-      ? // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-        mechanicMap[wgerMechanicName.toLowerCase()]
+
+    const mappedMechanic = wgerExerciseDetails.mechanic?.name
+      ? (mechanicMap[
+          wgerExerciseDetails.mechanic.name.toLowerCase() as keyof typeof mechanicMap
+        ] ?? null)
       : null;
-    const rawDescription =
-      (wgerExerciseDetails.translations &&
-        wgerExerciseDetails.translations.length > 0 &&
-        wgerExerciseDetails.translations[0].description) ||
-      '';
-    // Sanitize and split instructions
+
     const instructions = rawDescription
-      .replace(/<li>/g, '\n- ') // Add a marker for list items
-      .replace(/<[^>]*>/g, '') // Remove all other HTML tags
+      .replace(/<li>/g, '\n- ')
+      .replace(/<[^>]*>/g, '')
       .split('\n')
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .map((s: any) => s.trim())
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .filter((s: any) => s);
+      .map((s) => s.trim())
+      .filter(Boolean);
+
     const exerciseData = {
       name: exerciseName,
-      category: wgerExerciseDetails.category
-        ? wgerExerciseDetails.category.name
-        : 'general',
+      category: wgerExerciseDetails.category?.name ?? 'general',
       calories_per_hour: caloriesPerHour,
-      description: instructions[0] || exerciseName, // Use the first instruction as description
+      description: instructions[0] ?? exerciseName,
       user_id: authenticatedUserId,
-      is_custom: true, // Mark as custom as it's imported by the user
-      shared_with_public: false, // Imported exercises are private by default
-      source_external_id: wgerExerciseDetails.id.toString(), // Store wger ID
-      source: 'wger', // Explicitly set the source to 'wger'
-      level: mappedLevel,
+      is_custom: true,
+      shared_with_public: false,
+      source_external_id: wgerExerciseDetails.id.toString(),
+      source: 'wger',
+      level: 'intermediate',
       force: mappedForce,
       mechanic: mappedMechanic,
-      equipment:
-        wgerExerciseDetails.equipment?.map(
-          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (e: any) => reverseEquipmentMap[e.name.toLowerCase()] || e.name
-        ) || [],
-      primary_muscles:
-        wgerExerciseDetails.muscles?.map(
-          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (m: any) => reverseMuscleMap[m.name.toLowerCase()] || m.name
-        ) || [],
-      secondary_muscles:
-        wgerExerciseDetails.muscles_secondary?.map(
-          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (m: any) => reverseMuscleMap[m.name.toLowerCase()] || m.name
-        ) || [],
-      instructions: instructions,
-      images: [], // Initialize as empty, will be populated after download
+      equipment: wgerExerciseDetails.equipment.map(
+        (e) =>
+          reverseEquipmentMap[
+            e.name.toLowerCase() as keyof typeof reverseEquipmentMap
+          ] ?? e.name
+      ),
+      primary_muscles: wgerExerciseDetails.muscles.map(
+        (m) =>
+          reverseMuscleMap[
+            m.name.toLowerCase() as keyof typeof reverseMuscleMap
+          ] ?? m.name
+      ),
+      secondary_muscles: wgerExerciseDetails.muscles_secondary.map(
+        (m) =>
+          reverseMuscleMap[
+            m.name.toLowerCase() as keyof typeof reverseMuscleMap
+          ] ?? m.name
+      ),
+      instructions,
+      images: [] as string[],
     };
-    // Download images and update paths
-    if (wgerExerciseDetails.images && wgerExerciseDetails.images.length > 0) {
+
+    if (wgerExerciseDetails.images.length > 0) {
       const exerciseFolderName = exerciseName.replace(/[^a-zA-Z0-9]/g, '_');
       const localImagePaths = await Promise.all(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        wgerExerciseDetails.images.map(async (img: any) => {
+        wgerExerciseDetails.images.map(async (img) => {
           try {
-            const imageUrl = img.image;
-            if (imageUrl) {
-              const fullPath = await downloadImage(
-                imageUrl,
+            if (img.image) {
+              const fullPath = (await downloadImage(
+                img.image,
                 exerciseFolderName
-              );
-              // The frontend expects a path relative to the 'uploads/exercises' directory
-              // @ts-expect-error TS(2571): Object is of type 'unknown'.
+              )) as string;
               return fullPath.replace('/uploads/exercises/', '');
             }
           } catch (imgError) {
@@ -1085,15 +1039,16 @@ async function addExternalExerciseToUserExercises(
           return null;
         })
       );
-      // @ts-expect-error TS(2322): Type 'any[]' is not assignable to type 'never[]'.
-      exerciseData.images = localImagePaths.filter((p) => p !== null);
+      exerciseData.images = localImagePaths.filter(
+        (p): p is string => p !== null
+      );
     }
+
     log(
       'info',
       `Mapped exercise data before insert: ${JSON.stringify(exerciseData, null, 2)}`
     );
-    const newExercise = await exerciseDb.createExercise(exerciseData);
-    return newExercise;
+    return await exerciseDb.createExercise(exerciseData);
   } catch (error) {
     log(
       'error',

--- a/SparkyFitnessServer/types/externalProvider.ts
+++ b/SparkyFitnessServer/types/externalProvider.ts
@@ -1,0 +1,1 @@
+export type ExternalProviderType = 'wger' | 'nutritionix' | 'free-exercise-db';

--- a/SparkyFitnessServer/types/wger.ts
+++ b/SparkyFitnessServer/types/wger.ts
@@ -1,0 +1,66 @@
+// GET /api/v2/muscle/
+export interface WgerMuscle {
+  id: number;
+  name: string;
+  name_en: string;
+  is_front: boolean;
+  image_url_main: string;
+  image_url_secondary: string;
+}
+
+// GET /api/v2/equipment/
+export interface WgerEquipment {
+  id: number;
+  name: string;
+}
+
+// GET /api/v2/exerciseinfo/ and /api/v2/exerciseinfo/{id}/
+export interface WgerExerciseInfo {
+  id: number;
+  uuid: string;
+  created: string;
+  last_update: string;
+  last_update_global: string;
+  category: { id: number; name: string };
+  muscles: WgerMuscle[];
+  muscles_secondary: WgerMuscle[];
+  equipment: WgerEquipment[];
+  license_author: string | null;
+  images: WgerExerciseImage[];
+  translations: WgerExerciseTranslation[];
+  videos: WgerExerciseVideo[];
+  force: { name: string } | null;
+  mechanic: { name: string } | null;
+}
+
+export interface WgerExerciseTranslation {
+  id: number;
+  uuid: string;
+  name: string;
+  exercise: number;
+  description: string;
+  language: number; // maps to WGER_LANGUAGE_MAP: de=1, en=2, es=4, fr=10, it=13
+}
+
+export interface WgerExerciseImage {
+  id: number;
+  uuid: string;
+  image: string; // URL — this is what you use in your .map(img => img.image)
+  is_main: boolean;
+  style: string;
+}
+
+export interface WgerExerciseVideo {
+  id: number;
+  uuid: string;
+  video: string;
+  is_main: boolean;
+}
+
+// Paginated wrapper — shape of data returned by callWgerApi('/exerciseinfo', ...)
+export interface WgerPaginatedResponse<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Wger deprecated the endpoint we use. It also didn't respect the language of the user even though it's capable of doing that. Not every exercise has a translation, but most have a few. I also added all types to the wger service.

**How did you implement the solution?**
Switch to the new endpoint and use the langauge parameter from the frontend.

Linked Issue: Closes #1151
Closes #1045

## How to Test

1. Set language to spanish
2. Search for Incline Bench Reverse Fly
3. Verify you get a result and the result is spanish once you add it 

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="1245" height="413" alt="image" src="https://github.com/user-attachments/assets/3c80032f-2af2-4bab-b481-589d2ca1232c" />


</details>
