### PR TITLE
feat: refresh dashboard and other tabs after sync automatically

### DIFF
--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -49,7 +49,11 @@ import {
 import type { TimeRange } from './src/services/storage';
 import { initHealthConnect, loadHealthPreference , startObservers, stopObservers } from './src/services/healthConnectService';
 import { HEALTH_METRICS } from './src/HealthMetrics';
-import { configureBackgroundSync, performBackgroundSync } from './src/services/backgroundSyncService';
+import {
+  configureBackgroundSync,
+  performBackgroundSync,
+  flushPendingHealthSyncCacheRefresh,
+} from './src/services/backgroundSyncService';
 import {
   tryClaimAutoSync,
   isSyncClaimed,
@@ -404,6 +408,10 @@ function AppContent() {
       console.error('[App] Failed to initialize sync services:', error);
     });
 
+    flushPendingHealthSyncCacheRefresh().catch(error => {
+      console.error('[App] Failed to flush pending health sync refresh:', error);
+    });
+
     return () => {
       cancelled = true;
       if (Platform.OS === 'ios') {
@@ -459,6 +467,8 @@ function AppContent() {
         }
 
         if (nextAppState !== 'active') return;
+
+        await flushPendingHealthSyncCacheRefresh();
         if (!wasInBackgroundRef.current) return;
 
         const enteredAt = backgroundEnteredAtRef.current;

--- a/SparkyFitnessMobile/__tests__/hooks/refreshHealthSyncCache.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/refreshHealthSyncCache.test.ts
@@ -1,0 +1,42 @@
+import { refreshHealthSyncCache } from '../../src/hooks/refreshHealthSyncCache';
+import {
+  exerciseHistoryQueryKey,
+  exerciseHistoryResetQueryKey,
+  foodsQueryKey,
+} from '../../src/hooks/queryKeys';
+import { createTestQueryClient, type QueryClient } from './queryTestUtils';
+
+describe('refreshHealthSyncCache', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+    queryClient = createTestQueryClient();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  test('invalidates health-derived families and resets exercise history', () => {
+    const now = 1_713_182_400_000;
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    queryClient.setQueryData(exerciseHistoryQueryKey, { pages: [], pageParams: [] });
+    queryClient.setQueryData(foodsQueryKey, [{ id: 'food-1' }]);
+
+    refreshHealthSyncCache(queryClient);
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['dailySummary'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['measurements'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['measurementsRange'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['exerciseHistory'],
+      refetchType: 'none',
+    });
+    expect(queryClient.getQueryData(exerciseHistoryQueryKey)).toBeUndefined();
+    expect(queryClient.getQueryData(exerciseHistoryResetQueryKey)).toBe(now);
+    expect(queryClient.getQueryData(foodsQueryKey)).toEqual([{ id: 'food-1' }]);
+  });
+});

--- a/SparkyFitnessMobile/__tests__/hooks/useSyncHealthData.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useSyncHealthData.test.ts
@@ -4,7 +4,6 @@ import { useSyncHealthData } from '../../src/hooks/useSyncHealthData';
 import { syncHealthData as healthConnectSyncData } from '../../src/services/healthConnectService';
 import { saveLastSyncedTime } from '../../src/services/storage';
 import { addLog } from '../../src/services/LogService';
-import { refreshHealthSyncCache } from '../../src/hooks/refreshHealthSyncCache';
 import { serverConnectionQueryKey } from '../../src/hooks/queryKeys';
 import { createTestQueryClient, createQueryWrapper, type QueryClient } from './queryTestUtils';
 
@@ -20,10 +19,6 @@ jest.mock('../../src/services/LogService', () => ({
   addLog: jest.fn(),
 }));
 
-jest.mock('../../src/hooks/refreshHealthSyncCache', () => ({
-  refreshHealthSyncCache: jest.fn(),
-}));
-
 const mockToastShow = Toast.show as jest.MockedFunction<typeof Toast.show>;
 
 const mockHealthConnectSyncData = healthConnectSyncData as jest.MockedFunction<
@@ -33,9 +28,6 @@ const mockSaveLastSyncedTime = saveLastSyncedTime as jest.MockedFunction<
   typeof saveLastSyncedTime
 >;
 const mockAddLog = addLog as jest.MockedFunction<typeof addLog>;
-const mockRefreshHealthSyncCache = refreshHealthSyncCache as jest.MockedFunction<
-  typeof refreshHealthSyncCache
->;
 
 describe('useSyncHealthData', () => {
   let queryClient: QueryClient;
@@ -153,7 +145,7 @@ describe('useSyncHealthData', () => {
       });
     });
 
-    test('refreshes health caches and invalidates server connection on success', async () => {
+    test('invalidates server connection on success', async () => {
       const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
       mockHealthConnectSyncData.mockResolvedValue({ success: true, syncErrors: [] });
       mockSaveLastSyncedTime.mockResolvedValue('2024-01-15T10:00:00Z');
@@ -167,7 +159,7 @@ describe('useSyncHealthData', () => {
       });
 
       await waitFor(() => {
-        expect(mockRefreshHealthSyncCache).toHaveBeenCalledWith(queryClient);
+        expect(result.current.isSuccess).toBe(true);
       });
 
       expect(invalidateSpy).toHaveBeenCalledWith({
@@ -315,27 +307,6 @@ describe('useSyncHealthData', () => {
       });
     });
 
-    test('does not refresh health caches on failure', async () => {
-      mockHealthConnectSyncData.mockResolvedValue({
-        success: false,
-        error: 'Server unavailable',
-        syncErrors: [],
-      });
-
-      const { result } = renderHook(() => useSyncHealthData(), {
-        wrapper: createQueryWrapper(queryClient),
-      });
-
-      await act(async () => {
-        result.current.mutate(testParams);
-      });
-
-      await waitFor(() => {
-        expect(result.current.isError).toBe(true);
-      });
-
-      expect(mockRefreshHealthSyncCache).not.toHaveBeenCalled();
-    });
   });
 
   describe('mutation state', () => {

--- a/SparkyFitnessMobile/__tests__/hooks/useSyncHealthData.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useSyncHealthData.test.ts
@@ -4,6 +4,8 @@ import { useSyncHealthData } from '../../src/hooks/useSyncHealthData';
 import { syncHealthData as healthConnectSyncData } from '../../src/services/healthConnectService';
 import { saveLastSyncedTime } from '../../src/services/storage';
 import { addLog } from '../../src/services/LogService';
+import { refreshHealthSyncCache } from '../../src/hooks/refreshHealthSyncCache';
+import { serverConnectionQueryKey } from '../../src/hooks/queryKeys';
 import { createTestQueryClient, createQueryWrapper, type QueryClient } from './queryTestUtils';
 
 jest.mock('../../src/services/healthConnectService', () => ({
@@ -18,6 +20,10 @@ jest.mock('../../src/services/LogService', () => ({
   addLog: jest.fn(),
 }));
 
+jest.mock('../../src/hooks/refreshHealthSyncCache', () => ({
+  refreshHealthSyncCache: jest.fn(),
+}));
+
 const mockToastShow = Toast.show as jest.MockedFunction<typeof Toast.show>;
 
 const mockHealthConnectSyncData = healthConnectSyncData as jest.MockedFunction<
@@ -27,6 +33,9 @@ const mockSaveLastSyncedTime = saveLastSyncedTime as jest.MockedFunction<
   typeof saveLastSyncedTime
 >;
 const mockAddLog = addLog as jest.MockedFunction<typeof addLog>;
+const mockRefreshHealthSyncCache = refreshHealthSyncCache as jest.MockedFunction<
+  typeof refreshHealthSyncCache
+>;
 
 describe('useSyncHealthData', () => {
   let queryClient: QueryClient;
@@ -141,6 +150,28 @@ describe('useSyncHealthData', () => {
 
       await waitFor(() => {
         expect(onSuccess).toHaveBeenCalledWith('2024-01-15T10:00:00Z');
+      });
+    });
+
+    test('refreshes health caches and invalidates server connection on success', async () => {
+      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+      mockHealthConnectSyncData.mockResolvedValue({ success: true, syncErrors: [] });
+      mockSaveLastSyncedTime.mockResolvedValue('2024-01-15T10:00:00Z');
+
+      const { result } = renderHook(() => useSyncHealthData(), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(testParams);
+      });
+
+      await waitFor(() => {
+        expect(mockRefreshHealthSyncCache).toHaveBeenCalledWith(queryClient);
+      });
+
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: serverConnectionQueryKey,
       });
     });
   });
@@ -282,6 +313,28 @@ describe('useSyncHealthData', () => {
           })
         );
       });
+    });
+
+    test('does not refresh health caches on failure', async () => {
+      mockHealthConnectSyncData.mockResolvedValue({
+        success: false,
+        error: 'Server unavailable',
+        syncErrors: [],
+      });
+
+      const { result } = renderHook(() => useSyncHealthData(), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+
+      await act(async () => {
+        result.current.mutate(testParams);
+      });
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+
+      expect(mockRefreshHealthSyncCache).not.toHaveBeenCalled();
     });
   });
 

--- a/SparkyFitnessMobile/__tests__/services/backgroundSyncService.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/backgroundSyncService.test.ts
@@ -1,4 +1,10 @@
-import { triggerManualSync } from '../../src/services/backgroundSyncService';
+import {
+  triggerManualSync,
+  flushPendingHealthSyncCacheRefresh,
+} from '../../src/services/backgroundSyncService';
+import { refreshHealthSyncCache } from '../../src/hooks/refreshHealthSyncCache';
+import { TimeoutError } from '../../src/utils/concurrency';
+import { AppState } from 'react-native';
 
 jest.mock('../../src/services/LogService', () => ({
   addLog: jest.fn(),
@@ -12,6 +18,8 @@ jest.mock('../../src/services/storage', () => ({
   loadLastSyncedTime: jest.fn(),
   saveLastSyncedTime: jest.fn(),
   loadBackgroundSyncEnabled: jest.fn(),
+  savePendingHealthSyncCacheRefresh: jest.fn(),
+  consumePendingHealthSyncCacheRefresh: jest.fn(),
 }));
 
 jest.mock('../../src/HealthMetrics', () => ({
@@ -42,11 +50,17 @@ jest.mock('../../src/services/healthConnectService', () => ({
   getDatabaseInaccessibleCount: jest.fn().mockReturnValue(0),
 }));
 
+jest.mock('../../src/hooks/refreshHealthSyncCache', () => ({
+  refreshHealthSyncCache: jest.fn(),
+}));
+
 const api = require('../../src/services/api/healthDataApi') as { syncHealthData: jest.Mock };
 const storage = require('../../src/services/storage') as {
   loadLastSyncedTime: jest.Mock;
   saveLastSyncedTime: jest.Mock;
   loadBackgroundSyncEnabled: jest.Mock;
+  savePendingHealthSyncCacheRefresh: jest.Mock;
+  consumePendingHealthSyncCacheRefresh: jest.Mock;
 };
 const healthService = require('../../src/services/healthConnectService') as {
   loadHealthPreference: jest.Mock;
@@ -62,14 +76,27 @@ const healthService = require('../../src/services/healthConnectService') as {
   resetDatabaseInaccessibleCount: jest.Mock;
   getDatabaseInaccessibleCount: jest.Mock;
 };
+const mockRefreshHealthSyncCache = refreshHealthSyncCache as jest.MockedFunction<
+  typeof refreshHealthSyncCache
+>;
 
 describe('performBackgroundSync (via triggerManualSync)', () => {
+  const setAppState = (state: string) => {
+    Object.defineProperty(AppState, 'currentState', {
+      configurable: true,
+      value: state,
+    });
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2024-01-15T14:30:00Z'));
     jest.spyOn(console, 'log').mockImplementation();
     api.syncHealthData.mockResolvedValue(undefined);
+    storage.savePendingHealthSyncCacheRefresh.mockResolvedValue(undefined);
+    storage.consumePendingHealthSyncCacheRefresh.mockResolvedValue(false);
+    setAppState('active');
   });
 
   afterEach(() => {
@@ -405,6 +432,7 @@ describe('performBackgroundSync (via triggerManualSync)', () => {
           { value: 72 },
         ])
       );
+      expect(mockRefreshHealthSyncCache).toHaveBeenCalled();
       expect(storage.saveLastSyncedTime).toHaveBeenCalled();
     });
 
@@ -414,6 +442,7 @@ describe('performBackgroundSync (via triggerManualSync)', () => {
       await triggerManualSync();
 
       expect(api.syncHealthData).not.toHaveBeenCalled();
+      expect(mockRefreshHealthSyncCache).not.toHaveBeenCalled();
       expect(storage.saveLastSyncedTime).not.toHaveBeenCalled();
     });
 
@@ -426,6 +455,7 @@ describe('performBackgroundSync (via triggerManualSync)', () => {
       api.syncHealthData.mockRejectedValue(new Error('Network error'));
 
       await expect(triggerManualSync()).rejects.toThrow('Network error');
+      expect(mockRefreshHealthSyncCache).not.toHaveBeenCalled();
       expect(storage.saveLastSyncedTime).not.toHaveBeenCalled();
     });
 
@@ -437,7 +467,86 @@ describe('performBackgroundSync (via triggerManualSync)', () => {
       await triggerManualSync();
 
       expect(api.syncHealthData).not.toHaveBeenCalled();
+      expect(mockRefreshHealthSyncCache).not.toHaveBeenCalled();
       expect(storage.saveLastSyncedTime).not.toHaveBeenCalled();
+    });
+
+    test('refreshes caches even when timestamp save is skipped after a timeout', async () => {
+      healthService.loadHealthPreference.mockImplementation((key: string) => {
+        return key === 'isStepsSyncEnabled' || key === 'isActiveCaloriesSyncEnabled'
+          ? Promise.resolve(true)
+          : Promise.resolve(false);
+      });
+      healthService.getAggregatedStepsByDate.mockRejectedValue(
+        new TimeoutError('Background query for Steps', 60_000),
+      );
+      healthService.getAggregatedActiveCaloriesByDate.mockResolvedValue([{ value: 300 }]);
+      healthService.transformHealthRecords.mockImplementation((data: unknown[]) => data);
+
+      await triggerManualSync();
+
+      expect(api.syncHealthData).toHaveBeenCalledWith([{ value: 300 }]);
+      expect(mockRefreshHealthSyncCache).toHaveBeenCalled();
+      expect(storage.saveLastSyncedTime).not.toHaveBeenCalled();
+    });
+
+    test('does not refresh caches when sync finishes in the background', async () => {
+      setAppState('background');
+      healthService.loadHealthPreference.mockImplementation((key: string) => {
+        return key === 'isStepsSyncEnabled'
+          ? Promise.resolve(true)
+          : Promise.resolve(false);
+      });
+      healthService.getAggregatedStepsByDate.mockResolvedValue([{ value: 5000 }]);
+      healthService.transformHealthRecords.mockImplementation((data: unknown[]) => data);
+
+      await triggerManualSync();
+
+      expect(api.syncHealthData).toHaveBeenCalledWith([{ value: 5000 }]);
+      expect(mockRefreshHealthSyncCache).not.toHaveBeenCalled();
+      expect(storage.savePendingHealthSyncCacheRefresh).toHaveBeenCalled();
+      expect(storage.saveLastSyncedTime).toHaveBeenCalled();
+    });
+
+    test('flushes the pending refresh if the app becomes active while saving it', async () => {
+      setAppState('background');
+      healthService.loadHealthPreference.mockImplementation((key: string) => {
+        return key === 'isStepsSyncEnabled'
+          ? Promise.resolve(true)
+          : Promise.resolve(false);
+      });
+      healthService.getAggregatedStepsByDate.mockResolvedValue([{ value: 5000 }]);
+      healthService.transformHealthRecords.mockImplementation((data: unknown[]) => data);
+      storage.savePendingHealthSyncCacheRefresh.mockImplementation(async () => {
+        setAppState('active');
+        storage.consumePendingHealthSyncCacheRefresh.mockResolvedValueOnce(true);
+      });
+
+      await triggerManualSync();
+
+      expect(storage.savePendingHealthSyncCacheRefresh).toHaveBeenCalled();
+      expect(storage.consumePendingHealthSyncCacheRefresh).toHaveBeenCalled();
+      expect(mockRefreshHealthSyncCache).toHaveBeenCalledTimes(1);
+    });
+
+    test('flushes pending refresh when the app becomes active', async () => {
+      storage.consumePendingHealthSyncCacheRefresh.mockResolvedValue(true);
+
+      const refreshed = await flushPendingHealthSyncCacheRefresh();
+
+      expect(refreshed).toBe(true);
+      expect(storage.consumePendingHealthSyncCacheRefresh).toHaveBeenCalled();
+      expect(mockRefreshHealthSyncCache).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not flush pending refresh while the app is backgrounded', async () => {
+      setAppState('background');
+
+      const refreshed = await flushPendingHealthSyncCacheRefresh();
+
+      expect(refreshed).toBe(false);
+      expect(storage.consumePendingHealthSyncCacheRefresh).not.toHaveBeenCalled();
+      expect(mockRefreshHealthSyncCache).not.toHaveBeenCalled();
     });
   });
 

--- a/SparkyFitnessMobile/src/hooks/refreshHealthSyncCache.ts
+++ b/SparkyFitnessMobile/src/hooks/refreshHealthSyncCache.ts
@@ -1,0 +1,20 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { exerciseHistoryResetQueryKey } from './queryKeys';
+
+const dailySummaryQueryFamily = ['dailySummary'] as const;
+const measurementsQueryFamily = ['measurements'] as const;
+const measurementsRangeQueryFamily = ['measurementsRange'] as const;
+const exerciseHistoryQueryFamily = ['exerciseHistory'] as const;
+
+export function refreshHealthSyncCache(queryClient: QueryClient) {
+  void queryClient.invalidateQueries({ queryKey: dailySummaryQueryFamily });
+  void queryClient.invalidateQueries({ queryKey: measurementsQueryFamily });
+  void queryClient.invalidateQueries({ queryKey: measurementsRangeQueryFamily });
+  void queryClient.invalidateQueries({
+    queryKey: exerciseHistoryQueryFamily,
+    refetchType: 'none',
+  });
+
+  queryClient.removeQueries({ queryKey: exerciseHistoryQueryFamily, type: 'inactive' });
+  queryClient.setQueryData(exerciseHistoryResetQueryKey, Date.now());
+}

--- a/SparkyFitnessMobile/src/hooks/useSyncHealthData.ts
+++ b/SparkyFitnessMobile/src/hooks/useSyncHealthData.ts
@@ -5,6 +5,7 @@ import { saveLastSyncedTime } from '../services/storage';
 import { addLog } from '../services/LogService';
 import type { TimeRange } from '../services/storage';
 import { serverConnectionQueryKey } from './queryKeys';
+import { refreshHealthSyncCache } from './refreshHealthSyncCache';
 
 interface SyncHealthDataParams {
   timeRange: TimeRange;
@@ -38,6 +39,7 @@ export function useSyncHealthData(options?: {
       }
     },
     onSuccess: (data) => {
+      refreshHealthSyncCache(queryClient);
       queryClient.invalidateQueries({ queryKey: serverConnectionQueryKey });
       if (showToasts) {
         Toast.show({

--- a/SparkyFitnessMobile/src/services/backgroundSyncService.ts
+++ b/SparkyFitnessMobile/src/services/backgroundSyncService.ts
@@ -1,5 +1,6 @@
 import * as TaskManager from 'expo-task-manager';
 import * as BackgroundTask from 'expo-background-task';
+import { AppState } from 'react-native';
 import { syncHealthData, HealthDataPayload } from './api/healthDataApi';
 import { addLog, _flushBuffer } from './LogService';
 import { HEALTH_METRICS } from '../HealthMetrics';
@@ -18,8 +19,16 @@ import {
   getDatabaseInaccessibleCount,
 } from './healthConnectService';
 import type { TransformedRecord } from '../types/healthRecords';
-import { loadLastSyncedTime, saveLastSyncedTime, loadBackgroundSyncEnabled } from './storage';
+import {
+  loadLastSyncedTime,
+  saveLastSyncedTime,
+  loadBackgroundSyncEnabled,
+  savePendingHealthSyncCacheRefresh,
+  consumePendingHealthSyncCacheRefresh,
+} from './storage';
 import { runTasksInBatches, withTimeout, TimeoutError } from '../utils/concurrency';
+import { queryClient } from '../hooks/queryClient';
+import { refreshHealthSyncCache } from '../hooks/refreshHealthSyncCache';
 
 const METRIC_FETCH_CONCURRENCY = 3;
 const METRIC_TIMEOUT_MS = 60_000; // 60s per metric query
@@ -87,6 +96,32 @@ async function processBackgroundMetric(
 // Guard against overlapping syncs from concurrent triggers (background task,
 // manual trigger, HealthKit observer). Second caller awaits the in-flight run.
 let inflightSync: Promise<void> | null = null;
+
+async function refreshHealthSyncCacheWhenActive() {
+  if (AppState.currentState === 'active') {
+    refreshHealthSyncCache(queryClient);
+    return;
+  }
+
+  await savePendingHealthSyncCacheRefresh();
+  if (AppState.currentState === 'active') {
+    await flushPendingHealthSyncCacheRefresh();
+  }
+}
+
+export const flushPendingHealthSyncCacheRefresh = async (): Promise<boolean> => {
+  if (AppState.currentState !== 'active') {
+    return false;
+  }
+
+  const shouldRefresh = await consumePendingHealthSyncCacheRefresh();
+  if (!shouldRefresh) {
+    return false;
+  }
+
+  refreshHealthSyncCache(queryClient);
+  return true;
+}
 
 export const performBackgroundSync = async (taskId: string): Promise<void> => {
   if (inflightSync) {
@@ -208,6 +243,7 @@ const performBackgroundSyncInternal = async (taskId: string): Promise<void> => {
     addLog(`[Background Sync] Collected ${allData.length} records (${collectedCounts.join(', ')})`, 'DEBUG');
     addLog(`[Background Sync] Sending ${allData.length} records to server`, 'INFO');
     await syncHealthData(allData);
+    await refreshHealthSyncCacheWhenActive();
 
     if (hasTimeouts) {
       addLog(

--- a/SparkyFitnessMobile/src/services/storage.ts
+++ b/SparkyFitnessMobile/src/services/storage.ts
@@ -33,6 +33,7 @@ const TIME_RANGE_KEY = 'timeRange';
 const LAST_SYNCED_TIME_KEY = 'lastSyncedTime';
 const BACKGROUND_SYNC_ENABLED_KEY = 'backgroundSyncEnabled';
 const SYNC_ON_OPEN_ENABLED_KEY = 'syncOnOpenEnabled';
+const PENDING_HEALTH_SYNC_CACHE_REFRESH_KEY = 'pendingHealthSyncCacheRefresh';
 
 const secureStoreKey = (configId: string) => `apiKey_${configId}`;
 const sessionTokenSecureStoreKey = (configId: string) => `sessionToken_${configId}`;
@@ -318,6 +319,29 @@ export const loadSyncOnOpenEnabled = async (): Promise<boolean> => {
     return JSON.parse(value) as boolean;
   } catch (error) {
     console.error('Failed to load sync on open preference.', error);
+    return false;
+  }
+};
+
+export const savePendingHealthSyncCacheRefresh = async (): Promise<void> => {
+  try {
+    await AsyncStorage.setItem(PENDING_HEALTH_SYNC_CACHE_REFRESH_KEY, 'true');
+  } catch (error) {
+    console.error('Failed to save pending health sync cache refresh.', error);
+  }
+};
+
+export const consumePendingHealthSyncCacheRefresh = async (): Promise<boolean> => {
+  try {
+    const value = await AsyncStorage.getItem(PENDING_HEALTH_SYNC_CACHE_REFRESH_KEY);
+    if (value !== 'true') {
+      return false;
+    }
+
+    await AsyncStorage.removeItem(PENDING_HEALTH_SYNC_CACHE_REFRESH_KEY);
+    return true;
+  } catch (error) {
+    console.error('Failed to consume pending health sync cache refresh.', error);
     return false;
   }
 };


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Currently when the app would sync your dashboard and other tabs wouldn't update unless you pulled down to refresh them, now after a successfull sync it automatically refreshes them.

**How did you implement the solution?**
I made the app refresh its health data caches after a successful sync. For background syncs, it saves a pending refresh and applies it when the app is active again.

Linked Issue: #

## How to Test

1. Open app
2. sync data
3. watch dashboard update automatically

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
