### PR TITLE
fix(1158): garmin activity sync fail

### DIFF
--- a/SparkyFitnessServer/services/garminService.ts
+++ b/SparkyFitnessServer/services/garminService.ts
@@ -515,7 +515,9 @@ async function processGarminWorkoutSession(
         source_id: activity.activityId
           ? `${activity.activityId}_${exerciseSortOrder}`
           : null,
-        steps: activity.steps || activity.totalSteps || activity.stepCount || 0,
+        steps: Math.round(
+          activity.steps || activity.totalSteps || activity.stepCount || 0
+        ),
       };
       await exerciseEntryRepository.createExerciseEntry(
         userId,
@@ -659,14 +661,20 @@ async function processGarminSimpleActivity(
   const exerciseEntryData = {
     exercise_id: exercise.id,
     duration_minutes: activity.duration || 0,
-    calories_burned: activity.active_calories || 0,
+    calories_burned: Math.round(activity.active_calories || 0),
     entry_date: entryDate,
     notes: `Garmin Activity: ${activity.activityName} (${activity.activityType?.typeKey})`,
     distance: activity.distance,
     avg_heart_rate:
-      activity.averageHR || activity.averageHeartRateInBeatsPerMinute || null,
+      activity.averageHR || activity.averageHeartRateInBeatsPerMinute
+        ? Math.round(
+            activity.averageHR || activity.averageHeartRateInBeatsPerMinute
+          )
+        : null,
     source_id: activity.activityId?.toString() ?? null,
-    steps: activity.steps || activity.totalSteps || activity.stepCount || 0,
+    steps: Math.round(
+      activity.steps || activity.totalSteps || activity.stepCount || 0
+    ),
   };
   const newEntry = await exerciseEntryRepository.createExerciseEntry(
     userId,


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
The garmin sync fails when it delivers floats instead of integers.

**How did you implement the solution?**
Since I coulnd't replicate it, I rounded every value that could be float just to be sure

Linked Issue: Closes #1158

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.
