### PR TITLE
fix: exercises add from external and public workout presets

### DIFF
--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -268,7 +268,7 @@ app.get(
       }
       const originalRelativeImagePath = (
         (exercise as { images?: string[] }).images ?? []
-      ).find((img) => img.endsWith(String(imageFileName)));
+      ).find((img) => path.basename(img) === imageFileName);
       if (!originalRelativeImagePath) {
         return res.status(404).send('Image not found for this exercise.');
       }

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -82,7 +82,6 @@ import swaggerSpecs from './config/swagger.js';
 import { createCorsOriginChecker } from './utils/corsHelper.js';
 import authModule from './auth.js';
 import { toNodeHandler } from 'better-auth/node';
-import exerciseRepository from './models/exerciseRepository.js';
 import freeExerciseDBService from './integrations/freeexercisedb/FreeExerciseDBService.js';
 import { downloadImage } from './utils/imageDownloader.js';
 import authRoutes from './routes/authRoutes.js';
@@ -258,19 +257,18 @@ app.get(
     if (fs.existsSync(localImagePath)) {
       return res.sendFile(localImagePath);
     }
-    // If not found, attempt to re-download
+    // If not found, attempt to re-download. Resolve image paths from the
+    // upstream free-exercise-db record (the canonical source) rather than a
+    // per-user DB copy — different users may have locally diverged the images
+    // array, and this route is unauthenticated so we have no user context.
     try {
-      const exercise = await exerciseRepository.getExerciseBySourceAndSourceId(
-        'free-exercise-db',
-        exerciseId
-      );
+      const exercise = await freeExerciseDBService.getExerciseById(exerciseId);
       if (!exercise) {
         return res.status(404).send('Exercise not found.');
       }
-      // @ts-expect-error TS7006
-      const originalRelativeImagePath = exercise.images.find((img) =>
-        img.endsWith(imageFileName)
-      );
+      const originalRelativeImagePath = (
+        (exercise as { images?: string[] }).images ?? []
+      ).find((img) => img.endsWith(String(imageFileName)));
       if (!originalRelativeImagePath) {
         return res.status(404).send('Image not found for this exercise.');
       }

--- a/SparkyFitnessServer/db/migrations/20260420230132_scope_exercises_source_unique_to_user.sql
+++ b/SparkyFitnessServer/db/migrations/20260420230132_scope_exercises_source_unique_to_user.sql
@@ -1,0 +1,9 @@
+-- Scope the exercises (source, source_id) uniqueness to each user so that
+-- multiple users can import the same external-source exercise (e.g. the same
+-- Free-Exercise-DB entry) into their own per-user copies.
+
+DROP INDEX IF EXISTS idx_exercises_source_source_id_unique;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_exercises_user_source_source_id_unique
+ON exercises (user_id, source, source_id)
+WHERE source IS NOT NULL AND source_id IS NOT NULL;

--- a/SparkyFitnessServer/db/rls_policies.sql
+++ b/SparkyFitnessServer/db/rls_policies.sql
@@ -371,7 +371,7 @@ SELECT create_library_policy('foods', 'shared_with_public', ARRAY['can_view_food
 SELECT create_library_policy('meals', 'is_public', ARRAY['can_view_food_library', 'can_manage_diary']);
 SELECT create_library_policy('meal_plan_templates', 'false', ARRAY['can_view_food_library']);
 SELECT create_library_policy('workout_plan_templates', 'false', ARRAY['can_view_exercise_library']);
-SELECT create_library_policy('workout_presets', 'false', ARRAY['can_view_exercise_library']);
+SELECT create_library_policy('workout_presets', 'is_public', ARRAY['can_view_exercise_library']);
 
 
 -- Custom policies for special cases

--- a/SparkyFitnessServer/integrations/polar/polarDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/polar/polarDataProcessor.ts
@@ -94,7 +94,8 @@ async function processPolarExercises(
       const exerciseSourceId = `polar-workout-${exerciseId}`;
       let exerciseDef = await exerciseRepository.getExerciseBySourceAndSourceId(
         'Polar',
-        exerciseSourceId
+        exerciseSourceId,
+        userId
       );
       if (!exerciseDef) {
         // Search by name if source not found

--- a/SparkyFitnessServer/integrations/withings/withingsDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/withings/withingsDataProcessor.ts
@@ -959,7 +959,8 @@ async function processWithingsWorkouts(
       const exerciseSourceId = `withings-workout-${workoutCategory}`;
       let exercise = await exerciseRepository.getExerciseBySourceAndSourceId(
         'Withings',
-        exerciseSourceId
+        exerciseSourceId,
+        userId
       ); // Corrected variable name
       if (!exercise) {
         // If not found by source and sourceId, try to find by name (for user-created exercises)

--- a/SparkyFitnessServer/models/exercise.ts
+++ b/SparkyFitnessServer/models/exercise.ts
@@ -606,8 +606,14 @@ async function getTopExercises(userId: any, limit: any) {
     client.release();
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getExerciseBySourceAndSourceId(source: any, sourceId: any) {
+async function getExerciseBySourceAndSourceId(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  source: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sourceId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userId: any
+) {
   const client = await getSystemClient();
   try {
     const result = await client.query(
@@ -615,8 +621,8 @@ async function getExerciseBySourceAndSourceId(source: any, sourceId: any) {
               primary_muscles, secondary_muscles, instructions, category, images,
               calories_per_hour, description, user_id, is_custom, shared_with_public,
               created_at, updated_at
-       FROM exercises WHERE source = $1 AND source_id = $2`,
-      [source, sourceId]
+       FROM exercises WHERE source = $1 AND source_id = $2 AND user_id = $3`,
+      [source, sourceId, userId]
     );
     const exercise = result.rows[0];
     if (exercise && exercise.images) {

--- a/SparkyFitnessServer/services/exerciseService.ts
+++ b/SparkyFitnessServer/services/exerciseService.ts
@@ -192,7 +192,8 @@ async function prepareExerciseEntryForCreate(
   entryData: any
 ) {
   const resolvedExerciseId = await resolveExerciseIdToUuid(
-    entryData.exercise_id
+    entryData.exercise_id,
+    authenticatedUserId
   );
   const exercise = await exerciseDb.getExerciseById(
     resolvedExerciseId,
@@ -1298,7 +1299,10 @@ async function getExerciseHistory(
   limit: any
 ) {
   try {
-    const resolvedExerciseId = await resolveExerciseIdToUuid(exerciseId);
+    const resolvedExerciseId = await resolveExerciseIdToUuid(
+      exerciseId,
+      authenticatedUserId
+    );
     // getExerciseHistory is implemented in the exerciseEntry module
     const history = await exerciseEntryDb.getExerciseHistory(
       authenticatedUserId,

--- a/SparkyFitnessServer/services/workoutPresetService.ts
+++ b/SparkyFitnessServer/services/workoutPresetService.ts
@@ -6,7 +6,7 @@ import { resolveExerciseIdToUuid } from '../utils/uuidUtils.js';
 async function createWorkoutPreset(userId: any, presetData: any) {
   // Validate and resolve exercise_ids
   for (const ex of presetData.exercises) {
-    ex.exercise_id = await resolveExerciseIdToUuid(ex.exercise_id); // Resolve to UUID
+    ex.exercise_id = await resolveExerciseIdToUuid(ex.exercise_id, userId); // Resolve to UUID
     const exercise = await exerciseRepository.getExerciseById(
       ex.exercise_id,
       userId
@@ -71,7 +71,7 @@ async function updateWorkoutPreset(
   // Validate and resolve exercise_ids if exercises are being updated
   if (updateData.exercises) {
     for (const ex of updateData.exercises) {
-      ex.exercise_id = await resolveExerciseIdToUuid(ex.exercise_id); // Resolve to UUID
+      ex.exercise_id = await resolveExerciseIdToUuid(ex.exercise_id, userId); // Resolve to UUID
       const exercise = await exerciseRepository.getExerciseById(
         ex.exercise_id,
         userId

--- a/SparkyFitnessServer/tests/exerciseSourceScoping.test.ts
+++ b/SparkyFitnessServer/tests/exerciseSourceScoping.test.ts
@@ -1,0 +1,127 @@
+import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import exerciseDb from '../models/exercise.js';
+import { getSystemClient } from '../db/poolManager.js';
+import { resolveExerciseIdToUuid } from '../utils/uuidUtils.js';
+import exerciseRepository from '../models/exerciseRepository.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('../models/exerciseRepository', () => ({
+  default: {
+    getExerciseBySourceAndSourceId: vi.fn(),
+  },
+}));
+
+describe('exercise source/source_id scoping', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = { query: vi.fn(), release: vi.fn() };
+    // @ts-expect-error mock typing
+    getSystemClient.mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('exerciseDb.getExerciseBySourceAndSourceId', () => {
+    it('filters on user_id when userId is provided', async () => {
+      const userId = uuidv4();
+      const rowId = uuidv4();
+      mockClient.query.mockResolvedValueOnce({
+        rows: [
+          {
+            id: rowId,
+            source: 'free-exercise-db',
+            source_id: 'Barbell_Bench_Press',
+            user_id: userId,
+            images: null,
+          },
+        ],
+      });
+
+      const result = await exerciseDb.getExerciseBySourceAndSourceId(
+        'free-exercise-db',
+        'Barbell_Bench_Press',
+        userId
+      );
+
+      expect(result.id).toBe(rowId);
+      expect(mockClient.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockClient.query.mock.calls[0];
+      expect(sql).toContain('AND user_id = $3');
+      expect(params).toEqual([
+        'free-exercise-db',
+        'Barbell_Bench_Press',
+        userId,
+      ]);
+    });
+
+    it('returns undefined when the requested user has no copy even if another user does', async () => {
+      const userId = uuidv4();
+      mockClient.query.mockResolvedValueOnce({ rows: [] });
+
+      const result = await exerciseDb.getExerciseBySourceAndSourceId(
+        'free-exercise-db',
+        'Barbell_Bench_Press',
+        userId
+      );
+
+      expect(result).toBeUndefined();
+      const [sql, params] = mockClient.query.mock.calls[0];
+      expect(sql).toContain('AND user_id = $3');
+      expect(params[2]).toBe(userId);
+    });
+  });
+
+  describe('resolveExerciseIdToUuid', () => {
+    it('returns the input unchanged when it is already a UUID', async () => {
+      const existingUuid = uuidv4();
+
+      const result = await resolveExerciseIdToUuid(existingUuid, uuidv4());
+
+      expect(result).toBe(existingUuid);
+      expect(
+        exerciseRepository.getExerciseBySourceAndSourceId
+      ).not.toHaveBeenCalled();
+    });
+
+    it('forwards the userId to getExerciseBySourceAndSourceId so each user resolves to their own copy', async () => {
+      const userId = uuidv4();
+      const resolved = uuidv4();
+      exerciseRepository.getExerciseBySourceAndSourceId.mockResolvedValueOnce({
+        id: resolved,
+      });
+
+      const result = await resolveExerciseIdToUuid(
+        'Barbell_Bench_Press',
+        userId
+      );
+
+      expect(result).toBe(resolved);
+      expect(
+        exerciseRepository.getExerciseBySourceAndSourceId
+      ).toHaveBeenCalledWith('free-exercise-db', 'Barbell_Bench_Press', userId);
+    });
+
+    it('throws when no exercise is found for the caller', async () => {
+      exerciseRepository.getExerciseBySourceAndSourceId.mockResolvedValueOnce(
+        undefined
+      );
+
+      await expect(
+        resolveExerciseIdToUuid('Barbell_Bench_Press', uuidv4())
+      ).rejects.toThrow(/not found or is not a valid UUID/);
+    });
+  });
+});

--- a/SparkyFitnessServer/utils/uuidUtils.ts
+++ b/SparkyFitnessServer/utils/uuidUtils.ts
@@ -7,16 +7,22 @@ const isValidUuid = (uuid: any) => {
   return uuidRegex.test(uuid);
 };
 // Helper function to resolve exercise ID to a UUID
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function resolveExerciseIdToUuid(exerciseId: any) {
+async function resolveExerciseIdToUuid(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  exerciseId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userId: any
+) {
   if (isValidUuid(exerciseId)) {
     return exerciseId;
   }
-  // If not a UUID, assume it's an integer ID from a source like FreeExerciseDB
-  // We need to find the corresponding exercise in our DB that has this source_id
+  // If not a UUID, assume it's an ID from a source like FreeExerciseDB.
+  // Each user may have their own per-user copy of that source exercise, so
+  // callers pass userId to select the row owned by the current user.
   const exercise = await exerciseRepository.getExerciseBySourceAndSourceId(
     'free-exercise-db',
-    exerciseId
+    exerciseId,
+    userId
   );
   if (exercise) {
     return exercise.id;

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -3604,10 +3604,10 @@ CREATE INDEX idx_exercises_source ON public.exercises USING btree (source);
 
 
 --
--- Name: idx_exercises_source_source_id_unique; Type: INDEX; Schema: public; Owner: -
+-- Name: idx_exercises_user_source_source_id_unique; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_exercises_source_source_id_unique ON public.exercises USING btree (source, source_id) WHERE ((source IS NOT NULL) AND (source_id IS NOT NULL));
+CREATE UNIQUE INDEX idx_exercises_user_source_source_id_unique ON public.exercises USING btree (user_id, source, source_id) WHERE ((source IS NOT NULL) AND (source_id IS NOT NULL));
 
 
 --

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -5583,7 +5583,7 @@ CREATE POLICY select_policy ON public.workout_plan_templates FOR SELECT USING (p
 -- Name: workout_presets select_policy; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY select_policy ON public.workout_presets FOR SELECT USING (public.has_library_access_with_public(user_id, false, ARRAY['can_view_exercise_library'::text]));
+CREATE POLICY select_policy ON public.workout_presets FOR SELECT USING (public.has_library_access_with_public(user_id, is_public, ARRAY['can_view_exercise_library'::text]));
 
 
 --
@@ -7262,4 +7262,3 @@ ALTER DEFAULT PRIVILEGES FOR ROLE sparky IN SCHEMA public GRANT SELECT,INSERT,DE
 --
 
 \unrestrict G4DirQ0zC90iSaOGue74XukJ95cc6Vq4wGjrNcK3lM0nnBjsZQlAdgl73ISL7bj
-


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

This PR fixes two a bug with public workout sets (that are full of public exercises) not showing for other users.
I also discovered and fixed a bug where users couldn't privately have the same exercise from the same provider. For example, if user 1 has Bench Press from free exercise db, trying to add it on another user would result in a server error.

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
