### PR TITLE
fix(1169): focus for input unit keeps resetting while typing

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Check } from 'lucide-react';
 import {
   Dialog,
@@ -73,7 +73,7 @@ const FoodUnitSelector = ({
 
   const queryClient = useQueryClient();
   const createFoodVariantMutation = useCreateFoodVariantMutation();
-
+  const quantityInputRef = useRef<HTMLInputElement>(null);
   const {
     pendingUnit,
     setPendingUnit,
@@ -303,12 +303,17 @@ const FoodUnitSelector = ({
     };
   })();
 
-  const focusAndSelect = useCallback((e: HTMLInputElement) => {
-    if (e) {
-      e.focus();
-      e.select();
+  useEffect(() => {
+    if (open && quantityInputRef.current) {
+      const timeoutId = setTimeout(() => {
+        if (quantityInputRef.current) {
+          quantityInputRef.current.focus();
+          quantityInputRef.current.select();
+        }
+      }, 0);
+      return () => clearTimeout(timeoutId);
     }
-  }, []);
+  }, [open, loading]);
 
   const displayUnit = isConverting
     ? pendingUnit.trim() || '?'
@@ -342,12 +347,12 @@ const FoodUnitSelector = ({
                 <div>
                   <Label htmlFor="quantity">Quantity</Label>
                   <Input
+                    ref={quantityInputRef}
                     id="quantity"
                     type="number"
                     step="0.1"
                     min="0.1"
                     value={quantity}
-                    ref={focusAndSelect}
                     onChange={(e) => {
                       const newQuantity = Number(e.target.value);
                       debug(loggingLevel, 'Quantity changed:', newQuantity);


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The input field kept resetting the focus making it hard to type. 

**How did you implement the solution?**
Using a ref for focus.

Linked Issue: Closes #1169

## How to Test

1. Add food to diary
2. Enter quanity
3. Verify input is not bugged

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.
