### PR TITLE
fix(1139): filter active calories from workout reports

### DIFF
--- a/SparkyFitnessServer/models/reportRepository.ts
+++ b/SparkyFitnessServer/models/reportRepository.ts
@@ -568,8 +568,11 @@ async function getExerciseEntries(
 async function getExerciseNames(userId: any, muscle: any, equipment: any) {
   const client = await getClient(userId); // User-specific operation
   try {
+    // Exclude synced device calorie summaries (e.g. Apple Health "Active
+    // Calories") — they show up as exercise entries but aren't true workouts,
+    // and the Exercise Reports dashboard filters them out of its aggregates.
     let query =
-      'SELECT DISTINCT exercise_id as id, exercise_name as name FROM exercise_entries WHERE user_id = $1';
+      "SELECT DISTINCT exercise_id as id, exercise_name as name FROM exercise_entries WHERE user_id = $1 AND exercise_name <> 'Active Calories'";
     const params = [userId];
     let paramIndex = 2;
     if (muscle) {

--- a/SparkyFitnessServer/services/reportService.ts
+++ b/SparkyFitnessServer/services/reportService.ts
@@ -606,13 +606,20 @@ async function getExerciseDashboardData(
   exercise: any
 ) {
   try {
-    const exerciseEntries = await reportRepository.getExerciseEntries(
+    const allExerciseEntries = await reportRepository.getExerciseEntries(
       targetUserId,
       startDate,
       endDate,
       equipment,
       muscle,
       exercise
+    );
+    // Synced device calorie summaries (e.g. Apple Health "Active Calories") are
+    // logged as exercise entries but aren't true workouts — exclude them so
+    // every counter on the Exercise Reports dashboard matches user expectations.
+    const exerciseEntries = allExerciseEntries.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (entry: any) => entry.exercise_name !== 'Active Calories'
     );
     let totalVolume = 0;
     let totalReps = 0;


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Active Calories from mobile app counting as workout for reports. Showing up in streaks and the heatmap

**How did you implement the solution?**
Filter exercise entries named 'Active Calories' (already a special name elsewhere in the app)

Linked Issue: #1139

## How to Test

1. Have active calories
2. Look at reports

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
