### PR TITLE
feat(1080): add bundled postgresql resources to helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ lerna-debug.log*
 
 # Generic
 postgresql
+!helm/chart/templates/postgresql/
+!helm/chart/templates/postgresql/*.yaml
 node_modules
 dist
 dist-ssr

--- a/helm/README.md
+++ b/helm/README.md
@@ -20,13 +20,36 @@ A Helm chart for deploying [Sparkyfitness](https://github.com/CodeWithCJ/SparkyF
 helm install sparkyfitness ./chart
 ```
 
-This deploys Sparkyfitness with a bundled PostgreSQL instance, auto-generated secrets, and sane defaults. Access via `kubectl port-forward svc/sparkyfitness-frontend 8080:80`.
+This deploys Sparkyfitness with a bundled PostgreSQL instance, auto-generated secrets, and sane defaults.
+
+### Local Testing (Port-Forwarding)
+
+By default, the chart enables private network CORS and trusts `http://localhost:3004` to make local testing easy.
+
+In separate terminals, run:
+
+```bash
+kubectl port-forward svc/sparkyfitness-frontend 3004:80
+```
+```bash
+kubectl port-forward svc/sparkyfitness-server 3010:3010
+```
+
+Now, navigate to [http://localhost:3004](http://localhost:3004) in your browser.
+
+### Run Tests
+
+To verify that the frontend is up and running:
+
+```bash
+helm test sparkyfitness
+```
 
 ## Database
 
 ### Bundled PostgreSQL (default)
 
-Enabled by default. Credentials are auto-generated on first install and preserved across upgrades.
+Enabled by default. The chart creates a PostgreSQL `Service` + `StatefulSet` and chart-managed credentials (unless `postgresql.auth.existingSecret` is set). Passwords are auto-generated on first install when `postgresql.auth.password` is empty and preserved across upgrades.
 
 ```yaml
 postgresql:
@@ -81,7 +104,7 @@ The chart manages five separate Kubernetes Secrets:
 |--------|------|---------|
 | `<release>-app` | `api_encryption_key`, `better_auth_secret` | Server |
 | `<release>-appdb` | `username`, `password` | Server (app DB user) |
-| `<release>-postgres` | `username`, `password` | Server (DB owner) |
+| `<release>-postgres` | `username`, `password` (`database` optional) | Server (DB owner) + bundled PostgreSQL |
 | `<release>-oidc` | `client_id`, `client_secret` | Server (if OIDC enabled) |
 | `<release>-smtp` | `username`, `password` | Server (if email enabled) |
 

--- a/helm/chart/templates/NOTES.txt
+++ b/helm/chart/templates/NOTES.txt
@@ -57,3 +57,25 @@ Frontend URL: {{ include "sparkyfitness.frontendUrl" . }}
     -- Grant extension functions to the DB owner so the app can delegate them
     GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO "<owner>" WITH GRANT OPTION;
 {{- end }}
+
+================================================================================
+  PORT FORWARDING (Local Development / Testing)
+================================================================================
+To access the application locally via port-forwarding, run the following commands
+in separate terminal windows:
+
+  1. Port-forward the Frontend to localhost:3004:
+     kubectl port-forward svc/{{ include "sparkyfitness.fullname" . }}-frontend 3004:80
+
+  2. Port-forward the Server to localhost:3010:
+     kubectl port-forward svc/{{ include "sparkyfitness.fullname" . }}-server 3010:3010
+
+Then open your browser to: http://localhost:3004
+
+================================================================================
+  TESTING
+================================================================================
+To run the included Helm tests to verify connectivity:
+
+  helm test {{ .Release.Name }}
+

--- a/helm/chart/templates/postgresql/secret.yaml
+++ b/helm/chart/templates/postgresql/secret.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.postgresql.enabled (include "sparkyfitness.createDatabaseSecret" .) }}
+{{- $secretName := include "sparkyfitness.databaseSecretName" . -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $existingData := ($existing).data | default dict -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+type: Opaque
+data:
+  username: {{ .Values.postgresql.auth.username | b64enc }}
+  {{- if .Values.postgresql.auth.password }}
+  password: {{ .Values.postgresql.auth.password | b64enc }}
+  {{- else }}
+  password: {{ get $existingData "password" | default (randAlphaNum 48 | b64enc) }}
+  {{- end }}
+  database: {{ .Values.postgresql.auth.database | b64enc }}
+{{- end }}

--- a/helm/chart/templates/postgresql/service.yaml
+++ b/helm/chart/templates/postgresql/service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-postgresql
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+      protocol: TCP
+  selector:
+    {{- include "sparkyfitness.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+{{- end }}

--- a/helm/chart/templates/postgresql/statefulset.yaml
+++ b/helm/chart/templates/postgresql/statefulset.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "sparkyfitness.fullname" . }}-postgresql
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+spec:
+  serviceName: {{ include "sparkyfitness.fullname" . }}-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "sparkyfitness.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: postgresql
+  template:
+    metadata:
+      labels:
+        {{- include "sparkyfitness.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: postgresql
+    spec:
+      {{- include "sparkyfitness.imagePullSecrets" . | nindent 6 }}
+      {{- with .Values.postgresql.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: postgresql
+          image: {{ include "sparkyfitness.image" (dict "image" .Values.postgresql.image "global" .Values.global "appVersion" .Chart.AppVersion) }}
+          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.databaseSecretName" . }}
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.databaseSecretName" . }}
+                  key: password
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sparkyfitness.databaseSecretName" . }}
+                  key: password
+          {{- with .Values.postgresql.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.postgresql.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.postgresql.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.postgresql.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql
+      {{- if not .Values.postgresql.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "sparkyfitness.labels" . | nindent 10 }}
+          app.kubernetes.io/component: postgresql
+      spec:
+        accessModes:
+          - {{ .Values.postgresql.persistence.accessMode | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size }}
+        {{- $storageClass := include "sparkyfitness.storageClass" (dict "sc" .Values.postgresql.persistence.storageClass "global" .Values.global) }}
+        {{- if $storageClass }}
+        storageClassName: {{ $storageClass | quote }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/chart/templates/tests/test-connection.yaml
+++ b/helm/chart/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "sparkyfitness.fullname" . }}-test-connection"
+  labels:
+    {{- include "sparkyfitness.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "sparkyfitness.fullname" . }}-frontend:80']
+  restartPolicy: Never

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -40,9 +40,9 @@ config:
   adminEmail: ""
 
   # -- Allow CORS from private network ranges (only for self-hosted/private networks)
-  allowPrivateNetworkCors: false
+  allowPrivateNetworkCors: true
   # -- Extra trusted origins, comma-separated (e.g. "http://192.168.1.5:8080")
-  extraTrustedOrigins: ""
+  extraTrustedOrigins: "http://localhost:3004"
 
   # -- Force email/password login to be enabled (fail-safe against OIDC lockout)
   forceEmailLogin: true
@@ -330,8 +330,11 @@ postgresql:
   enabled: true
   image:
     repository: postgres
-    tag: "15-alpine"
+    tag: "18-alpine"
     pullPolicy: IfNotPresent
+  extraEnv:
+    - name: PGDATA
+      value: /var/lib/postgresql/data/pgdata
   livenessProbe:
     exec:
       command:
@@ -365,8 +368,9 @@ postgresql:
   auth:
     database: sparkyfitness
     username: sparky
+    # -- Password for PostgreSQL owner user (auto-generated if empty)
     password: ""
-    # -- Use an existing K8s Secret (keys: username, password)
+    # -- Use an existing K8s Secret (keys: username, password; optional: database)
     existingSecret: ""
   persistence:
     enabled: true


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The helm documentation said it would start the database but didn't contain any charts for it.

**How did you implement the solution?**
I added a template for postgres. I also adjusted the default values to allow private networks because most people will use a port forward to quickly test the app. It should work with a single command to make it as easy as possible to test.

Linked Issue: Closes #1080 

## How to Test

I tested it using Kind (Kubernetes in docker) and everything is starting fine and sign up is working.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.
