### PR TITLE
feat(702): support for custom uploads and backup location

### DIFF
--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -201,7 +201,10 @@ app.use((req, _res, next) => {
   next();
 });
 // Serve static files from the 'uploads' directory
-const UPLOADS_BASE_DIR = path.join(__dirname, 'uploads');
+const UPLOADS_BASE_DIR = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
+  ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY)
+  : path.join(__dirname, 'uploads');
+
 console.log('SparkyFitnessServer UPLOADS_BASE_DIR:', UPLOADS_BASE_DIR);
 // Mount at both paths for compatibility during transition
 app.use('/api/uploads', express.static(UPLOADS_BASE_DIR));
@@ -247,8 +250,8 @@ app.get(
   async (req, res, _next) => {
     const { exerciseId, imageFileName } = req.params;
     const localImagePath = path.join(
-      __dirname,
-      'uploads/exercises',
+      UPLOADS_BASE_DIR,
+      'exercises',
       // @ts-expect-error TS2345
       exerciseId,
       imageFileName
@@ -275,13 +278,8 @@ app.get(
       const externalImageUrl = freeExerciseDBService.getExerciseImageUrl(
         originalRelativeImagePath
       );
-      const downloadedLocalPath = await downloadImage(
-        externalImageUrl,
-        exerciseId
-      );
-      // @ts-expect-error TS2345
-      const finalImagePath = path.join(__dirname, downloadedLocalPath);
-      res.sendFile(finalImagePath);
+      await downloadImage(externalImageUrl, exerciseId);
+      res.sendFile(localImagePath);
     } catch (error) {
       // @ts-expect-error TS18046
       log('error', `Error serving image: ${error.message}`);

--- a/SparkyFitnessServer/routes/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/exerciseRoutes.ts
@@ -8,7 +8,16 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { ExternalProviderType } from 'types/externalProvider.ts';
+
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const router = express.Router();
+
+const baseUploadsDir = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
+  ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY)
+  : path.join(__dirname, '../uploads');
 // Setup Multer for file uploads
 const storage = multer.diskStorage({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -17,8 +26,8 @@ const storage = multer.diskStorage({
       ? JSON.parse(req.body.exerciseData).name
       : 'unknown-exercise';
     const uploadPath = path.join(
-      __dirname,
-      '../uploads/exercises',
+      baseUploadsDir,
+      'exercises',
       exerciseName.replace(/[^a-zA-Z0-9]/g, '_')
     );
     fs.mkdirSync(uploadPath, { recursive: true });

--- a/SparkyFitnessServer/services/backupService.ts
+++ b/SparkyFitnessServer/services/backupService.ts
@@ -13,8 +13,13 @@ const __dirname = path.dirname(__filename);
 
 const fsp = { promises }.promises; // Use fsp for promise-based fs operations
 // const { configureSessionMiddleware } = require('../SparkyFitnessServer'); // Removed to fix circular dependency
-const BACKUP_DIR = process.env.BACKUP_DIR || path.join(__dirname, '../backup');
-const UPLOADS_BASE_DIR = path.join(__dirname, '../uploads');
+const BACKUP_DIR = process.env.SPARKY_FITNESS_CUSTOM_BACKUP_DIRECTORY
+  ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_BACKUP_DIRECTORY)
+  : process.env.BACKUP_DIR || path.join(__dirname, '../backup');
+
+const UPLOADS_BASE_DIR = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
+  ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY)
+  : path.join(__dirname, '../uploads');
 // Ensure backup directory exists
 async function ensureBackupDirectory() {
   try {

--- a/SparkyFitnessServer/utils/imageDownloader.ts
+++ b/SparkyFitnessServer/utils/imageDownloader.ts
@@ -7,7 +7,11 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const fsp = { promises }.promises; // Import fs.promises as fsp
-const UPLOADS_DIR = path.join(__dirname, '../uploads/exercises'); // Relative to SparkyFitnessServer
+const baseUploadsDir = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
+  ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY)
+  : path.join(__dirname, 'uploads');
+
+const UPLOADS_DIR = path.join(baseUploadsDir, 'exercises');
 /**
  * Ensures the upload directory exists.
  */

--- a/SparkyFitnessServer/utils/imageDownloader.ts
+++ b/SparkyFitnessServer/utils/imageDownloader.ts
@@ -9,7 +9,7 @@ const __dirname = path.dirname(__filename);
 const fsp = { promises }.promises; // Import fs.promises as fsp
 const baseUploadsDir = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
   ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY)
-  : path.join(__dirname, 'uploads');
+  : path.join(__dirname, '../uploads');
 
 const UPLOADS_DIR = path.join(baseUploadsDir, 'exercises');
 /**

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -125,7 +125,10 @@ SPARKY_FITNESS_DISABLE_SIGNUP=false
 # SPARKY_FITNESS_OIDC_USERINFO_SIGNED_ALG=none
 # SPARKY_FITNESS_OIDC_TIMEOUT=30000
 
-
+# Set custom uploads and backups directory. Only needed for standalone installation
+# SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY=
+# SPARKY_FITNESS_CUSTOM_BACKUP_DIRECTORY=
+#
 # --- Login Management Fail-Safe ---
 # Set to 'true' to force email/password login to be enabled, overriding any in-app settings.
 # This is a fail-safe to prevent being locked out if OIDC is misconfigured.

--- a/docker/Dockerfile.backend.dev
+++ b/docker/Dockerfile.backend.dev
@@ -5,6 +5,7 @@ RUN corepack enable
 
 WORKDIR /app
 
+RUN apk add --no-cache postgresql-client
 # Copy workspace root files for pnpm resolution
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Upload/backup folder was hardcoded which is fine for docker, but not for standalone use.

**How did you implement the solution?**
Added  envrionment variables to allow setting custom directories. 

Linked Issue: Closes #702

## How to Test

1. Set variables
2. Verify the upload and backup still work

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.
