### PR TITLE
feat: improved ui for exercise entries

### DIFF
--- a/SparkyFitnessFrontend/src/constants/exercises.ts
+++ b/SparkyFitnessFrontend/src/constants/exercises.ts
@@ -1,4 +1,16 @@
 import { format } from 'date-fns';
+import {
+  Activity,
+  Dumbbell,
+  HeartPulse,
+  Flower2,
+  ArrowBigUp,
+  Zap,
+  Hammer,
+  ChevronsUp,
+  Expand,
+  Pause,
+} from 'lucide-react';
 export const EXERCISE_CATEGORIES = [
   {
     value: 'general',
@@ -52,6 +64,63 @@ export const EXERCISE_CATEGORIES = [
   },
 ] as const;
 
+export type ExerciseCategory = (typeof EXERCISE_CATEGORIES)[number]['value'];
+
+export const EXERCISE_CATEGORY_META: Record<
+  ExerciseCategory,
+  { icon: React.ElementType; color: string; bg: string }
+> = {
+  general: {
+    icon: Activity,
+    color: 'text-slate-500',
+    bg: 'bg-slate-100 dark:bg-slate-800',
+  },
+  strength: {
+    icon: Dumbbell,
+    color: 'text-blue-600',
+    bg: 'bg-blue-100 dark:bg-blue-900/40',
+  },
+  cardio: {
+    icon: HeartPulse,
+    color: 'text-rose-500',
+    bg: 'bg-rose-100 dark:bg-rose-900/40',
+  },
+  yoga: {
+    icon: Flower2,
+    color: 'text-emerald-500',
+    bg: 'bg-emerald-100 dark:bg-emerald-900/40',
+  },
+  powerlifting: {
+    icon: ArrowBigUp,
+    color: 'text-orange-600',
+    bg: 'bg-orange-100 dark:bg-orange-900/40',
+  },
+  'olympic weightlifting': {
+    icon: Zap,
+    color: 'text-yellow-500',
+    bg: 'bg-yellow-100 dark:bg-yellow-900/40',
+  },
+  strongman: {
+    icon: Hammer,
+    color: 'text-red-600',
+    bg: 'bg-red-100 dark:bg-red-900/40',
+  },
+  plyometrics: {
+    icon: ChevronsUp,
+    color: 'text-violet-500',
+    bg: 'bg-violet-100 dark:bg-violet-900/40',
+  },
+  stretching: {
+    icon: Expand,
+    color: 'text-teal-500',
+    bg: 'bg-teal-100 dark:bg-teal-900/40',
+  },
+  isometric: {
+    icon: Pause,
+    color: 'text-indigo-500',
+    bg: 'bg-indigo-100 dark:bg-indigo-900/40',
+  },
+};
 export const DAYS_OF_WEEK = [
   { id: 0, name: 'Sunday' },
   { id: 1, name: 'Monday' },

--- a/SparkyFitnessFrontend/src/pages/Diary/ExerciseEntryDisplay.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/ExerciseEntryDisplay.tsx
@@ -14,11 +14,16 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
-import { Dumbbell, Edit, Trash2, Settings, Play } from 'lucide-react';
+import { Edit, Trash2, Settings, Play } from 'lucide-react';
 import { formatWeight } from '@/utils/numberFormatting';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { formatMinutesToHHMM } from '@/utils/timeFormatters';
 import { ExerciseEntry, Exercise } from '@/types/exercises';
+import {
+  EXERCISE_CATEGORY_META,
+  ExerciseCategory,
+} from '@/constants/exercises';
+import { useState } from 'react';
 
 interface ExerciseEntryDisplayProps {
   exerciseEntry: ExerciseEntry;
@@ -37,6 +42,25 @@ interface ExerciseEntryDisplayProps {
   getEnergyUnitString: (unit: 'kcal' | 'kJ') => string;
 }
 
+// Source badge config
+const SOURCE_BADGES: Record<string, { label: string; className: string }> = {
+  wger: {
+    label: 'Wger',
+    className:
+      'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+  },
+  'free-exercise-db': {
+    label: 'Free DB',
+    className:
+      'bg-violet-100 text-violet-800 dark:bg-violet-900/40 dark:text-violet-300',
+  },
+  nutritionix: {
+    label: 'Nutritionix',
+    className:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+  },
+};
+
 const ExerciseEntryDisplay: React.FC<ExerciseEntryDisplayProps> = ({
   exerciseEntry,
   currentUserId,
@@ -49,225 +73,263 @@ const ExerciseEntryDisplay: React.FC<ExerciseEntryDisplayProps> = ({
   convertEnergy,
   getEnergyUnitString,
 }) => {
-  const { weightUnit } = usePreferences(); // Destructure weightUnit from usePreferences
+  const { weightUnit } = usePreferences();
+  const snapshot = exerciseEntry.exercise_snapshot;
 
+  const [imageError, setImageError] = useState(false);
+  const sourceBadge = snapshot?.source
+    ? SOURCE_BADGES[snapshot.source]
+    : snapshot?.is_custom
+      ? {
+          label: 'Custom',
+          className:
+            'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+        }
+      : null;
+
+  const isActiveCalories = snapshot?.name === 'Active Calories';
+
+  const durationDisplay = formatMinutesToHHMM(
+    exerciseEntry.sets && exerciseEntry.sets.length > 0
+      ? exerciseEntry.sets.reduce(
+          (sum, set) => sum + (set.duration || 0) + (set.rest_time || 0) / 60,
+          0
+        )
+      : exerciseEntry.duration_minutes || 0
+  );
+
+  const caloriesDisplay = `${Math.round(convertEnergy(exerciseEntry.calories_burned || 0, 'kcal', energyUnit))} ${getEnergyUnitString(energyUnit)}`;
+
+  const hasSets =
+    exerciseEntry.sets &&
+    Array.isArray(exerciseEntry.sets) &&
+    exerciseEntry.sets.length > 0;
+
+  const imageUrl = exerciseEntry.image_url
+    ? exerciseEntry.image_url
+    : snapshot?.images && snapshot.images.length > 0
+      ? exerciseEntry.source
+        ? `/uploads/exercises/${snapshot.images[0]}`
+        : snapshot.images[0]
+      : null;
+
+  const metaPills: string[] = [];
+  if (snapshot?.level) metaPills.push(snapshot.level);
+  if (snapshot?.force) metaPills.push(snapshot.force);
+  if (snapshot?.mechanic) metaPills.push(snapshot.mechanic);
+  const meta =
+    EXERCISE_CATEGORY_META[snapshot?.category as ExerciseCategory] ??
+    EXERCISE_CATEGORY_META['general'];
+  const CategoryIcon = meta.icon;
   return (
-    <div
-      key={exerciseEntry.id}
-      className="flex items-center justify-between p-3 bg-white rounded-md shadow-sm dark:bg-gray-700"
-    >
-      <div className="flex items-center">
-        <Dumbbell className="w-4 h-4 mr-2 text-gray-600 dark:text-gray-300" />
-        <div>
-          <span className="font-medium flex items-center gap-2 text-gray-800 dark:text-gray-200">
-            {exerciseEntry.exercise_snapshot?.name || 'Unknown Exercise'}
-            {exerciseEntry.exercise_snapshot?.source === 'wger' && (
-              <span className="text-xs px-2 py-1 rounded-full bg-green-100 text-green-800">
-                Wger
-              </span>
-            )}
-            {exerciseEntry.exercise_snapshot?.source === 'free-exercise-db' && (
-              <span className="text-xs px-2 py-1 rounded-full bg-purple-100 text-purple-800">
-                Free Exercise DB
-              </span>
-            )}
-            {exerciseEntry.exercise_snapshot?.source === 'nutritionix' && (
-              <span className="text-xs px-2 py-1 rounded-full bg-yellow-100 text-yellow-800">
-                Nutritionix
-              </span>
-            )}
-            {exerciseEntry.exercise_snapshot?.is_custom &&
-              !exerciseEntry.exercise_snapshot?.source && (
-                <span className="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-800">
-                  Custom
-                </span>
-              )}
+    <div className="group flex gap-3 p-3 rounded-lg bg-white dark:bg-gray-800/80 border border-gray-100 dark:border-gray-700/60 hover:border-blue-200 dark:hover:border-blue-800 hover:shadow-sm transition-all duration-150">
+      {/* Optional thumbnail */}
+      {imageUrl && !imageError ? (
+        <Dialog>
+          <DialogTrigger asChild>
+            <button className="flex-shrink-0 w-12 h-12 rounded-lg overflow-hidden cursor-pointer ring-1 ring-gray-200 dark:ring-gray-700 hover:ring-blue-400 transition-all">
+              <img
+                src={imageUrl}
+                alt={snapshot?.name || 'Exercise'}
+                onError={() => setImageError(true)}
+                className="w-full h-full object-cover"
+              />
+            </button>
+          </DialogTrigger>
+          <DialogContent className="max-w-4xl">
+            <DialogHeader>
+              <DialogTitle>{snapshot?.name || 'Exercise Image'}</DialogTitle>
+              <DialogDescription>
+                Preview of the exercise image.
+              </DialogDescription>
+            </DialogHeader>
+            <img
+              src={imageUrl}
+              alt={snapshot?.name || 'Exercise'}
+              onError={() => setImageError(true)}
+              className="w-full h-auto object-contain"
+            />
+          </DialogContent>
+        </Dialog>
+      ) : (
+        <div
+          className={`flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${meta.bg}`}
+        >
+          <CategoryIcon className={`w-4 h-4 ${meta.color}`} />
+        </div>
+      )}
+
+      {/* Main content */}
+      <div className="flex-1 min-w-0">
+        {/* Name row */}
+        <div className="flex items-center gap-1.5 flex-wrap mb-1">
+          <span className="font-semibold text-sm text-gray-800 dark:text-gray-100 leading-tight">
+            {snapshot?.name || 'Unknown Exercise'}
           </span>
-          <div className="text-xs text-gray-500 dark:text-gray-400">
-            {exerciseEntry.exercise_snapshot?.name === 'Active Calories'
-              ? `${Math.round(convertEnergy(exerciseEntry.calories_burned || 0, 'kcal', energyUnit))} active ${getEnergyUnitString(energyUnit)}`
-              : `${formatMinutesToHHMM(exerciseEntry.sets && exerciseEntry.sets.length > 0 ? exerciseEntry.sets.reduce((sum, set) => sum + (set.duration || 0) + (set.rest_time || 0) / 60, 0) : exerciseEntry.duration_minutes || 0)} • ${Math.round(convertEnergy(exerciseEntry.calories_burned || 0, 'kcal', energyUnit))} ${getEnergyUnitString(energyUnit)}`}
-            {exerciseEntry.sets &&
-              Array.isArray(exerciseEntry.sets) &&
-              exerciseEntry.sets.length > 0 && (
+          {sourceBadge && (
+            <span
+              className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full ${sourceBadge.className}`}
+            >
+              {sourceBadge.label}
+            </span>
+          )}
+        </div>
+
+        {/* Stats row */}
+        <div className="flex items-center gap-2 flex-wrap text-xs text-gray-500 dark:text-gray-400 mb-1">
+          {isActiveCalories ? (
+            <span className="font-medium text-orange-600 dark:text-orange-400">
+              {caloriesDisplay} active
+            </span>
+          ) : (
+            <>
+              <span>{durationDisplay}</span>
+              <span className="text-gray-300 dark:text-gray-600">·</span>
+              <span className="text-orange-600 dark:text-orange-400 font-medium">
+                {caloriesDisplay}
+              </span>
+              {hasSets && (
                 <>
-                  {` • Sets: ${String(exerciseEntry.sets.length)}`}
-                  {exerciseEntry.sets.map((set, index) => (
-                    <span key={index}>
-                      {Number.isFinite(set.reps) &&
-                        ` • Reps: ${String(set.reps)}`}
-                      {set.weight &&
-                        Number.isFinite(set.weight) &&
-                        ` • Weight: ${formatWeight(set.weight, weightUnit)}`}
-                      {Number.isFinite(set.rpe) && ` • RPE: ${set.rpe}`}
-                    </span>
-                  ))}
+                  <span className="text-gray-300 dark:text-gray-600">·</span>
+                  <span>{exerciseEntry.sets!.length} sets</span>
                 </>
               )}
-            {exerciseEntry.exercise_snapshot?.level &&
-              ` • Level: ${exerciseEntry.exercise_snapshot.level}`}
-            {exerciseEntry.exercise_snapshot?.force &&
-              ` • Force: ${exerciseEntry.exercise_snapshot.force}`}
-            {exerciseEntry.exercise_snapshot?.mechanic &&
-              ` • Mechanic: ${exerciseEntry.exercise_snapshot.mechanic}`}
+            </>
+          )}
+        </div>
+
+        {/* Sets detail chips */}
+        {hasSets && (
+          <div className="flex flex-wrap gap-1 mb-1.5">
+            {exerciseEntry.sets!.map((set, index) => {
+              const parts: string[] = [];
+              if (Number.isFinite(set.reps)) parts.push(`${set.reps} reps`);
+              if (set.weight && Number.isFinite(set.weight))
+                parts.push(formatWeight(set.weight, weightUnit));
+              if (Number.isFinite(set.rpe)) parts.push(`RPE ${set.rpe}`);
+              if (parts.length === 0) return null;
+              return (
+                <span
+                  key={index}
+                  className="text-[10px] px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 font-medium"
+                >
+                  {index + 1}: {parts.join(' · ')}
+                </span>
+              );
+            })}
           </div>
-          {exerciseEntry.exercise_snapshot?.equipment &&
-            Array.isArray(exerciseEntry.exercise_snapshot.equipment) &&
-            exerciseEntry.exercise_snapshot.equipment.length > 0 && (
-              <div className="text-xs text-gray-400 dark:text-gray-500">
-                Equipment:{' '}
-                {exerciseEntry.exercise_snapshot.equipment.join(', ')}
-              </div>
-            )}
-          {exerciseEntry.exercise_snapshot?.primary_muscles &&
-            Array.isArray(exerciseEntry.exercise_snapshot.primary_muscles) &&
-            exerciseEntry.exercise_snapshot.primary_muscles.length > 0 && (
-              <div className="text-xs text-gray-400 dark:text-gray-500">
-                Primary Muscles:{' '}
-                {exerciseEntry.exercise_snapshot.primary_muscles.join(', ')}
-              </div>
-            )}
-          {exerciseEntry.exercise_snapshot?.secondary_muscles &&
-            Array.isArray(exerciseEntry.exercise_snapshot.secondary_muscles) &&
-            exerciseEntry.exercise_snapshot.secondary_muscles.length > 0 && (
-              <div className="text-xs text-gray-400 dark:text-gray-500">
-                Secondary Muscles:{' '}
-                {exerciseEntry.exercise_snapshot.secondary_muscles.join(', ')}
-              </div>
-            )}
-          {exerciseEntry.notes && (
-            <div className="text-xs text-gray-400 dark:text-gray-500">
-              {exerciseEntry.notes}
+        )}
+
+        {/* Meta pills: level / force / mechanic */}
+        {metaPills.length > 0 && (
+          <div className="flex items-center gap-1 flex-wrap mb-1">
+            {metaPills.map((pill) => (
+              <span
+                key={pill}
+                className="text-[10px] px-1.5 py-0.5 rounded-full border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 capitalize"
+              >
+                {pill}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Muscles */}
+        {snapshot?.primary_muscles && snapshot.primary_muscles.length > 0 && (
+          <div className="text-[10px] text-gray-400 dark:text-gray-500 leading-snug">
+            <span className="font-medium text-gray-500 dark:text-gray-400">
+              Primary:{' '}
+            </span>
+            {snapshot.primary_muscles.join(', ')}
+          </div>
+        )}
+        {snapshot?.secondary_muscles &&
+          snapshot.secondary_muscles.length > 0 && (
+            <div className="text-[10px] text-gray-400 dark:text-gray-500 leading-snug">
+              <span className="font-medium text-gray-500 dark:text-gray-400">
+                Secondary:{' '}
+              </span>
+              {snapshot.secondary_muscles.join(', ')}
             </div>
           )}
-          {/* Image Display Logic */}
-          {(() => {
-            const snapshot = exerciseEntry.exercise_snapshot;
-
-            const imageUrl = exerciseEntry.image_url
-              ? exerciseEntry.image_url
-              : snapshot?.images && snapshot.images.length > 0
-                ? exerciseEntry.source
-                  ? `/uploads/exercises/${snapshot.images[0]}`
-                  : snapshot.images[0]
-                : null;
-
-            if (!imageUrl) return null;
-
-            return (
-              <div className="mt-2">
-                <Dialog>
-                  <DialogTrigger asChild>
-                    <img
-                      src={imageUrl}
-                      alt={exerciseEntry.exercise_snapshot?.name || 'Exercise'}
-                      className="w-16 h-16 object-cover rounded cursor-pointer"
-                    />
-                  </DialogTrigger>
-                  <DialogContent className="max-w-4xl">
-                    <DialogHeader>
-                      <DialogTitle>
-                        {exerciseEntry.exercise_snapshot?.name ||
-                          'Exercise Image'}
-                      </DialogTitle>
-                      <DialogDescription>
-                        Preview of the exercise image.
-                      </DialogDescription>
-                    </DialogHeader>
-                    <img
-                      src={imageUrl}
-                      alt={exerciseEntry.exercise_snapshot?.name || 'Exercise'}
-                      className="w-full h-auto object-contain"
-                    />
-                  </DialogContent>
-                </Dialog>
-              </div>
-            );
-          })()}
-        </div>
-      </div>
-      <div className="flex items-center space-x-1">
-        {exerciseEntry.exercise_snapshot?.instructions &&
-          exerciseEntry.exercise_snapshot.instructions.length > 0 && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => {
-                      setExerciseToPlay(exerciseEntry.exercise_snapshot);
-                      setIsPlaybackModalOpen(true);
-                    }}
-                    className="h-8 w-8"
-                  >
-                    <Play className="w-4 h-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Play Instructions</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => handleEdit(exerciseEntry)}
-                className="h-8 w-8"
-              >
-                <Edit className="w-4 h-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Edit Entry</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-        {exerciseEntry.exercise_snapshot?.user_id === currentUserId && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() =>
-                    handleEditExerciseDatabase(exerciseEntry.exercise_id)
-                  }
-                  className="h-8 w-8"
-                >
-                  <Settings className="w-4 h-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Edit Exercise in Database</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+        {snapshot?.equipment && snapshot.equipment.length > 0 && (
+          <div className="text-[10px] text-gray-400 dark:text-gray-500 leading-snug">
+            <span className="font-medium text-gray-500 dark:text-gray-400">
+              Equipment:{' '}
+            </span>
+            {snapshot.equipment.join(', ')}
+          </div>
         )}
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={() => handleDelete(exerciseEntry.id)}
-                className="h-8 w-8 hover:bg-gray-200 dark:hover:bg-gray-800"
-              >
-                <Trash2 className="w-4 h-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>Delete Entry</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+        {exerciseEntry.notes && (
+          <div className="text-[10px] italic text-gray-400 dark:text-gray-500 mt-0.5">
+            {exerciseEntry.notes}
+          </div>
+        )}
+      </div>
+
+      {/* Action buttons — visible on hover or always on mobile */}
+      <div className="flex-shrink-0 flex items-center gap-0.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150 self-start pt-0.5">
+        {snapshot?.instructions && snapshot.instructions.length > 0 && (
+          <ActionButton
+            icon={<Play className="w-3.5 h-3.5" />}
+            label="Play Instructions"
+            onClick={() => {
+              setExerciseToPlay(snapshot);
+              setIsPlaybackModalOpen(true);
+            }}
+            colorClass="hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-950/50"
+          />
+        )}
+        <ActionButton
+          icon={<Edit className="w-3.5 h-3.5" />}
+          label="Edit Entry"
+          onClick={() => handleEdit(exerciseEntry)}
+          colorClass="hover:text-indigo-600 hover:bg-indigo-50 dark:hover:bg-indigo-950/50"
+        />
+        {snapshot?.user_id === currentUserId && (
+          <ActionButton
+            icon={<Settings className="w-3.5 h-3.5" />}
+            label="Edit Exercise in Database"
+            onClick={() =>
+              handleEditExerciseDatabase(exerciseEntry.exercise_id)
+            }
+            colorClass="hover:text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700"
+          />
+        )}
+        <ActionButton
+          icon={<Trash2 className="w-3.5 h-3.5" />}
+          label="Delete Entry"
+          onClick={() => handleDelete(exerciseEntry.id)}
+          colorClass="hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50"
+        />
       </div>
     </div>
   );
 };
+
+const ActionButton: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  colorClass: string;
+}> = ({ icon, label, onClick, colorClass }) => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClick}
+          className={`h-7 w-7 text-gray-400 transition-colors ${colorClass}`}
+        >
+          {icon}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{label}</p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
 
 export default ExerciseEntryDisplay;

--- a/SparkyFitnessFrontend/src/pages/Diary/ExercisePresetEntryDisplay.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/ExercisePresetEntryDisplay.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
   Tooltip,
@@ -9,7 +9,14 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { Trash2, ChevronDown, ChevronUp } from 'lucide-react';
+import {
+  Trash2,
+  ChevronDown,
+  Flame,
+  Clock,
+  Activity,
+  Layers,
+} from 'lucide-react';
 import ExerciseEntryDisplay from './ExerciseEntryDisplay';
 import { formatMinutesToHHMM } from '@/utils/timeFormatters';
 import { Exercise, ExerciseEntry, PresetSessionEntry } from '@/types/exercises';
@@ -17,8 +24,8 @@ import { Exercise, ExerciseEntry, PresetSessionEntry } from '@/types/exercises';
 interface ExercisePresetEntryDisplayProps {
   presetEntry: PresetSessionEntry;
   currentUserId: string | undefined;
-  handleDelete: (presetEntryId: string) => void; // This is for deleting the preset itself
-  handleDeleteExerciseEntry: (entryId: string) => void; // New prop for deleting individual exercise entries
+  handleDelete: (presetEntryId: string) => void;
+  handleDeleteExerciseEntry: (entryId: string) => void;
   handleEdit: (entry: ExerciseEntry) => void;
   handleEditExerciseDatabase: (exerciseId: string) => void;
   setExerciseToPlay: (exercise: Exercise | null) => void;
@@ -36,7 +43,7 @@ const ExercisePresetEntryDisplay: React.FC<ExercisePresetEntryDisplayProps> = ({
   presetEntry,
   currentUserId,
   handleDelete,
-  handleDeleteExerciseEntry, // Destructure the new prop
+  handleDeleteExerciseEntry,
   handleEdit,
   handleEditExerciseDatabase,
   setExerciseToPlay,
@@ -46,114 +53,108 @@ const ExercisePresetEntryDisplay: React.FC<ExercisePresetEntryDisplayProps> = ({
   getEnergyUnitString,
 }) => {
   const { t } = useTranslation();
-  const [isExpanded, setIsExpanded] = useState(false); // State to manage expansion
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const toggleExpansion = useCallback(() => {
     setIsExpanded((prev) => !prev);
   }, []);
 
+  const totalSets =
+    presetEntry.exercises?.reduce(
+      (sum, ex) => sum + (ex.sets?.length || 0),
+      0
+    ) ?? 0;
+
+  const totalMinutes =
+    presetEntry.exercises?.reduce(
+      (sum, ex) =>
+        sum +
+        (ex.sets && ex.sets.length > 0
+          ? ex.sets.reduce(
+              (s, set) => s + (set.duration || 0) + (set.rest_time || 0) / 60,
+              0
+            )
+          : ex.duration_minutes || 0),
+      0
+    ) ?? 0;
+
+  const avgHR = (() => {
+    const withHR =
+      presetEntry.exercises?.filter((ex) => ex.avg_heart_rate) ?? [];
+    return withHR.length > 0
+      ? Math.round(
+          withHR.reduce((sum, ex) => sum + (ex.avg_heart_rate || 0), 0) /
+            withHR.length
+        )
+      : 0;
+  })();
+
+  const totalCalories = Math.round(
+    convertEnergy(
+      presetEntry.exercises?.reduce(
+        (sum, ex) => sum + (ex.calories_burned || 0),
+        0
+      ) ?? 0,
+      'kcal',
+      energyUnit
+    )
+  );
+
+  const hasExercises =
+    presetEntry.exercises && presetEntry.exercises.length > 0;
+  const exerciseCount = presetEntry.exercises?.length ?? 0;
+
   return (
-    <Card
-      key={presetEntry.id}
-      className="bg-gray-50 dark:bg-gray-800 border-l-4 border-blue-500"
-    >
-      <CardHeader className="pb-2">
-        <CardTitle className="text-lg font-semibold flex flex-col sm:flex-row items-start sm:items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Button variant="ghost" size="icon" onClick={toggleExpansion}>
-              {isExpanded ? (
-                <ChevronUp className="h-4 w-4" />
-              ) : (
-                <ChevronDown className="h-4 w-4" />
-              )}
-            </Button>
-            <div className="flex flex-col">
-              <span>
-                {presetEntry.name ||
-                  t('exerciseCard.workoutPreset', 'Workout Preset')}
+    <Card className="overflow-hidden border-0 shadow-md bg-white dark:bg-gray-900 rounded-xl">
+      {/* Accent bar + header */}
+      <div className="flex">
+        {/* Left accent stripe */}
+        <div className="w-1 flex-shrink-0 bg-gradient-to-b from-blue-500 to-indigo-600 rounded-l-xl" />
+
+        <div className="flex-1 min-w-0">
+          {/* Header row */}
+          <div className="flex items-center justify-between gap-2 px-4 pt-4 pb-3">
+            {/* Left: toggle + name */}
+            <button
+              onClick={toggleExpansion}
+              className="flex items-center gap-3 min-w-0 flex-1 text-left group"
+              aria-expanded={isExpanded}
+            >
+              <span
+                className={`flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-full border-2 transition-all duration-200
+                  ${
+                    isExpanded
+                      ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-600 dark:text-blue-400'
+                      : 'border-gray-200 dark:border-gray-700 text-gray-400 group-hover:border-blue-400 group-hover:text-blue-500'
+                  }`}
+              >
+                <ChevronDown
+                  className={`w-3.5 h-3.5 transition-transform duration-300 ${isExpanded ? 'rotate-180' : ''}`}
+                />
               </span>
-              {presetEntry.exercise_snapshot?.category && (
-                <p className="text-gray-500 text-[0.65rem] uppercase">
-                  {presetEntry.exercise_snapshot.category}
-                </p>
-              )}
-            </div>
-          </div>
-          <div className="flex items-center space-x-1">
-            {presetEntry.exercises && presetEntry.exercises.length > 0 && (
-              <>
-                <div className="text-center">
-                  <div className="font-bold text-gray-900 dark:text-gray-100 text-sm">
-                    {presetEntry.exercises.reduce(
-                      (sum, ex) => sum + (ex.sets?.length || 0),
-                      0
-                    )}
-                  </div>
-                  <div className="text-xs text-gray-500">
-                    {t('common.totalSets', 'Total Sets')}
-                  </div>
+
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="font-semibold text-gray-900 dark:text-gray-50 text-base leading-tight truncate">
+                    {presetEntry.name ||
+                      t('exerciseCard.workoutPreset', 'Workout Preset')}
+                  </span>
+                  {exerciseCount > 0 && (
+                    <span className="flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300">
+                      {exerciseCount}{' '}
+                      {exerciseCount === 1 ? 'exercise' : 'exercises'}
+                    </span>
+                  )}
                 </div>
-                <div className="text-center">
-                  <div className="font-bold text-gray-900 dark:text-gray-100 text-sm">
-                    {formatMinutesToHHMM(
-                      presetEntry.exercises.reduce(
-                        (sum, ex) =>
-                          sum +
-                          (ex.sets && ex.sets.length > 0
-                            ? ex.sets.reduce(
-                                (setSum, set) =>
-                                  setSum +
-                                  (set.duration || 0) +
-                                  (set.rest_time || 0) / 60,
-                                0
-                              )
-                            : ex.duration_minutes || 0),
-                        0
-                      )
-                    )}
-                  </div>
-                  <div className="text-xs text-gray-500">
-                    {t('common.minutesUnit', 'Min')}
-                  </div>
-                </div>
-                <div className="text-center">
-                  <div className="font-bold text-gray-900 dark:text-gray-100 text-sm">
-                    {presetEntry.exercises.filter((ex) => ex.avg_heart_rate)
-                      .length > 0
-                      ? Math.round(
-                          presetEntry.exercises.reduce(
-                            (sum, ex) => sum + (ex.avg_heart_rate || 0),
-                            0
-                          ) /
-                            presetEntry.exercises.filter(
-                              (ex) => ex.avg_heart_rate
-                            ).length
-                        )
-                      : 0}
-                  </div>
-                  <div className="text-xs text-gray-500">
-                    {t('common.avgHrUnit', 'Avg HR')}
-                  </div>
-                </div>
-                <div className="text-center">
-                  <div className="font-bold text-gray-900 dark:text-gray-100 text-sm">
-                    {Math.round(
-                      convertEnergy(
-                        presetEntry.exercises.reduce(
-                          (sum, ex) => sum + (ex.calories_burned || 0),
-                          0
-                        ),
-                        'kcal',
-                        energyUnit
-                      )
-                    )}
-                  </div>
-                  <div className="text-xs text-gray-500">
-                    {t('common.caloriesUnit', getEnergyUnitString(energyUnit))}
-                  </div>
-                </div>
-              </>
-            )}
+                {presetEntry.exercise_snapshot?.category && (
+                  <p className="text-[10px] font-medium uppercase tracking-widest text-gray-400 dark:text-gray-500 mt-0.5">
+                    {presetEntry.exercise_snapshot.category}
+                  </p>
+                )}
+              </div>
+            </button>
+
+            {/* Right: delete */}
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -161,9 +162,9 @@ const ExercisePresetEntryDisplay: React.FC<ExercisePresetEntryDisplayProps> = ({
                     variant="ghost"
                     size="icon"
                     onClick={() => handleDelete(presetEntry.id)}
-                    className="h-8 w-8 hover:bg-gray-200 dark:hover:bg-gray-800"
+                    className="flex-shrink-0 h-8 w-8 text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50 transition-colors"
                   >
-                    <Trash2 className="w-4 h-4" />
+                    <Trash2 className="w-3.5 h-3.5" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
@@ -174,48 +175,108 @@ const ExercisePresetEntryDisplay: React.FC<ExercisePresetEntryDisplayProps> = ({
               </Tooltip>
             </TooltipProvider>
           </div>
-        </CardTitle>
-        {presetEntry.description && (
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            {presetEntry.description}
-          </p>
-        )}
-        {presetEntry.notes && (
-          <p className="text-sm text-gray-600 dark:text-gray-400">
-            Notes: {presetEntry.notes}
-          </p>
-        )}
-      </CardHeader>
-      {isExpanded && (
-        <CardContent className="space-y-3 pt-2">
-          {presetEntry.exercises && presetEntry.exercises.length > 0 ? (
-            presetEntry.exercises.map((exerciseEntry) => (
-              <ExerciseEntryDisplay
-                key={exerciseEntry.id}
-                exerciseEntry={exerciseEntry}
-                currentUserId={currentUserId}
-                handleEdit={handleEdit}
-                handleDelete={handleDeleteExerciseEntry}
-                handleEditExerciseDatabase={handleEditExerciseDatabase}
-                setExerciseToPlay={setExerciseToPlay}
-                setIsPlaybackModalOpen={setIsPlaybackModalOpen}
-                energyUnit={energyUnit}
-                convertEnergy={convertEnergy}
-                getEnergyUnitString={getEnergyUnitString}
-              />
-            ))
-          ) : (
-            <p className="text-sm text-gray-500 dark:text-gray-400">
-              {t(
-                'exerciseCard.noExercisesInPreset',
-                'No exercises in this preset.'
+
+          {/* Description / notes */}
+          {(presetEntry.description || presetEntry.notes) && (
+            <div className="px-4 pb-2 space-y-0.5">
+              {presetEntry.description && (
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  {presetEntry.description}
+                </p>
               )}
-            </p>
+              {presetEntry.notes && (
+                <p className="text-xs text-gray-400 dark:text-gray-500 italic">
+                  {presetEntry.notes}
+                </p>
+              )}
+            </div>
           )}
+
+          {/* Stats strip */}
+          {hasExercises && (
+            <div className="mx-4 mb-4 mt-1 grid grid-cols-4 divide-x divide-gray-100 dark:divide-gray-800 bg-gray-50 dark:bg-gray-800/60 rounded-lg overflow-hidden">
+              <StatCell
+                icon={<Layers className="w-3 h-3" />}
+                value={String(totalSets)}
+                label={t('common.totalSets', 'Sets')}
+                color="text-blue-600 dark:text-blue-400"
+              />
+              <StatCell
+                icon={<Clock className="w-3 h-3" />}
+                value={formatMinutesToHHMM(totalMinutes)}
+                label={t('common.minutesUnit', 'Time')}
+                color="text-indigo-600 dark:text-indigo-400"
+              />
+              <StatCell
+                icon={<Activity className="w-3 h-3" />}
+                value={avgHR > 0 ? String(avgHR) : '—'}
+                label={t('common.avgHrUnit', 'Avg HR')}
+                color="text-rose-500 dark:text-rose-400"
+              />
+              <StatCell
+                icon={<Flame className="w-3 h-3" />}
+                value={String(totalCalories)}
+                label={getEnergyUnitString(energyUnit)}
+                color="text-orange-500 dark:text-orange-400"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded exercise list */}
+      {isExpanded && (
+        <CardContent className="px-4 pb-4 pt-0 space-y-2 border-t border-gray-100 dark:border-gray-800">
+          <div className="pt-3 space-y-2">
+            {hasExercises ? (
+              presetEntry.exercises!.map((exerciseEntry) => (
+                <ExerciseEntryDisplay
+                  key={exerciseEntry.id}
+                  exerciseEntry={exerciseEntry}
+                  currentUserId={currentUserId}
+                  handleEdit={handleEdit}
+                  handleDelete={handleDeleteExerciseEntry}
+                  handleEditExerciseDatabase={handleEditExerciseDatabase}
+                  setExerciseToPlay={setExerciseToPlay}
+                  setIsPlaybackModalOpen={setIsPlaybackModalOpen}
+                  energyUnit={energyUnit}
+                  convertEnergy={convertEnergy}
+                  getEnergyUnitString={getEnergyUnitString}
+                />
+              ))
+            ) : (
+              <p className="text-sm text-center text-gray-400 dark:text-gray-500 py-4">
+                {t(
+                  'exerciseCard.noExercisesInPreset',
+                  'No exercises in this preset.'
+                )}
+              </p>
+            )}
+          </div>
         </CardContent>
       )}
     </Card>
   );
 };
+
+// Small reusable stat cell
+const StatCell: React.FC<{
+  icon: React.ReactNode;
+  value: string;
+  label: string;
+  color: string;
+}> = ({ icon, value, label, color }) => (
+  <div className="flex flex-col items-center justify-center py-2.5 px-1 gap-0.5">
+    <span className={`${color} flex items-center gap-1`}>
+      {icon}
+      <span className="font-bold text-sm text-gray-800 dark:text-gray-100">
+        {value}
+      </span>
+    </span>
+    <span className="text-[10px] text-gray-400 dark:text-gray-500 uppercase tracking-wide font-medium">
+      {label}
+    </span>
+  </div>
+);
 
 export default ExercisePresetEntryDisplay;

--- a/SparkyFitnessFrontend/src/pages/Exercises/AddCustomExerciseForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/AddCustomExerciseForm.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/select';
 import { XCircle } from 'lucide-react';
 import type { useAddCustomExerciseForm } from '@/hooks/Exercises/useAddCustomExerciseForm';
+import { EXERCISE_CATEGORIES } from '@/constants/exercises';
 
 interface AddCustomExerciseFormProps {
   form: ReturnType<typeof useAddCustomExerciseForm>;
@@ -90,18 +91,11 @@ export default function AddCustomExerciseForm({
             />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="general">
-              {t('exercise.addExerciseDialog.categoryGeneral', 'General')}
-            </SelectItem>
-            <SelectItem value="strength">
-              {t('exercise.addExerciseDialog.categoryStrength', 'Strength')}
-            </SelectItem>
-            <SelectItem value="cardio">
-              {t('exercise.addExerciseDialog.categoryCardio', 'Cardio')}
-            </SelectItem>
-            <SelectItem value="yoga">
-              {t('exercise.addExerciseDialog.categoryYoga', 'Yoga')}
-            </SelectItem>
+            {EXERCISE_CATEGORIES.map(({ value, labelKey, defaultLabel }) => (
+              <SelectItem key={value} value={value}>
+                {t(labelKey, defaultLabel)}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>

--- a/SparkyFitnessFrontend/src/pages/Exercises/ExerciseListItem.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/ExerciseListItem.tsx
@@ -1,16 +1,28 @@
-// pages/Exercises/ExerciseListItem.tsx
+import type React from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { Edit, Trash2, Share2, Users, Lock } from 'lucide-react';
 import { getEnergyUnitString } from '@/utils/nutritionCalculations';
 import type { Exercise as ExerciseInterface } from '@/types/exercises';
+import {
+  EXERCISE_CATEGORY_META,
+  ExerciseCategory,
+} from '@/constants/exercises';
 
 interface ExerciseListItemProps {
   exercise: ExerciseInterface;
@@ -36,205 +48,190 @@ export default function ExerciseListItem({
   onToggleShare,
 }: ExerciseListItemProps) {
   const { t } = useTranslation();
+  const [imageError, setImageError] = useState(false);
   const isOwned = exercise.user_id === userId;
 
+  const imageUrl =
+    exercise.images && exercise.images.length > 0
+      ? exercise.source
+        ? `/uploads/exercises/${exercise.images[0]}`
+        : exercise.images[0]
+      : null;
+
+  const meta =
+    EXERCISE_CATEGORY_META[exercise.category as ExerciseCategory] ??
+    EXERCISE_CATEGORY_META['general'];
+  const CategoryIcon = meta.icon;
+
+  const metaPills: string[] = [];
+  if (exercise.level) metaPills.push(exercise.level);
+  if (exercise.force) metaPills.push(exercise.force);
+  if (exercise.mechanic) metaPills.push(exercise.mechanic);
+
+  const caloriesPerHour = Math.round(
+    convertEnergy(exercise.calories_per_hour ?? 0, 'kcal', energyUnit)
+  );
+
   return (
-    <div className="flex items-center justify-between p-4 border rounded-lg">
-      {/* Details */}
-      <div className="flex-1">
-        <div className="flex items-center gap-2 mb-1">
-          <h4 className="font-medium">{exercise.name}</h4>
-          {exercise.tags?.map((tag) => (
-            <Badge key={tag} variant="outline" className="text-xs">
-              {tag === 'public' && <Share2 className="h-3 w-3 mr-1" />}
-              {tag === 'family' && <Users className="h-3 w-3 mr-1" />}
-              {tag.charAt(0).toUpperCase() + tag.slice(1)}
-            </Badge>
-          ))}
+    <div className="group flex gap-3 p-3 rounded-lg bg-white dark:bg-gray-800/80 border border-gray-100 dark:border-gray-700/60 hover:border-blue-200 dark:hover:border-blue-800 hover:shadow-sm transition-all duration-150">
+      {imageUrl && !imageError ? (
+        <Dialog>
+          <DialogTrigger asChild>
+            <button className="flex-shrink-0 w-12 h-12 rounded-lg overflow-hidden cursor-pointer ring-1 ring-gray-200 dark:ring-gray-700 hover:ring-blue-400 transition-all">
+              <img
+                src={imageUrl}
+                alt={exercise.name}
+                onError={() => setImageError(true)}
+                className="w-full h-full object-cover"
+              />
+            </button>
+          </DialogTrigger>
+          <DialogContent className="max-w-4xl">
+            <DialogHeader>
+              <DialogTitle>{exercise.name}</DialogTitle>
+              <DialogDescription>Exercise image preview</DialogDescription>
+            </DialogHeader>
+            <img
+              src={imageUrl}
+              alt={exercise.name}
+              className="w-full h-auto object-contain"
+            />
+          </DialogContent>
+        </Dialog>
+      ) : (
+        <div
+          className={`flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${meta.bg}`}
+        >
+          <CategoryIcon className={`w-4 h-4 ${meta.color}`} />
+        </div>
+      )}
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 flex-wrap mb-1">
+          <span className="font-semibold text-sm text-gray-800 dark:text-gray-100 leading-tight">
+            {exercise.name}
+          </span>
+          {exercise.tags
+            ?.filter(
+              (tag) => !(tag === 'private' && exercise.tags?.includes('public'))
+            )
+            .map((tag) => (
+              <span
+                key={tag}
+                className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 flex items-center gap-1"
+              >
+                {tag === 'public' && <Share2 className="w-2.5 h-2.5" />}
+                {tag === 'family' && <Users className="w-2.5 h-2.5" />}
+                {tag}
+              </span>
+            ))}
         </div>
 
-        <div className="text-sm text-gray-600 mb-1">
-          {exercise.category}
-          {exercise.level &&
-            ` • ${t('exercise.databaseManager.levelDisplay', { level: exercise.level, defaultValue: `Level: ${exercise.level}` })}`}
-          {exercise.force &&
-            ` • ${t('exercise.databaseManager.forceDisplay', { force: exercise.force, defaultValue: `Force: ${exercise.force}` })}`}
-          {exercise.mechanic &&
-            ` • ${t('exercise.databaseManager.mechanicDisplay', { mechanic: exercise.mechanic, defaultValue: `Mechanic: ${exercise.mechanic}` })}`}
+        <div className="flex items-center gap-2 flex-wrap text-xs text-gray-500 dark:text-gray-400 mb-1">
+          <span className="font-medium text-blue-600 dark:text-blue-400">
+            {exercise.category}
+          </span>
+          <span className="text-gray-300 dark:text-gray-600">·</span>
+          <span className="text-orange-600 dark:text-orange-400 font-medium">
+            {caloriesPerHour} {getEnergyUnitString(energyUnit)}/h
+          </span>
         </div>
 
-        {Array.isArray(exercise.equipment) && exercise.equipment.length > 0 && (
-          <div className="text-xs text-gray-400">
-            {t('exercise.databaseManager.equipmentDisplay', {
-              equipment: exercise.equipment.join(', '),
-              defaultValue: `Equipment: ${exercise.equipment.join(', ')}`,
-            })}
+        {metaPills.length > 0 && (
+          <div className="flex items-center gap-1 flex-wrap mb-1.5">
+            {metaPills.map((pill) => (
+              <span
+                key={pill}
+                className="text-[10px] px-1.5 py-0.5 rounded-full border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 capitalize"
+              >
+                {pill}
+              </span>
+            ))}
           </div>
         )}
 
-        {Array.isArray(exercise.primary_muscles) &&
-          exercise.primary_muscles.length > 0 && (
-            <div className="text-xs text-gray-400">
-              {t('exercise.databaseManager.primaryMusclesDisplay', {
-                primaryMuscles: exercise.primary_muscles.join(', '),
-                defaultValue: `Primary Muscles: ${exercise.primary_muscles.join(', ')}`,
-              })}
+        <div className="space-y-0.5">
+          {exercise.primary_muscles && exercise.primary_muscles.length > 0 && (
+            <div className="text-[10px] text-gray-400 dark:text-gray-500 leading-snug">
+              <span className="font-medium text-gray-500 dark:text-gray-400">
+                Primary:{' '}
+              </span>
+              {exercise.primary_muscles.join(', ')}
             </div>
           )}
-
-        {Array.isArray(exercise.secondary_muscles) &&
-          exercise.secondary_muscles.length > 0 && (
-            <div className="text-xs text-gray-400">
-              {t('exercise.databaseManager.secondaryMusclesDisplay', {
-                secondaryMuscles: exercise.secondary_muscles.join(', '),
-                defaultValue: `Secondary Muscles: ${exercise.secondary_muscles.join(', ')}`,
-              })}
+          {exercise.equipment && exercise.equipment.length > 0 && (
+            <div className="text-[10px] text-gray-400 dark:text-gray-500 leading-snug">
+              <span className="font-medium text-gray-500 dark:text-gray-400">
+                Equipment:{' '}
+              </span>
+              {exercise.equipment.join(', ')}
             </div>
           )}
-
-        {Array.isArray(exercise.instructions) &&
-          exercise.instructions.length > 0 && (
-            <div className="text-xs text-gray-400">
-              {t('exercise.databaseManager.instructionsDisplay', {
-                instruction: exercise.instructions[0],
-                defaultValue: `Instructions: ${exercise.instructions[0]}`,
-              })}
-              ...
-            </div>
-          )}
-
-        <div className="text-sm text-gray-500">
-          {t('exercise.databaseManager.caloriesPerHourDisplay', {
-            caloriesPerHour: Math.round(
-              convertEnergy(exercise.calories_per_hour ?? 0, 'kcal', energyUnit)
-            ),
-            energyUnit: getEnergyUnitString(energyUnit),
-            defaultValue: `Calories/Hour: ${Math.round(convertEnergy(exercise.calories_per_hour ?? 0, 'kcal', energyUnit))} ${getEnergyUnitString(energyUnit)}`,
-          })}
         </div>
-
-        {exercise.description && (
-          <div className="text-sm text-gray-400 mt-1">
-            {exercise.description}
-          </div>
-        )}
-
-        {exercise.images && exercise.images.length > 0 && (
-          <img
-            src={
-              exercise.source
-                ? `/uploads/exercises/${exercise.images[0]}`
-                : exercise.images[0]
-            }
-            alt={exercise.name}
-            className="w-16 h-16 object-contain mt-2"
-          />
-        )}
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center space-x-1">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                disabled={!isOwned}
-                onClick={() =>
-                  onToggleShare(
-                    exercise.id,
-                    exercise.shared_with_public ?? false
-                  )
-                }
-              >
-                {exercise.shared_with_public ? (
-                  <Share2 className="w-4 h-4" />
-                ) : (
-                  <Lock className="w-4 h-4" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>
-                {isOwned
-                  ? exercise.shared_with_public
-                    ? t(
-                        'exercise.databaseManager.makePrivateTooltip',
-                        'Make private'
-                      )
-                    : t(
-                        'exercise.databaseManager.shareWithPublicTooltip',
-                        'Share with public'
-                      )
-                  : t(
-                      'exercise.databaseManager.notEditableTooltip',
-                      'Not editable'
-                    )}
-              </p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8"
-                disabled={!isOwned}
-                onClick={() => onEdit(exercise)}
-              >
-                <Edit className="w-4 h-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>
-                {isOwned
-                  ? t(
-                      'exercise.databaseManager.editExerciseTooltip',
-                      'Edit exercise'
-                    )
-                  : t(
-                      'exercise.databaseManager.notEditableTooltip',
-                      'Not editable'
-                    )}
-              </p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 hover:bg-gray-200 dark:hover:bg-gray-800"
-                disabled={!isOwned}
-                onClick={() => onDelete(exercise)}
-              >
-                <Trash2 className="w-4 h-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>
-                {isOwned
-                  ? t(
-                      'exercise.databaseManager.deleteExerciseTooltip',
-                      'Delete exercise'
-                    )
-                  : t(
-                      'exercise.databaseManager.notEditableTooltip',
-                      'Not editable'
-                    )}
-              </p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
+      <div className="flex-shrink-0 flex items-center gap-0.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity duration-150 self-start pt-0.5">
+        <ActionButton
+          icon={
+            exercise.shared_with_public ? (
+              <Share2 className="w-3.5 h-3.5" />
+            ) : (
+              <Lock className="w-3.5 h-3.5" />
+            )
+          }
+          label={
+            exercise.shared_with_public
+              ? t('exercise.databaseManager.makePrivateTooltip')
+              : t('exercise.databaseManager.shareWithPublicTooltip')
+          }
+          disabled={!isOwned}
+          onClick={() =>
+            onToggleShare(exercise.id, exercise.shared_with_public ?? false)
+          }
+          colorClass="hover:text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-950/50"
+        />
+        <ActionButton
+          icon={<Edit className="w-3.5 h-3.5" />}
+          label={t('exercise.databaseManager.editExerciseTooltip')}
+          disabled={!isOwned}
+          onClick={() => onEdit(exercise)}
+          colorClass="hover:text-indigo-600 hover:bg-indigo-50 dark:hover:bg-indigo-950/50"
+        />
+        <ActionButton
+          icon={<Trash2 className="w-3.5 h-3.5" />}
+          label={t('exercise.databaseManager.deleteExerciseTooltip')}
+          disabled={!isOwned}
+          onClick={() => onDelete(exercise)}
+          colorClass="hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50"
+        />
       </div>
     </div>
   );
 }
+
+const ActionButton: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  colorClass: string;
+  disabled?: boolean;
+}> = ({ icon, label, onClick, colorClass, disabled }) => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          disabled={disabled}
+          onClick={onClick}
+          className={`h-7 w-7 text-gray-400 transition-colors ${colorClass}`}
+        >
+          {icon}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{label}</p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);

--- a/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearch.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearch.tsx
@@ -8,7 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Plus, Loader2, Search } from 'lucide-react';
+import { Plus, Loader2, Search, Clock, TrendingUp } from 'lucide-react';
 import BodyMapFilter from './BodyMapFilter';
 
 import { Exercise } from '@/types/exercises';
@@ -63,6 +63,11 @@ const ExerciseSearch = ({
     initialSearchSource,
   });
 
+  const triggerSearch = () => {
+    handleSearch(searchTerm);
+    if (searchSource === 'external') setHasSearchedExternal(true);
+  };
+
   const renderExerciseList = (
     list: Exercise[],
     type: 'internal' | 'external',
@@ -89,120 +94,167 @@ const ExerciseSearch = ({
       />
     ));
 
-  return (
-    <div className="space-y-4">
-      <div className="mt-4 space-y-4">
-        {searchSource === 'external' && (
-          <Select
-            value={selectedProviderId ? String(selectedProviderId) : ''}
-            onValueChange={(value) => {
-              setSelectedProviderId(value);
-              setSelectedProviderType(
-                providers.find((p) => String(p.id) === value)?.provider_type ||
-                  null
-              );
-            }}
-          >
-            <SelectTrigger className="w-full mb-2">
-              <SelectValue placeholder="Select a provider" />
-            </SelectTrigger>
-            <SelectContent>
-              {providers.map((p) => (
-                <SelectItem key={p.id} value={String(p.id)}>
-                  {p.provider_name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
+  const isSearching = searchTerm.trim().length > 0;
+  const showRecent =
+    searchSource === 'internal' &&
+    !isSearching &&
+    !loading &&
+    recentExercises.length > 0;
+  const showTop =
+    searchSource === 'internal' &&
+    !isSearching &&
+    !loading &&
+    topExercises.length > 0;
+  const showInternalResults =
+    searchSource === 'internal' && isSearching && !loading;
+  const showExternalResults =
+    searchSource === 'external' &&
+    hasSearchedExternal &&
+    !loading &&
+    exercises.length > 0;
 
-        <div className="flex space-x-2 items-center">
+  return (
+    <div className="space-y-4 pt-2">
+      {/* Provider selector (external only) */}
+      {searchSource === 'external' && (
+        <Select
+          value={selectedProviderId ? String(selectedProviderId) : ''}
+          onValueChange={(value) => {
+            setSelectedProviderId(value);
+            setSelectedProviderType(
+              providers.find((p) => String(p.id) === value)?.provider_type ||
+                null
+            );
+          }}
+        >
+          <SelectTrigger className="w-full h-9 text-sm border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900">
+            <SelectValue placeholder="Select a provider" />
+          </SelectTrigger>
+          <SelectContent>
+            {providers.map((p) => (
+              <SelectItem key={p.id} value={String(p.id)}>
+                {p.provider_name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      {/* Search bar */}
+      <div className="flex gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
           <Input
             type="text"
-            placeholder="Search..."
+            placeholder={t(
+              'exercise.exerciseSearch.placeholder',
+              'Search exercises…'
+            )}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                handleSearch(searchTerm);
-                if (searchSource === 'external') setHasSearchedExternal(true);
-              }
+              if (e.key === 'Enter') triggerSearch();
             }}
-            className="flex-1"
+            className="pl-9 h-10 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 focus-visible:ring-blue-500"
           />
-          <Button
-            onClick={() => {
-              handleSearch(searchTerm);
-              if (searchSource === 'external') setHasSearchedExternal(true);
-            }}
-            disabled={loading}
-          >
-            {loading ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
-            ) : (
-              <Search className="w-4 h-4" />
-            )}
-          </Button>
         </div>
+        <Button
+          onClick={triggerSearch}
+          disabled={loading}
+          className="h-10 px-4 bg-blue-600 hover:bg-blue-700 text-white shrink-0"
+        >
+          {loading ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <Search className="w-4 h-4" />
+          )}
+        </Button>
+      </div>
 
-        <div className="flex flex-wrap gap-2">
+      {/* Equipment filter chips */}
+      {availableEquipment.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
           {availableEquipment.map((eq) => (
-            <Button
+            <button
               key={eq}
-              variant={equipmentFilter.includes(eq) ? 'default' : 'outline'}
               onClick={() => handleEquipmentToggle(eq)}
+              className={`text-xs px-2.5 py-1 rounded-full border font-medium transition-colors capitalize
+                ${
+                  equipmentFilter.includes(eq)
+                    ? 'bg-blue-600 border-blue-600 text-white'
+                    : 'bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-400 hover:border-blue-400 hover:text-blue-600'
+                }`}
             >
               {eq}
-            </Button>
+            </button>
           ))}
         </div>
+      )}
 
-        <BodyMapFilter
-          selectedMuscles={muscleGroupFilter}
-          onMuscleToggle={handleMuscleToggle}
-          availableMuscleGroups={availableMuscleGroups}
-        />
+      {/* Body map */}
+      <BodyMapFilter
+        selectedMuscles={muscleGroupFilter}
+        onMuscleToggle={handleMuscleToggle}
+        availableMuscleGroups={availableMuscleGroups}
+      />
 
-        {loading && <div>Searching...</div>}
+      {/* Loading state */}
+      {loading && (
+        <div className="flex items-center justify-center gap-2 py-6 text-sm text-gray-400">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <span>{t('exercise.exerciseSearch.searching', 'Searching…')}</span>
+        </div>
+      )}
 
-        {searchSource === 'internal' &&
-          searchTerm.trim().length === 0 &&
-          !loading && (
-            <>
-              {recentExercises.length > 0 && (
-                <div className="max-h-40 overflow-y-auto space-y-2 border-b pb-4 mb-4">
-                  {renderExerciseList(recentExercises, 'internal')}
-                </div>
-              )}
-              {topExercises.length > 0 && (
-                <div className="max-h-40 overflow-y-auto space-y-2">
-                  {renderExerciseList(topExercises, 'internal')}
-                </div>
-              )}
-            </>
+      {/* Recent exercises */}
+      {showRecent && (
+        <section className="space-y-1.5">
+          <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500 px-0.5">
+            <Clock className="w-3 h-3" />
+            {t('exercise.exerciseSearch.recent', 'Recent')}
+          </div>
+          <div className="space-y-1.5 max-h-48 overflow-y-auto pr-0.5">
+            {renderExerciseList(recentExercises, 'internal')}
+          </div>
+        </section>
+      )}
+
+      {/* Top exercises */}
+      {showTop && (
+        <section className="space-y-1.5">
+          <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-widest text-gray-400 dark:text-gray-500 px-0.5">
+            <TrendingUp className="w-3 h-3" />
+            {t('exercise.exerciseSearch.popular', 'Most Used')}
+          </div>
+          <div className="space-y-1.5 max-h-48 overflow-y-auto pr-0.5">
+            {renderExerciseList(topExercises, 'internal')}
+          </div>
+        </section>
+      )}
+
+      {/* Internal search results */}
+      {showInternalResults && (
+        <div className="space-y-1.5 max-h-64 overflow-y-auto pr-0.5">
+          {exercises.length > 0 ? (
+            renderExerciseList(exercises, 'internal')
+          ) : (
+            <p className="text-sm text-center text-gray-400 py-6">
+              {t('exercise.exerciseSearch.noResults', 'No exercises found.')}
+            </p>
           )}
+        </div>
+      )}
 
-        {searchSource === 'internal' &&
-          searchTerm.trim().length > 0 &&
-          !loading && (
-            <div className="max-h-60 overflow-y-auto space-y-2">
-              {renderExerciseList(exercises, 'internal')}
-            </div>
+      {/* External search results */}
+      {showExternalResults && (
+        <div className="space-y-1.5 max-h-64 overflow-y-auto pr-0.5">
+          {renderExerciseList(
+            exercises,
+            'external',
+            selectedProviderType !== 'nutritionix'
           )}
-
-        {searchSource === 'external' &&
-          hasSearchedExternal &&
-          !loading &&
-          exercises.length > 0 && (
-            <div className="max-h-60 overflow-y-auto space-y-2">
-              {renderExerciseList(
-                exercises,
-                'external',
-                selectedProviderType !== 'nutritionix'
-              )}
-            </div>
-          )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearchListItem.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearchListItem.tsx
@@ -1,5 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { EXERCISE_CATEGORY_META } from '@/constants/exercises';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { Exercise } from '@/types/exercises';
 import { getEnergyUnitString } from '@/utils/nutritionCalculations';
@@ -12,12 +13,32 @@ import {
 } from 'lucide-react';
 import { ElementType, useState } from 'react';
 
+type ExerciseCategory = keyof typeof EXERCISE_CATEGORY_META;
+
 interface ExerciseListItemProps {
   exercise: Exercise;
   onAction: (exercise: Exercise) => void | Promise<void>;
   actionText: string;
   actionIcon?: ElementType;
 }
+
+const SOURCE_BADGES: Record<string, { label: string; className: string }> = {
+  wger: {
+    label: 'Wger',
+    className:
+      'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300',
+  },
+  'free-exercise-db': {
+    label: 'Free DB',
+    className:
+      'bg-violet-100 text-violet-800 dark:bg-violet-900/40 dark:text-violet-300',
+  },
+  nutritionix: {
+    label: 'Nutritionix',
+    className:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300',
+  },
+};
 
 export const ExerciseSearchListItem = ({
   exercise,
@@ -26,8 +47,9 @@ export const ExerciseSearchListItem = ({
   actionIcon: ActionIcon,
 }: ExerciseListItemProps) => {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
-
+  const [isActioning, setIsActioning] = useState(false);
   const { energyUnit, convertEnergy } = usePreferences();
+  const [imageError, setImageError] = useState(false);
   const handleNextImage = () =>
     setCurrentImageIndex((prev) => (prev + 1) % (exercise.images?.length || 1));
   const handlePrevImage = () =>
@@ -46,109 +68,197 @@ export const ExerciseSearchListItem = ({
     }
   };
 
+  const handleAction = async () => {
+    setIsActioning(true);
+    try {
+      await onAction(exercise);
+    } finally {
+      setIsActioning(false);
+    }
+  };
+
+  const meta =
+    EXERCISE_CATEGORY_META[exercise.category as ExerciseCategory] ??
+    EXERCISE_CATEGORY_META['general'];
+  const CategoryIcon = meta.icon;
+
+  const sourceBadge = exercise.source ? SOURCE_BADGES[exercise.source] : null;
+
+  const metaPills: string[] = [];
+  if (exercise.level) metaPills.push(exercise.level);
+  if (exercise.force) metaPills.push(exercise.force);
+  if (exercise.mechanic) metaPills.push(exercise.mechanic);
+
+  const hasImage =
+    exercise.images && exercise.images.some((img) => img.trim() !== '[]');
+  const showFallback = !hasImage || imageError;
+
   return (
-    <div className="flex items-center justify-between p-3 border rounded-lg">
-      <div>
-        <div className="font-medium flex items-center gap-2">
-          {exercise.name}
+    <div className="group flex gap-3 p-3 rounded-lg bg-white dark:bg-gray-800/80 border border-gray-100 dark:border-gray-700/60 hover:border-blue-200 dark:hover:border-blue-800 hover:shadow-sm transition-all duration-150">
+      {/* Category icon or image thumbnail */}
+      {hasImage && !showFallback ? (
+        <div className="relative flex-shrink-0 w-12 h-12 rounded-lg overflow-hidden ring-1 ring-gray-200 dark:ring-gray-700 bg-gray-50 dark:bg-gray-800">
+          <img
+            src={
+              exercise.source
+                ? exercise.images![currentImageIndex]
+                : '/uploads/exercises/' + exercise.images![currentImageIndex]
+            }
+            alt={exercise.name}
+            className="w-full h-full object-contain"
+            onError={() => setImageError(true)}
+          />
+          {exercise.images!.length > 1 && (
+            <div className="absolute inset-x-0 bottom-0 flex justify-between px-0.5">
+              <button
+                onClick={handlePrevImage}
+                className="text-white bg-black/40 hover:bg-black/60 rounded p-0.5 transition-colors"
+              >
+                <ChevronLeft className="w-2.5 h-2.5" />
+              </button>
+              <button
+                onClick={handleNextImage}
+                className="text-white bg-black/40 hover:bg-black/60 rounded p-0.5 transition-colors"
+              >
+                <ChevronRight className="w-2.5 h-2.5" />
+              </button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div
+          className={`flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center ${meta.bg}`}
+        >
+          <CategoryIcon className={`w-4 h-4 ${meta.color}`} />
+        </div>
+      )}
+
+      {/* Main content */}
+      <div className="flex-1 min-w-0">
+        {/* Name + badges */}
+        <div className="flex items-center gap-1.5 flex-wrap mb-0.5">
+          <span className="font-semibold text-sm text-gray-800 dark:text-gray-100 leading-tight">
+            {exercise.name}
+          </span>
+          {sourceBadge && (
+            <span
+              className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full ${sourceBadge.className}`}
+            >
+              {sourceBadge.label}
+            </span>
+          )}
           {exercise.tags?.map((tag: string) => (
-            <Badge key={tag} variant="outline" className="text-xs">
-              {tag === 'public' && <Share2 className="h-3 w-3 mr-1" />}
-              {tag === 'family' && <Users className="h-3 w-3 mr-1" />}
+            <Badge
+              key={tag}
+              variant="outline"
+              className="text-[10px] px-1.5 py-0 h-4 gap-0.5"
+            >
+              {tag === 'public' && <Share2 className="h-2.5 w-2.5" />}
+              {tag === 'family' && <Users className="h-2.5 w-2.5" />}
               {tag.charAt(0).toUpperCase() + tag.slice(1)}
             </Badge>
           ))}
-          {exercise.source === 'wger' && (
-            <span className="text-xs px-2 py-1 rounded-full bg-green-100 text-green-800">
-              Wger
-            </span>
-          )}
-          {exercise.source === 'free-exercise-db' && (
-            <span className="text-xs px-2 py-1 rounded-full bg-purple-100 text-purple-800">
-              Free Exercise DB
-            </span>
-          )}
-          {exercise.source === 'nutritionix' && (
-            <span className="text-xs px-2 py-1 rounded-full bg-yellow-100 text-yellow-800">
-              Nutritionix
-            </span>
-          )}
         </div>
-        <div className="text-sm text-gray-500">
-          {exercise.category}
-          {exercise.calories_per_hour
-            ? ` • ${Math.round(convertEnergy(exercise.calories_per_hour, 'kcal', energyUnit))} ${getEnergyUnitString(energyUnit)}`
-            : ''}
-          {exercise.level && ` • Level: ${exercise.level}`}
-          {exercise.force && ` • Force: ${exercise.force}`}
-          {exercise.mechanic && ` • Mechanic: ${exercise.mechanic}`}
+
+        {/* Category + calories row */}
+        <div className="flex items-center gap-2 flex-wrap text-xs text-gray-500 dark:text-gray-400 mb-1">
+          {exercise.category && (
+            <span className="capitalize">{exercise.category}</span>
+          )}
+          {exercise.calories_per_hour ? (
+            <>
+              <span className="text-gray-300 dark:text-gray-600">·</span>
+              <span className="text-orange-500 dark:text-orange-400 font-medium">
+                {Math.round(
+                  convertEnergy(exercise.calories_per_hour, 'kcal', energyUnit)
+                )}{' '}
+                {getEnergyUnitString(energyUnit)}/hr
+              </span>
+            </>
+          ) : null}
         </div>
-        {exercise.equipment && exercise.equipment?.length > 0 && (
-          <div className="text-xs text-gray-400">
-            Equipment: {exercise.equipment.join(', ')}
+
+        {/* Meta pills */}
+        {metaPills.length > 0 && (
+          <div className="flex items-center gap-1 flex-wrap mb-1">
+            {metaPills.map((pill) => (
+              <span
+                key={pill}
+                className="text-[10px] px-1.5 py-0.5 rounded-full border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 capitalize"
+              >
+                {pill}
+              </span>
+            ))}
           </div>
         )}
-        {exercise.primary_muscles && exercise.primary_muscles?.length > 0 && (
-          <div className="text-xs text-gray-400">
-            Primary Muscles: {exercise.primary_muscles.join(', ')}
+
+        {/* Muscles + equipment */}
+        {exercise.primary_muscles && exercise.primary_muscles.length > 0 && (
+          <div className="text-[10px] text-gray-400 dark:text-gray-500 leading-snug">
+            <span className="font-medium text-gray-500 dark:text-gray-400">
+              Primary:{' '}
+            </span>
+            {exercise.primary_muscles.join(', ')}
           </div>
         )}
         {exercise.secondary_muscles &&
-          exercise.secondary_muscles?.length > 0 && (
-            <div className="text-xs text-gray-400">
-              Secondary Muscles: {exercise.secondary_muscles.join(', ')}
+          exercise.secondary_muscles.length > 0 && (
+            <div className="text-[10px] text-gray-400 dark:text-gray-500 leading-snug">
+              <span className="font-medium text-gray-500 dark:text-gray-400">
+                Secondary:{' '}
+              </span>
+              {exercise.secondary_muscles.join(', ')}
             </div>
           )}
-        {exercise.instructions && exercise.instructions?.length > 0 && (
-          <div className="text-xs text-gray-400 flex items-center">
-            Instructions: {exercise.instructions[0]}...
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleSpeak}
-              className="ml-2"
-            >
-              <Volume2 className="h-4 w-4" />
-            </Button>
+        {exercise.equipment && exercise.equipment.length > 0 && (
+          <div className="text-[10px] text-gray-400 dark:text-gray-500 leading-snug">
+            <span className="font-medium text-gray-500 dark:text-gray-400">
+              Equipment:{' '}
+            </span>
+            {exercise.equipment.join(', ')}
           </div>
         )}
+
+        {/* Description */}
         {exercise.description && (
-          <div className="text-xs text-gray-400">{exercise.description}</div>
+          <div className="text-[10px] text-gray-400 dark:text-gray-500 mt-0.5 line-clamp-2">
+            {exercise.description}
+          </div>
         )}
-        {exercise.images && exercise.images?.length > 0 && (
-          <div className="relative w-32 h-32 mt-2">
-            <img
-              src={exercise.images[currentImageIndex]}
-              alt={exercise.name}
-              className="w-full h-full object-contain"
-            />
-            {exercise.images.length > 1 && (
-              <>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="absolute left-0 top-1/2 -translate-y-1/2"
-                  onClick={handlePrevImage}
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="absolute right-0 top-1/2 -translate-y-1/2"
-                  onClick={handleNextImage}
-                >
-                  <ChevronRight className="h-4 w-4" />
-                </Button>
-              </>
-            )}
+
+        {/* Instructions (first line + speak) */}
+        {exercise.instructions && exercise.instructions.length > 0 && (
+          <div className="flex items-center gap-1 mt-0.5">
+            <span className="text-[10px] text-gray-400 dark:text-gray-500 line-clamp-1 flex-1">
+              {exercise.instructions[0]}
+            </span>
+            <button
+              onClick={handleSpeak}
+              className="flex-shrink-0 p-1 rounded text-gray-400 hover:text-blue-500 hover:bg-blue-50 dark:hover:bg-blue-950/50 transition-colors"
+              title="Read instructions aloud"
+            >
+              <Volume2 className="w-3 h-3" />
+            </button>
           </div>
         )}
       </div>
-      <Button onClick={() => onAction(exercise)}>
-        {ActionIcon && <ActionIcon className="h-4 w-4 mr-2" />}
-        {actionText}
-      </Button>
+
+      {/* Action button */}
+      <div className="flex-shrink-0 self-center">
+        <Button
+          onClick={handleAction}
+          disabled={isActioning}
+          size="sm"
+          className="h-8 px-3 text-xs bg-blue-600 hover:bg-blue-700 text-white gap-1.5"
+        >
+          {isActioning ? (
+            <span className="w-3.5 h-3.5 border-2 border-white/40 border-t-white rounded-full animate-spin" />
+          ) : (
+            ActionIcon && <ActionIcon className="h-3.5 w-3.5" />
+          )}
+          {actionText}
+        </Button>
+      </div>
     </div>
   );
 };

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPlansManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPlansManager.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
-
+import { Card } from '@/components/ui/card';
 import {
   Tooltip,
   TooltipContent,
@@ -10,7 +10,14 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-import { Plus, Edit, Trash2, CalendarDays } from 'lucide-react';
+import {
+  Plus,
+  Edit,
+  Trash2,
+  CalendarDays,
+  Activity,
+  Clock,
+} from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
 import { usePreferences } from '@/contexts/PreferencesContext';
@@ -86,7 +93,7 @@ const WorkoutPlansManager = () => {
       const planToUpdate = plans?.find((p) => p.id === planId);
       if (!planToUpdate) {
         toast({
-          title: t('common.error', 'Error'),
+          title: t('common.error'),
           description: t(
             'workoutPlansManager.updateStatusError',
             'Could not find the plan to update.'
@@ -97,29 +104,29 @@ const WorkoutPlansManager = () => {
       }
       await updateWorkoutPlanTemplate({
         id: planId,
-        data: {
-          ...planToUpdate,
-          is_active: isActive,
-        },
+        data: { ...planToUpdate, is_active: isActive },
       });
     } catch (err) {
       error(loggingLevel, 'Error toggling workout plan active status:', err);
     }
   };
 
-  if (!plans) {
-    return;
-  }
+  if (!plans) return null;
+
   return (
-    <>
-      <div className="flex flex-row items-center justify-end space-y-0 pb-2">
-        <Button size="sm" onClick={() => setIsAddPlanDialogOpen(true)}>
+    <div className="space-y-6">
+      <div className="flex justify-end px-1">
+        <Button
+          onClick={() => setIsAddPlanDialogOpen(true)}
+          className="rounded-xl shadow-sm"
+        >
           <Plus className="h-4 w-4 mr-2" />
           {t('workoutPlansManager.addPlanButton', 'Add Plan')}
         </Button>
       </div>
+
       {plans.length === 0 ? (
-        <p className="text-center text-muted-foreground">
+        <p className="text-center text-gray-400 py-10 italic">
           {t(
             'workoutPlansManager.noPlansFound',
             'No workout plans found. Create one to get started!'
@@ -128,116 +135,18 @@ const WorkoutPlansManager = () => {
       ) : (
         <div className="space-y-4">
           {plans.map((plan) => (
-            <div
+            <WorkoutPlanItem
               key={plan.id}
-              className="flex items-center justify-between p-4 border rounded-lg"
-            >
-              <div>
-                <h4 className="font-medium">{plan.plan_name}</h4>
-                <p className="text-sm text-muted-foreground">
-                  {plan.description}
-                </p>
-                <p className="text-xs text-muted-foreground flex items-center space-x-1">
-                  <CalendarDays className="h-3 w-3" />
-                  <span>{new Date(plan.start_date!).toLocaleDateString()}</span>
-                  {plan.end_date && (
-                    <>
-                      <span>-</span>
-                      <CalendarDays className="h-3 w-3" />
-                      <span>
-                        {new Date(plan.end_date).toLocaleDateString()}
-                      </span>
-                    </>
-                  )}
-                  {!plan.end_date && (
-                    <span>
-                      {t('workoutPlansManager.ongoingStatus', '- Ongoing')}
-                    </span>
-                  )}
-                </p>
-                <p className="text-xs text-muted-foreground">
-                  {t('workoutPlansManager.statusLabel', 'Status: ')}{' '}
-                  {plan.is_active
-                    ? t('workoutPlansManager.activeStatus', 'Active')
-                    : t('workoutPlansManager.inactiveStatus', 'Inactive')}
-                </p>
-              </div>
-              <div className="flex items-center space-x-2">
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => {
-                          setSelectedPlan(plan);
-                          setIsEditDialogOpen(true);
-                        }}
-                      >
-                        <Edit className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>
-                        {t(
-                          'workoutPlansManager.editPlanTooltip',
-                          'Edit Workout Plan'
-                        )}
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleDeletePlan(plan.id)}
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>
-                        {t(
-                          'workoutPlansManager.deletePlanTooltip',
-                          'Delete Workout Plan'
-                        )}
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                  <div className="flex items-center space-x-2">
-                    <Switch
-                      id={`plan-active-${plan.id}`}
-                      checked={plan.is_active}
-                      onCheckedChange={(checked) =>
-                        handleTogglePlanActive(plan.id, checked)
-                      }
-                    />
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <label
-                          htmlFor={`plan-active-${plan.id}`}
-                          className="cursor-pointer"
-                        ></label>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>
-                          {plan.is_active
-                            ? t(
-                                'workoutPlansManager.deactivatePlanTooltip',
-                                'Deactivate Plan'
-                              )
-                            : t(
-                                'workoutPlansManager.activatePlanTooltip',
-                                'Activate Plan'
-                              )}
-                        </p>
-                      </TooltipContent>
-                    </Tooltip>
-                  </div>
-                </TooltipProvider>
-              </div>
-            </div>
+              plan={plan}
+              onEdit={() => {
+                setSelectedPlan(plan);
+                setIsEditDialogOpen(true);
+              }}
+              onDelete={() => handleDeletePlan(plan.id)}
+              onToggleActive={(active) =>
+                handleTogglePlanActive(plan.id, active)
+              }
+            />
           ))}
         </div>
       )}
@@ -257,12 +166,186 @@ const WorkoutPlansManager = () => {
           setIsEditDialogOpen(false);
           setSelectedPlan(null);
         }}
-        onSave={handleCreatePlan} // This won't be used for editing, but required by prop type
+        onSave={handleCreatePlan}
         initialData={selectedPlan}
         onUpdate={handleUpdatePlan}
       />
-    </>
+    </div>
   );
 };
+
+const WorkoutPlanItem: React.FC<{
+  plan: WorkoutPlanTemplate;
+  onEdit: () => void;
+  onDelete: () => void;
+  onToggleActive: (active: boolean) => void;
+}> = ({ plan, onEdit, onDelete, onToggleActive }) => {
+  const { t } = useTranslation();
+
+  return (
+    <Card className="overflow-hidden border-0 shadow-md bg-white dark:bg-gray-900 rounded-xl">
+      <div className="flex">
+        {/* Left accent stripe - color changes based on active status */}
+        <div
+          className={`w-1 flex-shrink-0 rounded-l-xl transition-colors duration-300 ${
+            plan.is_active
+              ? 'bg-gradient-to-b from-emerald-500 to-teal-600'
+              : 'bg-gradient-to-b from-gray-400 to-gray-500'
+          }`}
+        />
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start justify-between gap-2 px-4 pt-4 pb-3">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2 flex-wrap mb-1">
+                <span className="font-semibold text-gray-900 dark:text-gray-50 text-base leading-tight truncate">
+                  {plan.plan_name}
+                </span>
+                <span
+                  className={`flex-shrink-0 text-[9px] font-bold px-1.5 py-0.5 rounded-full border ${
+                    plan.is_active
+                      ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400 border-emerald-100 dark:border-emerald-800'
+                      : 'bg-gray-50 dark:bg-gray-800 text-gray-500 border-gray-200 dark:border-gray-700'
+                  }`}
+                >
+                  {plan.is_active
+                    ? t('workoutPlansManager.activeStatus').toUpperCase()
+                    : t('workoutPlansManager.inactiveStatus').toUpperCase()}
+                </span>
+              </div>
+
+              {plan.description && (
+                <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-1 mb-2">
+                  {plan.description}
+                </p>
+              )}
+
+              <div className="flex items-center gap-3 text-[10px] text-gray-400 dark:text-gray-500 font-medium uppercase tracking-wider">
+                <div className="flex items-center gap-1">
+                  <CalendarDays className="h-3 w-3" />
+                  <span>{new Date(plan.start_date!).toLocaleDateString()}</span>
+                  <span>-</span>
+                  <span>
+                    {plan.end_date
+                      ? new Date(plan.end_date).toLocaleDateString()
+                      : t('workoutPlansManager.ongoingStatus', 'Ongoing')}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-1 shrink-0">
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div className="flex items-center px-2">
+                      <Switch
+                        id={`plan-active-${plan.id}`}
+                        checked={plan.is_active}
+                        onCheckedChange={onToggleActive}
+                        className="scale-75"
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      {plan.is_active
+                        ? t('workoutPlansManager.deactivatePlanTooltip')
+                        : t('workoutPlansManager.activatePlanTooltip')}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+
+              <ActionButton
+                icon={<Edit className="h-3.5 w-3.5" />}
+                label={t('workoutPlansManager.editPlanTooltip')}
+                onClick={onEdit}
+                colorClass="hover:text-indigo-600 hover:bg-indigo-50 dark:hover:bg-indigo-950/50"
+              />
+              <ActionButton
+                icon={<Trash2 className="h-3.5 w-3.5" />}
+                label={t('workoutPlansManager.deletePlanTooltip')}
+                onClick={onDelete}
+                colorClass="hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50"
+              />
+            </div>
+          </div>
+
+          {/* Stats strip for a Plan */}
+          <div className="mx-4 mb-4 mt-1 grid grid-cols-2 divide-x divide-gray-100 dark:divide-gray-800 bg-gray-50 dark:bg-gray-800/60 rounded-lg overflow-hidden">
+            <StatCell
+              icon={<Activity className="w-3 h-3" />}
+              value={plan.is_active ? 'LIVE' : 'IDLE'}
+              label="Status"
+              color={
+                plan.is_active
+                  ? 'text-emerald-600 dark:text-emerald-400'
+                  : 'text-gray-400'
+              }
+            />
+            <StatCell
+              icon={<Clock className="w-3 h-3" />}
+              value={
+                plan.end_date
+                  ? new Date(plan.end_date).toLocaleDateString(undefined, {
+                      month: 'short',
+                      day: 'numeric',
+                    })
+                  : '∞'
+              }
+              label="End Date"
+              color="text-blue-600 dark:text-blue-400"
+            />
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+const ActionButton: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  colorClass: string;
+}> = ({ icon, label, onClick, colorClass }) => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onClick}
+          className={`h-8 w-8 text-gray-400 transition-colors ${colorClass}`}
+        >
+          {icon}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{label}</p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
+const StatCell: React.FC<{
+  icon: React.ReactNode;
+  value: string;
+  label: string;
+  color: string;
+}> = ({ icon, value, label, color }) => (
+  <div className="flex flex-col items-center justify-center py-2 px-1 gap-0.5">
+    <span className={`${color} flex items-center gap-1`}>
+      {icon}
+      <span className="font-bold text-xs text-gray-800 dark:text-gray-100 uppercase tracking-tighter">
+        {value}
+      </span>
+    </span>
+    <span className="text-[9px] text-gray-400 dark:text-gray-500 uppercase tracking-widest font-bold">
+      {label}
+    </span>
+  </div>
+);
 
 export default WorkoutPlansManager;

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetSelector.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetSelector.tsx
@@ -2,8 +2,9 @@ import type React from 'react';
 import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/ui/input';
+import { Card } from '@/components/ui/card';
+import { Search, Layers, ChevronRight } from 'lucide-react';
 import type { WorkoutPreset } from '@/types/workout';
-import { Card, CardContent } from '@/components/ui/card';
 import { useWorkoutPresets } from '@/hooks/Exercises/useWorkoutPresets';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -24,128 +25,157 @@ const WorkoutPresetSelector: React.FC<WorkoutPresetSelectorProps> = ({
     () => presetData?.pages.flatMap((page) => page.presets) ?? [],
     [presetData]
   );
-  const recentPresets = allPresets.slice(0, 3);
-  const topPresets = allPresets.slice(3, 6);
 
-  const filteredPresets = allPresets.filter((preset) =>
-    preset.name.toLowerCase().includes(searchTerm.toLowerCase())
+  const filteredPresets = useMemo(
+    () =>
+      allPresets.filter((preset) =>
+        preset.name.toLowerCase().includes(searchTerm.toLowerCase())
+      ),
+    [allPresets, searchTerm]
   );
 
-  const handlePresetClick = (preset: WorkoutPreset) => {
-    onPresetSelected(preset);
-  };
+  const recentPresets = searchTerm === '' ? allPresets.slice(0, 3) : [];
+  const topPresets = searchTerm === '' ? allPresets.slice(3, 6) : [];
 
   return (
-    <div className="flex-grow overflow-y-auto py-4">
-      <Input
-        placeholder={t(
-          'exercise.workoutPresetSelector.searchPlaceholder',
-          'Search your workout presets...'
-        )}
-        value={searchTerm}
-        onChange={(e) => setSearchTerm(e.target.value)}
-        className="mb-4"
-      />
+    <div className="flex flex-col h-full py-4 space-y-6">
+      <div className="relative px-1">
+        <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+        <Input
+          placeholder={t(
+            'exercise.workoutPresetSelector.searchPlaceholder',
+            'Search your workout presets...'
+          )}
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
+          className="pl-11 bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-800 focus:ring-blue-500 rounded-xl h-11"
+        />
+      </div>
 
-      {searchTerm === '' ? (
-        <>
-          <h3 className="text-lg font-semibold mb-2">
-            {t(
-              'exercise.workoutPresetSelector.recentPresetsTitle',
-              'Recent Presets'
-            )}
-          </h3>
-          <div className="space-y-2 mb-4">
-            {recentPresets.length > 0 ? (
-              recentPresets.map((preset) => (
-                <Card
-                  key={preset.id}
-                  className="cursor-pointer"
-                  onClick={() => handlePresetClick(preset)}
-                >
-                  <CardContent className="p-4">
-                    <p className="font-medium">{preset.name}</p>
-                    <p className="text-sm text-muted-foreground">
-                      {preset.description}
-                    </p>
-                  </CardContent>
-                </Card>
-              ))
-            ) : (
-              <p className="text-muted-foreground">
-                {t(
-                  'exercise.workoutPresetSelector.noRecentPresets',
-                  'No recent presets.'
-                )}
-              </p>
-            )}
-          </div>
-
-          <h3 className="text-lg font-semibold mb-2">
-            {t('exercise.workoutPresetSelector.topPresetsTitle', 'Top Presets')}
-          </h3>
-          <div className="space-y-2">
-            {topPresets.length > 0 ? (
-              topPresets.map((preset) => (
-                <Card
-                  key={preset.id}
-                  className="cursor-pointer"
-                  onClick={() => handlePresetClick(preset)}
-                >
-                  <CardContent className="p-4">
-                    <p className="font-medium">{preset.name}</p>
-                    <p className="text-sm text-muted-foreground">
-                      {preset.description}
-                    </p>
-                  </CardContent>
-                </Card>
-              ))
-            ) : (
-              <p className="text-muted-foreground">
-                {t(
-                  'exercise.workoutPresetSelector.noTopPresets',
-                  'No top presets.'
-                )}
-              </p>
-            )}
-          </div>
-        </>
-      ) : (
-        <>
-          <h3 className="text-lg font-semibold mb-2">
-            {t(
+      <div className="flex-grow overflow-y-auto px-1 space-y-8 custom-scrollbar">
+        {searchTerm === '' ? (
+          <>
+            <PresetSection
+              title={t(
+                'exercise.workoutPresetSelector.recentPresetsTitle',
+                'Recent Presets'
+              )}
+              presets={recentPresets}
+              onSelect={onPresetSelected}
+              emptyMessage={t(
+                'exercise.workoutPresetSelector.noRecentPresets',
+                'No recent presets.'
+              )}
+            />
+            <PresetSection
+              title={t(
+                'exercise.workoutPresetSelector.topPresetsTitle',
+                'Top Presets'
+              )}
+              presets={topPresets}
+              onSelect={onPresetSelected}
+              emptyMessage={t(
+                'exercise.workoutPresetSelector.noTopPresets',
+                'No top presets.'
+              )}
+            />
+          </>
+        ) : (
+          <PresetSection
+            title={t(
               'exercise.workoutPresetSelector.searchResultsTitle',
               'Search Results'
             )}
-          </h3>
-          <div className="space-y-2">
-            {filteredPresets.length > 0 ? (
-              filteredPresets.map((preset) => (
-                <Card
-                  key={preset.id}
-                  className="cursor-pointer"
-                  onClick={() => handlePresetClick(preset)}
-                >
-                  <CardContent className="p-4">
-                    <p className="font-medium">{preset.name}</p>
-                    <p className="text-sm text-muted-foreground">
-                      {preset.description}
-                    </p>
-                  </CardContent>
-                </Card>
-              ))
-            ) : (
-              <p className="text-muted-foreground">
-                {t(
-                  'exercise.workoutPresetSelector.noMatchingPresets',
-                  'No presets found matching your search.'
-                )}
+            presets={filteredPresets}
+            onSelect={onPresetSelected}
+            emptyMessage={t(
+              'exercise.workoutPresetSelector.noMatchingPresets',
+              'No presets found matching your search.'
+            )}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const PresetSection: React.FC<{
+  title: string;
+  presets: WorkoutPreset[];
+  onSelect: (preset: WorkoutPreset) => void;
+  emptyMessage: string;
+}> = ({ title, presets, onSelect, emptyMessage }) => (
+  <div className="space-y-3">
+    <h3 className="text-[10px] font-bold uppercase tracking-[0.2em] text-gray-400 dark:text-gray-500 px-1">
+      {title}
+    </h3>
+    <div className="grid gap-3">
+      {presets.length > 0 ? (
+        presets.map((preset) => (
+          <PresetSelectionCard
+            key={preset.id}
+            preset={preset}
+            onClick={() => onSelect(preset)}
+          />
+        ))
+      ) : (
+        <p className="text-sm text-gray-400 dark:text-gray-500 italic py-2 px-1">
+          {emptyMessage}
+        </p>
+      )}
+    </div>
+  </div>
+);
+
+const PresetSelectionCard: React.FC<{
+  preset: WorkoutPreset;
+  onClick: () => void;
+}> = ({ preset, onClick }) => {
+  const exerciseCount = preset.exercises?.length ?? 0;
+
+  return (
+    <Card
+      onClick={onClick}
+      className="group overflow-hidden border-0 shadow-sm bg-white dark:bg-gray-900 rounded-xl cursor-pointer hover:shadow-md hover:ring-1 hover:ring-blue-500/30 transition-all duration-200"
+    >
+      <div className="flex">
+        <div className="w-1 flex-shrink-0 bg-gradient-to-b from-blue-500 to-indigo-600" />
+
+        <div className="flex-1 flex items-center justify-between p-4 gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="font-semibold text-gray-900 dark:text-gray-50 text-sm leading-tight truncate">
+                {preset.name}
+              </span>
+              {exerciseCount > 0 && (
+                <span className="flex-shrink-0 text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400 border border-blue-100 dark:border-blue-800">
+                  {exerciseCount}{' '}
+                  {exerciseCount === 1 ? 'Exercise' : 'Exercises'}
+                </span>
+              )}
+            </div>
+
+            {preset.description && (
+              <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-1">
+                {preset.description}
               </p>
             )}
           </div>
-        </>
-      )}
-    </div>
+
+          <div className="flex items-center gap-3">
+            <div className="hidden sm:flex flex-col items-end text-right">
+              <div className="flex items-center gap-1 text-gray-300 dark:text-gray-700">
+                <Layers className="w-3 h-3" />
+                <span className="text-[10px] font-medium uppercase tracking-wider">
+                  Preset
+                </span>
+              </div>
+            </div>
+            <ChevronRight className="w-4 h-4 text-gray-300 group-hover:text-blue-500 group-hover:translate-x-0.5 transition-all" />
+          </div>
+        </div>
+      </div>
+    </Card>
   );
 };
 

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
@@ -1,8 +1,25 @@
+import type React from 'react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatDateToYYYYMMDD } from '@/lib/utils';
+import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Plus, Edit, Trash2, CalendarPlus, Loader2 } from 'lucide-react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import {
+  Plus,
+  Edit,
+  Trash2,
+  CalendarPlus,
+  Loader2,
+  ChevronDown,
+  Layers,
+  Dumbbell,
+} from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 import { useAuth } from '@/hooks/useAuth';
 import type { WorkoutPreset } from '@/types/workout';
@@ -14,6 +31,7 @@ import {
   useWorkoutPresets,
 } from '@/hooks/Exercises/useWorkoutPresets';
 import { useLogWorkoutPresetMutation } from '@/hooks/Exercises/useExerciseEntries';
+import { usePreferences } from '@/contexts/PreferencesContext';
 
 const WorkoutPresetsManager = () => {
   const { t } = useTranslation();
@@ -25,7 +43,6 @@ const WorkoutPresetsManager = () => {
     null
   );
 
-  // Infinite Query & Mutations
   const { data, fetchNextPage, hasNextPage, isLoading, isFetchingNextPage } =
     useWorkoutPresets(user?.id);
 
@@ -82,16 +99,19 @@ const WorkoutPresetsManager = () => {
   };
 
   return (
-    <>
-      <div className="flex flex-row items-center justify-end space-y-0 pb-2">
-        <Button size="sm" onClick={() => setIsAddPresetDialogOpen(true)}>
+    <div className="space-y-6">
+      <div className="flex justify-end px-1">
+        <Button
+          onClick={() => setIsAddPresetDialogOpen(true)}
+          className="rounded-xl shadow-sm"
+        >
           <Plus className="h-4 w-4 mr-2" />
           {t('workoutPresetsManager.addPresetButton', 'Add presets')}
         </Button>
       </div>
 
       {presets.length === 0 && !isLoading ? (
-        <p className="text-center text-muted-foreground">
+        <p className="text-center text-gray-400 py-10 italic">
           {t(
             'workoutPresetsManager.noPresetsFound',
             'No workout presets found.'
@@ -100,107 +120,240 @@ const WorkoutPresetsManager = () => {
       ) : (
         <div className="space-y-4">
           {presets.map((preset) => (
-            <div
+            <WorkoutPresetItem
               key={preset.id}
-              className="flex items-center justify-between p-4 border rounded-lg"
-            >
-              <div className="flex-1 min-w-0 mr-4">
-                <h4 className="font-medium truncate">{preset.name}</h4>
-                {preset.description && (
-                  <p className="text-sm text-muted-foreground truncate">
-                    {preset.description}
-                  </p>
-                )}
-                <div className="text-xs text-muted-foreground mt-1">
-                  {preset.exercises?.slice(0, 3).map((ex, idx) => (
-                    <p key={idx} className="flex items-center gap-2">
-                      <span className="font-medium">{ex.exercise_name}</span>
-                      {ex.sets && <span>• {ex.sets.length} Sätze</span>}
-                    </p>
-                  ))}
-                  {preset.exercises && preset.exercises.length > 3 && (
-                    <p className="text-gray-400 italic mt-0.5">
-                      + {preset.exercises.length - 3} more
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              <div className="flex items-center space-x-2 shrink-0">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={() => handleLogPresetToDiary(preset)}
-                  title={t('workoutPresetsManager.logToDiary', 'Log to Diary')}
-                >
-                  <CalendarPlus className="h-4 w-4" />
-                </Button>
-                {preset.user_id === user?.id && (
-                  <>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        setSelectedPreset(preset);
-                        setIsEditDialogOpen(true);
-                      }}
-                    >
-                      <Edit className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => handleDeletePreset(String(preset.id))}
-                    >
-                      <Trash2 className="h-4 w-4 text-destructive" />
-                    </Button>
-                  </>
-                )}
-              </div>
-            </div>
+              preset={preset}
+              userId={user?.id}
+              onLog={() => handleLogPresetToDiary(preset)}
+              onEdit={() => {
+                setSelectedPreset(preset);
+                setIsEditDialogOpen(true);
+              }}
+              onDelete={() => handleDeletePreset(preset.id.toString())}
+            />
           ))}
         </div>
       )}
+
       {hasNextPage && (
-        <div className="flex justify-center mt-6">
+        <div className="flex justify-center pt-4">
           <Button
-            variant="outline"
+            variant="ghost"
             onClick={() => fetchNextPage()}
             disabled={isFetchingNextPage}
+            className="text-gray-500"
           >
             {isFetchingNextPage ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                {t('workoutPresetsManager.loading', 'Loading...')}
-              </>
+              <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
               t('workoutPresetsManager.loadMore', 'Load more')
             )}
           </Button>
         </div>
       )}
+
       <WorkoutPresetForm
-        key={selectedPreset?.id || (isEditDialogOpen ? 'open' : 'closed')}
         isOpen={isAddPresetDialogOpen}
         onClose={() => setIsAddPresetDialogOpen(false)}
         onSave={handleCreatePreset}
       />
+
       {selectedPreset && (
         <WorkoutPresetForm
-          key={selectedPreset?.id || (isEditDialogOpen ? 'open' : 'closed')}
           isOpen={isEditDialogOpen}
           onClose={() => {
             setIsEditDialogOpen(false);
             setSelectedPreset(null);
           }}
           onSave={(updatedData) =>
-            handleUpdatePreset(String(selectedPreset.id), updatedData)
+            handleUpdatePreset(selectedPreset.id.toString(), updatedData)
           }
           initialPreset={selectedPreset}
         />
       )}
-    </>
+    </div>
   );
 };
+
+const WorkoutPresetItem: React.FC<{
+  preset: WorkoutPreset;
+  userId: string | undefined;
+  onLog: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}> = ({ preset, userId, onLog, onEdit, onDelete }) => {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
+  const { weightUnit } = usePreferences();
+
+  const totalSets =
+    preset.exercises?.reduce((sum, ex) => sum + (ex.sets?.length || 0), 0) ?? 0;
+  const totalWeight =
+    preset.exercises?.reduce((sum, ex) => {
+      const exerciseVolume =
+        ex.sets?.reduce((setSum, set) => {
+          return setSum + (set.weight || 0) * (set.reps || 0);
+        }, 0) ?? 0;
+      return sum + exerciseVolume;
+    }, 0) ?? 0;
+
+  return (
+    <Card className="overflow-hidden border-0 shadow-md bg-white dark:bg-gray-900 rounded-xl">
+      <div className="flex">
+        <div className="w-1 flex-shrink-0 bg-gradient-to-b from-blue-500 to-indigo-600 rounded-l-xl" />
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2 px-4 pt-4 pb-3">
+            <button
+              onClick={() => setIsExpanded(!isExpanded)}
+              className="flex items-center gap-3 min-w-0 flex-1 text-left group"
+            >
+              <span
+                className={`flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-full border-2 transition-all duration-200
+                  ${
+                    isExpanded
+                      ? 'border-blue-500 bg-blue-50 dark:bg-blue-950 text-blue-600 dark:text-blue-400'
+                      : 'border-gray-200 dark:border-gray-700 text-gray-400 group-hover:border-blue-400 group-hover:text-blue-500'
+                  }`}
+              >
+                <ChevronDown
+                  className={`w-3.5 h-3.5 transition-transform duration-300 ${isExpanded ? 'rotate-180' : ''}`}
+                />
+              </span>
+
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="font-semibold text-gray-900 dark:text-gray-50 text-base leading-tight truncate">
+                    {preset.name}
+                  </span>
+                  {preset.exercises && preset.exercises.length > 0 && (
+                    <span className="flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/50 text-blue-700 dark:text-blue-300">
+                      {preset.exercises.length}{' '}
+                      {preset.exercises.length === 1 ? 'exercise' : 'exercises'}
+                    </span>
+                  )}
+                </div>
+                {preset.description && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate">
+                    {preset.description}
+                  </p>
+                )}
+              </div>
+            </button>
+
+            <div className="flex items-center gap-1">
+              <ActionButton
+                icon={<CalendarPlus className="h-3.5 w-3.5" />}
+                label={t('workoutPresetsManager.logToDiary', 'Log to Diary')}
+                onClick={onLog}
+                colorClass="hover:text-green-600 hover:bg-green-50 dark:hover:bg-green-950/50"
+              />
+              {preset.user_id === userId && (
+                <>
+                  <ActionButton
+                    icon={<Edit className="h-3.5 w-3.5" />}
+                    label={t('common.edit', 'Edit')}
+                    onClick={onEdit}
+                    colorClass="hover:text-indigo-600 hover:bg-indigo-50 dark:hover:bg-indigo-950/50"
+                  />
+                  <ActionButton
+                    icon={<Trash2 className="h-3.5 w-3.5" />}
+                    label={t('common.delete', 'Delete')}
+                    onClick={onDelete}
+                    colorClass="hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950/50"
+                  />
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="mx-4 mb-4 mt-1 grid grid-cols-2 divide-x divide-gray-100 dark:divide-gray-800 bg-gray-50 dark:bg-gray-800/60 rounded-lg overflow-hidden">
+            <StatCell
+              icon={<Layers className="w-3 h-3" />}
+              value={totalSets.toString()}
+              label={t('common.totalSets', 'Sets')}
+              color="text-blue-600 dark:text-blue-400"
+            />
+            <StatCell
+              icon={<Dumbbell className="w-3 h-3" />}
+              value={totalWeight.toString() + weightUnit}
+              label={t('common.totalWeight', 'Total Weight')}
+              color="text-indigo-600 dark:text-indigo-400"
+            />
+          </div>
+        </div>
+      </div>
+
+      {isExpanded && (
+        <CardContent className="px-4 pb-4 pt-0 border-t border-gray-100 dark:border-gray-800">
+          <div className="pt-3 space-y-2">
+            {preset.exercises?.map((ex, idx) => (
+              <div
+                key={idx}
+                className="flex items-center justify-between p-2 rounded-lg bg-gray-50 dark:bg-gray-800/40 border border-transparent hover:border-gray-200 dark:hover:border-gray-700 transition-all"
+              >
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {ex.exercise_name}
+                </span>
+                {ex.sets && (
+                  <span className="text-[10px] px-1.5 py-0.5 rounded bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-800 text-gray-500 font-bold">
+                    {ex.sets.length} {t('common.sets', 'Sets').toUpperCase()}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+};
+
+const ActionButton: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  colorClass: string;
+}> = ({ icon, label, onClick, colorClass }) => (
+  <TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={(e) => {
+            e.stopPropagation();
+            onClick();
+          }}
+          className={`h-8 w-8 text-gray-400 transition-colors ${colorClass}`}
+        >
+          {icon}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>
+        <p>{label}</p>
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
+const StatCell: React.FC<{
+  icon: React.ReactNode;
+  value: string;
+  label: string;
+  color: string;
+}> = ({ icon, value, label, color }) => (
+  <div className="flex flex-col items-center justify-center py-2 px-1 gap-0.5">
+    <span className={`${color} flex items-center gap-1`}>
+      {icon}
+      <span className="font-bold text-sm text-gray-800 dark:text-gray-100">
+        {value}
+      </span>
+    </span>
+    <span className="text-[10px] text-gray-400 dark:text-gray-500 uppercase tracking-wide font-medium">
+      {label}
+    </span>
+  </div>
+);
 
 export default WorkoutPresetsManager;


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The workout preset entry did not look good and also had a dead edit button. Checking for images was also broken which led to displaying the fallback name for every exercise without an image. The exercise database took up a lot of space because it showed every information possible about an exercise.

**How did you implement the solution?**
I used the category of the exercise to show different logo and made it look better. I fixed the exercise creation, which did not show every category and fixed the fallback to be the default icon instead of a string. I also adjusted the visuals in /exercises. Because of my prior work of moving the logic out of the components, this was simpler than anticipated. I used the same colors as in the food database.

I showcased every possible icon for the categories in the screenshots below

Linked Issue: #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

| Category | Before | After |
| :--- | :--- | :--- |
| **Diary** | <img width="400" src="https://github.com/user-attachments/assets/d6c687d6-a617-4db9-9cc8-6e9a73b7d656" /> | <img width="400" src="https://github.com/user-attachments/assets/11336d60-90d8-489a-ac31-23ccab60b8d0" /> |
| **Search** | <img width="400" src="https://github.com/user-attachments/assets/e6ee8942-7fbc-4d0b-806f-d1335630b57c" /> | <img width="400" src="https://github.com/user-attachments/assets/84481e9e-a416-43ad-8e0a-17bf82f9a6d9" /> |
| **Preset** | <img width="400" src="https://github.com/user-attachments/assets/89a5045c-1f8c-4cf9-ae30-161ed300b5c0" /> | <img width="400" src="https://github.com/user-attachments/assets/c64cc8a4-9315-49fc-b016-9c76b72eb81c" /> |
| **Creation** | <img width="400" src="https://github.com/user-attachments/assets/abdcb5f6-7201-465b-a830-28336b0c6bc2" /> | <img width="400" src="https://github.com/user-attachments/assets/554835e7-877a-4453-90ca-0831b1229332" /> |
| **Workout** | <img width="400" src="https://github.com/user-attachments/assets/1f0ae0a4-5d1a-4965-8a81-a54dc3870591" /> | <img width="400" src="https://github.com/user-attachments/assets/b9ba9378-f4cb-46fd-8429-c36ada958653" /> |
| **Exercises** | <img width="400" src="https://github.com/user-attachments/assets/2cdee3eb-6f9f-41a6-8820-e36f6bca0b24" /> | <img width="400" src="https://github.com/user-attachments/assets/cb166206-b15c-4f86-bddc-580cdd2e6029" /> |
