### PR TITLE
feat(1044): equivalent variants for foods

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
@@ -11,8 +11,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Copy, Trash2, Check } from 'lucide-react';
-import type { GlycemicIndex } from '@/types/food';
+import { Copy, Trash2, Check, Plus } from 'lucide-react';
+import type { EquivalentUnit, GlycemicIndex } from '@/types/food';
 import type { FormFoodVariant } from '@/utils/foodForm';
 import { getConversionFactor } from '@/utils/servingSizeConversions';
 import { UNIT_GROUPS } from '@/constants/foodForm';
@@ -21,7 +21,7 @@ import { NutrientGrid } from './NutrientFormGrid';
 
 interface VariantCardProps {
   index: number;
-  variant: FormFoodVariant;
+  variant: FormFoodVariant & { equivalents?: EquivalentUnit[] };
   variantError: string;
   visibleNutrients: string[];
   energyUnit: 'kcal' | 'kJ';
@@ -35,7 +35,7 @@ interface VariantCardProps {
   onUpdate: (
     index: number,
     field: string,
-    value: string | number | boolean | GlycemicIndex
+    value: string | number | boolean | GlycemicIndex | EquivalentUnit[]
   ) => void;
   onDuplicate: (index: number) => void;
   onRemove: (index: number) => void;
@@ -54,116 +54,216 @@ export function VariantCard({
   onDuplicate,
   onRemove,
 }: VariantCardProps) {
+  const equivalents = variant.equivalents ?? [];
+
+  const addEquivalent = () => {
+    onUpdate(index, 'equivalents', [
+      ...equivalents,
+      { serving_size: 1, serving_unit: '' },
+    ]);
+  };
+
+  const updateEquivalent = (
+    eqIndex: number,
+    field: keyof EquivalentUnit,
+    value: string | number
+  ) => {
+    const updated = [...equivalents];
+    updated[eqIndex] = {
+      ...updated[eqIndex],
+      [field]: value,
+    } as EquivalentUnit;
+    onUpdate(index, 'equivalents', updated);
+  };
+
+  const removeEquivalent = (eqIndex: number) => {
+    const updated = equivalents.filter((_, i) => i !== eqIndex);
+    onUpdate(index, 'equivalents', updated);
+  };
+
   return (
     <Card key={index} className="p-4">
-      <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 flex-wrap mb-4">
-        {/* Unit Select and Serving Size Inputs go here (omitted for brevity, same as your original) */}
-        <div className="flex items-end gap-2">
-          <div className="flex flex-col">
-            <Label htmlFor={`serving-size-${index}`}>Serving Size</Label>
-            <Input
-              id={`serving-size-${index}`}
-              type="number"
-              step="0.1"
-              value={variant.serving_size}
-              onChange={(e) =>
-                onUpdate(index, 'serving_size', Number(e.target.value))
-              }
-              className="w-24"
-            />
+      <div className="flex flex-col gap-4 mb-4">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 flex-wrap">
+          <div className="flex items-end gap-2">
+            <div className="flex flex-col">
+              <Label htmlFor={`serving-size-${index}`}>Serving Size</Label>
+              <Input
+                id={`serving-size-${index}`}
+                type="number"
+                step="0.1"
+                value={variant.serving_size}
+                onChange={(e) =>
+                  onUpdate(index, 'serving_size', Number(e.target.value))
+                }
+                className="w-24"
+              />
+            </div>
+
+            <div className="flex flex-col">
+              <Label htmlFor={`serving-unit-${index}`}>Unit Type</Label>
+              <Select
+                value={variant.serving_unit}
+                onValueChange={(value) =>
+                  onUpdate(index, 'serving_unit', value)
+                }
+              >
+                <SelectTrigger id={`serving-unit-${index}`} className="w-32">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {UNIT_GROUPS.map((group) => (
+                    <SelectGroup key={group.label}>
+                      <SelectLabel>{group.label}</SelectLabel>
+                      {group.units.map((unit) => {
+                        const compatible =
+                          unit !== baseServingUnit &&
+                          getConversionFactor(baseServingUnit, unit) !== null;
+                        return (
+                          <SelectItem key={unit} value={unit}>
+                            <span className="flex items-center gap-1.5">
+                              {unit}
+                              {compatible && (
+                                <Check className="h-3 w-3 text-green-500" />
+                              )}
+                            </span>
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectGroup>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
 
-          <div className="flex flex-col">
-            <Label htmlFor={`serving-unit-${index}`}>Unit Type</Label>
-            <Select
-              value={variant.serving_unit}
-              onValueChange={(value) => onUpdate(index, 'serving_unit', value)}
-            >
-              <SelectTrigger id={`serving-unit-${index}`} className="w-32">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {UNIT_GROUPS.map((group) => (
-                  <SelectGroup key={group.label}>
-                    <SelectLabel>{group.label}</SelectLabel>
-                    {group.units.map((unit) => {
-                      const compatible =
-                        unit !== baseServingUnit &&
-                        getConversionFactor(baseServingUnit, unit) !== null;
-                      return (
-                        <SelectItem key={unit} value={unit}>
-                          <span className="flex items-center gap-1.5">
-                            {unit}
-                            {compatible && (
-                              <Check className="h-3 w-3 text-green-500" />
-                            )}
-                          </span>
-                        </SelectItem>
-                      );
-                    })}
-                  </SelectGroup>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
+          {variantError && (
+            <p className="text-red-500 text-sm mt-1">{variantError}</p>
+          )}
 
-        {variantError && (
-          <p className="text-red-500 text-sm mt-1">{variantError}</p>
-        )}
+          <div className="flex items-center gap-4 flex-wrap">
+            <div className="flex items-center space-x-2">
+              <Input
+                type="checkbox"
+                id={`is-default-${index}`}
+                checked={variant.is_default ?? false}
+                onChange={(e) =>
+                  onUpdate(index, 'is_default', e.target.checked)
+                }
+                className="form-checkbox h-4 w-4 text-blue-600"
+              />
+              <Label htmlFor={`is-default-${index}`} className="text-sm">
+                Default
+              </Label>
+            </div>
 
-        {/* Default / Auto-Scale Checkboxes */}
-        <div className="flex items-center gap-4 flex-wrap">
-          <div className="flex items-center space-x-2">
-            <input
-              type="checkbox"
-              id={`is-default-${index}`}
-              checked={variant.is_default ?? false}
-              onChange={(e) => onUpdate(index, 'is_default', e.target.checked)}
-              className="form-checkbox h-4 w-4 text-blue-600"
-            />
-            <Label htmlFor={`is-default-${index}`} className="text-sm">
-              Default
-            </Label>
+            <div className="flex items-center space-x-2">
+              <Input
+                type="checkbox"
+                id={`is-locked-${index}`}
+                checked={variant.is_locked ?? false}
+                onChange={(e) => onUpdate(index, 'is_locked', e.target.checked)}
+                className="form-checkbox h-4 w-4 text-blue-600"
+              />
+              <Label htmlFor={`is-locked-${index}`} className="text-sm">
+                Auto-Scale
+              </Label>
+            </div>
           </div>
 
-          <div className="flex items-center space-x-2">
-            <input
-              type="checkbox"
-              id={`is-locked-${index}`}
-              checked={variant.is_locked ?? false}
-              onChange={(e) => onUpdate(index, 'is_locked', e.target.checked)}
-              className="form-checkbox h-4 w-4 text-blue-600"
-            />
-            <Label htmlFor={`is-locked-${index}`} className="text-sm">
-              Auto-Scale
-            </Label>
-          </div>
-        </div>
-
-        {/* Action Buttons */}
-        <div className="flex items-center gap-2 ml-auto sm:ml-0">
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() => onDuplicate(index)}
-            title="Duplicate Unit"
-          >
-            <Copy className="w-4 h-4" />
-          </Button>
-          {index > 0 && (
+          <div className="flex items-center gap-2 ml-auto m:ml-0">
             <Button
               type="button"
               variant="ghost"
               size="sm"
-              onClick={() => onRemove(index)}
-              title="Remove Unit"
+              onClick={addEquivalent}
+              title="Add Equivalent Unit"
+            >
+              <Plus className="w-4 h-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => onDuplicate(index)}
+              title="Duplicate Unit"
+            >
+              <Copy className="w-4 h-4" />
+            </Button>
+            {index > 0 && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => onRemove(index)}
+                title="Remove Unit"
+              >
+                <Trash2 className="w-4 h-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {equivalents.map((eq, eqIndex) => (
+          <div key={eqIndex} className="flex items-end gap-2 ">
+            <div className="flex flex-col">
+              <Label htmlFor={`eq-size-${index}-${eqIndex}`}>
+                Equivalent Size
+              </Label>
+              <Input
+                id={`eq-size-${index}-${eqIndex}`}
+                type="number"
+                step="0.1"
+                value={eq.serving_size}
+                onChange={(e) =>
+                  updateEquivalent(
+                    eqIndex,
+                    'serving_size',
+                    Number(e.target.value)
+                  )
+                }
+                className="w-24"
+              />
+            </div>
+            <div className="flex flex-col">
+              <Label htmlFor={`eq-unit-${index}-${eqIndex}`}>Unit Type</Label>
+              <Select
+                value={eq.serving_unit}
+                onValueChange={(value) =>
+                  updateEquivalent(eqIndex, 'serving_unit', value)
+                }
+              >
+                <SelectTrigger
+                  id={`eq-unit-${index}-${eqIndex}`}
+                  className="w-32"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {UNIT_GROUPS.map((group) => (
+                    <SelectGroup key={group.label}>
+                      <SelectLabel>{group.label}</SelectLabel>
+                      {group.units.map((unit) => (
+                        <SelectItem key={unit} value={unit}>
+                          {unit}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => removeEquivalent(eqIndex)}
+              title="Remove Equivalent"
             >
               <Trash2 className="w-4 h-4" />
             </Button>
-          )}
-        </div>
+          </div>
+        ))}
       </div>
 
       <h4 className="text-md font-medium mb-2">

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
@@ -25,8 +25,10 @@ import {
   getUnitCategory,
 } from '@/utils/servingSizeConversions';
 import type {
+  EquivalentUnit,
   Food,
   FoodVariant,
+  FormFoodVariantWithEquivalents,
   GlycemicIndex,
   NumericFoodVariantKeys,
 } from '@/types/food';
@@ -60,6 +62,42 @@ function zeroOutVariantNutrition(variant: FormFoodVariant): FormFoodVariant {
   return zeroedVariant;
 }
 
+function groupEquivalentVariants(
+  variants: FormFoodVariant[]
+): (FormFoodVariant & { equivalents: EquivalentUnit[] })[] {
+  const grouped: (FormFoodVariant & { equivalents: EquivalentUnit[] })[] = [];
+
+  for (const variant of variants) {
+    const matchIndex = grouped.findIndex((g) => {
+      for (const field of nutrientFields) {
+        if (g[field] !== variant[field]) return false;
+      }
+      const c1 = g.custom_nutrients || {};
+      const c2 = variant.custom_nutrients || {};
+      const keys1 = Object.keys(c1);
+      const keys2 = Object.keys(c2);
+
+      if (keys1.length !== keys2.length) return false;
+      for (const key of keys1) {
+        if (c1[key] !== c2[key]) return false;
+      }
+      return true;
+    });
+    const match = grouped[matchIndex];
+    if (matchIndex !== -1) {
+      match?.equivalents.push({
+        id: variant.id,
+        serving_size: Number(variant.serving_size),
+        serving_unit: variant.serving_unit,
+      });
+    } else {
+      grouped.push({ ...variant, equivalents: [] });
+    }
+  }
+
+  return grouped;
+}
+
 export function useCustomFoodForm({
   food,
   initialVariants,
@@ -78,11 +116,15 @@ export function useCustomFoodForm({
   const { mutateAsync: saveFood } = useSaveFoodMutation();
 
   const [loading, setLoading] = useState(false);
-  const [variants, setVariants] = useState<FormFoodVariant[]>([]);
-  const [originalVariants, setOriginalVariants] = useState<FormFoodVariant[]>(
+  const [variants, setVariants] = useState<FormFoodVariantWithEquivalents[]>(
     []
   );
-  const [loadedVariants, setLoadedVariants] = useState<FormFoodVariant[]>([]);
+  const [originalVariants, setOriginalVariants] = useState<
+    FormFoodVariantWithEquivalents[]
+  >([]);
+  const [loadedVariants, setLoadedVariants] = useState<
+    FormFoodVariantWithEquivalents[]
+  >([]);
   const [manualUnitConversionPending, setManualUnitConversionPending] =
     useState<boolean[]>([]);
   const [variantErrors, setVariantErrors] = useState<string[]>([]);
@@ -97,8 +139,9 @@ export function useCustomFoodForm({
   const resetForm = useCallback(() => {
     setFormData({ name: '', brand: '', is_quick_food: false });
     const defaultVariant = createDefaultFormVariant(customNutrients);
-    const snapshot = [deepClone(defaultVariant)];
-    setVariants([defaultVariant]);
+    const grouped = groupEquivalentVariants([defaultVariant]);
+    const snapshot = deepClone(grouped);
+    setVariants(grouped);
     setOriginalVariants(snapshot);
     setLoadedVariants(snapshot);
     setManualUnitConversionPending([false]);
@@ -137,16 +180,18 @@ export function useCustomFoodForm({
         loaded = [createDefaultFormVariant(customNutrients)];
       }
 
-      const snapshot = deepClone(loaded);
-      setVariants(loaded);
+      const grouped = groupEquivalentVariants(loaded);
+      const snapshot = deepClone(grouped);
+      setVariants(grouped);
       setOriginalVariants(snapshot);
       setLoadedVariants(snapshot);
-      setManualUnitConversionPending(new Array(loaded.length).fill(false));
+      setManualUnitConversionPending(new Array(grouped.length).fill(false));
     } catch (err) {
       console.error('Error loading variants:', err);
       const fallback = createDefaultFormVariant(customNutrients);
-      const snapshot = [deepClone(fallback)];
-      setVariants([fallback]);
+      const grouped = groupEquivalentVariants([fallback]);
+      const snapshot = deepClone(grouped);
+      setVariants(grouped);
       setOriginalVariants(snapshot);
       setLoadedVariants(snapshot);
       setManualUnitConversionPending([false]);
@@ -169,24 +214,32 @@ export function useCustomFoodForm({
             glycemic_index: sanitizeGlycemicIndexFrontend(v.glycemic_index),
           })
         );
-        const snapshot = deepClone(mapped);
-        setVariants(mapped);
+        mapped.sort((a, b) => (b.is_default ? 1 : 0) - (a.is_default ? 1 : 0));
+
+        const grouped = groupEquivalentVariants(mapped);
+        const snapshot = deepClone(grouped);
+
+        setVariants(grouped);
         setOriginalVariants(snapshot);
         setLoadedVariants(snapshot);
-        setManualUnitConversionPending(new Array(mapped.length).fill(false));
-        setVariantErrors(new Array(food.variants.length).fill(null));
+        setManualUnitConversionPending(new Array(grouped.length).fill(false));
+        setVariantErrors(new Array(grouped.length).fill(''));
       } else {
         loadExistingVariants();
       }
     } else if (initialVariants && initialVariants.length > 0) {
       setFormData({ name: '', brand: '', is_quick_food: false });
       const mapped = initialVariants.map(foodVariantToFormVariant);
-      const snapshot = deepClone(mapped);
-      setVariants(mapped);
+      mapped.sort((a, b) => (b.is_default ? 1 : 0) - (a.is_default ? 1 : 0));
+
+      const grouped = groupEquivalentVariants(mapped);
+      const snapshot = deepClone(grouped);
+
+      setVariants(grouped);
       setOriginalVariants(snapshot);
       setLoadedVariants(snapshot);
-      setManualUnitConversionPending(new Array(mapped.length).fill(false));
-      setVariantErrors(new Array(initialVariants.length).fill(null));
+      setManualUnitConversionPending(new Array(grouped.length).fill(false));
+      setVariantErrors(new Array(grouped.length).fill(''));
     } else {
       resetForm();
     }
@@ -204,8 +257,10 @@ export function useCustomFoodForm({
       serving_size: 1,
       is_default: false,
     });
-    const clone = deepClone(newVariant);
-    setVariants((prev) => [...prev, newVariant]);
+    const groupedVariant = { ...newVariant, equivalents: [] };
+    const clone = deepClone(groupedVariant);
+
+    setVariants((prev) => [...prev, groupedVariant]);
     setOriginalVariants((prev) => [...prev, clone]);
     setLoadedVariants((prev) => [...prev, clone]);
     setManualUnitConversionPending((prev) => [...prev, false]);
@@ -218,6 +273,7 @@ export function useCustomFoodForm({
     const sourceLoadedVariant = loadedVariants[index];
     const sourceRequiresManualConversion =
       manualUnitConversionPending[index] ?? false;
+
     if (!src) {
       error(
         loggingLevel,
@@ -226,12 +282,15 @@ export function useCustomFoodForm({
       );
       return;
     }
-    const newVariant: FormFoodVariant = {
+
+    const newVariant: FormFoodVariant & { equivalents: EquivalentUnit[] } = {
       ...src,
       id: undefined,
       is_default: false,
       is_locked: false,
+      equivalents: deepClone(src.equivalents || []),
     };
+
     const originalClone = deepClone(
       sourceRequiresManualConversion ? sourceOriginalVariant || src : newVariant
     );
@@ -240,6 +299,7 @@ export function useCustomFoodForm({
         ? sourceLoadedVariant || sourceOriginalVariant || src
         : newVariant
     );
+
     setVariants((prev) => [...prev, newVariant]);
     setOriginalVariants((prev) => [...prev, originalClone]);
     setLoadedVariants((prev) => [...prev, loadedClone]);
@@ -272,12 +332,13 @@ export function useCustomFoodForm({
   const updateVariant = (
     index: number,
     field: keyof FormFoodVariant | string,
-    value: string | number | boolean | GlycemicIndex
+    value: string | number | boolean | GlycemicIndex | EquivalentUnit[]
   ) => {
     const updatedVariants = [...variants];
     const updatedOriginalVariants = [...originalVariants];
     const updatedManualUnitConversionPending = [...manualUnitConversionPending];
     const currentVariant = updatedVariants[index];
+
     if (!currentVariant) {
       error(loggingLevel, 'Could not find variant to update at index:', index);
       return;
@@ -288,8 +349,8 @@ export function useCustomFoodForm({
       nutrientFields.includes(field as NumericFoodVariantKeys) ||
       isCustomNutrient;
 
-    // Build updated variant
-    let newVariant: FormFoodVariant;
+    let newVariant: FormFoodVariant & { equivalents?: EquivalentUnit[] };
+
     if (isCustomNutrient) {
       newVariant = {
         ...currentVariant,
@@ -306,8 +367,8 @@ export function useCustomFoodForm({
     } else {
       newVariant = {
         ...currentVariant,
-        [field as keyof FormFoodVariant]: value,
       };
+      (newVariant as Record<string, unknown>)[field] = value;
     }
 
     // Validate serving_size
@@ -480,9 +541,29 @@ export function useCustomFoodForm({
         provider_type: food?.provider_type,
       };
 
+      const expandedVariants: FormFoodVariant[] = [];
+
+      variants.forEach((variant) => {
+        const { equivalents, ...baseVariant } = variant;
+
+        expandedVariants.push(baseVariant as FormFoodVariant);
+
+        if (equivalents && equivalents.length > 0) {
+          equivalents.forEach((eq) => {
+            expandedVariants.push({
+              ...baseVariant,
+              id: eq.id, // TS now knows this exists
+              is_default: false,
+              serving_size: eq.serving_size,
+              serving_unit: eq.serving_unit,
+            } as FormFoodVariant);
+          });
+        }
+      });
+
       const savedFood = await saveFood({
         foodData,
-        variants: variants.map(formVariantToFoodVariant),
+        variants: expandedVariants.map(formVariantToFoodVariant),
         userId: user.id,
         foodId: food?.id,
       });

--- a/SparkyFitnessFrontend/src/types/food.ts
+++ b/SparkyFitnessFrontend/src/types/food.ts
@@ -1,3 +1,5 @@
+import { FormFoodVariant } from '@/utils/foodForm';
+
 export type GlycemicIndex =
   | 'None'
   | 'Very Low'
@@ -182,3 +184,12 @@ export type NumericFoodVariantKeys = Exclude<
   | 'glycemic_index'
   | 'custom_nutrients'
 >;
+export interface EquivalentUnit {
+  id?: string;
+  serving_size: number;
+  serving_unit: string;
+}
+
+export type FormFoodVariantWithEquivalents = FormFoodVariant & {
+  equivalents?: EquivalentUnit[];
+};


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
If you want multiple variants with the same value like 100g = 4 cups = 2 pieces you had to create 3 seperate entries.

**How did you implement the solution?**
I changed the logic to save equivalent variants without changes in the backend. It's saved normally, but the frontend makes editing and adding easier by comparing them to find out if they are equivalent.

Linked Issue: Closes #1044

## How to Test

1. Create food with multiple equivalent variants

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<img width="1119" height="1354" alt="image" src="https://github.com/user-attachments/assets/7cd36dd6-1a3f-428c-8641-c22efeb33b6f" />


