### PR TITLE
fix(1180): recalc sleep after merge

### DIFF
--- a/SparkyFitnessServer/db/migrations/20260423120000_sleep_entry_stages_unique_natural_key.sql
+++ b/SparkyFitnessServer/db/migrations/20260423120000_sleep_entry_stages_unique_natural_key.sql
@@ -1,0 +1,25 @@
+-- Sleep stages now merge by natural key (entry_id, start_time, end_time) on re-sync
+-- (issue #1180). Defensively dedupe legacy duplicates before adding the unique index.
+--
+-- Survivor rule: keep the row most recently touched. updated_at and created_at both have
+-- DEFAULT CURRENT_TIMESTAMP but neither column is declared NOT NULL, so COALESCE through
+-- both, falling back to epoch. Tiebreak on id only when timestamps are identical
+-- (UUID order is random and uncorrelated with recency).
+DELETE FROM sleep_entry_stages a
+USING sleep_entry_stages b
+WHERE a.entry_id = b.entry_id
+  AND a.start_time = b.start_time
+  AND a.end_time = b.end_time
+  AND a.id <> b.id
+  AND (
+    COALESCE(a.updated_at, a.created_at, '1970-01-01'::timestamptz)
+      < COALESCE(b.updated_at, b.created_at, '1970-01-01'::timestamptz)
+    OR (
+      COALESCE(a.updated_at, a.created_at, '1970-01-01'::timestamptz)
+        = COALESCE(b.updated_at, b.created_at, '1970-01-01'::timestamptz)
+      AND a.id < b.id
+    )
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS sleep_entry_stages_entry_natural_key_idx
+  ON public.sleep_entry_stages (entry_id, start_time, end_time);

--- a/SparkyFitnessServer/integrations/fitbit/fitbitDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/fitbit/fitbitDataProcessor.ts
@@ -511,12 +511,17 @@ async function processFitbitSleep(
         if (stageType === 'wake' || stageType === 'restless')
           stageType = 'awake';
         if (stageType === 'asleep') stageType = 'light';
-        await sleepRepository.upsertSleepStageEvent(userId, result.id, {
-          stage_type: stageType,
-          start_time: startIso,
-          end_time: endTime.toISOString(),
-          duration_in_seconds: stage.seconds,
-        });
+        await sleepRepository.upsertSleepStageEvent(
+          userId,
+          result.id,
+          {
+            stage_type: stageType,
+            start_time: startIso,
+            end_time: endTime.toISOString(),
+            duration_in_seconds: stage.seconds,
+          },
+          createdByUserId
+        );
       }
     }
   }

--- a/SparkyFitnessServer/integrations/polar/polarDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/polar/polarDataProcessor.ts
@@ -478,14 +478,19 @@ async function processPolarSleep(
             durationSec = Math.round((endDateUTC - stageStartTimeUTC) / 1000);
           }
           if (durationSec > 0) {
-            await sleepRepository.upsertSleepStageEvent(userId, entry.id, {
-              stage_type: stageType,
-              start_time: stageStartTimeUTC.toISOString(),
-              end_time: new Date(
-                stageStartTimeUTC.getTime() + durationSec * 1000
-              ).toISOString(),
-              duration_in_seconds: durationSec,
-            });
+            await sleepRepository.upsertSleepStageEvent(
+              userId,
+              entry.id,
+              {
+                stage_type: stageType,
+                start_time: stageStartTimeUTC.toISOString(),
+                end_time: new Date(
+                  stageStartTimeUTC.getTime() + durationSec * 1000
+                ).toISOString(),
+                duration_in_seconds: durationSec,
+              },
+              createdByUserId
+            );
           }
         }
       }

--- a/SparkyFitnessServer/integrations/withings/withingsDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/withings/withingsDataProcessor.ts
@@ -709,12 +709,17 @@ async function processWithingsSleepData(
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         stageAggregates[stageKey] += duration;
       }
-      await sleepRepository.upsertSleepStageEvent(userId, entryId, {
-        stage_type: stageType,
-        start_time: new Date(segment.startdate * 1000).toISOString(),
-        end_time: new Date(segment.enddate * 1000).toISOString(),
-        duration_in_seconds: duration,
-      });
+      await sleepRepository.upsertSleepStageEvent(
+        userId,
+        entryId,
+        {
+          stage_type: stageType,
+          start_time: new Date(segment.startdate * 1000).toISOString(),
+          end_time: new Date(segment.enddate * 1000).toISOString(),
+          duration_in_seconds: duration,
+        },
+        createdByUserId
+      );
     }
     await sleepRepository.updateSleepEntry(userId, entryId, createdByUserId, {
       deep_sleep_seconds: stageAggregates.deep,

--- a/SparkyFitnessServer/models/sleepRepository.ts
+++ b/SparkyFitnessServer/models/sleepRepository.ts
@@ -171,117 +171,342 @@ async function upsertSleepEntry(
   }
 }
 
+function normalizeSleepStageEventData(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sleepStageEventData: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userId: any
+) {
+  const normalized = { ...sleepStageEventData };
+  const { stage_type, start_time, duration_in_seconds } = normalized;
+  let { end_time } = normalized;
+  if (!end_time && start_time && duration_in_seconds) {
+    const start = new Date(start_time);
+    end_time = new Date(
+      start.getTime() + duration_in_seconds * 1000
+    ).toISOString();
+    log(
+      'info',
+      `[sleepRepository] Derived missing end_time (${end_time}) for stage ${stage_type} at ${start_time} for user ${userId}`
+    );
+  }
+  normalized.end_time = end_time;
+  return normalized;
+}
+
+async function upsertSleepStageEventWithClient(
+  client: Awaited<ReturnType<typeof getClient>>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  entryId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sleepStageEventData: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  actingUserId: any = null
+) {
+  const normalized = normalizeSleepStageEventData(sleepStageEventData, userId);
+  const { id, stage_type, start_time, end_time, duration_in_seconds } =
+    normalized;
+  let sleepStageEventId;
+  const isUUID =
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
+      id
+    );
+  const upsertByNaturalKey = `
+    INSERT INTO sleep_entry_stages
+      (entry_id, user_id, stage_type, start_time, end_time, duration_in_seconds, created_by_user_id, updated_by_user_id)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $7)
+    ON CONFLICT (entry_id, start_time, end_time) DO UPDATE SET
+      stage_type = EXCLUDED.stage_type,
+      duration_in_seconds = EXCLUDED.duration_in_seconds,
+      updated_by_user_id = EXCLUDED.updated_by_user_id,
+      updated_at = CURRENT_TIMESTAMP
+    RETURNING id;
+  `;
+  if (id && isUUID) {
+    const updateQuery = `
+      UPDATE sleep_entry_stages
+      SET stage_type = $4,
+          start_time = $5,
+          end_time = $6,
+          duration_in_seconds = $7,
+          updated_by_user_id = $8,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = $1 AND entry_id = $2 AND user_id = $3
+      RETURNING id;
+    `;
+    const updateResult = await client.query(updateQuery, [
+      id,
+      entryId,
+      userId,
+      stage_type,
+      start_time,
+      end_time,
+      duration_in_seconds,
+      actingUserId,
+    ]);
+    if (updateResult.rows.length > 0) {
+      sleepStageEventId = updateResult.rows[0].id;
+      log(
+        'info',
+        `Updated sleep stage event ${sleepStageEventId} for entry ${entryId}.`
+      );
+    } else {
+      const insertResult = await client.query(upsertByNaturalKey, [
+        entryId,
+        userId,
+        stage_type,
+        start_time,
+        end_time,
+        duration_in_seconds,
+        actingUserId,
+      ]);
+      sleepStageEventId = insertResult.rows[0].id;
+      log(
+        'info',
+        `Upserted sleep stage event ${sleepStageEventId} for entry ${entryId} (id ${id} not found).`
+      );
+    }
+  } else {
+    const insertResult = await client.query(upsertByNaturalKey, [
+      entryId,
+      userId,
+      stage_type,
+      start_time,
+      end_time,
+      duration_in_seconds,
+      actingUserId,
+    ]);
+    sleepStageEventId = insertResult.rows[0].id;
+    const reason =
+      id === undefined ? 'no ID provided' : `ignoring invalid ID: ${id}`;
+    log(
+      'info',
+      `Upserted sleep stage event ${sleepStageEventId} for entry ${entryId} (${reason}).`
+    );
+  }
+  const { id: _originalId, ...restOfData } = normalized;
+  return { id: sleepStageEventId, ...restOfData };
+}
+
 async function upsertSleepStageEvent(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   userId: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   entryId: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  sleepStageEventData: any
+  sleepStageEventData: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  actingUserId: any = null
 ) {
   const client = await getClient(userId);
   try {
     await client.query('BEGIN');
-    const { id } = sleepStageEventData; // Optional: if provided, attempt to update
-    const { stage_type, start_time, duration_in_seconds } = sleepStageEventData;
-    let { end_time } = sleepStageEventData;
-    // Defense: If end_time is missing but duration and start_time are present, calculate it
-    if (!end_time && start_time && duration_in_seconds) {
-      const start = new Date(start_time);
-      end_time = new Date(
-        start.getTime() + duration_in_seconds * 1000
-      ).toISOString();
-      log(
-        'info',
-        `[sleepRepository] Derived missing end_time (${end_time}) for stage ${stage_type} at ${start_time} for user ${userId}`
-      );
-    }
-    let sleepStageEventId;
-    // Basic UUID validation
-    const isUUID =
-      /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
-        id
-      );
-    if (id && isUUID) {
-      // Attempt to update existing event
-      const updateQuery = `
-                UPDATE sleep_entry_stages
-        SET
-        stage_type = $4,
-            start_time = $5,
-            end_time = $6,
-            duration_in_seconds = $7,
-            updated_at = CURRENT_TIMESTAMP
-                WHERE id = $1 AND entry_id = $2 AND user_id = $3
-                RETURNING id;
-        `;
-      const updateResult = await client.query(updateQuery, [
-        id,
-        entryId,
-        userId,
-        stage_type,
-        start_time,
-        end_time,
-        duration_in_seconds,
-      ]);
-      if (updateResult.rows.length > 0) {
-        sleepStageEventId = updateResult.rows[0].id;
-        log(
-          'info',
-          `Updated sleep stage event ${sleepStageEventId} for entry ${entryId}.`
-        );
-      } else {
-        // If no row was updated, insert new event
-        const insertQuery = `
-                    INSERT INTO sleep_entry_stages(entry_id, user_id, stage_type, start_time, end_time, duration_in_seconds)
-        VALUES($1, $2, $3, $4, $5, $6)
-                    RETURNING id;
-        `;
-        const insertResult = await client.query(insertQuery, [
-          entryId,
-          userId,
-          stage_type,
-          start_time,
-          end_time,
-          duration_in_seconds,
-        ]);
-        sleepStageEventId = insertResult.rows[0].id;
-        log(
-          'info',
-          `Inserted new sleep stage event ${sleepStageEventId} for entry ${entryId}.`
-        );
-      }
-    } else {
-      // Insert new event, ignoring the invalid ID
-      const insertQuery = `
-                INSERT INTO sleep_entry_stages(entry_id, user_id, stage_type, start_time, end_time, duration_in_seconds)
-        VALUES($1, $2, $3, $4, $5, $6)
-                RETURNING id;
-        `;
-      const insertResult = await client.query(insertQuery, [
-        entryId,
-        userId,
-        stage_type,
-        start_time,
-        end_time,
-        duration_in_seconds,
-      ]);
-      sleepStageEventId = insertResult.rows[0].id;
-      const reason =
-        id === undefined ? 'no ID provided' : `ignoring invalid ID: ${id}`;
-      log(
-        'info',
-        `Inserted new sleep stage event ${sleepStageEventId} for entry ${entryId} (${reason}).`
-      );
-    }
+    const result = await upsertSleepStageEventWithClient(
+      client,
+      userId,
+      entryId,
+      sleepStageEventData,
+      actingUserId
+    );
     await client.query('COMMIT');
-    const { id: _originalId, ...restOfData } = sleepStageEventData;
-    return { id: sleepStageEventId, ...restOfData };
+    return result;
   } catch (error) {
     await client.query('ROLLBACK');
     log(
       'error',
       `Error upserting sleep stage event for entry ${entryId}: `,
+      error
+    );
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function deleteSupersededSleepStagesWithClient(
+  client: Awaited<ReturnType<typeof getClient>>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  entryId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  windowStart: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  windowEnd: any,
+  keptStages: Array<{
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    start_time: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    end_time: any;
+  }>
+) {
+  const keptStarts = keptStages.map((s) =>
+    s.start_time instanceof Date
+      ? s.start_time.toISOString()
+      : new Date(s.start_time).toISOString()
+  );
+  const keptEnds = keptStages.map((s) =>
+    s.end_time instanceof Date
+      ? s.end_time.toISOString()
+      : new Date(s.end_time).toISOString()
+  );
+  const result = await client.query(
+    `DELETE FROM sleep_entry_stages s
+     WHERE s.entry_id = $1
+       AND s.user_id = $2
+       AND s.start_time >= $3
+       AND s.end_time   <= $4
+       AND NOT EXISTS (
+         SELECT 1 FROM unnest($5::timestamptz[], $6::timestamptz[]) AS kept(st, et)
+         WHERE kept.st = s.start_time AND kept.et = s.end_time
+       )
+     RETURNING id`,
+    [entryId, userId, windowStart, windowEnd, keptStarts, keptEnds]
+  );
+  if (result.rows.length > 0) {
+    log(
+      'info',
+      `Deleted ${result.rows.length} superseded sleep stage events for entry ${entryId} (re-sync refined boundaries).`
+    );
+  }
+  return { deleted: result.rows.length };
+}
+
+async function mergeSleepStageEvents(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  entryId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  sleepStageEvents: any[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  actingUserId: any = null
+) {
+  const client = await getClient(userId);
+  try {
+    await client.query('BEGIN');
+    const normalizedEvents = sleepStageEvents.map((event) =>
+      normalizeSleepStageEventData(event, userId)
+    );
+    const startMs = normalizedEvents.map((s) =>
+      new Date(s.start_time).getTime()
+    );
+    const endMs = normalizedEvents.map((s) => new Date(s.end_time).getTime());
+    const payloadStart = new Date(Math.min(...startMs));
+    const payloadEnd = new Date(Math.max(...endMs));
+    await deleteSupersededSleepStagesWithClient(
+      client,
+      userId,
+      entryId,
+      payloadStart,
+      payloadEnd,
+      normalizedEvents
+    );
+    const results = [];
+    for (const stageEvent of normalizedEvents) {
+      results.push(
+        await upsertSleepStageEventWithClient(
+          client,
+          userId,
+          entryId,
+          stageEvent,
+          actingUserId
+        )
+      );
+    }
+    await client.query('COMMIT');
+    return results;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    log(
+      'error',
+      `Error merging sleep stage events for entry ${entryId}: `,
+      error
+    );
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getSleepStageEventsByEntryId(userId: any, entryId: any) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT id, stage_type, start_time, end_time, duration_in_seconds
+       FROM sleep_entry_stages
+       WHERE entry_id = $1 AND user_id = $2
+       ORDER BY start_time ASC`,
+      [entryId, userId]
+    );
+    return result.rows;
+  } catch (error) {
+    log(
+      'error',
+      `Error fetching sleep stage events for entry ${entryId} for user ${userId}: `,
+      error
+    );
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function updateSleepEntryAggregates(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  entryId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  actingUserId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  aggregates: any
+) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `UPDATE sleep_entries
+       SET bedtime = $3,
+           wake_time = $4,
+           duration_in_seconds = $5,
+           time_asleep_in_seconds = $6,
+           sleep_score = $7,
+           deep_sleep_seconds = $8,
+           light_sleep_seconds = $9,
+           rem_sleep_seconds = $10,
+           awake_sleep_seconds = $11,
+           updated_by_user_id = $12,
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = $1 AND user_id = $2
+       RETURNING id`,
+      [
+        entryId,
+        userId,
+        aggregates.bedtime,
+        aggregates.wake_time,
+        aggregates.duration_in_seconds,
+        aggregates.time_asleep_in_seconds,
+        aggregates.sleep_score,
+        aggregates.deep_sleep_seconds,
+        aggregates.light_sleep_seconds,
+        aggregates.rem_sleep_seconds,
+        aggregates.awake_sleep_seconds,
+        actingUserId,
+      ]
+    );
+    if (result.rows.length === 0) {
+      throw new Error(
+        `Sleep entry ${entryId} not found for user ${userId} during aggregate update.`
+      );
+    }
+    return { id: result.rows[0].id, ...aggregates };
+  } catch (error) {
+    log(
+      'error',
+      `Error updating sleep entry aggregates for entry ${entryId} for user ${userId}: `,
       error
     );
     throw error;
@@ -753,6 +978,9 @@ async function deleteSleepEntry(userId: any, entryId: any) {
 }
 export { upsertSleepEntry };
 export { upsertSleepStageEvent };
+export { mergeSleepStageEvents };
+export { getSleepStageEventsByEntryId };
+export { updateSleepEntryAggregates };
 export { getSleepEntriesByUserIdAndDateRange };
 export { updateSleepEntry };
 export { deleteSleepStageEventsByEntryId };
@@ -762,6 +990,9 @@ export { deleteSleepEntriesByEntrySourceAndDate };
 export default {
   upsertSleepEntry,
   upsertSleepStageEvent,
+  mergeSleepStageEvents,
+  getSleepStageEventsByEntryId,
+  updateSleepEntryAggregates,
   getSleepEntriesByUserIdAndDateRange,
   updateSleepEntry,
   deleteSleepStageEventsByEntryId,

--- a/SparkyFitnessServer/models/sleepRepository.ts
+++ b/SparkyFitnessServer/models/sleepRepository.ts
@@ -384,6 +384,11 @@ async function mergeSleepStageEvents(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   actingUserId: any = null
 ) {
+  // Guard at the module boundary: an empty payload window would collapse to
+  // Math.min(...[]) = Infinity → Invalid Date → confusing SQL failure.
+  if (!Array.isArray(sleepStageEvents) || sleepStageEvents.length === 0) {
+    return [];
+  }
   const client = await getClient(userId);
   try {
     await client.query('BEGIN');

--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -322,14 +322,14 @@ async function processHealthData(
   const errors = [];
   const tzMetadataByType = {};
   const tzFallbackByType = {};
-  // 0. Pre-Cleanup: Delete existing Sleep/Exercise entries for the date range to prevent duplicates
-  // This implements a "delete-then-insert" strategy for idempotent sync
+  // 0. Pre-Cleanup: Delete existing Exercise entries for the date range to prevent duplicates
+  // (delete-then-insert idempotency for exercise/workout sessions).
+  // Sleep is intentionally excluded: a partial-window re-sync (e.g. only post-midnight stages)
+  // must NOT wipe the previously-stored full night. Sleep ingest is merge-based via
+  // upsertSleepStageEvent ON CONFLICT + aggregate recompute. See issue #1180.
   const entriesToClean = healthDataArray.filter(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (d: any) =>
-      d.type === 'SleepSession' ||
-      d.type === 'ExerciseSession' ||
-      d.type === 'Workout'
+    (d: any) => d.type === 'ExerciseSession' || d.type === 'Workout'
   );
   if (entriesToClean.length > 0) {
     const datesBySource = {};
@@ -351,27 +351,11 @@ async function processHealthData(
       const dates = Object.keys(datesBySource[source]).sort();
       if (dates.length > 0) {
         const startDate = dates[0];
-        const endDate = dates[dates.length - 1]; // Inclusive end date for the function call
-        // Calculate max date + 1 day for database range logic if needed, but the current repo methods usually take inclusive/specific range
-        // Looking at sleepRepository.deleteSleepEntriesByEntrySourceAndDate(user_id, source, start_date, end_date), it typically handles range.
-        // Let's assume inclusive range which is standard for these helpers.
+        const endDate = dates[dates.length - 1];
         log(
           'info',
-          `[processHealthData] Pre-cleanup: Deleting existing entries for source '${source}' from ${startDate} to ${endDate}.`
+          `[processHealthData] Pre-cleanup: Deleting existing exercise entries for source '${source}' from ${startDate} to ${endDate}.`
         );
-        // Clean Sleep
-        await sleepRepository.deleteSleepEntriesByEntrySourceAndDate(
-          userId,
-          source,
-          startDate,
-          endDate
-        );
-        // Clean Exercises
-        // Note: deleteExerciseEntriesByEntrySourceAndDate expects (userId, startDate, endDate, source) - verify arg order!
-        // Based on typical repo patterns, let's verify.
-        // Wait, standard exerciseEntryRepo usually puts userId first.
-        // I will use safe assumption or verify garminService usage:
-        // garminService: await exerciseEntryRepository.deleteExerciseEntriesByEntrySourceAndDate(userId, startDate, endDate, 'garmin');
         await exerciseEntryDb.deleteExerciseEntriesByEntrySourceAndDate(
           userId,
           startDate,
@@ -1897,6 +1881,9 @@ async function processSleepEntry(
     `[processSleepEntry] Received sleepEntryData: ${JSON.stringify(sleepEntryData)}`
   );
   try {
+    const originalHadStages =
+      Array.isArray(sleepEntryData.stage_events) &&
+      sleepEntryData.stage_events.length > 0;
     let stage_events = sleepEntryData.stage_events;
     const {
       stage_events: _stage_events,
@@ -1913,7 +1900,9 @@ async function processSleepEntry(
       awake_sleep_seconds,
       ...rest
     } = sleepEntryData;
-    // If no stage events are provided, create a default "light sleep" stage
+    // If no stage events are provided, create a default "light sleep" stage. We do NOT
+    // run overlap-delete in this path — the synthetic default would wipe legitimate
+    // pre-existing stages stored from earlier real syncs.
     if (!stage_events || stage_events.length === 0) {
       log(
         'info',
@@ -1976,33 +1965,152 @@ async function processSleepEntry(
       actingUserId,
       entryToUpsert
     );
-    if (stage_events && stage_events.length > 0) {
-      // Deleting existing stages is handled by upsertSleepStageEvent if we treat them as new or updates?
-      // Actually handling stages usually implies wiping for a new sync or upserting individually.
-      // Since upsertSleepEntry returns an ID, we can just insert them.
-      // NOTE: Sync logic usually replaces for a given day.
-      for (const stageEvent of stage_events) {
-        // Round duration for each stage event
-        const duration =
-          Math.round(Number(stageEvent.duration_in_seconds)) || 0;
-        // Pass actingUserId to upsertSleepStageEvent
-        await sleepRepository.upsertSleepStageEvent(
-          userId,
-          newSleepEntry.id,
-          {
-            ...stageEvent,
-            duration_in_seconds: duration,
-          },
-          // @ts-expect-error TS(2554): Expected 3 arguments, but got 4.
-          actingUserId
-        );
-      }
+    if (originalHadStages && stage_events && stage_events.length > 0) {
+      // Stages merge by natural key (entry_id, start_time, end_time) inside one
+      // repository transaction so partial-window cleanup and reinserts are atomic.
+      await sleepRepository.mergeSleepStageEvents(
+        userId,
+        newSleepEntry.id,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        stage_events.map((stageEvent: any) => ({
+          ...stageEvent,
+          duration_in_seconds:
+            Math.round(Number(stageEvent.duration_in_seconds)) || 0,
+        })),
+        actingUserId
+      );
     }
-    return newSleepEntry;
+    // Recompute sleep_entries aggregates from the stored stage rows so they reflect the
+    // durable merged state. For summary-only retries with no incoming stage data, preserve
+    // any previously stored detailed stages instead of layering a synthetic full-night
+    // fallback on top of them. If no stages exist at all, seed a single fallback stage.
+    let mergedStages = await sleepRepository.getSleepStageEventsByEntryId(
+      userId,
+      newSleepEntry.id
+    );
+    if (
+      !originalHadStages &&
+      mergedStages.length === 0 &&
+      stage_events.length > 0
+    ) {
+      await sleepRepository.mergeSleepStageEvents(
+        userId,
+        newSleepEntry.id,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        stage_events.map((stageEvent: any) => ({
+          ...stageEvent,
+          duration_in_seconds:
+            Math.round(Number(stageEvent.duration_in_seconds)) || 0,
+        })),
+        actingUserId
+      );
+      mergedStages = await sleepRepository.getSleepStageEventsByEntryId(
+        userId,
+        newSleepEntry.id
+      );
+    } else if (!originalHadStages && mergedStages.length > 0) {
+      log(
+        'info',
+        `[processSleepEntry] Preserving ${mergedStages.length} existing stage events for entry ${newSleepEntry.id} because the payload had no authoritative stage data.`
+      );
+    }
+    const recomputed = recomputeSleepAggregatesFromStages(mergedStages);
+    const recomputedSleepScore = await calculateSleepScore(
+      {
+        duration_in_seconds: recomputed.duration_in_seconds,
+        time_asleep_in_seconds: recomputed.time_asleep_in_seconds,
+      },
+      mergedStages,
+      age,
+      // @ts-expect-error TS(2554): Expected 2-3 arguments, but got 4.
+      gender
+    );
+    await sleepRepository.updateSleepEntryAggregates(
+      userId,
+      newSleepEntry.id,
+      actingUserId,
+      {
+        ...recomputed,
+        sleep_score: Number(recomputedSleepScore) || 0,
+      }
+    );
+    return {
+      ...newSleepEntry,
+      ...recomputed,
+      sleep_score: Number(recomputedSleepScore) || 0,
+    };
   } catch (error) {
     log('error', `Error in processSleepEntry for user ${userId}:`, error);
     throw error;
   }
+}
+
+// Pure aggregate derivation from a stage list. Limitation: overlapping stage segments
+// (rare, but HealthKit can emit them) are SUMmed and would double-count.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function recomputeSleepAggregatesFromStages(stages: any[]) {
+  if (!stages || stages.length === 0) {
+    return {
+      bedtime: null,
+      wake_time: null,
+      duration_in_seconds: 0,
+      time_asleep_in_seconds: 0,
+      deep_sleep_seconds: 0,
+      light_sleep_seconds: 0,
+      rem_sleep_seconds: 0,
+      awake_sleep_seconds: 0,
+    };
+  }
+  let minStart = new Date(stages[0].start_time).getTime();
+  let maxEnd = new Date(stages[0].end_time).getTime();
+  let deep = 0;
+  let light = 0;
+  let rem = 0;
+  let awake = 0;
+  for (const s of stages) {
+    const startMs = new Date(s.start_time).getTime();
+    const endMs = new Date(s.end_time).getTime();
+    if (startMs < minStart) minStart = startMs;
+    if (endMs > maxEnd) maxEnd = endMs;
+    const duration = Math.round(Number(s.duration_in_seconds)) || 0;
+    switch (s.stage_type) {
+      case 'deep':
+        deep += duration;
+        break;
+      case 'light':
+        light += duration;
+        break;
+      case 'rem':
+        rem += duration;
+        break;
+      case 'awake':
+        awake += duration;
+        break;
+      default:
+        // Unknown stage type — counted in time_asleep below if not 'awake'.
+        break;
+    }
+  }
+  const durationInSeconds = Math.max(0, Math.round((maxEnd - minStart) / 1000));
+  const timeAsleep = stages
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .filter((s: any) => s.stage_type !== 'awake')
+    .reduce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sum: number, s: any) =>
+        sum + (Math.round(Number(s.duration_in_seconds)) || 0),
+      0
+    );
+  return {
+    bedtime: new Date(minStart),
+    wake_time: new Date(maxEnd),
+    duration_in_seconds: durationInSeconds,
+    time_asleep_in_seconds: timeAsleep,
+    deep_sleep_seconds: deep,
+    light_sleep_seconds: light,
+    rem_sleep_seconds: rem,
+    awake_sleep_seconds: awake,
+  };
 }
 async function updateSleepEntry(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -2074,12 +2182,10 @@ async function updateSleepEntry(
       // Then, insert the new stage events
       if (stage_events.length > 0) {
         for (const stageEvent of stage_events) {
-          // Pass actingUserId (assuming upsertSleepStageEvent now takes it)
           await sleepRepository.upsertSleepStageEvent(
             userId,
             entryId,
             stageEvent,
-            // @ts-expect-error TS(2554): Expected 3 arguments, but got 4.
             actingUserId
           );
         }

--- a/SparkyFitnessServer/tests/measurementService.healthConnectSleepStages.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.healthConnectSleepStages.test.ts
@@ -20,6 +20,12 @@ vi.mock('../config/logging', () => ({
 describe('processHealthData Health Connect sleep stages', () => {
   const userId = 'user-hc-sleep';
   const actingUserId = 'user-hc-sleep';
+  type StageEvent = {
+    stage_type: string;
+    start_time: string;
+    end_time: string;
+    duration_in_seconds: number;
+  };
   beforeEach(() => {
     vi.clearAllMocks();
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
@@ -31,14 +37,52 @@ describe('processHealthData Health Connect sleep stages', () => {
     sleepRepository.upsertSleepEntry = vi
       .fn()
       .mockResolvedValue({ id: 'sleep-entry-1' });
+    // Mock returns the exact stage objects we were asked to upsert, so the recompute
+    // step in processSleepEntry sees a consistent merged set.
+    const upsertedStages: StageEvent[] = [];
+    sleepRepository.mergeSleepStageEvents = vi
+      .fn()
+      .mockImplementation(
+        async (
+          _uid: string,
+          _eid: string,
+          stages: StageEvent[],
+          _aid: string
+        ) => {
+          upsertedStages.length = 0;
+          for (const stage of stages) {
+            upsertedStages.push(stage);
+          }
+          return stages.map((stage, index) => ({
+            id: `sleep-stage-${index + 1}`,
+            ...stage,
+          }));
+        }
+      );
     sleepRepository.upsertSleepStageEvent = vi
       .fn()
-      .mockResolvedValue({ id: 'sleep-stage-1' });
+      .mockResolvedValue(undefined);
+    sleepRepository.getSleepStageEventsByEntryId = vi
+      .fn()
+      .mockImplementation(async () => upsertedStages);
+    sleepRepository.updateSleepEntryAggregates = vi
+      .fn()
+      .mockImplementation(
+        async (
+          _uid: string,
+          _eid: string,
+          _aid: string,
+          agg: Record<string, unknown>
+        ) => ({
+          id: 'sleep-entry-1',
+          ...agg,
+        })
+      );
     exerciseEntryDb.deleteExerciseEntriesByEntrySourceAndDate = vi
       .fn()
       .mockResolvedValue(undefined);
   });
-  it('sanitizes staged Health Connect sleep events before generic sleep processing', async () => {
+  it('sanitizes staged Health Connect sleep events and merges (no pre-cleanup delete)', async () => {
     const healthData = [
       {
         type: 'SleepSession',
@@ -105,22 +149,16 @@ describe('processHealthData Health Connect sleep stages', () => {
       userId,
       actingUserId
     );
+    // Regression guard: sleep is no longer pre-deleted on sync ingest (issue #1180).
     expect(
       sleepRepository.deleteSleepEntriesByEntrySourceAndDate
-    ).toHaveBeenCalledWith(
-      userId,
-      'Health Connect',
-      '2024-01-16',
-      '2024-01-16'
-    );
+    ).not.toHaveBeenCalled();
+    // Sleep-only payload should not trigger exercise pre-cleanup — that wipes
+    // unrelated data. Exercise cleanup only fires when ExerciseSession/Workout
+    // entries are present.
     expect(
       exerciseEntryDb.deleteExerciseEntriesByEntrySourceAndDate
-    ).toHaveBeenCalledWith(
-      userId,
-      '2024-01-16',
-      '2024-01-16',
-      'Health Connect'
-    );
+    ).not.toHaveBeenCalled();
     expect(sleepRepository.upsertSleepEntry).toHaveBeenCalledWith(
       userId,
       actingUserId,
@@ -136,11 +174,7 @@ describe('processHealthData Health Connect sleep stages', () => {
     );
     expect(
       // @ts-expect-error TS(2339): Property 'mock' does not exist on type '(userId: a... Remove this comment to see the full error message
-
-      sleepRepository.upsertSleepStageEvent.mock.calls.map(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (call: any) => call[2]
-      )
+      sleepRepository.mergeSleepStageEvents.mock.calls[0][2]
     ).toEqual([
       {
         stage_type: 'light',
@@ -173,6 +207,30 @@ describe('processHealthData Health Connect sleep stages', () => {
         duration_in_seconds: 20700,
       },
     ]);
+    expect(sleepRepository.mergeSleepStageEvents).toHaveBeenCalledWith(
+      userId,
+      'sleep-entry-1',
+      expect.any(Array),
+      actingUserId
+    );
+    // Aggregates were recomputed from merged stages and persisted via the new helper.
+    expect(sleepRepository.updateSleepEntryAggregates).toHaveBeenCalledTimes(1);
+    const aggCall = (
+      sleepRepository.updateSleepEntryAggregates as unknown as {
+        mock: { calls: unknown[][] };
+      }
+    ).mock.calls[0];
+    expect(aggCall[0]).toBe(userId);
+    expect(aggCall[1]).toBe('sleep-entry-1');
+    expect(aggCall[2]).toBe(actingUserId);
+    expect(aggCall[3]).toMatchObject({
+      duration_in_seconds: 28800,
+      time_asleep_in_seconds: 27900,
+      deep_sleep_seconds: 3600,
+      light_sleep_seconds: 22500,
+      rem_sleep_seconds: 1800,
+      awake_sleep_seconds: 900,
+    });
   });
   it('accepts the legacy HealthConnect source spelling for staged sleep payloads', async () => {
     const healthData = [
@@ -217,9 +275,11 @@ describe('processHealthData Health Connect sleep stages', () => {
         time_asleep_in_seconds: 3600,
       })
     );
-    expect(sleepRepository.upsertSleepStageEvent).toHaveBeenCalledTimes(1);
-    // @ts-expect-error TS(2339): Property 'mock' does not exist on type '(userId: a... Remove this comment to see the full error message
-    expect(sleepRepository.upsertSleepStageEvent.mock.calls[0][2]).toEqual({
+    expect(sleepRepository.mergeSleepStageEvents).toHaveBeenCalledTimes(1);
+    expect(
+      // @ts-expect-error TS(2339): Property 'mock' does not exist on type '(userId: a... Remove this comment to see the full error message
+      sleepRepository.mergeSleepStageEvents.mock.calls[0][2][0]
+    ).toEqual({
       stage_type: 'deep',
       start_time: '2024-01-15T22:00:00.000Z',
       end_time: '2024-01-15T23:00:00.000Z',

--- a/SparkyFitnessServer/tests/measurementService.sleepResyncMerge.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.sleepResyncMerge.test.ts
@@ -1,0 +1,515 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import measurementService from '../services/measurementService.js';
+import sleepRepository from '../models/sleepRepository.js';
+import userRepository from '../models/userRepository.js';
+import exerciseEntryDb from '../models/exerciseEntry.js';
+import { loadUserTimezone } from '../utils/timezoneLoader.js';
+vi.mock('../models/measurementRepository');
+vi.mock('../models/userRepository');
+vi.mock('../models/exerciseRepository');
+vi.mock('../models/exerciseEntry');
+vi.mock('../models/sleepRepository');
+vi.mock('../models/waterContainerRepository');
+vi.mock('../models/activityDetailsRepository');
+vi.mock('../utils/timezoneLoader', () => ({
+  loadUserTimezone: vi.fn(),
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+// Regression test for issue #1180: a second HealthKit/Health Connect sync covering
+// only part of the same night must NOT wipe the previously-stored full-night data.
+// This test simulates two sequential processHealthData calls and asserts:
+//   1. deleteSleepEntriesByEntrySourceAndDate is NEVER called for sleep.
+//   2. Stages from both syncs accumulate in the merged set (union, not replace).
+//   3. After the second sync, the recomputed aggregates reflect the union:
+//      bedtime preserved (full-night start), wake_time covers full range,
+//      per-stage seconds = sum across both syncs.
+describe('processHealthData sleep re-sync merge (issue #1180)', () => {
+  const userId = 'user-resync';
+  const actingUserId = 'user-resync';
+
+  // Stable storage simulating sleep_entry_stages with the new (entry_id, start_time, end_time)
+  // unique key. Stages keyed by start_time alone is sufficient here since the test data has
+  // distinct starts.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let storedStages: any[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storedStages = [];
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    loadUserTimezone.mockResolvedValue('UTC');
+    userRepository.getUserProfile = vi.fn().mockResolvedValue(null);
+    sleepRepository.deleteSleepEntriesByEntrySourceAndDate = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    sleepRepository.upsertSleepEntry = vi
+      .fn()
+      .mockResolvedValue({ id: 'entry-night-1' });
+    sleepRepository.mergeSleepStageEvents = vi
+      .fn()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation(async (_uid: any, _eid: any, stages: any[]) => {
+        const normalizedStages = stages.map((stage) => {
+          const start_time = new Date(stage.start_time).toISOString();
+          const end_time = stage.end_time
+            ? new Date(stage.end_time).toISOString()
+            : new Date(
+                new Date(stage.start_time).getTime() +
+                  (Math.round(Number(stage.duration_in_seconds)) || 0) * 1000
+              ).toISOString();
+          return {
+            ...stage,
+            start_time,
+            end_time,
+            duration_in_seconds:
+              Math.round(Number(stage.duration_in_seconds)) || 0,
+          };
+        });
+        const ws = Math.min(
+          ...normalizedStages.map((stage) =>
+            new Date(stage.start_time).getTime()
+          )
+        );
+        const we = Math.max(
+          ...normalizedStages.map((stage) => new Date(stage.end_time).getTime())
+        );
+        const keptKeys = new Set(
+          normalizedStages.map(
+            (stage) => `${stage.start_time}|${stage.end_time}`
+          )
+        );
+        storedStages = storedStages.filter((stored) => {
+          const ss = new Date(stored.start_time).getTime();
+          const se = new Date(stored.end_time).getTime();
+          const fullyContained = ss >= ws && se <= we;
+          const isKept = keptKeys.has(
+            `${new Date(stored.start_time).toISOString()}|${new Date(stored.end_time).toISOString()}`
+          );
+          return !fullyContained || isKept;
+        });
+        for (const stage of normalizedStages) {
+          const idx = storedStages.findIndex(
+            (stored) =>
+              new Date(stored.start_time).toISOString() === stage.start_time &&
+              new Date(stored.end_time).toISOString() === stage.end_time
+          );
+          if (idx >= 0) {
+            storedStages[idx] = { ...storedStages[idx], ...stage };
+          } else {
+            storedStages.push({ ...stage });
+          }
+        }
+        return normalizedStages.map((stage, index) => ({
+          id: `stage-${index + 1}`,
+          ...stage,
+        }));
+      });
+    sleepRepository.upsertSleepStageEvent = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    sleepRepository.getSleepStageEventsByEntryId = vi
+      .fn()
+      .mockImplementation(async () =>
+        [...storedStages].sort((a, b) =>
+          a.start_time.localeCompare(b.start_time)
+        )
+      );
+    sleepRepository.updateSleepEntryAggregates = vi.fn().mockResolvedValue({});
+    exerciseEntryDb.deleteExerciseEntriesByEntrySourceAndDate = vi
+      .fn()
+      .mockResolvedValue(undefined);
+  });
+
+  it('preserves the full-night data when a second sync covers only post-midnight stages', async () => {
+    const fullNightSync = [
+      {
+        type: 'SleepSession',
+        source: 'Health Connect',
+        timestamp: '2024-01-15T22:00:00Z',
+        bedtime: '2024-01-15T22:00:00Z',
+        wake_time: '2024-01-16T06:00:00Z',
+        duration_in_seconds: 28800,
+        stage_events: [
+          {
+            stage_type: 'light',
+            start_time: '2024-01-15T22:00:00Z',
+            end_time: '2024-01-15T23:30:00Z',
+            duration_in_seconds: 5400,
+          },
+          {
+            stage_type: 'deep',
+            start_time: '2024-01-15T23:30:00Z',
+            end_time: '2024-01-16T01:00:00Z',
+            duration_in_seconds: 5400,
+          },
+          {
+            stage_type: 'rem',
+            start_time: '2024-01-16T01:00:00Z',
+            end_time: '2024-01-16T02:00:00Z',
+            duration_in_seconds: 3600,
+          },
+          {
+            stage_type: 'light',
+            start_time: '2024-01-16T02:00:00Z',
+            end_time: '2024-01-16T06:00:00Z',
+            duration_in_seconds: 14400,
+          },
+        ],
+      },
+    ];
+    await measurementService.processHealthData(
+      fullNightSync,
+      userId,
+      actingUserId
+    );
+
+    // Second sync simulates a 24h-rolling window that excludes the early-night stages:
+    // includes only post-midnight, AND HealthKit re-classified one segment from light → deep.
+    const partialResync = [
+      {
+        type: 'SleepSession',
+        source: 'Health Connect',
+        timestamp: '2024-01-16T00:30:00Z',
+        bedtime: '2024-01-16T00:30:00Z',
+        wake_time: '2024-01-16T06:00:00Z',
+        duration_in_seconds: 19800,
+        stage_events: [
+          // Re-classified: same exact (start_time, end_time) as the original "deep"
+          // but the segment from 02:00–06:00 stays "light".
+          {
+            stage_type: 'rem',
+            start_time: '2024-01-16T01:00:00Z',
+            end_time: '2024-01-16T02:00:00Z',
+            duration_in_seconds: 3600,
+          },
+          {
+            stage_type: 'light',
+            start_time: '2024-01-16T02:00:00Z',
+            end_time: '2024-01-16T06:00:00Z',
+            duration_in_seconds: 14400,
+          },
+        ],
+      },
+    ];
+    await measurementService.processHealthData(
+      partialResync,
+      userId,
+      actingUserId
+    );
+
+    // 1. Sleep was never pre-deleted across either sync.
+    expect(
+      sleepRepository.deleteSleepEntriesByEntrySourceAndDate
+    ).not.toHaveBeenCalled();
+
+    // 2. The merged stage set contains the union: pre-midnight stages from sync 1
+    // plus all post-midnight stages. Re-classifications updated in place (no dup row).
+    expect(storedStages).toHaveLength(4);
+    const startsInOrder = [...storedStages]
+      .map((s) => s.start_time)
+      .sort((a, b) => a.localeCompare(b));
+    expect(startsInOrder).toEqual([
+      '2024-01-15T22:00:00.000Z',
+      '2024-01-15T23:30:00.000Z',
+      '2024-01-16T01:00:00.000Z',
+      '2024-01-16T02:00:00.000Z',
+    ]);
+
+    // 3. Aggregates after the second sync reflect the full-night union, not the partial payload.
+    const aggCalls = (
+      sleepRepository.updateSleepEntryAggregates as unknown as {
+        mock: { calls: unknown[][] };
+      }
+    ).mock.calls;
+    expect(aggCalls).toHaveLength(2);
+    const lastAggregates = aggCalls[1][3] as {
+      bedtime: Date;
+      wake_time: Date;
+      duration_in_seconds: number;
+      time_asleep_in_seconds: number;
+      deep_sleep_seconds: number;
+      light_sleep_seconds: number;
+      rem_sleep_seconds: number;
+      awake_sleep_seconds: number;
+    };
+    // bedtime preserved at the original full-night start (22:00), NOT truncated to 00:30.
+    expect(lastAggregates.bedtime.toISOString()).toBe(
+      '2024-01-15T22:00:00.000Z'
+    );
+    expect(lastAggregates.wake_time.toISOString()).toBe(
+      '2024-01-16T06:00:00.000Z'
+    );
+    expect(lastAggregates.duration_in_seconds).toBe(8 * 3600);
+    expect(lastAggregates.time_asleep_in_seconds).toBe(8 * 3600);
+    // Per-type sums: light = 5400 (22:00–23:30) + 14400 (02:00–06:00) = 19800
+    expect(lastAggregates.light_sleep_seconds).toBe(19800);
+    // deep = 5400 (23:30–01:00, never re-classified because not in the second sync's window)
+    expect(lastAggregates.deep_sleep_seconds).toBe(5400);
+    // rem = 3600 (01:00–02:00, originally rem; second sync re-asserted it as rem — no change)
+    expect(lastAggregates.rem_sleep_seconds).toBe(3600);
+    expect(lastAggregates.awake_sleep_seconds).toBe(0);
+  });
+
+  it('updates a re-classified stage in place when natural key matches', async () => {
+    // First sync stores the segment as 'light'.
+    await measurementService.processHealthData(
+      [
+        {
+          type: 'SleepSession',
+          source: 'Health Connect',
+          timestamp: '2024-02-01T22:00:00Z',
+          bedtime: '2024-02-01T22:00:00Z',
+          wake_time: '2024-02-01T23:00:00Z',
+          duration_in_seconds: 3600,
+          stage_events: [
+            {
+              stage_type: 'light',
+              start_time: '2024-02-01T22:00:00Z',
+              end_time: '2024-02-01T23:00:00Z',
+              duration_in_seconds: 3600,
+            },
+          ],
+        },
+      ],
+      userId,
+      actingUserId
+    );
+
+    // Second sync: same natural key, re-classified to 'deep'.
+    await measurementService.processHealthData(
+      [
+        {
+          type: 'SleepSession',
+          source: 'Health Connect',
+          timestamp: '2024-02-01T22:00:00Z',
+          bedtime: '2024-02-01T22:00:00Z',
+          wake_time: '2024-02-01T23:00:00Z',
+          duration_in_seconds: 3600,
+          stage_events: [
+            {
+              stage_type: 'deep',
+              start_time: '2024-02-01T22:00:00Z',
+              end_time: '2024-02-01T23:00:00Z',
+              duration_in_seconds: 3600,
+            },
+          ],
+        },
+      ],
+      userId,
+      actingUserId
+    );
+
+    // No duplicate row — stage updated in place.
+    expect(storedStages).toHaveLength(1);
+    expect(storedStages[0].stage_type).toBe('deep');
+  });
+
+  it('drops superseded rows when a re-sync refines stage boundaries', async () => {
+    // Sync 1: one coarse light segment for the whole hour.
+    await measurementService.processHealthData(
+      [
+        {
+          type: 'SleepSession',
+          source: 'Health Connect',
+          timestamp: '2024-03-01T22:00:00Z',
+          bedtime: '2024-03-01T22:00:00Z',
+          wake_time: '2024-03-01T23:00:00Z',
+          duration_in_seconds: 3600,
+          stage_events: [
+            {
+              stage_type: 'light',
+              start_time: '2024-03-01T22:00:00Z',
+              end_time: '2024-03-01T23:00:00Z',
+              duration_in_seconds: 3600,
+            },
+          ],
+        },
+      ],
+      userId,
+      actingUserId
+    );
+    expect(storedStages).toHaveLength(1);
+
+    // Sync 2: source refined the same hour into two shorter segments. The original
+    // 22:00–23:00 row must be dropped (overlaps the new payload's window AND is not
+    // an exact match of either incoming segment) so aggregates don't double-count.
+    await measurementService.processHealthData(
+      [
+        {
+          type: 'SleepSession',
+          source: 'Health Connect',
+          timestamp: '2024-03-01T22:00:00Z',
+          bedtime: '2024-03-01T22:00:00Z',
+          wake_time: '2024-03-01T23:00:00Z',
+          duration_in_seconds: 3600,
+          stage_events: [
+            {
+              stage_type: 'light',
+              start_time: '2024-03-01T22:00:00Z',
+              end_time: '2024-03-01T22:30:00Z',
+              duration_in_seconds: 1800,
+            },
+            {
+              stage_type: 'deep',
+              start_time: '2024-03-01T22:30:00Z',
+              end_time: '2024-03-01T23:00:00Z',
+              duration_in_seconds: 1800,
+            },
+          ],
+        },
+      ],
+      userId,
+      actingUserId
+    );
+
+    // Only the two refined rows survive (the original coarse row was superseded).
+    expect(storedStages).toHaveLength(2);
+    const aggCalls = (
+      sleepRepository.updateSleepEntryAggregates as unknown as {
+        mock: { calls: unknown[][] };
+      }
+    ).mock.calls;
+    const lastAggregates = aggCalls[aggCalls.length - 1][3] as {
+      duration_in_seconds: number;
+      time_asleep_in_seconds: number;
+      light_sleep_seconds: number;
+      deep_sleep_seconds: number;
+    };
+    expect(lastAggregates.duration_in_seconds).toBe(3600);
+    expect(lastAggregates.time_asleep_in_seconds).toBe(3600);
+    // Without overlap-delete this would inflate to 5400 (3600 + 1800).
+    expect(lastAggregates.light_sleep_seconds).toBe(1800);
+    expect(lastAggregates.deep_sleep_seconds).toBe(1800);
+  });
+
+  it('preserves a stored stage that straddles the payload window boundary', async () => {
+    // Sync 1: a coarse stage spans local midnight (23:30 → 01:30).
+    await measurementService.processHealthData(
+      [
+        {
+          type: 'SleepSession',
+          source: 'Health Connect',
+          timestamp: '2024-04-01T23:30:00Z',
+          bedtime: '2024-04-01T23:30:00Z',
+          wake_time: '2024-04-02T01:30:00Z',
+          duration_in_seconds: 7200,
+          stage_events: [
+            {
+              stage_type: 'light',
+              start_time: '2024-04-01T23:30:00Z',
+              end_time: '2024-04-02T01:30:00Z',
+              duration_in_seconds: 7200,
+            },
+          ],
+        },
+      ],
+      userId,
+      actingUserId
+    );
+    expect(storedStages).toHaveLength(1);
+
+    // Sync 2: payload window starts at 01:00 (after the stored stage's start). The
+    // stored 23:30–01:30 row straddles the boundary — the 23:30–01:00 portion is
+    // outside this resync's scope and must NOT be wiped.
+    await measurementService.processHealthData(
+      [
+        {
+          type: 'SleepSession',
+          source: 'Health Connect',
+          timestamp: '2024-04-02T01:00:00Z',
+          bedtime: '2024-04-02T01:00:00Z',
+          wake_time: '2024-04-02T02:00:00Z',
+          duration_in_seconds: 3600,
+          stage_events: [
+            {
+              stage_type: 'deep',
+              start_time: '2024-04-02T01:30:00Z',
+              end_time: '2024-04-02T02:00:00Z',
+              duration_in_seconds: 1800,
+            },
+          ],
+        },
+      ],
+      userId,
+      actingUserId
+    );
+
+    // Straddling row preserved + new row added.
+    expect(storedStages).toHaveLength(2);
+    const starts = storedStages
+      .map((s) => new Date(s.start_time).toISOString())
+      .sort();
+    expect(starts).toEqual([
+      '2024-04-01T23:30:00.000Z',
+      '2024-04-02T01:30:00.000Z',
+    ]);
+  });
+
+  it('preserves existing detailed stages when a later retry has no stage_events', async () => {
+    await measurementService.processHealthData(
+      [
+        {
+          type: 'SleepSession',
+          source: 'Health Connect',
+          timestamp: '2024-05-01T22:00:00Z',
+          bedtime: '2024-05-01T22:00:00Z',
+          wake_time: '2024-05-01T23:00:00Z',
+          duration_in_seconds: 3600,
+          stage_events: [
+            {
+              stage_type: 'light',
+              start_time: '2024-05-01T22:00:00Z',
+              end_time: '2024-05-01T22:30:00Z',
+              duration_in_seconds: 1800,
+            },
+            {
+              stage_type: 'deep',
+              start_time: '2024-05-01T22:30:00Z',
+              end_time: '2024-05-01T23:00:00Z',
+              duration_in_seconds: 1800,
+            },
+          ],
+        },
+      ],
+      userId,
+      actingUserId
+    );
+
+    await measurementService.processHealthData(
+      [
+        {
+          type: 'SleepSession',
+          source: 'Health Connect',
+          timestamp: '2024-05-01T22:00:00Z',
+          bedtime: '2024-05-01T22:00:00Z',
+          wake_time: '2024-05-01T23:00:00Z',
+          duration_in_seconds: 3600,
+          time_asleep_in_seconds: 3600,
+        },
+      ],
+      userId,
+      actingUserId
+    );
+
+    expect(storedStages).toHaveLength(2);
+    expect(sleepRepository.mergeSleepStageEvents).toHaveBeenCalledTimes(1);
+    const aggCalls = (
+      sleepRepository.updateSleepEntryAggregates as unknown as {
+        mock: { calls: unknown[][] };
+      }
+    ).mock.calls;
+    const lastAggregates = aggCalls[aggCalls.length - 1][3] as {
+      duration_in_seconds: number;
+      time_asleep_in_seconds: number;
+      light_sleep_seconds: number;
+      deep_sleep_seconds: number;
+    };
+    expect(lastAggregates.duration_in_seconds).toBe(3600);
+    expect(lastAggregates.time_asleep_in_seconds).toBe(3600);
+    expect(lastAggregates.light_sleep_seconds).toBe(1800);
+    expect(lastAggregates.deep_sleep_seconds).toBe(1800);
+  });
+});

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -3688,6 +3688,13 @@ CREATE INDEX idx_sleep_entry_stages_user_id ON public.sleep_entry_stages USING b
 
 
 --
+-- Name: sleep_entry_stages_entry_natural_key_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX sleep_entry_stages_entry_natural_key_idx ON public.sleep_entry_stages USING btree (entry_id, start_time, end_time);
+
+
+--
 -- Name: idx_sleep_need_calc_user; Type: INDEX; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Resyncing sleep data would delete it in certain circumstances.

**How did you implement the solution?**
Merge based sleep ingest

Linked Issue: #1180

## How to Test

1. Sync sleep
2. Watch recalculates sleep
3. Sync it again

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
