### PR TITLE
Fix(1187): misleading placement of height input

### DIFF
--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInForm.tsx
@@ -49,14 +49,12 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
   customValues,
   handleCalculateBodyFat,
   handleSubmit,
-  height,
   hips,
   loading,
   neck,
   setBodyFatPercentage,
   setCustomNotes,
   setCustomValues,
-  setHeight,
   setHips,
   setNeck,
   setSteps,
@@ -139,18 +137,6 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
                 onChange={(val) => setHips(val.toString())}
               />
             </div>
-
-            <div>
-              <Label htmlFor="height">{t('checkIn.height', 'Height')}</Label>
-              <UnitInput
-                id="height"
-                type="height"
-                unit={defaultMeasurementUnit}
-                value={height}
-                onChange={(val) => setHeight(val.toString())}
-              />
-            </div>
-
             <div>
               <div className="flex items-center justify-between">
                 <Label htmlFor="bodyFat">

--- a/SparkyFitnessFrontend/src/pages/Diary/DailyProgress.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/DailyProgress.tsx
@@ -408,31 +408,30 @@ const DailyProgress = ({ selectedDate }: { selectedDate: string }) => {
           {bmr === 0 && (
             <Alert variant="destructive" className="bg-red-50 border-red-200">
               <AlertCircle className="h-4 w-4 text-red-600" />
-              <div className="flex flex-col">
-                <AlertTitle className="text-red-800 font-bold mb-1">
-                  {t(
-                    'exercise.dailyProgress.profileIncompleteTitle',
-                    'Profile Incomplete'
-                  )}
-                </AlertTitle>
-                <AlertDescription className="text-red-700 text-xs leading-relaxed">
+              <AlertTitle className="text-red-800 font-bold mb-1">
+                {t(
+                  'exercise.dailyProgress.profileIncompleteTitle',
+                  'Profile Incomplete'
+                )}
+              </AlertTitle>
+              <AlertDescription className="text-red-700 text-xs leading-relaxed flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-y-1 sm:gap-x-1">
+                <span>
                   {t(
                     'exercise.dailyProgress.profileIncompleteDesc',
                     'Weight, Height, and Age are missing. Calorie goals may be inaccurate.'
                   )}
-                  <Button
-                    variant="link"
-                    size="sm"
-                    className="p-0 h-auto text-red-800 font-bold ml-1 underline decoration-2 underline-offset-2"
-                    onClick={() => navigate('/settings')}
-                  >
-                    {t(
-                      'exercise.dailyProgress.updateProfile',
-                      'Update Profile'
-                    )}
-                  </Button>
-                </AlertDescription>
-              </div>
+                </span>
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="p-0 h-auto text-red-800 font-bold underline decoration-2 underline-offset-2 whitespace-normal text-left justify-start"
+                  onClick={() =>
+                    navigate('/settings?section=profile-information')
+                  }
+                >
+                  {t('exercise.dailyProgress.updateProfile', 'Update Profile')}
+                </Button>
+              </AlertDescription>
             </Alert>
           )}
 

--- a/SparkyFitnessFrontend/src/pages/Settings/PreferenceSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/PreferenceSettings.tsx
@@ -13,11 +13,7 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Save, Settings as SettingsIcon } from 'lucide-react';
-import {
-  AccordionItem,
-  AccordionTrigger,
-  AccordionContent,
-} from '@/components/ui/accordion'; // Import Accordion components
+import { AccordionTrigger, AccordionContent } from '@/components/ui/accordion'; // Import Accordion components
 import { useTranslation } from 'react-i18next';
 import {
   usePreferences,
@@ -99,7 +95,7 @@ export const PreferenceSettings = () => {
     }
   };
   return (
-    <AccordionItem value="user-preferences" className="border rounded-lg mb-4">
+    <>
       <AccordionTrigger
         className="flex items-center gap-2 p-4 hover:no-underline"
         description={t(
@@ -444,6 +440,6 @@ export const PreferenceSettings = () => {
             : t('settings.preferences.savePreferences', 'Save Preferences')}
         </Button>
       </AccordionContent>
-    </AccordionItem>
+    </>
   );
 };

--- a/SparkyFitnessFrontend/src/pages/Settings/ProfileFormContent.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ProfileFormContent.tsx
@@ -24,20 +24,28 @@ import { useAuth } from '@/hooks/useAuth';
 import { useUpdateProfileMutation } from '@/hooks/Settings/useProfile';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { Profile, ProfileFormState } from '@/types/settings';
+import { useMostRecentHeightQuery } from '@/hooks/Diary/useDailyProgress';
+import { UpdateCheckInMeasurementsRequest } from '@workspace/shared';
+import { useSaveCheckInMeasurementsMutation } from '@/hooks/CheckIn/useCheckIn';
 
 export const ProfileFormContent = ({ profile }: { profile: Profile }) => {
   const { t } = useTranslation();
   const { user } = useAuth();
-  const { formatDate } = usePreferences();
+  const { formatDate, formatDateInUserTimezone } = usePreferences();
   const { mutateAsync: updateProfile, isPending: updatingProfile } =
     useUpdateProfileMutation(user?.id || ''); // can't be undefined or null because of check inside the function
 
+  const { mutateAsync: saveCheckInMeasurements } =
+    useSaveCheckInMeasurementsMutation();
+  const { measurementUnit: defaultMeasurementUnit } = usePreferences();
+  const { data: heightData } = useMostRecentHeightQuery();
   const [profileForm, setProfileForm] = useState<ProfileFormState>({
     full_name: profile.full_name || '',
     phone: profile.phone_number || '',
     date_of_birth: profile.date_of_birth || '',
     bio: profile.bio || '',
     gender: profile.gender || '',
+    height: heightData?.height || '',
   });
 
   const handleProfileUpdate = async () => {
@@ -51,6 +59,11 @@ export const ProfileFormContent = ({ profile }: { profile: Profile }) => {
         bio: profileForm.bio,
         gender: profileForm.gender || null,
       });
+      const measurementData: UpdateCheckInMeasurementsRequest = {
+        entry_date: formatDateInUserTimezone(new Date(), 'yyyy-MM-dd'),
+        height: Number(profileForm.height),
+      };
+      await saveCheckInMeasurements(measurementData);
     } catch (error: unknown) {
       console.error(error);
     }
@@ -165,6 +178,31 @@ export const ProfileFormContent = ({ profile }: { profile: Profile }) => {
               </SelectItem>
             </SelectContent>
           </Select>
+        </div>
+        <div>
+          <Label htmlFor="height">
+            {t('settings.profileInformation.height', 'Height')}
+          </Label>
+          <div className="relative">
+            <Input
+              id="height"
+              type="number"
+              value={profileForm.height}
+              onChange={(e) =>
+                setProfileForm((prev) => ({
+                  ...prev,
+                  height: e.target.value,
+                }))
+              }
+              placeholder={t(
+                'settings.profileInformation.enterHeight',
+                'Enter your Height'
+              )}
+            />
+            <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500 pointer-events-none">
+              {defaultMeasurementUnit}
+            </span>
+          </div>
         </div>
         <div className="md:col-span-2">
           <Label htmlFor="bio">

--- a/SparkyFitnessFrontend/src/pages/Settings/ProfileInformation.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ProfileInformation.tsx
@@ -4,11 +4,7 @@ import { Label } from '@/components/ui/label';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { Separator } from '@/components/ui/separator';
 import { User, Camera } from 'lucide-react';
-import {
-  AccordionItem,
-  AccordionTrigger,
-  AccordionContent,
-} from '@/components/ui/accordion';
+import { AccordionTrigger, AccordionContent } from '@/components/ui/accordion';
 import { useTranslation } from 'react-i18next';
 import { getInitials } from '@/utils/settings';
 import { useAuth } from '@/hooks/useAuth';
@@ -66,10 +62,7 @@ export const ProfileInformation = () => {
   };
   if (isProfileLoading || !profile) return null;
   return (
-    <AccordionItem
-      value="profile-information"
-      className="border rounded-lg mb-4"
-    >
+    <>
       <AccordionTrigger
         className="flex items-center gap-2 p-4 hover:no-underline"
         description={t(
@@ -131,6 +124,6 @@ export const ProfileInformation = () => {
 
         <ProfileFormContent key={profile.id} profile={profile} />
       </AccordionContent>
-    </AccordionItem>
+    </>
   );
 };

--- a/SparkyFitnessFrontend/src/pages/Settings/SettingsPage.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/SettingsPage.tsx
@@ -40,13 +40,18 @@ export interface PasswordFormState {
 const Settings = () => {
   const { t } = useTranslation();
 
-  const location = useLocation(); // Hook to get current location
-
+  const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
-  const defaultExpanded =
-    queryParams.get('section') === 'integrations'
-      ? ['food-and-exercise-data-providers']
-      : [];
+  const section = queryParams.get('section');
+  const defaultExpanded: string[] = [];
+
+  if (section) {
+    if (section === 'integrations') {
+      defaultExpanded.push('food-and-exercise-data-providers');
+    } else {
+      defaultExpanded.push(section);
+    }
+  }
 
   return (
     <div className="space-y-6 w-full">
@@ -57,11 +62,25 @@ const Settings = () => {
         defaultValue={defaultExpanded}
       >
         {/* Profile Information */}
-        <ProfileInformation />
+        <AccordionItem
+          value="profile-information"
+          className="border rounded-lg mb-4"
+        >
+          <ProfileInformation />
+        </AccordionItem>
+        <AccordionItem
+          value="user-preferences"
+          className="border rounded-lg mb-4"
+        >
+          <PreferenceSettings />
+        </AccordionItem>
 
-        <PreferenceSettings />
-
-        <WaterTrackingSettings />
+        <AccordionItem
+          value="water-tracking"
+          className="border rounded-lg mb-4"
+        >
+          <WaterTrackingSettings />
+        </AccordionItem>
 
         <AccordionItem
           value="custom-nutrients"

--- a/SparkyFitnessFrontend/src/pages/Settings/WaterTrackingSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/WaterTrackingSettings.tsx
@@ -10,11 +10,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { Save, Droplet } from 'lucide-react';
 import WaterContainerManager from './WaterContainerManager';
-import {
-  AccordionItem,
-  AccordionTrigger,
-  AccordionContent,
-} from '@/components/ui/accordion'; // Import Accordion components
+import { AccordionTrigger, AccordionContent } from '@/components/ui/accordion'; // Import Accordion components
 import { useTranslation } from 'react-i18next';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { useEffect, useState } from 'react';
@@ -58,7 +54,7 @@ export const WaterTrackingSettings = () => {
   };
 
   return (
-    <AccordionItem value="water-tracking" className="border rounded-lg mb-4">
+    <>
       <AccordionTrigger
         className="flex items-center gap-2 p-4 hover:no-underline"
         description={t(
@@ -108,6 +104,6 @@ export const WaterTrackingSettings = () => {
         <Separator />
         <WaterContainerManager />
       </AccordionContent>
-    </AccordionItem>
+    </>
   );
 };

--- a/SparkyFitnessFrontend/src/types/settings.ts
+++ b/SparkyFitnessFrontend/src/types/settings.ts
@@ -64,4 +64,5 @@ export interface ProfileFormState {
   date_of_birth: string;
   bio: string;
   gender: string;
+  height: number | string;
 }


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Height input is required for tdee and the "update profile" link leads to profile information. But height was in the daily checkin tab. While height can change, nobody will track it daily.

**How did you implement the solution?**
I moved the height field to the profile information and removed it from daily check in. It's still saved the same way as before. I added the ability for a link to expand any sections in the settings and fixed a UI bug with the warning on small screens.

Linked Issue: Closes #1187

## How to Test

1. Verify height is in profile information and saving works

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [x] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.
