### PR TITLE
fix: backup doesn't work with 18.3 due to old image version

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 
@@ -149,7 +149,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
           cache-dependency-path: pnpm-lock.yaml
 

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**'
-      - '.github/workflows/docs-deploy.yml'
+      - "docs/**"
+      - ".github/workflows/docs-deploy.yml"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,9 +17,9 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
       # Pick your own package manager and build script
       - run: |
           cd docs
@@ -35,8 +35,8 @@ jobs:
     needs: build
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
     # Deploy to the github_pages environment
     environment:
       name: github_pages

--- a/.github/workflows/docs-test.yml
+++ b/.github/workflows/docs-test.yml
@@ -6,9 +6,9 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**'
-      - '.github/workflows/docs-deploy.yml'
-      - '.github/workflows/docs-test.yml'
+      - "docs/**"
+      - ".github/workflows/docs-deploy.yml"
+      - ".github/workflows/docs-test.yml"
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,9 +18,9 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: "20"
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
       # Pick your own package manager and build script
       - run: |
           cd docs

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'The tag name of the release to attach assets to (e.g., v1.0.0)'
+        description: "The tag name of the release to attach assets to (e.g., v1.0.0)"
         required: false
         type: string
 
@@ -24,14 +24,13 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10.32.1
 
-      
       - name: Install workspace deps
         run: pnpm install --frozen-lockfile
 
@@ -48,7 +47,7 @@ jobs:
         run: |
           mkdir -p release/frontend
           mkdir -p release/backend
-          
+
           cp -r SparkyFitnessFrontend/dist/* release/frontend/
           cp -r deploy/* release/backend/
 
@@ -64,5 +63,3 @@ jobs:
             docker/docker-compose.prod.yml
             docker/.env.example
             SparkyFitness.tar.gz
-
-        

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 
 # Stage 1: Install workspace dependencies and deploy server
-FROM node:20-slim AS backend_builder
+FROM node:24-alpine AS backend_builder
 
 RUN corepack enable
 
@@ -28,12 +28,11 @@ COPY shared/ shared/
 RUN pnpm --filter=sparkyfitnessserver deploy --legacy /deploy
 
 # Stage 2: Runtime container for backend
-FROM node:20-slim
+FROM node:24-alpine
 
 WORKDIR /app/SparkyFitnessServer
 
-# Install curl for healthcheck
-RUN apt-get update && apt-get install -y curl postgresql-client tar gzip && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache curl postgresql18-client~=18.3 tar gzip
 
 # Copy the deployed server (includes source + standalone node_modules)
 COPY --from=backend_builder /deploy ./

--- a/docker/Dockerfile.backend.dev
+++ b/docker/Dockerfile.backend.dev
@@ -1,11 +1,11 @@
 # Use an official Node.js runtime as a parent image
-FROM node:22-alpine
+FROM node:24-alpine
 
 RUN corepack enable
 
 WORKDIR /app
 
-RUN apk add --no-cache postgresql-client
+RUN apk add --no-cache postgresql18-client~=18.3
 # Copy workspace root files for pnpm resolution
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 

--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,5 +1,5 @@
 # Stage 1: Build the React application
-FROM node:20-slim AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 
 # Install pnpm

--- a/docker/Dockerfile.frontend.dev
+++ b/docker/Dockerfile.frontend.dev
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as a parent image
-FROM node:20-slim
+FROM node:24-alpine
 
 RUN corepack enable
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,6 +1,7 @@
 services:
   sparkyfitness-db:
-    image: postgres:15-alpine
+    image: postgres:18.3-alpine
+    container_name: sparkyfitness-db
     restart: always
     env_file:
       - ../.env


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Postgresql-client that is needed for the update does not exist in debian 12 or 13. I also realized we use node 20-slim which is outdated and will be eol in 2 weeks. 

**How did you implement the solution?**
Alpine contains the correct package and also reduces the image size. I switched to node 24 too

Linked Issue:
- Closes #1124
- Closes #1105

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/` or `src/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

This should also be closed:
- Closes #1111 
- Closes #1199
- Closes #1200