### PR TITLE
feat: saving selected date to search parameters and improve calendar UI

### DIFF
--- a/SparkyFitnessFrontend/src/components/ui/DateRangeWithPresets.tsx
+++ b/SparkyFitnessFrontend/src/components/ui/DateRangeWithPresets.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { addDays } from 'date-fns';
+import { DateRange } from 'react-day-picker';
+import { Button } from '@/components/ui/button';
+import { Calendar } from '@/components/ui/calendar';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { CalendarIcon } from 'lucide-react';
+import { usePreferences } from '@/contexts/PreferencesContext';
+
+const PRESETS = [
+  { label: 'Last 7 days', days: 7 },
+  { label: 'Last 14 days', days: 14 },
+  { label: 'Last 30 days', days: 30 },
+  { label: 'Last 90 days', days: 90 },
+  { label: '6 months', days: 180 },
+  { label: '1 year', days: 365 },
+];
+
+interface Props {
+  startDate: string;
+  endDate: string;
+  onStartDateChange: (date: string) => void;
+  onEndDateChange: (date: string) => void;
+}
+
+export const DateRangePickerWithPresets = ({
+  startDate,
+  endDate,
+  onStartDateChange,
+  onEndDateChange,
+}: Props) => {
+  const { formatDate, formatDateInUserTimezone } = usePreferences();
+  const [open, setOpen] = React.useState(false);
+  const [activePreset, setActivePreset] = React.useState<number | null>(null);
+  const [range, setRange] = React.useState<DateRange | undefined>({
+    from: new Date(`${startDate}T00:00:00`),
+    to: new Date(`${endDate}T00:00:00`),
+  });
+  const [currentMonth, setCurrentMonth] = React.useState<Date>(
+    new Date(`${startDate}T00:00:00`)
+  );
+
+  const handleSelect = (newRange: DateRange | undefined) => {
+    setRange(newRange);
+    setActivePreset(null);
+    if (newRange?.from)
+      onStartDateChange(formatDateInUserTimezone(newRange.from, 'yyyy-MM-dd'));
+    if (newRange?.to && newRange?.from && newRange.to > newRange.from) {
+      onEndDateChange(formatDateInUserTimezone(newRange.to, 'yyyy-MM-dd'));
+      setOpen(false);
+    }
+  };
+
+  const handlePreset = (days: number) => {
+    const end = new Date();
+    const start = addDays(new Date(), -days);
+    const newRange = { from: start, to: end };
+    setRange(newRange);
+    setActivePreset(days);
+    setCurrentMonth(new Date(start.getFullYear(), start.getMonth(), 1));
+    onStartDateChange(formatDateInUserTimezone(start, 'yyyy-MM-dd'));
+    onEndDateChange(formatDateInUserTimezone(end, 'yyyy-MM-dd'));
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className="gap-2 font-normal rounded-md px-4 text-sm h-9 border-border/60 hover:border-border transition-colors"
+        >
+          <CalendarIcon className="h-3.5 w-3.5 text-muted-foreground" />
+          <span>
+            {formatDate(startDate)}
+            <span className="mx-1.5 text-muted-foreground">–</span>
+            {formatDate(endDate)}
+          </span>
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        className="w-auto p-0 rounded-md shadow-lg border-border/60 overflow-hidden"
+        align="end"
+        sideOffset={8}
+      >
+        <div className="flex">
+          {/* Presets sidebar */}
+          <div className="flex flex-col gap-0.5 p-2 border-r border-border/40 bg-muted/30 min-w-[130px]">
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground px-2 pt-1 pb-2">
+              Quick select
+            </p>
+            {PRESETS.map(({ label, days }) => (
+              <button
+                key={days}
+                onClick={() => handlePreset(days)}
+                className={`
+                  text-left text-sm px-2.5 py-1.5 rounded-lg transition-colors w-full
+                  ${
+                    activePreset === days
+                      ? 'bg-primary text-primary-foreground font-medium'
+                      : 'text-foreground/80 hover:bg-accent hover:text-accent-foreground'
+                  }
+                `}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {/* Calendar */}
+          <div className="">
+            <Calendar
+              mode="range"
+              selected={range}
+              captionLayout="dropdown"
+              numberOfMonths={1}
+              onSelect={handleSelect}
+              month={currentMonth}
+              onMonthChange={setCurrentMonth}
+              fixedWeeks
+            />
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/SparkyFitnessFrontend/src/components/ui/calendar.tsx
+++ b/SparkyFitnessFrontend/src/components/ui/calendar.tsx
@@ -1,9 +1,19 @@
-import type * as React from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
-import { DayPicker } from 'react-day-picker';
+'use client';
+import * as React from 'react';
+import {
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+} from 'lucide-react';
+import {
+  DayPicker,
+  getDefaultClassNames,
+  type DayButton,
+  type Locale,
+} from 'react-day-picker';
+
 import { cn } from '@/lib/utils';
-import { buttonVariants } from '@/components/ui/button';
-import { usePreferences } from '@/contexts/PreferencesContext';
+import { Button, buttonVariants } from '@/components/ui/button';
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker> & {
   yearsRange?: number;
@@ -13,68 +23,222 @@ function Calendar({
   className,
   classNames,
   showOutsideDays = true,
-  yearsRange = 10, // Default to 10 years if not provided
+  captionLayout = 'label',
+  locale,
+  yearsRange = 10,
+  formatters,
+  components,
   ...props
 }: CalendarProps) {
-  const { firstDayOfWeek } = usePreferences();
+  const defaultClassNames = getDefaultClassNames();
 
   return (
     <DayPicker
-      weekStartsOn={firstDayOfWeek}
       showOutsideDays={showOutsideDays}
-      className={cn('p-3', className)}
-      captionLayout="dropdown"
+      className={cn(
+        'group/calendar bg-background p-2 [--cell-radius:var(--radius-full)] [--cell-size:--spacing(8)] in-data-[slot=card-content]:bg-transparent in-data-[slot=popover-content]:bg-transparent',
+        String.raw`rtl:**:[.rdp-button\_next>svg]:rotate-180`,
+        String.raw`rtl:**:[.rdp-button\_previous>svg]:rotate-180`,
+        className
+      )}
+      captionLayout={captionLayout}
+      locale={locale}
+      reverseYears
       fromYear={new Date().getFullYear() - yearsRange}
       toYear={new Date().getFullYear() + 1}
+      formatters={{
+        formatMonthDropdown: (date) =>
+          date.toLocaleString(locale?.code, { month: 'short' }),
+        ...formatters,
+      }}
       classNames={{
-        months: 'flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0',
-        month: 'space-y-4',
-        caption: 'flex justify-center pt-1 relative items-center',
-        caption_label: 'hidden',
-        caption_dropdowns: 'flex justify-center gap-1',
-        dropdown:
-          'rounded-md border border-input bg-background px-1 py-0.5 text-xs font-medium ring-offset-background transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
-        nav: 'space-x-1 flex items-center',
-        nav_button: cn(
-          buttonVariants({ variant: 'outline' }),
-          'h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100'
+        root: cn('w-fit', defaultClassNames.root),
+        months: cn(
+          'relative flex flex-col gap-4 md:flex-row',
+          defaultClassNames.months
         ),
-        nav_button_previous: 'absolute left-1',
-        nav_button_next: 'absolute right-1',
-        table: 'w-full border-collapse space-y-1',
-        head_row: 'flex',
-        head_cell:
-          'text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]',
-        row: 'flex w-full mt-2',
-        day: 'h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
-        day_button: cn(
+        month: cn('flex w-full flex-col gap-4', defaultClassNames.month),
+        nav: cn(
+          'absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1',
+          defaultClassNames.nav
+        ),
+        button_previous: cn(
           buttonVariants({ variant: 'ghost' }),
-          'h-9 w-9 p-0 font-normal aria-selected:opacity-100'
+          'size-(--cell-size) rounded-full p-0 select-none opacity-50 hover:opacity-100 transition-opacity aria-disabled:opacity-30',
+          defaultClassNames.button_previous
         ),
-        range_end: 'day-range-end',
-        selected:
-          'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
-        today: 'bg-accent text-accent-foreground',
-        outside:
-          'day-outside text-muted-foreground opacity-50 aria-selected:bg-accent/50 aria-selected:text-muted-foreground aria-selected:opacity-30',
-        disabled: 'text-muted-foreground opacity-50',
-        range_middle:
-          'aria-selected:bg-accent aria-selected:text-accent-foreground',
-        hidden: 'invisible',
+        button_next: cn(
+          buttonVariants({ variant: 'ghost' }),
+          'size-(--cell-size) rounded-full p-0 select-none opacity-50 hover:opacity-100 transition-opacity aria-disabled:opacity-30',
+          defaultClassNames.button_next
+        ),
+        month_caption: cn(
+          'flex h-(--cell-size) w-full items-center justify-center px-(--cell-size)',
+          defaultClassNames.month_caption
+        ),
+        dropdowns: cn(
+          'flex h-(--cell-size) w-full items-center justify-center gap-1.5 text-sm font-medium',
+          defaultClassNames.dropdowns
+        ),
+        dropdown_root: cn(
+          'cn-calendar-dropdown-root relative rounded-(--cell-radius)',
+          defaultClassNames.dropdown_root
+        ),
+        dropdown: cn(
+          'absolute inset-0 bg-popover opacity-0',
+          defaultClassNames.dropdown
+        ),
+        caption_label: cn(
+          'font-medium select-none',
+          captionLayout === 'label'
+            ? 'cn-calendar-caption text-sm'
+            : 'cn-calendar-caption-label flex items-center gap-1 rounded-(--cell-radius) text-sm [&>svg]:size-3.5 [&>svg]:text-muted-foreground',
+          defaultClassNames.caption_label
+        ),
+        table: 'w-full border-collapse',
+        weekdays: cn('flex', defaultClassNames.weekdays),
+        weekday: cn(
+          'flex-1 rounded-(--cell-radius) text-[0.7rem] font-medium uppercase tracking-widest text-muted-foreground/50 text-center select-none',
+          defaultClassNames.weekday
+        ),
+        week: cn('mt-2 flex w-full', defaultClassNames.week),
+        week_number_header: cn(
+          'w-(--cell-size) select-none',
+          defaultClassNames.week_number_header
+        ),
+        week_number: cn(
+          'text-[0.8rem] text-muted-foreground select-none',
+          defaultClassNames.week_number
+        ),
+        day: cn(
+          'group/day relative aspect-square h-full w-full rounded-(--cell-radius) p-0 text-center select-none [&:last-child[data-selected=true]_button]:rounded-r-(--cell-radius)',
+          props.showWeekNumber
+            ? '[&:nth-child(2)[data-selected=true]_button]:rounded-l-(--cell-radius)'
+            : '[&:first-child[data-selected=true]_button]:rounded-l-(--cell-radius)',
+          defaultClassNames.day
+        ),
+        range_start: cn(
+          'bg-[linear-gradient(90deg,transparent_50%,hsl(var(--primary)/0.1)_50%)]',
+          defaultClassNames.range_start
+        ),
+        range_middle: cn(
+          'rounded-none bg-primary/10',
+          defaultClassNames.range_middle
+        ),
+        range_end: cn(
+          'bg-[linear-gradient(90deg,hsl(var(--primary)/0.1)_50%,transparent_50%)]',
+          defaultClassNames.range_end
+        ),
+        today: cn(
+          'rounded-(--cell-radius) font-semibold text-foreground data-[selected=true]:rounded-none',
+          defaultClassNames.today
+        ),
+        outside: cn(
+          'text-muted-foreground opacity-40 aria-selected:text-muted-foreground',
+          defaultClassNames.outside
+        ),
+        disabled: cn(
+          'text-muted-foreground opacity-50',
+          defaultClassNames.disabled
+        ),
+        hidden: cn('invisible', defaultClassNames.hidden),
         ...classNames,
       }}
       components={{
-        Chevron: ({ ...props }) => {
-          if (props.orientation === 'left') {
-            return <ChevronLeft className="h-4 w-4" />;
-          }
-          return <ChevronRight className="h-4 w-4" />;
+        Root: ({ className, rootRef, ...props }) => {
+          return (
+            <div
+              data-slot="calendar"
+              ref={rootRef}
+              className={cn(className)}
+              {...props}
+            />
+          );
         },
+        Chevron: ({ className, orientation, ...props }) => {
+          if (orientation === 'left') {
+            return (
+              <ChevronLeftIcon
+                className={cn('cn-rtl-flip size-4', className)}
+                {...props}
+              />
+            );
+          }
+          if (orientation === 'right') {
+            return (
+              <ChevronRightIcon
+                className={cn('cn-rtl-flip size-4', className)}
+                {...props}
+              />
+            );
+          }
+          return (
+            <ChevronDownIcon className={cn('size-4', className)} {...props} />
+          );
+        },
+        DayButton: ({ ...props }) => (
+          <CalendarDayButton locale={locale} {...props} />
+        ),
+        WeekNumber: ({ children, ...props }) => {
+          return (
+            <td {...props}>
+              <div className="flex size-(--cell-size) items-center justify-center text-center">
+                {children}
+              </div>
+            </td>
+          );
+        },
+        ...components,
       }}
       {...props}
     />
   );
 }
-Calendar.displayName = 'Calendar';
 
-export { Calendar };
+function CalendarDayButton({
+  className,
+  day,
+  modifiers,
+  locale,
+  ...props
+}: React.ComponentProps<typeof DayButton> & { locale?: Partial<Locale> }) {
+  const defaultClassNames = getDefaultClassNames();
+
+  const ref = React.useRef<HTMLButtonElement>(null);
+  React.useEffect(() => {
+    if (modifiers['focused']) ref.current?.focus();
+  }, [modifiers]);
+
+  return (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon"
+      data-day={day.date.toLocaleDateString(locale?.code)}
+      data-selected-single={
+        modifiers['selected'] &&
+        !modifiers['range_start'] &&
+        !modifiers['range_end'] &&
+        !modifiers['range_middle']
+      }
+      data-range-start={modifiers['range_start']}
+      data-range-end={modifiers['range_end']}
+      data-range-middle={modifiers['range_middle']}
+      className={cn(
+        'relative isolate z-10 flex aspect-square size-auto w-full min-w-(--cell-size) flex-col gap-1 rounded-full border-0 leading-none font-normal text-foreground',
+        'hover:bg-accent hover:text-foreground',
+        'group-data-[focused=true]/day:relative group-data-[focused=true]/day:z-10 group-data-[focused=true]/day:border-ring group-data-[focused=true]/day:ring-[3px] group-data-[focused=true]/day:ring-ring/50',
+        'data-[range-start=true]:rounded-full data-[range-start=true]:bg-primary data-[range-start=true]:text-primary-foreground data-[range-start=true]:hover:bg-primary',
+        'data-[range-end=true]:rounded-full data-[range-end=true]:bg-primary data-[range-end=true]:text-primary-foreground data-[range-end=true]:hover:bg-primary',
+        'data-[range-middle=true]:rounded-none data-[range-middle=true]:bg-transparent data-[range-middle=true]:text-foreground data-[range-middle=true]:hover:bg-primary/15',
+        'data-[selected-single=true]:rounded-full data-[selected-single=true]:bg-primary data-[selected-single=true]:text-primary-foreground data-[selected-single=true]:hover:bg-primary',
+        '[&>span]:text-xs [&>span]:opacity-70',
+        defaultClassNames.day,
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Calendar, CalendarDayButton };

--- a/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInLogic.ts
+++ b/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInLogic.ts
@@ -34,6 +34,7 @@ import {
   UpdateCustomMeasurementsRequest,
 } from '@workspace/shared';
 import { useAuth } from '../useAuth';
+import { useSearchParams } from 'react-router-dom';
 
 function useDerivedState<T>(derivedValue: T, selectedDate: string) {
   const [stateMap, setStateMap] = useState<Record<string, T>>({});
@@ -71,8 +72,11 @@ export const useCheckInLogic = (currentUserId: string | undefined) => {
     bodyFatAlgorithm,
   } = usePreferences();
 
+  const [searchParams] = useSearchParams();
+
   const [selectedDate, setSelectedDate] = useState(
-    formatDateInUserTimezone(new Date(), 'yyyy-MM-dd')
+    searchParams.get('date') ??
+      formatDateInUserTimezone(new Date(), 'yyyy-MM-dd')
   );
 
   const { mutateAsync: saveCheckInMeasurements, isPending: isSavingCheckIn } =

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx
@@ -7,6 +7,7 @@ import { CheckInForm } from './CheckInForm';
 import { RecentActivity } from './RecentActivity';
 import { CheckInTopRow } from './CheckInTopRow';
 import { useCheckInLogic } from '@/hooks/CheckIn/useCheckInLogic';
+import { useSearchParams } from 'react-router-dom';
 
 const CheckIn = () => {
   const { user } = useAuth();
@@ -51,12 +52,15 @@ const CheckIn = () => {
     weight,
   } = useCheckInLogic(currentUserId);
 
+  const [, setSearchParams] = useSearchParams();
+
   return (
     <div className="container mx-auto p-6 space-y-6">
       <CheckInPreferences
         selectedDate={selectedDate}
         onDateChange={(dateString) => {
           setSelectedDate(dateString);
+          setSearchParams({ date: dateString });
         }}
       />
 

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx
@@ -55,7 +55,7 @@ const CheckIn = () => {
   const [, setSearchParams] = useSearchParams();
 
   return (
-    <div className="container mx-auto p-6 space-y-6">
+    <div className="container mx-auto space-y-6">
       <CheckInPreferences
         selectedDate={selectedDate}
         onDateChange={(dateString) => {

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPreferences.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPreferences.tsx
@@ -1,4 +1,3 @@
-import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import {
@@ -8,7 +7,6 @@ import {
 } from '@/components/ui/popover';
 import { ChevronLeft, ChevronRight, CalendarIcon } from 'lucide-react';
 import { usePreferences } from '@/contexts/PreferencesContext';
-import { cn } from '@/lib/utils';
 import { debug, info, warn } from '@/utils/logging';
 import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
@@ -57,62 +55,64 @@ const CheckInPreferences = ({
   };
 
   return (
-    <div className="space-y-4">
-      <Card>
-        <CardContent className="p-4">
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between space-y-4 md:space-y-0">
-            <div />
-
-            {/* Date Navigation */}
-            <div className="flex items-center gap-2">
+    <div className="space-y-6">
+      <div className="flex justify-center mb-5 gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-xs text-muted-foreground h-9 px-3 rounded-full border border-border/60"
+          onClick={() => handleDateSelect(new Date())}
+        >
+          Today
+        </Button>
+        <div className="flex items-center gap-0 rounded-full border border-border/60 bg-background overflow-hidden">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handlePreviousDay}
+            className="h-9 w-9 rounded-none border-r border-border/60"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Popover>
+            <PopoverTrigger asChild>
               <Button
-                variant="outline"
-                size="icon"
-                onClick={handlePreviousDay}
-                className="h-8 w-8"
+                variant="ghost"
+                className="h-9 px-4 rounded-none font-normal text-sm gap-2"
               >
-                <ChevronLeft className="h-4 w-4" />
+                <CalendarIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                {date ? (
+                  formatDate(date)
+                ) : (
+                  <span className="text-muted-foreground">
+                    {t('foodDiary.pickADate', 'Pick a Date')}
+                  </span>
+                )}
               </Button>
-
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className={cn(
-                      'justify-start text-left font-normal',
-                      !date && 'text-muted-foreground'
-                    )}
-                  >
-                    <CalendarIcon className="mr-2 h-4 w-4" />
-                    {date ? (
-                      formatDate(date)
-                    ) : (
-                      <span>{t('common.pickADate', 'Pick a Date')}</span>
-                    )}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0">
-                  <Calendar
-                    mode="single"
-                    selected={date} // Use the date object parsed in user's timezone
-                    onSelect={handleDateSelect}
-                    yearsRange={10} // Default to 10 years for general date selection
-                  />
-                </PopoverContent>
-              </Popover>
-
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={handleNextDay}
-                className="h-8 w-8"
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-auto p-0"
+              align="center"
+              sideOffset={8}
+            >
+              <Calendar
+                mode="single"
+                selected={date}
+                onSelect={handleDateSelect}
+                yearsRange={10}
+              />
+            </PopoverContent>
+          </Popover>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleNextDay}
+            className="h-9 w-9 rounded-none border-l border-border/60"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
     </div>
   );
 };

--- a/SparkyFitnessFrontend/src/pages/Diary/Diary.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/Diary.tsx
@@ -63,7 +63,7 @@ const Diary = () => {
   const [editingEntry, setEditingEntry] = useState<FoodEntry | null>(null);
   const [editingFoodEntryMeal, setEditingFoodEntryMeal] =
     useState<FoodEntryMeal | null>(null); // State for editing logged meal entry
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [selectedDate, setSelectedDate] = useState(
     searchParams.get('date') ??
@@ -193,6 +193,7 @@ const Diary = () => {
       const dateString = formatDateToYYYYMMDD(newDate);
       info(loggingLevel, 'Date selected:', dateString);
       setSelectedDate(dateString);
+      setSearchParams({ date: dateString });
     }
   };
 

--- a/SparkyFitnessFrontend/src/pages/Diary/Diary.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/Diary.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
-import { Card, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Calendar } from '@/components/ui/calendar';
 import {
@@ -10,7 +9,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { CalendarIcon, ChevronLeft, ChevronRight } from 'lucide-react';
-import { cn, formatDateToYYYYMMDD } from '@/lib/utils';
+import { formatDateToYYYYMMDD } from '@/lib/utils';
 import { useActiveUser } from '@/contexts/ActiveUserContext';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import DiaryTopControls, { DayTotals } from './DiaryTopControls';
@@ -330,61 +329,63 @@ const Diary = () => {
   return (
     <div className="space-y-6">
       {/* Date Navigation */}
-      <Card className="dark:text-slate-300">
-        <CardHeader>
-          <div className="flex flex-col space-y-4 items-center sm:flex-row sm:justify-between sm:space-y-0">
-            <CardTitle className="text-xl font-semibold ">
-              {t('foodDiary.title', 'Food Diary')}
-            </CardTitle>
-            <div className="flex items-center gap-2">
+      <div className="flex justify-center mb-5 gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-xs text-muted-foreground h-9 px-3 rounded-full border border-border/60"
+          onClick={() => handleDateSelect(new Date())}
+        >
+          Today
+        </Button>
+        <div className="flex items-center gap-0 rounded-full border border-border/60 bg-background overflow-hidden">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handlePreviousDay}
+            className="h-9 w-9 rounded-none border-r border-border/60"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Popover>
+            <PopoverTrigger asChild>
               <Button
-                variant="outline"
-                size="icon"
-                onClick={handlePreviousDay}
-                className="h-8 w-8"
+                variant="ghost"
+                className="h-9 px-4 rounded-none font-normal text-sm gap-2"
               >
-                <ChevronLeft className="h-4 w-4" />
+                <CalendarIcon className="h-3.5 w-3.5 text-muted-foreground" />
+                {date ? (
+                  formatDate(date)
+                ) : (
+                  <span className="text-muted-foreground">
+                    {t('foodDiary.pickADate', 'Pick a Date')}
+                  </span>
+                )}
               </Button>
-
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className={cn(
-                      'justify-start text-left font-normal',
-                      !date && 'text-muted-foreground'
-                    )}
-                  >
-                    <CalendarIcon className="mr-2 h-4 w-4" />
-                    {date ? (
-                      formatDate(date)
-                    ) : (
-                      <span>{t('foodDiary.pickADate', 'Pick a Date')}</span>
-                    )}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0">
-                  <Calendar
-                    mode="single"
-                    selected={date}
-                    onSelect={handleDateSelect}
-                    yearsRange={10} // Default to 10 years for general date selection
-                  />
-                </PopoverContent>
-              </Popover>
-
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={handleNextDay}
-                className="h-8 w-8"
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
-        </CardHeader>
-      </Card>
+            </PopoverTrigger>
+            <PopoverContent
+              className="w-auto p-0"
+              align="center"
+              sideOffset={8}
+            >
+              <Calendar
+                mode="single"
+                selected={date}
+                onSelect={handleDateSelect}
+                yearsRange={10}
+              />
+            </PopoverContent>
+          </Popover>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleNextDay}
+            className="h-9 w-9 rounded-none border-l border-border/60"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
 
       {/* Top Controls Section */}
       {goals && (

--- a/SparkyFitnessFrontend/src/pages/Reports/Reports.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/Reports.tsx
@@ -44,6 +44,7 @@ import { CustomCategoryReport } from './CustomCategoryReport';
 import { ChartErrorBoundary } from '../Errors/ChartErrorFallback';
 import { CustomCategoriesResponse } from '@workspace/shared';
 import { useDailyGoalsRange } from '@/hooks/Goals/useGoals';
+import { useSearchParams } from 'react-router-dom';
 
 const Reports = () => {
   const { t } = useTranslation();
@@ -77,15 +78,22 @@ const Reports = () => {
       console.warn = originalConsoleWarn;
     };
   }, []);
+
+  const [searchParams, setSearchParams] = useSearchParams();
+
   const [startDate, setStartDate] = useState<string>(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('startDate')) return params.get('startDate')!;
     const date = new Date();
     date.setDate(date.getDate() - 14);
     return formatDateInUserTimezone(date, 'yyyy-MM-dd');
   });
 
-  const [endDate, setEndDate] = useState<string>(() => {
-    return formatDateInUserTimezone(new Date(), 'yyyy-MM-dd');
-  });
+  const [endDate, setEndDate] = useState(
+    searchParams.get('endDate') ??
+      formatDateInUserTimezone(new Date(), 'yyyy-MM-dd')
+  );
+
   const [activeTab, setActiveTab] = useState('charts');
 
   const { data: customNutrients = [], isLoading: customNutrientsLoading } =
@@ -135,6 +143,10 @@ const Reports = () => {
       currentStartDate: startDate,
     });
     setStartDate(date);
+    setSearchParams((prev) => {
+      prev.set('startDate', date);
+      return prev;
+    });
   };
 
   const handleEndDateChange = (date: string) => {
@@ -143,6 +155,10 @@ const Reports = () => {
       currentEndDate: endDate,
     });
     setEndDate(date);
+    setSearchParams((prev) => {
+      prev.set('endDate', date);
+      return prev;
+    });
   };
 
   info(loggingLevel, 'Reports: Rendering reports component.');

--- a/SparkyFitnessFrontend/src/pages/Reports/ReportsControls.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/ReportsControls.tsx
@@ -1,15 +1,4 @@
-import { Card, CardContent } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Calendar } from '@/components/ui/calendar';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
-import { ChevronLeft, ChevronRight, CalendarIcon } from 'lucide-react';
-import { usePreferences } from '@/contexts/PreferencesContext';
-import { cn, formatDateToYYYYMMDD } from '@/lib/utils';
-import { debug, info } from '@/utils/logging';
+import { DateRangePickerWithPresets } from '@/components/ui/DateRangeWithPresets';
 
 interface ReportsControlsProps {
   startDate: string;
@@ -23,181 +12,15 @@ const ReportsControls = ({
   endDate,
   onStartDateChange,
   onEndDateChange,
-}: ReportsControlsProps) => {
-  const { formatDate, parseDateInUserTimezone, loggingLevel } =
-    usePreferences();
-  info(loggingLevel, 'ReportsControls: Rendering component.');
-
-  const handleStartDateSelect = (newDate: Date | undefined) => {
-    if (newDate) {
-      const dateString = formatDateToYYYYMMDD(newDate);
-      debug(loggingLevel, 'ReportsControls: Start date selected:', dateString);
-      onStartDateChange(dateString);
-    } else {
-      debug(loggingLevel, 'ReportsControls: Start date selection cleared.');
-    }
-  };
-
-  const handleEndDateSelect = (newDate: Date | undefined) => {
-    if (newDate) {
-      const dateString = formatDateToYYYYMMDD(newDate);
-      debug(loggingLevel, 'ReportsControls: End date selected:', dateString);
-      onEndDateChange(dateString);
-    } else {
-      debug(loggingLevel, 'ReportsControls: End date selection cleared.');
-    }
-  };
-
-  const handlePreviousStartDate = () => {
-    debug(loggingLevel, 'ReportsControls: Handling previous start date.');
-    const previousDay = parseDateInUserTimezone(startDate);
-    previousDay.setDate(previousDay.getDate() - 1);
-    handleStartDateSelect(previousDay);
-  };
-
-  const handleNextStartDate = () => {
-    debug(loggingLevel, 'ReportsControls: Handling next start date.');
-    const nextDay = parseDateInUserTimezone(startDate);
-    nextDay.setDate(nextDay.getDate() + 1);
-    handleStartDateSelect(nextDay);
-  };
-
-  const handlePreviousEndDate = () => {
-    debug(loggingLevel, 'ReportsControls: Handling previous end date.');
-    const previousDay = parseDateInUserTimezone(endDate);
-    previousDay.setDate(previousDay.getDate() - 1);
-    handleEndDateSelect(previousDay);
-  };
-
-  const handleNextEndDate = () => {
-    debug(loggingLevel, 'ReportsControls: Handling next end date.');
-    const nextDay = parseDateInUserTimezone(endDate);
-    nextDay.setDate(nextDay.getDate() + 1);
-    handleEndDateSelect(nextDay);
-  };
-
-  return (
-    <Card>
-      <CardContent className="p-4">
-        <div className="flex flex-col md:flex-row md:items-center md:justify-between space-y-4 md:space-y-0">
-          <div />
-
-          {/* Date Range Controls */}
-          <div className="flex flex-col md:flex-row md:items-center gap-4">
-            {/* Start Date Navigation */}
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="default" // Changed from "icon" to "default"
-                onClick={handlePreviousStartDate}
-                className="h-8 w-auto px-2" // Adjusted width and padding
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </Button>
-
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className={cn(
-                      'justify-start text-left font-normal w-fit px-3' // Added w-fit and adjusted padding
-                    )}
-                  >
-                    <CalendarIcon className="mr-2 h-4 w-4" />
-                    {formatDate(startDate)}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0">
-                  <Calendar
-                    mode="single"
-                    selected={parseDateInUserTimezone(startDate)}
-                    onSelect={handleStartDateSelect}
-                    initialFocus
-                    className={cn('p-3 pointer-events-auto')}
-                    yearsRange={10} // Default to 10 years for general date selection
-                    // Ensure the calendar displays the date in the local timezone
-                    // by setting the timezone to the user's local timezone
-                    // This is important for react-day-picker to correctly highlight the selected day
-                    // based on the local date, not UTC.
-                    // This prop is not directly available in react-day-picker,
-                    // but the Date object passed to 'selected' is interpreted based on its internal time.
-                    // The key is to ensure the Date object passed to 'selected'
-                    // accurately reflects the local date.
-                    // Since startDate is already a 'yyyy-MM-dd' string, new Date(startDate)
-                    // will create a Date object in the local timezone at midnight.
-                  />
-                </PopoverContent>
-              </Popover>
-
-              <Button
-                variant="outline"
-                size="default" // Changed from "icon" to "default"
-                onClick={handleNextStartDate}
-                className="h-8 w-auto px-2" // Adjusted width and padding
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-
-            {/* End Date Navigation */}
-            <div className="flex items-center gap-2">
-              <Button
-                variant="outline"
-                size="default" // Changed from "icon" to "default"
-                onClick={handlePreviousEndDate}
-                className="h-8 w-auto px-2" // Adjusted width and padding
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </Button>
-
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className={cn(
-                      'justify-start text-left font-normal w-fit px-3' // Added w-fit and adjusted padding
-                    )}
-                  >
-                    <CalendarIcon className="mr-2 h-4 w-4" />
-                    {formatDate(endDate)}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0">
-                  <Calendar
-                    mode="single"
-                    selected={parseDateInUserTimezone(endDate)}
-                    onSelect={handleEndDateSelect}
-                    initialFocus
-                    className={cn('p-3 pointer-events-auto')}
-                    yearsRange={10} // Default to 10 years for general date selection
-                    // Ensure the calendar displays the date in the local timezone
-                    // by setting the timezone to the user's local timezone
-                    // This is important for react-day-picker to correctly highlight the selected day
-                    // based on the local date, not UTC.
-                    // This prop is not directly available in react-day-picker,
-                    // but the Date object passed to 'selected' is interpreted based on its internal time.
-                    // The key is to ensure the Date object passed to 'selected'
-                    // accurately reflects the local date.
-                    // Since endDate is already a 'yyyy-MM-dd' string, new Date(endDate)
-                    // will create a Date object in the local timezone at midnight.
-                  />
-                </PopoverContent>
-              </Popover>
-
-              <Button
-                variant="outline"
-                size="default" // Changed from "icon" to "default"
-                onClick={handleNextEndDate}
-                className="h-8 w-auto px-2" // Adjusted width and padding
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
-};
+}: ReportsControlsProps) => (
+  <div className="flex justify-center">
+    <DateRangePickerWithPresets
+      startDate={startDate}
+      endDate={endDate}
+      onStartDateChange={onStartDateChange}
+      onEndDateChange={onEndDateChange}
+    />
+  </div>
+);
 
 export default ReportsControls;


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The selected date on Diary, Checkin and Reports was lost when reloading the page. The range select on reports also wasn't very intuitive. 

**How did you implement the solution?**
The selected date is saved as a search parameter, allowing the state to be preserved and also allow to have direct links to specific dates.
I used the shadcn date picker with presets to allow easier range select and also improved the look of the calendar in general.

Linked Issue: Closes #1204

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<img width="717" height="45" alt="image" src="https://github.com/user-attachments/assets/e49c34ca-168a-4fbf-8663-ca4bd464e574" />

<img width="546" height="494" alt="image" src="https://github.com/user-attachments/assets/38e52dbd-b3e1-4efb-b3fa-03cb6e3a63f0" />

