### PR TITLE
fix(1214): prevent re-presenting AddSheet after dismiss

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/AddSheet.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/AddSheet.test.tsx
@@ -96,6 +96,31 @@ describe('AddSheet', () => {
     expect(mockBottomSheetControls.openCount).toBe(2);
   });
 
+  it('does not re-present after dismiss when no new present was requested', () => {
+    const ref = React.createRef<AddSheetRef>();
+
+    render(
+      <AddSheet
+        ref={ref}
+        onAddFood={jest.fn()}
+        onAddWorkout={jest.fn()}
+        onAddActivity={jest.fn()}
+        onAddFromPreset={jest.fn()}
+        onSyncHealthData={jest.fn()}
+        onBarcodeScan={jest.fn()}
+        onAddMeasurements={jest.fn()}
+      />,
+    );
+
+    ref.current?.present();
+    expect(mockBottomSheetControls.openCount).toBe(1);
+
+    mockBottomSheetControls.onAnimate?.(0, -1);
+    mockBottomSheetControls.onDismiss?.();
+
+    expect(mockBottomSheetControls.openCount).toBe(1);
+  });
+
   it('renders the Measurements tile in the main grid', () => {
     const ref = React.createRef<AddSheetRef>();
 

--- a/SparkyFitnessMobile/src/components/AddSheet.tsx
+++ b/SparkyFitnessMobile/src/components/AddSheet.tsx
@@ -38,6 +38,7 @@ const AddSheet = React.forwardRef<AddSheetRef, AddSheetProps>(
     const bottomSheetRef = useRef<BottomSheetModal>(null);
     const isDismissingRef = useRef(false);
     const isOpenRef = useRef(false);
+    const isPresentingRef = useRef(false);
     const pendingPresentRef = useRef(false);
     const pendingInitialMenuRef = useRef<'exercise' | null>(null);
     const presentFrameRef = useRef<number | null>(null);
@@ -63,6 +64,7 @@ const AddSheet = React.forwardRef<AddSheetRef, AddSheetProps>(
 
     const schedulePresent = useCallback(() => {
       clearScheduledPresent();
+      isPresentingRef.current = true;
       presentFrameRef.current = requestAnimationFrame(() => {
         presentFrameRef.current = null;
         bottomSheetRef.current?.present();
@@ -72,20 +74,26 @@ const AddSheet = React.forwardRef<AddSheetRef, AddSheetProps>(
     useImperativeHandle(ref, () => ({
       present: (options) => {
         const initialMenu = options?.initialMenu ?? null;
-        if (isOpenRef.current || (pendingPresentRef.current && !isDismissingRef.current)) {
-          return;
-        }
-        pendingPresentRef.current = true;
-        pendingInitialMenuRef.current = initialMenu;
-        setShowExerciseMenu(initialMenu === 'exercise');
         if (isDismissingRef.current) {
+          pendingPresentRef.current = true;
+          pendingInitialMenuRef.current = initialMenu;
+          setShowExerciseMenu(initialMenu === 'exercise');
           return;
         }
+
+        if (isOpenRef.current || isPresentingRef.current) {
+          return;
+        }
+
+        pendingPresentRef.current = false;
+        pendingInitialMenuRef.current = null;
+        setShowExerciseMenu(initialMenu === 'exercise');
         schedulePresent();
       },
       dismiss: () => {
         pendingPresentRef.current = false;
         pendingInitialMenuRef.current = null;
+        isPresentingRef.current = false;
         isDismissingRef.current = true;
         clearScheduledPresent();
         bottomSheetRef.current?.dismiss();
@@ -113,17 +121,26 @@ const AddSheet = React.forwardRef<AddSheetRef, AddSheetProps>(
     );
 
     const handleAction = useCallback((action?: () => void) => {
+      pendingPresentRef.current = false;
+      pendingInitialMenuRef.current = null;
+      isPresentingRef.current = false;
+      isDismissingRef.current = true;
+      clearScheduledPresent();
       bottomSheetRef.current?.dismiss();
       action?.();
-    }, []);
+    }, [clearScheduledPresent]);
 
     const handleDismiss = useCallback(() => {
       isDismissingRef.current = false;
       isOpenRef.current = false;
-      setShowExerciseMenu(pendingPresentRef.current && pendingInitialMenuRef.current === 'exercise');
       if (pendingPresentRef.current) {
+        const initialMenu = pendingInitialMenuRef.current;
+        pendingPresentRef.current = false;
+        pendingInitialMenuRef.current = null;
+        setShowExerciseMenu(initialMenu === 'exercise');
         schedulePresent();
       } else {
+        isPresentingRef.current = false;
         pendingInitialMenuRef.current = null;
       }
     }, [schedulePresent]);
@@ -132,13 +149,16 @@ const AddSheet = React.forwardRef<AddSheetRef, AddSheetProps>(
       if (fromIndex >= 0 && toIndex === -1) {
         isDismissingRef.current = true;
         isOpenRef.current = false;
+        isPresentingRef.current = false;
         return;
       }
 
       if (toIndex >= 0) {
         isDismissingRef.current = false;
         isOpenRef.current = true;
+        isPresentingRef.current = false;
         pendingPresentRef.current = false;
+        pendingInitialMenuRef.current = null;
         clearScheduledPresent();
       }
     }, [clearScheduledPresent]);


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

This PR fixes where the add sheet wouldn't stay closed after closing when reduced motion or similar settings are enabled.

Linked Issue: Closes #1214 

## How to Test

1. Open add sheet
2. Close add sheet

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
