### PR TITLE
fix: assume decimal for period and comma in number inputs

### DIFF
--- a/SparkyFitnessMobile/__tests__/utils/numericInput.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/numericInput.test.ts
@@ -49,16 +49,8 @@ describe('parseDecimalInput', () => {
       expect(parseDecimalInput('1,234,567.89')).toBeCloseTo(1234567.89);
     });
 
-    it('parses comma-thousands with no decimal part', () => {
+    it('parses multi-group comma-thousands with no decimal part', () => {
       expect(parseDecimalInput('1,000,000')).toBe(1000000);
-    });
-
-    it('parses a single-group thousands value as an integer', () => {
-      // 3-decimal-place precision is unused in the app; 4-digit integer
-      // values (1500 kcal, 2000 ml, 2300 mg sodium) are everywhere.
-      expect(parseDecimalInput('1,234')).toBe(1234);
-      expect(parseDecimalInput('1,500')).toBe(1500);
-      expect(parseDecimalInput('999,000')).toBe(999000);
     });
   });
 
@@ -68,13 +60,8 @@ describe('parseDecimalInput', () => {
       expect(parseDecimalInput('1.234.567,89')).toBeCloseTo(1234567.89);
     });
 
-    it('parses dot-thousands with no decimal part', () => {
+    it('parses multi-group dot-thousands with no decimal part', () => {
       expect(parseDecimalInput('1.000.000')).toBe(1000000);
-    });
-
-    it('parses a single-group thousands value as an integer', () => {
-      expect(parseDecimalInput('1.234')).toBe(1234);
-      expect(parseDecimalInput('1.500')).toBe(1500);
     });
   });
 
@@ -94,11 +81,26 @@ describe('parseDecimalInput', () => {
   });
 
   describe('single-separator decimal vs thousands disambiguation', () => {
-    // A trailing group of exactly 3 digits is treated as thousands.
-    // A trailing group of 1–2 digits (or anything else) is a decimal.
-    it('treats single-group thousands as an integer', () => {
-      expect(parseDecimalInput('1,000')).toBe(1000);
-      expect(parseDecimalInput('1.000')).toBe(1000);
+    // A naked single-group value with an exactly-3-digit trailing group
+    // ("1,234" / "28.349") is genuinely ambiguous and resolves to the
+    // decimal interpretation — see the comment in numericInput.ts for why.
+    // Naked thousands require ≥2 groups; values with an explicit decimal
+    // portion ("1,234.56" / "1.234,56") still parse as thousands.
+    it('treats single-group naked values as decimals', () => {
+      expect(parseDecimalInput('1,000')).toBe(1);
+      expect(parseDecimalInput('1.000')).toBe(1);
+      expect(parseDecimalInput('1,234')).toBe(1.234);
+      expect(parseDecimalInput('1.234')).toBe(1.234);
+      expect(parseDecimalInput('1,500')).toBe(1.5);
+      expect(parseDecimalInput('1.500')).toBe(1.5);
+      expect(parseDecimalInput('999,000')).toBe(999);
+    });
+    it('reads a precise decimal like 28.349 (1 oz in g) as 28.349, not 28349', () => {
+      // Regression: parseDecimalInput("28.349") used to match the EU
+      // thousands shape and silently return 28349, mangling Open Food
+      // Facts serving sizes on save.
+      expect(parseDecimalInput('28.349')).toBeCloseTo(28.349);
+      expect(parseDecimalInput('100.500')).toBe(100.5);
     });
     it('keeps short trailing groups as decimals', () => {
       expect(parseDecimalInput('1,5')).toBe(1.5);
@@ -171,7 +173,7 @@ describe('parseDecimalInput', () => {
       // outer whitespace is safe because it cannot change the structural
       // interpretation of what's between.
       expect(parseDecimalInput('  1234  ')).toBe(1234);
-      expect(parseDecimalInput('\t1,234\n')).toBe(1234);
+      expect(parseDecimalInput('\t1,234\n')).toBe(1.234);
       expect(parseDecimalInput('  1 234,5  ')).toBe(1234.5);
     });
   });

--- a/SparkyFitnessMobile/src/components/auth/MfaForm.tsx
+++ b/SparkyFitnessMobile/src/components/auth/MfaForm.tsx
@@ -8,8 +8,8 @@ import type { MfaFactors } from '../../services/api/authService';
 
 export const ErrorBanner = ({ message }: { message: string }) =>
   message ? (
-    <View className="mb-4 p-3 rounded-lg bg-status-danger-bg">
-      <Text className="text-sm text-status-danger-text">{message}</Text>
+    <View className="mb-4 p-3 rounded-lg bg-bg-danger">
+      <Text className="text-sm text-text-danger">{message}</Text>
     </View>
   ) : null;
 

--- a/SparkyFitnessMobile/src/utils/numericInput.ts
+++ b/SparkyFitnessMobile/src/utils/numericInput.ts
@@ -36,19 +36,23 @@ const SPACE_THOUSANDS = /^\d{1,3}(?:[\s\u00a0\u202f]\d{3})+(?:[.,]\d+)?$/;
 
 // Well-formed number shapes, checked in order of specificity.
 //
-// A strict single thousand group (`1,234` / `1.234`) is interpreted as
-// thousands, not decimal. Three-decimal-place precision is effectively
-// unused in SparkyFitness (weight/distance use 1 decimal, macros use
-// integers), while 4-digit integer values — 1500 kcal burned, 2000 ml
-// water, 2300 mg sodium, 1800 kcal goal — come up constantly. A user
-// pasting `"1,234"` for calories almost always means 1234. A value like
-// `"1,5"` stays a decimal because the trailing group is too short to be a
-// thousand group.
+// A naked single-group value like `"1.234"` or `"1,234"` is genuinely
+// ambiguous: it could be 1234 (thousands) or 1.234 (decimal). We default
+// to the decimal interpretation — the naked thousands forms below require
+// ≥2 groups (`"1.234.567"`, `"1,234,567"`) — because 3-decimal precision
+// is real in this app: Open Food Facts returns serving sizes like
+// `28.349 g` (1 oz). A single-group thousands rule used to silently
+// inflate those to `28349 g` on save. The reverse failure mode — pasting
+// `"1,234"` for 1234 calories and getting 1.234 — surfaces immediately
+// (1 cal vs 1234 cal is impossible to miss), so we prefer it to silent
+// integer inflation. Values with an explicit decimal portion
+// (`"1,234.56"` / `"1.234,56"`) stay unambiguous and still parse as
+// thousands even with a single group.
 const PLAIN_INT = /^\d+$/;
 const US_THOUSANDS_WITH_DECIMAL = /^\d{1,3}(?:,\d{3})+\.\d+$/;   // 1,234.56 / 1,234,567.89
-const US_THOUSANDS = /^\d{1,3}(?:,\d{3})+$/;                      // 1,234 / 1,234,567
-const EU_THOUSANDS_WITH_DECIMAL = /^\d{1,3}(?:\.\d{3})+,\d+$/;    // 1.234,56
-const EU_THOUSANDS = /^\d{1,3}(?:\.\d{3})+$/;                     // 1.234 / 1.234.567
+const US_THOUSANDS = /^\d{1,3}(?:,\d{3}){2,}$/;                   // 1,234,567 (≥2 groups)
+const EU_THOUSANDS_WITH_DECIMAL = /^\d{1,3}(?:\.\d{3})+,\d+$/;    // 1.234,56 / 1.234.567,89
+const EU_THOUSANDS = /^\d{1,3}(?:\.\d{3}){2,}$/;                  // 1.234.567 (≥2 groups)
 const DOT_DECIMAL = /^(?:\d+\.\d*|\.\d+)$/;                       // 1.5 / 1. / .5
 const COMMA_DECIMAL = /^(?:\d+,\d*|,\d+)$/;                       // 1,5 / 1, / ,5
 


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Numbers returned from external services with three decimal places being treated as thousands. (23.539g saved as 23539g)

**How did you implement the solution?**
Switched to a decimal first solution. Thousands will only be assumed with both separators are present. This aligns with the numpad keyboard that mobile users get. EU users don't get a period and US users don't get a comma so unless it is pasted in, the thousands separator won't be typed.

Linked Issue: Closes #

## How to Test

1. Add food with 4.259g fat
2. Make sure it saves with 4.259g fat

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
