### PR TITLE
 feat(1216): add auto scale nutrition feature to food form

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/FoodForm.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/FoodForm.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import FoodForm from '../../src/components/FoodForm';
+
+jest.mock('../../src/components/BottomSheetPicker', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ renderTrigger }: any) => (
+      <View>
+        {renderTrigger?.({
+          onPress: () => {},
+          selectedOption: { label: 'g', value: 'g' },
+        })}
+      </View>
+    ),
+  };
+});
+
+jest.mock('../../src/components/Icon', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ name }: any) => <View testID={`icon-${name}`} />,
+  };
+});
+
+describe('FoodForm', () => {
+  it('scales nutrition values when auto scale is enabled and serving size changes', () => {
+    const screen = render(
+      <FoodForm
+        initialValues={{
+          name: 'Greek Yogurt',
+          servingSize: '100',
+          servingUnit: 'g',
+          calories: '120',
+          protein: '10',
+          carbs: '8.23',
+          fat: '4',
+          fiber: '',
+        }}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    fireEvent(screen.getByLabelText('Auto Scale Nutrition'), 'valueChange', true);
+    fireEvent.changeText(screen.getByDisplayValue('100'), '150');
+
+    expect(screen.getByDisplayValue('180')).toBeTruthy();
+    expect(screen.getByDisplayValue('15')).toBeTruthy();
+    expect(screen.getByDisplayValue('12.3')).toBeTruthy();
+    expect(screen.getByDisplayValue('6')).toBeTruthy();
+  });
+
+  it('leaves nutrition values unchanged when auto scale is disabled', () => {
+    const screen = render(
+      <FoodForm
+        initialValues={{
+          name: 'Greek Yogurt',
+          servingSize: '100',
+          servingUnit: 'g',
+          calories: '120',
+          protein: '10',
+          carbs: '8',
+          fat: '4',
+        }}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    fireEvent.changeText(screen.getByDisplayValue('100'), '150');
+
+    expect(screen.getByDisplayValue('120')).toBeTruthy();
+    expect(screen.getByDisplayValue('10')).toBeTruthy();
+    expect(screen.getByDisplayValue('8')).toBeTruthy();
+    expect(screen.getByDisplayValue('4')).toBeTruthy();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/screens/ExerciseFormScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ExerciseFormScreen.test.tsx
@@ -4,6 +4,7 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
 import { CommonActions } from '@react-navigation/native';
 import ExerciseFormScreen, {
+  buildCreatePayload,
   buildEditPayload,
   splitCsvList,
   joinCsvList,
@@ -93,6 +94,65 @@ describe('ExerciseFormScreen — helpers', () => {
 
   it('joinLines uses newlines', () => {
     expect(joinLines(['a', 'b'])).toBe('a\nb');
+  });
+});
+
+describe('ExerciseFormScreen — buildCreatePayload', () => {
+  const blankState = {
+    name: '',
+    category: 'strength',
+    caloriesPerHourText: '',
+    description: '',
+    equipment: '',
+    primaryMuscles: '',
+    secondaryMuscles: '',
+    instructions: '',
+    level: null,
+    force: null,
+    mechanic: null,
+  };
+
+  it('omits empty advanced fields', () => {
+    expect(buildCreatePayload('Lunges', blankState, undefined)).toEqual({
+      name: 'Lunges',
+      category: 'strength',
+      description: null,
+    });
+  });
+
+  it('includes equipment, muscles, instructions, level, force, and mechanic when set', () => {
+    const state = {
+      ...blankState,
+      caloriesPerHourText: '350',
+      description: 'Notes',
+      equipment: 'barbell, bench',
+      primaryMuscles: 'chest',
+      secondaryMuscles: 'triceps, shoulders',
+      instructions: 'Lie on bench\nPress up',
+      level: 'intermediate',
+      force: 'push',
+      mechanic: 'compound',
+    };
+
+    expect(buildCreatePayload('Bench Press', state, 350)).toEqual({
+      name: 'Bench Press',
+      category: 'strength',
+      description: 'Notes',
+      calories_per_hour: 350,
+      equipment: ['barbell', 'bench'],
+      primary_muscles: ['chest'],
+      secondary_muscles: ['triceps', 'shoulders'],
+      instructions: ['Lie on bench', 'Press up'],
+      level: 'intermediate',
+      force: 'push',
+      mechanic: 'compound',
+    });
+  });
+
+  it('defaults missing category to "general"', () => {
+    expect(
+      buildCreatePayload('Lunges', { ...blankState, category: null }, undefined),
+    ).toMatchObject({ category: 'general' });
   });
 });
 

--- a/SparkyFitnessMobile/__tests__/screens/LibraryScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/LibraryScreen.test.tsx
@@ -44,6 +44,8 @@ const mockFetchWorkoutPresetsPage = fetchWorkoutPresetsPage as jest.MockedFuncti
 const insets = { top: 0, bottom: 0, left: 0, right: 0 };
 const frame = { x: 0, y: 0, width: 390, height: 844 };
 
+type CountQueryName = 'foods' | 'exercises' | 'presets';
+
 function createFood(id: string, name: string, calories: number) {
   return {
     id,
@@ -104,10 +106,21 @@ describe('LibraryScreen', () => {
     params: undefined,
   };
 
-  const renderScreen = () => {
+  const renderScreen = ({ fetchCounts = [] }: { fetchCounts?: CountQueryName[] } = {}) => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
+
+    if (!fetchCounts.includes('foods')) {
+      queryClient.setQueryData(['foods', 'count'], 0);
+    }
+    if (!fetchCounts.includes('exercises')) {
+      queryClient.setQueryData(['exercises', 'count'], 0);
+    }
+    if (!fetchCounts.includes('presets')) {
+      queryClient.setQueryData(['workoutPresets', 'count'], 0);
+    }
+
     return render(
       <QueryClientProvider client={queryClient}>
         <SafeAreaProvider initialMetrics={{ insets, frame }}>
@@ -177,14 +190,16 @@ describe('LibraryScreen', () => {
     });
     mockFetchExercisesCount.mockResolvedValue(17);
 
-    const screen = renderScreen();
+    const screen = renderScreen({ fetchCounts: ['foods', 'exercises'] });
 
     expect(screen.getByText('Meals')).toBeTruthy();
     expect(screen.getByText('Foods')).toBeTruthy();
     expect(screen.getByText('Exercises')).toBeTruthy();
     expect(screen.getByText('2')).toBeTruthy();
-    await waitFor(() => expect(screen.getByText('448')).toBeTruthy());
-    await waitFor(() => expect(screen.getByText('17')).toBeTruthy());
+    await waitFor(() => {
+      expect(screen.getByText('448')).toBeTruthy();
+      expect(screen.getByText('17')).toBeTruthy();
+    });
   });
 
   it('navigates to MealsLibrary when the Meals row is pressed', () => {
@@ -298,7 +313,7 @@ describe('LibraryScreen', () => {
       pagination: { page: 1, pageSize: 1, totalCount: 9, hasMore: true },
     });
 
-    const screen = renderScreen();
+    const screen = renderScreen({ fetchCounts: ['presets'] });
 
     await waitFor(() => expect(screen.getByText('9')).toBeTruthy());
   });

--- a/SparkyFitnessMobile/src/components/FoodForm.tsx
+++ b/SparkyFitnessMobile/src/components/FoodForm.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { View, Text, TextInput, TouchableOpacity, ActivityIndicator, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, Text, TextInput, TouchableOpacity, ActivityIndicator, ScrollView, KeyboardAvoidingView, Platform, Switch } from 'react-native';
 import { useCSSVariable } from 'uniwind';
 import BottomSheetPicker from './BottomSheetPicker';
 import Button from './ui/Button';
 import FormInput from './FormInput';
 import Icon from './Icon';
-import { DECIMAL_INPUT_REGEX } from '../utils/numericInput';
+import { DECIMAL_INPUT_REGEX, parseDecimalInput } from '../utils/numericInput';
 
 export interface FoodFormData {
   name: string;
@@ -44,6 +44,24 @@ const SERVING_UNIT_OPTIONS = [
   'ml', 'l', 'kg', 'lb', 'mg',
 ].map((u) => ({ label: u, value: u }));
 
+const NUTRITION_FIELDS: (keyof FoodFormData)[] = [
+  'calories',
+  'protein',
+  'carbs',
+  'fat',
+  'fiber',
+  'saturatedFat',
+  'transFat',
+  'sodium',
+  'sugars',
+  'potassium',
+  'cholesterol',
+  'calcium',
+  'iron',
+  'vitaminA',
+  'vitaminC',
+];
+
 const EMPTY_FORM: FoodFormData = {
   name: '',
   brand: '',
@@ -66,6 +84,23 @@ const EMPTY_FORM: FoodFormData = {
   vitaminC: '',
 };
 
+function isPositiveNumber(value: number): boolean {
+  return Number.isFinite(value) && value > 0;
+}
+
+function formatScaledInput(value: number): string {
+  const rounded = Math.round((value + Number.EPSILON) * 10) / 10;
+  return String(Object.is(rounded, -0) ? 0 : rounded);
+}
+
+function scaleNutritionInput(value: string, ratio: number): string {
+  const parsed = parseDecimalInput(value);
+  if (!Number.isFinite(parsed)) {
+    return value;
+  }
+  return formatScaledInput(parsed * ratio);
+}
+
 const FoodForm: React.FC<FoodFormProps> = ({
   initialValues,
   onSubmit,
@@ -76,7 +111,14 @@ const FoodForm: React.FC<FoodFormProps> = ({
 }) => {
   const [form, setForm] = useState<FoodFormData>({ ...EMPTY_FORM, ...initialValues });
   const [showMoreNutrients, setShowMoreNutrients] = useState(false);
-  const [textMuted, accentColor] = useCSSVariable(['--color-text-muted', '--color-accent-primary']) as [string, string];
+  const [autoScaleNutrition, setAutoScaleNutrition] = useState(false);
+  const [textMuted, accentColor, formEnabled, formDisabled] = useCSSVariable([
+    '--color-text-muted',
+    '--color-accent-primary',
+    '--color-form-enabled',
+    '--color-form-disabled',
+  ]) as [string, string, string, string];
+  const lastServingSizeRef = useRef(parseDecimalInput(initialValues?.servingSize ?? ''));
 
   const fieldRefs = {
     name: useRef<TextInput>(null),
@@ -104,7 +146,29 @@ const FoodForm: React.FC<FoodFormProps> = ({
   };
 
   const update = (field: keyof FoodFormData, value: string) => {
-    setForm((prev) => ({ ...prev, [field]: value }));
+    setForm((prev) => {
+      if (field !== 'servingSize' || !autoScaleNutrition) {
+        return { ...prev, [field]: value };
+      }
+
+      const nextServingSize = parseDecimalInput(value);
+      const currentServingSize = parseDecimalInput(prev.servingSize);
+      const previousServingSize = isPositiveNumber(currentServingSize)
+        ? currentServingSize
+        : lastServingSizeRef.current;
+
+      if (!isPositiveNumber(nextServingSize) || !isPositiveNumber(previousServingSize)) {
+        return { ...prev, servingSize: value };
+      }
+
+      const ratio = nextServingSize / previousServingSize;
+      const nutritionUpdates: Partial<FoodFormData> = {};
+      NUTRITION_FIELDS.forEach((nutritionField) => {
+        nutritionUpdates[nutritionField] = scaleNutritionInput(prev[nutritionField], ratio);
+      });
+
+      return { ...prev, servingSize: value, ...nutritionUpdates };
+    });
   };
 
   useEffect(() => {
@@ -112,6 +176,13 @@ const FoodForm: React.FC<FoodFormProps> = ({
       onServingChange?.(form.servingSize, form.servingUnit);
     }
   }, [form.servingSize, form.servingUnit, onServingChange]);
+
+  useEffect(() => {
+    const servingSize = parseDecimalInput(form.servingSize);
+    if (isPositiveNumber(servingSize)) {
+      lastServingSizeRef.current = servingSize;
+    }
+  }, [form.servingSize]);
 
   const renderTextField = (
     label: string,
@@ -203,6 +274,17 @@ const FoodForm: React.FC<FoodFormProps> = ({
                 )}
               />
             </View>
+          </View>
+
+          <View className="flex-row items-center justify-between mt-1.5">
+            <Text className="text-text-secondary text-base">Auto Scale Nutrition</Text>
+            <Switch
+              accessibilityLabel="Auto Scale Nutrition"
+              value={autoScaleNutrition}
+              onValueChange={setAutoScaleNutrition}
+              trackColor={{ false: formDisabled, true: formEnabled }}
+              thumbColor="#FFFFFF"
+            />
           </View>
 
           <View className="gap-1.5 mt-1.5">

--- a/SparkyFitnessMobile/src/screens/ExerciseFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ExerciseFormScreen.tsx
@@ -14,7 +14,7 @@ import type {
   RootStackParamList,
   RootStackScreenProps,
 } from '../types/navigation';
-import type { UpdateExercisePayload } from '../services/api/exerciseApi';
+import type { CreateExercisePayload, UpdateExercisePayload } from '../services/api/exerciseApi';
 
 const CATEGORY_OPTIONS = [
   { label: 'General', value: 'general' },
@@ -88,6 +88,23 @@ interface ExerciseFormBodyProps {
   showCategory: boolean;
 }
 
+const hasAdvancedContent = (state: ExerciseFormState): boolean =>
+  Boolean(
+    state.equipment ||
+      state.primaryMuscles ||
+      state.secondaryMuscles ||
+      state.instructions ||
+      state.level ||
+      state.force ||
+      state.mechanic,
+  );
+
+const SectionHeader: React.FC<{ children: string }> = ({ children }) => (
+  <Text className="text-text-secondary text-sm font-semibold uppercase tracking-wider">
+    {children}
+  </Text>
+);
+
 const labelForOption = (
   options: readonly { label: string; value: string }[],
   value: string | null,
@@ -103,6 +120,7 @@ const ExerciseFormBody: React.FC<ExerciseFormBodyProps> = ({
   showCategory,
 }) => {
   const textMuted = useCSSVariable('--color-text-muted') as string;
+  const [showAdvanced, setShowAdvanced] = useState(() => hasAdvancedContent(state));
 
   const categoryOptions = useMemo(() => {
     if (
@@ -116,6 +134,36 @@ const ExerciseFormBody: React.FC<ExerciseFormBodyProps> = ({
     }
     return CATEGORY_OPTIONS.map((opt) => ({ label: opt.label, value: opt.value }));
   }, [state.category]);
+
+  const renderPicker = (
+    label: string,
+    options: readonly { label: string; value: string }[],
+    value: string | null,
+    onSelect: (next: string) => void,
+  ) => (
+    <View className="gap-1.5">
+      <Text className="text-text-secondary text-sm font-medium">{label}</Text>
+      <BottomSheetPicker<string>
+        value={value ?? ''}
+        options={options.map((opt) => ({ label: opt.label, value: opt.value }))}
+        onSelect={onSelect}
+        title={`Select ${label}`}
+        renderTrigger={({ onPress }) => (
+          <TouchableOpacity
+            onPress={onPress}
+            activeOpacity={0.7}
+            className="bg-raised rounded-lg border border-border-subtle px-3 py-2.5 flex-row items-center justify-between"
+            style={{ height: 44 }}
+          >
+            <Text className="text-text-primary" style={{ fontSize: 16 }}>
+              {labelForOption(options, value)}
+            </Text>
+            <Icon name="chevron-down" size={16} color={textMuted} />
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  );
 
   return (
     <View className="bg-surface rounded-xl p-4 gap-4 shadow-sm">
@@ -132,30 +180,11 @@ const ExerciseFormBody: React.FC<ExerciseFormBodyProps> = ({
         />
       </View>
 
-      {showCategory ? (
-        <View className="gap-1.5">
-          <Text className="text-text-secondary text-sm font-medium">Category</Text>
-          <BottomSheetPicker<string>
-            value={state.category ?? 'general'}
-            options={categoryOptions}
-            onSelect={(category) => setState((prev) => ({ ...prev, category }))}
-            title="Select Category"
-            renderTrigger={({ onPress }) => (
-              <TouchableOpacity
-                onPress={onPress}
-                activeOpacity={0.7}
-                className="bg-raised rounded-lg border border-border-subtle px-3 py-2.5 flex-row items-center justify-between"
-                style={{ height: 44 }}
-              >
-                <Text className="text-text-primary" style={{ fontSize: 16 }}>
-                  {labelForOption(categoryOptions, state.category)}
-                </Text>
-                <Icon name="chevron-down" size={16} color={textMuted} />
-              </TouchableOpacity>
-            )}
-          />
-        </View>
-      ) : null}
+      {showCategory
+        ? renderPicker('Category', categoryOptions, state.category, (category) =>
+            setState((prev) => ({ ...prev, category })),
+          )
+        : null}
 
       <View className="gap-1.5">
         <Text className="text-text-secondary text-sm font-medium">
@@ -175,132 +204,6 @@ const ExerciseFormBody: React.FC<ExerciseFormBodyProps> = ({
       </View>
 
       <View className="gap-1.5">
-        <Text className="text-text-secondary text-sm font-medium">Equipment</Text>
-        <FormInput
-          placeholder="Comma-separated (e.g. dumbbell, bench)"
-          value={state.equipment}
-          onChangeText={(equipment) => setState((prev) => ({ ...prev, equipment }))}
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-      </View>
-
-      <View className="gap-1.5">
-        <Text className="text-text-secondary text-sm font-medium">
-          Primary muscles
-        </Text>
-        <FormInput
-          placeholder="Comma-separated (e.g. quadriceps, glutes)"
-          value={state.primaryMuscles}
-          onChangeText={(primaryMuscles) =>
-            setState((prev) => ({ ...prev, primaryMuscles }))
-          }
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-      </View>
-
-      <View className="gap-1.5">
-        <Text className="text-text-secondary text-sm font-medium">
-          Secondary muscles
-        </Text>
-        <FormInput
-          placeholder="Comma-separated"
-          value={state.secondaryMuscles}
-          onChangeText={(secondaryMuscles) =>
-            setState((prev) => ({ ...prev, secondaryMuscles }))
-          }
-          autoCapitalize="none"
-          autoCorrect={false}
-        />
-      </View>
-
-      <View className="gap-1.5">
-        <Text className="text-text-secondary text-sm font-medium">
-          Instructions
-        </Text>
-        <FormInput
-          placeholder="One step per line"
-          value={state.instructions}
-          onChangeText={(instructions) =>
-            setState((prev) => ({ ...prev, instructions }))
-          }
-          multiline
-          numberOfLines={6}
-          style={{ minHeight: 120, textAlignVertical: 'top' }}
-        />
-      </View>
-
-      <View className="gap-1.5">
-        <Text className="text-text-secondary text-sm font-medium">Level</Text>
-        <BottomSheetPicker<string>
-          value={state.level ?? ''}
-          options={LEVEL_OPTIONS.map((opt) => ({ label: opt.label, value: opt.value }))}
-          onSelect={(level) => setState((prev) => ({ ...prev, level }))}
-          title="Select Level"
-          renderTrigger={({ onPress }) => (
-            <TouchableOpacity
-              onPress={onPress}
-              activeOpacity={0.7}
-              className="bg-raised rounded-lg border border-border-subtle px-3 py-2.5 flex-row items-center justify-between"
-              style={{ height: 44 }}
-            >
-              <Text className="text-text-primary" style={{ fontSize: 16 }}>
-                {labelForOption(LEVEL_OPTIONS, state.level)}
-              </Text>
-              <Icon name="chevron-down" size={16} color={textMuted} />
-            </TouchableOpacity>
-          )}
-        />
-      </View>
-
-      <View className="gap-1.5">
-        <Text className="text-text-secondary text-sm font-medium">Force</Text>
-        <BottomSheetPicker<string>
-          value={state.force ?? ''}
-          options={FORCE_OPTIONS.map((opt) => ({ label: opt.label, value: opt.value }))}
-          onSelect={(force) => setState((prev) => ({ ...prev, force }))}
-          title="Select Force"
-          renderTrigger={({ onPress }) => (
-            <TouchableOpacity
-              onPress={onPress}
-              activeOpacity={0.7}
-              className="bg-raised rounded-lg border border-border-subtle px-3 py-2.5 flex-row items-center justify-between"
-              style={{ height: 44 }}
-            >
-              <Text className="text-text-primary" style={{ fontSize: 16 }}>
-                {labelForOption(FORCE_OPTIONS, state.force)}
-              </Text>
-              <Icon name="chevron-down" size={16} color={textMuted} />
-            </TouchableOpacity>
-          )}
-        />
-      </View>
-
-      <View className="gap-1.5">
-        <Text className="text-text-secondary text-sm font-medium">Mechanic</Text>
-        <BottomSheetPicker<string>
-          value={state.mechanic ?? ''}
-          options={MECHANIC_OPTIONS.map((opt) => ({ label: opt.label, value: opt.value }))}
-          onSelect={(mechanic) => setState((prev) => ({ ...prev, mechanic }))}
-          title="Select Mechanic"
-          renderTrigger={({ onPress }) => (
-            <TouchableOpacity
-              onPress={onPress}
-              activeOpacity={0.7}
-              className="bg-raised rounded-lg border border-border-subtle px-3 py-2.5 flex-row items-center justify-between"
-              style={{ height: 44 }}
-            >
-              <Text className="text-text-primary" style={{ fontSize: 16 }}>
-                {labelForOption(MECHANIC_OPTIONS, state.mechanic)}
-              </Text>
-              <Icon name="chevron-down" size={16} color={textMuted} />
-            </TouchableOpacity>
-          )}
-        />
-      </View>
-
-      <View className="gap-1.5">
         <Text className="text-text-secondary text-sm font-medium">Description</Text>
         <FormInput
           placeholder="Optional notes about the exercise"
@@ -313,6 +216,104 @@ const ExerciseFormBody: React.FC<ExerciseFormBodyProps> = ({
           style={{ minHeight: 96, textAlignVertical: 'top' }}
         />
       </View>
+
+      <TouchableOpacity
+        onPress={() => setShowAdvanced((prev) => !prev)}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: showAdvanced }}
+        className="flex-row items-center justify-between py-2"
+      >
+        <Text className="text-text-primary font-medium" style={{ fontSize: 16 }}>
+          Advanced
+        </Text>
+        <Icon
+          name={showAdvanced ? 'chevron-down' : 'chevron-forward'}
+          size={16}
+          color={textMuted}
+        />
+      </TouchableOpacity>
+
+      {showAdvanced ? (
+        <View className="gap-4">
+          <SectionHeader>Muscles</SectionHeader>
+
+          <View className="gap-1.5">
+            <Text className="text-text-secondary text-sm font-medium">
+              Primary muscles
+            </Text>
+            <FormInput
+              placeholder="Comma-separated (e.g. quadriceps, glutes)"
+              value={state.primaryMuscles}
+              onChangeText={(primaryMuscles) =>
+                setState((prev) => ({ ...prev, primaryMuscles }))
+              }
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+          </View>
+
+          <View className="gap-1.5">
+            <Text className="text-text-secondary text-sm font-medium">
+              Secondary muscles
+            </Text>
+            <FormInput
+              placeholder="Comma-separated"
+              value={state.secondaryMuscles}
+              onChangeText={(secondaryMuscles) =>
+                setState((prev) => ({ ...prev, secondaryMuscles }))
+              }
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+          </View>
+
+          <SectionHeader>Classification</SectionHeader>
+
+          {renderPicker('Level', LEVEL_OPTIONS, state.level, (level) =>
+            setState((prev) => ({ ...prev, level })),
+          )}
+          {renderPicker('Force', FORCE_OPTIONS, state.force, (force) =>
+            setState((prev) => ({ ...prev, force })),
+          )}
+          {renderPicker('Mechanic', MECHANIC_OPTIONS, state.mechanic, (mechanic) =>
+            setState((prev) => ({ ...prev, mechanic })),
+          )}
+
+          <SectionHeader>Details</SectionHeader>
+
+          <View className="gap-1.5">
+            <Text className="text-text-secondary text-sm font-medium">
+              Equipment
+            </Text>
+            <FormInput
+              placeholder="Comma-separated (e.g. dumbbell, bench)"
+              value={state.equipment}
+              onChangeText={(equipment) =>
+                setState((prev) => ({ ...prev, equipment }))
+              }
+              autoCapitalize="none"
+              autoCorrect={false}
+            />
+          </View>
+
+          <View className="gap-1.5">
+            <Text className="text-text-secondary text-sm font-medium">
+              Instructions
+            </Text>
+            <FormInput
+              placeholder="One step per line"
+              value={state.instructions}
+              onChangeText={(instructions) =>
+                setState((prev) => ({ ...prev, instructions }))
+              }
+              multiline
+              numberOfLines={6}
+              style={{ minHeight: 120, textAlignVertical: 'top' }}
+            />
+          </View>
+        </View>
+      ) : null}
     </View>
   );
 };
@@ -332,6 +333,35 @@ const validateAndParseCalories = (
     return { ok: false };
   }
   return { ok: true, value: parsed };
+};
+
+const buildCreatePayload = (
+  trimmedName: string,
+  state: ExerciseFormState,
+  caloriesValue: number | undefined,
+): CreateExercisePayload => {
+  const trimmedDescription = state.description.trim();
+  const equipmentList = splitCsvList(state.equipment);
+  const primaryList = splitCsvList(state.primaryMuscles);
+  const secondaryList = splitCsvList(state.secondaryMuscles);
+  const stepsList = splitLines(state.instructions);
+
+  const payload: CreateExercisePayload = {
+    name: trimmedName,
+    category: state.category ?? 'general',
+    description: trimmedDescription.length > 0 ? trimmedDescription : null,
+  };
+
+  if (caloriesValue !== undefined) payload.calories_per_hour = caloriesValue;
+  if (equipmentList.length > 0) payload.equipment = equipmentList;
+  if (primaryList.length > 0) payload.primary_muscles = primaryList;
+  if (secondaryList.length > 0) payload.secondary_muscles = secondaryList;
+  if (stepsList.length > 0) payload.instructions = stepsList;
+  if (state.level) payload.level = state.level;
+  if (state.force) payload.force = state.force;
+  if (state.mechanic) payload.mechanic = state.mechanic;
+
+  return payload;
 };
 
 interface CreateExerciseModeProps {
@@ -368,15 +398,10 @@ const CreateExerciseMode: React.FC<CreateExerciseModeProps> = ({ navigation }) =
     const calories = validateAndParseCalories(state.caloriesPerHourText);
     if (!calories.ok) return;
 
-    const trimmedDescription = state.description.trim();
+    const payload = buildCreatePayload(trimmedName, state, calories.value);
 
     try {
-      const created = await createExerciseAsync({
-        name: trimmedName,
-        category: state.category ?? 'general',
-        ...(calories.value !== undefined ? { calories_per_hour: calories.value } : {}),
-        description: trimmedDescription.length > 0 ? trimmedDescription : null,
-      });
+      const created = await createExerciseAsync(payload);
       Toast.show({ type: 'success', text1: 'Exercise created' });
       navigation.replace('ExerciseDetail', { item: created });
     } catch {
@@ -557,5 +582,12 @@ const ExerciseFormScreen: React.FC<ExerciseFormScreenProps> = ({
 export default ExerciseFormScreen;
 
 // Exposed for testing.
-export { splitCsvList, joinCsvList, splitLines, joinLines, buildEditPayload };
+export {
+  splitCsvList,
+  joinCsvList,
+  splitLines,
+  joinLines,
+  buildCreatePayload,
+  buildEditPayload,
+};
 export type { ExerciseFormState, EditParams };

--- a/SparkyFitnessMobile/src/services/api/exerciseApi.ts
+++ b/SparkyFitnessMobile/src/services/api/exerciseApi.ts
@@ -111,6 +111,13 @@ export interface CreateExercisePayload {
   /** Omit when blank — server defaults missing/falsy values to 0. */
   calories_per_hour?: number;
   description: string | null;
+  equipment?: string[];
+  primary_muscles?: string[];
+  secondary_muscles?: string[];
+  instructions?: string[];
+  level?: string;
+  force?: string;
+  mechanic?: string;
 }
 
 export interface UpdateExercisePayload {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

Adds an option to auto scale nutrients, similar to the web version. When this is enabled, values are rounded to 1 decimal place.
Also fixed an issue with create exercise not sending all fields to the api

Linked Issue: Closes #1216

## How to Test

1. Add a food (custom or from online)
2. Turn on auto scale
3. Change serving size

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<img width="1080" height="2400" alt="sf" src="https://github.com/user-attachments/assets/c4b96b25-30b9-423e-9868-69ac50b86c7c" />


## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
