### PR TITLE
fix(mobile): show Start Workout button for workout plan sessions

### DIFF
--- a/SparkyFitnessMobile/src/utils/workoutSession.ts
+++ b/SparkyFitnessMobile/src/utils/workoutSession.ts
@@ -87,7 +87,7 @@ const SOURCE_DISPLAY_NAMES: Record<string, string> = {
 
 export function getSourceLabel(source: string | null): { label: string; isSparky: boolean } {
   const s = source?.toLowerCase() ?? null;
-  if (s == null || s === 'manual' || s === 'sparky') {
+  if (s == null || s === 'manual' || s === 'sparky' || s === 'workout plan') {
     return { label: 'Sparky', isSparky: true };
   }
   return { label: SOURCE_DISPLAY_NAMES[s] ?? source!, isSparky: false };


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
When a workout plan template is activated, sessions are generated for each scheduled day with `source = 'Workout Plan'`. The `getSourceLabel` utility did not recognise this source as a first-party (Sparky) session, so `isSparky` was `false` — hiding the Start Workout button, Edit button, and rest period chips on every plan-generated session.

**How did you implement the solution?**
Added `workout plan` to the recognised first-party sources in `getSourceLabel`. One-line change in `src/utils/workoutSession.ts`.

Linked Issue: Closes #

## How to Test

1. Create a workout plan template with preset assignments
2. Set the plan active for a date range
3. Navigate to any scheduled workout day
4. Verify the **Start Workout** button is now visible
5. Tap it — workout HUD should start as normal

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on Android.

## Screenshots

N/A — the fix restores a missing button; no visual redesign.

## Notes for Reviewers

Only `SparkyFitnessMobile/src/utils/workoutSession.ts` changed (1 line). Mobile lint passes. The pre-existing test failure in `dataAggregation.test.ts` is unrelated to this change.