### PR TITLE
Fix(strava): round float average_heartrate before insert (#1256)

### DIFF
--- a/SparkyFitnessServer/integrations/strava/stravaDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/strava/stravaDataProcessor.ts
@@ -147,8 +147,11 @@ async function processStravaActivities(
         duration_minutes: durationMinutes,
         calories_burned: caloriesAuto,
         distance: distanceKm,
+        // Strava returns average_heartrate as a float (e.g. 126.9), but
+        // exercise_entries.avg_heart_rate is INTEGER → Postgres rejects the insert.
+        // Round before passing through. See issue #1256.
         // @ts-expect-error TS(2339): Property 'average_heartrate' does not exist on typ... Remove this comment to see the full error message
-        avg_heart_rate: activity.average_heartrate || null,
+        avg_heart_rate: activity.average_heartrate ? Math.round(activity.average_heartrate) : null,
         // @ts-expect-error TS(2339): Property 'moving_time' does not exist on type 'nev... Remove this comment to see the full error message
         notes: `Synced from Strava. Type: ${sportType}${activity.moving_time ? `. Moving time: ${Math.round(activity.moving_time / 60)}min` : ''}${activity.total_elevation_gain ? `. Elevation: ${activity.total_elevation_gain}m` : ''}`,
         entry_source: 'Strava',


### PR DESCRIPTION
Fixes #1256.

## Problem

`stravaDataProcessor.ts` passes `activity.average_heartrate` (a float, e.g. `126.9`) directly to `exercise_entries.avg_heart_rate`, which is declared as `integer` in schema. Postgres rejects every such INSERT with:

```
invalid input syntax for type integer: "126.9"
```

So **no Strava activity with heart-rate data ever lands in the diary** for affected users.

The failure is invisible to clients: `activitiesProcessed` in `stravaService.ts` is incremented per loop iteration regardless of insert success, so the API returns `{"success":true,"activitiesProcessed":N}` even when zero rows were written. Locally I confirmed every activity failing this way before the fix.

## Fix

One-line change: round `average_heartrate` to integer before passing it to the persistence layer. Keeps the column type unchanged, matches what the diary actually displays, and there's no semantically meaningful precision lost on bpm averages.

## Verification

After applying the patch and re-running a full backfill (`POST /api/integrations/strava/sync` with `startDate: "2010-01-01"`), all 312 historical activities imported successfully — `avg_heart_rate` correctly rounded (e.g. `127`, `108`, `133`).

## Out of scope (suggested follow-ups)

- Surface partial failures in the sync response (e.g. `activitiesFailed`) so silent insert errors don't go unnoticed.
- Consider migrating `exercise_entries.avg_heart_rate` to `numeric` for consistency with `distance`, `duration_minutes`, `calories_burned` — would also let the field carry more precision if a future provider needs it.