### PR TITLE
fix: Auto-scale and unit conversions

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
@@ -35,6 +35,7 @@ const CustomFoodForm = ({
     showSyncConfirmation,
     setShowSyncConfirmation,
     conversionBaseVariants,
+    hasTrustedCompatibilityBase,
     updateField,
     addVariant,
     duplicateVariant,
@@ -128,6 +129,9 @@ const CustomFoodForm = ({
                     baseServingUnit={
                       conversionBaseVariants[index]?.serving_unit ??
                       variant.serving_unit
+                    }
+                    showCompatibleUnitIndicators={
+                      hasTrustedCompatibilityBase[index] ?? false
                     }
                     onUpdate={updateVariant}
                     onDuplicate={duplicateVariant}

--- a/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
@@ -32,6 +32,7 @@ interface VariantCardProps {
   ) => number;
   customNutrients?: UserCustomNutrient[];
   baseServingUnit: string;
+  showCompatibleUnitIndicators: boolean;
   onUpdate: (
     index: number,
     field: string,
@@ -50,6 +51,7 @@ export function VariantCard({
   convertEnergy,
   customNutrients,
   baseServingUnit,
+  showCompatibleUnitIndicators,
   onUpdate,
   onDuplicate,
   onRemove,
@@ -117,6 +119,7 @@ export function VariantCard({
                       <SelectLabel>{group.label}</SelectLabel>
                       {group.units.map((unit) => {
                         const compatible =
+                          showCompatibleUnitIndicators &&
                           unit !== baseServingUnit &&
                           getConversionFactor(baseServingUnit, unit) !== null;
                         return (

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
@@ -20,10 +20,7 @@ import {
   sanitizeGlycemicIndexFrontend,
 } from '@/utils/foodForm';
 import { nutrientFields } from '@/constants/foodForm';
-import {
-  getConversionFactor,
-  getUnitCategory,
-} from '@/utils/servingSizeConversions';
+import { getConversionFactor } from '@/utils/servingSizeConversions';
 import type {
   EquivalentUnit,
   Food,
@@ -39,6 +36,8 @@ interface UseCustomFoodFormProps {
   onSave: (foodData: Food) => void;
 }
 
+type GroupedFormFoodVariant = FormFoodVariantWithEquivalents;
+
 function buildManualConversionToast(baseUnit: string, targetUnit: string) {
   return {
     title: 'Manual conversion required',
@@ -46,26 +45,44 @@ function buildManualConversionToast(baseUnit: string, targetUnit: string) {
   } as const;
 }
 
-function zeroOutVariantNutrition(variant: FormFoodVariant): FormFoodVariant {
-  const zeroedVariant = { ...variant };
+function scaleVariantNutrition(
+  variant: FormFoodVariant,
+  ratio: number,
+  precision: number = 4
+): FormFoodVariant {
+  const scaledVariant = {
+    ...variant,
+  };
 
-  for (const nutrient of nutrientFields) {
-    zeroedVariant[nutrient] = 0;
-  }
+  nutrientFields.forEach((nutrient) => {
+    const originalValue = Number(variant[nutrient]);
+    if (!isNaN(originalValue)) {
+      scaledVariant[nutrient] = Number(
+        (originalValue * ratio).toFixed(precision)
+      );
+    }
+  });
 
   if (variant.custom_nutrients) {
-    zeroedVariant.custom_nutrients = Object.fromEntries(
-      Object.keys(variant.custom_nutrients).map((name) => [name, 0])
-    );
+    const scaledCustomNutrients = { ...variant.custom_nutrients };
+    Object.keys(variant.custom_nutrients).forEach((name) => {
+      const originalValue = Number(variant.custom_nutrients?.[name]);
+      if (!isNaN(originalValue)) {
+        scaledCustomNutrients[name] = Number(
+          (originalValue * ratio).toFixed(precision)
+        );
+      }
+    });
+    scaledVariant.custom_nutrients = scaledCustomNutrients;
   }
 
-  return zeroedVariant;
+  return scaledVariant;
 }
 
 function groupEquivalentVariants(
   variants: FormFoodVariant[]
-): (FormFoodVariant & { equivalents: EquivalentUnit[] })[] {
-  const grouped: (FormFoodVariant & { equivalents: EquivalentUnit[] })[] = [];
+): GroupedFormFoodVariant[] {
+  const grouped: GroupedFormFoodVariant[] = [];
 
   for (const variant of variants) {
     const matchIndex = grouped.findIndex((g) => {
@@ -85,7 +102,7 @@ function groupEquivalentVariants(
     });
     const match = grouped[matchIndex];
     if (matchIndex !== -1) {
-      match?.equivalents.push({
+      match?.equivalents?.push({
         id: variant.id,
         serving_size: Number(variant.serving_size),
         serving_unit: variant.serving_unit,
@@ -116,16 +133,17 @@ export function useCustomFoodForm({
   const { mutateAsync: saveFood } = useSaveFoodMutation();
 
   const [loading, setLoading] = useState(false);
-  const [variants, setVariants] = useState<FormFoodVariantWithEquivalents[]>(
-    []
-  );
+  const [variants, setVariants] = useState<GroupedFormFoodVariant[]>([]);
   const [originalVariants, setOriginalVariants] = useState<
-    FormFoodVariantWithEquivalents[]
+    GroupedFormFoodVariant[]
   >([]);
   const [loadedVariants, setLoadedVariants] = useState<
-    FormFoodVariantWithEquivalents[]
+    GroupedFormFoodVariant[]
   >([]);
   const [manualUnitConversionPending, setManualUnitConversionPending] =
+    useState<boolean[]>([]);
+  const [autoScaleIntents, setAutoScaleIntents] = useState<boolean[]>([]);
+  const [hasTrustedCompatibilityBase, setHasTrustedCompatibilityBase] =
     useState<boolean[]>([]);
   const [variantErrors, setVariantErrors] = useState<string[]>([]);
   const [showSyncConfirmation, setShowSyncConfirmation] = useState(false);
@@ -136,17 +154,36 @@ export function useCustomFoodForm({
     is_quick_food: false,
   });
 
+  const initializeVariantState = useCallback(
+    (
+      grouped: GroupedFormFoodVariant[],
+      options: { autoScaleIntent: boolean; hasTrustedBase: boolean }
+    ) => {
+      const snapshot = deepClone(grouped);
+      setVariants(grouped);
+      setOriginalVariants(snapshot);
+      setLoadedVariants(snapshot);
+      setManualUnitConversionPending(new Array(grouped.length).fill(false));
+      setAutoScaleIntents(
+        new Array(grouped.length).fill(options.autoScaleIntent)
+      );
+      setHasTrustedCompatibilityBase(
+        new Array(grouped.length).fill(options.hasTrustedBase)
+      );
+      setVariantErrors(new Array(grouped.length).fill(''));
+    },
+    []
+  );
+
   const resetForm = useCallback(() => {
     setFormData({ name: '', brand: '', is_quick_food: false });
     const defaultVariant = createDefaultFormVariant(customNutrients);
     const grouped = groupEquivalentVariants([defaultVariant]);
-    const snapshot = deepClone(grouped);
-    setVariants(grouped);
-    setOriginalVariants(snapshot);
-    setLoadedVariants(snapshot);
-    setManualUnitConversionPending([false]);
-    setVariantErrors(['']);
-  }, [customNutrients]);
+    initializeVariantState(grouped, {
+      autoScaleIntent: false,
+      hasTrustedBase: false,
+    });
+  }, [customNutrients, initializeVariantState]);
 
   const loadExistingVariants = useCallback(async () => {
     if (!food?.id || !isUUID(food.id)) return;
@@ -166,37 +203,59 @@ export function useCustomFoodForm({
         if (defaultVariant) {
           defaultVariant = { ...defaultVariant, is_default: true };
           loaded = [
-            foodVariantToFormVariant({ ...defaultVariant, is_locked: false }),
+            foodVariantToFormVariant({
+              ...defaultVariant,
+              is_locked: autoScaleOnlineImports,
+            }),
             ...data
               .filter((v) => v.id !== defaultVariant?.id)
-              .map((v) => foodVariantToFormVariant({ ...v, is_locked: false })),
+              .map((v) =>
+                foodVariantToFormVariant({
+                  ...v,
+                  is_locked: autoScaleOnlineImports,
+                })
+              ),
           ];
         } else {
           loaded = data.map((v) =>
-            foodVariantToFormVariant({ ...v, is_locked: false })
+            foodVariantToFormVariant({
+              ...v,
+              is_locked: autoScaleOnlineImports,
+            })
           );
         }
       } else {
-        loaded = [createDefaultFormVariant(customNutrients)];
+        loaded = [
+          createDefaultFormVariant(customNutrients, {
+            is_locked: autoScaleOnlineImports,
+          }),
+        ];
       }
 
       const grouped = groupEquivalentVariants(loaded);
-      const snapshot = deepClone(grouped);
-      setVariants(grouped);
-      setOriginalVariants(snapshot);
-      setLoadedVariants(snapshot);
-      setManualUnitConversionPending(new Array(grouped.length).fill(false));
+      initializeVariantState(grouped, {
+        autoScaleIntent: autoScaleOnlineImports,
+        hasTrustedBase: true,
+      });
     } catch (err) {
       console.error('Error loading variants:', err);
-      const fallback = createDefaultFormVariant(customNutrients);
+      const fallback = createDefaultFormVariant(customNutrients, {
+        is_locked: autoScaleOnlineImports,
+      });
       const grouped = groupEquivalentVariants([fallback]);
-      const snapshot = deepClone(grouped);
-      setVariants(grouped);
-      setOriginalVariants(snapshot);
-      setLoadedVariants(snapshot);
-      setManualUnitConversionPending([false]);
+      initializeVariantState(grouped, {
+        autoScaleIntent: autoScaleOnlineImports,
+        hasTrustedBase: true,
+      });
     }
-  }, [food?.default_variant, food?.id, queryClient, customNutrients]);
+  }, [
+    autoScaleOnlineImports,
+    customNutrients,
+    food?.default_variant,
+    food?.id,
+    initializeVariantState,
+    queryClient,
+  ]);
 
   useEffect(() => {
     if (food) {
@@ -210,45 +269,45 @@ export function useCustomFoodForm({
         const mapped = food.variants.map((v) =>
           foodVariantToFormVariant({
             ...v,
-            is_locked: v.is_locked ?? autoScaleOnlineImports,
+            is_locked: autoScaleOnlineImports,
             glycemic_index: sanitizeGlycemicIndexFrontend(v.glycemic_index),
           })
         );
         mapped.sort((a, b) => (b.is_default ? 1 : 0) - (a.is_default ? 1 : 0));
 
         const grouped = groupEquivalentVariants(mapped);
-        const snapshot = deepClone(grouped);
-
-        setVariants(grouped);
-        setOriginalVariants(snapshot);
-        setLoadedVariants(snapshot);
-        setManualUnitConversionPending(new Array(grouped.length).fill(false));
-        setVariantErrors(new Array(grouped.length).fill(''));
+        initializeVariantState(grouped, {
+          autoScaleIntent: autoScaleOnlineImports,
+          hasTrustedBase: true,
+        });
       } else {
         loadExistingVariants();
       }
     } else if (initialVariants && initialVariants.length > 0) {
       setFormData({ name: '', brand: '', is_quick_food: false });
-      const mapped = initialVariants.map(foodVariantToFormVariant);
+      const mapped = initialVariants.map((variant) =>
+        foodVariantToFormVariant({
+          ...variant,
+          is_locked: autoScaleOnlineImports,
+        })
+      );
       mapped.sort((a, b) => (b.is_default ? 1 : 0) - (a.is_default ? 1 : 0));
 
       const grouped = groupEquivalentVariants(mapped);
-      const snapshot = deepClone(grouped);
-
-      setVariants(grouped);
-      setOriginalVariants(snapshot);
-      setLoadedVariants(snapshot);
-      setManualUnitConversionPending(new Array(grouped.length).fill(false));
-      setVariantErrors(new Array(grouped.length).fill(''));
+      initializeVariantState(grouped, {
+        autoScaleIntent: autoScaleOnlineImports,
+        hasTrustedBase: true,
+      });
     } else {
       resetForm();
     }
   }, [
+    autoScaleOnlineImports,
+    customNutrients,
     food,
     initialVariants,
-    customNutrients,
+    initializeVariantState,
     loadExistingVariants,
-    autoScaleOnlineImports,
     resetForm,
   ]);
 
@@ -256,6 +315,7 @@ export function useCustomFoodForm({
     const newVariant = createDefaultFormVariant(customNutrients, {
       serving_size: 1,
       is_default: false,
+      is_locked: false,
     });
     const groupedVariant = { ...newVariant, equivalents: [] };
     const clone = deepClone(groupedVariant);
@@ -264,6 +324,8 @@ export function useCustomFoodForm({
     setOriginalVariants((prev) => [...prev, clone]);
     setLoadedVariants((prev) => [...prev, clone]);
     setManualUnitConversionPending((prev) => [...prev, false]);
+    setAutoScaleIntents((prev) => [...prev, false]);
+    setHasTrustedCompatibilityBase((prev) => [...prev, false]);
     setVariantErrors((prev) => [...prev, '']);
   };
 
@@ -273,6 +335,7 @@ export function useCustomFoodForm({
     const sourceLoadedVariant = loadedVariants[index];
     const sourceRequiresManualConversion =
       manualUnitConversionPending[index] ?? false;
+    const sourceAutoScaleIntent = autoScaleIntents[index] ?? false;
 
     if (!src) {
       error(
@@ -287,7 +350,7 @@ export function useCustomFoodForm({
       ...src,
       id: undefined,
       is_default: false,
-      is_locked: false,
+      is_locked: sourceAutoScaleIntent && !sourceRequiresManualConversion,
       equivalents: deepClone(src.equivalents || []),
     };
 
@@ -307,6 +370,8 @@ export function useCustomFoodForm({
       ...prev,
       sourceRequiresManualConversion,
     ]);
+    setAutoScaleIntents((prev) => [...prev, sourceAutoScaleIntent]);
+    setHasTrustedCompatibilityBase((prev) => [...prev, false]);
     setVariantErrors((prev) => [...prev, '']);
   };
 
@@ -326,6 +391,10 @@ export function useCustomFoodForm({
     setManualUnitConversionPending((prev) =>
       prev.filter((_, i) => i !== index)
     );
+    setAutoScaleIntents((prev) => prev.filter((_, i) => i !== index));
+    setHasTrustedCompatibilityBase((prev) =>
+      prev.filter((_, i) => i !== index)
+    );
     setVariantErrors((prev) => prev.filter((_, i) => i !== index));
   };
 
@@ -337,6 +406,7 @@ export function useCustomFoodForm({
     const updatedVariants = [...variants];
     const updatedOriginalVariants = [...originalVariants];
     const updatedManualUnitConversionPending = [...manualUnitConversionPending];
+    const updatedAutoScaleIntents = [...autoScaleIntents];
     const currentVariant = updatedVariants[index];
 
     if (!currentVariant) {
@@ -371,7 +441,6 @@ export function useCustomFoodForm({
       (newVariant as Record<string, unknown>)[field] = value;
     }
 
-    // Validate serving_size
     const updatedErrors = [...variantErrors];
     if (field === 'serving_size') {
       const num = Number(value);
@@ -380,70 +449,86 @@ export function useCustomFoodForm({
       setVariantErrors(updatedErrors);
     }
 
-    // Energy conversion: input arrives in display unit, store as kcal
     if (field === 'calories' && value !== '' && typeof value === 'number') {
       newVariant.calories = convertEnergy(value, energyUnit, 'kcal');
     }
 
-    // Unit change — restore loaded values on revert, otherwise scale
+    if (field === 'is_locked') {
+      const nextLocked = Boolean(value);
+      updatedAutoScaleIntents[index] = nextLocked;
+      newVariant.is_locked = nextLocked;
+
+      if (nextLocked) {
+        updatedManualUnitConversionPending[index] = false;
+        updatedOriginalVariants[index] = deepClone(newVariant);
+        setOriginalVariants(updatedOriginalVariants);
+      }
+    }
+
     if (field === 'serving_unit') {
       const oldUnit = currentVariant.serving_unit;
       const newUnit = String(value);
       const loadedVariant = loadedVariants[index];
-      const trustedBaseUnit =
-        updatedOriginalVariants[index]?.serving_unit ??
-        loadedVariant?.serving_unit ??
-        oldUnit;
+      const variantHasTrustedCompatibilityBase =
+        hasTrustedCompatibilityBase[index] ?? false;
+      const scalingBaseVariant =
+        updatedOriginalVariants[index] ?? loadedVariant ?? currentVariant;
+      const trustedBaseUnit = scalingBaseVariant?.serving_unit ?? oldUnit;
       const manualConversionPendingForVariant =
         updatedManualUnitConversionPending[index] ?? false;
+      const autoScaleIntentForVariant = updatedAutoScaleIntents[index] ?? false;
 
-      if (loadedVariant && newUnit === loadedVariant.serving_unit) {
+      if (!variantHasTrustedCompatibilityBase) {
+        newVariant.serving_unit = newUnit;
+        updatedManualUnitConversionPending[index] = false;
+        newVariant.is_locked = autoScaleIntentForVariant;
+      } else if (loadedVariant && newUnit === loadedVariant.serving_unit) {
         for (const nutrient of nutrientFields) {
           newVariant[nutrient] = loadedVariant[nutrient];
         }
         newVariant.custom_nutrients = deepClone(loadedVariant.custom_nutrients);
         updatedManualUnitConversionPending[index] = false;
+        newVariant.is_locked = autoScaleIntentForVariant;
       } else {
-        const factor = getConversionFactor(oldUnit, newUnit);
-        const bothServing =
-          getUnitCategory(oldUnit) === null &&
-          getUnitCategory(newUnit) === null;
-        if (manualConversionPendingForVariant) {
-          toast(buildManualConversionToast(trustedBaseUnit, newUnit));
-          updatedManualUnitConversionPending[index] = true;
-        } else if (factor !== null && factor !== 1) {
-          for (const nutrient of nutrientFields) {
-            const old = Number(currentVariant[nutrient]);
-            if (!isNaN(old))
-              newVariant[nutrient] = Number((old * factor).toFixed(4));
-          }
-          if (currentVariant.custom_nutrients) {
-            const scaled = { ...newVariant.custom_nutrients };
-            Object.keys(currentVariant.custom_nutrients).forEach((name) => {
-              const old = Number(currentVariant.custom_nutrients?.[name]);
-              if (!isNaN(old)) scaled[name] = Number((old * factor).toFixed(4));
-            });
-            newVariant.custom_nutrients = scaled;
-          }
+        const directFactor = getConversionFactor(oldUnit, newUnit);
+        const trustedBaseFactor = getConversionFactor(trustedBaseUnit, newUnit);
+
+        if (
+          manualConversionPendingForVariant &&
+          trustedBaseFactor !== null &&
+          scalingBaseVariant
+        ) {
+          const baseServingSize = Number(scalingBaseVariant.serving_size || 1);
+          const newServingSize = Number(currentVariant.serving_size || 1);
+          const ratio = (newServingSize * trustedBaseFactor) / baseServingSize;
+          newVariant = scaleVariantNutrition(scalingBaseVariant, ratio);
+          newVariant.serving_size = currentVariant.serving_size;
+          newVariant.serving_unit = newUnit;
           updatedManualUnitConversionPending[index] = false;
-        } else if (factor === null && !bothServing) {
-          newVariant = zeroOutVariantNutrition(newVariant);
-          toast(buildManualConversionToast(trustedBaseUnit, newUnit));
-          updatedManualUnitConversionPending[index] = true;
+          newVariant.is_locked = autoScaleIntentForVariant;
+        } else if (
+          !manualConversionPendingForVariant &&
+          directFactor !== null
+        ) {
+          newVariant = scaleVariantNutrition(currentVariant, directFactor);
+          newVariant.serving_size = currentVariant.serving_size;
+          newVariant.serving_unit = newUnit;
+          updatedManualUnitConversionPending[index] = false;
+          newVariant.is_locked = autoScaleIntentForVariant;
         } else {
-          updatedManualUnitConversionPending[index] = false;
+          toast(buildManualConversionToast(trustedBaseUnit, newUnit));
+          updatedManualUnitConversionPending[index] = true;
+          newVariant.is_locked = false;
         }
       }
     }
 
-    // Ensure only one default
     if (field === 'is_default' && value === true) {
       updatedVariants.forEach((v, i) => {
         if (i !== index) v.is_default = false;
       });
     }
 
-    // Proportional scaling for locked variants
     if (
       field === 'serving_size' &&
       newVariant.is_locked &&
@@ -456,34 +541,21 @@ export function useCustomFoodForm({
       }
       const ratio = Number(value) / Number(originalVariant.serving_size);
       if (!isNaN(ratio) && ratio >= 0) {
-        nutrientFields.forEach((nf) => {
-          newVariant[nf] = Number(
-            (Number(originalVariant[nf]) * ratio).toFixed(2)
-          );
-        });
-        if (originalVariant.custom_nutrients) {
-          const scaled = { ...newVariant.custom_nutrients };
-          Object.keys(originalVariant.custom_nutrients).forEach((name) => {
-            const orig = Number(originalVariant.custom_nutrients?.[name]);
-            if (!isNaN(orig)) scaled[name] = Number((orig * ratio).toFixed(2));
-          });
-          newVariant.custom_nutrients = scaled;
-        }
+        newVariant = scaleVariantNutrition(originalVariant, ratio, 2);
+        newVariant.serving_size = Number(value);
       }
-    } else {
-      // Update scaling baseline for any non-scaling change
-      if (
-        field !== 'serving_unit' ||
-        !(updatedManualUnitConversionPending[index] ?? false)
-      ) {
-        updatedOriginalVariants[index] = deepClone(newVariant);
-        setOriginalVariants(updatedOriginalVariants);
-      }
+    } else if (
+      field !== 'serving_unit' ||
+      !(updatedManualUnitConversionPending[index] ?? false)
+    ) {
+      updatedOriginalVariants[index] = deepClone(newVariant);
+      setOriginalVariants(updatedOriginalVariants);
     }
 
     updatedVariants[index] = newVariant;
     setVariants(updatedVariants);
     setManualUnitConversionPending(updatedManualUnitConversionPending);
+    setAutoScaleIntents(updatedAutoScaleIntents);
   };
 
   const updateField = (field: string, value: string | boolean) => {
@@ -501,7 +573,7 @@ export function useCustomFoodForm({
     );
     setVariantErrors(newVariantErrors);
 
-    if (newVariantErrors.some((e) => e !== '')) {
+    if (newVariantErrors.some((entry) => entry !== '')) {
       toast({
         title: 'Validation Error',
         description: 'Please correct the errors in the unit variants.',
@@ -552,7 +624,7 @@ export function useCustomFoodForm({
           equivalents.forEach((eq) => {
             expandedVariants.push({
               ...baseVariant,
-              id: eq.id, // TS now knows this exists
+              id: eq.id,
               is_default: false,
               serving_size: eq.serving_size,
               serving_unit: eq.serving_unit,
@@ -595,7 +667,6 @@ export function useCustomFoodForm({
   };
 
   return {
-    // State
     formData,
     variants,
     variantErrors,
@@ -604,8 +675,8 @@ export function useCustomFoodForm({
     setShowSyncConfirmation,
     loadedVariants,
     conversionBaseVariants: originalVariants,
+    hasTrustedCompatibilityBase,
     platform,
-    // Handlers
     updateField,
     addVariant,
     duplicateVariant,

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
@@ -38,6 +38,15 @@ interface UseCustomFoodFormProps {
 
 type GroupedFormFoodVariant = FormFoodVariantWithEquivalents;
 
+function toPositiveNumber(value: unknown): number | null {
+  const numericValue = Number(value);
+  if (!Number.isFinite(numericValue) || numericValue <= 0) {
+    return null;
+  }
+
+  return numericValue;
+}
+
 function buildManualConversionToast(baseUnit: string, targetUnit: string) {
   return {
     title: 'Manual conversion required',
@@ -371,7 +380,10 @@ export function useCustomFoodForm({
       sourceRequiresManualConversion,
     ]);
     setAutoScaleIntents((prev) => [...prev, sourceAutoScaleIntent]);
-    setHasTrustedCompatibilityBase((prev) => [...prev, false]);
+    setHasTrustedCompatibilityBase((prev) => [
+      ...prev,
+      hasTrustedCompatibilityBase[index] ?? false,
+    ]);
     setVariantErrors((prev) => [...prev, '']);
   };
 
@@ -460,8 +472,10 @@ export function useCustomFoodForm({
 
       if (nextLocked) {
         updatedManualUnitConversionPending[index] = false;
-        updatedOriginalVariants[index] = deepClone(newVariant);
-        setOriginalVariants(updatedOriginalVariants);
+        if (toPositiveNumber(newVariant.serving_size) !== null) {
+          updatedOriginalVariants[index] = deepClone(newVariant);
+          setOriginalVariants(updatedOriginalVariants);
+        }
       }
     }
 
@@ -498,10 +512,16 @@ export function useCustomFoodForm({
           trustedBaseFactor !== null &&
           scalingBaseVariant
         ) {
-          const baseServingSize = Number(scalingBaseVariant.serving_size || 1);
-          const newServingSize = Number(currentVariant.serving_size || 1);
-          const ratio = (newServingSize * trustedBaseFactor) / baseServingSize;
-          newVariant = scaleVariantNutrition(scalingBaseVariant, ratio);
+          const baseServingSize = toPositiveNumber(
+            scalingBaseVariant.serving_size
+          );
+          const newServingSize = toPositiveNumber(currentVariant.serving_size);
+
+          if (baseServingSize !== null && newServingSize !== null) {
+            const ratio =
+              (newServingSize * trustedBaseFactor) / baseServingSize;
+            newVariant = scaleVariantNutrition(scalingBaseVariant, ratio);
+          }
           newVariant.serving_size = currentVariant.serving_size;
           newVariant.serving_unit = newUnit;
           updatedManualUnitConversionPending[index] = false;
@@ -539,10 +559,12 @@ export function useCustomFoodForm({
         error(loggingLevel, 'Could not find original variant at index:', index);
         return;
       }
-      const ratio = Number(value) / Number(originalVariant.serving_size);
-      if (!isNaN(ratio) && ratio >= 0) {
-        newVariant = scaleVariantNutrition(originalVariant, ratio, 2);
-        newVariant.serving_size = Number(value);
+      const baseServingSize = toPositiveNumber(originalVariant.serving_size);
+      const nextServingSize = toPositiveNumber(value);
+      if (baseServingSize !== null && nextServingSize !== null) {
+        const ratio = nextServingSize / baseServingSize;
+        newVariant = scaleVariantNutrition(originalVariant, ratio, 4);
+        newVariant.serving_size = nextServingSize;
       }
     } else if (
       field !== 'serving_unit' ||

--- a/SparkyFitnessFrontend/src/tests/components/VariantCard.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/VariantCard.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { VariantCard } from '@/components/FoodSearch/VariantCard';
+import type { FoodVariant } from '@/types/food';
+
+jest.mock('@/components/FoodSearch/NutrientFormGrid', () => ({
+  NutrientGrid: () => <div data-testid="nutrient-grid" />,
+}));
+
+jest.mock('@/components/ui/select', () => {
+  const SelectContext = React.createContext<(value: string) => void>(() => {});
+
+  return {
+    Select: ({
+      children,
+      onValueChange,
+    }: {
+      children: React.ReactNode;
+      onValueChange?: (value: string) => void;
+    }) => (
+      <SelectContext.Provider value={onValueChange ?? (() => {})}>
+        {children}
+      </SelectContext.Provider>
+    ),
+    SelectContent: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectGroup: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectItem: ({
+      children,
+      value,
+    }: {
+      children: React.ReactNode;
+      value: string;
+    }) => {
+      const onValueChange = React.useContext(SelectContext);
+
+      return (
+        <button
+          type="button"
+          data-value={value}
+          onClick={() => onValueChange(value)}
+        >
+          {children}
+        </button>
+      );
+    },
+    SelectLabel: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectTrigger: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SelectValue: () => <span />,
+  };
+});
+
+jest.mock('lucide-react', () => {
+  const actual = jest.requireActual('lucide-react');
+
+  return {
+    ...actual,
+    Check: ({ className }: { className?: string }) => (
+      <svg data-testid="check-icon" className={className} />
+    ),
+  };
+});
+
+const createVariant = (
+  overrides: Partial<FoodVariant> = {}
+): FoodVariant & { equivalents: [] } => ({
+  id: 'variant-1',
+  serving_size: 10,
+  serving_unit: 'g',
+  calories: 100,
+  protein: 10,
+  carbs: 20,
+  fat: 5,
+  custom_nutrients: {},
+  equivalents: [],
+  ...overrides,
+});
+
+const renderVariantCard = (showCompatibleUnitIndicators: boolean) =>
+  render(
+    <VariantCard
+      index={0}
+      variant={createVariant()}
+      variantError=""
+      visibleNutrients={['calories']}
+      energyUnit="kcal"
+      convertEnergy={(value) => value}
+      baseServingUnit="g"
+      showCompatibleUnitIndicators={showCompatibleUnitIndicators}
+      onUpdate={jest.fn()}
+      onDuplicate={jest.fn()}
+      onRemove={jest.fn()}
+    />
+  );
+
+describe('VariantCard', () => {
+  it('hides compatible-unit checkmarks for unsaved custom variants', () => {
+    renderVariantCard(false);
+
+    expect(screen.queryByTestId('check-icon')).not.toBeInTheDocument();
+  });
+
+  it('shows compatible-unit checkmarks when the variant has a trusted base', () => {
+    renderVariantCard(true);
+
+    expect(screen.getAllByTestId('check-icon').length).toBeGreaterThan(0);
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/hooks/useFoodForm.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useFoodForm.test.tsx
@@ -361,5 +361,53 @@ describe('useCustomFoodForm', () => {
 
     expect(result.current.variants[1]?.serving_unit).toBe('tsp');
     expect(result.current.conversionBaseVariants[1]?.serving_unit).toBe('g');
+    expect(result.current.hasTrustedCompatibilityBase[1]).toBe(true);
+  });
+
+  it('preserves trusted compatibility status when duplicating a trusted variant', async () => {
+    mockAutoScaleOnlineImports = true;
+    const initialVariants = [createVariant()];
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        initialVariants,
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.hasTrustedCompatibilityBase[0]).toBe(true);
+    });
+
+    act(() => {
+      result.current.duplicateVariant(0);
+    });
+
+    expect(result.current.hasTrustedCompatibilityBase[1]).toBe(true);
+    expect(result.current.variants[1]?.is_locked).toBe(true);
+  });
+
+  it('skips scaling math when serving sizes are invalid instead of producing destructive values', async () => {
+    mockAutoScaleOnlineImports = true;
+    const initialVariants = [createVariant({ serving_size: 0 })];
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        initialVariants,
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.is_locked).toBe(true);
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_size', 2);
+    });
+
+    expect(result.current.variants[0]?.serving_size).toBe(2);
+    expect(result.current.variants[0]?.calories).toBe(100);
+    expect(result.current.variants[0]?.protein).toBe(10);
   });
 });

--- a/SparkyFitnessFrontend/src/tests/hooks/useFoodForm.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useFoodForm.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { useCustomFoodForm } from '@/hooks/Foods/useFoodForm';
 import { getConversionFactor } from '@/utils/servingSizeConversions';
-import type { FoodVariant } from '@/types/food';
+import type { Food, FoodVariant } from '@/types/food';
 
 const mockToast = jest.fn();
 const mockFetchQuery = jest.fn();
@@ -9,6 +9,8 @@ const mockCustomNutrients: [] = [];
 const mockQueryClient = {
   fetchQuery: mockFetchQuery,
 };
+
+let mockAutoScaleOnlineImports = false;
 
 jest.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({
@@ -21,7 +23,7 @@ jest.mock('@/contexts/PreferencesContext', () => ({
     energyUnit: 'kcal' as const,
     convertEnergy: (value: number) => value,
     loggingLevel: 'ERROR',
-    autoScaleOnlineImports: false,
+    autoScaleOnlineImports: mockAutoScaleOnlineImports,
   }),
 }));
 
@@ -83,12 +85,22 @@ const createVariant = (overrides: Partial<FoodVariant> = {}): FoodVariant => ({
   ...overrides,
 });
 
+const createFood = (overrides: Partial<Food> = {}): Food => ({
+  id: 'food-1',
+  name: 'Imported Food',
+  is_custom: true,
+  variants: [createVariant()],
+  ...overrides,
+});
+
 describe('useCustomFoodForm', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockAutoScaleOnlineImports = false;
   });
 
-  it('zeros nutrition and keeps manual mode after an incompatible unit change', async () => {
+  it('preserves nutrition values and turns auto-scale off after an incompatible unit change', async () => {
+    mockAutoScaleOnlineImports = true;
     const initialVariants = [createVariant()];
 
     const { result } = renderHook(() =>
@@ -99,7 +111,7 @@ describe('useCustomFoodForm', () => {
     );
 
     await waitFor(() => {
-      expect(result.current.variants[0]?.serving_unit).toBe('g');
+      expect(result.current.variants[0]?.is_locked).toBe(true);
     });
 
     act(() => {
@@ -107,8 +119,9 @@ describe('useCustomFoodForm', () => {
     });
 
     expect(result.current.variants[0]?.serving_unit).toBe('tsp');
-    expect(result.current.variants[0]?.calories).toBe(0);
-    expect(result.current.variants[0]?.protein).toBe(0);
+    expect(result.current.variants[0]?.calories).toBe(100);
+    expect(result.current.variants[0]?.protein).toBe(10);
+    expect(result.current.variants[0]?.is_locked).toBe(false);
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
         title: 'Manual conversion required',
@@ -116,21 +129,212 @@ describe('useCustomFoodForm', () => {
           '"g" and "tsp" are incompatible unit types. Please update the serving size and nutrition values manually.',
       })
     );
+  });
 
-    act(() => {
-      result.current.updateVariant(0, 'serving_unit', 'tbsp');
-    });
+  it('opens existing food edits with auto-scale on when the preference is enabled', async () => {
+    mockAutoScaleOnlineImports = true;
+    const food = createFood();
 
-    expect(result.current.variants[0]?.serving_unit).toBe('tbsp');
-    expect(result.current.variants[0]?.calories).toBe(0);
-    expect(result.current.variants[0]?.protein).toBe(0);
-    expect(mockToast).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        title: 'Manual conversion required',
-        description:
-          '"g" and "tbsp" are incompatible unit types. Please update the serving size and nutrition values manually.',
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        food,
+        onSave: jest.fn(),
       })
     );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.is_locked).toBe(true);
+    });
+
+    expect(result.current.hasTrustedCompatibilityBase[0]).toBe(true);
+  });
+
+  it('opens brand-new custom foods with auto-scale off even when the preference is enabled', async () => {
+    mockAutoScaleOnlineImports = true;
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.serving_unit).toBe('g');
+    });
+
+    expect(result.current.variants[0]?.is_locked).toBe(false);
+    expect(result.current.hasTrustedCompatibilityBase[0]).toBe(false);
+  });
+
+  it('keeps newly added unsaved custom variants auto-scale off by default', async () => {
+    mockAutoScaleOnlineImports = true;
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants).toHaveLength(1);
+    });
+
+    act(() => {
+      result.current.addVariant();
+    });
+
+    expect(result.current.variants[1]?.is_locked).toBe(false);
+    expect(result.current.hasTrustedCompatibilityBase[1]).toBe(false);
+  });
+
+  it('does not show incompatible-unit toasts for unsaved custom foods before save', async () => {
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.serving_unit).toBe('g');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'calories', 100);
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'serving');
+    });
+
+    expect(result.current.variants[0]?.serving_unit).toBe('serving');
+    expect(result.current.variants[0]?.calories).toBe(100);
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('keeps auto-scale on during compatible unit changes when the preference intent is on', async () => {
+    mockAutoScaleOnlineImports = true;
+    const initialVariants = [createVariant()];
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        initialVariants,
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.is_locked).toBe(true);
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'oz');
+    });
+
+    expect(result.current.variants[0]?.serving_unit).toBe('oz');
+    expect(result.current.variants[0]?.is_locked).toBe(true);
+    expect(Number(result.current.variants[0]?.calories)).toBeCloseTo(
+      100 * (getConversionFactor('g', 'oz') ?? 0),
+      4
+    );
+  });
+
+  it('restores auto-scale when returning to a compatible unit after an incompatible one', async () => {
+    mockAutoScaleOnlineImports = true;
+    const initialVariants = [createVariant()];
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        initialVariants,
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.is_locked).toBe(true);
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'tsp');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'oz');
+    });
+
+    expect(result.current.variants[0]?.serving_unit).toBe('oz');
+    expect(result.current.variants[0]?.is_locked).toBe(true);
+    expect(Number(result.current.variants[0]?.calories)).toBeCloseTo(
+      100 * (getConversionFactor('g', 'oz') ?? 0),
+      4
+    );
+  });
+
+  it('keeps auto-scale off when returning to a compatible unit after the user preference intent is off', async () => {
+    const initialVariants = [createVariant()];
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        initialVariants,
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.is_locked).toBe(false);
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'tsp');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'oz');
+    });
+
+    expect(result.current.variants[0]?.serving_unit).toBe('oz');
+    expect(result.current.variants[0]?.is_locked).toBe(false);
+  });
+
+  it('creates a new scaling baseline when auto-scale is re-enabled after a manual custom-unit edit', async () => {
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.serving_unit).toBe('g');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_unit', 'serving');
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_size', 1);
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'calories', 100);
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'protein', 10);
+    });
+
+    act(() => {
+      result.current.updateVariant(0, 'is_locked', true);
+    });
+
+    expect(result.current.variants[0]?.is_locked).toBe(true);
+
+    act(() => {
+      result.current.updateVariant(0, 'serving_size', 2);
+    });
+
+    expect(result.current.variants[0]?.serving_size).toBe(2);
+    expect(result.current.variants[0]?.calories).toBe(200);
+    expect(result.current.variants[0]?.protein).toBe(20);
   });
 
   it('keeps the original compatibility base when duplicating a manual-only variant', async () => {
@@ -157,84 +361,5 @@ describe('useCustomFoodForm', () => {
 
     expect(result.current.variants[1]?.serving_unit).toBe('tsp');
     expect(result.current.conversionBaseVariants[1]?.serving_unit).toBe('g');
-  });
-
-  it('allows automatic conversion again after reverting to the loaded unit', async () => {
-    const baseVariant = createVariant();
-    const initialVariants = [baseVariant];
-
-    const { result } = renderHook(() =>
-      useCustomFoodForm({
-        initialVariants,
-        onSave: jest.fn(),
-      })
-    );
-
-    await waitFor(() => {
-      expect(result.current.variants[0]?.serving_unit).toBe('g');
-    });
-
-    act(() => {
-      result.current.updateVariant(0, 'serving_unit', 'tsp');
-    });
-
-    act(() => {
-      result.current.updateVariant(0, 'serving_unit', 'g');
-    });
-
-    act(() => {
-      result.current.updateVariant(0, 'serving_unit', 'oz');
-    });
-
-    expect(result.current.variants[0]?.serving_unit).toBe('oz');
-    expect(Number(result.current.variants[0]?.calories)).toBeCloseTo(
-      baseVariant.calories * (getConversionFactor('g', 'oz') ?? 0),
-      4
-    );
-    expect(Number(result.current.variants[0]?.protein)).toBeCloseTo(
-      baseVariant.protein * (getConversionFactor('g', 'oz') ?? 0),
-      4
-    );
-  });
-
-  it('scales custom nutrients during compatible automatic unit conversion', async () => {
-    const baseVariant = createVariant({
-      custom_nutrients: {
-        caffeine: 25,
-        taurine: 12.5,
-      },
-    });
-    const initialVariants = [baseVariant];
-
-    const { result } = renderHook(() =>
-      useCustomFoodForm({
-        initialVariants,
-        onSave: jest.fn(),
-      })
-    );
-
-    await waitFor(() => {
-      expect(result.current.variants[0]?.serving_unit).toBe('g');
-    });
-
-    act(() => {
-      result.current.updateVariant(0, 'serving_unit', 'oz');
-    });
-
-    const conversionFactor = getConversionFactor('g', 'oz') ?? 0;
-
-    expect(result.current.variants[0]?.serving_unit).toBe('oz');
-    expect(
-      Number(result.current.variants[0]?.custom_nutrients?.['caffeine'])
-    ).toBeCloseTo(
-      Number(baseVariant.custom_nutrients?.['caffeine']) * conversionFactor,
-      4
-    );
-    expect(
-      Number(result.current.variants[0]?.custom_nutrients?.['taurine'])
-    ).toBeCloseTo(
-      Number(baseVariant.custom_nutrients?.['taurine']) * conversionFactor,
-      4
-    );
   });
 });


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
This fixes a few bugs with auto converting units and auto scaling custom foods.

- Incompatible unit changes no longer zero out nutrition values.
- Existing food edits now respect your Auto-Scale preference when the form opens.
- Brand-new custom foods start with Auto-Scale off until you turn it on.
- Auto-Scale now stays on across compatible unit changes if your preference is on.
- Incompatible unit changes temporarily turn Auto-Scale off so you can edit manually.
- Switching back to a compatible unit can turn Auto-Scale back on again when appropriate.
- Custom foods now properly scale macros after you manually set values and then enable Auto-Scale.
- Unsaved custom foods no longer show green compatible-unit checkmarks too early.
- Unsaved custom foods also no longer show incompatible-unit toast warnings before the food has been saved.

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
