### PR TITLE
feat: workout playback for frontend

### DIFF
--- a/SparkyFitnessFrontend/src/App.tsx
+++ b/SparkyFitnessFrontend/src/App.tsx
@@ -54,6 +54,9 @@ const Reports = lazyWithChunkRecovery(() => import('./pages/Reports/Reports'));
 const ExerciseDatabaseManager = lazyWithChunkRecovery(
   () => import('./pages/Exercises/Exercises')
 );
+const WorkoutPlaybackPage = lazyWithChunkRecovery(
+  () => import('./pages/Diary/WorkoutPlaybackPage')
+);
 const GoalsSettings = lazyWithChunkRecovery(
   () => import('./pages/Goals/Goals')
 );
@@ -302,6 +305,11 @@ const router = createBrowserRouter([
           {
             path: 'exercises',
             Component: ExerciseDatabaseManager,
+            ErrorBoundary: RouteErrorBoundary,
+          },
+          {
+            path: 'workout-playback',
+            Component: WorkoutPlaybackPage,
             ErrorBoundary: RouteErrorBoundary,
           },
           {

--- a/SparkyFitnessFrontend/src/api/Exercises/exerciseEntryService.ts
+++ b/SparkyFitnessFrontend/src/api/Exercises/exerciseEntryService.ts
@@ -9,6 +9,7 @@ import {
   exerciseSessionResponseSchema,
   ExerciseEntryResponse,
   CreateExerciseEntryRequest,
+  CreatePresetSessionRequest,
   UpdateExerciseEntryRequest,
   exerciseProgressResponseSchema,
   ExerciseProgressResponse,
@@ -106,6 +107,16 @@ export const logWorkoutPreset = async (
       workout_preset_id: workoutPresetId,
       entry_date: entryDate,
     }),
+  });
+};
+
+export const createPresetSession = async (
+  payload: CreatePresetSessionRequest
+): Promise<void> => {
+  return apiCall('/exercise-preset-entries', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: { 'Content-Type': 'application/json' },
   });
 };
 

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useExerciseEntries.ts
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useExerciseEntries.ts
@@ -10,6 +10,7 @@ import {
   createExerciseEntry,
   updateExerciseEntry,
   deleteExerciseEntry,
+  createPresetSession,
   logWorkoutPreset,
   deleteExercisePresetEntry,
   fetchExerciseDetails,
@@ -150,6 +151,29 @@ export const useLogWorkoutPresetMutation = () => {
       errorMessage: t(
         'diary.exerciseEntry.logPresetError',
         'Failed to log workout preset.'
+      ),
+    },
+  });
+};
+
+export const useCreatePresetSessionMutation = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: createPresetSession,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: exerciseEntryKeys.all });
+      queryClient.invalidateQueries({ queryKey: dailyProgressKeys.all });
+    },
+    meta: {
+      successMessage: t(
+        'diary.exerciseEntry.createPresetSessionSuccess',
+        'Workout saved successfully.'
+      ),
+      errorMessage: t(
+        'diary.exerciseEntry.createPresetSessionError',
+        'Failed to save workout.'
       ),
     },
   });

--- a/SparkyFitnessFrontend/src/pages/Diary/ExerciseCard.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/ExerciseCard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -8,7 +9,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { Dumbbell } from 'lucide-react';
+import { Dumbbell, Play } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
 import { useActiveUser } from '@/contexts/ActiveUserContext';
 import EditExerciseEntryDialog from './EditExerciseEntryDialog';
@@ -31,10 +32,10 @@ import {
   useDeleteExerciseEntryMutation,
   useDeleteExercisePresetEntryMutation,
   useExerciseEntries,
-  useLogWorkoutPresetMutation,
 } from '@/hooks/Exercises/useExerciseEntries';
 import { useQueryClient } from '@tanstack/react-query';
 import { exerciseByIdOptions } from '@/hooks/Exercises/useExercises';
+import { createWorkoutPlaybackRouteState } from '@/utils/workoutPlayback';
 import {
   Exercise,
   ExerciseEntry,
@@ -61,6 +62,7 @@ const ExerciseCard = ({
   onExercisesLogged,
 }: ExerciseCardProps) => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const { user } = useAuth();
   const { activeUserId } = useActiveUser();
   const { loggingLevel, energyUnit, convertEnergy, getEnergyUnitString } =
@@ -71,6 +73,9 @@ const ExerciseCard = ({
     selectedDate
   );
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [addDialogInitialTab, setAddDialogInitialTab] = useState<
+    'my-exercises' | 'workout-preset'
+  >('my-exercises');
   const [editingEntry, setEditingEntry] = useState<ExerciseEntry | null>(null); // Use ExerciseEntry from service
   const [isPlaybackModalOpen, setIsPlaybackModalOpen] = useState(false); // State for playback modal
   const [exerciseToPlay, setExerciseToPlay] = useState<Exercise | null>(null); // State for exercise to play
@@ -94,8 +99,6 @@ const ExerciseCard = ({
   const { mutateAsync: deleteExerciseEntry } = useDeleteExerciseEntryMutation();
   const { mutateAsync: deleteExercisePresetEntry } =
     useDeleteExercisePresetEntryMutation();
-  const { mutateAsync: logWorkoutPreset } = useLogWorkoutPresetMutation();
-
   const { data: exerciseEntries, isLoading: loading } = useExerciseEntries(
     selectedDate,
     currentUserId
@@ -162,6 +165,13 @@ const ExerciseCard = ({
 
   const handleOpenAddDialog = () => {
     debug(loggingLevel, 'Opening add exercise dialog.');
+    setAddDialogInitialTab('my-exercises');
+    setIsAddDialogOpen(true);
+  };
+
+  const handleStartWorkoutPlayback = () => {
+    debug(loggingLevel, 'Opening workout preset selector.');
+    setAddDialogInitialTab('workout-preset');
     setIsAddDialogOpen(true);
   };
 
@@ -204,21 +214,18 @@ const ExerciseCard = ({
     setIsAddDialogOpen(false);
   };
 
-  const handleWorkoutPresetSelected = async (preset: WorkoutPreset) => {
+  const handleWorkoutPresetSelected = (preset: WorkoutPreset) => {
     debug(loggingLevel, 'Workout preset selected in ExerciseCard:', preset);
-    try {
-      await logWorkoutPreset({ presetId: preset.id, date: selectedDate });
-      handleCloseAddDialog(); // Close the add exercise dialog
-      onExercisesLogged(); // Signal to parent that exercises have been logged
-    } catch (err) {
-      error(
-        loggingLevel,
-        `Error logging workout preset "${preset.name}":`,
-        err
-      );
-    } finally {
-      setIsAddDialogOpen(false); // Close the add dialog
-    }
+    const routeState = createWorkoutPlaybackRouteState(
+      preset,
+      selectedDate,
+      `${window.location.pathname}${window.location.search}`
+    );
+
+    handleCloseAddDialog();
+    navigate(`/workout-playback?date=${selectedDate}`, {
+      state: routeState,
+    });
   };
 
   const handleDeleteExerciseEntry = async (entryId: string) => {
@@ -381,25 +388,45 @@ const ExerciseCard = ({
           <CardTitle className="dark:text-slate-300">
             {t('exerciseCard.title', 'Exercise')}
           </CardTitle>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button size="default" onClick={handleOpenAddDialog}>
-                  <Dumbbell className="w-4 h-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>{t('exerciseCard.addExercise', 'Add Exercise')}</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <div className="flex items-center gap-2">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    size="default"
+                    variant="outline"
+                    onClick={handleStartWorkoutPlayback}
+                  >
+                    <Play className="w-4 h-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{t('exerciseCard.startWorkout', 'Start Workout')}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button size="default" onClick={handleOpenAddDialog}>
+                    <Dumbbell className="w-4 h-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{t('exerciseCard.addExercise', 'Add Exercise')}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </div>
           {/* Render the AddExerciseDialog directly. It manages its own Dialog/Content and headers. */}
           <AddExerciseDialog
+            key={`add-dialog-${addDialogInitialTab}-${isAddDialogOpen ? 'open' : 'closed'}`}
             open={isAddDialogOpen}
             onOpenChange={setIsAddDialogOpen}
             onExerciseAdded={handleExerciseSelect}
             onWorkoutPresetSelected={handleWorkoutPresetSelected}
             mode="diary"
+            initialTab={addDialogInitialTab}
           />
         </div>
       </CardHeader>

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackDialogs.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackDialogs.tsx
@@ -1,0 +1,130 @@
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
+import ConfirmationDialog from '@/components/ui/ConfirmationDialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import type { WorkoutSetPointer } from '@/utils/workoutPlayback';
+import { formatSecondsClock } from '@/utils/timeFormatters';
+
+const REST_PRESETS = [30, 45, 60, 90, 120, 180, 300];
+const MIN_REST_SECONDS = 15;
+const MAX_REST_SECONDS = 900;
+
+interface WorkoutPlaybackDialogsProps {
+  restEditorPointer: WorkoutSetPointer | null;
+  restEditorCustomValue: string;
+  onCloseRestEditor: () => void;
+  onUpdateRestForPointer: (seconds: number) => void;
+  onSetRestEditorCustomValue: (value: string) => void;
+  onSaveCustomRest: () => void;
+  isDiscardDialogOpen: boolean;
+  onDiscardDialogChange: (open: boolean) => void;
+  onConfirmDiscard: () => void;
+}
+
+const WorkoutPlaybackDialogs = ({
+  restEditorPointer,
+  restEditorCustomValue,
+  onCloseRestEditor,
+  onUpdateRestForPointer,
+  onSetRestEditorCustomValue,
+  onSaveCustomRest,
+  isDiscardDialogOpen,
+  onDiscardDialogChange,
+  onConfirmDiscard,
+}: WorkoutPlaybackDialogsProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Dialog
+        open={!!restEditorPointer}
+        onOpenChange={(open) => !open && onCloseRestEditor()}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {t('exercise.workoutPlaybackPage.restEditorTitle', 'Edit Rest')}
+            </DialogTitle>
+            <DialogDescription>
+              {t(
+                'exercise.workoutPlaybackPage.restEditorDescription',
+                'Pick a rest duration for this set.'
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="flex flex-wrap gap-2">
+              {REST_PRESETS.map((seconds) => (
+                <Button
+                  key={seconds}
+                  type="button"
+                  variant="outline"
+                  className="tabular-nums"
+                  onClick={() => onUpdateRestForPointer(seconds)}
+                >
+                  {formatSecondsClock(seconds)}
+                </Button>
+              ))}
+            </div>
+            <div className="space-y-2">
+              <label
+                className="text-sm font-medium"
+                htmlFor="custom-rest-seconds"
+              >
+                {t(
+                  'exercise.workoutPlaybackPage.customRest',
+                  'Custom (seconds)'
+                )}
+              </label>
+              <Input
+                id="custom-rest-seconds"
+                type="number"
+                min={MIN_REST_SECONDS}
+                max={MAX_REST_SECONDS}
+                step={5}
+                value={restEditorCustomValue}
+                onChange={(event) =>
+                  onSetRestEditorCustomValue(event.target.value)
+                }
+              />
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={onCloseRestEditor}
+              >
+                {t('common.cancel', 'Cancel')}
+              </Button>
+              <Button type="button" onClick={onSaveCustomRest}>
+                {t('common.save', 'Save')}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <ConfirmationDialog
+        open={isDiscardDialogOpen}
+        onOpenChange={onDiscardDialogChange}
+        onConfirm={onConfirmDiscard}
+        title={t('exercise.workoutPlaybackDialog.discard', 'Discard')}
+        description={t(
+          'exercise.workoutPlaybackDialog.discardConfirm',
+          'Discard this in-progress workout? This cannot be undone.'
+        )}
+        variant="destructive"
+        confirmLabel={t('exercise.workoutPlaybackDialog.discard', 'Discard')}
+      />
+    </>
+  );
+};
+
+export default WorkoutPlaybackDialogs;

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
@@ -1,0 +1,187 @@
+import { useState, memo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ChevronDown } from 'lucide-react';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import {
+  WORKOUT_PLAYBACK_SET_GRID_CLASSES,
+  type WorkoutPlaybackExerciseDraft,
+  type WorkoutSetPointer,
+} from '@/utils/workoutPlayback';
+import WorkoutPlaybackSetRow from './WorkoutPlaybackSetRow';
+
+interface WorkoutPlaybackExercisesListProps {
+  exercises: WorkoutPlaybackExerciseDraft[];
+  setNotesVisibility: Record<string, boolean>;
+  onToggleSetNotesVisibility: (setKey: string) => void;
+  onSelectSet: (pointer: WorkoutSetPointer) => void;
+  onCompleteSet: (pointer: WorkoutSetPointer) => void;
+  onUncompleteSet: (pointer: WorkoutSetPointer) => void;
+  onSetFieldChange: (
+    pointer: WorkoutSetPointer,
+    field: 'reps' | 'weight' | 'rest_time' | 'set_type' | 'notes',
+    value: number | string | null
+  ) => void;
+  onOpenRestEditor: (pointer: WorkoutSetPointer) => void;
+  onRemoveSet: (pointer: WorkoutSetPointer) => void;
+  onAddSet: (exerciseIndex: number) => void;
+}
+
+const WorkoutPlaybackExercisesList = ({
+  exercises,
+  setNotesVisibility,
+  onToggleSetNotesVisibility,
+  onSelectSet,
+  onCompleteSet,
+  onUncompleteSet,
+  onSetFieldChange,
+  onOpenRestEditor,
+  onRemoveSet,
+  onAddSet,
+}: WorkoutPlaybackExercisesListProps) => {
+  const { t } = useTranslation();
+  const [expandedCompletedExercises, setExpandedCompletedExercises] = useState<
+    Record<string, boolean>
+  >({});
+
+  return (
+    <div className="space-y-2">
+      {exercises.map((exercise, exerciseIndex) => {
+        const completedSets = exercise.sets.filter(
+          (set) => set.completed
+        ).length;
+        const totalSets = exercise.sets.length;
+        const isComplete = totalSets > 0 && completedSets === totalSets;
+        const exerciseKey = `${exercise.exercise_id}-${exerciseIndex}`;
+        const isExpanded =
+          !isComplete || expandedCompletedExercises[exerciseKey] === true;
+        const toggleLabel = isExpanded
+          ? t('common.collapse', 'Collapse')
+          : t('common.expand', 'Expand');
+
+        return (
+          <Card
+            key={`${exercise.exercise_id}-${exerciseIndex}`}
+            className="border-border/70 shadow-none"
+          >
+            <CardHeader className="px-3 py-2">
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <h3 className="truncate text-sm font-medium">
+                    {exercise.exercise_name}
+                  </h3>
+                  <p className="text-[11px] text-muted-foreground">
+                    {completedSets}/{totalSets}{' '}
+                    {t('exercise.workoutPlaybackDialog.sets', 'sets')}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="flex cursor-pointer items-center gap-1.5 text-left"
+                  aria-label={`${toggleLabel} ${exercise.exercise_name}`}
+                  onClick={() => {
+                    if (!isComplete) return;
+                    setExpandedCompletedExercises((current) => ({
+                      ...current,
+                      [exerciseKey]: !current[exerciseKey],
+                    }));
+                  }}
+                >
+                  <ChevronDown
+                    className={`h-4 w-4 transition-transform ${
+                      isExpanded ? 'rotate-180' : ''
+                    } ${isComplete ? 'text-emerald-500' : ''}`}
+                  />
+                  <span className="text-[11px] text-muted-foreground">
+                    {isComplete
+                      ? t('exercise.workoutPlaybackPage.completed', 'Completed')
+                      : t(
+                          'exercise.workoutPlaybackPage.inProgress',
+                          'In Progress'
+                        )}
+                  </span>
+                </button>
+              </div>
+            </CardHeader>
+            {isExpanded && (
+              <CardContent className="px-3 pb-2 pt-0">
+                <div className="space-y-1">
+                  <div className="hidden overflow-x-auto pb-1 sm:block">
+                    <div
+                      className={`text-[10px] font-medium text-muted-foreground ${WORKOUT_PLAYBACK_SET_GRID_CLASSES}`}
+                    >
+                      <div className="flex justify-center px-3">
+                        {t('exercise.workoutPlaybackPage.columnSet', 'Set')}
+                      </div>
+                      <div className="flex justify-center px-3">
+                        {t('exercise.workoutPlaybackPage.columnType', 'Type')}
+                      </div>
+                      <div className="flex justify-center px-3">
+                        {t('exercise.workoutPlaybackPage.columnReps', 'Reps')}
+                      </div>
+                      <div className="flex justify-center px-3">
+                        {t(
+                          'exercise.workoutPlaybackPage.columnWeight',
+                          'Weight'
+                        )}
+                      </div>
+                      <div className="flex justify-center px-3">
+                        {t('exercise.workoutPlaybackPage.columnRest', 'Rest')}
+                      </div>
+                      <div className="flex justify-end px-3">
+                        {t('common.actions', 'Actions')}
+                      </div>
+                    </div>
+                  </div>
+
+                  {exercise.sets.map((set, setIndex) => {
+                    return (
+                      <WorkoutPlaybackSetRow
+                        key={`${exercise.exercise_id}-${exerciseIndex}-${setIndex}`}
+                        exerciseName={exercise.exercise_name}
+                        exerciseKey={exerciseKey}
+                        exerciseIndex={exerciseIndex}
+                        setIndex={setIndex}
+                        setNumber={set.set_number}
+                        setType={set.set_type}
+                        reps={set.reps}
+                        weight={set.weight}
+                        restTime={set.rest_time}
+                        notes={set.notes}
+                        completed={set.completed}
+                        isNotesVisible={
+                          setNotesVisibility[`${exerciseKey}-${setIndex}`] ??
+                          false
+                        }
+                        onToggleNotesVisibility={onToggleSetNotesVisibility}
+                        onSelectSet={onSelectSet}
+                        onCompleteSet={onCompleteSet}
+                        onUncompleteSet={onUncompleteSet}
+                        onSetFieldChange={onSetFieldChange}
+                        onOpenRestEditor={onOpenRestEditor}
+                        onRemoveSet={onRemoveSet}
+                        canRemove={exercise.sets.length > 1}
+                      />
+                    );
+                  })}
+                </div>
+
+                <div className="mt-2 flex justify-center">
+                  <button
+                    type="button"
+                    aria-label={`Add set for ${exercise.exercise_name}`}
+                    className="inline-flex items-center justify-center px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                    onClick={() => onAddSet(exerciseIndex)}
+                  >
+                    {t('exercise.workoutPlaybackPage.addSet', 'Add Set')}
+                  </button>
+                </div>
+              </CardContent>
+            )}
+          </Card>
+        );
+      })}
+    </div>
+  );
+};
+
+export default memo(WorkoutPlaybackExercisesList);

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackPage.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackPage.tsx
@@ -1,0 +1,579 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardDescription, CardHeader } from '@/components/ui/card';
+import { useCreatePresetSessionMutation } from '@/hooks/Exercises/useExerciseEntries';
+import {
+  DEFAULT_REST_SECONDS,
+  addWorkoutSetToExercise,
+  clearWorkoutPlaybackDraftFromStorage,
+  buildPresetSessionCreateRequestFromDraft,
+  completeCurrentWorkoutSet,
+  getCurrentWorkoutSetPointer,
+  getWorkoutPlaybackRestRemainingSeconds,
+  getWorkoutPlaybackStats,
+  isWorkoutPlaybackComplete,
+  loadWorkoutPlaybackDraftFromStorage,
+  removeWorkoutSetFromExercise,
+  saveWorkoutPlaybackDraftToStorage,
+  setWorkoutPlaybackPointer,
+  setWorkoutPlaybackRestTimer,
+  toggleWorkoutSetCompletion,
+  type WorkoutPlaybackRouteState,
+  type WorkoutPlaybackDraft,
+  type WorkoutSetPointer,
+  updateWorkoutSetAtPointer,
+} from '@/utils/workoutPlayback';
+import { formatSecondsClock } from '@/utils/timeFormatters';
+import WorkoutPlaybackDialogs from './WorkoutPlaybackDialogs';
+import WorkoutPlaybackExercisesList from './WorkoutPlaybackExercisesList';
+import WorkoutPlaybackSummary from './WorkoutPlaybackSummary';
+
+const MIN_REST_SECONDS = 15;
+const MAX_REST_SECONDS = 900;
+
+function clampRestSeconds(seconds: number): number {
+  if (!Number.isFinite(seconds)) {
+    return DEFAULT_REST_SECONDS;
+  }
+
+  const clamped = Math.max(
+    MIN_REST_SECONDS,
+    Math.min(MAX_REST_SECONDS, seconds)
+  );
+  return Math.round(clamped / 5) * 5;
+}
+
+function getInitialDraft(
+  requestedDate: string | null,
+  routeState: WorkoutPlaybackRouteState | null
+): WorkoutPlaybackDraft | null {
+  const existingDraft = routeState?.draft ?? null;
+  if (existingDraft) {
+    if (requestedDate && existingDraft.entry_date !== requestedDate) {
+      return null;
+    }
+
+    return existingDraft;
+  }
+
+  if (!requestedDate) {
+    return null;
+  }
+
+  return loadWorkoutPlaybackDraftFromStorage(requestedDate);
+}
+
+function getReturnPath(
+  requestedDate: string | null,
+  routeState: WorkoutPlaybackRouteState | null
+): string {
+  if (routeState?.returnTo) {
+    return routeState.returnTo;
+  }
+
+  if (requestedDate) {
+    return `/?date=${requestedDate}`;
+  }
+
+  return '/';
+}
+
+function startRestTimer(
+  draft: WorkoutPlaybackDraft,
+  restSeconds: number,
+  targetPointer?: WorkoutSetPointer
+): WorkoutPlaybackDraft {
+  const normalizedRestSeconds = Math.max(0, restSeconds);
+
+  if (normalizedRestSeconds === 0) {
+    return setWorkoutPlaybackRestTimer(draft, {
+      state: 'idle',
+      duration_seconds: 0,
+      remaining_seconds: 0,
+      target_exercise_index: undefined,
+      target_set_index: undefined,
+    });
+  }
+
+  return setWorkoutPlaybackRestTimer(draft, {
+    state: 'running',
+    duration_seconds: normalizedRestSeconds,
+    remaining_seconds: normalizedRestSeconds,
+    target_end_timestamp_ms: Date.now() + normalizedRestSeconds * 1000,
+    target_exercise_index: targetPointer?.exerciseIndex,
+    target_set_index: targetPointer?.setIndex,
+  });
+}
+
+const WorkoutPlaybackPage = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const requestedDate = searchParams.get('date');
+  const routeState =
+    (location.state as WorkoutPlaybackRouteState | null) ?? null;
+  const returnPath = getReturnPath(requestedDate, routeState);
+
+  const scrubbedRouteStateRef = useRef(false);
+  const persistedDraftDateRef = useRef<string | null>(null);
+  const [draft, setDraft] = useState<WorkoutPlaybackDraft | null>(() =>
+    getInitialDraft(requestedDate, routeState)
+  );
+  const draftRef = useRef<WorkoutPlaybackDraft | null>(draft);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [elapsedTickMs, setElapsedTickMs] = useState(() => Date.now());
+  const [setNotesVisibility, setSetNotesVisibility] = useState<
+    Record<string, boolean>
+  >({});
+  const [restEditorPointer, setRestEditorPointer] =
+    useState<WorkoutSetPointer | null>(null);
+  const [restEditorCustomValue, setRestEditorCustomValue] = useState('');
+  const [isDiscardDialogOpen, setIsDiscardDialogOpen] = useState(false);
+
+  const { mutateAsync: createPresetSession, isPending: isSaving } =
+    useCreatePresetSessionMutation();
+
+  useEffect(() => {
+    if (scrubbedRouteStateRef.current || !routeState?.draft) {
+      return;
+    }
+
+    scrubbedRouteStateRef.current = true;
+    navigate(`${location.pathname}${location.search}`, {
+      replace: true,
+      state: routeState.returnTo
+        ? { returnTo: routeState.returnTo }
+        : undefined,
+    });
+  }, [
+    location.pathname,
+    location.search,
+    navigate,
+    routeState,
+    routeState?.draft,
+    routeState?.returnTo,
+  ]);
+
+  // Debounce draft saves to avoid excessive localStorage writes on timer ticks
+  useEffect(() => {
+    if (!draft) {
+      if (persistedDraftDateRef.current) {
+        clearWorkoutPlaybackDraftFromStorage(persistedDraftDateRef.current);
+        persistedDraftDateRef.current = null;
+      }
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      if (
+        persistedDraftDateRef.current &&
+        persistedDraftDateRef.current !== draft.entry_date
+      ) {
+        clearWorkoutPlaybackDraftFromStorage(persistedDraftDateRef.current);
+      }
+
+      saveWorkoutPlaybackDraftToStorage(draft);
+      persistedDraftDateRef.current = draft.entry_date;
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [draft]);
+
+  useEffect(() => {
+    draftRef.current = draft;
+  }, [draft]);
+
+  // Combined interval for both rest timer and elapsed time
+  // Only update draft when timer expires; remaining time derives from target_end_timestamp_ms
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setElapsedTickMs(Date.now());
+
+      setDraft((currentDraft) => {
+        if (!currentDraft || currentDraft.rest_timer.state !== 'running') {
+          return currentDraft;
+        }
+
+        const nextRemaining = getWorkoutPlaybackRestRemainingSeconds(
+          currentDraft.rest_timer
+        );
+
+        // Only update draft state when timer expires to avoid triggering localStorage saves
+        if (nextRemaining <= 0) {
+          return setWorkoutPlaybackRestTimer(currentDraft, {
+            ...currentDraft.rest_timer,
+            state: 'idle',
+            remaining_seconds: 0,
+            target_end_timestamp_ms: null,
+          });
+        }
+
+        // Don't update draft; remaining time is derived from target_end_timestamp_ms in render
+        return currentDraft;
+      });
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const stats = useMemo(() => {
+    if (!draft) return null;
+    return getWorkoutPlaybackStats(draft);
+  }, [draft]);
+
+  const totalVolume = useMemo(() => {
+    if (!draft) return 0;
+
+    return draft.exercises.reduce(
+      (exerciseSum, exercise) =>
+        exerciseSum +
+        exercise.sets.reduce(
+          (setSum, set) =>
+            set.completed
+              ? setSum + (Number(set.weight) || 0) * (Number(set.reps) || 0)
+              : setSum,
+          0
+        ),
+      0
+    );
+  }, [draft]);
+
+  const startedAtMs = useMemo(() => {
+    if (!draft) {
+      return NaN;
+    }
+
+    return Date.parse(draft.started_at);
+  }, [draft]);
+
+  const elapsedSeconds = useMemo(() => {
+    if (!draft || Number.isNaN(startedAtMs)) return 0;
+    return Math.max(0, Math.floor((elapsedTickMs - startedAtMs) / 1000));
+  }, [draft, elapsedTickMs, startedAtMs]);
+
+  const updateDraft = useCallback(
+    (updater: (currentDraft: WorkoutPlaybackDraft) => WorkoutPlaybackDraft) => {
+      setDraft((currentDraft) => {
+        if (!currentDraft) return currentDraft;
+        return updater(currentDraft);
+      });
+    },
+    []
+  );
+
+  const handleCompleteSet = useCallback(
+    (pointer: WorkoutSetPointer) => {
+      updateDraft((currentDraft) => {
+        const set =
+          currentDraft.exercises[pointer.exerciseIndex]?.sets[pointer.setIndex];
+        if (!set || set.completed) {
+          return currentDraft;
+        }
+
+        let nextDraft = setWorkoutPlaybackPointer(currentDraft, pointer);
+        nextDraft = completeCurrentWorkoutSet(nextDraft);
+
+        if (!isWorkoutPlaybackComplete(nextDraft)) {
+          const restSeconds = set.rest_time ?? DEFAULT_REST_SECONDS;
+          const targetPointer = getCurrentWorkoutSetPointer(nextDraft);
+          nextDraft = startRestTimer(nextDraft, restSeconds, targetPointer);
+        }
+
+        return nextDraft;
+      });
+    },
+    [updateDraft]
+  );
+
+  const handleUncompleteSet = useCallback(
+    (pointer: WorkoutSetPointer) => {
+      updateDraft((currentDraft) => {
+        const updated = toggleWorkoutSetCompletion(
+          setWorkoutPlaybackPointer(currentDraft, pointer),
+          pointer
+        );
+
+        if (
+          updated.rest_timer.target_exercise_index === pointer.exerciseIndex &&
+          updated.rest_timer.target_set_index === pointer.setIndex &&
+          updated.rest_timer.state !== 'idle'
+        ) {
+          return setWorkoutPlaybackRestTimer(updated, {
+            ...updated.rest_timer,
+            state: 'idle',
+            remaining_seconds: 0,
+          });
+        }
+
+        return updated;
+      });
+    },
+    [updateDraft]
+  );
+
+  const handleSetFieldChange = useCallback(
+    (
+      pointer: WorkoutSetPointer,
+      field: 'reps' | 'weight' | 'rest_time' | 'set_type' | 'notes',
+      value: number | string | null
+    ) => {
+      updateDraft((currentDraft) =>
+        updateWorkoutSetAtPointer(currentDraft, pointer, { [field]: value })
+      );
+    },
+    [updateDraft]
+  );
+
+  const handleSessionNotesChange = useCallback(
+    (value: string) => {
+      updateDraft((currentDraft) => ({ ...currentDraft, notes: value }));
+    },
+    [updateDraft]
+  );
+
+  const toggleSetNotesVisibility = useCallback((setKey: string) => {
+    setSetNotesVisibility((current) => ({
+      ...current,
+      [setKey]: !current[setKey],
+    }));
+  }, []);
+
+  const handleAddSet = useCallback(
+    (exerciseIndex: number) => {
+      updateDraft((currentDraft) =>
+        addWorkoutSetToExercise(currentDraft, exerciseIndex)
+      );
+    },
+    [updateDraft]
+  );
+
+  const handleRemoveSet = useCallback(
+    (pointer: WorkoutSetPointer) => {
+      updateDraft((currentDraft) =>
+        removeWorkoutSetFromExercise(currentDraft, pointer)
+      );
+    },
+    [updateDraft]
+  );
+
+  const handlePauseResumeRest = useCallback(() => {
+    updateDraft((currentDraft) => {
+      if (currentDraft.rest_timer.state === 'running') {
+        const remainingSeconds = getWorkoutPlaybackRestRemainingSeconds(
+          currentDraft.rest_timer
+        );
+        return setWorkoutPlaybackRestTimer(currentDraft, {
+          ...currentDraft.rest_timer,
+          state: 'paused',
+          remaining_seconds: remainingSeconds,
+          target_end_timestamp_ms: null,
+        });
+      }
+
+      if (currentDraft.rest_timer.state === 'paused') {
+        return setWorkoutPlaybackRestTimer(currentDraft, {
+          ...currentDraft.rest_timer,
+          state: 'running',
+          target_end_timestamp_ms:
+            Date.now() + currentDraft.rest_timer.remaining_seconds * 1000,
+        });
+      }
+
+      return currentDraft;
+    });
+  }, [updateDraft]);
+
+  const handleSkipRest = useCallback(() => {
+    updateDraft((currentDraft) =>
+      setWorkoutPlaybackRestTimer(currentDraft, {
+        ...currentDraft.rest_timer,
+        state: 'idle',
+        remaining_seconds: currentDraft.rest_timer.duration_seconds,
+        target_end_timestamp_ms: null,
+        target_exercise_index: undefined,
+        target_set_index: undefined,
+      })
+    );
+  }, [updateDraft]);
+
+  const handleOpenRestEditor = useCallback((pointer: WorkoutSetPointer) => {
+    const currentDraft = draftRef.current;
+    if (!currentDraft) return;
+    const selectedSet =
+      currentDraft.exercises[pointer.exerciseIndex]?.sets[pointer.setIndex];
+    if (!selectedSet) return;
+    setRestEditorPointer(pointer);
+    setRestEditorCustomValue(
+      String(selectedSet.rest_time ?? DEFAULT_REST_SECONDS)
+    );
+  }, []);
+
+  const closeRestEditor = useCallback(() => {
+    setRestEditorPointer(null);
+    setRestEditorCustomValue('');
+  }, []);
+
+  const updateRestForPointer = useCallback(
+    (seconds: number) => {
+      if (!restEditorPointer) return;
+      const normalized = clampRestSeconds(seconds);
+      updateDraft((currentDraft) =>
+        updateWorkoutSetAtPointer(currentDraft, restEditorPointer, {
+          rest_time: normalized,
+        })
+      );
+      closeRestEditor();
+    },
+    [closeRestEditor, restEditorPointer, updateDraft]
+  );
+
+  const handleSaveCustomRest = useCallback(() => {
+    const parsed = Number(restEditorCustomValue);
+    updateRestForPointer(
+      Number.isFinite(parsed) ? parsed : DEFAULT_REST_SECONDS
+    );
+  }, [restEditorCustomValue, updateRestForPointer]);
+
+  const handleSelectSet = useCallback(
+    (pointer: WorkoutSetPointer) => {
+      updateDraft((currentDraft) =>
+        setWorkoutPlaybackPointer(currentDraft, pointer)
+      );
+    },
+    [updateDraft]
+  );
+
+  const handleCloseKeepDraft = useCallback(() => {
+    navigate(returnPath);
+  }, [navigate, returnPath]);
+
+  const handleDiscard = useCallback(() => {
+    setIsDiscardDialogOpen(true);
+  }, []);
+
+  const handleConfirmDiscard = useCallback(() => {
+    if (draft) {
+      clearWorkoutPlaybackDraftFromStorage(draft.entry_date);
+    }
+    setDraft(null);
+    setSaveError(null);
+    setIsDiscardDialogOpen(false);
+    navigate(returnPath);
+  }, [draft, navigate, returnPath]);
+
+  const handleFinishWorkout = useCallback(async () => {
+    if (!draft) return;
+
+    const payload = buildPresetSessionCreateRequestFromDraft(draft);
+    if (!payload.exercises || payload.exercises.length === 0) {
+      setSaveError(
+        t(
+          'exercise.workoutPlaybackDialog.completeAtLeastOneSet',
+          'Complete at least one set before finishing.'
+        )
+      );
+      return;
+    }
+
+    try {
+      await createPresetSession(payload);
+      clearWorkoutPlaybackDraftFromStorage(draft.entry_date);
+      setDraft(null);
+      setSaveError(null);
+      navigate(returnPath, { replace: true });
+    } catch {
+      setSaveError(
+        t(
+          'exercise.workoutPlaybackDialog.finishError',
+          'Failed to save workout. Your local progress is still preserved, and you can retry.'
+        )
+      );
+    }
+  }, [createPresetSession, draft, navigate, returnPath, t]);
+
+  if (!draft) {
+    return (
+      <div className="mx-auto w-full max-w-4xl space-y-4">
+        <Button
+          type="button"
+          variant="ghost"
+          className="gap-2"
+          onClick={() => navigate(returnPath)}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {t('common.back', 'Back')}
+        </Button>
+        <Card>
+          <CardHeader>
+            <h2 className="text-lg font-semibold">
+              {t('exercise.workoutPlaybackDialog.title', 'Live Workout')}
+            </h2>
+            <CardDescription>
+              {t(
+                'exercise.workoutPlaybackDialog.noDraft',
+                'No active workout draft was found for this date.'
+              )}
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  const isRestActive = draft && draft.rest_timer.state !== 'idle';
+  const restRemaining = formatSecondsClock(
+    draft ? getWorkoutPlaybackRestRemainingSeconds(draft.rest_timer) : 0
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-4">
+      <WorkoutPlaybackSummary
+        draft={draft}
+        elapsedSeconds={elapsedSeconds}
+        totalVolume={totalVolume}
+        stats={stats}
+        restRemaining={restRemaining}
+        isRestActive={!!isRestActive}
+        saveError={saveError}
+        isSaving={isSaving}
+        onCloseKeepDraft={handleCloseKeepDraft}
+        onDiscard={handleDiscard}
+        onFinishWorkout={handleFinishWorkout}
+        onPauseResumeRest={handlePauseResumeRest}
+        onSkipRest={handleSkipRest}
+        onSessionNotesChange={handleSessionNotesChange}
+      />
+
+      <WorkoutPlaybackExercisesList
+        exercises={draft.exercises}
+        setNotesVisibility={setNotesVisibility}
+        onToggleSetNotesVisibility={toggleSetNotesVisibility}
+        onSelectSet={handleSelectSet}
+        onCompleteSet={handleCompleteSet}
+        onUncompleteSet={handleUncompleteSet}
+        onSetFieldChange={handleSetFieldChange}
+        onOpenRestEditor={handleOpenRestEditor}
+        onRemoveSet={handleRemoveSet}
+        onAddSet={handleAddSet}
+      />
+
+      <WorkoutPlaybackDialogs
+        restEditorPointer={restEditorPointer}
+        restEditorCustomValue={restEditorCustomValue}
+        onCloseRestEditor={closeRestEditor}
+        onUpdateRestForPointer={updateRestForPointer}
+        onSetRestEditorCustomValue={setRestEditorCustomValue}
+        onSaveCustomRest={handleSaveCustomRest}
+        isDiscardDialogOpen={isDiscardDialogOpen}
+        onDiscardDialogChange={setIsDiscardDialogOpen}
+        onConfirmDiscard={handleConfirmDiscard}
+      />
+    </div>
+  );
+};
+
+export default WorkoutPlaybackPage;

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSetRow.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSetRow.tsx
@@ -1,0 +1,273 @@
+import { useTranslation } from 'react-i18next';
+import { memo } from 'react';
+import { MessageSquare, Timer, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { excerciseWorkoutSetTypes } from '@/constants/excerciseWorkoutSetTypes';
+import { formatSecondsClock } from '@/utils/timeFormatters';
+import {
+  DEFAULT_REST_SECONDS,
+  WORKOUT_PLAYBACK_SET_GRID_CLASSES,
+  type WorkoutSetPointer,
+} from '@/utils/workoutPlayback';
+
+function formatRestChip(seconds: number | null | undefined): string {
+  const value = seconds ?? DEFAULT_REST_SECONDS;
+  if (value < 60) {
+    return `${value}s`;
+  }
+
+  return formatSecondsClock(value);
+}
+
+function parseNullableInteger(raw: string): number | null {
+  if (raw.trim() === '') {
+    return null;
+  }
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function parseNullableDecimal(raw: string): number | null {
+  if (raw.trim() === '') {
+    return null;
+  }
+
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+interface WorkoutPlaybackSetRowProps {
+  exerciseName: string;
+  exerciseKey: string;
+  exerciseIndex: number;
+  setIndex: number;
+  setNumber: number;
+  setType: string | null | undefined;
+  reps: number | null | undefined;
+  weight: number | null | undefined;
+  restTime: number | null | undefined;
+  notes: string | null | undefined;
+  completed: boolean;
+  isNotesVisible: boolean;
+  onToggleNotesVisibility: (setKey: string) => void;
+  onSelectSet: (pointer: WorkoutSetPointer) => void;
+  onCompleteSet: (pointer: WorkoutSetPointer) => void;
+  onUncompleteSet: (pointer: WorkoutSetPointer) => void;
+  onSetFieldChange: (
+    pointer: WorkoutSetPointer,
+    field: 'reps' | 'weight' | 'rest_time' | 'set_type' | 'notes',
+    value: number | string | null
+  ) => void;
+  onOpenRestEditor: (pointer: WorkoutSetPointer) => void;
+  onRemoveSet: (pointer: WorkoutSetPointer) => void;
+  canRemove: boolean;
+}
+
+const WorkoutPlaybackSetRow = ({
+  exerciseName,
+  exerciseKey,
+  exerciseIndex,
+  setIndex,
+  setNumber,
+  setType,
+  reps,
+  weight,
+  restTime,
+  notes,
+  completed,
+  isNotesVisible,
+  onToggleNotesVisibility,
+  onSelectSet,
+  onCompleteSet,
+  onUncompleteSet,
+  onSetFieldChange,
+  onOpenRestEditor,
+  onRemoveSet,
+  canRemove,
+}: WorkoutPlaybackSetRowProps) => {
+  const { t } = useTranslation();
+  const pointer: WorkoutSetPointer = { exerciseIndex, setIndex };
+  const notesKey = `${exerciseKey}-${setIndex}`;
+
+  return (
+    <div>
+      <div
+        className={`w-full rounded-sm border px-2 py-1.5 text-left ${
+          completed
+            ? 'border-border/60 bg-muted/40 text-muted-foreground'
+            : 'border-border/70 bg-background'
+        }`}
+      >
+        <div className={WORKOUT_PLAYBACK_SET_GRID_CLASSES}>
+          <div className="col-span-2 flex min-w-0 items-center justify-between gap-2 sm:col-start-1 sm:col-span-1 sm:justify-start">
+            <div className="flex min-w-0 items-center gap-2">
+              <Checkbox
+                aria-label={`Complete set ${setNumber}`}
+                checked={completed}
+                className="data-[state=checked]:border-emerald-500 data-[state=checked]:bg-emerald-500 data-[state=checked]:text-white"
+                onClick={(event) => {
+                  event.stopPropagation();
+                }}
+                onCheckedChange={(checked) => {
+                  if (checked === true) {
+                    onCompleteSet(pointer);
+                  } else {
+                    onUncompleteSet(pointer);
+                  }
+                }}
+              />
+              <Button
+                type="button"
+                variant="ghost"
+                className="h-auto p-0 text-sm font-medium hover:bg-transparent"
+                aria-label={`Select set ${setNumber} for ${exerciseName}`}
+                onClick={() => onSelectSet(pointer)}
+              >
+                {t(
+                  'exercise.workoutPlaybackDialog.setRow',
+                  'Set {{setNumber}}',
+                  {
+                    setNumber,
+                  }
+                )}
+              </Button>
+            </div>
+          </div>
+
+          <Select
+            value={setType ?? 'Working Set'}
+            onValueChange={(value) =>
+              onSetFieldChange(pointer, 'set_type', value)
+            }
+          >
+            <SelectTrigger
+              aria-label={`Type set ${setNumber}`}
+              onClick={(event) => event.stopPropagation()}
+              className="col-span-2 border-border/70 bg-transparent shadow-none outline-none ring-0 focus:border-border/70 focus:outline-none focus:ring-0 focus:ring-offset-0 focus-visible:border-border/70 focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 data-[state=open]:border-border/70 data-[state=open]:outline-none data-[state=open]:ring-0 data-[state=open]:shadow-none sm:col-start-2 sm:col-span-1"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {excerciseWorkoutSetTypes.map((type) => (
+                <SelectItem key={type} value={type}>
+                  {t(`workout.setType.${type}`, type)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            step={1}
+            aria-label={`Reps set ${setNumber}`}
+            value={reps ?? ''}
+            onClick={(event) => event.stopPropagation()}
+            onChange={(event) =>
+              onSetFieldChange(
+                pointer,
+                'reps',
+                parseNullableInteger(event.target.value)
+              )
+            }
+            placeholder={t('common.reps', 'reps')}
+            className="col-span-1 w-full focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:col-start-3"
+          />
+
+          <Input
+            type="number"
+            inputMode="decimal"
+            min={0}
+            step={0.5}
+            aria-label={`Weight set ${setNumber}`}
+            value={weight ?? ''}
+            onClick={(event) => event.stopPropagation()}
+            onChange={(event) =>
+              onSetFieldChange(
+                pointer,
+                'weight',
+                parseNullableDecimal(event.target.value)
+              )
+            }
+            placeholder={t('common.weight', 'Weight')}
+            className="col-span-1 w-full focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:col-start-4"
+          />
+
+          <Button
+            type="button"
+            variant="outline"
+            className="col-span-1 w-full min-w-0 justify-center px-2 text-xs tabular-nums sm:col-start-5 sm:col-span-1"
+            aria-label={`Edit rest for set ${setNumber}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onOpenRestEditor(pointer);
+            }}
+          >
+            <Timer className="h-3.5 w-3.5 text-muted-foreground" />
+            {formatRestChip(restTime)}
+          </Button>
+
+          <div className="col-span-1 flex items-center justify-end gap-1 sm:col-start-6 sm:col-span-1 sm:justify-center">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="cursor-pointer"
+              aria-label={`Toggle notes for set ${setNumber}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onToggleNotesVisibility(notesKey);
+              }}
+            >
+              <MessageSquare className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="cursor-pointer"
+              disabled={!canRemove}
+              aria-label={`Remove set ${setNumber} for ${exerciseName}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onRemoveSet(pointer);
+              }}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+
+          {isNotesVisible && (
+            <Textarea
+              aria-label={`Set notes ${setNumber}`}
+              value={notes ?? ''}
+              onClick={(event) => event.stopPropagation()}
+              onChange={(event) =>
+                onSetFieldChange(pointer, 'notes', event.target.value)
+              }
+              placeholder={t(
+                'workout.notesPlaceholder',
+                'Add a note for this set...'
+              )}
+              className="min-h-16 resize-none text-sm focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default memo(WorkoutPlaybackSetRow);

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSummary.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSummary.tsx
@@ -1,0 +1,203 @@
+import { useTranslation } from 'react-i18next';
+import {
+  ArrowLeft,
+  Flag,
+  Pause,
+  Play,
+  SkipForward,
+  X,
+  AlertTriangle,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+} from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import type {
+  WorkoutPlaybackDraft,
+  WorkoutPlaybackStats,
+} from '@/utils/workoutPlayback';
+import { formatSecondsClock } from '@/utils/timeFormatters';
+
+const DEFAULT_REST_DISPLAY = '0:00';
+
+function formatWorkoutVolume(totalVolume: number): string {
+  return `${Number(totalVolume.toFixed(1))}`;
+}
+
+interface WorkoutPlaybackSummaryProps {
+  draft: WorkoutPlaybackDraft;
+  elapsedSeconds: number;
+  totalVolume: number;
+  stats: WorkoutPlaybackStats | null;
+  restRemaining: string;
+  isRestActive: boolean;
+  saveError: string | null;
+  isSaving: boolean;
+  onCloseKeepDraft: () => void;
+  onDiscard: () => void;
+  onFinishWorkout: () => void;
+  onPauseResumeRest: () => void;
+  onSkipRest: () => void;
+  onSessionNotesChange: (value: string) => void;
+}
+
+const WorkoutPlaybackSummary = ({
+  draft,
+  elapsedSeconds,
+  totalVolume,
+  stats,
+  restRemaining,
+  isRestActive,
+  saveError,
+  isSaving,
+  onCloseKeepDraft,
+  onDiscard,
+  onFinishWorkout,
+  onPauseResumeRest,
+  onSkipRest,
+  onSessionNotesChange,
+}: WorkoutPlaybackSummaryProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <Button
+          type="button"
+          variant="ghost"
+          className="w-fit gap-2"
+          onClick={onCloseKeepDraft}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          {t('common.back', 'Back')}
+        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="outline" onClick={onCloseKeepDraft}>
+            <X className="mr-1 h-4 w-4" />
+            {t('exercise.workoutPlaybackDialog.closeKeepDraft', 'Close')}
+          </Button>
+          <Button type="button" variant="outline" onClick={onDiscard}>
+            {t('exercise.workoutPlaybackDialog.discard', 'Discard')}
+          </Button>
+          <Button type="button" onClick={onFinishWorkout} disabled={isSaving}>
+            <Flag className="mr-1 h-4 w-4" />
+            {isSaving
+              ? t('exercise.workoutPlaybackDialog.finishing', 'Saving...')
+              : t('exercise.workoutPlaybackDialog.finish', 'Finish Workout')}
+          </Button>
+        </div>
+      </div>
+
+      <Card className="border-0 bg-transparent shadow-none">
+        <CardHeader className="space-y-1 px-0 pb-2 pt-0">
+          <h1 className="text-sm font-semibold leading-tight">{draft.name}</h1>
+          <CardDescription className="text-[11px] leading-tight">
+            {t(
+              'exercise.workoutPlaybackPage.description',
+              'Track your sets live, follow rest countdowns, and save when you finish.'
+            )}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-1 px-0 pt-0">
+          <div className="grid w-full grid-cols-2 gap-px overflow-hidden rounded-sm border border-border/60 bg-border text-center sm:grid-cols-4">
+            <div className="flex min-w-0 flex-col items-center justify-center bg-background px-1 py-2">
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                {t('exercise.workoutPlaybackPage.elapsedTime', 'Duration')}
+              </span>
+              <span className="mt-0.5 text-sm font-medium tabular-nums text-foreground">
+                {formatSecondsClock(elapsedSeconds)}
+              </span>
+            </div>
+            <div className="flex min-w-0 flex-col items-center justify-center bg-background px-1 py-2">
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                {t('exercise.workoutPlaybackPage.volume', 'Volume')}
+              </span>
+              <span className="mt-0.5 text-sm font-medium tabular-nums text-foreground">
+                {formatWorkoutVolume(totalVolume)}
+              </span>
+            </div>
+            <div className="flex min-w-0 flex-col items-center justify-center bg-background px-1 py-2">
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                {t('exercise.workoutPlaybackPage.progress', 'Sets')}
+              </span>
+              <span className="mt-0.5 text-sm font-medium tabular-nums text-foreground">
+                {stats?.completedSets ?? 0}/{stats?.totalSets ?? 0}
+              </span>
+            </div>
+            <div className="flex min-w-0 flex-col items-center justify-center bg-background px-1 py-2">
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                {t('exercise.workoutPlaybackPage.restTimer', 'Rest')}
+              </span>
+              <span className="mt-0.5 text-sm font-medium tabular-nums text-foreground">
+                {draft.rest_timer.state === 'idle'
+                  ? DEFAULT_REST_DISPLAY
+                  : restRemaining}
+              </span>
+              {isRestActive && (
+                <div className="mt-1 flex items-center gap-0.5">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-5 w-5"
+                    aria-label={
+                      draft.rest_timer.state === 'running'
+                        ? t('common.pause', 'Pause')
+                        : t('common.resume', 'Resume')
+                    }
+                    onClick={onPauseResumeRest}
+                  >
+                    {draft.rest_timer.state === 'running' ? (
+                      <Pause className="h-3 w-3" />
+                    ) : (
+                      <Play className="h-3 w-3" />
+                    )}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-5 w-5"
+                    aria-label={t('common.skip', 'Skip')}
+                    onClick={onSkipRest}
+                  >
+                    <SkipForward className="h-3 w-3" />
+                  </Button>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium">
+              {t('exercise.logExerciseEntryDialog.sessionNotes', 'Notes')}
+            </label>
+            <Textarea
+              value={draft.notes ?? ''}
+              rows={2}
+              className="resize-none text-sm"
+              placeholder={t(
+                'exercise.logExerciseEntryDialog.notesPlaceholder',
+                'Any notes about this session...'
+              )}
+              onChange={(event) => onSessionNotesChange(event.target.value)}
+            />
+          </div>
+
+          {saveError && (
+            <div className="flex gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{saveError}</span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </>
+  );
+};
+
+export default WorkoutPlaybackSummary;

--- a/SparkyFitnessFrontend/src/pages/Exercises/AddExerciseDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/AddExerciseDialog.tsx
@@ -36,7 +36,16 @@ interface AddExerciseDialogProps {
   ) => void;
   onWorkoutPresetSelected?: (preset: WorkoutPreset) => void; // New prop for selecting a workout preset
   mode: 'preset' | 'workout-plan' | 'diary' | 'database-manager';
+  initialTab?:
+    | 'my-exercises'
+    | 'workout-preset'
+    | 'online'
+    | 'custom'
+    | 'import-csv'
+    | 'import-history-csv';
 }
+
+type AddExerciseDialogTab = NonNullable<AddExerciseDialogProps['initialTab']>;
 
 const AddExerciseDialog = ({
   open,
@@ -44,11 +53,12 @@ const AddExerciseDialog = ({
   onExerciseAdded,
   mode,
   onWorkoutPresetSelected,
+  initialTab,
 }: AddExerciseDialogProps) => {
   const { t } = useTranslation();
   const customForm = useAddCustomExerciseForm(onExerciseAdded, onOpenChange);
   const [activeTab, setActiveTab] = useState(
-    mode === 'database-manager' ? 'online' : 'my-exercises'
+    initialTab ?? (mode === 'database-manager' ? 'online' : 'my-exercises')
   );
   const { mutateAsync: importExerciseFromJson } =
     useImportExercisesJsonMutation();
@@ -119,7 +129,10 @@ const AddExerciseDialog = ({
             )}
           </DialogDescription>
         </DialogHeader>
-        <Tabs defaultValue={activeTab} onValueChange={setActiveTab}>
+        <Tabs
+          defaultValue={activeTab}
+          onValueChange={(value) => setActiveTab(value as AddExerciseDialogTab)}
+        >
           <TabsList className="h-10 flex w-full justify-center flex-wrap">
             {mode !== 'database-manager' && (
               <TabsTrigger value="my-exercises">

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
@@ -1,8 +1,15 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { formatDateToYYYYMMDD } from '@/lib/utils';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import {
   Plus,
   Edit,
@@ -12,6 +19,7 @@ import {
   Layers,
   Dumbbell,
   CheckSquare,
+  Play,
   X,
   MoreHorizontal,
 } from 'lucide-react';
@@ -35,6 +43,8 @@ import {
 } from '@/hooks/Exercises/useWorkoutPresets';
 import { useLogWorkoutPresetMutation } from '@/hooks/Exercises/useExerciseEntries';
 import { usePreferences } from '@/contexts/PreferencesContext';
+import { createWorkoutPlaybackRouteState } from '@/utils/workoutPlayback';
+import WorkoutPresetSelector from './WorkoutPresetSelector';
 
 import { useBulkSelection } from '@/hooks/useBulkSelection';
 import BulkActionToolbar from '@/components/BulkActionToolbar';
@@ -47,11 +57,15 @@ import { Badge } from '@/components/ui/badge';
 
 const WorkoutPresetsManager = () => {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
   const { user } = useAuth();
   const isMobile = useIsMobile();
   const { weightUnit } = usePreferences();
 
   const [isAddPresetDialogOpen, setIsAddPresetDialogOpen] = useState(false);
+  const [isStartWorkoutDialogOpen, setIsStartWorkoutDialogOpen] =
+    useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [selectedPreset, setSelectedPreset] = useState<WorkoutPreset | null>(
     null
@@ -155,6 +169,22 @@ const WorkoutPresetsManager = () => {
       }
     },
     [logWorkoutPreset, t]
+  );
+
+  const handleStartWorkoutPlayback = React.useCallback(
+    (preset: WorkoutPreset) => {
+      const today = formatDateToYYYYMMDD(new Date());
+      const routeState = createWorkoutPlaybackRouteState(
+        preset,
+        today,
+        `${location.pathname}${location.search}`
+      );
+
+      navigate(`/workout-playback?date=${today}`, {
+        state: routeState,
+      });
+    },
+    [location.pathname, location.search, navigate]
   );
 
   const columns = React.useMemo<ColumnDef<WorkoutPreset>[]>(
@@ -266,6 +296,12 @@ const WorkoutPresetsManager = () => {
                   {t('common.actions', 'Actions')}
                 </DropdownMenuLabel>
                 <DropdownMenuItem
+                  onClick={() => handleStartWorkoutPlayback(preset)}
+                >
+                  <Play className="mr-2 h-4 w-4" />
+                  {t('workoutPresetsManager.startWorkout', 'Start Workout')}
+                </DropdownMenuItem>
+                <DropdownMenuItem
                   onClick={() => handleLogPresetToDiary(preset)}
                 >
                   <CalendarPlus className="mr-2 h-4 w-4" />
@@ -296,7 +332,14 @@ const WorkoutPresetsManager = () => {
         },
       },
     ],
-    [t, user?.id, weightUnit, handleLogPresetToDiary, handleDeletePreset]
+    [
+      t,
+      user?.id,
+      weightUnit,
+      handleLogPresetToDiary,
+      handleDeletePreset,
+      handleStartWorkoutPlayback,
+    ]
   );
 
   return (
@@ -335,6 +378,20 @@ const WorkoutPresetsManager = () => {
                 <CheckSquare className="w-5 h-5" />
               ) : (
                 t('common.select', 'Select')
+              )}
+            </Button>
+            <Button
+              variant="outline"
+              size={isMobile ? 'icon' : 'default'}
+              onClick={() => setIsStartWorkoutDialogOpen(true)}
+              className="shrink-0"
+              title={t('workoutPresetsManager.startWorkout', 'Start Workout')}
+            >
+              <Play className={isMobile ? 'w-5 h-5' : 'h-4 w-4 mr-2'} />
+              {!isMobile && (
+                <span>
+                  {t('workoutPresetsManager.startWorkout', 'Start Workout')}
+                </span>
               )}
             </Button>
             <Button
@@ -401,6 +458,22 @@ const WorkoutPresetsManager = () => {
           )}
         </CardContent>
       </Card>
+
+      <Dialog
+        open={isStartWorkoutDialogOpen}
+        onOpenChange={setIsStartWorkoutDialogOpen}
+      >
+        <DialogContent className="sm:max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>
+              {t('workoutPresetsManager.startWorkout', 'Start Workout')}
+            </DialogTitle>
+          </DialogHeader>
+          <WorkoutPresetSelector
+            onPresetSelected={handleStartWorkoutPlayback}
+          />
+        </DialogContent>
+      </Dialog>
 
       <BulkActionToolbar
         selectedCount={selectedCount}

--- a/SparkyFitnessFrontend/src/tests/components/WorkoutPlaybackPage.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/WorkoutPlaybackPage.test.tsx
@@ -1,0 +1,206 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WorkoutPlaybackPage from '@/pages/Diary/WorkoutPlaybackPage';
+import type { WorkoutPreset } from '@/types/workout';
+import { createWorkoutPlaybackDraftFromPreset } from '@/utils/workoutPlayback';
+
+const mockNavigate = jest.fn();
+const mockCreatePresetSession = jest.fn();
+const mockSearchParams = new URLSearchParams('date=2026-04-27');
+let mockLocationState: { returnTo?: string; draft?: unknown } | null = null;
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultValue?: string) => defaultValue || key,
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ state: mockLocationState }),
+  useSearchParams: () => [mockSearchParams],
+}));
+
+jest.mock('@/hooks/Exercises/useExerciseEntries', () => ({
+  useCreatePresetSessionMutation: () => ({
+    mutateAsync: (...args: unknown[]) => mockCreatePresetSession(...args),
+    isPending: false,
+  }),
+}));
+
+const presetFixture: WorkoutPreset = {
+  id: 'preset-1',
+  user_id: 'user-1',
+  name: 'Upper Body',
+  description: 'Push + Pull',
+  exercises: [
+    {
+      exercise_id: 'exercise-1',
+      exercise_name: 'Bench Press',
+      sets: [{ set_number: 1, reps: 8, weight: 80, rest_time: 90 }],
+    },
+    {
+      exercise_id: 'exercise-2',
+      exercise_name: 'Barbell Row',
+      sets: [{ set_number: 1, reps: 10, weight: 60, rest_time: 90 }],
+    },
+  ],
+} as unknown as WorkoutPreset;
+
+describe('WorkoutPlaybackPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockCreatePresetSession.mockReset();
+    window.localStorage.clear();
+    mockLocationState = { returnTo: '/?date=2026-04-27' };
+  });
+
+  it('shows elapsed timer and collapses completed exercises', () => {
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      presetFixture,
+      '2026-04-27'
+    );
+    if (draft.exercises[0]?.sets[0]) {
+      draft.exercises[0].sets[0].completed = true;
+    }
+    draft.active_exercise_index = 1;
+    draft.active_set_index = 0;
+    mockLocationState = { returnTo: '/?date=2026-04-27', draft };
+
+    render(<WorkoutPlaybackPage />);
+
+    expect(screen.getAllByText('Duration').length).toBeGreaterThan(0);
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getAllByRole('checkbox').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('restores a draft from localStorage on reload', async () => {
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      presetFixture,
+      '2026-04-27'
+    );
+    window.localStorage.setItem(
+      'sparky.workoutPlaybackDraft.v1:2026-04-27',
+      JSON.stringify(draft)
+    );
+    mockLocationState = { returnTo: '/?date=2026-04-27' };
+
+    render(<WorkoutPlaybackPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Upper Body')).toBeInTheDocument();
+    });
+    expect(screen.getAllByLabelText('Reps set 1')[0]).toBeInTheDocument();
+  });
+
+  it('starts rest countdown when current set is completed', () => {
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      presetFixture,
+      '2026-04-27'
+    );
+    mockLocationState = { returnTo: '/?date=2026-04-27', draft };
+
+    render(<WorkoutPlaybackPage />);
+
+    fireEvent.click(screen.getAllByLabelText('Complete set 1')[0]!);
+
+    expect(
+      screen.getAllByRole('button', { name: 'Pause' }).length
+    ).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Pause')).toBeInTheDocument();
+    expect(screen.getByText('640')).toBeInTheDocument();
+  });
+
+  it('allows editing set values and adding/removing sets', () => {
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      presetFixture,
+      '2026-04-27'
+    );
+    mockLocationState = { returnTo: '/?date=2026-04-27', draft };
+
+    render(<WorkoutPlaybackPage />);
+
+    const repsInput = screen.getAllByLabelText(
+      'Reps set 1'
+    )[0] as HTMLInputElement;
+    fireEvent.change(repsInput, { target: { value: '12' } });
+    expect(repsInput.value).toBe('12');
+
+    fireEvent.click(screen.getByLabelText('Add set for Bench Press'));
+    expect(screen.getAllByLabelText('Reps set 2').length).toBeGreaterThan(0);
+
+    fireEvent.click(
+      screen.getAllByLabelText('Remove set 2 for Bench Press')[0]!
+    );
+    expect(screen.queryByLabelText('Reps set 2')).not.toBeInTheDocument();
+
+    const sessionNotes = screen.getAllByPlaceholderText(
+      'Any notes about this session...'
+    )[0] as HTMLTextAreaElement;
+    fireEvent.change(sessionNotes, { target: { value: 'Felt strong today' } });
+    expect(sessionNotes.value).toBe('Felt strong today');
+
+    expect(screen.queryByLabelText('Set notes 1')).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByLabelText('Toggle notes for set 1')[0]!);
+    expect(screen.getByLabelText('Set notes 1')).toBeInTheDocument();
+  });
+
+  it('allows extending a finished exercise after expanding it', () => {
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      presetFixture,
+      '2026-04-27'
+    );
+    if (draft.exercises[0]?.sets[0]) {
+      draft.exercises[0].sets[0].completed = true;
+    }
+    mockLocationState = { returnTo: '/?date=2026-04-27', draft };
+
+    render(<WorkoutPlaybackPage />);
+
+    fireEvent.click(screen.getByLabelText('Expand Bench Press'));
+    fireEvent.click(screen.getByLabelText('Add set for Bench Press'));
+
+    expect(screen.getAllByLabelText('Reps set 2').length).toBeGreaterThan(0);
+  });
+
+  it('edits rest via rest chip presets', () => {
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      presetFixture,
+      '2026-04-27'
+    );
+    mockLocationState = { returnTo: '/?date=2026-04-27', draft };
+
+    render(<WorkoutPlaybackPage />);
+
+    fireEvent.click(screen.getAllByLabelText('Edit rest for set 1')[0]!);
+    fireEvent.click(screen.getByRole('button', { name: '2:00' }));
+
+    fireEvent.click(screen.getAllByLabelText('Edit rest for set 1')[0]!);
+    expect(screen.getByLabelText('Custom (seconds)')).toHaveValue(120);
+  });
+
+  it('keeps rest indicator anchored to next set even when selecting others', () => {
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      presetFixture,
+      '2026-04-27'
+    );
+    if (draft.exercises[0]?.sets[0]) {
+      draft.exercises[0].sets.push({
+        ...draft.exercises[0].sets[0],
+        set_number: 2,
+      });
+    }
+    mockLocationState = { returnTo: '/?date=2026-04-27', draft };
+
+    render(<WorkoutPlaybackPage />);
+
+    fireEvent.click(screen.getAllByLabelText('Complete set 1')[0]!);
+    expect(screen.getByLabelText('Pause')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getAllByLabelText('Select set 2 for Bench Press')[0]!
+    );
+
+    expect(screen.getByLabelText('Pause')).toBeInTheDocument();
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/utils/workoutPlayback.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/workoutPlayback.test.ts
@@ -1,0 +1,223 @@
+import type { WorkoutPreset } from '@/types/workout';
+import {
+  addWorkoutSetToExercise,
+  clearWorkoutPlaybackDraftFromStorage,
+  buildPresetSessionCreateRequestFromDraft,
+  completeCurrentWorkoutSet,
+  createWorkoutPlaybackDraftFromPreset,
+  createWorkoutPlaybackRouteState,
+  getCurrentWorkoutSetPointer,
+  getWorkoutPlaybackStats,
+  getWorkoutPlaybackRestRemainingSeconds,
+  getWorkoutPlaybackDraftStorageKey,
+  loadWorkoutPlaybackDraftFromStorage,
+  removeWorkoutSetFromExercise,
+  saveWorkoutPlaybackDraftToStorage,
+  setWorkoutPlaybackPointer,
+  toggleWorkoutSetCompletion,
+  updateWorkoutSetAtPointer,
+} from '@/utils/workoutPlayback';
+
+const createPresetFixture = (): WorkoutPreset =>
+  ({
+    id: 'preset-1',
+    user_id: 'user-1',
+    name: 'Upper Body',
+    description: 'Push + Pull',
+    exercises: [
+      {
+        exercise_id: 'exercise-1',
+        exercise_name: 'Bench Press',
+        sets: [
+          { set_number: 1, reps: 8, weight: 80, rest_time: 90 },
+          { set_number: 2, reps: 8, weight: 80, rest_time: 90 },
+        ],
+      },
+      {
+        exercise_id: 'exercise-2',
+        exercise_name: 'Barbell Row',
+        sets: [{ set_number: 1, reps: 10, weight: 60, rest_time: 90 }],
+      },
+    ],
+  }) as unknown as WorkoutPreset;
+
+describe('workoutPlayback utils', () => {
+  it('creates a local draft from a workout preset', () => {
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      createPresetFixture(),
+      '2026-04-27'
+    );
+
+    expect(draft.name).toBe('Upper Body');
+    expect(draft.entry_date).toBe('2026-04-27');
+    expect(draft.exercises).toHaveLength(2);
+    expect(draft.exercises[0]?.sets).toHaveLength(2);
+    expect(
+      draft.exercises
+        .flatMap((exercise) => exercise.sets)
+        .every((set) => !set.completed)
+    ).toBe(true);
+  });
+
+  it('builds a route state that carries the draft and return path', () => {
+    const routeState = createWorkoutPlaybackRouteState(
+      createPresetFixture(),
+      '2026-04-27',
+      '/diary'
+    );
+
+    expect(routeState.returnTo).toBe('/diary');
+    expect(routeState.draft?.entry_date).toBe('2026-04-27');
+    expect(routeState.draft?.name).toBe('Upper Body');
+  });
+
+  it('saves, loads, and clears a persisted draft by date', () => {
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      createPresetFixture(),
+      '2026-04-27'
+    );
+
+    saveWorkoutPlaybackDraftToStorage(draft);
+    expect(
+      window.localStorage.getItem(
+        getWorkoutPlaybackDraftStorageKey('2026-04-27')
+      )
+    ).not.toBeNull();
+
+    const restored = loadWorkoutPlaybackDraftFromStorage('2026-04-27');
+
+    expect(restored?.preset_id).toBe('preset-1');
+    expect(restored?.entry_date).toBe('2026-04-27');
+
+    clearWorkoutPlaybackDraftFromStorage('2026-04-27');
+    expect(
+      window.localStorage.getItem(
+        getWorkoutPlaybackDraftStorageKey('2026-04-27')
+      )
+    ).toBeNull();
+  });
+
+  it('derives rest remaining from the target end timestamp', () => {
+    expect(
+      getWorkoutPlaybackRestRemainingSeconds(
+        {
+          state: 'running',
+          duration_seconds: 90,
+          remaining_seconds: 90,
+          target_end_timestamp_ms: 1_030_000,
+        },
+        1_000_000
+      )
+    ).toBe(30);
+  });
+
+  it('marks the current set complete and advances the active pointer', () => {
+    const initialDraft = createWorkoutPlaybackDraftFromPreset(
+      createPresetFixture(),
+      '2026-04-27'
+    );
+
+    const nextDraft = completeCurrentWorkoutSet(initialDraft);
+    const pointer = getCurrentWorkoutSetPointer(nextDraft);
+    const stats = getWorkoutPlaybackStats(nextDraft);
+
+    expect(nextDraft.exercises[0]?.sets[0]?.completed).toBe(true);
+    expect(pointer).toEqual({ exerciseIndex: 0, setIndex: 1 });
+    expect(stats.completedSets).toBe(1);
+    expect(stats.totalSets).toBe(3);
+  });
+
+  it('builds grouped-session payload from completed sets only', () => {
+    const initialDraft = createWorkoutPlaybackDraftFromPreset(
+      createPresetFixture(),
+      '2026-04-27'
+    );
+
+    let nextDraft = toggleWorkoutSetCompletion(initialDraft, {
+      exerciseIndex: 0,
+      setIndex: 0,
+    });
+    nextDraft = toggleWorkoutSetCompletion(nextDraft, {
+      exerciseIndex: 1,
+      setIndex: 0,
+    });
+
+    const payload = buildPresetSessionCreateRequestFromDraft(nextDraft);
+
+    expect(payload.name).toBe('Upper Body');
+    expect(payload.source).toBe('sparky');
+    expect(payload.exercises).toHaveLength(2);
+    expect(payload.exercises?.[0]?.sets).toHaveLength(1);
+    expect(payload.exercises?.[0]?.sets?.[0]?.set_number).toBe(1);
+    expect(payload.exercises?.[1]?.sets).toHaveLength(1);
+  });
+
+  it('tracks exercise timing when the active exercise changes', () => {
+    const initialDraft = createWorkoutPlaybackDraftFromPreset(
+      createPresetFixture(),
+      '2026-04-27'
+    );
+
+    const movedDraft = setWorkoutPlaybackPointer(initialDraft, {
+      exerciseIndex: 1,
+      setIndex: 0,
+    });
+
+    expect(movedDraft.exercises[0]?.started_at).toBeTruthy();
+    expect(movedDraft.exercises[0]?.ended_at).toBeTruthy();
+    expect(movedDraft.exercises[1]?.started_at).toBeTruthy();
+    expect(movedDraft.exercises[1]?.ended_at).toBeNull();
+  });
+
+  it('uses exercise start/end timestamps for duration minutes', () => {
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      createPresetFixture(),
+      '2026-04-27'
+    );
+
+    const completedDraft = {
+      ...draft,
+      exercises: draft.exercises.map((exercise, index) =>
+        index === 0
+          ? {
+              ...exercise,
+              started_at: '2026-04-27T10:00:00.000Z',
+              ended_at: '2026-04-27T10:03:30.000Z',
+              sets: exercise.sets.map((set) => ({
+                ...set,
+                completed: true,
+              })),
+            }
+          : exercise
+      ),
+    };
+
+    const payload = buildPresetSessionCreateRequestFromDraft(completedDraft);
+
+    expect(payload.exercises?.[0]?.duration_minutes).toBeCloseTo(3.5, 5);
+  });
+
+  it('updates set fields and supports add/remove set editing', () => {
+    const initialDraft = createWorkoutPlaybackDraftFromPreset(
+      createPresetFixture(),
+      '2026-04-27'
+    );
+
+    let nextDraft = updateWorkoutSetAtPointer(
+      initialDraft,
+      { exerciseIndex: 0, setIndex: 0 },
+      { reps: 12, weight: 85 }
+    );
+    nextDraft = addWorkoutSetToExercise(nextDraft, 0);
+
+    expect(nextDraft.exercises[0]?.sets).toHaveLength(3);
+    expect(nextDraft.exercises[0]?.sets[0]?.reps).toBe(12);
+    expect(nextDraft.exercises[0]?.sets[0]?.weight).toBe(85);
+
+    nextDraft = removeWorkoutSetFromExercise(nextDraft, {
+      exerciseIndex: 0,
+      setIndex: 2,
+    });
+    expect(nextDraft.exercises[0]?.sets).toHaveLength(2);
+  });
+});

--- a/SparkyFitnessFrontend/src/utils/timeFormatters.ts
+++ b/SparkyFitnessFrontend/src/utils/timeFormatters.ts
@@ -26,3 +26,17 @@ export const formatSecondsToHHMM = (totalSeconds: number): string => {
   const formatted = `${hours}h ${minutes}m`;
   return isNegative ? `-${formatted}` : formatted;
 };
+
+export const formatSecondsClock = (totalSeconds: number): string => {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds
+      .toString()
+      .padStart(2, '0')}`;
+  }
+
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+};

--- a/SparkyFitnessFrontend/src/utils/workoutPlayback.ts
+++ b/SparkyFitnessFrontend/src/utils/workoutPlayback.ts
@@ -1,0 +1,740 @@
+import type { CreatePresetSessionRequest } from '@workspace/shared';
+import type { WorkoutPreset, WorkoutPresetSet } from '@/types/workout';
+
+export const DEFAULT_REST_SECONDS = 90;
+export const WORKOUT_PLAYBACK_SET_GRID_CLASSES =
+  'grid w-full min-w-[48rem] grid-cols-4 gap-2 sm:grid-cols-[7rem_10rem_5rem_6rem_6rem_6rem] sm:gap-x-6 sm:gap-y-2';
+
+export type WorkoutPlaybackRestState = 'idle' | 'running' | 'paused';
+
+export interface WorkoutPlaybackRestTimer {
+  state: WorkoutPlaybackRestState;
+  duration_seconds: number;
+  remaining_seconds: number;
+  target_end_timestamp_ms?: number | null;
+  target_exercise_index?: number;
+  target_set_index?: number;
+}
+
+export interface WorkoutPlaybackSetDraft extends WorkoutPresetSet {
+  completed: boolean;
+}
+
+export interface WorkoutPlaybackExerciseDraft {
+  exercise_id: string;
+  exercise_name: string;
+  image_url?: string;
+  notes: string | null;
+  started_at?: string | null;
+  ended_at?: string | null;
+  sets: WorkoutPlaybackSetDraft[];
+}
+
+export interface WorkoutPlaybackDraft {
+  version: 1;
+  preset_id: string;
+  name: string;
+  description: string | null;
+  entry_date: string;
+  notes: string | null;
+  source: 'sparky';
+  active_exercise_index: number;
+  active_set_index: number;
+  rest_timer: WorkoutPlaybackRestTimer;
+  exercises: WorkoutPlaybackExerciseDraft[];
+  started_at: string;
+  updated_at: string;
+}
+
+export interface WorkoutSetPointer {
+  exerciseIndex: number;
+  setIndex: number;
+}
+
+export interface WorkoutPlaybackStats {
+  totalSets: number;
+  completedSets: number;
+  completionRate: number;
+}
+
+export interface WorkoutPlaybackRouteState {
+  returnTo?: string;
+  draft?: WorkoutPlaybackDraft | null;
+}
+
+const WORKOUT_PLAYBACK_STORAGE_PREFIX = 'sparky.workoutPlaybackDraft.v1';
+
+const DEFAULT_REST_TIMER: WorkoutPlaybackRestTimer = {
+  state: 'idle',
+  duration_seconds: DEFAULT_REST_SECONDS,
+  remaining_seconds: DEFAULT_REST_SECONDS,
+  target_end_timestamp_ms: null,
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function getWorkoutPlaybackDraftStorageKey(entryDate: string): string {
+  return `${WORKOUT_PLAYBACK_STORAGE_PREFIX}:${entryDate}`;
+}
+
+function isWorkoutPlaybackDraft(value: unknown): value is WorkoutPlaybackDraft {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const draft = value as WorkoutPlaybackDraft;
+  return (
+    draft.version === 1 &&
+    typeof draft.preset_id === 'string' &&
+    typeof draft.entry_date === 'string' &&
+    typeof draft.started_at === 'string' &&
+    Array.isArray(draft.exercises)
+  );
+}
+
+export function loadWorkoutPlaybackDraftFromStorage(
+  entryDate: string
+): WorkoutPlaybackDraft | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const storageKey = getWorkoutPlaybackDraftStorageKey(entryDate);
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!isWorkoutPlaybackDraft(parsed)) {
+      window.localStorage.removeItem(storageKey);
+      return null;
+    }
+
+    return parsed;
+  } catch (error) {
+    console.error('Failed to load workout playback draft from storage', error);
+    return null;
+  }
+}
+
+export function saveWorkoutPlaybackDraftToStorage(
+  draft: WorkoutPlaybackDraft
+): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const storageKey = getWorkoutPlaybackDraftStorageKey(draft.entry_date);
+
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(draft));
+  } catch (error) {
+    console.error('Failed to save workout playback draft to storage', error);
+  }
+}
+
+export function clearWorkoutPlaybackDraftFromStorage(entryDate: string): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.removeItem(
+      getWorkoutPlaybackDraftStorageKey(entryDate)
+    );
+  } catch (error) {
+    console.error('Failed to clear workout playback draft from storage', error);
+  }
+}
+
+function touchDraft(draft: WorkoutPlaybackDraft): WorkoutPlaybackDraft {
+  return { ...draft, updated_at: nowIso() };
+}
+
+function syncActiveExerciseTiming(
+  draft: WorkoutPlaybackDraft,
+  previousExerciseIndex: number,
+  nextExerciseIndex: number
+): WorkoutPlaybackDraft {
+  if (previousExerciseIndex === nextExerciseIndex) {
+    const timestamp = nowIso();
+    const exercises = draft.exercises.map((exercise, index) => {
+      if (index !== nextExerciseIndex) {
+        return exercise;
+      }
+
+      return {
+        ...exercise,
+        started_at: exercise.started_at ?? timestamp,
+        ended_at: null,
+      };
+    });
+
+    return touchDraft({ ...draft, exercises });
+  }
+
+  const timestamp = nowIso();
+  const exercises = draft.exercises.map((exercise, index) => {
+    if (index === previousExerciseIndex) {
+      return {
+        ...exercise,
+        ended_at: timestamp,
+      };
+    }
+
+    if (index === nextExerciseIndex) {
+      return {
+        ...exercise,
+        started_at: exercise.started_at ?? timestamp,
+        ended_at: null,
+      };
+    }
+
+    return exercise;
+  });
+
+  return touchDraft({ ...draft, exercises });
+}
+
+function isValidPointer(
+  draft: WorkoutPlaybackDraft,
+  pointer: WorkoutSetPointer
+): boolean {
+  const exercise = draft.exercises[pointer.exerciseIndex];
+  if (!exercise) return false;
+  return pointer.setIndex >= 0 && pointer.setIndex < exercise.sets.length;
+}
+
+function fallbackPointer(draft: WorkoutPlaybackDraft): WorkoutSetPointer {
+  for (
+    let exerciseIndex = 0;
+    exerciseIndex < draft.exercises.length;
+    exerciseIndex += 1
+  ) {
+    const exercise = draft.exercises[exerciseIndex];
+    if (exercise && exercise.sets.length > 0) {
+      return { exerciseIndex, setIndex: 0 };
+    }
+  }
+
+  return { exerciseIndex: 0, setIndex: 0 };
+}
+
+function getSetByPointer(
+  draft: WorkoutPlaybackDraft,
+  pointer: WorkoutSetPointer
+): WorkoutPlaybackSetDraft | null {
+  const exercise = draft.exercises[pointer.exerciseIndex];
+  if (!exercise) return null;
+  return exercise.sets[pointer.setIndex] ?? null;
+}
+
+export function listWorkoutSetPointers(
+  draft: WorkoutPlaybackDraft
+): WorkoutSetPointer[] {
+  const pointers: WorkoutSetPointer[] = [];
+  draft.exercises.forEach((exercise, exerciseIndex) => {
+    exercise.sets.forEach((_, setIndex) => {
+      pointers.push({ exerciseIndex, setIndex });
+    });
+  });
+  return pointers;
+}
+
+export function getCurrentWorkoutSetPointer(
+  draft: WorkoutPlaybackDraft
+): WorkoutSetPointer {
+  const pointer = {
+    exerciseIndex: draft.active_exercise_index,
+    setIndex: draft.active_set_index,
+  };
+  if (isValidPointer(draft, pointer)) {
+    return pointer;
+  }
+  return fallbackPointer(draft);
+}
+
+export function getWorkoutPlaybackStats(
+  draft: WorkoutPlaybackDraft
+): WorkoutPlaybackStats {
+  let totalSets = 0;
+  let completedSets = 0;
+
+  draft.exercises.forEach((exercise) => {
+    totalSets += exercise.sets.length;
+    completedSets += exercise.sets.filter((set) => set.completed).length;
+  });
+
+  return {
+    totalSets,
+    completedSets,
+    completionRate: totalSets > 0 ? completedSets / totalSets : 0,
+  };
+}
+
+export function isWorkoutPlaybackComplete(
+  draft: WorkoutPlaybackDraft
+): boolean {
+  const stats = getWorkoutPlaybackStats(draft);
+  return stats.totalSets > 0 && stats.completedSets === stats.totalSets;
+}
+
+export function createWorkoutPlaybackDraftFromPreset(
+  preset: WorkoutPreset,
+  entryDate: string
+): WorkoutPlaybackDraft {
+  const createdAt = nowIso();
+
+  const exercises: WorkoutPlaybackExerciseDraft[] = preset.exercises.map(
+    (exercise, exerciseIndex) => ({
+      exercise_id: exercise.exercise_id,
+      exercise_name:
+        exercise.exercise_name ||
+        exercise.exercise?.name ||
+        `Exercise ${exerciseIndex + 1}`,
+      image_url: exercise.image_url || exercise.exercise?.images?.[0],
+      notes: null,
+      started_at: null,
+      ended_at: null,
+      sets: exercise.sets.map((set, setIndex) => ({
+        set_number: set.set_number ?? setIndex + 1,
+        set_type: set.set_type ?? 'Working Set',
+        reps: set.reps ?? null,
+        weight: set.weight ?? null,
+        duration: set.duration ?? null,
+        rest_time: set.rest_time ?? DEFAULT_REST_SECONDS,
+        notes: set.notes ?? null,
+        rpe: set.rpe ?? null,
+        completed: false,
+      })),
+    })
+  );
+
+  const draft: WorkoutPlaybackDraft = {
+    version: 1,
+    preset_id: String(preset.id),
+    name: preset.name,
+    description: preset.description ?? null,
+    entry_date: entryDate,
+    notes: null,
+    source: 'sparky',
+    active_exercise_index: 0,
+    active_set_index: 0,
+    rest_timer: DEFAULT_REST_TIMER,
+    exercises,
+    started_at: createdAt,
+    updated_at: createdAt,
+  };
+
+  const pointer = fallbackPointer(draft);
+  draft.active_exercise_index = pointer.exerciseIndex;
+  draft.active_set_index = pointer.setIndex;
+  draft.exercises = draft.exercises.map((exercise, index) =>
+    index === pointer.exerciseIndex
+      ? { ...exercise, started_at: createdAt, ended_at: null }
+      : exercise
+  );
+
+  return draft;
+}
+
+export function createWorkoutPlaybackRouteState(
+  preset: WorkoutPreset,
+  entryDate: string,
+  returnTo?: string
+): WorkoutPlaybackRouteState {
+  return {
+    returnTo,
+    draft: createWorkoutPlaybackDraftFromPreset(preset, entryDate),
+  };
+}
+
+export function getWorkoutPlaybackRestRemainingSeconds(
+  restTimer: WorkoutPlaybackRestTimer,
+  nowMs: number = Date.now()
+): number {
+  if (restTimer.state !== 'running') {
+    return Math.max(0, restTimer.remaining_seconds);
+  }
+
+  if (typeof restTimer.target_end_timestamp_ms !== 'number') {
+    return Math.max(0, restTimer.remaining_seconds);
+  }
+
+  return Math.max(
+    0,
+    Math.ceil((restTimer.target_end_timestamp_ms - nowMs) / 1000)
+  );
+}
+
+export function setWorkoutPlaybackPointer(
+  draft: WorkoutPlaybackDraft,
+  pointer: WorkoutSetPointer
+): WorkoutPlaybackDraft {
+  if (!isValidPointer(draft, pointer)) {
+    return draft;
+  }
+
+  return syncActiveExerciseTiming(
+    {
+      ...draft,
+      active_exercise_index: pointer.exerciseIndex,
+      active_set_index: pointer.setIndex,
+    },
+    draft.active_exercise_index,
+    pointer.exerciseIndex
+  );
+}
+
+function getPointerIndex(
+  pointers: WorkoutSetPointer[],
+  pointer: WorkoutSetPointer
+): number {
+  return pointers.findIndex(
+    (p) =>
+      p.exerciseIndex === pointer.exerciseIndex &&
+      p.setIndex === pointer.setIndex
+  );
+}
+
+export function getNextWorkoutSetPointer(
+  draft: WorkoutPlaybackDraft,
+  pointer: WorkoutSetPointer = getCurrentWorkoutSetPointer(draft)
+): WorkoutSetPointer | null {
+  const pointers = listWorkoutSetPointers(draft);
+  const currentIndex = getPointerIndex(pointers, pointer);
+  if (currentIndex < 0 || currentIndex >= pointers.length - 1) {
+    return null;
+  }
+  return pointers[currentIndex + 1] ?? null;
+}
+
+export function getPreviousWorkoutSetPointer(
+  draft: WorkoutPlaybackDraft,
+  pointer: WorkoutSetPointer = getCurrentWorkoutSetPointer(draft)
+): WorkoutSetPointer | null {
+  const pointers = listWorkoutSetPointers(draft);
+  const currentIndex = getPointerIndex(pointers, pointer);
+  if (currentIndex <= 0) {
+    return null;
+  }
+  return pointers[currentIndex - 1] ?? null;
+}
+
+export function moveToNextWorkoutSet(
+  draft: WorkoutPlaybackDraft
+): WorkoutPlaybackDraft {
+  const nextPointer = getNextWorkoutSetPointer(draft);
+  if (!nextPointer) {
+    return draft;
+  }
+  return setWorkoutPlaybackPointer(draft, nextPointer);
+}
+
+export function moveToPreviousWorkoutSet(
+  draft: WorkoutPlaybackDraft
+): WorkoutPlaybackDraft {
+  const previousPointer = getPreviousWorkoutSetPointer(draft);
+  if (!previousPointer) {
+    return draft;
+  }
+  return setWorkoutPlaybackPointer(draft, previousPointer);
+}
+
+function updateSetAtPointer(
+  draft: WorkoutPlaybackDraft,
+  pointer: WorkoutSetPointer,
+  updater: (set: WorkoutPlaybackSetDraft) => WorkoutPlaybackSetDraft
+): WorkoutPlaybackDraft {
+  if (!isValidPointer(draft, pointer)) {
+    return draft;
+  }
+
+  const exercises = draft.exercises.map((exercise, exerciseIndex) => {
+    if (exerciseIndex !== pointer.exerciseIndex) {
+      return exercise;
+    }
+
+    const sets = exercise.sets.map((set, setIndex) =>
+      setIndex === pointer.setIndex ? updater(set) : set
+    );
+    return { ...exercise, sets };
+  });
+
+  return touchDraft({ ...draft, exercises });
+}
+
+export function toggleWorkoutSetCompletion(
+  draft: WorkoutPlaybackDraft,
+  pointer: WorkoutSetPointer
+): WorkoutPlaybackDraft {
+  return updateSetAtPointer(draft, pointer, (set) => ({
+    ...set,
+    completed: !set.completed,
+  }));
+}
+
+export function updateWorkoutSetAtPointer(
+  draft: WorkoutPlaybackDraft,
+  pointer: WorkoutSetPointer,
+  updates: Partial<WorkoutPlaybackSetDraft>
+): WorkoutPlaybackDraft {
+  return updateSetAtPointer(draft, pointer, (set) => ({
+    ...set,
+    ...updates,
+  }));
+}
+
+export function addWorkoutSetToExercise(
+  draft: WorkoutPlaybackDraft,
+  exerciseIndex: number
+): WorkoutPlaybackDraft {
+  const exercise = draft.exercises[exerciseIndex];
+  if (!exercise) {
+    return draft;
+  }
+
+  const lastSet = exercise.sets[exercise.sets.length - 1];
+  const newSet: WorkoutPlaybackSetDraft = {
+    set_number: exercise.sets.length + 1,
+    set_type: lastSet?.set_type ?? 'Working Set',
+    reps: lastSet?.reps ?? null,
+    weight: lastSet?.weight ?? null,
+    duration: lastSet?.duration ?? null,
+    rest_time: lastSet?.rest_time ?? DEFAULT_REST_SECONDS,
+    notes: lastSet?.notes ?? null,
+    rpe: lastSet?.rpe ?? null,
+    completed: false,
+  };
+
+  const exercises = draft.exercises.map((currentExercise, index) => {
+    if (index !== exerciseIndex) {
+      return currentExercise;
+    }
+    return {
+      ...currentExercise,
+      sets: [...currentExercise.sets, newSet].map((set, setIndex) => ({
+        ...set,
+        set_number: setIndex + 1,
+      })),
+    };
+  });
+
+  const nextDraft: WorkoutPlaybackDraft = {
+    ...draft,
+    exercises,
+  };
+
+  if (exercise.sets.length === 0) {
+    nextDraft.active_exercise_index = exerciseIndex;
+    nextDraft.active_set_index = 0;
+  }
+
+  return touchDraft(nextDraft);
+}
+
+export function removeWorkoutSetFromExercise(
+  draft: WorkoutPlaybackDraft,
+  pointer: WorkoutSetPointer
+): WorkoutPlaybackDraft {
+  const exercise = draft.exercises[pointer.exerciseIndex];
+  if (!exercise || exercise.sets.length <= 1) {
+    return draft;
+  }
+
+  const exercises = draft.exercises.map((currentExercise, exerciseIndex) => {
+    if (exerciseIndex !== pointer.exerciseIndex) {
+      return currentExercise;
+    }
+
+    return {
+      ...currentExercise,
+      sets: currentExercise.sets
+        .filter((_, setIndex) => setIndex !== pointer.setIndex)
+        .map((set, setIndex) => ({
+          ...set,
+          set_number: setIndex + 1,
+        })),
+    };
+  });
+
+  const nextDraft: WorkoutPlaybackDraft = {
+    ...draft,
+    exercises,
+  };
+
+  if (nextDraft.active_exercise_index === pointer.exerciseIndex) {
+    if (nextDraft.active_set_index > pointer.setIndex) {
+      nextDraft.active_set_index -= 1;
+    } else if (nextDraft.active_set_index === pointer.setIndex) {
+      const remainingSets =
+        nextDraft.exercises[pointer.exerciseIndex]?.sets.length ?? 0;
+      nextDraft.active_set_index = Math.max(
+        0,
+        Math.min(pointer.setIndex, remainingSets - 1)
+      );
+    }
+  }
+
+  const nextPointer = getCurrentWorkoutSetPointer(nextDraft);
+  const previousActiveExerciseIndex = draft.active_exercise_index;
+  nextDraft.active_exercise_index = nextPointer.exerciseIndex;
+  nextDraft.active_set_index = nextPointer.setIndex;
+
+  if (nextDraft.rest_timer.target_exercise_index === pointer.exerciseIndex) {
+    const targetSetIndex = nextDraft.rest_timer.target_set_index;
+
+    if (targetSetIndex === pointer.setIndex) {
+      nextDraft.rest_timer = {
+        ...nextDraft.rest_timer,
+        state: 'idle',
+        remaining_seconds: nextDraft.rest_timer.duration_seconds,
+        target_end_timestamp_ms: null,
+        target_exercise_index: undefined,
+        target_set_index: undefined,
+      };
+    } else if (
+      typeof targetSetIndex === 'number' &&
+      targetSetIndex > pointer.setIndex
+    ) {
+      nextDraft.rest_timer = {
+        ...nextDraft.rest_timer,
+        target_set_index: targetSetIndex - 1,
+      };
+    }
+  }
+
+  return syncActiveExerciseTiming(
+    nextDraft,
+    previousActiveExerciseIndex,
+    nextPointer.exerciseIndex
+  );
+}
+
+function getNextIncompletePointer(
+  draft: WorkoutPlaybackDraft,
+  fromPointer: WorkoutSetPointer
+): WorkoutSetPointer | null {
+  const pointers = listWorkoutSetPointers(draft);
+  const currentIndex = getPointerIndex(pointers, fromPointer);
+  if (currentIndex < 0) {
+    return null;
+  }
+
+  for (let i = currentIndex + 1; i < pointers.length; i += 1) {
+    const pointer = pointers[i];
+    if (pointer && !getSetByPointer(draft, pointer)?.completed) {
+      return pointer;
+    }
+  }
+
+  for (let i = 0; i < currentIndex; i += 1) {
+    const pointer = pointers[i];
+    if (pointer && !getSetByPointer(draft, pointer)?.completed) {
+      return pointer;
+    }
+  }
+
+  return null;
+}
+
+export function completeCurrentWorkoutSet(
+  draft: WorkoutPlaybackDraft
+): WorkoutPlaybackDraft {
+  const currentPointer = getCurrentWorkoutSetPointer(draft);
+  const currentSet = getSetByPointer(draft, currentPointer);
+  if (!currentSet || currentSet.completed) {
+    return draft;
+  }
+
+  let nextDraft = updateSetAtPointer(draft, currentPointer, (set) => ({
+    ...set,
+    completed: true,
+  }));
+
+  const nextPointer = getNextIncompletePointer(nextDraft, currentPointer);
+  if (!nextPointer) {
+    return nextDraft;
+  }
+
+  nextDraft = setWorkoutPlaybackPointer(nextDraft, nextPointer);
+  return nextDraft;
+}
+
+export function setWorkoutPlaybackRestTimer(
+  draft: WorkoutPlaybackDraft,
+  restTimer: WorkoutPlaybackRestTimer
+): WorkoutPlaybackDraft {
+  return touchDraft({ ...draft, rest_timer: restTimer });
+}
+
+function toNullableNumber(value: number | null | undefined): number | null {
+  return value === undefined ? null : value;
+}
+
+function deriveDurationMinutes(sets: WorkoutPlaybackSetDraft[]): number {
+  return sets.reduce((sum, set) => {
+    const duration = set.duration ?? 0;
+    const rest = (set.rest_time ?? 0) / 60;
+    return sum + duration + rest;
+  }, 0);
+}
+
+function deriveExerciseDurationMinutes(
+  exercise: WorkoutPlaybackExerciseDraft,
+  nowMs: number = Date.now()
+): number {
+  const startMs = exercise.started_at ? Date.parse(exercise.started_at) : NaN;
+  if (!Number.isNaN(startMs)) {
+    const endMs = exercise.ended_at ? Date.parse(exercise.ended_at) : nowMs;
+    if (!Number.isNaN(endMs) && endMs >= startMs) {
+      return (endMs - startMs) / 60000;
+    }
+  }
+
+  return deriveDurationMinutes(exercise.sets);
+}
+
+export function buildPresetSessionCreateRequestFromDraft(
+  draft: WorkoutPlaybackDraft
+): CreatePresetSessionRequest {
+  const exercises = draft.exercises
+    .map((exercise, exerciseIndex) => {
+      const completedSets = exercise.sets.filter((set) => set.completed);
+      if (completedSets.length === 0) {
+        return null;
+      }
+
+      return {
+        exercise_id: exercise.exercise_id,
+        sort_order: exerciseIndex,
+        duration_minutes: deriveExerciseDurationMinutes(exercise),
+        notes: exercise.notes ?? null,
+        sets: completedSets.map((set, setIndex) => ({
+          set_number: setIndex + 1,
+          set_type: set.set_type ?? null,
+          reps: toNullableNumber(set.reps),
+          weight: toNullableNumber(set.weight),
+          duration: toNullableNumber(set.duration),
+          rest_time: toNullableNumber(set.rest_time),
+          notes: set.notes ?? null,
+          rpe: toNullableNumber(set.rpe),
+        })),
+      };
+    })
+    .filter((exercise): exercise is NonNullable<typeof exercise> => !!exercise);
+
+  return {
+    name: draft.name,
+    description: draft.description,
+    notes: draft.notes,
+    entry_date: draft.entry_date,
+    source: draft.source,
+    exercises,
+  };
+}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The mobile app allows workout playback, while the frontend doesn't. 

**How did you implement the solution?**
New route for the playback, sessions data is saved to localstorage to prevent a reload from deleting the data. Finishing a workout logs it to the current day. Workout can be started from diary or from exercises tab.

Linked Issue: Closes #

## How to Test

1. Start workout
2. End Workout
## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<img width="1401" height="1769" alt="image" src="https://github.com/user-attachments/assets/cb9e26e7-e6a9-4db8-9151-fabbb6fa8f65" />


## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.