### PR TITLE
fix(1264): improve sleep consistency chart's readability

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsCharts.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsCharts.tsx
@@ -450,9 +450,20 @@ const SleepAnalyticsCharts = ({
                           tick={{ fill: tickColor }}
                         />
                         <YAxis
+                          yAxisId="left"
+                          orientation="left"
                           tickFormatter={formatBedWakeTime}
-                          stroke={tickColor}
-                          tick={{ fill: tickColor }}
+                          stroke="#8884d8"
+                          tick={{ fill: '#8884d8' }}
+                          domain={['auto', 'auto']}
+                        />
+                        <YAxis
+                          yAxisId="right"
+                          orientation="right"
+                          tickFormatter={formatBedWakeTime}
+                          stroke="#82ca9d"
+                          tick={{ fill: '#82ca9d' }}
+                          domain={['auto', 'auto']}
                         />
                         <Tooltip
                           labelFormatter={(label) =>
@@ -482,6 +493,7 @@ const SleepAnalyticsCharts = ({
                         />
                         <Legend wrapperStyle={{ color: tickColor }} />
                         <Line
+                          yAxisId="left"
                           type="monotone"
                           dataKey="bedtime"
                           stroke="#8884d8"
@@ -491,6 +503,7 @@ const SleepAnalyticsCharts = ({
                           isAnimationActive={false}
                         />
                         <Line
+                          yAxisId="right"
                           type="monotone"
                           dataKey="wakeTime"
                           stroke="#82ca9d"


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The chart was hard to read

**How did you implement the solution?**
2 y axis scales, in the respective colors

Linked Issue: Closes #1264

## How to Test

1. Look at sleep consistency chart

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots


### Before

![before](https://private-user-images.githubusercontent.com/6374469/590265818-482915a7-c638-4eac-a184-a303954c7ecf.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Nzg4NjI3NzksIm5iZiI6MTc3ODg2MjQ3OSwicGF0aCI6Ii82Mzc0NDY5LzU5MDI2NTgxOC00ODI5MTVhNy1jNjM4LTRlYWMtYTE4NC1hMzAzOTU0YzdlY2YucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI2MDUxNSUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNjA1MTVUMTYyNzU5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9ZjhlMmY4MTk3OGNmZGY0MzhjODNjNzNkN2Q4NWFkOTM3Y2E1ZmJiZWNiMzM1ZTk4YTMzZTM5NjU4ZDk4MDU1NSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmcmVzcG9uc2UtY29udGVudC10eXBlPWltYWdlJTJGcG5nIn0.LS7c0jCekgs_fTe6y1gJWRNnKHjgWygJaHSd60A3tII)

### After

![after](https://github.com/user-attachments/assets/c1eb5cb1-9e7a-4746-8656-36fed0b62b70)
