### PR TITLE
fix: revert individual measurement reports removal

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Reports/BodyBatteryCard.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/BodyBatteryCard.tsx
@@ -181,6 +181,7 @@ const BodyBatteryCard: React.FC<BodyBatteryCardProps> = ({
                   data={transformedData}
                   barGap={0}
                   barCategoryGap="20%"
+                  syncId="nutrition-charts"
                 >
                   <CartesianGrid
                     strokeDasharray="3 3"
@@ -188,10 +189,13 @@ const BodyBatteryCard: React.FC<BodyBatteryCardProps> = ({
                     stroke="hsl(var(--border))"
                   />
                   <XAxis
-                    dataKey="displayDate"
+                    dataKey="date"
                     fontSize={11}
                     tickLine={false}
                     tick={{ fill: 'hsl(var(--muted-foreground))' }}
+                    tickFormatter={(value) =>
+                      formatDateInUserTimezone(parseISO(value), 'MMM dd')
+                    }
                   />
                   <YAxis
                     domain={[0, 100]}

--- a/SparkyFitnessFrontend/src/pages/Reports/CustomCategoryReport.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/CustomCategoryReport.tsx
@@ -106,7 +106,7 @@ export const CustomCategoryReport = ({
                         minHeight={0}
                         debounce={100}
                       >
-                        <LineChart data={chartData}>
+                        <LineChart data={chartData} syncId="nutrition-charts">
                           <CartesianGrid strokeDasharray="3 3" />
                           <XAxis dataKey="date" />
                           <YAxis

--- a/SparkyFitnessFrontend/src/pages/Reports/MeasurementChartsGrid.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/MeasurementChartsGrid.tsx
@@ -46,6 +46,7 @@ const MeasurementChartsGrid = ({
   const chartData = React.useMemo(() => {
     return measurementData.map((d) => ({
       ...d,
+      date: d.entry_date,
       rawWeight: d.weight,
       rawNeck: d.neck,
       rawWaist: d.waist,
@@ -269,13 +270,14 @@ const MeasurementChartsGrid = ({
                       debounce={100}
                     >
                       <LineChart
+                        syncId="nutrition-charts"
                         data={chartData.filter(
                           (d) => d[metric.dataKey as keyof typeof d]
                         )}
                       >
                         <CartesianGrid strokeDasharray="3 3" />
                         <XAxis
-                          dataKey="entry_date"
+                          dataKey="date"
                           fontSize={10}
                           tickFormatter={formatDateForChart}
                           tickCount={
@@ -358,10 +360,13 @@ const MeasurementChartsGrid = ({
                   minHeight={0}
                   debounce={100}
                 >
-                  <BarChart data={chartData.filter((d) => d.steps)}>
+                  <BarChart
+                    data={chartData.filter((d) => d.steps)}
+                    syncId="nutrition-charts"
+                  >
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis
-                      dataKey="entry_date"
+                      dataKey="date"
                       tickFormatter={formatDateForChart}
                       tickCount={
                         isMaximized ? Math.max(chartData.length, 10) : undefined

--- a/SparkyFitnessFrontend/src/pages/Reports/NutritionChartsGrid.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/NutritionChartsGrid.tsx
@@ -1,0 +1,292 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import ZoomableChart from '@/components/ZoomableChart';
+import { usePreferences } from '@/contexts/PreferencesContext';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { info } from '@/utils/logging';
+import { parseISO, format } from 'date-fns';
+import {
+  calculateSmartYAxisDomain,
+  excludeIncompleteDay,
+  getChartConfig,
+} from '@/utils/chartUtils';
+import type { UserCustomNutrient } from '@/types/customNutrient';
+import { CENTRAL_NUTRIENT_CONFIG } from '@/constants/nutrients';
+import { formatNutrientValue } from '@/utils/nutrientUtils';
+import { NutritionData } from '@/types/reports';
+import { calculateAverage } from '@/utils/reportUtil';
+import { ExpandedGoals } from '@/types/goals';
+
+interface NutritionChartsGridProps {
+  nutritionData: NutritionData[];
+  customNutrients: UserCustomNutrient[];
+  goals?: Record<string, ExpandedGoals>;
+}
+
+const NutritionChartsGrid = ({
+  nutritionData,
+  customNutrients,
+  goals,
+}: NutritionChartsGridProps) => {
+  const { t } = useTranslation();
+  const {
+    loggingLevel,
+    formatDateInUserTimezone,
+    nutrientDisplayPreferences,
+    energyUnit,
+    convertEnergy,
+  } = usePreferences(); // Destructure formatDateInUserTimezone, energyUnit, convertEnergy
+  const isMobile = useIsMobile();
+  const platform = isMobile ? 'mobile' : 'desktop';
+  const reportChartPreferences = nutrientDisplayPreferences.find(
+    (p) => p.view_group === 'report_chart' && p.platform === platform
+  );
+
+  info(loggingLevel, 'NutritionChartsGrid: Rendering component.');
+
+  const formatDateForChart = (dateStr: string) => {
+    return formatDateInUserTimezone(parseISO(dateStr), 'MMM dd');
+  };
+
+  // Helper function to prepare chart data with optional incomplete day exclusion
+  const prepareChartData = (data: NutritionData[], chartKey: string) => {
+    const config = getChartConfig(chartKey);
+    let result = config.excludeIncompleteDay
+      ? excludeIncompleteDay(data, format(new Date(), 'yyyy-MM-dd'))
+      : data;
+
+    // Merge goal value per date if goals is a map
+    if (goals && typeof goals === 'object' && !('calories' in goals)) {
+      result = result.map((point) => {
+        const goalValue = (goals as Record<string, ExpandedGoals>)[
+          point.date
+        ]?.[chartKey as keyof ExpandedGoals];
+        return goalValue !== undefined
+          ? { ...point, [`${chartKey}_goal`]: goalValue }
+          : point;
+      }) as NutritionData[];
+    }
+
+    return result;
+  };
+
+  // Helper function to get smart Y-axis domain for nutrition metrics
+  const getYAxisDomain = (data: NutritionData[], dataKey: string) => {
+    const config = getChartConfig(dataKey);
+    const chartData = prepareChartData(data, dataKey);
+    return calculateSmartYAxisDomain(chartData, dataKey, {
+      marginPercent: config.marginPercent,
+      minRangeThreshold: config.minRangeThreshold,
+    });
+  };
+
+  const allNutritionCharts = useMemo(() => {
+    // Standard nutrients - use centralized chartColor
+    const charts = Object.values(CENTRAL_NUTRIENT_CONFIG).map((n) => ({
+      key: n.id,
+      label: t(n.label, n.defaultLabel),
+      color: n.chartColor, // Use centralized chartColor
+      unit: n.id === 'calories' ? energyUnit : n.unit,
+    }));
+
+    // Generate deterministic color from string for custom nutrients
+    const getStringColor = (str: string) => {
+      const colors = [
+        '#FF6B6B', // Red
+        '#4ECDC4', // Teal
+        '#45B7D1', // Cyan
+        '#FFA07A', // Salmon
+        '#98D8E3', // Light Blue
+        '#FFBE76', // Orange
+        '#FF7979', // Lighter Red
+        '#BADC58', // Green
+        '#DFF9FB', // Very Light Blue
+        '#F6E58D', // Yellow
+        '#686de0', // Purple
+        '#e056fd', // Violet
+        '#30336b', // Dark Blue
+        '#95afc0', // Blue Gray
+        '#22a6b3', // Dark Teal
+      ];
+      let hash = 0;
+      for (let i = 0; i < str.length; i++) {
+        hash = str.charCodeAt(i) + ((hash << 5) - hash);
+      }
+      return colors[Math.abs(hash) % colors.length];
+    };
+
+    // Add custom nutrients
+    customNutrients.forEach((cn) => {
+      charts.push({
+        key: cn.name,
+        label: cn.name,
+        color: getStringColor(cn.name) ?? '',
+        unit: cn.unit,
+      });
+    });
+
+    return charts;
+  }, [t, energyUnit, customNutrients]);
+
+  const visibleCharts = useMemo(() => {
+    if (reportChartPreferences && reportChartPreferences.visible_nutrients) {
+      return reportChartPreferences.visible_nutrients
+        .map((key) => allNutritionCharts.find((chart) => chart.key === key))
+        .filter(
+          (chart): chart is NonNullable<typeof chart> => chart !== undefined
+        );
+    }
+    return allNutritionCharts;
+  }, [reportChartPreferences, allNutritionCharts]);
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 min-w-0">
+      {visibleCharts.map((chart) => {
+        const chartData = prepareChartData(nutritionData, chart.key);
+        const yAxisDomain = getYAxisDomain(nutritionData, chart.key);
+        const average = calculateAverage(chartData, chart.key);
+
+        let formattedAverage = '';
+        if (chart.key === 'calories') {
+          formattedAverage = Math.round(
+            convertEnergy(average, 'kcal', energyUnit)
+          ).toString();
+        } else {
+          formattedAverage = formatNutrientValue(
+            chart.key,
+            average,
+            customNutrients
+          );
+        }
+
+        return (
+          <ZoomableChart
+            key={chart.key}
+            title={`${chart.label} (${chart.unit})`}
+          >
+            {(isMaximized, zoomLevel) => (
+              <Card>
+                <CardHeader className="pb-2">
+                  <div className="flex items-center justify-between">
+                    <CardTitle className="text-sm">
+                      {chart.label} ({chart.unit})
+                    </CardTitle>
+                    <span className="text-xs text-muted-foreground font-normal">
+                      {t('reports.average', 'Avg')}: {formattedAverage}{' '}
+                      {chart.unit}
+                    </span>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <div
+                    className={
+                      (isMaximized ? 'h-[calc(95vh-150px)]' : 'h-48') +
+                      ' min-w-0'
+                    }
+                  >
+                    <ResponsiveContainer
+                      width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                      height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                      minWidth={0}
+                      minHeight={0}
+                      debounce={100}
+                    >
+                      <LineChart data={chartData} syncId="nutrition-charts">
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis
+                          dataKey="date"
+                          fontSize={10}
+                          tickFormatter={formatDateForChart} // Apply formatter
+                          tickCount={
+                            isMaximized
+                              ? Math.max(chartData.length, 10)
+                              : undefined
+                          } // More ticks when maximized
+                        />
+                        <YAxis
+                          fontSize={10}
+                          domain={yAxisDomain || undefined}
+                          tickFormatter={(value: number) => {
+                            if (chart.key === 'calories') {
+                              return Math.round(
+                                convertEnergy(value, 'kcal', energyUnit)
+                              ).toString();
+                            }
+                            return formatNutrientValue(
+                              chart.key,
+                              value,
+                              customNutrients
+                            );
+                          }}
+                        />
+                        <Tooltip
+                          labelFormatter={(value) =>
+                            formatDateForChart(value as string)
+                          } // Apply formatter
+                          formatter={(
+                            value:
+                              | string
+                              | number
+                              | ReadonlyArray<string | number>
+                              | undefined
+                          ) => {
+                            if (value === null || value === undefined) {
+                              return 'N/A';
+                            }
+
+                            const numValue = Number(
+                              Array.isArray(value) ? value[0] : value
+                            );
+
+                            if (chart.key === 'calories') {
+                              return `${Math.round(convertEnergy(numValue, 'kcal', energyUnit))} ${chart.unit}`;
+                            }
+
+                            return `${formatNutrientValue(chart.key, numValue, customNutrients)} ${chart.unit}`;
+                          }}
+                          contentStyle={{
+                            backgroundColor: 'hsl(var(--background))',
+                          }}
+                        />
+                        <Line
+                          type="monotone"
+                          dataKey={chart.key}
+                          stroke={chart.color}
+                          strokeWidth={2}
+                          dot={false}
+                          isAnimationActive={false}
+                        />
+                        <Line
+                          type="monotone"
+                          dataKey={`${chart.key}_goal`}
+                          stroke={chart.color}
+                          strokeWidth={1}
+                          strokeDasharray="7 3"
+                          dot={false}
+                          isAnimationActive={false}
+                          name={t('reports.goal', 'Goal')}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </ZoomableChart>
+        );
+      })}
+    </div>
+  );
+};
+
+export default NutritionChartsGrid;

--- a/SparkyFitnessFrontend/src/pages/Reports/NutritionPeriodSummary.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/NutritionPeriodSummary.tsx
@@ -138,9 +138,12 @@ const NutritionPeriodSummary = ({
         (acc, point) => {
           const dayGoals = goals?.[point.date];
 
-          // Calculate variance for ALL selected nutrients
+          // Calculate variance for ALL selected nutrients (except sodium)
           const variances: Record<string, number> = {};
           selectedNutrients.forEach((nutKey) => {
+            // Skip cumulative calculation for sodium
+            if (nutKey === 'sodium') return;
+
             let dayGoal: number | undefined;
             const isCustom = customNutrients.some((cn) => cn.name === nutKey);
             if (dayGoals) {
@@ -169,7 +172,6 @@ const NutritionPeriodSummary = ({
                 acc.vDays += 1;
               }
             }
-            variances[nutKey] = dayEaten;
             variances[`${nutKey}_cumulative`] = acc.running[nutKey] || 0;
           });
 
@@ -224,6 +226,10 @@ const NutritionPeriodSummary = ({
       : selectedOption?.unit || '';
 
   const chartTitle = `${t('reports.cumulativeBalanceTitle', 'Cumulative Balance')} - ${selectedOption?.label}`;
+
+  const showCumulativeChart =
+    primaryNutrient !== 'sodium' ||
+    selectedNutrients.some((n) => n !== 'sodium');
 
   const dailyChartData = useMemo(() => {
     return filteredNutritionData.map((point) => {
@@ -312,7 +318,9 @@ const NutritionPeriodSummary = ({
 
       {/* KPI Dashboard and Daily Chart */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 items-stretch">
-        <div className="flex flex-col gap-4 h-full">
+        <div
+          className={`flex flex-col gap-4 h-full ${!showCumulativeChart ? 'hidden' : ''}`}
+        >
           <Card className="flex-1">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
               <CardTitle className="text-sm font-medium">
@@ -358,7 +366,9 @@ const NutritionPeriodSummary = ({
           </Card>
         </div>
 
-        <div className="lg:col-span-2 h-full min-h-0">
+        <div
+          className={`${showCumulativeChart ? 'lg:col-span-2' : 'lg:col-span-3'} h-full min-h-0`}
+        >
           <ZoomableChart
             title={`${selectedOption?.label} (${unitStr})`}
             className="h-full"
@@ -390,7 +400,10 @@ const NutritionPeriodSummary = ({
                       minHeight={0}
                       debounce={100}
                     >
-                      <LineChart data={dailyChartData}>
+                      <LineChart
+                        data={dailyChartData}
+                        syncId="nutrition-charts"
+                      >
                         <CartesianGrid strokeDasharray="3 3" />
                         <XAxis
                           dataKey="date"
@@ -510,147 +523,153 @@ const NutritionPeriodSummary = ({
       </div>
 
       {/* Cumulative Surplus/Deficit Trend Chart */}
-      <ZoomableChart title={chartTitle}>
-        {(isMaximized, zoomLevel) => (
-          <Card>
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm">{chartTitle}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div
-                className={
-                  (isMaximized ? 'h-[calc(95vh-150px)]' : 'h-64') + ' min-w-0'
-                }
-              >
-                <ResponsiveContainer
-                  width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                  height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                  minWidth={0}
-                  minHeight={0}
-                  debounce={100}
+      {showCumulativeChart && (
+        <ZoomableChart title={chartTitle}>
+          {(isMaximized, zoomLevel) => (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm">{chartTitle}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div
+                  className={
+                    (isMaximized ? 'h-[calc(95vh-150px)]' : 'h-64') + ' min-w-0'
+                  }
                 >
-                  <AreaChart data={cumulativeData}>
-                    <defs>
-                      <linearGradient
-                        id="colorNutrient"
-                        x1="0"
-                        y1="0"
-                        x2="0"
-                        y2="1"
-                      >
-                        <stop
-                          offset="5%"
-                          stopColor={selectedOption?.chartColor || '#8884d8'}
-                          stopOpacity={0.8}
-                        />
-                        <stop
-                          offset="95%"
-                          stopColor={selectedOption?.chartColor || '#8884d8'}
-                          stopOpacity={0}
-                        />
-                      </linearGradient>
-                    </defs>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis
-                      dataKey="date"
-                      fontSize={10}
-                      tickFormatter={formatDateForChart}
-                      tickCount={
-                        isMaximized
-                          ? Math.max(cumulativeData.length, 10)
-                          : undefined
-                      }
-                    />
-                    <YAxis
-                      fontSize={10}
-                      tickFormatter={(value: number) => {
-                        return getDisplayValue(value);
-                      }}
-                    />
-                    <Tooltip
-                      labelFormatter={(value) =>
-                        formatDateForChart(value as string)
-                      }
-                      formatter={(
-                        value:
-                          | string
-                          | number
-                          | ReadonlyArray<string | number>
-                          | undefined,
-                        name: string | number | undefined
-                      ) => {
-                        if (value === null || value === undefined) {
-                          return ['N/A', name];
-                        }
-                        const numValue = Number(
-                          Array.isArray(value) ? value[0] : value
-                        );
-
-                        const nutrientKey = name as string;
-                        const isCumulative =
-                          nutrientKey.endsWith('_cumulative');
-                        const baseKey = isCumulative
-                          ? nutrientKey.replace('_cumulative', '')
-                          : nutrientKey;
-                        const opt = allNutritionOptions.find(
-                          (o) => o.key === baseKey
-                        );
-
-                        const formattedValue =
-                          baseKey === 'calories'
-                            ? Math.round(
-                                convertEnergy(numValue, 'kcal', energyUnit)
-                              ).toString()
-                            : formatNutrientValue(
-                                baseKey,
-                                numValue,
-                                customNutrients
-                              );
-
-                        return [
-                          `${numValue > 0 ? '+' : ''}${formattedValue} ${opt?.unit || ''}`,
-                          isCumulative ? `${opt?.label} Balance` : opt?.label,
-                        ];
-                      }}
-                      contentStyle={{
-                        backgroundColor: 'hsl(var(--background))',
-                      }}
-                    />
-                    <ReferenceLine y={0} stroke="#666" strokeDasharray="3 3" />
-                    <Area
-                      type="monotone"
-                      dataKey={`${primaryNutrient}_cumulative`}
-                      stroke={selectedOption?.chartColor || '#8884d8'}
-                      fillOpacity={1}
-                      fill="url(#colorNutrient)"
-                      baseValue={0}
-                    />
-                    {selectedNutrients
-                      .filter((k) => k !== primaryNutrient)
-                      .map((nutKey) => {
-                        const opt = allNutritionOptions.find(
-                          (o) => o.key === nutKey
-                        );
-                        return (
-                          <Line
-                            key={nutKey}
-                            type="monotone"
-                            dataKey={`${nutKey}_cumulative`}
-                            stroke={opt?.chartColor || '#8884d8'}
-                            strokeWidth={1.5}
-                            dot={false}
-                            isAnimationActive={false}
-                            name={`${nutKey}_cumulative`}
+                  <ResponsiveContainer
+                    width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                    height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                    minWidth={0}
+                    minHeight={0}
+                    debounce={100}
+                  >
+                    <AreaChart data={cumulativeData} syncId="nutrition-charts">
+                      <defs>
+                        <linearGradient
+                          id="colorNutrient"
+                          x1="0"
+                          y1="0"
+                          x2="0"
+                          y2="1"
+                        >
+                          <stop
+                            offset="5%"
+                            stopColor={selectedOption?.chartColor || '#8884d8'}
+                            stopOpacity={0.8}
                           />
-                        );
-                      })}
-                  </AreaChart>
-                </ResponsiveContainer>
-              </div>
-            </CardContent>
-          </Card>
-        )}
-      </ZoomableChart>
+                          <stop
+                            offset="95%"
+                            stopColor={selectedOption?.chartColor || '#8884d8'}
+                            stopOpacity={0}
+                          />
+                        </linearGradient>
+                      </defs>
+                      <CartesianGrid strokeDasharray="3 3" />
+                      <XAxis
+                        dataKey="date"
+                        fontSize={10}
+                        tickFormatter={formatDateForChart}
+                        tickCount={
+                          isMaximized
+                            ? Math.max(cumulativeData.length, 10)
+                            : undefined
+                        }
+                      />
+                      <YAxis
+                        fontSize={10}
+                        tickFormatter={(value: number) => {
+                          return getDisplayValue(value);
+                        }}
+                      />
+                      <Tooltip
+                        labelFormatter={(value) =>
+                          formatDateForChart(value as string)
+                        }
+                        formatter={(
+                          value:
+                            | string
+                            | number
+                            | ReadonlyArray<string | number>
+                            | undefined,
+                          name: string | number | undefined
+                        ) => {
+                          if (value === null || value === undefined) {
+                            return ['N/A', name];
+                          }
+                          const numValue = Number(
+                            Array.isArray(value) ? value[0] : value
+                          );
+
+                          const nutrientKey = name as string;
+                          const isCumulative =
+                            nutrientKey.endsWith('_cumulative');
+                          const baseKey = isCumulative
+                            ? nutrientKey.replace('_cumulative', '')
+                            : nutrientKey;
+                          const opt = allNutritionOptions.find(
+                            (o) => o.key === baseKey
+                          );
+
+                          const formattedValue =
+                            baseKey === 'calories'
+                              ? Math.round(
+                                  convertEnergy(numValue, 'kcal', energyUnit)
+                                ).toString()
+                              : formatNutrientValue(
+                                  baseKey,
+                                  numValue,
+                                  customNutrients
+                                );
+
+                          return [
+                            `${numValue > 0 ? '+' : ''}${formattedValue} ${opt?.unit || ''}`,
+                            isCumulative ? `${opt?.label} Balance` : opt?.label,
+                          ];
+                        }}
+                        contentStyle={{
+                          backgroundColor: 'hsl(var(--background))',
+                        }}
+                      />
+                      <ReferenceLine
+                        y={0}
+                        stroke="#666"
+                        strokeDasharray="3 3"
+                      />
+                      <Area
+                        type="monotone"
+                        dataKey={`${primaryNutrient}_cumulative`}
+                        stroke={selectedOption?.chartColor || '#8884d8'}
+                        fillOpacity={1}
+                        fill="url(#colorNutrient)"
+                        baseValue={0}
+                      />
+                      {selectedNutrients
+                        .filter((k) => k !== primaryNutrient && k !== 'sodium')
+                        .map((nutKey) => {
+                          const opt = allNutritionOptions.find(
+                            (o) => o.key === nutKey
+                          );
+                          return (
+                            <Line
+                              key={nutKey}
+                              type="monotone"
+                              dataKey={`${nutKey}_cumulative`}
+                              stroke={opt?.chartColor || '#8884d8'}
+                              strokeWidth={1.5}
+                              dot={false}
+                              isAnimationActive={false}
+                              name={`${nutKey}_cumulative`}
+                            />
+                          );
+                        })}
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </ZoomableChart>
+      )}
     </div>
   );
 };

--- a/SparkyFitnessFrontend/src/pages/Reports/Reports.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/Reports.tsx
@@ -6,6 +6,7 @@ import { useActiveUser } from '@/contexts/ActiveUserContext';
 import ZoomableChart from '@/components/ZoomableChart';
 import ReportsControls from '@/pages/Reports/ReportsControls';
 import NutritionPeriodSummary from '@/pages/Reports/NutritionPeriodSummary';
+import NutritionChartsGrid from '@/pages/Reports/NutritionChartsGrid';
 import MeasurementChartsGrid from '@/pages/Reports/MeasurementChartsGrid';
 import ReportsTables from '@/pages/Reports/ReportsTables';
 import ExerciseReportsDashboard from '@/pages/Reports/ExerciseReportsDashboard';
@@ -13,7 +14,6 @@ import SleepReport from '@/pages/Reports/SleepReport';
 import BodyBatteryCard from '@/pages/Reports/BodyBatteryCard';
 import RespirationCard from '@/pages/Reports/RespirationCard';
 
-// Metrics to hide from the custom measurements charts (shown in dedicated cards instead)
 import StressChart from '@/pages/Reports/StressChart';
 import { debug, info } from '@/utils/logging';
 
@@ -169,13 +169,22 @@ const Reports = () => {
     switch (activeTab) {
       case 'charts':
         return (
-          <ChartErrorBoundary>
-            <NutritionPeriodSummary
-              nutritionData={nutritionData}
-              customNutrients={customNutrients}
-              goals={goalData}
-            />
-          </ChartErrorBoundary>
+          <div className="space-y-12">
+            <ChartErrorBoundary>
+              <NutritionPeriodSummary
+                nutritionData={nutritionData}
+                customNutrients={customNutrients}
+                goals={goalData}
+              />
+            </ChartErrorBoundary>
+            <ChartErrorBoundary>
+              <NutritionChartsGrid
+                nutritionData={nutritionData}
+                customNutrients={customNutrients}
+                goals={goalData}
+              />
+            </ChartErrorBoundary>
+          </div>
         );
       case 'measurements':
         return (

--- a/SparkyFitnessFrontend/src/pages/Reports/RespirationCard.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/RespirationCard.tsx
@@ -298,18 +298,21 @@ const RespirationCard: React.FC<RespirationCardProps> = ({
                 minHeight={0}
                 debounce={100}
               >
-                <LineChart data={transformedData}>
+                <LineChart data={transformedData} syncId="nutrition-charts">
                   <CartesianGrid
                     strokeDasharray="3 3"
                     vertical={false}
                     stroke="hsl(var(--border))"
                   />
                   <XAxis
-                    dataKey="displayDate"
+                    dataKey="date"
                     fontSize={11}
                     tickLine={false}
                     stroke="hsl(var(--muted-foreground))"
                     tick={{ fill: 'hsl(var(--muted-foreground))' }}
+                    tickFormatter={(value) =>
+                      formatDateInUserTimezone(parseISO(value), 'MMM dd')
+                    }
                   />
                   <YAxis
                     domain={[8, 24]}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Adds the individual reports back to the measurements while keeping the other improvments.
Also removes cumulative balance for sodium since sodium doesn't work that way.

Linked Issue: Closes #1237 

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.
