### PR TITLE
fix(mobile): unlink serving and serving size when creating custom food

### DIFF
--- a/SparkyFitnessMobile/src/screens/FoodFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodFormScreen.tsx
@@ -210,6 +210,7 @@ function CreateFoodMode({ params, navigation }: { params: CreateFoodParams; navi
   const [formServingSize, setFormServingSize] = useState(initialServingSize);
   const [formServingUnit, setFormServingUnit] = useState(initialFood?.servingUnit ?? 'g');
   const [quantityText, setQuantityText] = useState(String(initialServingSize));
+  const [quantityTouched, setQuantityTouched] = useState(false);
   const quantity = parseDecimalInput(quantityText) || 0;
   const servings = formServingSize > 0 ? quantity / formServingSize : 0;
 
@@ -217,11 +218,14 @@ function CreateFoodMode({ params, navigation }: { params: CreateFoodParams; navi
     const size = parseDecimalInput(sizeStr) || 0;
     setFormServingSize(size);
     setFormServingUnit(unit);
-    if (size > 0) setQuantityText(String(size));
+    if (size > 0 && !quantityTouched) setQuantityText(String(size));
   };
 
   const updateQuantityText = (text: string) => {
-    if (DECIMAL_INPUT_REGEX.test(text)) setQuantityText(text);
+    if (DECIMAL_INPUT_REGEX.test(text)) {
+      setQuantityText(text);
+      setQuantityTouched(true);
+    }
   };
 
   const clampQuantity = () => {
@@ -237,7 +241,10 @@ function CreateFoodMode({ params, navigation }: { params: CreateFoodParams; navi
     const increment = step * 0.5;
     const minQuantity = increment;
     if (quantity < minQuantity) {
-      if (delta > 0) setQuantityText(String(minQuantity));
+      if (delta > 0) {
+        setQuantityText(String(minQuantity));
+        setQuantityTouched(true);
+      }
       return;
     }
     const boundary =
@@ -246,6 +253,7 @@ function CreateFoodMode({ params, navigation }: { params: CreateFoodParams; navi
         : Math.floor(quantity / increment) * increment;
     const next = boundary !== quantity ? boundary : quantity + delta * increment;
     setQuantityText(String(Math.max(minQuantity, next)));
+    setQuantityTouched(true);
   };
 
   const mealPickerOptions = mealTypes.map((mt) => ({ label: getMealTypeLabel(mt.name), value: mt.id }));


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
When creating a custom food through the add screen, the serving and serving size (for that entry) fields were changing together. 
**How did you implement the solution?**
Only update the serving until it's manually changed.
 
Linked Issue: Closes #1280

## How to Test

1. Add button
2. Food
3. + in upper right
4. Adjust serving size and serving separately

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
