### PR TITLE
fix: auto scale nutrition option for barcode and label scans

### DIFF
--- a/SparkyFitnessMobile/src/screens/FoodFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodFormScreen.tsx
@@ -363,11 +363,13 @@ function CreateFoodMode({ params, navigation }: { params: CreateFoodParams; navi
   const isMealBuilderMode = pickerMode === 'meal-builder';
   const isLibraryMode = pickerMode === 'library';
   const isLogEntryMode = !isMealBuilderMode && !isLibraryMode;
-  const { preferences } = usePreferences({ enabled: isMealBuilderMode });
+  const initialFood = params.initialFood;
+  const hasImportedInitialFood = !!initialFood;
+  const showAutoScaleNutrition = isMealBuilderMode || hasImportedInitialFood;
+  const { preferences } = usePreferences({ enabled: showAutoScaleNutrition });
   const initialAutoScaleNutritionEnabled =
     preferences?.auto_scale_online_imports ?? false;
 
-  const initialFood = params.initialFood;
   const barcode = params.barcode;
   const providerType = params.providerType;
   const importedSourceVariant = useMemo(
@@ -570,7 +572,7 @@ function CreateFoodMode({ params, navigation }: { params: CreateFoodParams; navi
         isSubmitting={isSubmitting}
         initialValues={initialFood}
         submitLabel={isLibraryMode ? 'Save Food' : undefined}
-        showAutoScaleNutrition={isMealBuilderMode}
+        showAutoScaleNutrition={showAutoScaleNutrition}
         initialAutoScaleNutritionEnabled={initialAutoScaleNutritionEnabled}
         unitSelector={
           importedSourceVariant

--- a/SparkyFitnessMobile/tsconfig.json
+++ b/SparkyFitnessMobile/tsconfig.json
@@ -22,6 +22,6 @@
     "drivers",
     "reports",
     "plans",
-    
+    "devdocs"
   ]
 }


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Auto scale nutrient option was showing for adding foods when searching external providers and for editing foods but not barcode or nutrition label scanning.

**How did you implement the solution?**
Add the option

Linked Issue: Closes #1216 again

## How to Test

1. Scan a barcode
2. Scale nutrients

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
