### PR TITLE
feat(mobile): fix exercise session calorie source selection

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
@@ -754,32 +754,157 @@ describe('enrichExerciseSessions', () => {
     expect(mockAggregateRecord).not.toHaveBeenCalled();
   });
 
-  test('does not query TotalCaloriesBurned when ActiveCaloriesBurned has data', async () => {
-    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
-      if (recordType === 'ActiveCaloriesBurned') {
-        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 300 } });
-      }
-      if (recordType === 'Distance') {
-        return Promise.resolve({});
-      }
-      return Promise.resolve({});
-    });
-
-    await enrichExerciseSessions([makeSession()]);
-
-    const recordTypes = mockAggregateRecord.mock.calls.map((c: unknown[]) => (c[0] as { recordType: string }).recordType);
-    expect(recordTypes).not.toContain('TotalCaloriesBurned');
-  });
-
-  test('passes dataOriginFilter from session metadata', async () => {
+  test('issues all three aggregates in parallel with the same dataOriginFilter', async () => {
     mockAggregateRecord.mockResolvedValue({});
 
     await enrichExerciseSessions([makeSession({ metadata: { dataOrigin: 'com.ohealth' } })]);
 
-    // All aggregate calls should include the data origin filter
+    const recordTypes = mockAggregateRecord.mock.calls.map((c: unknown[]) => (c[0] as { recordType: string }).recordType);
+    expect(recordTypes).toHaveLength(3);
+    expect(recordTypes).toEqual(expect.arrayContaining(['ActiveCaloriesBurned', 'TotalCaloriesBurned', 'Distance']));
     for (const call of mockAggregateRecord.mock.calls) {
       expect(call[0].dataOriginFilter).toEqual(['com.ohealth']);
     }
+  });
+
+  test('prefers TotalCaloriesBurned when ActiveCaloriesBurned is a tiny passive fragment (issue #1296: 41-min walk)', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 43.5 } });
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 265 } });
+      }
+      return Promise.resolve({});
+    });
+
+    // 41-minute walk
+    const result = await enrichExerciseSessions([
+      makeSession({ startTime: '2024-01-15T10:00:00Z', endTime: '2024-01-15T10:41:00Z' }),
+    ]);
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 265 });
+  });
+
+  test('prefers TotalCaloriesBurned when ActiveCaloriesBurned is near-zero passive noise (issue #1296: indoor bike)', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 2.4 } });
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 314 } });
+      }
+      return Promise.resolve({});
+    });
+
+    // 35-minute indoor bike
+    const result = await enrichExerciseSessions([
+      makeSession({ startTime: '2024-01-15T10:00:00Z', endTime: '2024-01-15T10:35:00Z' }),
+    ]);
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 314 });
+  });
+
+  test('keeps ActiveCaloriesBurned when its ratio to TotalCaloriesBurned is high (issue #593: Garmin BMR exclusion)', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 337 } });
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 385 } });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await enrichExerciseSessions([makeSession()]);
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 337 });
+  });
+
+  test('keeps ActiveCaloriesBurned at the exact ratio=0.5 boundary', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 200 } });
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 400 } });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await enrichExerciseSessions([makeSession()]);
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 200 });
+  });
+
+  test('keeps ActiveCaloriesBurned when delta is plausible BMR for the duration even if ratio is below 0.5', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 100 } });
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 180 } });
+      }
+      return Promise.resolve({});
+    });
+
+    // 60-minute session: cap = 120, delta = 80 → passes OR-clause
+    const result = await enrichExerciseSessions([
+      makeSession({ startTime: '2024-01-15T10:00:00Z', endTime: '2024-01-15T11:00:00Z' }),
+    ]);
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 100 });
+  });
+
+  test('falls back to TotalCaloriesBurned when delta exceeds plausible BMR for the duration', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 20 } });
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 300 } });
+      }
+      return Promise.resolve({});
+    });
+
+    // 35-minute session: cap = 70, delta = 280 → fails OR-clause; ratio = 0.067 → fails
+    const result = await enrichExerciseSessions([
+      makeSession({ startTime: '2024-01-15T10:00:00Z', endTime: '2024-01-15T10:35:00Z' }),
+    ]);
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 300 });
+  });
+
+  test('drops fabricated distance for long sessions with implausibly small aggregate (issue #1296)', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'Distance') {
+        return Promise.resolve({ DISTANCE: { inMeters: 51 } });
+      }
+      return Promise.resolve({});
+    });
+
+    // 35-minute session, 51 m aggregate distance (HealthSync indoor bike contamination)
+    const result = await enrichExerciseSessions([
+      makeSession({ startTime: '2024-01-15T10:00:00Z', endTime: '2024-01-15T10:35:00Z' }),
+    ]);
+
+    expect('distance' in (result[0] as Record<string, unknown>)).toBe(false);
+  });
+
+  test('keeps short-session distances near the floor', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'Distance') {
+        return Promise.resolve({ DISTANCE: { inMeters: 90 } });
+      }
+      return Promise.resolve({});
+    });
+
+    // 5-minute session, 90 m: short enough that the plausibility floor doesn't apply
+    const result = await enrichExerciseSessions([
+      makeSession({ startTime: '2024-01-15T10:00:00Z', endTime: '2024-01-15T10:05:00Z' }),
+    ]);
+
+    expect((result[0] as { distance: { inMeters: number } }).distance).toEqual({ inMeters: 90 });
   });
 });
 

--- a/SparkyFitnessMobile/src/services/healthconnect/index.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/index.ts
@@ -298,10 +298,67 @@ export const getAggregatedActiveCaloriesByDate = async (
   }
 };
 
+// Distance plausibility floor: drop tiny distance aggregates on long sessions —
+// Health Sync writes a few dozen meters of passive step-distance over the
+// session window for stationary or indoor workouts (issue #1296).
+const MIN_DURATION_FOR_DISTANCE_CHECK_MS = 10 * 60 * 1000;
+const MIN_DISTANCE_FOR_LONG_SESSION_M = 100;
+
+// Calorie selection thresholds — see selectSessionCalories.
+// Citing #593 (Garmin Total includes BMR → prefer Active) and #1296
+// (Health Sync Active is passive contamination → prefer Total).
+// Known data points: 0.8% (HealthSync bike), 16% (HealthSync walk),
+// 87% (Garmin ride), and a HealthSync bike where Active was absent.
+const CALORIE_ACTIVE_RATIO_MIN = 0.5;
+const CALORIE_BMR_KCAL_PER_MIN_CAP = 2;
+
+/**
+ * Picks the session calorie value from the Active/Total pair.
+ * Treats 0 and undefined as "missing" (Android bridge returns 0.0 for empty ranges).
+ *
+ * - Both missing → undefined
+ * - One present → that one
+ * - Both present and (ratio ≥ 0.5 OR delta ≤ duration_min × 2) → Active
+ *   (Active is session-aligned; the Total - Active delta is plausibly just BMR)
+ * - Otherwise → Total (Active is passive contamination from a separate stream)
+ */
+export const selectSessionCalories = (
+  active: number | undefined,
+  total: number | undefined,
+  durationMs: number,
+): number | undefined => {
+  const activeValid = active != null && active > 0 ? active : undefined;
+  const totalValid = total != null && total > 0 ? total : undefined;
+
+  if (activeValid == null && totalValid == null) return undefined;
+  if (activeValid == null) return totalValid;
+  if (totalValid == null) return activeValid;
+
+  const ratio = activeValid / totalValid;
+  const durationMinutes = durationMs / 60_000;
+  const delta = totalValid - activeValid;
+  const bmrCap = durationMinutes * CALORIE_BMR_KCAL_PER_MIN_CAP;
+
+  if (ratio >= CALORIE_ACTIVE_RATIO_MIN || delta <= bmrCap) {
+    return activeValid;
+  }
+  return totalValid;
+};
+
+/**
+ * Distance is plausible unless the session is long enough that a real workout
+ * would have covered more than a token amount.
+ */
+export const isPlausibleSessionDistance = (meters: number, durationMs: number): boolean => {
+  if (durationMs <= MIN_DURATION_FOR_DISTANCE_CHECK_MS) return true;
+  return meters >= MIN_DISTANCE_FOR_LONG_SESSION_M;
+};
+
 /**
  * Enriches raw exercise session records with calories and distance data.
  * Health Connect stores these as separate record types, so we query
- * ActiveCaloriesBurned and Distance aggregated over each session's time range.
+ * ActiveCaloriesBurned, TotalCaloriesBurned, and Distance aggregated over
+ * each session's time range and apply plausibility checks (see #593, #1296).
  */
 export const enrichExerciseSessions = async (records: unknown[]): Promise<unknown[]> => {
   if (records.length === 0) return records;
@@ -323,9 +380,16 @@ export const enrichExerciseSessions = async (records: unknown[]): Promise<unknow
       endTime,
     };
 
-    const [activeCaloriesResult, distanceResult] = await Promise.allSettled([
+    const durationMs = new Date(endTime).getTime() - new Date(startTime).getTime();
+
+    const [activeCaloriesResult, totalCaloriesResult, distanceResult] = await Promise.allSettled([
       aggregateRecord({
         recordType: 'ActiveCaloriesBurned',
+        timeRangeFilter,
+        dataOriginFilter,
+      }),
+      aggregateRecord({
+        recordType: 'TotalCaloriesBurned',
         timeRangeFilter,
         dataOriginFilter,
       }),
@@ -336,42 +400,19 @@ export const enrichExerciseSessions = async (records: unknown[]): Promise<unknow
       }),
     ]);
 
-    // Only attach enriched values when the aggregate call succeeded.
-    // If permissions for ActiveCaloriesBurned or Distance aren't granted,
-    // the call rejects — leave the record untouched so we don't overwrite
-    // potentially valid data with a synthetic zero.
+    // Only attach enriched values when an aggregate call succeeded and returned
+    // a plausible value. Leave the record untouched otherwise so we don't
+    // overwrite potentially valid data with a synthetic zero.
     const enrichedFields: Record<string, unknown> = {};
 
-    // Try ActiveCaloriesBurned first, fall back to TotalCaloriesBurned.
-    // Many apps (Fitbit, OHealth, etc.) only write TotalCaloriesBurned to
-    // Health Connect, so ActiveCaloriesBurned alone misses those sessions.
-    // Treat 0 as missing — the Android Health Connect bridge defaults
-    // ACTIVE_CALORIES_TOTAL to 0.0 when no records exist for the range.
-    let kcal: number | undefined;
-    if (activeCaloriesResult.status === 'fulfilled') {
-      const result = activeCaloriesResult.value as { ACTIVE_CALORIES_TOTAL?: { inKilocalories?: number } };
-      const active = result.ACTIVE_CALORIES_TOTAL?.inKilocalories;
-      if (active != null && active > 0) {
-        kcal = active;
-      }
-    }
+    const active = activeCaloriesResult.status === 'fulfilled'
+      ? (activeCaloriesResult.value as { ACTIVE_CALORIES_TOTAL?: { inKilocalories?: number } }).ACTIVE_CALORIES_TOTAL?.inKilocalories
+      : undefined;
+    const total = totalCaloriesResult.status === 'fulfilled'
+      ? (totalCaloriesResult.value as { ENERGY_TOTAL?: { inKilocalories?: number } }).ENERGY_TOTAL?.inKilocalories
+      : undefined;
 
-    if (kcal == null) {
-      try {
-        const totalResult = await aggregateRecord({
-          recordType: 'TotalCaloriesBurned',
-          timeRangeFilter,
-          dataOriginFilter,
-        }) as { ENERGY_TOTAL?: { inKilocalories?: number } };
-        const total = totalResult.ENERGY_TOTAL?.inKilocalories;
-        if (total != null && total > 0) {
-          kcal = total;
-        }
-      } catch {
-        // Permission not granted or no data — leave untouched
-      }
-    }
-
+    const kcal = selectSessionCalories(active, total, durationMs);
     if (kcal != null) {
       enrichedFields.energy = { inKilocalories: kcal };
     }
@@ -379,7 +420,7 @@ export const enrichExerciseSessions = async (records: unknown[]): Promise<unknow
     if (distanceResult.status === 'fulfilled') {
       const result = distanceResult.value as { DISTANCE?: { inMeters?: number } };
       const meters = result.DISTANCE?.inMeters;
-      if (meters != null) {
+      if (meters != null && isPlausibleSessionDistance(meters, durationMs)) {
         enrichedFields.distance = { inMeters: meters };
       }
     }


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Wrong calorie counts used for some healthconnect services that sync workouts.

**How did you implement the solution?**
Switched to a plausibility based solution. Implemented:

- selectSessionCalories - picks Active when ratio >= 0.5 OR delta <= duration_min * 2; otherwise picks Total. Treats 0/undefined as missing.
- isPlausibleSessionDistance -drops the field when duration > 10min AND meters < 100 (Health Sync's passive 30–51 m contamination on stationary/indoor sessions).

Linked Issue: Closes #1296

## How to Test

1. Sync from fitbit
2. Notice correct calories on workout

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
