### PR TITLE
fix(toast): surface backend error detail in mutation toast

### DIFF
--- a/SparkyFitnessFrontend/src/main.tsx
+++ b/SparkyFitnessFrontend/src/main.tsx
@@ -61,9 +61,15 @@ const queryClient = new QueryClient({
         err,
         variables
       );
+      // Surface backend-provided error detail alongside the meta-defined
+      // friendly message. Previously the meta string would always win,
+      // hiding 401/429/500 detail from the user (e.g. Garmin auth, MFA,
+      // rate-limit reasons all collapsed to "Failed to connect to Garmin.").
+      const errDetail = err instanceof Error && err.message ? err.message : '';
       const description =
-        resolvedErrorMessage ||
-        (err instanceof Error ? err.message : 'An error occurred');
+        resolvedErrorMessage && errDetail && errDetail !== resolvedErrorMessage
+          ? `${resolvedErrorMessage} — ${errDetail}`
+          : resolvedErrorMessage || errDetail || 'An error occurred';
       toast({
         title:
           (mutation.meta?.errorTitle as string) ||


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
When a react-query mutation fails, the global `mutationCache.onError` toast prefers `mutation.meta.errorMessage` (a generic friendly string) over `err.message` (the actual API detail). The result: every failed mutation collapses to its generic meta string — 401/429/500 reasons from the backend, MFA/captcha/auth/rate-limit specifics, all hidden from the user. Garmin login is the most visible casualty (`"Failed to connect to Garmin."` regardless of underlying cause), but the issue applies to every mutation with a meta `errorMessage` configured.

**How did you implement the solution?**
In `SparkyFitnessFrontend/src/main.tsx`, the `MutationCache.onError` description now joins the meta-defined friendly context and the actual `err.message` with an em-dash when both exist and differ. If only one is set the behavior is unchanged. No mutations need editing; the fix is one place and applies globally.

Linked Issue: n/a (surfaced while debugging a Garmin login problem locally — same root cause as #1303 which fixes the backend half)

## How to Test

1. Check out this branch and run `cd SparkyFitnessFrontend && pnpm install`
2. `pnpm run validate` — typecheck + eslint + prettier all clean.
3. Walk through the change by inspecting `SparkyFitnessFrontend/src/main.tsx` lines 55-78. The `description` resolution is the only behavior change.

### Code-level Before / After

**Before** (current `main`, lines 64-66):
```ts
const description =
  resolvedErrorMessage ||
  (err instanceof Error ? err.message : 'An error occurred');
```
If `resolvedErrorMessage` is set (every mutation that defines `meta.errorMessage`), `err.message` is discarded.

**After** (this PR):
```ts
const errDetail =
  err instanceof Error && err.message ? err.message : '';
const description =
  resolvedErrorMessage && errDetail && errDetail !== resolvedErrorMessage
    ? `${resolvedErrorMessage} — ${errDetail}`
    : resolvedErrorMessage || errDetail || 'An error occurred';
```

### Concrete toast output diff for the Garmin-login failure mode

Backend (post #1303, deployed) throws `new Error('Failed to login to Garmin: ECONNREFUSED')` when the microservice is unreachable. `apiCall` propagates that as `err.message`. The Garmin login mutation's `meta.errorMessage` is `'Failed to connect to Garmin.'`.

- **Before this PR:** toast description = `"Failed to connect to Garmin."` (no idea why)
- **After this PR:** toast description = `"Failed to connect to Garmin. — Failed to login to Garmin: ECONNREFUSED"` (operator can see the actual cause)

Same shape applies to wrong-password (`"... — Garmin authentication failed: invalid credentials"`), rate-limit (`"... — Garmin rate limit hit: ..."`), and the MFA-not-handled error path.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. (Actually no translation files touched — the en string `'errorMessage'` already exists in every mutation that uses one.)

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

A **Before screenshot** of the bug — the rendered `"Failed to connect to Garmin."` toast on a real failed Garmin login — will be added to this PR as a comment by the submitter shortly. (The deployment this was reproduced against has been updated since reproduction, so we need to re-stage; the bug is independent of that deployment and is reproducible on any current `main` build by attempting any failing mutation that defines `meta.errorMessage`.)

### After

A live **After screenshot** would require building and deploying a patched frontend image to a real Sparky instance and inducing a failure. The code-level After diff is shown above (`"Failed to connect to Garmin. — Failed to login to Garmin: ECONNREFUSED"`). Happy to produce a live screenshot if a reviewer would like it — the change is small enough that I considered the code-level demonstration sufficient given the testing burden.

</details>

## Notes for Reviewers

This change is intentionally minimal: one file, ~7 lines, zero new dependencies, no new APIs, no migrations, no test changes. It's a global fix because the bug is in the global `mutationCache.onError` handler — fixing it once benefits every mutation in the app, not just the Garmin one that surfaced the issue for me.

I considered an opt-in approach (e.g. `mutation.meta.preferErrorDetail: true`) but rejected it: the existing behavior of always preferring generic meta over actual detail is wrong for every mutation, not just Garmin's. Adding an opt-in flag would push the fix to N call-sites and silently leave most of them broken.

I considered just swapping `meta` and `err.message` priority (always prefer `err.message`), but that would degrade i18n for cases where the backend returns English text but the meta message is the user's locale.

The chosen "show both, joined with em-dash, only when they differ" preserves i18n on the leading context while always surfacing actionable detail.

This PR pairs naturally with #1303 (which makes the backend produce non-empty detail for axios connection failures). Either PR is useful alone; both together close the visibility loop end-to-end.