### PR TITLE
fix: short-circuit API-key rate-limit lockout (#1302)

### DIFF
--- a/SparkyFitnessMobile/__tests__/hooks/queryClient.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/queryClient.test.ts
@@ -1,0 +1,28 @@
+import { queryClient } from '../../src/hooks/queryClient';
+import { ApiError } from '../../src/services/api/errors';
+
+type RetryFn = (failureCount: number, err: unknown) => boolean;
+
+describe('queryClient default retry predicate', () => {
+  const retry = queryClient.getDefaultOptions().queries!.retry as RetryFn;
+
+  test('does not retry on ApiError 4xx (incl. 429)', () => {
+    expect(retry(0, new ApiError('x', 400))).toBe(false);
+    expect(retry(0, new ApiError('x', 401))).toBe(false);
+    expect(retry(0, new ApiError('x', 404))).toBe(false);
+    expect(retry(0, new ApiError('x', 429))).toBe(false);
+    expect(retry(0, new ApiError('x', 499))).toBe(false);
+  });
+
+  test('retries up to twice on ApiError 5xx', () => {
+    expect(retry(0, new ApiError('x', 500))).toBe(true);
+    expect(retry(1, new ApiError('x', 503))).toBe(true);
+    expect(retry(2, new ApiError('x', 500))).toBe(false);
+  });
+
+  test('retries on generic Error (treat as transient)', () => {
+    expect(retry(0, new Error('network'))).toBe(true);
+    expect(retry(1, new Error('timeout'))).toBe(true);
+    expect(retry(2, new Error('network'))).toBe(false);
+  });
+});

--- a/SparkyFitnessMobile/__tests__/services/api/apiClient.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/api/apiClient.test.ts
@@ -1,0 +1,68 @@
+import { apiFetch } from '../../../src/services/api/apiClient';
+import { ApiError } from '../../../src/services/api/errors';
+
+jest.mock('../../../src/services/storage', () => ({
+  getActiveServerConfig: jest.fn(),
+  proxyHeadersToRecord: jest.fn(() => ({})),
+}));
+
+jest.mock('../../../src/services/LogService', () => ({
+  addLog: jest.fn(),
+}));
+
+jest.mock('../../../src/services/api/authService', () => ({
+  getAuthHeaders: jest.fn(() => ({})),
+  notifySessionExpired: jest.fn(),
+}));
+
+import { getActiveServerConfig } from '../../../src/services/storage';
+
+const mockedGetConfig = getActiveServerConfig as jest.MockedFunction<
+  typeof getActiveServerConfig
+>;
+
+describe('apiFetch error handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetConfig.mockResolvedValue({
+      id: 'cfg-1',
+      url: 'https://example.invalid',
+      authType: 'apikey',
+      proxyHeaders: [],
+    } as never);
+  });
+
+  test('throws ApiError with statusCode on 4xx', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      text: async () => 'Rate limit exceeded.',
+      headers: new Headers(),
+    }) as never;
+
+    await expect(
+      apiFetch({ endpoint: '/api/x', serviceName: 's', operation: 'get' })
+    ).rejects.toMatchObject({
+      name: 'ApiError',
+      statusCode: 429,
+      body: 'Rate limit exceeded.',
+    });
+  });
+
+  test('throws ApiError with statusCode on 5xx', async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      text: async () => 'Service unavailable',
+      headers: new Headers(),
+    }) as never;
+
+    const promise = apiFetch({
+      endpoint: '/api/x',
+      serviceName: 's',
+      operation: 'get',
+    });
+    await expect(promise).rejects.toBeInstanceOf(ApiError);
+    await expect(promise).rejects.toMatchObject({ statusCode: 503 });
+  });
+});

--- a/SparkyFitnessMobile/src/hooks/queryClient.ts
+++ b/SparkyFitnessMobile/src/hooks/queryClient.ts
@@ -1,10 +1,23 @@
 import { QueryClient } from '@tanstack/react-query';
+import { ApiError } from '../services/api/errors';
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: Infinity, // Only refetch when explicitly triggered or polled
-      retry: 2,
+      // Don't retry on 4xx — those are caller-state errors (auth, validation,
+      // 429 rate-limit) that won't change on a retry. Retrying amplified
+      // 429s by 3× and accelerated the api-key rate-limit lockout in #1302.
+      retry: (failureCount, err) => {
+        if (
+          err instanceof ApiError &&
+          err.statusCode >= 400 &&
+          err.statusCode < 500
+        ) {
+          return false;
+        }
+        return failureCount < 2;
+      },
       retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
     },
     mutations: {

--- a/SparkyFitnessMobile/src/services/api/apiClient.ts
+++ b/SparkyFitnessMobile/src/services/api/apiClient.ts
@@ -1,6 +1,7 @@
 import { getActiveServerConfig, proxyHeadersToRecord } from '../storage';
 import { addLog } from '../LogService';
 import { getAuthHeaders, notifySessionExpired } from './authService';
+import { ApiError } from './errors';
 
 export const normalizeUrl = (url: string): string => {
   return url.endsWith('/') ? url.slice(0, -1) : url;
@@ -52,7 +53,7 @@ export async function apiFetch<T>(options: ApiFetchOptions): Promise<T> {
       }
       const errorText = await response.text();
       addLog(`[${serviceName}] Failed to ${operation}: ${response.status}`, 'ERROR', [errorText]);
-      throw new Error(`Server error: ${response.status} - ${errorText}`);
+      throw new ApiError(`Server error: ${response.status} - ${errorText}`, response.status, errorText);
     }
 
     if (response.status === 204 || response.headers?.get('content-length') === '0') {

--- a/SparkyFitnessMobile/src/services/api/errors.ts
+++ b/SparkyFitnessMobile/src/services/api/errors.ts
@@ -1,0 +1,10 @@
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public statusCode: number,
+    public body?: string
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}

--- a/SparkyFitnessMobile/src/services/api/exerciseApi.ts
+++ b/SparkyFitnessMobile/src/services/api/exerciseApi.ts
@@ -1,4 +1,5 @@
 import { apiFetch, normalizeUrl } from './apiClient';
+import { ApiError } from './errors';
 import { getActiveServerConfig, proxyHeadersToRecord } from '../storage';
 import { getAuthHeaders, notifySessionExpired } from './authService';
 import { addLog } from '../LogService';
@@ -245,7 +246,7 @@ export async function createExercise(payload: CreateExercisePayload): Promise<Ex
     }
     const text = await response.text();
     addLog('[Exercise API] Failed to create exercise', 'ERROR', [text]);
-    throw new Error(`Server error: ${response.status} - ${text}`);
+    throw new ApiError(`Server error: ${response.status} - ${text}`, response.status, text);
   }
 
   const raw = await response.json();
@@ -378,7 +379,7 @@ export async function updateExercise(
     }
     const text = await response.text();
     addLog('[Exercise API] Failed to update exercise', 'ERROR', [text]);
-    throw new Error(`Server error: ${response.status} - ${text}`);
+    throw new ApiError(`Server error: ${response.status} - ${text}`, response.status, text);
   }
 
   const raw = await response.json();

--- a/SparkyFitnessMobile/src/services/api/healthDataApi.ts
+++ b/SparkyFitnessMobile/src/services/api/healthDataApi.ts
@@ -1,6 +1,7 @@
 import { getActiveServerConfig, proxyHeadersToRecord, ServerConfig } from '../storage';
 import { addLog } from '../LogService';
 import { normalizeUrl } from './apiClient';
+import { ApiError } from './errors';
 import { getAuthHeaders, notifySessionExpired } from './authService';
 import { ensureTimezoneBootstrapped } from './preferencesApi';
 import type { SleepStageEvent } from '../../types/mobileHealthData';
@@ -114,7 +115,7 @@ export const fetchWithRetry = async (
           notifySessionExpired(serverConfig.id);
         }
         const errorText = await response.text();
-        throw new Error(`Server error: ${response.status} - ${errorText}`);
+        throw new ApiError(`Server error: ${response.status} - ${errorText}`, response.status, errorText);
       }
 
       // 5xx — retryable

--- a/SparkyFitnessServer/middleware/authMiddleware.ts
+++ b/SparkyFitnessServer/middleware/authMiddleware.ts
@@ -3,10 +3,18 @@ import userRepository from '../models/userRepository.js';
 import { serializeSignedCookie } from 'better-call';
 import { auth } from '../auth.js';
 import { canAccessUserData } from '../utils/permissionUtils.js';
+import {
+  getCachedSession,
+  setCachedSession,
+} from '../utils/apiKeySessionCache.js';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const authenticate = async (req: any, res: any, next: any) => {
   //log("debug", `authenticate middleware: req.path = ${req.path}, req.headers.cookie = ${req.headers.cookie}`);
   // 1. Better Auth Session & API Key Check (Unified Identity)
+  // Tracks the raw API key when this request is API-key-authed, so we can
+  // short-circuit Better Auth's per-request verify (which ticks the per-key
+  // rate-limit bucket — see issue #1302).
+  let apiKeyToken: string | null = null;
   try {
     // Route Bearer tokens to the correct auth mechanism:
     // - API keys (64+ alphanumeric chars, no dots) → x-api-key header
@@ -19,6 +27,7 @@ const authenticate = async (req: any, res: any, next: any) => {
       if (token && token.length >= 64 && !token.includes('.')) {
         req.headers['x-api-key'] = token;
         delete req.headers.authorization;
+        apiKeyToken = token;
         log(
           'debug',
           'Authentication: Mapped Bearer token to x-api-key (API key detected).'
@@ -50,10 +59,30 @@ const authenticate = async (req: any, res: any, next: any) => {
         );
       }
     }
-    // getSession resolves from session cookies or x-api-key header
-    const session = await auth.api.getSession({
-      headers: req.headers,
-    });
+    // Pre-existing x-api-key header (i.e. not from the Bearer mapping above)
+    // is also subject to the same per-key rate-limit ticking. Treat it the
+    // same as a mapped Bearer for cache purposes.
+    if (!apiKeyToken && typeof req.headers['x-api-key'] === 'string') {
+      apiKeyToken = req.headers['x-api-key'];
+    }
+    // Short-circuit Better Auth's per-request verify when we have a cached
+    // session for this API key. Better Auth's api-key plugin treats every
+    // getSession() call as a verification tick and increments
+    // api_key.request_count, which trivially exhausts the default
+    // 100-req/60s bucket under normal mobile/SPA traffic (issue #1302).
+    // Session cookie auth is unaffected and never cached here.
+    let session: Awaited<ReturnType<typeof auth.api.getSession>> | null = null;
+    if (apiKeyToken) {
+      session = getCachedSession(apiKeyToken) as typeof session;
+    }
+    if (!session) {
+      session = await auth.api.getSession({
+        headers: req.headers,
+      });
+      if (session && session.user && apiKeyToken) {
+        setCachedSession(apiKeyToken, session);
+      }
+    }
     if (session && session.user) {
       log(
         'debug',

--- a/SparkyFitnessServer/tests/apiKeySessionCache.test.ts
+++ b/SparkyFitnessServer/tests/apiKeySessionCache.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getCachedSession,
+  setCachedSession,
+  clearApiKeySessionCache,
+  _internalApiKeyCacheSize,
+} from '../utils/apiKeySessionCache.js';
+
+describe('apiKeySessionCache', () => {
+  beforeEach(() => {
+    clearApiKeySessionCache();
+  });
+
+  it('returns null on miss', () => {
+    expect(getCachedSession('nonexistent')).toBeNull();
+  });
+
+  it('returns the cached session within TTL', () => {
+    const session = { user: { id: 'u1' } };
+    setCachedSession('tok-abc', session);
+    expect(getCachedSession('tok-abc')).toBe(session);
+  });
+
+  it('returns null after the TTL window expires', () => {
+    const session = { user: { id: 'u1' } };
+    setCachedSession('tok-abc', session, 1000, 1_000_000);
+    expect(getCachedSession('tok-abc', 1_000_999)).toBe(session);
+    expect(getCachedSession('tok-abc', 1_001_000)).toBeNull();
+  });
+
+  it('lazy-evicts expired entries on read', () => {
+    setCachedSession('tok-x', { user: { id: 'u1' } }, 1000, 1_000_000);
+    expect(_internalApiKeyCacheSize()).toBe(1);
+    expect(getCachedSession('tok-x', 1_001_500)).toBeNull();
+    expect(_internalApiKeyCacheSize()).toBe(0);
+  });
+
+  it('distinguishes between different API keys', () => {
+    setCachedSession('tok-A', { user: { id: 'uA' } });
+    setCachedSession('tok-B', { user: { id: 'uB' } });
+    expect(getCachedSession('tok-A')).toMatchObject({ user: { id: 'uA' } });
+    expect(getCachedSession('tok-B')).toMatchObject({ user: { id: 'uB' } });
+    expect(getCachedSession('tok-C')).toBeNull();
+  });
+
+  it('clears all entries', () => {
+    setCachedSession('tok-1', { user: { id: 'u1' } });
+    setCachedSession('tok-2', { user: { id: 'u2' } });
+    expect(_internalApiKeyCacheSize()).toBe(2);
+    clearApiKeySessionCache();
+    expect(_internalApiKeyCacheSize()).toBe(0);
+  });
+});

--- a/SparkyFitnessServer/tests/apiKeySessionCache.test.ts
+++ b/SparkyFitnessServer/tests/apiKeySessionCache.test.ts
@@ -4,6 +4,7 @@ import {
   setCachedSession,
   clearApiKeySessionCache,
   _internalApiKeyCacheSize,
+  MAX_API_KEY_SESSION_CACHE_SIZE,
 } from '../utils/apiKeySessionCache.js';
 
 describe('apiKeySessionCache', () => {
@@ -49,5 +50,35 @@ describe('apiKeySessionCache', () => {
     expect(_internalApiKeyCacheSize()).toBe(2);
     clearApiKeySessionCache();
     expect(_internalApiKeyCacheSize()).toBe(0);
+  });
+
+  it('caps cache size and evicts the oldest entry on overflow (FIFO)', () => {
+    for (let i = 0; i < MAX_API_KEY_SESSION_CACHE_SIZE + 50; i++) {
+      setCachedSession(`tok-${i}`, { user: { id: `u${i}` } });
+    }
+    expect(_internalApiKeyCacheSize()).toBe(MAX_API_KEY_SESSION_CACHE_SIZE);
+    // First 50 inserts should have been evicted; the remaining range is hits.
+    expect(getCachedSession('tok-0')).toBeNull();
+    expect(getCachedSession('tok-49')).toBeNull();
+    expect(getCachedSession('tok-50')).toMatchObject({ user: { id: 'u50' } });
+    expect(
+      getCachedSession(`tok-${MAX_API_KEY_SESSION_CACHE_SIZE + 49}`)
+    ).toMatchObject({
+      user: { id: `u${MAX_API_KEY_SESSION_CACHE_SIZE + 49}` },
+    });
+  });
+
+  it('does not evict on re-set of an existing key (no churn for steady traffic)', () => {
+    for (let i = 0; i < MAX_API_KEY_SESSION_CACHE_SIZE; i++) {
+      setCachedSession(`tok-${i}`, { user: { id: `u${i}` } });
+    }
+    expect(_internalApiKeyCacheSize()).toBe(MAX_API_KEY_SESSION_CACHE_SIZE);
+    // Refresh an existing key — size must stay constant, oldest must survive.
+    setCachedSession('tok-500', { user: { id: 'u500-refreshed' } });
+    expect(_internalApiKeyCacheSize()).toBe(MAX_API_KEY_SESSION_CACHE_SIZE);
+    expect(getCachedSession('tok-0')).toMatchObject({ user: { id: 'u0' } });
+    expect(getCachedSession('tok-500')).toMatchObject({
+      user: { id: 'u500-refreshed' },
+    });
   });
 });

--- a/SparkyFitnessServer/tests/authMiddleware.cache.test.ts
+++ b/SparkyFitnessServer/tests/authMiddleware.cache.test.ts
@@ -1,0 +1,140 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+
+// Hoisted so vi.mock factories (also hoisted) can reference it.
+const { mockGetSession } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+}));
+
+vi.mock('../auth.js', () => ({
+  auth: {
+    api: { getSession: mockGetSession },
+    options: {
+      advanced: { cookiePrefix: 'sparky', useSecureCookies: false },
+      secret: 'test-secret',
+    },
+  },
+}));
+
+vi.mock('../models/userRepository.js', () => ({
+  default: {
+    ensureUserInitialization: vi.fn().mockResolvedValue(undefined),
+    getUserRole: vi.fn().mockResolvedValue('user'),
+  },
+}));
+
+vi.mock('../utils/permissionUtils.js', () => ({
+  canAccessUserData: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('../config/logging.js', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('better-call', () => ({
+  serializeSignedCookie: vi.fn().mockResolvedValue('cookie-value'),
+}));
+
+import { authenticate } from '../middleware/authMiddleware.js';
+import { clearApiKeySessionCache } from '../utils/apiKeySessionCache.js';
+
+const VALID_TOKEN_A = 'a'.repeat(64);
+const VALID_TOKEN_B = 'b'.repeat(64);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeReq(token: string): any {
+  return {
+    headers: { authorization: `Bearer ${token}` },
+    cookies: {},
+    path: '/api/x',
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeRes(): any {
+  const res: Record<string, unknown> = {
+    statusCode: null,
+    headers: {},
+    body: null,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res.set = function (k: string, v: any) {
+    (res.headers as Record<string, unknown>)[k] = v;
+    return res;
+  };
+  res.status = function (c: number) {
+    res.statusCode = c;
+    return res;
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res.json = function (d: any) {
+    res.body = d;
+    return res;
+  };
+  return res;
+}
+
+describe('authenticate middleware: API-key session cache (issue #1302)', () => {
+  beforeEach(() => {
+    clearApiKeySessionCache();
+    mockGetSession.mockReset();
+  });
+
+  it('calls auth.api.getSession exactly once for repeated requests with the same API key within TTL', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', name: 'U' } });
+    const next = vi.fn();
+
+    await authenticate(makeReq(VALID_TOKEN_A), makeRes(), next);
+    await authenticate(makeReq(VALID_TOKEN_A), makeRes(), next);
+    await authenticate(makeReq(VALID_TOKEN_A), makeRes(), next);
+
+    expect(mockGetSession).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(3);
+  });
+
+  it('calls getSession independently for different API keys', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', name: 'U' } });
+    const next = vi.fn();
+
+    await authenticate(makeReq(VALID_TOKEN_A), makeRes(), next);
+    await authenticate(makeReq(VALID_TOKEN_B), makeRes(), next);
+
+    expect(mockGetSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache null sessions (Better Auth returns null on no-session)', async () => {
+    mockGetSession.mockResolvedValue(null);
+    const next = vi.fn();
+    const res1 = makeRes();
+    const res2 = makeRes();
+
+    await authenticate(makeReq(VALID_TOKEN_A), res1, next);
+    await authenticate(makeReq(VALID_TOKEN_A), res2, next);
+
+    expect(mockGetSession).toHaveBeenCalledTimes(2);
+    expect(res1.statusCode).toBe(401);
+    expect(res2.statusCode).toBe(401);
+  });
+
+  it('respects pre-set x-api-key header (not just Bearer mapping)', async () => {
+    mockGetSession.mockResolvedValue({ user: { id: 'u1', name: 'U' } });
+    const next = vi.fn();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const req1: any = {
+      headers: { 'x-api-key': VALID_TOKEN_A },
+      cookies: {},
+      path: '/api/x',
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const req2: any = {
+      headers: { 'x-api-key': VALID_TOKEN_A },
+      cookies: {},
+      path: '/api/x',
+    };
+
+    await authenticate(req1, makeRes(), next);
+    await authenticate(req2, makeRes(), next);
+
+    expect(mockGetSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/SparkyFitnessServer/utils/apiKeySessionCache.ts
+++ b/SparkyFitnessServer/utils/apiKeySessionCache.ts
@@ -1,6 +1,12 @@
 import { createHash } from 'node:crypto';
 
 const DEFAULT_TTL_MS = 5_000;
+// Defensive ceiling. Realistic steady state is O(active API keys), which for
+// a self-hosted instance is small — but cap so a pathological mix of unique
+// authenticated callers can't grow the map without bound. FIFO eviction is
+// fine here because the short TTL means the oldest insertion is almost
+// always already expired by the time we hit the cap.
+export const MAX_API_KEY_SESSION_CACHE_SIZE = 1000;
 
 interface CacheEntry {
   session: unknown;
@@ -33,7 +39,12 @@ export function setCachedSession(
   ttlMs: number = DEFAULT_TTL_MS,
   now: number = Date.now()
 ): void {
-  cache.set(hashKey(token), {
+  const key = hashKey(token);
+  if (cache.size >= MAX_API_KEY_SESSION_CACHE_SIZE && !cache.has(key)) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey !== undefined) cache.delete(oldestKey);
+  }
+  cache.set(key, {
     session,
     expiresAt: now + ttlMs,
   });

--- a/SparkyFitnessServer/utils/apiKeySessionCache.ts
+++ b/SparkyFitnessServer/utils/apiKeySessionCache.ts
@@ -1,0 +1,48 @@
+import { createHash } from 'node:crypto';
+
+const DEFAULT_TTL_MS = 5_000;
+
+interface CacheEntry {
+  session: unknown;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function hashKey(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function getCachedSession(
+  token: string,
+  now: number = Date.now()
+): unknown | null {
+  const key = hashKey(token);
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (now >= entry.expiresAt) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.session;
+}
+
+export function setCachedSession(
+  token: string,
+  session: unknown,
+  ttlMs: number = DEFAULT_TTL_MS,
+  now: number = Date.now()
+): void {
+  cache.set(hashKey(token), {
+    session,
+    expiresAt: now + ttlMs,
+  });
+}
+
+export function clearApiKeySessionCache(): void {
+  cache.clear();
+}
+
+export function _internalApiKeyCacheSize(): number {
+  return cache.size;
+}


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
The Android app gets HTTP 429s under normal use because the Better Auth api-key plugin's per-key rate-limit bucket (default 100/60s) is ticked on every authenticated request, and the mobile retry layer amplifies every rejection.

**How did you implement the solution?**
Server: cache the resolved session for API-key authenticated requests for 5s, keyed on a sha256 of the key. Skips Better Auth's verify on cache hits within the window. Session-cookie auth is unaffected. 
Mobile: introduce `ApiError(message, statusCode, body)` thrown from the central `apiClient`, and a `queryClient` retry predicate that does not retry on 4xx (incl. 429).

Linked Issue: Closes #1302

## How to Test

1. Check out this branch and run `pnpm install`. Start backend + frontend per `CONTRIBUTING.md`; build/run the mobile app.
2. **Server cache, manual smoke**: log in via the Android app, then open the dashboard / log a meal / open settings repeatedly so the app fans out queries. With the same `api_key.rate_limit_max=100`, you should no longer hit 429 within a minute. Inspect `SELECT request_count FROM api_key;` — the counter should now grow far more slowly (roughly one tick per 5s window of activity per key).
3. **Server cache, automated**:
   - `pnpm --filter sparkyfitnessserver test -- apiKeySessionCache.test.ts` (vitest, unit) — covers hit, miss, TTL expiry, lazy eviction, key isolation, clear.
   - `pnpm --filter sparkyfitnessserver test -- authMiddleware.cache.test.ts` (vitest, integration) — covers the middleware actually using the cache: same-key requests collapse to one `auth.api.getSession()` call, different keys are independent, null sessions are not cached, pre-set `x-api-key` headers are covered alongside the Bearer mapping.
4. **Mobile retry predicate, automated**: `pnpm --filter sparkyfitnessmobile test -- --testPathPattern=queryClient` (jest) — covers `ApiError` 4xx → no retry, 5xx → 2 retries, generic Error → 2 retries.
5. **Mobile apiClient, automated**: `pnpm --filter sparkyfitnessmobile test -- --testPathPattern=apiClient` (jest) — covers 4xx and 5xx both throw `ApiError` with `statusCode` and `body` populated.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] N/A — bug fix.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] N/A — no frontend changes in this PR.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: Typecheck + lint + tests pass. New file (`utils/apiKeySessionCache.ts`) is TypeScript; no new endpoints (middleware-internal helper); covered by unit tests (`tests/apiKeySessionCache.test.ts`).
- [x] **[MANDATORY for Backend changes] Database Security**: No new tables — no schema or RLS changes.

**UI changes (components, screens, pages):**

- [ ] N/A — no UI changes in this PR.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: Built `assembleRelease` from this branch, sideloaded on Android, sustained navigation across Dashboard/Diary/Library and meal logging without any "disconnected" / 429 — see "End-to-end validation" note below for the measured cache hit ratio.

## Screenshots

<details>
<summary>Not applicable - no UI changes</summary>
</details>

## Notes for Reviewers

- **End-to-end validation on my self-hosted instance** — built the server image from this branch, deployed it to the `sparkyfitness` stack with the api-key row left at stock defaults (`rate_limit_max=100`, `time_window=60000`), then sideloaded the `assembleRelease` APK and navigated hard (Dashboard, Diary scroll, Library, meal log) until well past the point that previously triggered a disconnect. Measurements after the test:
  - `api_key.request_count`: **21** of 100 cap
  - "Rate limit exceeded" errors in backend logs since deploy: **0**
  - Bearer-API-key incoming requests since deploy: **145**
  - → cache hit ratio ≈ **85%** (145 incoming requests → 21 verifier ticks), no 429s reached the client.
- **Typed error per @apedley's review** — `ApiError extends Error` in `SparkyFitnessMobile/src/services/api/errors.ts`, mirroring the existing `LoginError` pattern in `authService.ts`. Predicate uses `err instanceof ApiError` rather than property mutation.
- **Cache TTL of 5s** is the worst-case staleness if a key is rotated or disabled — the next request after the window will hit Better Auth again. Happy to make this an env knob (`SPARKY_FITNESS_API_KEY_SESSION_CACHE_TTL_MS`) if you'd prefer.
- **Cache key is a sha256 hash** of the API key — defense-in-depth so a memory dump of the cache doesn't reveal raw keys.
- **`Retry-After` is not yet honored** on the mobile side. Left as a follow-up — the immediate 3× amplification problem is solved by not retrying 4xx at all.
- **Local validation on this branch**:
  - server `pnpm run validate` ✅, `pnpm test` ✅ (653/653 — 4 new tests in `authMiddleware.cache.test.ts`, 6 in `apiKeySessionCache.test.ts`)
  - mobile `pnpm run validate` ✅, `pnpm test` for `queryClient` + `apiClient` + `apiKeySessionCache` ✅ (25/25)
  - Two unrelated test files (`LibraryScreen`, `FoodScanScreen`) timed out under full-suite parallelism but pass cleanly on isolated runs — appears to be pre-existing jest flakiness in those screens, not regressions from this PR.
  - device smoke + measured end-to-end cache effect (see "End-to-end validation on my self-hosted instance" above) ✅
