### PR TITLE
feat(mobile): prefill last workout stats and show personal best

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/EditableExerciseCard.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/EditableExerciseCard.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import EditableExerciseCard from '../../src/components/EditableExerciseCard';
+import { useExerciseStats } from '../../src/hooks/useExerciseStats';
+import type { WorkoutDraftExercise } from '../../src/types/drafts';
+
+jest.mock('../../src/hooks/useExerciseStats', () => ({
+  useExerciseStats: jest.fn(),
+}));
+
+jest.mock('../../src/components/EditableSetList', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => React.createElement(View, { testID: 'editable-set-list' }),
+  };
+});
+
+jest.mock('../../src/components/SafeImage', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => React.createElement(View, { testID: 'safe-image' }),
+  };
+});
+
+jest.mock('../../src/components/Icon', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ name }: { name: string }) =>
+      React.createElement(View, { testID: `icon-${name}` }),
+  };
+});
+
+const mockUseExerciseStats = useExerciseStats as jest.MockedFunction<typeof useExerciseStats>;
+
+function makeExercise(overrides: Partial<WorkoutDraftExercise> = {}): WorkoutDraftExercise {
+  return {
+    clientId: 'ex-1',
+    exerciseId: 'srv-ex-1',
+    exerciseName: 'Bench Press',
+    exerciseCategory: 'strength',
+    images: [],
+    sets: [{ clientId: 'set-1', weight: '', reps: '', restTime: 90 }],
+    ...overrides,
+  };
+}
+
+function statsResult(data: any) {
+  return {
+    data,
+    isLoading: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useExerciseStats>;
+}
+
+function renderCard({
+  exercise,
+  eligibleForPrefill = true,
+  onUpdateSetField = jest.fn(),
+  weightUnit = 'kg',
+}: {
+  exercise: WorkoutDraftExercise;
+  eligibleForPrefill?: boolean;
+  onUpdateSetField?: jest.Mock;
+  weightUnit?: 'kg' | 'lbs';
+}) {
+  return render(
+    <EditableExerciseCard
+      exercise={exercise}
+      imagePath={null}
+      getImageSource={() => null}
+      activeSetKey={null}
+      activeSetField="weight"
+      weightUnit={weightUnit}
+      eligibleForPrefill={eligibleForPrefill}
+      onActivateSet={jest.fn()}
+      onDeactivateSet={jest.fn()}
+      onUpdateSetField={onUpdateSetField}
+      onRemoveSet={jest.fn()}
+      onAddSet={jest.fn()}
+      onRemove={jest.fn()}
+      onOpenRestSheet={jest.fn()}
+    />,
+  );
+}
+
+describe('EditableExerciseCard prefill', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prefills weight + reps from lastSet when both fields are blank', () => {
+    mockUseExerciseStats.mockReturnValue(
+      statsResult({
+        bestSet: { entryDate: '2026-04-01', weight: 100, reps: 5, setNumber: 1 },
+        lastSet: { entryDate: '2026-04-10', weight: 95, reps: 5, setNumber: 1 },
+      }),
+    );
+
+    const onUpdate = jest.fn();
+    renderCard({ exercise: makeExercise(), onUpdateSetField: onUpdate });
+
+    expect(onUpdate).toHaveBeenCalledTimes(2);
+    expect(onUpdate).toHaveBeenCalledWith('ex-1', 'set-1', 'weight', '95');
+    expect(onUpdate).toHaveBeenCalledWith('ex-1', 'set-1', 'reps', '5');
+  });
+
+  it('only prefills the blank field when reps is already populated', () => {
+    mockUseExerciseStats.mockReturnValue(
+      statsResult({
+        bestSet: { entryDate: '2026-04-01', weight: 100, reps: 5, setNumber: 1 },
+        lastSet: { entryDate: '2026-04-10', weight: 95, reps: 5, setNumber: 1 },
+      }),
+    );
+
+    const onUpdate = jest.fn();
+    renderCard({
+      exercise: makeExercise({
+        sets: [{ clientId: 'set-1', weight: '', reps: '8', restTime: 90 }],
+      }),
+      onUpdateSetField: onUpdate,
+    });
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith('ex-1', 'set-1', 'weight', '95');
+  });
+
+  it('does not prefill when eligibleForPrefill is false', () => {
+    mockUseExerciseStats.mockReturnValue(
+      statsResult({
+        bestSet: { entryDate: '2026-04-01', weight: 100, reps: 5, setNumber: 1 },
+        lastSet: { entryDate: '2026-04-10', weight: 95, reps: 5, setNumber: 1 },
+      }),
+    );
+
+    const onUpdate = jest.fn();
+    renderCard({
+      exercise: makeExercise(),
+      eligibleForPrefill: false,
+      onUpdateSetField: onUpdate,
+    });
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does not prefill a second time on re-render', () => {
+    mockUseExerciseStats.mockReturnValue(
+      statsResult({
+        bestSet: { entryDate: '2026-04-01', weight: 100, reps: 5, setNumber: 1 },
+        lastSet: { entryDate: '2026-04-10', weight: 95, reps: 5, setNumber: 1 },
+      }),
+    );
+
+    const onUpdate = jest.fn();
+    const exercise = makeExercise();
+    const { rerender } = renderCard({ exercise, onUpdateSetField: onUpdate });
+
+    rerender(
+      <EditableExerciseCard
+        exercise={exercise}
+        imagePath={null}
+        getImageSource={() => null}
+        activeSetKey={null}
+        activeSetField="weight"
+        weightUnit="kg"
+        eligibleForPrefill={true}
+        onActivateSet={jest.fn()}
+        onDeactivateSet={jest.fn()}
+        onUpdateSetField={onUpdate}
+        onRemoveSet={jest.fn()}
+        onAddSet={jest.fn()}
+        onRemove={jest.fn()}
+        onOpenRestSheet={jest.fn()}
+      />,
+    );
+
+    expect(onUpdate).toHaveBeenCalledTimes(2); // weight + reps from first render only
+  });
+
+  it('does not prefill when stats lastSet is null', () => {
+    mockUseExerciseStats.mockReturnValue(
+      statsResult({
+        bestSet: null,
+        lastSet: null,
+      }),
+    );
+
+    const onUpdate = jest.fn();
+    renderCard({ exercise: makeExercise(), onUpdateSetField: onUpdate });
+
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('converts kg → lbs when weightUnit is lbs', () => {
+    mockUseExerciseStats.mockReturnValue(
+      statsResult({
+        bestSet: { entryDate: '2026-04-01', weight: 100, reps: 5, setNumber: 1 },
+        lastSet: { entryDate: '2026-04-10', weight: 100, reps: 5, setNumber: 1 },
+      }),
+    );
+
+    const onUpdate = jest.fn();
+    renderCard({
+      exercise: makeExercise(),
+      onUpdateSetField: onUpdate,
+      weightUnit: 'lbs',
+    });
+
+    // 100kg ≈ 220.5 lbs — rounded to 1 decimal
+    expect(onUpdate).toHaveBeenCalledWith('ex-1', 'set-1', 'weight', '220.5');
+  });
+});

--- a/SparkyFitnessMobile/__tests__/hooks/useExerciseStats.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useExerciseStats.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useExerciseStats } from '../../src/hooks/useExerciseStats';
+import { fetchExerciseStats } from '../../src/services/api/exerciseApi';
+import { createTestQueryClient, createQueryWrapper, type QueryClient } from './queryTestUtils';
+
+jest.mock('../../src/services/api/exerciseApi', () => ({
+  fetchExerciseStats: jest.fn(),
+}));
+
+const mockFetchStats = fetchExerciseStats as jest.MockedFunction<typeof fetchExerciseStats>;
+
+describe('useExerciseStats', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = createTestQueryClient();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  it('returns fetched data when exerciseId is provided', async () => {
+    const data = {
+      bestSet: { entryDate: '2026-04-01', weight: 100, reps: 5, setNumber: 1 },
+      lastSet: { entryDate: '2026-04-10', weight: 95, reps: 5, setNumber: 1 },
+    };
+    mockFetchStats.mockResolvedValue(data);
+
+    const { result } = renderHook(() => useExerciseStats('ex-1'), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(data);
+    });
+    expect(mockFetchStats).toHaveBeenCalledWith('ex-1');
+  });
+
+  it('does not fire when exerciseId is null/undefined', () => {
+    renderHook(() => useExerciseStats(null), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+    renderHook(() => useExerciseStats(undefined), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+    expect(mockFetchStats).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when exerciseId is empty string', () => {
+    renderHook(() => useExerciseStats(''), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+    expect(mockFetchStats).not.toHaveBeenCalled();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/hooks/useWorkoutForm.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useWorkoutForm.test.ts
@@ -33,6 +33,12 @@ const makeEmptyDraft = (): WorkoutDraft => ({
   exercises: [],
 });
 
+const presetClientIds = (preset: WorkoutPreset) =>
+  preset.exercises.map((e, i) => ({
+    exerciseClientId: `gen-ex-${i}`,
+    setClientIds: e.sets.map((_, j) => `gen-set-${i}-${j}`),
+  }));
+
 describe('workoutFormReducer', () => {
   describe('RESTORE_DRAFT', () => {
     it('replaces entire state with the provided draft', () => {
@@ -723,6 +729,7 @@ describe('workoutFormReducer', () => {
         preset,
         weightUnit: 'kg',
         date: '2026-03-20',
+        clientIds: presetClientIds(preset),
       });
 
       expect(result.name).toBe('Full Body');
@@ -743,6 +750,7 @@ describe('workoutFormReducer', () => {
         type: 'POPULATE_FROM_PRESET',
         preset,
         weightUnit: 'lbs',
+        clientIds: presetClientIds(preset),
       });
 
       // 100 kg in lbs ≈ 220.5
@@ -757,6 +765,7 @@ describe('workoutFormReducer', () => {
         type: 'POPULATE_FROM_PRESET',
         preset,
         weightUnit: 'kg',
+        clientIds: presetClientIds(preset),
       });
 
       expect(result.entryDate).toBe('2026-03-12');
@@ -781,6 +790,7 @@ describe('workoutFormReducer', () => {
         type: 'POPULATE_FROM_PRESET',
         preset,
         weightUnit: 'kg',
+        clientIds: presetClientIds(preset),
       });
 
       expect(result.exercises[0].sets[0].weight).toBe('');
@@ -807,6 +817,7 @@ describe('workoutFormReducer', () => {
         type: 'POPULATE_FROM_PRESET',
         preset,
         weightUnit: 'kg',
+        clientIds: presetClientIds(preset),
       });
 
       expect(result.exercises[0].sets[0].restTime).toBe(120);
@@ -838,6 +849,7 @@ describe('workoutFormReducer', () => {
         preset,
         weightUnit: 'kg',
         date: '2026-03-20',
+        clientIds: presetClientIds(preset),
       });
 
       expect(result.exercises).toHaveLength(2);

--- a/SparkyFitnessMobile/src/components/EditableExerciseCard.tsx
+++ b/SparkyFitnessMobile/src/components/EditableExerciseCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { Text, View } from 'react-native';
 import { useCSSVariable } from 'uniwind';
 import Icon from './Icon';
@@ -6,7 +6,10 @@ import Button from './ui/Button';
 import SafeImage from './SafeImage';
 import EditableSetList from './EditableSetList';
 import RestPeriodChip from './RestPeriodChip';
+import ExerciseStatsChip from './ExerciseStatsChip';
 import { CATEGORY_ICON_MAP } from '../utils/workoutSession';
+import { useExerciseStats } from '../hooks/useExerciseStats';
+import { weightFromKg } from '../utils/unitConversions';
 import type { WorkoutDraftExercise } from '../types/drafts';
 import type { GetImageSource } from '../hooks/useExerciseImageSource';
 
@@ -18,6 +21,7 @@ interface EditableExerciseCardProps {
   activeSetKey: string | null;
   activeSetField: 'weight' | 'reps';
   weightUnit: string;
+  eligibleForPrefill?: boolean;
   onActivateSet: (setKey: string, field: 'weight' | 'reps') => void;
   onDeactivateSet: () => void;
   onUpdateSetField: (exerciseClientId: string, setClientId: string, field: 'weight' | 'reps', value: string) => void;
@@ -35,6 +39,7 @@ function EditableExerciseCard({
   activeSetKey,
   activeSetField,
   weightUnit,
+  eligibleForPrefill = false,
   onActivateSet,
   onDeactivateSet,
   onUpdateSetField,
@@ -52,7 +57,38 @@ function EditableExerciseCard({
     [getImageSource, imagePath],
   );
   const exerciseIcon = (exercise.exerciseCategory && CATEGORY_ICON_MAP[exercise.exerciseCategory]) || 'exercise-weights';
-  const firstSetRest = exercise.sets[0]?.restTime;
+  const firstSet = exercise.sets[0];
+  const firstSetRest = firstSet?.restTime;
+
+  const { data: stats } = useExerciseStats(exercise.exerciseId);
+  const didPrefillRef = useRef(false);
+
+  useEffect(() => {
+    if (didPrefillRef.current) return;
+    if (!eligibleForPrefill || !stats?.lastSet || !firstSet) return;
+
+    didPrefillRef.current = true;
+    if (firstSet.weight === '' && stats.lastSet.weight != null) {
+      const w = weightFromKg(stats.lastSet.weight, weightUnit as 'kg' | 'lbs');
+      onUpdateSetField(
+        exercise.clientId,
+        firstSet.clientId,
+        'weight',
+        String(parseFloat(w.toFixed(1))),
+      );
+    }
+    if (firstSet.reps === '' && stats.lastSet.reps != null) {
+      onUpdateSetField(
+        exercise.clientId,
+        firstSet.clientId,
+        'reps',
+        String(stats.lastSet.reps),
+      );
+    }
+    // Deps reference the stable identifiers + `stats?.lastSet` so typing into
+    // the row (which mutates firstSet.weight/reps) doesn't re-trigger this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stats?.lastSet, eligibleForPrefill, exercise.clientId, firstSet?.clientId, weightUnit, onUpdateSetField]);
 
   return (
     <View className="py-4">
@@ -73,23 +109,33 @@ function EditableExerciseCard({
               variant="ghost"
               onPress={() => onRemove(exercise)}
               hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-              className="py-0 px-0"
+              className="py-0 px-0 shrink-0"
             >
               <Icon name="close" size={20} color={textMuted} />
             </Button>
           </View>
 
-          {subtitle ? (
-            <Text className="text-xs text-text-muted mt-0.5">
-              {subtitle}
-            </Text>
-          ) : null}
+          <View className="flex-row items-center justify-between">
+            <View className="flex-1 mr-2">
+              {subtitle ? (
+                <Text className="text-xs text-text-muted mt-0.5">
+                  {subtitle}
+                </Text>
+              ) : null}
 
-          <View className="flex-row self-start mt-1.5">
-            <RestPeriodChip
-              value={firstSetRest}
-              onPress={() => onOpenRestSheet(exercise.clientId, firstSetRest)}
-            />
+              <View className="flex-row self-start mt-1.5">
+                <RestPeriodChip
+                  value={firstSetRest}
+                  onPress={() => onOpenRestSheet(exercise.clientId, firstSetRest)}
+                />
+              </View>
+            </View>
+            {stats?.bestSet ? (
+              <ExerciseStatsChip
+                bestSet={stats.bestSet}
+                weightUnit={weightUnit as 'kg' | 'lbs'}
+              />
+            ) : null}
           </View>
         </View>
       </View>

--- a/SparkyFitnessMobile/src/components/ExerciseStatsChip.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseStatsChip.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Text, View } from 'react-native';
+import { useCSSVariable } from 'uniwind';
+import type { ExerciseSetStats } from '@workspace/shared';
+import { weightFromKg } from '../utils/unitConversions';
+
+interface ExerciseStatsChipProps {
+  bestSet: ExerciseSetStats | null | undefined;
+  weightUnit: 'kg' | 'lbs';
+}
+
+function formatLabel(bestSet: ExerciseSetStats, weightUnit: 'kg' | 'lbs'): string | null {
+  if (bestSet.weight == null) return null;
+  const weight = parseFloat(weightFromKg(bestSet.weight, weightUnit).toFixed(1));
+  if (bestSet.reps != null) {
+    return `PB ${weight} × ${bestSet.reps}`;
+  }
+  return `PB ${weight} ${weightUnit}`;
+}
+
+function ExerciseStatsChip({ bestSet, weightUnit }: ExerciseStatsChipProps) {
+  const [textSecondary] = useCSSVariable(['--color-text-secondary']) as [string];
+
+  if (!bestSet) return null;
+  const label = formatLabel(bestSet, weightUnit);
+  if (!label) return null;
+
+  return (
+    <View
+      className="rounded-full px-2 py-0.5"
+      style={{ backgroundColor: `${textSecondary}1A` }}
+    >
+      <Text
+        className="text-xs font-medium"
+        style={{ color: textSecondary, maxWidth: 96 }}
+        numberOfLines={1}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+export default React.memo(ExerciseStatsChip);

--- a/SparkyFitnessMobile/src/components/WorkoutEditableExerciseList.tsx
+++ b/SparkyFitnessMobile/src/components/WorkoutEditableExerciseList.tsx
@@ -27,6 +27,7 @@ interface WorkoutEditableExerciseListProps {
   onRemoveExercise: (exercise: WorkoutDraftExercise) => void;
   onAddExercisePress: () => void;
   onChangeRest: (exerciseClientId: string, seconds: number) => void;
+  isEligibleForPrefill?: (clientId: string) => boolean;
   mode?: 'add' | 'detail';
 }
 
@@ -44,6 +45,7 @@ function WorkoutEditableExerciseList({
   onRemoveExercise,
   onAddExercisePress,
   onChangeRest,
+  isEligibleForPrefill,
   mode = 'add',
 }: WorkoutEditableExerciseListProps) {
   const accentPrimary = useCSSVariable('--color-accent-primary') as string;
@@ -92,6 +94,7 @@ function WorkoutEditableExerciseList({
             activeSetKey={exerciseActiveSetKey}
             activeSetField={exerciseActiveSetKey ? activeSetField : 'weight'}
             weightUnit={weightUnit}
+            eligibleForPrefill={isEligibleForPrefill?.(exercise.clientId) ?? false}
             onActivateSet={onActivateSet}
             onDeactivateSet={onDeactivateSet}
             onUpdateSetField={onUpdateSetField}

--- a/SparkyFitnessMobile/src/hooks/invalidateExerciseCache.ts
+++ b/SparkyFitnessMobile/src/hooks/invalidateExerciseCache.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import {
   exerciseHistoryQueryKey,
   exerciseHistoryResetQueryKey,
+  exerciseStatsQueryKeyRoot,
   suggestedExercisesQueryKey,
   dailySummaryQueryKey,
 } from './queryKeys';
@@ -11,5 +12,6 @@ export function invalidateExerciseCache(queryClient: QueryClient, entryDate: str
   queryClient.removeQueries({ queryKey: [...exerciseHistoryQueryKey], type: 'inactive' });
   queryClient.setQueryData(exerciseHistoryResetQueryKey, Date.now());
   void queryClient.invalidateQueries({ queryKey: [...suggestedExercisesQueryKey] });
+  void queryClient.invalidateQueries({ queryKey: [...exerciseStatsQueryKeyRoot] });
   void queryClient.invalidateQueries({ queryKey: dailySummaryQueryKey(entryDate) });
 }

--- a/SparkyFitnessMobile/src/hooks/queryKeys.ts
+++ b/SparkyFitnessMobile/src/hooks/queryKeys.ts
@@ -51,6 +51,11 @@ export const exerciseHistoryQueryKey = ['exerciseHistory'] as const;
 
 export const exerciseHistoryResetQueryKey = ['exerciseHistoryReset'] as const;
 
+export const exerciseStatsQueryKeyRoot = ['exerciseStats'] as const;
+
+export const exerciseStatsQueryKey = (exerciseId: string) =>
+  [...exerciseStatsQueryKeyRoot, exerciseId] as const;
+
 export const suggestedExercisesQueryKey = ['suggestedExercises'] as const;
 
 export const exerciseSearchQueryKey = (searchTerm: string) => ['exerciseSearch', searchTerm] as const;

--- a/SparkyFitnessMobile/src/hooks/useExerciseStats.ts
+++ b/SparkyFitnessMobile/src/hooks/useExerciseStats.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchExerciseStats } from '../services/api/exerciseApi';
+import { exerciseStatsQueryKey } from './queryKeys';
+
+export function useExerciseStats(exerciseId: string | null | undefined) {
+  return useQuery({
+    queryKey: exerciseStatsQueryKey(exerciseId ?? ''),
+    queryFn: () => fetchExerciseStats(exerciseId!),
+    enabled: !!exerciseId,
+  });
+}

--- a/SparkyFitnessMobile/src/hooks/useWorkoutForm.ts
+++ b/SparkyFitnessMobile/src/hooks/useWorkoutForm.ts
@@ -65,6 +65,8 @@ export function getWorkoutDraftSubmission(
 
 // --- Reducer ---
 
+export type PresetClientIds = { exerciseClientId: string; setClientIds: string[] }[];
+
 type WorkoutFormAction =
   | { type: 'RESTORE_DRAFT'; draft: WorkoutDraft }
   | { type: 'SET_DATE'; date: string }
@@ -77,7 +79,13 @@ type WorkoutFormAction =
   | { type: 'SET_EXERCISE_REST'; exerciseClientId: string; seconds: number }
   | { type: 'RESET' }
   | { type: 'POPULATE'; session: PresetSessionResponse; weightUnit: 'kg' | 'lbs' }
-  | { type: 'POPULATE_FROM_PRESET'; preset: WorkoutPreset; weightUnit: 'kg' | 'lbs'; date?: string };
+  | {
+      type: 'POPULATE_FROM_PRESET';
+      preset: WorkoutPreset;
+      weightUnit: 'kg' | 'lbs';
+      date?: string;
+      clientIds: PresetClientIds;
+    };
 
 export function workoutFormReducer(state: WorkoutDraft, action: WorkoutFormAction): WorkoutDraft {
   switch (action.type) {
@@ -216,14 +224,14 @@ export function workoutFormReducer(state: WorkoutDraft, action: WorkoutFormActio
         name: action.preset.name,
         nameManuallySet: true,
         entryDate: action.date ?? getTodayDate(),
-        exercises: action.preset.exercises.map(exercise => ({
-          clientId: generateClientId(),
+        exercises: action.preset.exercises.map((exercise, exerciseIdx) => ({
+          clientId: action.clientIds[exerciseIdx].exerciseClientId,
           exerciseId: exercise.exercise_id,
           exerciseName: exercise.exercise_name,
           exerciseCategory: exercise.category ?? null,
           images: exercise.image_url ? [exercise.image_url] : [],
-          sets: exercise.sets.map(set => ({
-            clientId: generateClientId(),
+          sets: exercise.sets.map((set, setIdx) => ({
+            clientId: action.clientIds[exerciseIdx].setClientIds[setIdx],
             restTime: set.rest_time,
             weight: set.weight != null
               ? String(parseFloat(weightFromKg(set.weight, action.weightUnit).toFixed(1)))
@@ -326,10 +334,18 @@ export function useWorkoutForm(options?: UseWorkoutFormOptions) {
     dispatch({ type: 'POPULATE', session, weightUnit });
   }, []);
 
-  const populateFromPreset = useCallback((preset: WorkoutPreset, weightUnit: 'kg' | 'lbs', date?: string) => {
-    exercisesModifiedRef.current = false;
-    dispatch({ type: 'POPULATE_FROM_PRESET', preset, weightUnit, date });
-  }, []);
+  const populateFromPreset = useCallback(
+    (preset: WorkoutPreset, weightUnit: 'kg' | 'lbs', date?: string): string[] => {
+      const clientIds: PresetClientIds = preset.exercises.map(e => ({
+        exerciseClientId: generateClientId(),
+        setClientIds: e.sets.map(() => generateClientId()),
+      }));
+      exercisesModifiedRef.current = false;
+      dispatch({ type: 'POPULATE_FROM_PRESET', preset, weightUnit, date, clientIds });
+      return clientIds.map(c => c.exerciseClientId);
+    },
+    [],
+  );
 
   return {
     state,

--- a/SparkyFitnessMobile/src/hooks/useWorkoutPresetForm.ts
+++ b/SparkyFitnessMobile/src/hooks/useWorkoutPresetForm.ts
@@ -23,6 +23,8 @@ function createEmptyDraft(): PresetDraft {
   };
 }
 
+export type PresetClientIds = { exerciseClientId: string; setClientIds: string[] }[];
+
 type PresetFormAction =
   | { type: 'SET_NAME'; name: string }
   | { type: 'SET_DESCRIPTION'; description: string }
@@ -38,7 +40,12 @@ type PresetFormAction =
       value: string;
     }
   | { type: 'SET_EXERCISE_REST'; exerciseClientId: string; seconds: number }
-  | { type: 'POPULATE_FROM_PRESET'; preset: WorkoutPreset; weightUnit: 'kg' | 'lbs' };
+  | {
+      type: 'POPULATE_FROM_PRESET';
+      preset: WorkoutPreset;
+      weightUnit: 'kg' | 'lbs';
+      clientIds: PresetClientIds;
+    };
 
 export function presetFormReducer(state: PresetDraft, action: PresetFormAction): PresetDraft {
   switch (action.type) {
@@ -137,14 +144,14 @@ export function presetFormReducer(state: PresetDraft, action: PresetFormAction):
       return {
         name: action.preset.name,
         description: action.preset.description ?? '',
-        exercises: action.preset.exercises.map(exercise => ({
-          clientId: generateClientId(),
+        exercises: action.preset.exercises.map((exercise, exerciseIdx) => ({
+          clientId: action.clientIds[exerciseIdx].exerciseClientId,
           exerciseId: exercise.exercise_id,
           exerciseName: exercise.exercise_name,
           exerciseCategory: exercise.category ?? null,
           images: exercise.image_url ? [exercise.image_url] : [],
-          sets: exercise.sets.map(set => ({
-            clientId: generateClientId(),
+          sets: exercise.sets.map((set, setIdx) => ({
+            clientId: action.clientIds[exerciseIdx].setClientIds[setIdx],
             restTime: set.rest_time,
             weight:
               set.weight != null
@@ -223,10 +230,15 @@ export function useWorkoutPresetForm() {
   }, []);
 
   const populateFromPreset = useCallback(
-    (preset: WorkoutPreset, weightUnit: 'kg' | 'lbs') => {
+    (preset: WorkoutPreset, weightUnit: 'kg' | 'lbs'): string[] => {
+      const clientIds: PresetClientIds = preset.exercises.map(e => ({
+        exerciseClientId: generateClientId(),
+        setClientIds: e.sets.map(() => generateClientId()),
+      }));
       exercisesModifiedRef.current = false;
       initialDescriptionRef.current = preset.description ?? '';
-      dispatch({ type: 'POPULATE_FROM_PRESET', preset, weightUnit });
+      dispatch({ type: 'POPULATE_FROM_PRESET', preset, weightUnit, clientIds });
+      return clientIds.map(c => c.exerciseClientId);
     },
     [],
   );

--- a/SparkyFitnessMobile/src/screens/WorkoutAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutAddScreen.tsx
@@ -74,6 +74,21 @@ const WorkoutAddScreen: React.FC<Props> = ({ navigation, route }) => {
     exercisesModifiedRef,
   } = useWorkoutForm({ isEditMode, skipDraftLoad, initialDate });
 
+  const [eligibleIds, setEligibleIds] = useState<Set<string>>(() => new Set());
+
+  const wrappedAddExercise = useCallback(
+    (exercise: Parameters<typeof addExercise>[0]) => {
+      const result = addExercise(exercise);
+      setEligibleIds(prev => {
+        const next = new Set(prev);
+        next.add(result.exerciseClientId);
+        return next;
+      });
+      return result;
+    },
+    [addExercise],
+  );
+
   const {
     activeSetKey,
     activeSetField,
@@ -82,7 +97,12 @@ const WorkoutAddScreen: React.FC<Props> = ({ navigation, route }) => {
     handleAddSet,
     activateSet,
     deactivateSet,
-  } = useExerciseSetEditing({ addExercise, removeExercise, addSet });
+  } = useExerciseSetEditing({ addExercise: wrappedAddExercise, removeExercise, addSet });
+
+  const isEligibleForPrefill = useCallback(
+    (clientId: string) => eligibleIds.has(clientId),
+    [eligibleIds],
+  );
 
   const {
     createSession,
@@ -122,7 +142,12 @@ const WorkoutAddScreen: React.FC<Props> = ({ navigation, route }) => {
   useEffect(() => {
     if (!preset || isEditMode || hasPopulatedPresetRef.current || isPreferencesLoading) return;
     hasPopulatedPresetRef.current = true;
-    populateFromPreset(preset, weightUnit as 'kg' | 'lbs', initialDate);
+    const populatedIds = populateFromPreset(preset, weightUnit as 'kg' | 'lbs', initialDate);
+    setEligibleIds(prev => {
+      const next = new Set(prev);
+      populatedIds.forEach(id => next.add(id));
+      return next;
+    });
   }, [preset, isEditMode, isPreferencesLoading, populateFromPreset, weightUnit, initialDate]);
 
   const isInitializingEditForm = isEditMode && !hasPopulatedRef.current;
@@ -284,6 +309,7 @@ const WorkoutAddScreen: React.FC<Props> = ({ navigation, route }) => {
                   onRemoveExercise={handleRemoveExercise}
                   onAddExercisePress={openExerciseSearch}
                   onChangeRest={setExerciseRest}
+                  isEligibleForPrefill={isEligibleForPrefill}
                 />
 
                 {/* Bottom spacer so content isn't hidden behind footer */}

--- a/SparkyFitnessMobile/src/screens/WorkoutDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutDetailScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { View, Text, ActivityIndicator, TouchableOpacity, Pressable, Alert } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming } from 'react-native-reanimated';
 import FadeView from '../components/FadeView';
@@ -353,6 +353,21 @@ const WorkoutDetailScreen: React.FC<Props> = ({ navigation, route }) => {
   const submission = getWorkoutDraftSubmission(formState, weightUnit as 'kg' | 'lbs');
   const hasEditedExercisesWithSets = submission.canSave;
 
+  const [eligibleIds, setEligibleIds] = useState<Set<string>>(() => new Set());
+
+  const wrappedAddExercise = useCallback(
+    (exercise: Parameters<typeof addExercise>[0]) => {
+      const result = addExercise(exercise);
+      setEligibleIds(prev => {
+        const next = new Set(prev);
+        next.add(result.exerciseClientId);
+        return next;
+      });
+      return result;
+    },
+    [addExercise],
+  );
+
   const {
     activeSetKey,
     activeSetField,
@@ -361,11 +376,17 @@ const WorkoutDetailScreen: React.FC<Props> = ({ navigation, route }) => {
     handleAddSet,
     activateSet,
     deactivateSet,
-  } = useExerciseSetEditing({ addExercise, removeExercise, addSet });
+  } = useExerciseSetEditing({ addExercise: wrappedAddExercise, removeExercise, addSet });
+
+  const isEligibleForPrefill = useCallback(
+    (clientId: string) => eligibleIds.has(clientId),
+    [eligibleIds],
+  );
 
   const startEditing = () => {
     populate(session, weightUnit as 'kg' | 'lbs');
     setEditNotes(session.notes ?? '');
+    setEligibleIds(new Set());
     setIsEditing(true);
   };
 
@@ -737,6 +758,7 @@ const WorkoutDetailScreen: React.FC<Props> = ({ navigation, route }) => {
             onRemoveExercise={handleRemoveExercise}
             onAddExercisePress={openExerciseSearch}
             onChangeRest={setExerciseRest}
+            isEligibleForPrefill={isEligibleForPrefill}
             mode="detail"
           />
         ) : renderViewExercises()}

--- a/SparkyFitnessMobile/src/screens/WorkoutPresetFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutPresetFormScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { View, Text } from 'react-native';
 import Toast from 'react-native-toast-message';
 import { CommonActions } from '@react-navigation/native';
@@ -46,6 +46,7 @@ interface PresetFormBodyProps {
   ) => void;
   removeSet: (exerciseClientId: string, setClientId: string) => void;
   setExerciseRest: (exerciseClientId: string, seconds: number) => void;
+  isEligibleForPrefill: (clientId: string) => boolean;
   onAddExercisePress: () => void;
 }
 
@@ -58,6 +59,7 @@ const PresetFormBody: React.FC<PresetFormBodyProps> = ({
   updateSetField,
   removeSet,
   setExerciseRest,
+  isEligibleForPrefill,
   onAddExercisePress,
 }) => {
   const { getImageSource } = useExerciseImageSource();
@@ -107,6 +109,7 @@ const PresetFormBody: React.FC<PresetFormBodyProps> = ({
           onRemoveExercise={exerciseSetEditing.handleRemoveExercise}
           onAddExercisePress={onAddExercisePress}
           onChangeRest={setExerciseRest}
+          isEligibleForPrefill={isEligibleForPrefill}
         />
       </View>
     </View>
@@ -141,7 +144,29 @@ const CreatePresetMode: React.FC<CreatePresetModeProps> = ({ navigation, route }
     setExerciseRest,
   } = useWorkoutPresetForm();
 
-  const exerciseSetEditing = useExerciseSetEditing({ addExercise, removeExercise, addSet });
+  const [eligibleIds, setEligibleIds] = useState<Set<string>>(() => new Set());
+  const wrappedAddExercise = useCallback(
+    (exercise: Parameters<typeof addExercise>[0]) => {
+      const result = addExercise(exercise);
+      setEligibleIds(prev => {
+        const next = new Set(prev);
+        next.add(result.exerciseClientId);
+        return next;
+      });
+      return result;
+    },
+    [addExercise],
+  );
+  const isEligibleForPrefill = useCallback(
+    (clientId: string) => eligibleIds.has(clientId),
+    [eligibleIds],
+  );
+
+  const exerciseSetEditing = useExerciseSetEditing({
+    addExercise: wrappedAddExercise,
+    removeExercise,
+    addSet,
+  });
   useSelectedExercise(route.params, exerciseSetEditing.handleAddExercise);
 
   const { createPresetAsync, isPending } = useCreateWorkoutPreset();
@@ -218,6 +243,7 @@ const CreatePresetMode: React.FC<CreatePresetModeProps> = ({ navigation, route }
         updateSetField={updateSetField}
         removeSet={removeSet}
         setExerciseRest={setExerciseRest}
+        isEligibleForPrefill={isEligibleForPrefill}
         onAddExercisePress={openExerciseSearch}
       />
     </FormScreenChrome>
@@ -280,7 +306,29 @@ const EditPresetMode: React.FC<EditPresetModeProps> = ({ navigation, route, para
     initialDescriptionRef,
   } = useWorkoutPresetForm();
 
-  const exerciseSetEditing = useExerciseSetEditing({ addExercise, removeExercise, addSet });
+  const [eligibleIds, setEligibleIds] = useState<Set<string>>(() => new Set());
+  const wrappedAddExercise = useCallback(
+    (exercise: Parameters<typeof addExercise>[0]) => {
+      const result = addExercise(exercise);
+      setEligibleIds(prev => {
+        const next = new Set(prev);
+        next.add(result.exerciseClientId);
+        return next;
+      });
+      return result;
+    },
+    [addExercise],
+  );
+  const isEligibleForPrefill = useCallback(
+    (clientId: string) => eligibleIds.has(clientId),
+    [eligibleIds],
+  );
+
+  const exerciseSetEditing = useExerciseSetEditing({
+    addExercise: wrappedAddExercise,
+    removeExercise,
+    addSet,
+  });
   useSelectedExercise(route.params, exerciseSetEditing.handleAddExercise);
 
   const hasPopulatedRef = useRef(false);
@@ -357,6 +405,7 @@ const EditPresetMode: React.FC<EditPresetModeProps> = ({ navigation, route, para
         updateSetField={updateSetField}
         removeSet={removeSet}
         setExerciseRest={setExerciseRest}
+        isEligibleForPrefill={isEligibleForPrefill}
         onAddExercisePress={openExerciseSearch}
       />
     </FormScreenChrome>

--- a/SparkyFitnessMobile/src/services/api/exerciseApi.ts
+++ b/SparkyFitnessMobile/src/services/api/exerciseApi.ts
@@ -6,6 +6,7 @@ import type { Exercise, SuggestedExercisesResponse } from '../../types/exercise'
 import type {
   ExerciseHistoryResponse,
   ExerciseSessionResponse,
+  ExerciseStatsResponse,
   CreatePresetSessionRequest,
   UpdatePresetSessionRequest,
   PresetSessionResponse,
@@ -29,6 +30,16 @@ export const fetchExerciseHistory = async (
     endpoint: `/api/v2/exercise-entries/history?page=${page}&pageSize=${pageSize}`,
     serviceName: 'Exercise API',
     operation: 'fetch exercise history',
+  });
+};
+
+export const fetchExerciseStats = async (
+  exerciseId: string,
+): Promise<ExerciseStatsResponse> => {
+  return apiFetch<ExerciseStatsResponse>({
+    endpoint: `/api/v2/exercises/${encodeURIComponent(exerciseId)}/stats`,
+    serviceName: 'Exercise API',
+    operation: 'fetch exercise stats',
   });
 };
 

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -1115,6 +1115,54 @@ async function getExerciseHistory(userId: any, exerciseId: any, limit = 5) {
     client.release();
   }
 }
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getBestSetForExercise(userId: any, exerciseId: any) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT ee.entry_date::TEXT AS entry_date, ees.weight, ees.reps, ees.set_number
+         FROM exercise_entries ee
+         JOIN exercise_entry_sets ees ON ees.exercise_entry_id = ee.id
+        WHERE ee.user_id = $1
+          AND ee.exercise_id = $2
+          AND ees.weight IS NOT NULL
+        ORDER BY ees.weight DESC,
+                 ees.reps DESC NULLS LAST,
+                 ee.entry_date DESC,
+                 ee.created_at DESC,
+                 ees.set_number DESC,
+                 ees.id DESC
+        LIMIT 1`,
+      [userId, exerciseId]
+    );
+    return result.rows[0] ?? null;
+  } finally {
+    client.release();
+  }
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getLastSetForExercise(userId: any, exerciseId: any) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT ee.entry_date::TEXT AS entry_date, ees.weight, ees.reps, ees.set_number
+         FROM exercise_entries ee
+         JOIN exercise_entry_sets ees ON ees.exercise_entry_id = ee.id
+        WHERE ee.user_id = $1
+          AND ee.exercise_id = $2
+          AND (ees.weight IS NOT NULL OR ees.reps IS NOT NULL)
+        ORDER BY ee.entry_date DESC,
+                 ee.created_at DESC,
+                 ees.set_number DESC,
+                 ees.id DESC
+        LIMIT 1`,
+      [userId, exerciseId]
+    );
+    return result.rows[0] ?? null;
+  } finally {
+    client.release();
+  }
+}
 async function deleteExerciseEntriesByEntrySourceAndDate(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   userId: any,
@@ -1201,6 +1249,8 @@ export { deleteExerciseEntry };
 export { getExerciseEntriesByDate };
 export { getExerciseProgressData };
 export { getExerciseHistory };
+export { getBestSetForExercise };
+export { getLastSetForExercise };
 export { deleteExerciseEntriesByEntrySourceAndDate };
 export default {
   upsertExerciseEntryData,
@@ -1218,5 +1268,7 @@ export default {
   getExerciseEntriesByDate,
   getExerciseProgressData,
   getExerciseHistory,
+  getBestSetForExercise,
+  getLastSetForExercise,
   deleteExerciseEntriesByEntrySourceAndDate,
 };

--- a/SparkyFitnessServer/routes/v2/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/exerciseRoutes.ts
@@ -1,9 +1,12 @@
 import express, { RequestHandler } from 'express';
+import { z } from 'zod';
 import {
   exerciseSearchQuerySchema,
+  exerciseStatsResponseSchema,
   paginatedExercisesResponseSchema,
 } from '@workspace/shared';
 import { authenticate } from '../../middleware/authMiddleware.js';
+import checkPermissionMiddleware from '../../middleware/checkPermissionMiddleware.js';
 import exerciseService from '../../services/exerciseService.js';
 import { log } from '../../config/logging.js';
 
@@ -117,5 +120,75 @@ const searchHandler: RequestHandler = async (req, res, next) => {
 };
 
 router.get('/search', searchHandler);
+
+/**
+ * @swagger
+ * /v2/exercises/{exerciseId}/stats:
+ *   get:
+ *     summary: Per-exercise best set + last set stats
+ *     tags: [Exercise & Workouts]
+ *     description: |
+ *       Returns the caller's all-time best set (heaviest weight; tie-broken by reps DESC, entry_date DESC, created_at DESC)
+ *       and most recent set (entry_date + created_at DESC, then highest set_number) for a single exercise.
+ *       Both fields are null when the user has no qualifying history. Scoped to req.userId.
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: exerciseId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Exercise UUID.
+ *     responses:
+ *       200:
+ *         description: Best set + last set stats.
+ *       400:
+ *         description: Invalid exerciseId (not a UUID).
+ *       401:
+ *         description: Unauthenticated.
+ *       403:
+ *         description: Forbidden (no diary permission when acting on behalf of another user).
+ *       500:
+ *         description: Internal server error.
+ */
+const statsHandler: RequestHandler = async (req, res, next) => {
+  try {
+    const parsed = z
+      .object({ exerciseId: z.string().uuid() })
+      .safeParse(req.params);
+    if (!parsed.success) {
+      res.status(400).json({
+        error: 'Invalid exerciseId',
+        details: parsed.error.flatten().fieldErrors,
+      });
+      return;
+    }
+    const stats = await exerciseService.getExerciseStats(
+      req.userId,
+      parsed.data.exerciseId
+    );
+    const response = exerciseStatsResponseSchema.parse(stats);
+    res.status(200).json(response);
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'ZodError') {
+      log('error', 'v2 exercises stats response validation failed:', error);
+      next(
+        Object.assign(new Error('Internal response validation failed'), {
+          status: 500,
+        })
+      );
+      return;
+    }
+    next(error);
+  }
+};
+
+router.get(
+  '/:exerciseId/stats',
+  checkPermissionMiddleware('diary'),
+  statsHandler
+);
 
 module.exports = router;

--- a/SparkyFitnessServer/services/exerciseService.ts
+++ b/SparkyFitnessServer/services/exerciseService.ts
@@ -202,6 +202,26 @@ async function searchExercisesPaginated(
     throw error;
   }
 }
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mapSetStatsRow(row: any) {
+  return {
+    entryDate: row.entry_date,
+    weight: row.weight,
+    reps: row.reps,
+    setNumber: row.set_number,
+  };
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function getExerciseStats(userId: any, exerciseId: any) {
+  const [bestRow, lastRow] = await Promise.all([
+    exerciseEntryDb.getBestSetForExercise(userId, exerciseId),
+    exerciseEntryDb.getLastSetForExercise(userId, exerciseId),
+  ]);
+  return {
+    bestSet: bestRow ? mapSetStatsRow(bestRow) : null,
+    lastSet: lastRow ? mapSetStatsRow(lastRow) : null,
+  };
+}
 async function getAvailableEquipment() {
   try {
     const equipment = await exerciseDb.getDistinctEquipment();
@@ -2241,6 +2261,7 @@ export { upsertExerciseEntryData };
 export { getExercisesWithPagination };
 export { searchExercises };
 export { searchExercisesPaginated };
+export { getExerciseStats };
 export { getAvailableEquipment };
 export { getAvailableMuscleGroups };
 export { createExercise };
@@ -2277,6 +2298,7 @@ export default {
   getExercisesWithPagination,
   searchExercises,
   searchExercisesPaginated,
+  getExerciseStats,
   getAvailableEquipment,
   getAvailableMuscleGroups,
   createExercise,

--- a/SparkyFitnessServer/tests/exerciseEntriesApiSchemas.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntriesApiSchemas.test.ts
@@ -129,4 +129,84 @@ describe('Exercise entry API schemas', () => {
     const result = runSchema('updatePresetSessionRequestSchema', {});
     expect(result.success).toBe(false);
   });
+
+  it('accepts a stats payload with both bestSet and lastSet populated', () => {
+    const result = runSchema('exerciseStatsResponseSchema', {
+      bestSet: {
+        entryDate: '2026-05-20',
+        weight: 100,
+        reps: 5,
+        setNumber: 3,
+      },
+      lastSet: {
+        entryDate: '2026-05-19',
+        weight: 80,
+        reps: 8,
+        setNumber: 1,
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.bestSet.weight).toBe(100);
+    expect(result.data.lastSet.setNumber).toBe(1);
+  });
+
+  it('accepts a stats payload with both nulls (no history)', () => {
+    const result = runSchema('exerciseStatsResponseSchema', {
+      bestSet: null,
+      lastSet: null,
+    });
+    expect(result).toEqual({
+      success: true,
+      data: { bestSet: null, lastSet: null },
+    });
+  });
+
+  it('accepts lastSet with null weight (bodyweight exercise)', () => {
+    const result = runSchema('exerciseStatsResponseSchema', {
+      bestSet: null,
+      lastSet: {
+        entryDate: '2026-05-19',
+        weight: null,
+        reps: 10,
+        setNumber: 2,
+      },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data.lastSet.weight).toBeNull();
+  });
+
+  it('rejects stats payloads with non-YYYY-MM-DD entryDate', () => {
+    const result = runSchema('exerciseStatsResponseSchema', {
+      bestSet: {
+        entryDate: '05/20/2026',
+        weight: 100,
+        reps: 5,
+        setNumber: 1,
+      },
+      lastSet: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects stats payloads with unknown keys (strict)', () => {
+    const result = runSchema('exerciseStatsResponseSchema', {
+      bestSet: null,
+      lastSet: null,
+      extra: 'nope',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer reps in a set stats row', () => {
+    const result = runSchema('exerciseStatsResponseSchema', {
+      bestSet: {
+        entryDate: '2026-05-20',
+        weight: 100,
+        reps: 5.5,
+        setNumber: 1,
+      },
+      lastSet: null,
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/SparkyFitnessServer/tests/exerciseRoutesV2.test.ts
+++ b/SparkyFitnessServer/tests/exerciseRoutesV2.test.ts
@@ -9,7 +9,25 @@ import exerciseRoutesV2 from '../routes/v2/exerciseRoutes.js';
 vi.mock('../services/exerciseService.js', () => ({
   default: {
     searchExercisesPaginated: vi.fn(),
+    getExerciseStats: vi.fn(),
   },
+}));
+
+// The route registers `checkPermissionMiddleware('diary')` once at module load,
+// so we mock the factory to return a stable middleware that delegates to a
+// swappable handler — tests then mutate `permissionHandler` per-case.
+const { permissionHandlerRef } = vi.hoisted(() => ({
+  permissionHandlerRef: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    current: (_req: any, _res: any, next: any) => next(),
+  },
+}));
+vi.mock('../middleware/checkPermissionMiddleware.js', () => ({
+  default:
+    () =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (req: any, res: any, next: any) =>
+      permissionHandlerRef.current(req, res, next),
 }));
 
 vi.mock('../config/logging.js', () => ({
@@ -73,6 +91,14 @@ describe('GET /v2/exercises/search', () => {
         next();
       }
     );
+    permissionHandlerRef.current = (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      _req: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      _res: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      next: any
+    ) => next();
   });
 
   it('returns 200 with default pagination shape', async () => {
@@ -252,5 +278,122 @@ describe('GET /v2/exercises/search', () => {
 
     expect(res.statusCode).toBe(401);
     expect(exerciseService.searchExercisesPaginated).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /v2/exercises/:exerciseId/stats', () => {
+  const EXERCISE_UUID = '11111111-1111-4111-8111-111111111111';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authenticateMock.mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (req: any, _res: any, next: any) => {
+        req.userId = 'user-123';
+        req.authenticatedUserId = 'user-123';
+        next();
+      }
+    );
+    permissionHandlerRef.current = (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      _req: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      _res: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      next: any
+    ) => next();
+  });
+
+  it('returns 200 with a full payload when both sets are present', async () => {
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseService.getExerciseStats.mockResolvedValue({
+      bestSet: {
+        entryDate: '2026-05-20',
+        weight: 100,
+        reps: 5,
+        setNumber: 3,
+      },
+      lastSet: {
+        entryDate: '2026-05-19',
+        weight: 80,
+        reps: 8,
+        setNumber: 1,
+      },
+    });
+
+    const res = await request(app).get(`/v2/exercises/${EXERCISE_UUID}/stats`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({
+      bestSet: {
+        entryDate: '2026-05-20',
+        weight: 100,
+        reps: 5,
+        setNumber: 3,
+      },
+      lastSet: {
+        entryDate: '2026-05-19',
+        weight: 80,
+        reps: 8,
+        setNumber: 1,
+      },
+    });
+    expect(exerciseService.getExerciseStats).toHaveBeenCalledWith(
+      'user-123',
+      EXERCISE_UUID
+    );
+  });
+
+  it('returns 200 with both nulls when the user has no history', async () => {
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseService.getExerciseStats.mockResolvedValue({
+      bestSet: null,
+      lastSet: null,
+    });
+
+    const res = await request(app).get(`/v2/exercises/${EXERCISE_UUID}/stats`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ bestSet: null, lastSet: null });
+  });
+
+  it('returns 400 when exerciseId is not a UUID', async () => {
+    const res = await request(app).get('/v2/exercises/not-a-uuid/stats');
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Invalid exerciseId');
+    expect(exerciseService.getExerciseStats).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when authenticate rejects', async () => {
+    authenticateMock.mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (_req: any, res: any, _next: any) => {
+        res.status(401).json({ error: 'Unauthenticated' });
+      }
+    );
+
+    const res = await request(app).get(`/v2/exercises/${EXERCISE_UUID}/stats`);
+
+    expect(res.statusCode).toBe(401);
+    expect(exerciseService.getExerciseStats).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when diary permission is denied', async () => {
+    permissionHandlerRef.current = (
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      _req: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      res: any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      _next: any
+    ) => {
+      res.status(403).json({ error: 'Forbidden' });
+    };
+
+    const res = await request(app).get(`/v2/exercises/${EXERCISE_UUID}/stats`);
+
+    expect(res.statusCode).toBe(403);
+    expect(exerciseService.getExerciseStats).not.toHaveBeenCalled();
   });
 });

--- a/SparkyFitnessServer/tests/exerciseService.stats.test.ts
+++ b/SparkyFitnessServer/tests/exerciseService.stats.test.ts
@@ -1,0 +1,155 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import exerciseEntryDb from '../models/exerciseEntry.js';
+import exerciseService from '../services/exerciseService.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+vi.mock('../models/exerciseRepository', () => ({}));
+vi.mock('../models/exercise', () => ({ default: {} }));
+vi.mock('../models/exerciseEntry', () => ({
+  default: {
+    getBestSetForExercise: vi.fn(),
+    getLastSetForExercise: vi.fn(),
+  },
+}));
+vi.mock('../models/activityDetailsRepository', () => ({}));
+vi.mock('../models/exercisePresetEntryRepository.js', () => ({ default: {} }));
+vi.mock('../models/preferenceRepository', () => ({}));
+vi.mock('../models/workoutPresetRepository', () => ({ default: {} }));
+vi.mock('../config/logging', () => ({ log: vi.fn() }));
+vi.mock('../integrations/wger/wgerService', () => ({}));
+vi.mock('../integrations/nutritionix/nutritionixService', () => ({}));
+vi.mock('../integrations/freeexercisedb/FreeExerciseDBService', () => ({}));
+vi.mock('../models/measurementRepository', () => ({}));
+vi.mock('../utils/imageDownloader', () => ({ downloadImage: vi.fn() }));
+vi.mock('../services/CalorieCalculationService', () => ({ default: {} }));
+vi.mock('../utils/uuidUtils', () => ({
+  isValidUuid: vi.fn(),
+  resolveExerciseIdToUuid: vi.fn(),
+}));
+vi.mock('../models/familyAccessRepository', () => ({
+  checkFamilyAccessPermission: vi.fn(),
+}));
+vi.mock('../services/exerciseEntryHistoryService', () => ({
+  getGroupedExerciseSessionById: vi.fn(),
+  getGroupedExerciseSessionByIdWithClient: vi.fn(),
+}));
+
+describe('exerciseService.getExerciseStats', () => {
+  const userId = 'user-1';
+  const exerciseId = '11111111-1111-4111-8111-111111111111';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns mapped best and last sets and runs both queries in parallel', async () => {
+    let resolveBest: (value: unknown) => void = () => {};
+    let resolveLast: (value: unknown) => void = () => {};
+    const bestPromise = new Promise((resolve) => {
+      resolveBest = resolve;
+    });
+    const lastPromise = new Promise((resolve) => {
+      resolveLast = resolve;
+    });
+    // @ts-expect-error TS(2339): mockImplementation not on typed function.
+    exerciseEntryDb.getBestSetForExercise.mockImplementation(() => bestPromise);
+    // @ts-expect-error TS(2339): mockImplementation not on typed function.
+    exerciseEntryDb.getLastSetForExercise.mockImplementation(() => lastPromise);
+
+    const statsPromise = exerciseService.getExerciseStats(userId, exerciseId);
+
+    // Both DB calls must have been issued before either resolves -> parallel.
+    expect(exerciseEntryDb.getBestSetForExercise).toHaveBeenCalledWith(
+      userId,
+      exerciseId
+    );
+    expect(exerciseEntryDb.getLastSetForExercise).toHaveBeenCalledWith(
+      userId,
+      exerciseId
+    );
+
+    resolveBest({
+      entry_date: '2026-05-20',
+      weight: 100,
+      reps: 5,
+      set_number: 3,
+    });
+    resolveLast({
+      entry_date: '2026-05-19',
+      weight: 80,
+      reps: 8,
+      set_number: 1,
+    });
+
+    const result = await statsPromise;
+
+    expect(result).toEqual({
+      bestSet: {
+        entryDate: '2026-05-20',
+        weight: 100,
+        reps: 5,
+        setNumber: 3,
+      },
+      lastSet: {
+        entryDate: '2026-05-19',
+        weight: 80,
+        reps: 8,
+        setNumber: 1,
+      },
+    });
+  });
+
+  it('returns null bestSet when there are no weighted sets', async () => {
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseEntryDb.getBestSetForExercise.mockResolvedValue(null);
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseEntryDb.getLastSetForExercise.mockResolvedValue({
+      entry_date: '2026-05-19',
+      weight: null,
+      reps: 10,
+      set_number: 2,
+    });
+
+    const result = await exerciseService.getExerciseStats(userId, exerciseId);
+
+    expect(result).toEqual({
+      bestSet: null,
+      lastSet: {
+        entryDate: '2026-05-19',
+        weight: null,
+        reps: 10,
+        setNumber: 2,
+      },
+    });
+  });
+
+  it('returns both nulls when the user has no history for the exercise', async () => {
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseEntryDb.getBestSetForExercise.mockResolvedValue(null);
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseEntryDb.getLastSetForExercise.mockResolvedValue(null);
+
+    const result = await exerciseService.getExerciseStats(userId, exerciseId);
+
+    expect(result).toEqual({ bestSet: null, lastSet: null });
+  });
+
+  it('passes entry_date through untouched (already day-string from ::TEXT)', async () => {
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseEntryDb.getBestSetForExercise.mockResolvedValue({
+      entry_date: '2025-12-31',
+      weight: 50,
+      reps: 12,
+      set_number: 1,
+    });
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseEntryDb.getLastSetForExercise.mockResolvedValue(null);
+
+    const result = await exerciseService.getExerciseStats(userId, exerciseId);
+
+    expect(result.bestSet?.entryDate).toBe('2025-12-31');
+  });
+});

--- a/shared/src/schemas/api/ExerciseEntries.api.zod.ts
+++ b/shared/src/schemas/api/ExerciseEntries.api.zod.ts
@@ -262,6 +262,24 @@ export const exerciseHistoryResponseSchema = z
   })
   .strict();
 
+// --- Per-exercise stats endpoint ---
+
+export const exerciseSetStatsSchema = z
+  .object({
+    entryDate: dateStringSchema,
+    weight: z.number().nullable(),
+    reps: z.number().int().nullable(),
+    setNumber: z.number().int(),
+  })
+  .strict();
+
+export const exerciseStatsResponseSchema = z
+  .object({
+    bestSet: exerciseSetStatsSchema.nullable(),
+    lastSet: exerciseSetStatsSchema.nullable(),
+  })
+  .strict();
+
 // --- Types ---
 
 export type ExerciseHistoryQuery = z.infer<typeof exerciseHistoryQuerySchema>;
@@ -306,3 +324,5 @@ export type ExerciseHistoryResponse = z.infer<
 export type ExerciseProgressResponse = z.infer<
   typeof exerciseProgressResponseSchema
 >;
+export type ExerciseSetStats = z.infer<typeof exerciseSetStatsSchema>;
+export type ExerciseStatsResponse = z.infer<typeof exerciseStatsResponseSchema>;


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

This PR adds a feature that prefills the last workout reps and weight when creating a new workout.
It also shows the user's personal best.
I chose to use the highest historical weight for PB but can change it to 1RM if people think that's better.


Linked Issue: Addresses #1262

## How to Test

1. Create a new workout
2. Add exercise
3. See prefilled values and PB
4. Also PB on edit form

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots


<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-05-22 at 18 38 31" src="https://github.com/user-attachments/assets/93b44795-001d-4b98-b12f-68e0ff2c0468" />

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
