### PR TITLE
feat(mobile): what's new screen

### DIFF
--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -57,6 +57,7 @@ import FoodSettingsScreen from './src/screens/FoodSettingsScreen';
 import ServerSettingsScreen from './src/screens/ServerSettingsScreen';
 import AppSettingsScreen from './src/screens/AppSettingsScreen';
 import AboutScreen from './src/screens/AboutScreen';
+import WhatsNewScreen from './src/screens/WhatsNewScreen';
 import MeasurementsAddScreen from './src/screens/MeasurementsAddScreen';
 import OnboardingScreen from './src/screens/OnboardingScreen';
 import ReauthModal from './src/components/ReauthModal';
@@ -159,6 +160,7 @@ const SafeFoodSettings = withErrorBoundary(FoodSettingsScreen, 'FoodSettings', {
 const SafeServerSettings = withErrorBoundary(ServerSettingsScreen, 'ServerSettings', { canGoBack: true });
 const SafeAppSettings = withErrorBoundary(AppSettingsScreen, 'AppSettings', { canGoBack: true });
 const SafeAbout = withErrorBoundary(AboutScreen, 'About', { canGoBack: true });
+const SafeWhatsNew = withErrorBoundary(WhatsNewScreen, 'WhatsNew', { canGoBack: true });
 
 function AppContent() {
   const { theme } = useUniwind();
@@ -967,6 +969,13 @@ function AppContent() {
           <Stack.Screen
             name="About"
             component={SafeAbout}
+            options={{
+              headerShown: false,
+            }}
+          />
+          <Stack.Screen
+            name="WhatsNew"
+            component={SafeWhatsNew}
             options={{
               headerShown: false,
             }}

--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -99,6 +99,7 @@ import AddSheet, { addSheetRef } from './src/components/AddSheet';
 import { toastConfig } from './src/components/ui/toastConfig';
 import CustomTabBar from './src/components/CustomTabBar';
 import ActiveWorkoutBar, { navigationRef as rootNavigationRef } from './src/components/ActiveWorkoutBar';
+import WhatsNewBanner from './src/components/WhatsNewBanner';
 import { withErrorBoundary } from './src/components/ScreenErrorBoundary';
 
 SplashScreen.preventAutoHideAsync();
@@ -665,6 +666,7 @@ function AppContent() {
                   // paints on top of the embedded bar — matching the mockup
                   // where the + button visually bridges both bars.
                   <View collapsable={false}>
+                    <WhatsNewBanner />
                     <ActiveWorkoutBar variant="embedded" />
                     <CustomTabBar {...props} />
                   </View>

--- a/SparkyFitnessMobile/__tests__/services/whatsNewBanner.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/whatsNewBanner.test.ts
@@ -1,0 +1,49 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  getLastSeenWhatsNewVersion,
+  markCurrentVersionSeen,
+  markWhatsNewVersionSeen,
+} from '../../src/services/whatsNewBanner';
+
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: { expoConfig: { version: '1.4.0' } },
+}));
+
+jest.mock('../../src/services/LogService', () => ({
+  addLog: jest.fn(),
+}));
+
+describe('whatsNewBanner', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  test('getLastSeenWhatsNewVersion returns null before mark', async () => {
+    await expect(getLastSeenWhatsNewVersion()).resolves.toBeNull();
+  });
+
+  test('markWhatsNewVersionSeen persists, getLastSeen returns the version', async () => {
+    await markWhatsNewVersionSeen('1.4.0');
+    await expect(getLastSeenWhatsNewVersion()).resolves.toBe('1.4.0');
+  });
+
+  test('markWhatsNewVersionSeen overwrites previous value', async () => {
+    await markWhatsNewVersionSeen('1.4.0');
+    await markWhatsNewVersionSeen('1.5.0');
+    await expect(getLastSeenWhatsNewVersion()).resolves.toBe('1.5.0');
+  });
+
+  test('storage key matches namespaced format', async () => {
+    await markWhatsNewVersionSeen('1.4.0');
+    await expect(
+      AsyncStorage.getItem('@WhatsNew:lastSeenVersion'),
+    ).resolves.toBe('1.4.0');
+  });
+
+  test('markCurrentVersionSeen stamps the Expo config version', async () => {
+    await markCurrentVersionSeen();
+    await expect(getLastSeenWhatsNewVersion()).resolves.toBe('1.4.0');
+  });
+});

--- a/SparkyFitnessMobile/src/components/DevTools.tsx
+++ b/SparkyFitnessMobile/src/components/DevTools.tsx
@@ -6,6 +6,7 @@ import { seedHealthData, seedHistoricalSteps } from '../services/seedHealthData'
 import { triggerManualSync } from '../services/backgroundSyncService';
 import { notifySessionExpired } from '../services/api/authService';
 import { getActiveServerConfig } from '../services/storage';
+import { resetWhatsNewBanner } from '../services/whatsNewBanner';
 import { openHealthConnectSettings, openHealthConnectDataManagement, getGrantedPermissions } from 'react-native-health-connect';
 
 const DevTools: React.FC = () => {
@@ -190,6 +191,29 @@ const DevTools: React.FC = () => {
             }}
           >
             <Text className="text-white text-base font-bold">Show ReauthModal</Text>
+          </Button>
+        </View>
+      </View>
+
+      <View className="mt-5">
+        <Text className="text-sm text-text-primary">What's New Banner</Text>
+        <Text className="text-text-muted mb-3 text-[13px]">
+          Clear the last-seen version so the banner re-appears above the tab bar.
+        </Text>
+        <View className="flex-row gap-2 flex-wrap">
+          <Button
+            variant="primary"
+            className="py-2 px-4 rounded-lg my-1 self-center min-w-30"
+            onPress={async () => {
+              await resetWhatsNewBanner();
+              Toast.show({
+                type: 'success',
+                text1: 'Reset',
+                text2: "What's New banner will re-appear.",
+              });
+            }}
+          >
+            <Text className="text-white text-base font-bold">Reset Banner</Text>
           </Button>
         </View>
       </View>

--- a/SparkyFitnessMobile/src/components/DevTools.tsx
+++ b/SparkyFitnessMobile/src/components/DevTools.tsx
@@ -196,7 +196,7 @@ const DevTools: React.FC = () => {
       </View>
 
       <View className="mt-5">
-        <Text className="text-sm text-text-primary">What's New Banner</Text>
+        <Text className="text-sm text-text-primary">What&apos;s New Banner</Text>
         <Text className="text-text-muted mb-3 text-[13px]">
           Clear the last-seen version so the banner re-appears above the tab bar.
         </Text>

--- a/SparkyFitnessMobile/src/components/ExerciseProgressCard.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseProgressCard.tsx
@@ -18,7 +18,8 @@ const ProgressBar: React.FC<ProgressBarProps> = ({ label, current, goal, unit, c
   const [barWidth, setBarWidth] = useState(0);
   const barHeight = 8;
   const borderRadius = 4;
-  const progress = goal > 0 ? current / goal : 0;
+  const progress = goal > 0 ? current / goal : current > 0 ? 1 : 0;
+  const showBar = goal > 0 || current > 0;
 
   const animatedProgress = useSharedValue(0);
 
@@ -60,48 +61,44 @@ const ProgressBar: React.FC<ProgressBarProps> = ({ label, current, goal, unit, c
     width: overflowWidth.value,
   }));
 
-  const hasGoal = goal > 0;
-
   return (
     <View>
       <View className="flex-row justify-between items-center mb-2">
         <Text className="text-sm font-semibold text-text-primary">{label}</Text>
         <Text className="text-sm text-text-primary">
-          {hasGoal ? `${Math.round(current)} / ${Math.round(goal)} ${unit}` : `${Math.round(current)} ${unit}`}
+          {goal > 0 ? `${Math.round(current)} / ${Math.round(goal)} ${unit}` : `${Math.round(current)} ${unit}`}
         </Text>
       </View>
-      {hasGoal && (
-        <View
-          className="h-3"
-          onLayout={(e) => setBarWidth(e.nativeEvent.layout.width)}
-        >
-          {barWidth > 0 && (
-            <View
-              style={{
-                width: barWidth,
-                height: barHeight,
-                borderRadius,
-                overflow: 'hidden',
-                backgroundColor: trackColor,
-                opacity,
-              }}
-            >
-              <Animated.View
-                style={[
-                  { position: 'absolute', left: 0, top: 0, height: barHeight, backgroundColor: color },
-                  fillStyle,
-                ]}
-              />
-              <Animated.View
-                style={[
-                  { position: 'absolute', top: 0, height: barHeight, backgroundColor: color, opacity: 0.65 },
-                  overflowStyle,
-                ]}
-              />
-            </View>
-          )}
-        </View>
-      )}
+      {showBar && <View
+        className="h-3"
+        onLayout={(e) => setBarWidth(e.nativeEvent.layout.width)}
+      >
+        {barWidth > 0 && (
+          <View
+            style={{
+              width: barWidth,
+              height: barHeight,
+              borderRadius,
+              overflow: 'hidden',
+              backgroundColor: trackColor,
+              opacity,
+            }}
+          >
+            <Animated.View
+              style={[
+                { position: 'absolute', left: 0, top: 0, height: barHeight, backgroundColor: color },
+                fillStyle,
+              ]}
+            />
+            <Animated.View
+              style={[
+                { position: 'absolute', top: 0, height: barHeight, backgroundColor: color, opacity: 0.65 },
+                overflowStyle,
+              ]}
+            />
+          </View>
+        )}
+      </View>}
     </View>
   );
 };

--- a/SparkyFitnessMobile/src/components/Icon.tsx
+++ b/SparkyFitnessMobile/src/components/Icon.tsx
@@ -105,6 +105,7 @@ const ICON_MAP = {
   'app-settings': { sf: 'slider.horizontal.3', ion: 'options-outline' },
   'logs': { sf: 'doc.plaintext', ion: 'document-text-outline' },
   'about': { sf: 'info.circle', ion: 'information-circle-outline' },
+  'sparkle': { sf: 'sparkles', ion: 'sparkles-outline' },
 } as const;
 
 export type IconName = keyof typeof ICON_MAP;

--- a/SparkyFitnessMobile/src/components/WhatsNewBanner.tsx
+++ b/SparkyFitnessMobile/src/components/WhatsNewBanner.tsx
@@ -102,10 +102,10 @@ const WhatsNewBanner: React.FC = () => {
         </View>
         <View className="flex-1 px-3">
           <Text className="text-sm font-semibold text-text-primary">
-            What's new
+            What&apos;s new
           </Text>
           <Text numberOfLines={1} className="text-xs text-text-secondary">
-            See what's improved in this update
+            See what&apos;s improved in this update
           </Text>
         </View>
         <Pressable

--- a/SparkyFitnessMobile/src/components/WhatsNewBanner.tsx
+++ b/SparkyFitnessMobile/src/components/WhatsNewBanner.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useState } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import Constants from 'expo-constants';
+import { useCSSVariable } from 'uniwind';
+
+import Icon from './Icon';
+import { navigationRef } from './ActiveWorkoutBar';
+import { useActiveWorkoutStore } from '../stores/activeWorkoutStore';
+import {
+  getLastSeenWhatsNewVersion,
+  markWhatsNewVersionSeen,
+  subscribeToWhatsNewBannerReset,
+} from '../services/whatsNewBanner';
+
+// CustomTabBar's floating Add button rises 20pt above the tab bar's top edge
+// (`-mt-5`). When no workout is active, this banner is the direct sibling
+// above the tab bar, so it must reserve a 20pt dead strip below its content
+// or the FAB will overlap the row.
+const FAB_CLEARANCE = 20;
+
+type Phase = 'evaluating' | 'eligible' | 'dismissed' | 'ineligible';
+
+const WhatsNewBanner: React.FC = () => {
+  const workoutActive = useActiveWorkoutStore((s) => s.sessionId !== null);
+  const [phase, setPhase] = useState<Phase>('evaluating');
+  const [resetTick, setResetTick] = useState(0);
+  const currentVersion = Constants.expoConfig?.version ?? null;
+
+  // Dev Tools can clear `lastSeenVersion` at runtime — bump the tick so the
+  // evaluation effect below re-runs and the banner can re-appear without
+  // restarting the app.
+  useEffect(
+    () => subscribeToWhatsNewBannerReset(() => setResetTick((t) => t + 1)),
+    [],
+  );
+
+  const [accentPrimary, textMuted] = useCSSVariable([
+    '--color-accent-primary',
+    '--color-text-muted',
+  ]) as [string, string];
+
+  useEffect(() => {
+    if (!currentVersion) {
+      setPhase('ineligible');
+      return;
+    }
+    setPhase('evaluating');
+    let cancelled = false;
+    void (async () => {
+      const lastSeen = await getLastSeenWhatsNewVersion();
+      if (cancelled) return;
+      if (lastSeen === currentVersion) {
+        setPhase('ineligible');
+        return;
+      }
+      // A null lastSeen means this user is upgrading from a pre-banner build.
+      // Fresh installs are stamped via `markCurrentVersionSeen` on onboarding
+      // completion, so by the time the banner mounts on Tabs, null can only
+      // mean an in-place upgrade — show the banner.
+      setPhase('eligible');
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentVersion, resetTick]);
+
+  // Mark the version seen as soon as the banner actually renders — a banner
+  // the user ignores still consumes the prompt, so we don't re-pester next
+  // launch. Skipped while a workout is active so launching with an in-flight
+  // workout doesn't burn the prompt without ever displaying.
+  const shouldRender = phase === 'eligible' && !workoutActive;
+  useEffect(() => {
+    if (shouldRender && currentVersion) {
+      void markWhatsNewVersionSeen(currentVersion);
+    }
+  }, [shouldRender, currentVersion]);
+
+  if (!shouldRender) return null;
+
+  const handleTap = () => {
+    setPhase('dismissed');
+    if (navigationRef.isReady()) {
+      navigationRef.navigate('WhatsNew');
+    }
+  };
+
+  const handleDismiss = () => setPhase('dismissed');
+
+  return (
+    <View
+      className="bg-chrome border-t border-chrome-border"
+      style={{ paddingBottom: FAB_CLEARANCE }}
+    >
+      <Pressable
+        onPress={handleTap}
+        accessibilityRole="button"
+        accessibilityLabel="See what's new in this update"
+        className="flex-row items-center px-4 py-3"
+      >
+        <View className="h-9 w-9 items-center justify-center rounded-full bg-accent-primary/15">
+          <Icon name="sparkle" size={20} color={accentPrimary} weight="bold" />
+        </View>
+        <View className="flex-1 px-3">
+          <Text className="text-sm font-semibold text-text-primary">
+            What's new
+          </Text>
+          <Text numberOfLines={1} className="text-xs text-text-secondary">
+            See what's improved in this update
+          </Text>
+        </View>
+        <Pressable
+          onPress={handleDismiss}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+          accessibilityRole="button"
+          accessibilityLabel="Dismiss"
+          className="p-2"
+        >
+          <Icon name="close" size={20} color={textMuted} weight="bold" />
+        </Pressable>
+      </Pressable>
+    </View>
+  );
+};
+
+export default WhatsNewBanner;

--- a/SparkyFitnessMobile/src/screens/AboutScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/AboutScreen.tsx
@@ -72,7 +72,7 @@ const AboutScreen: React.FC<AboutScreenProps> = ({ navigation }) => {
           </TouchableOpacity>
 
           <TouchableOpacity
-            className="p-4 flex-row items-center justify-between"
+            className="p-4 flex-row items-center justify-between border-b border-border-subtle"
             onPress={() => openUrl(DOCUMENTATION_URL)}
             activeOpacity={0.7}
           >

--- a/SparkyFitnessMobile/src/screens/OnboardingScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/OnboardingScreen.tsx
@@ -30,6 +30,7 @@ import {
 } from '../services/api/authService';
 import { saveServerConfig } from '../services/storage';
 import { addLog } from '../services/LogService';
+import { markCurrentVersionSeen } from '../services/whatsNewBanner';
 import { queryClient, serverConnectionQueryKey } from '../hooks';
 import type { RootStackScreenProps } from '../types/navigation';
 
@@ -117,10 +118,12 @@ export default function OnboardingScreen({ navigation }: Props) {
   // --- Navigation helpers ---
 
   const finishOnboarding = () => {
+    void markCurrentVersionSeen();
     navigation.replace('Tabs', { screen: 'Settings' });
   };
 
   const finishWithConnection = () => {
+    void markCurrentVersionSeen();
     queryClient.invalidateQueries({ queryKey: serverConnectionQueryKey });
     navigation.replace('Tabs', { screen: 'Dashboard' });
   };

--- a/SparkyFitnessMobile/src/screens/ServerSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ServerSettingsScreen.tsx
@@ -41,7 +41,7 @@ const ServerSettingsScreen: React.FC<ServerSettingsScreenProps> = ({ navigation 
     '--color-accent-primary',
     '--color-text-secondary',
     '--color-text-link',
-    '--color-text-success',
+    '--color-icon-success',
     '--color-bg-danger',
   ]) as [string, string, string, string, string];
 

--- a/SparkyFitnessMobile/src/screens/SettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SettingsScreen.tsx
@@ -157,15 +157,21 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation }) => {
                   onPress={() => navigation.navigate('FoodSettings')}
                   iconColor={catOrange}
                 />
+                <SettingsRow
+                  icon="app-settings"
+                  title="App Settings"
+                  onPress={() => navigation.navigate('AppSettings')}
+                  iconColor={catViolet}
+                />
               </SettingsRowGroup>
             )}
 
             <SettingsRowGroup>
               <SettingsRow
-                icon="app-settings"
-                title="App Settings"
-                onPress={() => navigation.navigate('AppSettings')}
-                iconColor={catViolet}
+                icon="sparkle"
+                title="What's New"
+                onPress={() => navigation.navigate('WhatsNew')}
+                iconColor={catPink}
               />
               <SettingsRow
                 icon="document-text"

--- a/SparkyFitnessMobile/src/screens/SettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SettingsScreen.tsx
@@ -54,7 +54,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation }) => {
     : 'Never synced';
 
   const [success, danger, catSlate, catPink, catViolet, catOrange, catCalories, hydration] = useCSSVariable([
-    '--color-text-success',
+    '--color-icon-success',
     '--color-bg-danger',
     '--color-cat-slate',
     '--color-cat-pink',
@@ -143,28 +143,30 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation }) => {
               iconColor={catPink}
             />
 
-            {isConnected && (
-              <SettingsRowGroup>
+            <SettingsRowGroup>
+              {isConnected && (
                 <SettingsRow
                   icon="calorie-settings"
                   title="Calorie Settings"
                   onPress={() => navigation.navigate('CalorieSettings')}
                   iconColor={catCalories}
                 />
+              )}
+              {isConnected && (
                 <SettingsRow
                   icon="food-search-settings"
                   title="Food Search Settings"
                   onPress={() => navigation.navigate('FoodSettings')}
                   iconColor={catOrange}
                 />
-                <SettingsRow
-                  icon="app-settings"
-                  title="App Settings"
-                  onPress={() => navigation.navigate('AppSettings')}
-                  iconColor={catViolet}
-                />
-              </SettingsRowGroup>
-            )}
+              )}
+              <SettingsRow
+                icon="app-settings"
+                title="App Settings"
+                onPress={() => navigation.navigate('AppSettings')}
+                iconColor={catViolet}
+              />
+            </SettingsRowGroup>
 
             <SettingsRowGroup>
               <SettingsRow

--- a/SparkyFitnessMobile/src/screens/WhatsNewScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WhatsNewScreen.tsx
@@ -4,7 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
 
 import Button from '../components/ui/Button';
-import Icon, { type IconName } from '../components/Icon';
+import Icon from '../components/Icon';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { getTodayDate } from '../utils/dateUtils';
 import type { RootStackScreenProps } from '../types/navigation';
@@ -12,38 +12,221 @@ import type { RootStackScreenProps } from '../types/navigation';
 type WhatsNewScreenProps = RootStackScreenProps<'WhatsNew'>;
 
 type Feature = {
-  icon: IconName;
-  tint: string;
   eyebrow: string;
   headline: string;
   body: string;
+  hero: React.ReactNode;
   cta?: { label: string; onPress: () => void };
+};
+
+const WidgetMockup: React.FC = () => {
+  const [
+    calorieColor,
+    catViolet,
+    macroProtein,
+    macroCarbs,
+    macroFat,
+    hydration,
+    exercise,
+    catPink,
+    catOrange,
+  ] = useCSSVariable([
+    '--color-calories',
+    '--color-cat-violet',
+    '--color-macro-protein',
+    '--color-macro-carbs',
+    '--color-macro-fat',
+    '--color-hydration',
+    '--color-exercise',
+    '--color-cat-pink',
+    '--color-cat-orange',
+  ]) as [string, string, string, string, string, string, string, string, string];
+
+  const iconPositions: Array<{
+    top?: number;
+    bottom?: number;
+    left?: number;
+    right?: number;
+    color: string;
+  }> = [
+    { top: 14, left: 24, color: macroProtein },
+    { top: 14, left: 68, color: macroCarbs },
+    { top: 14, right: 68, color: macroFat },
+    { top: 14, right: 24, color: hydration },
+    { top: 75, left: 18, color: exercise },
+    { top: 75, right: 18, color: catPink },
+    { bottom: 14, left: 24, color: catOrange },
+    { bottom: 14, left: 68, color: hydration },
+    { bottom: 14, right: 68, color: macroProtein },
+    { bottom: 14, right: 24, color: macroCarbs },
+  ];
+
+  return (
+    <View
+      className="h-44 items-center justify-center overflow-hidden"
+      style={{ backgroundColor: `${catViolet}20` }}
+    >
+      {iconPositions.map((pos, i) => (
+        <View
+          key={i}
+          className="absolute rounded-md"
+          style={{
+            width: 22,
+            height: 22,
+            top: pos.top,
+            bottom: pos.bottom,
+            left: pos.left,
+            right: pos.right,
+            backgroundColor: pos.color,
+            opacity: 0.5,
+          }}
+        />
+      ))}
+
+      <View
+        className="bg-surface rounded-2xl shadow-md justify-center px-4"
+        style={{ width: 132, height: 108 }}
+      >
+        <Text className="text-[10px] font-semibold tracking-wider text-text-secondary mb-0.5">
+          TODAY
+        </Text>
+        <Text className="text-2xl font-bold text-text-primary" style={{ color: calorieColor }}>
+          1,515
+        </Text>
+        <Text className="text-[11px] text-text-secondary mb-2">kcal left</Text>
+        <View className="flex-row">
+          <View className="flex-1">
+            <Text className="text-[9px] text-text-secondary">In</Text>
+            <Text className="text-[11px] font-medium text-text-primary">1,540</Text>
+          </View>
+          <View className="flex-1">
+            <Text className="text-[9px] text-text-secondary">Out</Text>
+            <Text className="text-[11px] font-medium text-text-primary">255</Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const PhotoMockup: React.FC = () => {
+  const [catOrange, macroProtein, macroCarbs, macroFat, textPrimary] = useCSSVariable([
+    '--color-cat-orange',
+    '--color-macro-protein',
+    '--color-macro-carbs',
+    '--color-macro-fat',
+    '--color-text-primary',
+  ]) as [string, string, string, string, string];
+
+  return (
+    <View
+      className="h-44 items-center justify-center"
+      style={{ backgroundColor: `${catOrange}20` }}
+    >
+      <View
+        className="bg-surface rounded-2xl shadow-md overflow-hidden"
+        style={{ width: 200, height: 132, transform: [{ rotate: '-3deg' }] }}
+      >
+        <View
+          className="absolute"
+          style={{
+            left: 60,
+            top: 22,
+            width: 88,
+            height: 88,
+            borderRadius: 44,
+            backgroundColor: `${textPrimary}12`,
+          }}
+        />
+        <View
+          className="absolute"
+          style={{
+            left: 70,
+            top: 32,
+            width: 42,
+            height: 36,
+            borderRadius: 18,
+            backgroundColor: macroProtein,
+          }}
+        />
+        <View
+          className="absolute"
+          style={{
+            left: 96,
+            top: 56,
+            width: 46,
+            height: 36,
+            borderRadius: 18,
+            backgroundColor: macroCarbs,
+          }}
+        />
+        <View
+          className="absolute"
+          style={{
+            left: 62,
+            top: 68,
+            width: 32,
+            height: 30,
+            borderRadius: 15,
+            backgroundColor: macroFat,
+          }}
+        />
+        <View
+          className="absolute rounded-full items-center justify-center"
+          style={{
+            top: 8,
+            right: 8,
+            width: 24,
+            height: 24,
+            backgroundColor: catOrange,
+          }}
+        >
+          <Icon name="sparkle" size={12} color="#FFFFFF" weight="semibold" />
+        </View>
+      </View>
+
+      <View
+        className="bg-surface rounded-full px-3 py-1.5 shadow-md flex-row items-center"
+        style={{
+          position: 'absolute',
+          bottom: 22,
+          right: 28,
+          transform: [{ rotate: '2deg' }],
+        }}
+      >
+        <View
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: 3,
+            backgroundColor: catOrange,
+            marginRight: 6,
+          }}
+        />
+        <Text className="text-xs font-semibold text-text-primary">~412 kcal</Text>
+      </View>
+    </View>
+  );
 };
 
 const WhatsNewScreen: React.FC<WhatsNewScreenProps> = ({ navigation }) => {
   const insets = useSafeAreaInsets();
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
 
-  const [accentPrimary, catViolet, catOrange] = useCSSVariable([
-    '--color-accent-primary',
-    '--color-cat-violet',
-    '--color-cat-orange',
-  ]) as [string, string, string];
+  const accentPrimary = useCSSVariable('--color-accent-primary') as string;
 
   const features: Feature[] = [
     {
-      icon: 'app-settings',
-      tint: catViolet,
       eyebrow: 'HOME SCREEN WIDGET',
       headline: 'Calories on your home screen',
       body: "See where your day stands at a glance. Add SparkyFitness from your home screen's widget gallery.",
+      hero: <WidgetMockup />,
     },
     {
-      icon: 'camera-reverse',
-      tint: catOrange,
       eyebrow: 'AI PHOTO SCAN',
       headline: 'Snap a meal, log the macros',
       body: "Estimate nutrition from a photo when you're short on time.",
+      hero: <PhotoMockup />,
       cta: {
         label: 'Try it out',
         onPress: () =>
@@ -81,12 +264,7 @@ const WhatsNewScreen: React.FC<WhatsNewScreenProps> = ({ navigation }) => {
             key={feature.headline}
             className="bg-surface rounded-xl mb-4 shadow-sm overflow-hidden"
           >
-            <View
-              className="h-32 items-center justify-center"
-              style={{ backgroundColor: `${feature.tint}20` }}
-            >
-              <Icon name={feature.icon} size={56} color={feature.tint} weight="semibold" />
-            </View>
+            {feature.hero}
 
             <View className="p-4">
               <Text className="text-xs font-semibold tracking-wider text-accent-primary mb-1">

--- a/SparkyFitnessMobile/src/screens/WhatsNewScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WhatsNewScreen.tsx
@@ -42,13 +42,13 @@ const WidgetMockup: React.FC = () => {
     '--color-cat-orange',
   ]) as [string, string, string, string, string, string, string, string, string];
 
-  const iconPositions: Array<{
+  const iconPositions: {
     top?: number;
     bottom?: number;
     left?: number;
     right?: number;
     color: string;
-  }> = [
+  }[] = [
     { top: 14, left: 24, color: macroProtein },
     { top: 14, left: 68, color: macroCarbs },
     { top: 14, right: 68, color: macroFat },
@@ -243,7 +243,7 @@ const WhatsNewScreen: React.FC<WhatsNewScreenProps> = ({ navigation }) => {
       <ScrollView
         contentContainerStyle={{
           padding: 16,
-          paddingBottom: insets.bottom + 80 + activeWorkoutBarPadding,
+          paddingBottom: insets.bottom + 16 + activeWorkoutBarPadding,
         }}
         contentInsetAdjustmentBehavior="never"
       >
@@ -256,7 +256,7 @@ const WhatsNewScreen: React.FC<WhatsNewScreenProps> = ({ navigation }) => {
           >
             <Icon name="chevron-back" size={22} color={accentPrimary} />
           </Button>
-          <Text className="text-2xl font-bold text-text-primary">What's New</Text>
+          <Text className="text-2xl font-bold text-text-primary">What&apos;s New</Text>
         </View>
 
         {features.map((feature) => (

--- a/SparkyFitnessMobile/src/screens/WhatsNewScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WhatsNewScreen.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { View, Text, ScrollView } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useCSSVariable } from 'uniwind';
+
+import Button from '../components/ui/Button';
+import Icon, { type IconName } from '../components/Icon';
+import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
+import { getTodayDate } from '../utils/dateUtils';
+import type { RootStackScreenProps } from '../types/navigation';
+
+type WhatsNewScreenProps = RootStackScreenProps<'WhatsNew'>;
+
+type Feature = {
+  icon: IconName;
+  tint: string;
+  eyebrow: string;
+  headline: string;
+  body: string;
+  cta?: { label: string; onPress: () => void };
+};
+
+const WhatsNewScreen: React.FC<WhatsNewScreenProps> = ({ navigation }) => {
+  const insets = useSafeAreaInsets();
+  const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
+
+  const [accentPrimary, catViolet, catOrange] = useCSSVariable([
+    '--color-accent-primary',
+    '--color-cat-violet',
+    '--color-cat-orange',
+  ]) as [string, string, string];
+
+  const features: Feature[] = [
+    {
+      icon: 'app-settings',
+      tint: catViolet,
+      eyebrow: 'HOME SCREEN WIDGET',
+      headline: 'Calories on your home screen',
+      body: "See where your day stands at a glance. Add SparkyFitness from your home screen's widget gallery.",
+    },
+    {
+      icon: 'camera-reverse',
+      tint: catOrange,
+      eyebrow: 'AI PHOTO SCAN',
+      headline: 'Snap a meal, log the macros',
+      body: "Estimate nutrition from a photo when you're short on time.",
+      cta: {
+        label: 'Try it out',
+        onPress: () =>
+          navigation.navigate('FoodScan', {
+            date: getTodayDate(),
+            initialMode: 'photo',
+          }),
+      },
+    },
+  ];
+
+  return (
+    <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
+      <ScrollView
+        contentContainerStyle={{
+          padding: 16,
+          paddingBottom: insets.bottom + 80 + activeWorkoutBarPadding,
+        }}
+        contentInsetAdjustmentBehavior="never"
+      >
+        <View className="flex-row items-center mb-4">
+          <Button
+            variant="ghost"
+            onPress={() => navigation.goBack()}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            className="py-0 px-0 mr-2"
+          >
+            <Icon name="chevron-back" size={22} color={accentPrimary} />
+          </Button>
+          <Text className="text-2xl font-bold text-text-primary">What's New</Text>
+        </View>
+
+        {features.map((feature) => (
+          <View
+            key={feature.headline}
+            className="bg-surface rounded-xl mb-4 shadow-sm overflow-hidden"
+          >
+            <View
+              className="h-32 items-center justify-center"
+              style={{ backgroundColor: `${feature.tint}20` }}
+            >
+              <Icon name={feature.icon} size={56} color={feature.tint} weight="semibold" />
+            </View>
+
+            <View className="p-4">
+              <Text className="text-xs font-semibold tracking-wider text-accent-primary mb-1">
+                {feature.eyebrow}
+              </Text>
+              <Text className="text-lg font-bold text-text-primary mb-1">
+                {feature.headline}
+              </Text>
+              <Text className="text-text-secondary text-sm leading-5 mb-4">
+                {feature.body}
+              </Text>
+
+              {feature.cta ? (
+                <Button variant="primary" onPress={feature.cta.onPress} className="self-start">
+                  {feature.cta.label}
+                </Button>
+              ) : null}
+            </View>
+          </View>
+        ))}
+      </ScrollView>
+    </View>
+  );
+};
+
+export default WhatsNewScreen;

--- a/SparkyFitnessMobile/src/services/whatsNewBanner.ts
+++ b/SparkyFitnessMobile/src/services/whatsNewBanner.ts
@@ -1,0 +1,72 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Constants from 'expo-constants';
+import { addLog } from './LogService';
+
+const LAST_SEEN_VERSION_KEY = '@WhatsNew:lastSeenVersion';
+
+export async function getLastSeenWhatsNewVersion(): Promise<string | null> {
+  try {
+    return await AsyncStorage.getItem(LAST_SEEN_VERSION_KEY);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    addLog(
+      `[WhatsNew Banner] Failed to read last seen version: ${message}`,
+      'WARNING',
+    );
+    return null;
+  }
+}
+
+export async function markWhatsNewVersionSeen(version: string): Promise<void> {
+  try {
+    await AsyncStorage.setItem(LAST_SEEN_VERSION_KEY, version);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    addLog(
+      `[WhatsNew Banner] Failed to persist last seen version: ${message}`,
+      'WARNING',
+    );
+  }
+}
+
+// Stamps the current app version as already-seen. Called from the onboarding
+// completion paths so that fresh installs never see the banner — by contrast,
+// users upgrading from a pre-banner build never pass through onboarding, so
+// their `lastSeenVersion` stays null and the banner fires for them.
+export async function markCurrentVersionSeen(): Promise<void> {
+  const version = Constants.expoConfig?.version;
+  if (!version) return;
+  await markWhatsNewVersionSeen(version);
+}
+
+// Dev-only: subscribers fire after `resetWhatsNewBanner` clears storage so the
+// already-mounted banner can re-evaluate without needing an app restart.
+const resetSubscribers = new Set<() => void>();
+
+export function subscribeToWhatsNewBannerReset(cb: () => void): () => void {
+  resetSubscribers.add(cb);
+  return () => {
+    resetSubscribers.delete(cb);
+  };
+}
+
+export async function resetWhatsNewBanner(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(LAST_SEEN_VERSION_KEY);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    addLog(
+      `[WhatsNew Banner] Failed to reset last seen version: ${message}`,
+      'WARNING',
+    );
+    return;
+  }
+  resetSubscribers.forEach((cb) => {
+    try {
+      cb();
+    } catch {
+      // Subscribers are dev-only listeners; failures here shouldn't crash the
+      // reset path.
+    }
+  });
+}

--- a/SparkyFitnessMobile/src/types/navigation.ts
+++ b/SparkyFitnessMobile/src/types/navigation.ts
@@ -139,6 +139,7 @@ export type RootStackParamList = {
   ServerSettings: undefined;
   AppSettings: undefined;
   About: undefined;
+  WhatsNew: undefined;
 };
 
 declare global {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

This PR adds a What's New screen under the settings screen. Currently it advertises the home screen widget and the ai food scan features.
Also a banner link to what's new will be displayed above the tab bar after the user updates. It will only show once and can be dismissed.

Linked Issue: Closes #

## How to Test

1. Update app
2. See what's new screen

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-05-24 at 06 19 14" src="https://github.com/user-attachments/assets/21a9c1c2-0f08-4bd4-b091-11418f986010" />


## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
