### PR TITLE
Feat/mobile net carbs

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/FoodNutritionSummary.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/FoodNutritionSummary.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import FoodNutritionSummary from '../../src/components/FoodNutritionSummary';
+
+jest.mock('../../src/components/MacroCompositionRing', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => <View testID="macro-composition-ring" />,
+  };
+});
+
+jest.mock('uniwind', () => ({
+  useCSSVariable: (keys: string | string[]) =>
+    Array.isArray(keys) ? keys.map(() => '#111827') : '#111827',
+}));
+
+const baseValues = {
+  servingSize: 1,
+  servingUnit: 'serving',
+  calories: 200,
+  protein: 10,
+  carbs: 30,
+  fat: 5,
+  fiber: 10,
+  sugars: 6,
+};
+
+describe('FoodNutritionSummary — Total Carbs row', () => {
+  describe('default behavior (showNetCarbs off)', () => {
+    it('does not render a Total Carbs row', () => {
+      const { queryByText } = render(
+        <FoodNutritionSummary name="Oats" values={baseValues} />,
+      );
+      expect(queryByText('Total Carbs')).toBeNull();
+    });
+  });
+
+  describe('showNetCarbs on (with fiber available)', () => {
+    it('injects Total Carbs at servings=1 with the unscaled carbs value', () => {
+      const { getByText } = render(
+        <FoodNutritionSummary
+          name="Oats"
+          values={baseValues}
+          servings={1}
+          showNetCarbs
+        />,
+      );
+      expect(getByText('Total Carbs')).toBeTruthy();
+      // 30g raw carbs * 1 serving = 30g
+      expect(getByText('30g')).toBeTruthy();
+    });
+
+    it('scales the Total Carbs row value by servings (servings>1)', () => {
+      const { getByText } = render(
+        <FoodNutritionSummary
+          name="Oats"
+          values={baseValues}
+          servings={2.5}
+          showNetCarbs
+        />,
+      );
+      expect(getByText('Total Carbs')).toBeTruthy();
+      // 30g raw carbs * 2.5 servings = 75g
+      // Previously this row was double-scaled (would have shown 187g)
+      expect(getByText('75g')).toBeTruthy();
+    });
+
+    it('scales fiber, sugars, and the new Total Carbs row consistently', () => {
+      // Distinct base numbers so each scaled value is unique on screen.
+      const distinctValues = {
+        ...baseValues,
+        protein: 7,
+        fat: 4,
+        carbs: 30,
+        fiber: 8,
+        sugars: 5,
+      };
+      const { getByText } = render(
+        <FoodNutritionSummary
+          name="Oats"
+          values={distinctValues}
+          servings={2}
+          showNetCarbs
+        />,
+      );
+      // Fiber 8 * 2 = 16g
+      expect(getByText('16g')).toBeTruthy();
+      // Sugars 5 * 2 = 10g
+      expect(getByText('10g')).toBeTruthy();
+      // Total Carbs 30 * 2 = 60g (this was 187g under the double-scaling bug)
+      expect(getByText('60g')).toBeTruthy();
+    });
+  });
+
+  describe('showNetCarbs on but fiber missing', () => {
+    it('does NOT inject Total Carbs (matches macro-bar fallback to total carbs)', () => {
+      const valuesWithoutFiber = { ...baseValues, fiber: undefined };
+      const { queryByText } = render(
+        <FoodNutritionSummary
+          name="Plain food"
+          values={valuesWithoutFiber}
+          showNetCarbs
+        />,
+      );
+      // The macro bar in NutritionMacroCard falls back to "Carbs" with total
+      // carbs in this case; we shouldn't add a redundant Total Carbs row.
+      expect(queryByText('Total Carbs')).toBeNull();
+    });
+  });
+});

--- a/SparkyFitnessMobile/__tests__/components/NutritionMacroCard.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/NutritionMacroCard.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import NutritionMacroCard from '../../src/components/NutritionMacroCard';
+
+jest.mock('../../src/components/MacroCompositionRing', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: () => <View testID="macro-composition-ring" />,
+  };
+});
+
+describe('NutritionMacroCard', () => {
+  const baseProps = {
+    calories: 600,
+    protein: 30,
+    carbs: 50,
+    fat: 20,
+  };
+
+  describe('default behavior (showNetCarbs not set or false)', () => {
+    it('renders the Carbs label with total carbs value', () => {
+      const { getByText } = render(<NutritionMacroCard {...baseProps} />);
+      expect(getByText('Carbs')).toBeTruthy();
+      expect(getByText('50g')).toBeTruthy();
+    });
+
+    it('ignores fiber when showNetCarbs is false', () => {
+      const { getByText, queryByText } = render(
+        <NutritionMacroCard {...baseProps} fiber={15} showNetCarbs={false} />,
+      );
+      expect(getByText('Carbs')).toBeTruthy();
+      expect(getByText('50g')).toBeTruthy();
+      expect(queryByText('Net Carbs')).toBeNull();
+    });
+  });
+
+  describe('showNetCarbs enabled', () => {
+    it('swaps label to "Net Carbs" and shows max(0, carbs - fiber)', () => {
+      const { getByText, queryByText } = render(
+        <NutritionMacroCard {...baseProps} fiber={15} showNetCarbs />,
+      );
+      expect(getByText('Net Carbs')).toBeTruthy();
+      expect(getByText('35g')).toBeTruthy();
+      expect(queryByText('Carbs')).toBeNull();
+    });
+
+    it('floors at zero when fiber exceeds carbs', () => {
+      const { getByText } = render(
+        <NutritionMacroCard
+          calories={400}
+          protein={20}
+          carbs={10}
+          fat={15}
+          fiber={25}
+          showNetCarbs
+        />,
+      );
+      expect(getByText('Net Carbs')).toBeTruthy();
+      expect(getByText('0g')).toBeTruthy();
+    });
+
+    it('falls back to total carbs when fiber prop is omitted', () => {
+      // Defensive: opting in without fiber data should not blow up; we just
+      // show the raw carbs value with the original label.
+      const { getByText, queryByText } = render(
+        <NutritionMacroCard {...baseProps} showNetCarbs />,
+      );
+      expect(getByText('Carbs')).toBeTruthy();
+      expect(getByText('50g')).toBeTruthy();
+      expect(queryByText('Net Carbs')).toBeNull();
+    });
+  });
+
+  describe('with goal percentages (bar layout)', () => {
+    it('renders the Net Carbs label in the goal-bar layout', () => {
+      const { getByText } = render(
+        <NutritionMacroCard
+          {...baseProps}
+          fiber={15}
+          showNetCarbs
+          goalPercentages={{ calories: 30, protein: 60, carbs: 35, fat: 50 }}
+        />,
+      );
+      expect(getByText('Net Carbs')).toBeTruthy();
+      expect(getByText('35g')).toBeTruthy();
+    });
+  });
+});

--- a/SparkyFitnessMobile/__tests__/screens/EditLoggedMealScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/EditLoggedMealScreen.test.tsx
@@ -22,6 +22,7 @@ jest.mock('../../src/hooks/useDeleteFoodEntryMeal', () => ({
 
 jest.mock('../../src/hooks', () => ({
   useMealTypes: jest.fn(),
+  usePreferences: jest.fn(() => ({ preferences: undefined, isLoading: false, isError: false, refetch: jest.fn() })),
 }));
 
 jest.mock('../../src/components/ActiveWorkoutBar', () => ({

--- a/SparkyFitnessMobile/__tests__/screens/FoodDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodDetailScreen.test.tsx
@@ -9,6 +9,7 @@ jest.mock('../../src/hooks', () => ({
   useFoodVariants: jest.fn(),
   useProfile: jest.fn(),
   useServerConnection: jest.fn(),
+  usePreferences: jest.fn(() => ({ preferences: undefined, isLoading: false, isError: false, refetch: jest.fn() })),
 }));
 
 jest.mock('../../src/components/ActiveWorkoutBar', () => ({

--- a/SparkyFitnessMobile/__tests__/screens/FoodEntryAddScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodEntryAddScreen.test.tsx
@@ -34,6 +34,8 @@ jest.mock('@tanstack/react-query', () => ({
 
 jest.mock('../../src/hooks', () => ({
   useMealTypes: jest.fn(),
+  usePreferences: jest.fn(() => ({ preferences: undefined, isLoading: false, isError: false, refetch: jest.fn() })),
+  useServerConnection: jest.fn(() => ({ isConnected: true, isLoading: false })),
 }));
 
 jest.mock('../../src/hooks/useFoodVariants', () => ({

--- a/SparkyFitnessMobile/__tests__/screens/FoodEntryViewScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodEntryViewScreen.test.tsx
@@ -13,6 +13,7 @@ import { useProfile } from '../../src/hooks/useProfile';
 
 jest.mock('../../src/hooks', () => ({
   useMealTypes: jest.fn(),
+  usePreferences: jest.fn(() => ({ preferences: undefined, isLoading: false, isError: false, refetch: jest.fn() })),
 }));
 
 jest.mock('../../src/hooks/useFoodVariants', () => ({

--- a/SparkyFitnessMobile/__tests__/screens/FoodSettingsScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodSettingsScreen.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import FoodSettingsScreen from '../../src/screens/FoodSettingsScreen';
+import * as preferencesApi from '../../src/services/api/preferencesApi';
+import { preferencesQueryKey } from '../../src/hooks/queryKeys';
+
+jest.mock('../../src/hooks/useExternalProviders', () => ({
+  useExternalProviders: () => ({ providers: [], isLoading: false }),
+}));
+
+jest.mock('../../src/components/BottomSheetPicker', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="bottom-sheet-picker" /> };
+});
+
+jest.mock('../../src/components/Icon', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="icon" /> };
+});
+
+jest.mock('../../src/components/ActiveWorkoutBar', () => ({
+  useActiveWorkoutBarPadding: () => 0,
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const navigation = { goBack: jest.fn() } as any;
+const route = { params: {} } as any;
+
+function renderScreen(initialPrefs: any) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  queryClient.setQueryData(preferencesQueryKey, initialPrefs);
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <FoodSettingsScreen navigation={navigation} route={route} />
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+describe('FoodSettingsScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the renamed "Food Settings" header', () => {
+    const { getByText } = renderScreen({});
+    expect(getByText('Food Settings')).toBeTruthy();
+  });
+
+  it('renders the Show Net Carbs toggle row with description', () => {
+    const { getByText } = renderScreen({});
+    expect(getByText('Show Net Carbs')).toBeTruthy();
+    expect(
+      getByText(
+        /When enabled, carbohydrate summaries display net carbs/i,
+      ),
+    ).toBeTruthy();
+  });
+
+  it('reflects the current preference state on the Switch', () => {
+    const { UNSAFE_getAllByType } = renderScreen({ show_net_carbs: true });
+    const { Switch } = require('react-native');
+    const switches = UNSAFE_getAllByType(Switch);
+    // The Show Net Carbs switch is the first switch on the screen.
+    expect(switches[0].props.value).toBe(true);
+  });
+
+  it('calls updatePreferences when the toggle is flipped', async () => {
+    const spy = jest
+      .spyOn(preferencesApi, 'updatePreferences')
+      .mockResolvedValue({ show_net_carbs: true } as any);
+    const { UNSAFE_getAllByType } = renderScreen({ show_net_carbs: false });
+    const { Switch } = require('react-native');
+    const switches = UNSAFE_getAllByType(Switch);
+    fireEvent(switches[0], 'valueChange', true);
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({ show_net_carbs: true });
+    });
+  });
+});

--- a/SparkyFitnessMobile/__tests__/screens/MealDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/MealDetailScreen.test.tsx
@@ -10,6 +10,7 @@ jest.mock('../../src/hooks', () => ({
   useMeal: jest.fn(),
   useProfile: jest.fn(),
   useServerConnection: jest.fn(),
+  usePreferences: jest.fn(() => ({ preferences: undefined, isLoading: false, isError: false, refetch: jest.fn() })),
 }));
 
 jest.mock('../../src/components/ActiveWorkoutBar', () => ({

--- a/SparkyFitnessMobile/__tests__/types/foodInfo.test.ts
+++ b/SparkyFitnessMobile/__tests__/types/foodInfo.test.ts
@@ -1,0 +1,97 @@
+import { buildNutrientDisplayList } from '../../src/types/foodInfo';
+
+describe('buildNutrientDisplayList', () => {
+  describe('default behavior (showNetCarbs not set or false)', () => {
+    it('returns existing primary/additional split without Total Carbs row', () => {
+      const result = buildNutrientDisplayList({
+        fiber: 5,
+        sugars: 10,
+        saturatedFat: 2,
+        potassium: 200,
+      });
+      expect(result.primary.map((r) => r.label)).toEqual([
+        'Fiber',
+        'Sugars',
+        'Saturated Fat',
+      ]);
+      expect(result.additional.map((r) => r.label)).toEqual(['Potassium']);
+    });
+
+    it('does not inject Total Carbs even if carbs is provided when showNetCarbs is false', () => {
+      const result = buildNutrientDisplayList(
+        { fiber: 5, sugars: 10 },
+        { showNetCarbs: false, carbs: 30 },
+      );
+      expect(result.primary.map((r) => r.label)).toEqual(['Fiber', 'Sugars']);
+    });
+  });
+
+  describe('with showNetCarbs enabled', () => {
+    it('injects Total Carbs row immediately after Sugars', () => {
+      const result = buildNutrientDisplayList(
+        { fiber: 5, sugars: 10, saturatedFat: 2 },
+        { showNetCarbs: true, carbs: 30 },
+      );
+      expect(result.primary.map((r) => r.label)).toEqual([
+        'Fiber',
+        'Sugars',
+        'Total Carbs',
+        'Saturated Fat',
+      ]);
+      const totalCarbs = result.primary.find((r) => r.label === 'Total Carbs');
+      expect(totalCarbs).toEqual({ label: 'Total Carbs', value: 30, unit: 'g' });
+    });
+
+    it('inserts after Fiber when Sugars is absent', () => {
+      const result = buildNutrientDisplayList(
+        { fiber: 5, saturatedFat: 2 },
+        { showNetCarbs: true, carbs: 30 },
+      );
+      expect(result.primary.map((r) => r.label)).toEqual([
+        'Fiber',
+        'Total Carbs',
+        'Saturated Fat',
+      ]);
+    });
+
+    it('inserts at top of primary when neither Fiber nor Sugars is present', () => {
+      const result = buildNutrientDisplayList(
+        { saturatedFat: 2, cholesterol: 50 },
+        { showNetCarbs: true, carbs: 30 },
+      );
+      expect(result.primary.map((r) => r.label)).toEqual([
+        'Total Carbs',
+        'Saturated Fat',
+        'Cholesterol',
+      ]);
+    });
+
+    it('handles zero carbs', () => {
+      const result = buildNutrientDisplayList(
+        { fiber: 0, sugars: 0 },
+        { showNetCarbs: true, carbs: 0 },
+      );
+      const totalCarbs = result.primary.find((r) => r.label === 'Total Carbs');
+      expect(totalCarbs?.value).toBe(0);
+    });
+
+    it('omits Total Carbs row when carbs option is undefined (defensive fallback)', () => {
+      const result = buildNutrientDisplayList(
+        { fiber: 5, sugars: 10 },
+        { showNetCarbs: true, carbs: undefined },
+      );
+      expect(result.primary.map((r) => r.label)).toEqual(['Fiber', 'Sugars']);
+    });
+
+    it('does not change additional list when injecting', () => {
+      const result = buildNutrientDisplayList(
+        { fiber: 5, sugars: 10, potassium: 200, calcium: 100 },
+        { showNetCarbs: true, carbs: 30 },
+      );
+      expect(result.additional.map((r) => r.label)).toEqual([
+        'Potassium',
+        'Calcium',
+      ]);
+    });
+  });
+});

--- a/SparkyFitnessMobile/__tests__/utils/nutrientUtils.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/nutrientUtils.test.ts
@@ -1,0 +1,39 @@
+import { getNetCarbsValue } from '../../src/utils/nutrientUtils';
+
+describe('getNetCarbsValue', () => {
+  it('subtracts fiber from carbs when both are positive', () => {
+    expect(getNetCarbsValue(30, 10)).toBe(20);
+    expect(getNetCarbsValue(100, 25)).toBe(75);
+    expect(getNetCarbsValue(5, 5)).toBe(0);
+  });
+
+  it('floors at zero when fiber exceeds carbs', () => {
+    expect(getNetCarbsValue(10, 25)).toBe(0);
+    expect(getNetCarbsValue(0, 10)).toBe(0);
+  });
+
+  it('treats nullish carbs as zero', () => {
+    expect(getNetCarbsValue(null, 5)).toBe(0);
+    expect(getNetCarbsValue(undefined, 5)).toBe(0);
+  });
+
+  it('treats nullish fiber as zero (carbs unchanged)', () => {
+    expect(getNetCarbsValue(30, null)).toBe(30);
+    expect(getNetCarbsValue(30, undefined)).toBe(30);
+  });
+
+  it('returns zero when both inputs are nullish', () => {
+    expect(getNetCarbsValue(null, null)).toBe(0);
+    expect(getNetCarbsValue(undefined, undefined)).toBe(0);
+  });
+
+  it('handles fractional inputs', () => {
+    expect(getNetCarbsValue(12.5, 3.2)).toBeCloseTo(9.3, 5);
+    expect(getNetCarbsValue(7.1, 7.1)).toBeCloseTo(0, 5);
+  });
+
+  it('handles NaN inputs as zero (numeric fallback)', () => {
+    expect(getNetCarbsValue(Number.NaN, 5)).toBe(0);
+    expect(getNetCarbsValue(30, Number.NaN)).toBe(30);
+  });
+});

--- a/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
+++ b/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
@@ -37,16 +37,18 @@ const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
   const [showMoreNutrients, setShowMoreNutrients] = useState(false);
 
   const scale = (value: number) => value * servings;
-  const scaledCarbs = scale(values.carbs);
+  // Gate the Total Carbs row injection on the same condition NutritionMacroCard
+  // uses to swap the macro bar to "Net Carbs" — if fiber is unavailable the
+  // bar falls back to total carbs and the row would otherwise duplicate it.
+  const useNetCarbs = showNetCarbs && values.fiber !== undefined;
   const { primary: primaryNutrients, additional: additionalNutrients } = useMemo(
     () =>
       buildNutrientDisplayList(values, {
-        showNetCarbs,
-        // Pre-scale carbs so the injected Total Carbs row matches the macro-bar
-        // value, which is also scaled by `servings` below.
-        carbs: showNetCarbs ? scaledCarbs : undefined,
+        showNetCarbs: useNetCarbs,
+        // Pass raw carbs; renderRow scales by `servings` like every other row.
+        carbs: useNetCarbs ? values.carbs : undefined,
       }),
-    [values, showNetCarbs, scaledCarbs],
+    [values, useNetCarbs],
   );
 
   const renderRow = (nutrient: NutrientDisplayItem, showBorder: boolean) => (

--- a/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
+++ b/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
@@ -35,11 +35,18 @@ const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
 
   const [showMoreNutrients, setShowMoreNutrients] = useState(false);
 
-  const { primary: primaryNutrients, additional: additionalNutrients } = useMemo(
-    () => buildNutrientDisplayList(values),
-    [values],
-  );
   const scale = (value: number) => value * servings;
+  const scaledCarbs = scale(values.carbs);
+  const { primary: primaryNutrients, additional: additionalNutrients } = useMemo(
+    () =>
+      buildNutrientDisplayList(values, {
+        showNetCarbs,
+        // Pre-scale carbs so the injected Total Carbs row matches the macro-bar
+        // value, which is also scaled by `servings` below.
+        carbs: showNetCarbs ? scaledCarbs : undefined,
+      }),
+    [values, showNetCarbs, scaledCarbs],
+  );
 
   const renderRow = (nutrient: NutrientDisplayItem, showBorder: boolean) => (
     <View

--- a/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
+++ b/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
@@ -15,10 +15,11 @@ interface FoodNutritionSummaryProps {
   goalPercentages?: NutritionGoalPercentages;
   goalsLoading?: boolean;
   // Opt-in: when true and values.fiber is available, the carbs row of the
-  // macro card swaps to "Net Carbs" (max(0, carbs - fiber)). Callers that
-  // display per-food/per-meal nutrition (food detail, meal builder) should
-  // leave this false; summary surfaces aggregating user consumption (e.g.
-  // MealTypeDetailScreen) opt in based on user_preferences.show_net_carbs.
+  // macro card swaps to "Net Carbs" (max(0, carbs - fiber)), and a
+  // "Total Carbs" row is injected into the nutrient breakdown below.
+  // Applied across all surfaces (food detail, meal detail, meal-type detail,
+  // food entry, food photo flow) when user_preferences.show_net_carbs is
+  // enabled.
   showNetCarbs?: boolean;
 }
 

--- a/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
+++ b/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
@@ -14,6 +14,12 @@ interface FoodNutritionSummaryProps {
   servings?: number;
   goalPercentages?: NutritionGoalPercentages;
   goalsLoading?: boolean;
+  // Opt-in: when true and values.fiber is available, the carbs row of the
+  // macro card swaps to "Net Carbs" (max(0, carbs - fiber)). Callers that
+  // display per-food/per-meal nutrition (food detail, meal builder) should
+  // leave this false; summary surfaces aggregating user consumption (e.g.
+  // MealTypeDetailScreen) opt in based on user_preferences.show_net_carbs.
+  showNetCarbs?: boolean;
 }
 
 const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
@@ -23,6 +29,7 @@ const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
   servings = 1,
   goalPercentages,
   goalsLoading,
+  showNetCarbs = false,
 }) => {
   const accentColor = useCSSVariable('--color-accent-primary') as string;
 
@@ -65,8 +72,10 @@ const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
         protein={scale(values.protein)}
         carbs={scale(values.carbs)}
         fat={scale(values.fat)}
+        fiber={values.fiber !== undefined ? scale(values.fiber) : undefined}
         goalPercentages={goalPercentages}
         goalsLoading={goalsLoading}
+        showNetCarbs={showNetCarbs}
       />
 
       {primaryNutrients.length > 0 ? (

--- a/SparkyFitnessMobile/src/components/NutritionMacroCard.tsx
+++ b/SparkyFitnessMobile/src/components/NutritionMacroCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import { useCSSVariable } from 'uniwind';
 import MacroCompositionRing from './MacroCompositionRing';
+import { getNetCarbsValue } from '../utils/nutrientUtils';
 
 export interface NutritionGoalPercentages {
   calories?: number | null;
@@ -20,6 +21,11 @@ interface NutritionMacroCardProps {
   // When true, render the goal-bars layout even if percentages aren't computed
   // yet — avoids a ring→bars flash while the goals query is in flight.
   goalsLoading?: boolean;
+  // When showNetCarbs is true and fiber is provided, the carbs row swaps to
+  // "Net Carbs" with value max(0, carbs - fiber). Goal percentage and ring
+  // share are computed against this net value too, mirroring the web behavior.
+  showNetCarbs?: boolean;
+  fiber?: number;
 }
 
 const RING_SIZE = 130;
@@ -33,6 +39,8 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
   heading,
   goalPercentages,
   goalsLoading,
+  showNetCarbs = false,
+  fiber,
 }) => {
   const [proteinColor, carbsColor, fatColor, trackColor] = useCSSVariable([
     '--color-macro-protein',
@@ -41,8 +49,12 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
     '--color-progress-track',
   ]) as [string, string, string, string];
 
+  const useNetCarbs = showNetCarbs && fiber !== undefined;
+  const displayCarbs = useNetCarbs ? getNetCarbsValue(carbs, fiber) : carbs;
+  const carbsLabel = useNetCarbs ? 'Net Carbs' : 'Carbs';
+
   const proteinCals = protein * 4;
-  const carbsCals = carbs * 4;
+  const carbsCals = displayCarbs * 4;
   const fatCals = fat * 9;
   const totalMacroCals = proteinCals + carbsCals + fatCals;
 
@@ -65,8 +77,8 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
     },
     {
       key: 'Carbs',
-      label: 'Carbs',
-      value: carbs,
+      label: carbsLabel,
+      value: displayCarbs,
       color: carbsColor,
       goalPercent: goalPercentages?.carbs,
     },

--- a/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
@@ -13,6 +13,7 @@ import DateNavigator from '../components/DateNavigator';
 import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarSheet';
 import { addDays, getTodayDate } from '../utils/dateUtils';
 import { weightFromKg } from '../utils/unitConversions';
+import { getNetCarbsValue } from '../utils/nutrientUtils';
 import HydrationGauge from '../components/HydrationGauge';
 import SegmentedControl, { type Segment } from '../components/SegmentedControl';
 import HealthTrendsPager from '../components/HealthTrendsPager';
@@ -225,7 +226,12 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
           />
         )}
         {/* Macros Section - 2x2 grid in one card */}
-        {summary.foodEntries.length > 0 ? (
+        {summary.foodEntries.length > 0 ? (() => {
+          const showNetCarbs = preferences.show_net_carbs === true;
+          const carbsConsumed = showNetCarbs
+            ? getNetCarbsValue(summary.carbs.consumed, summary.fiber.consumed)
+            : summary.carbs.consumed;
+          return (
           <View className="bg-surface rounded-xl p-3 mb-3 shadow-sm">
             <Text className="text-md font-bold text-text-secondary mb-2 px-1">Macronutrients</Text>
             <View className="flex-row flex-wrap justify-between">
@@ -237,8 +243,8 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
               overfillColor={progressTrackOverfillColor}
             />
             <MacroCard
-              label="Carbs"
-              consumed={summary.carbs.consumed}
+              label={showNetCarbs ? 'Net Carbs' : 'Carbs'}
+              consumed={carbsConsumed}
               goal={summary.carbs.goal}
               color={carbsColor}
               overfillColor={progressTrackOverfillColor}
@@ -259,7 +265,8 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
             />
             </View>
           </View>
-        ) : null}
+          );
+        })() : null}
 
         {summary.foodEntries.length === 0 && (
           <Pressable

--- a/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
@@ -196,6 +196,10 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
     }
 
     const { eaten, burned, remaining, goal, progress } = summary.calorieBalance;
+    const showNetCarbs = preferences.show_net_carbs === true;
+    const carbsConsumed = showNetCarbs
+      ? getNetCarbsValue(summary.carbs.consumed, summary.fiber.consumed)
+      : summary.carbs.consumed;
 
     return (
       <ScrollView
@@ -226,12 +230,7 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
           />
         )}
         {/* Macros Section - 2x2 grid in one card */}
-        {summary.foodEntries.length > 0 ? (() => {
-          const showNetCarbs = preferences.show_net_carbs === true;
-          const carbsConsumed = showNetCarbs
-            ? getNetCarbsValue(summary.carbs.consumed, summary.fiber.consumed)
-            : summary.carbs.consumed;
-          return (
+        {summary.foodEntries.length > 0 ? (
           <View className="bg-surface rounded-xl p-3 mb-3 shadow-sm">
             <Text className="text-md font-bold text-text-secondary mb-2 px-1">Macronutrients</Text>
             <View className="flex-row flex-wrap justify-between">
@@ -265,8 +264,7 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
             />
             </View>
           </View>
-          );
-        })() : null}
+        ) : null}
 
         {summary.foodEntries.length === 0 && (
           <Pressable

--- a/SparkyFitnessMobile/src/screens/EditLoggedMealScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/EditLoggedMealScreen.tsx
@@ -11,7 +11,7 @@ import BottomSheetPicker from '../components/BottomSheetPicker';
 import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarSheet';
 import NutritionMacroCard from '../components/NutritionMacroCard';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
-import { useMealTypes } from '../hooks';
+import { useMealTypes, usePreferences } from '../hooks';
 import { useFoodEntryMealDetails } from '../hooks/useFoodEntryMealDetails';
 import { useUpdateFoodEntryMeal } from '../hooks/useUpdateFoodEntryMeal';
 import { useDeleteFoodEntryMeal } from '../hooks/useDeleteFoodEntryMeal';
@@ -32,6 +32,8 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
 
   const { meal, isLoading, isError, error } = useFoodEntryMealDetails(foodEntryMealId, { initialMeal });
   const { mealTypes } = useMealTypes();
+  const { preferences } = usePreferences();
+  const showNetCarbs = preferences?.show_net_carbs === true;
 
   const [name, setName] = useState<string | null>(null);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
@@ -141,6 +143,8 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
   const scaledProtein = (meal.protein ?? 0) * scaleFactor;
   const scaledCarbs = (meal.carbs ?? 0) * scaleFactor;
   const scaledFat = (meal.fat ?? 0) * scaleFactor;
+  const scaledFiber =
+    meal.dietary_fiber != null ? meal.dietary_fiber * scaleFactor : undefined;
 
   return (
     <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
@@ -189,6 +193,8 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
           protein={scaledProtein}
           carbs={scaledCarbs}
           fat={scaledFat}
+          fiber={scaledFiber}
+          showNetCarbs={showNetCarbs}
         />
 
         {/* Quantity */}

--- a/SparkyFitnessMobile/src/screens/FoodDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodDetailScreen.tsx
@@ -9,7 +9,7 @@ import FoodNutritionSummary from '../components/FoodNutritionSummary';
 import StatusView from '../components/StatusView';
 import SettingsRow, { SettingsRowGroup } from '../components/SettingsRow';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
-import { useDeleteFood, useFoodVariants, useProfile, useServerConnection } from '../hooks';
+import { useDeleteFood, useFoodVariants, useProfile, useServerConnection, usePreferences } from '../hooks';
 import {
   buildExternalVariantOptions,
   buildLocalVariantOptions,
@@ -34,6 +34,8 @@ const FoodDetailScreen: React.FC<FoodDetailScreenProps> = ({ navigation, route }
   ]) as [string, string];
   const { isConnected, isLoading: isConnectionLoading } = useServerConnection();
   const { profile } = useProfile();
+  const { preferences } = usePreferences({ enabled: isConnected });
+  const showNetCarbs = preferences?.show_net_carbs === true;
   const [food, setFood] = useState(item);
 
   const isLocalFood = food.source === 'local';
@@ -182,6 +184,7 @@ const FoodDetailScreen: React.FC<FoodDetailScreenProps> = ({ navigation, route }
           name={food.name}
           brand={food.brand}
           values={displayValues}
+          showNetCarbs={showNetCarbs}
         />
 
         <View className="bg-surface rounded-xl p-4">

--- a/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
@@ -24,6 +24,7 @@ import { getTodayDate, formatDateLabel } from '../utils/dateUtils';
 import { getMealTypeLabel } from '../constants/meals';
 import { goalsQueryKey } from '../hooks/queryKeys';
 import { useMealTypes, usePreferences, useServerConnection } from '../hooks';
+import { getNetCarbsValue } from '../utils/nutrientUtils';
 import {
   useCreateFoodVariant,
   useFoodVariants,
@@ -862,9 +863,13 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
     return Math.round((value / goalValue) * 100);
   };
 
+  const carbsForGoal =
+    showNetCarbs && displayValues.fiber !== undefined
+      ? getNetCarbsValue(displayValues.carbs, displayValues.fiber)
+      : displayValues.carbs;
   const calorieGoalPct = goalPercent(scaled(displayValues.calories), goals?.calories);
   const proteinGoalPct = goalPercent(scaled(displayValues.protein), goals?.protein);
-  const carbsGoalPct = goalPercent(scaled(displayValues.carbs), goals?.carbs);
+  const carbsGoalPct = goalPercent(scaled(carbsForGoal), goals?.carbs);
   const fatGoalPct = goalPercent(scaled(displayValues.fat), goals?.fat);
 
   const mealPickerOptions = mealTypes.map((mealType) => ({

--- a/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
@@ -23,7 +23,7 @@ import { CreateFoodEntryPayload } from '../services/api/foodEntriesApi';
 import { getTodayDate, formatDateLabel } from '../utils/dateUtils';
 import { getMealTypeLabel } from '../constants/meals';
 import { goalsQueryKey } from '../hooks/queryKeys';
-import { useMealTypes } from '../hooks';
+import { useMealTypes, usePreferences, useServerConnection } from '../hooks';
 import {
   useCreateFoodVariant,
   useFoodVariants,
@@ -162,6 +162,9 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
   );
   const calendarRef = useRef<CalendarSheetRef>(null);
   const { mealTypes, defaultMealTypeId } = useMealTypes();
+  const { isConnected } = useServerConnection();
+  const { preferences } = usePreferences({ enabled: isConnected });
+  const showNetCarbs = preferences?.show_net_carbs === true;
   const [selectedMealId, setSelectedMealId] = useState<string | undefined>();
   const [adjustedValues, setAdjustedValues] = useState<FoodFormData | null>(null);
   const [savedFoodOverride, setSavedFoodOverride] =
@@ -968,6 +971,7 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
             fat: fatGoalPct,
           }}
           goalsLoading={isGoalsLoading}
+          showNetCarbs={showNetCarbs}
         />
 
         <View className="mt-2">

--- a/SparkyFitnessMobile/src/screens/FoodEntryViewScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryViewScreen.tsx
@@ -22,7 +22,7 @@ import BottomSheetPicker from '../components/BottomSheetPicker';
 import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarSheet';
 import { normalizeDate, formatDateLabel } from '../utils/dateUtils';
 import { getMealTypeLabel } from '../constants/meals';
-import { useMealTypes } from '../hooks';
+import { useMealTypes, usePreferences } from '../hooks';
 import { useFoodVariants } from '../hooks/useFoodVariants';
 import { useDeleteFoodEntry } from '../hooks/useDeleteFoodEntry';
 import { useUpdateFoodEntry } from '../hooks/useUpdateFoodEntry';
@@ -30,6 +30,7 @@ import { useProfile } from '../hooks/useProfile';
 import type { UpdateFoodEntryPayload } from '../services/api/foodEntriesApi';
 import type { FoodFormData } from '../components/FoodForm';
 import { toFormString, parseOptional, buildNutrientDisplayList } from '../types/foodInfo';
+import { getNetCarbsValue } from '../utils/nutrientUtils';
 import type { FoodVariantDetail } from '../types/foods';
 import type { FoodEntry } from '../types/foodEntries';
 import type {
@@ -543,19 +544,38 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
       '--color-macro-fat',
     ]) as [string, string, string, string, string];
 
+  const { preferences } = usePreferences();
+  const showNetCarbs = preferences?.show_net_carbs === true;
+
   const viewCalories = Math.round(scaledValue(entry.calories, entry));
   const viewProtein = Math.round(scaledValue(entry.protein, entry));
   const viewCarbs = Math.round(scaledValue(entry.carbs, entry));
   const viewFat = Math.round(scaledValue(entry.fat, entry));
+  const viewFiber = Math.round(scaledValue(entry.dietary_fiber, entry));
+
+  // displayCarbs swaps to max(0, carbs - fiber) only when the toggle is on AND
+  // fiber data is available; otherwise it stays at total carbs. Used for both
+  // the bar value and bar-fill proportion so the visual representation reflects
+  // what the label claims. The Total Carbs row is preserved separately via
+  // buildNutrientDisplayList below.
+  const viewDisplayCarbs =
+    showNetCarbs && entry.dietary_fiber != null
+      ? getNetCarbsValue(viewCarbs, viewFiber)
+      : viewCarbs;
+  const editDisplayCarbs =
+    showNetCarbs && displayValues.fiber !== undefined
+      ? getNetCarbsValue(displayValues.carbs, displayValues.fiber)
+      : displayValues.carbs;
+  const carbsLabel = showNetCarbs ? 'Net Carbs' : 'Carbs';
 
   const viewProteinCals = viewProtein * 4;
-  const viewCarbsCals = viewCarbs * 4;
+  const viewCarbsCals = viewDisplayCarbs * 4;
   const viewFatCals = viewFat * 9;
   const viewTotalMacroCals =
     viewProteinCals + viewCarbsCals + viewFatCals;
 
   const editProteinCals = displayValues.protein * 4;
-  const editCarbsCals = displayValues.carbs * 4;
+  const editCarbsCals = editDisplayCarbs * 4;
   const editFatCals = displayValues.fat * 9;
   const editTotalMacroCals =
     editProteinCals + editCarbsCals + editFatCals;
@@ -572,7 +592,16 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
 
   const [showMoreNutrients, setShowMoreNutrients] = useState(false);
   const { primary: primaryNutrients, additional: additionalNutrients } =
-    buildNutrientDisplayList(displayValues);
+    buildNutrientDisplayList(displayValues, {
+      showNetCarbs,
+      // Scale the displayed Total Carbs row to whatever quantity the user is
+      // currently viewing/editing — matches the macro-bar carbs reading above.
+      carbs: showNetCarbs
+        ? isEditing
+          ? Math.round(scaled(displayValues.carbs))
+          : viewCarbs
+        : undefined,
+    });
   const hasAdditional = additionalNutrients.length > 0;
   const showAdditionalRows = showMoreNutrients && hasAdditional;
   const renderNutrientValue = (value: number, unit: string) =>
@@ -738,12 +767,12 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
                         displayValue: Math.round(scaled(displayValues.protein)),
                       },
                       {
-                        label: 'Carbs',
-                        value: displayValues.carbs,
+                        label: carbsLabel,
+                        value: editDisplayCarbs,
                         color: carbsColor,
                         calFactor: 4,
                         totalCals: editTotalMacroCals,
-                        displayValue: Math.round(scaled(displayValues.carbs)),
+                        displayValue: Math.round(scaled(editDisplayCarbs)),
                       },
                       {
                         label: 'Fat',
@@ -764,12 +793,12 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
                         displayValue: viewProtein,
                       },
                       {
-                        label: 'Carbs',
-                        value: viewCarbs,
+                        label: carbsLabel,
+                        value: viewDisplayCarbs,
                         color: carbsColor,
                         calFactor: 4,
                         totalCals: viewTotalMacroCals,
-                        displayValue: viewCarbs,
+                        displayValue: viewDisplayCarbs,
                       },
                       {
                         label: 'Fat',

--- a/SparkyFitnessMobile/src/screens/FoodEntryViewScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryViewScreen.tsx
@@ -553,20 +553,20 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
   const viewFat = Math.round(scaledValue(entry.fat, entry));
   const viewFiber = Math.round(scaledValue(entry.dietary_fiber, entry));
 
-  // displayCarbs swaps to max(0, carbs - fiber) only when the toggle is on AND
-  // fiber data is available; otherwise it stays at total carbs. Used for both
-  // the bar value and bar-fill proportion so the visual representation reflects
-  // what the label claims. The Total Carbs row is preserved separately via
-  // buildNutrientDisplayList below.
-  const viewDisplayCarbs =
-    showNetCarbs && entry.dietary_fiber != null
-      ? getNetCarbsValue(viewCarbs, viewFiber)
-      : viewCarbs;
-  const editDisplayCarbs =
-    showNetCarbs && displayValues.fiber !== undefined
-      ? getNetCarbsValue(displayValues.carbs, displayValues.fiber)
-      : displayValues.carbs;
-  const carbsLabel = showNetCarbs ? 'Net Carbs' : 'Carbs';
+  // Per-mode gates: each mode reads from a different source (view = entry,
+  // edit = displayValues), so each needs its own fiber check. Without these
+  // the label could say "Net Carbs" while the value silently fell back to
+  // total carbs.
+  const viewUseNetCarbs = showNetCarbs && entry.dietary_fiber != null;
+  const editUseNetCarbs = showNetCarbs && displayValues.fiber !== undefined;
+  const viewDisplayCarbs = viewUseNetCarbs
+    ? getNetCarbsValue(viewCarbs, viewFiber)
+    : viewCarbs;
+  const editDisplayCarbs = editUseNetCarbs
+    ? getNetCarbsValue(displayValues.carbs, displayValues.fiber)
+    : displayValues.carbs;
+  const viewCarbsLabel = viewUseNetCarbs ? 'Net Carbs' : 'Carbs';
+  const editCarbsLabel = editUseNetCarbs ? 'Net Carbs' : 'Carbs';
 
   const viewProteinCals = viewProtein * 4;
   const viewCarbsCals = viewDisplayCarbs * 4;
@@ -591,16 +591,14 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
       : `${servingsCount} servings \u00b7 ${entry.serving_size} ${entry.unit} per serving`;
 
   const [showMoreNutrients, setShowMoreNutrients] = useState(false);
+  // Use the same per-mode gate the macro bar uses, and pass carbs raw —
+  // renderNutrientValue scales every other row the same way, so pre-scaling
+  // here would double-scale the displayed Total Carbs value.
+  const useNetCarbsInList = isEditing ? editUseNetCarbs : viewUseNetCarbs;
   const { primary: primaryNutrients, additional: additionalNutrients } =
     buildNutrientDisplayList(displayValues, {
-      showNetCarbs,
-      // Scale the displayed Total Carbs row to whatever quantity the user is
-      // currently viewing/editing — matches the macro-bar carbs reading above.
-      carbs: showNetCarbs
-        ? isEditing
-          ? Math.round(scaled(displayValues.carbs))
-          : viewCarbs
-        : undefined,
+      showNetCarbs: useNetCarbsInList,
+      carbs: useNetCarbsInList ? displayValues.carbs : undefined,
     });
   const hasAdditional = additionalNutrients.length > 0;
   const showAdditionalRows = showMoreNutrients && hasAdditional;
@@ -767,7 +765,7 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
                         displayValue: Math.round(scaled(displayValues.protein)),
                       },
                       {
-                        label: carbsLabel,
+                        label: editCarbsLabel,
                         value: editDisplayCarbs,
                         color: carbsColor,
                         calFactor: 4,
@@ -793,7 +791,7 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
                         displayValue: viewProtein,
                       },
                       {
-                        label: carbsLabel,
+                        label: viewCarbsLabel,
                         value: viewDisplayCarbs,
                         color: carbsColor,
                         calFactor: 4,

--- a/SparkyFitnessMobile/src/screens/FoodPhotoLogEntryScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodPhotoLogEntryScreen.tsx
@@ -19,6 +19,7 @@ import BottomSheetPicker from '../components/BottomSheetPicker';
 import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarSheet';
 import { useAddFoodEntry } from '../hooks/useAddFoodEntry';
 import { useMealTypes } from '../hooks/useMealTypes';
+import { usePreferences } from '../hooks';
 import { goalsQueryKey } from '../hooks/queryKeys';
 import { fetchDailyGoals } from '../services/api/goalsApi';
 import { fireSuccessHaptic } from '../services/haptics';
@@ -80,6 +81,9 @@ const FoodPhotoLogEntryScreen: React.FC<Props> = ({ navigation, route }) => {
     () => saveFoodPayloadToDisplayValues(saveFoodPayload),
     [saveFoodPayload],
   );
+
+  const { preferences } = usePreferences();
+  const showNetCarbs = preferences?.show_net_carbs === true;
 
   const servingsNumber = useMemo(() => {
     const parsed = parseDecimalInput(quantity);
@@ -205,6 +209,7 @@ const FoodPhotoLogEntryScreen: React.FC<Props> = ({ navigation, route }) => {
             servings={servingsNumber}
             goalPercentages={goalPercentages}
             goalsLoading={isGoalsLoading}
+            showNetCarbs={showNetCarbs}
           />
         </View>
 

--- a/SparkyFitnessMobile/src/screens/FoodPhotoLogEntryScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodPhotoLogEntryScreen.tsx
@@ -20,6 +20,7 @@ import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarShee
 import { useAddFoodEntry } from '../hooks/useAddFoodEntry';
 import { useMealTypes } from '../hooks/useMealTypes';
 import { usePreferences } from '../hooks';
+import { getNetCarbsValue } from '../utils/nutrientUtils';
 import { goalsQueryKey } from '../hooks/queryKeys';
 import { fetchDailyGoals } from '../services/api/goalsApi';
 import { fireSuccessHaptic } from '../services/haptics';
@@ -94,10 +95,14 @@ const FoodPhotoLogEntryScreen: React.FC<Props> = ({ navigation, route }) => {
     if (!goalValue || goalValue === 0) return null;
     return Math.round((value / goalValue) * 100);
   };
+  const carbsForGoal =
+    showNetCarbs && displayValues.fiber !== undefined
+      ? getNetCarbsValue(displayValues.carbs, displayValues.fiber)
+      : displayValues.carbs;
   const goalPercentages = {
     calories: goalPercent(displayValues.calories * servingsNumber, goals?.calories),
     protein: goalPercent(displayValues.protein * servingsNumber, goals?.protein),
-    carbs: goalPercent(displayValues.carbs * servingsNumber, goals?.carbs),
+    carbs: goalPercent(carbsForGoal * servingsNumber, goals?.carbs),
     fat: goalPercent(displayValues.fat * servingsNumber, goals?.fat),
   };
 

--- a/SparkyFitnessMobile/src/screens/FoodSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSettingsScreen.tsx
@@ -49,6 +49,7 @@ const FoodSettingsScreen: React.FC<FoodSettingsScreenProps> = ({ navigation }) =
   const foodDataProviderId = preferences?.default_food_data_provider_id ?? '';
   const autoScale = preferences?.auto_scale_open_food_facts_imports ?? true;
   const barcodeFallback = preferences?.barcode_fallback_open_food_facts ?? true;
+  const showNetCarbs = preferences?.show_net_carbs ?? false;
 
   const mutation = useMutation({
     mutationFn: (data: Partial<UserPreferences>) => updatePreferences(data),
@@ -91,6 +92,11 @@ const FoodSettingsScreen: React.FC<FoodSettingsScreenProps> = ({ navigation }) =
     [mutation],
   );
 
+  const handleShowNetCarbsToggle = useCallback(
+    (value: boolean) => mutation.mutate({ show_net_carbs: value }),
+    [mutation],
+  );
+
   return (
     <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
       <ScrollView
@@ -107,7 +113,25 @@ const FoodSettingsScreen: React.FC<FoodSettingsScreenProps> = ({ navigation }) =
           >
             <Icon name="chevron-back" size={22} color={accentPrimary} />
           </Button>
-          <Text className="text-2xl font-bold text-text-primary">Food Search Settings</Text>
+          <Text className="text-2xl font-bold text-text-primary">Food Settings</Text>
+        </View>
+
+        {/* Show Net Carbs */}
+        <View className="bg-surface rounded-xl p-3 mb-4 shadow-sm">
+          <View className="flex-row justify-between items-center">
+            <Text className="text-base font-semibold text-text-primary flex-shrink">
+              Show Net Carbs
+            </Text>
+            <Switch
+              onValueChange={handleShowNetCarbsToggle}
+              value={showNetCarbs}
+              trackColor={{ false: formDisabled, true: formEnabled }}
+              thumbColor="#FFFFFF"
+            />
+          </View>
+          <Text className="text-text-secondary text-sm mt-4">
+            When enabled, carbohydrate summaries display net carbs (total carbs − fiber), and a Total Carbs row is added in nutrient breakdowns.
+          </Text>
         </View>
 
         {/* Default Online Search Provider */}

--- a/SparkyFitnessMobile/src/screens/MealDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MealDetailScreen.tsx
@@ -8,7 +8,7 @@ import FoodNutritionSummary from '../components/FoodNutritionSummary';
 import SegmentedControl, { type Segment } from '../components/SegmentedControl';
 import StatusView from '../components/StatusView';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
-import { useDeleteMeal, useMeal, useProfile, useServerConnection } from '../hooks';
+import { useDeleteMeal, useMeal, useProfile, useServerConnection, usePreferences } from '../hooks';
 import { mealToFoodInfo } from '../types/foodInfo';
 import type { FoodDisplayValues } from '../utils/foodDetails';
 import type { Meal, MealFood } from '../types/meals';
@@ -104,6 +104,8 @@ const MealDetailScreen: React.FC<MealDetailScreenProps> = ({ navigation, route }
 
   const { isConnected, isLoading: isConnectionLoading } = useServerConnection();
   const { profile } = useProfile();
+  const { preferences } = usePreferences({ enabled: isConnected });
+  const showNetCarbs = preferences?.show_net_carbs === true;
   const { meal, isLoading, isError, refetch } = useMeal(mealId, {
     enabled: isConnected,
     initialMeal,
@@ -184,6 +186,7 @@ const MealDetailScreen: React.FC<MealDetailScreenProps> = ({ navigation, route }
           name={meal.name}
           brand={meal.description}
           values={displayValues}
+          showNetCarbs={showNetCarbs}
         />
 
         <View className="bg-surface rounded-xl p-4 shadow-sm">

--- a/SparkyFitnessMobile/src/screens/MealTypeDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MealTypeDetailScreen.tsx
@@ -10,6 +10,7 @@ import SwipeableFoodRow from '../components/SwipeableFoodRow';
 import StatusView from '../components/StatusView';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { useDailySummary, useServerConnection } from '../hooks';
+import { usePreferences } from '../hooks/usePreferences';
 import { formatDateLabel } from '../utils/dateUtils';
 import {
   calculateEntryNutrition,
@@ -33,6 +34,8 @@ const MealTypeDetailScreen: React.FC<MealTypeDetailScreenProps> = ({ navigation,
     date,
     enabled: isConnected,
   });
+  const { preferences } = usePreferences({ enabled: isConnected });
+  const showNetCarbs = preferences?.show_net_carbs === true;
 
   const [refreshing, setRefreshing] = useState(false);
 
@@ -119,6 +122,7 @@ const MealTypeDetailScreen: React.FC<MealTypeDetailScreenProps> = ({ navigation,
           name={label}
           brand={formatDateLabel(date)}
           values={nutrition}
+          showNetCarbs={showNetCarbs}
         />
 
         <View className="bg-surface rounded-xl p-4 shadow-sm">

--- a/SparkyFitnessMobile/src/screens/SettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SettingsScreen.tsx
@@ -155,7 +155,7 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation }) => {
               {isConnected && (
                 <SettingsRow
                   icon="food-search-settings"
-                  title="Food Search Settings"
+                  title="Food Settings"
                   onPress={() => navigation.navigate('FoodSettings')}
                   iconColor={catOrange}
                 />

--- a/SparkyFitnessMobile/src/types/foodInfo.ts
+++ b/SparkyFitnessMobile/src/types/foodInfo.ts
@@ -59,8 +59,20 @@ export interface NutrientDisplayItem {
   unit: string;
 }
 
+export interface BuildNutrientDisplayListOptions {
+  // When true and `carbs` is provided, a "Total Carbs" row is inserted in the
+  // primary list immediately after the carb-cluster entries (Fiber, Sugars).
+  // Used by callers that have swapped the macro-bar Carbs label to "Net Carbs"
+  // so users can still see the unsubtracted total without losing the row.
+  showNetCarbs?: boolean;
+  carbs?: number;
+}
+
 /** Build primary + additional display lists from a camelCase nutrient source. */
-export function buildNutrientDisplayList(source: Partial<Record<ExtraNutrientKey, number>>) {
+export function buildNutrientDisplayList(
+  source: Partial<Record<ExtraNutrientKey, number>>,
+  options: BuildNutrientDisplayListOptions = {},
+) {
   const primary: NutrientDisplayItem[] = [];
   const additional: NutrientDisplayItem[] = [];
   for (const field of EXTRA_NUTRIENT_FIELDS) {
@@ -73,6 +85,22 @@ export function buildNutrientDisplayList(source: Partial<Record<ExtraNutrientKey
       primary.push(item);
     }
   }
+
+  if (options.showNetCarbs && options.carbs !== undefined) {
+    const carbClusterLabels = new Set(['Fiber', 'Sugars']);
+    let insertIdx = 0;
+    for (let i = 0; i < primary.length; i++) {
+      if (carbClusterLabels.has(primary[i].label)) {
+        insertIdx = i + 1;
+      }
+    }
+    primary.splice(insertIdx, 0, {
+      label: 'Total Carbs',
+      value: options.carbs,
+      unit: 'g',
+    });
+  }
+
   return { primary, additional };
 }
 

--- a/SparkyFitnessMobile/src/types/preferences.ts
+++ b/SparkyFitnessMobile/src/types/preferences.ts
@@ -16,6 +16,7 @@ export interface UserPreferences {
   water_display_unit?: 'ml' | 'oz' | 'liter';
 
   include_bmr_in_net_calories?: boolean;
+  show_net_carbs?: boolean;
   calorie_goal_adjustment_mode?: string;
   auto_scale_open_food_facts_imports?: boolean;
   auto_scale_online_imports?: boolean;

--- a/SparkyFitnessMobile/src/utils/nutrientUtils.ts
+++ b/SparkyFitnessMobile/src/utils/nutrientUtils.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns net carbs: `max(0, carbs - dietaryFiber)`.
+ *
+ * Floored at zero so an entry with over-reported fiber (fiber > carbs) does
+ * not surface as a negative carb count. Mirrors the web implementation in
+ * `SparkyFitnessFrontend/src/utils/nutrientUtils.ts` so behavior matches
+ * across clients honoring the same `show_net_carbs` user preference.
+ */
+export const getNetCarbsValue = (
+  carbs: number | null | undefined,
+  dietaryFiber: number | null | undefined,
+): number => {
+  const carbsValue = Number(carbs) || 0;
+  const fiberValue = Number(dietaryFiber) || 0;
+  return Math.max(0, carbsValue - fiberValue);
+};


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
PR #1298 added a "Show Net Carbs" preference toggle to the web app - when enabled, the carbs label/value/goal-progress swap to net carbs (`max(0, carbs − fiber)`). The preference is persisted on the backend and exposed via the existing preferences endpoint, but the mobile (Expo / React Native) client wasn't reading or applying it. A user turning the toggle on in the web app still saw *total* carbs in the Android/iOS diary, which is inconsistent for a user-level preference.

**How did you implement the solution?**
Three coordinated pieces, all driven by the same `user_preferences.show_net_carbs` field:

1. **Macro-bar swap across all summary surfaces.** When the toggle is on, the protein/carbs/fat bar trio (or composition ring) swaps the "Carbs" label to "Net Carbs" and uses `max(0, carbs − fiber)` for the value, bar/ring share, and goal-progress. Applied on Dashboard, MealTypeDetail, FoodDetail, FoodEntryAdd, FoodEntryView, MealDetail, EditLoggedMeal, and FoodPhotoLogEntry screens - anywhere the macro trio renders. The Fiber tile/row stays as-is so users can still see fiber intake separately.

2. **Total Carbs row preserved in nutrient breakdowns.** Most surfaces show a per-nutrient list (Fiber, Sugars, etc.) below the macro bars via `buildNutrientDisplayList`. When the toggle is on, that helper now injects a "Total Carbs" row immediately after Sugars (or after Fiber if Sugars is absent; at the top of the primary cluster if neither is present). This means total carbs is never lost from the screen- the bar shows net, the row preserves total, and the user can reconcile `net = total − fiber` in one glance. Per apedley's Discord guidance.

3. **Mobile-side "Show Net Carbs" toggle.** Added to `FoodSettingsScreen` alongside the existing food-source / barcode toggles, using the same optimistic-update + rollback + cache-invalidation mutation pattern that already wires up `auto_scale_open_food_facts_imports` etc. Header renamed from "Food Search Settings" → "Food Settings" per @apedley suggestion (the screen is broader than search). Web Calculation Settings still owns the toggle too - both clients write the same DB field via `PUT /api/user-preferences`, so flipping it anywhere syncs everywhere.

The macro-bar Carbs label/value, the buildNutrientDisplayList Total Carbs row, and the mobile toggle are all gated on `preferences.show_net_carbs === true`; default behavior is unchanged for existing users.

Linked Issue: Closes #1325

## How to Test

1. Check out this branch, run `pnpm install`, then start the mobile app per `SparkyFitnessMobile/CLAUDE.md`.
2. Log a few foods on a day with non-trivial carbs *and* fiber (e.g. oats, beans, broccoli - ~100 g carbs / 25 g fiber across the day).
3. In the **mobile** app, **Settings → Food Settings**, confirm "Show Net Carbs" is OFF.
4. On the mobile **Dashboard**, pull to refresh. Verify the Macronutrients card shows label "Carbs" with the total carbs value.
5. Open a food via the Diary or Library, check the Food detail / Food entry view / Meal detail / Meal builder screens - all should show "Carbs" with total carbs in the macro bars.
6. Flip the mobile toggle ON. Pull to refresh / revisit the same screens.
7. Verify everywhere the macro bar trio appears: the Carbs tile now reads "Net Carbs" with `max(0, total − fiber)`. The Fiber tile (where present) is unchanged. Goal progress (where present) is computed against the net value.
8. On screens with a per-nutrient breakdown list below the bars (Food detail, Food entry view, Meal detail, etc.): verify a new "Total Carbs" row appears immediately after Sugars (or after Fiber if no Sugars row is present).
9. Open the web app on the same account, **Settings → Calculation Settings**, and verify "Show Net Carbs" is ON there too - both clients write the same DB field.
10. Flip OFF from web, pull to refresh mobile - everything reverts to "Carbs" with total values and the Total Carbs row disappears.
11. Cross-check by toggling from mobile and verifying the change propagates to the web Diary on next load.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers. *(Issue #1325, approved.)*

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Code Quality**: `pnpm run validate` (typecheck + lint) passes; full jest suite is green (2324/2324 tests, including new tests for `getNetCarbsValue`, `buildNutrientDisplayList` row injection, `NutritionMacroCard` net-carbs display, and the `FoodSettingsScreen` toggle).
- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: Sideloaded a release APK (debug-signed, `applicationId .dev`) against a live v0.16.6.3 backend **on Android**. Verified the golden-path web↔mobile toggle behavior, mobile-side toggle round-trips through to web, edge cases (zero fiber, fiber > carbs flooring), Total Carbs row appears under Sugars when the toggle is on, regression-safety (macro bars still display total carbs when the toggle is off), and visual layout in dark/light themes. **I have not run this on iOS** - I don't have a Mac/iOS device to validate against - but the changes are pure cross-platform React Native (no `Platform.OS` branches, no `.ios.tsx` / `.android.tsx` splits in any touched file), so iOS behavior should be identical. See "iOS assumption and verification" under Notes for Reviewers for the specific assertion + how someone with a Mac can confirm it in under five minutes.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] N/A - no backend changes. The `show_net_carbs` column, repository, service, and Zod schema all already exist from #1298. The new mobile toggle writes through the existing `PUT /api/user-preferences` endpoint.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] N/A - no web frontend changes.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="1440" height="1514" alt="Screenshot_20260526_191314_SparkyFitness" src="https://github.com/user-attachments/assets/1d70e072-5f33-482c-8f96-a3f2aef71520" />

<img width="1440" height="1808" alt="Screenshot_20260526_191338_SparkyFitness" src="https://github.com/user-attachments/assets/1841255b-e854-487e-9d92-4d9018ad7834" />

### After

<img width="1440" height="2196" alt="Screenshot_20260526_191706_SparkyFitness" src="https://github.com/user-attachments/assets/b2aecb0e-bd57-4348-9474-524a0961e235" />

<img width="1440" height="1521" alt="Screenshot_20260526_191327_SparkyFitness" src="https://github.com/user-attachments/assets/9a6d4600-b3f4-4eb3-aab0-27038bb4656e" />

<img width="1440" height="1901" alt="Screenshot_20260526_191348_SparkyFitness" src="https://github.com/user-attachments/assets/f3f9325b-a29f-4183-95a2-6b9a9b5a6252" />

</details>

## Notes for Reviewers

- **Scope decision.** Took the broad scope rather than a tight one: macro-bar swap on every summary surface that has one, plus a new Total Carbs row in the nutrient breakdown when the toggle is on, plus a mobile-side toggle. This is in response to  Discord feedback on the original tighter scope - happy to narrow if any specific surface feels wrong.
- **Surface decision.** Macro bars swap (Dashboard, MealTypeDetail, FoodDetail, FoodEntryAdd, FoodEntryView, MealDetail, EditLoggedMeal, FoodPhotoLogEntry). The bar value and the bar's proportional fill use the net carbs value so the visual representation matches the label. Total carbs is preserved as a new row in the nutrient breakdown below - never lost from the screen.
- **Behavior on missing fiber data.** The `NutritionMacroCard` `showNetCarbs` opt-in is conditional on `fiber !== undefined`. If a caller opts in but fiber is unavailable (a future surface where the data shape doesn't include it), the component falls back to the raw carbs label/value rather than rendering a misleading number. Same defensive fallback in `FoodEntryViewScreen`'s bespoke macro bar.
- **No widget changes.** iOS/Android home-screen widgets still render total carbs. Easy follow-up if desired but felt better to keep this PR scoped to in-app surfaces.
- **No i18n keys added.** Mobile uses hardcoded English strings throughout - adding i18n is a separate, larger refactor.
- **iOS assumption and verification.** The assertion is that iOS will pick up this change without code modifications, because the touched files (`NutritionMacroCard.tsx`, `FoodNutritionSummary.tsx`, `DashboardScreen.tsx`, `MealTypeDetailScreen.tsx`, `FoodDetailScreen.tsx`, `FoodEntryAddScreen.tsx`, `FoodEntryViewScreen.tsx`, `MealDetailScreen.tsx`, `EditLoggedMealScreen.tsx`, `FoodPhotoLogEntryScreen.tsx`, `FoodSettingsScreen.tsx`, `nutrientUtils.ts`, `preferences.ts`, `foodInfo.ts`) contain zero `Platform.OS` / `Platform.select` calls and no `.ios.tsx` / `.android.tsx` sibling files exist for them. The components use only platform-agnostic React Native primitives (`View`, `Text`, `Switch`, `useCSSVariable` via `uniwind`), and the preference is read through the same `usePreferences` hook the iOS app already consumes. **Suggested 3-minute iOS sanity check for anyone with a Mac:** (1) check out this branch, (2) `pnpm install && cd SparkyFitnessMobile && npx expo run:ios --device`, (3) flip Show Net Carbs on either the web app or the new mobile Food Settings toggle, (4) pull-to-refresh the iOS Dashboard and confirm the Carbs tile swaps to "Net Carbs" with the reduced value, plus the Total Carbs row appears on a food entry detail screen. If anyone with a Mac would rather hold the merge until iOS is sanity-checked, that's reasonable.
- **Validation summary**: `pnpm run typecheck` ✅, `pnpm run lint` ✅, `jest 2324/2324` ✅. Sideload-tested on Android against a live v0.16.6.3 backend.
