### PR TITLE
fix(mcp): publish proper inputSchema for sparky_manage_* tools

### DIFF
--- a/SparkyFitnessMCP/src/schemas/checkin.ts
+++ b/SparkyFitnessMCP/src/schemas/checkin.ts
@@ -97,3 +97,56 @@ export const manageCheckinSchema = z.discriminatedUnion("action", [
 ]);
 
 export type ManageCheckinInput = z.infer<typeof manageCheckinSchema>;
+
+
+// Flat input shape published to MCP clients as `inputSchema`. See comment on
+// manageFoodInput in ./food.js for the rationale. Runtime validation still
+// uses manageCheckinSchema in the tool handler via safeParse.
+export const manageCheckinInput = z.object({
+  action: z.enum([
+    "log_biometrics",
+    "log_custom_metric",
+    "list_categories",
+    "create_category",
+    "log_mood",
+    "log_fasting",
+    "log_sleep",
+    "list_checkin_diary",
+    "get_fasting_status",
+    "get_biometrics_history",
+  ]).describe("Action to perform. Each value selects a per-action signature; see the tool description for required fields per action."),
+  entry_date: dateSchema.optional().describe("Date for the entry (YYYY-MM-DD)"),
+  // biometrics
+  weight: z.coerce.number().min(0).optional().describe("Weight value"),
+  weight_unit: weightUnitEnum.optional().describe("Unit for weight (defaults to kg)"),
+  steps: z.coerce.number().int().min(0).optional().describe("Daily step count"),
+  height: z.coerce.number().min(0).optional().describe("Height value"),
+  height_unit: heightUnitEnum.optional().describe("Unit for height"),
+  neck: z.coerce.number().min(0).optional().describe("Neck measurement"),
+  waist: z.coerce.number().min(0).optional().describe("Waist measurement"),
+  hips: z.coerce.number().min(0).optional().describe("Hips measurement"),
+  measurements_unit: measurementsUnitEnum.optional().describe("Unit for body measurements"),
+  body_fat: z.coerce.number().min(0).optional().describe("Body fat percentage"),
+  // custom metrics / categories
+  category_name: z.string().min(1).max(200).optional().describe("Name of the custom category"),
+  value: z.union([z.string(), z.coerce.number()]).optional().describe("Value to record (numeric or string)"),
+  unit: z.string().max(50).optional().describe("Unit for the recorded value"),
+  notes: z.string().max(2000).optional().describe("Optional notes"),
+  data_type: z.enum(["numeric", "boolean"]).optional().describe("Type of data for create_category"),
+  // mood
+  mood_value: z.coerce.number().int().min(1).max(10).optional().describe("Mood score (1-10)"),
+  // fasting
+  start_time: z.string().optional().describe("Start timestamp (ISO 8601) — for log_fasting"),
+  end_time: z.string().optional().describe("End timestamp (ISO 8601) — for log_fasting"),
+  fasting_status: fastingStatusEnum.optional().describe("Fasting session status"),
+  fasting_type: z.string().max(100).optional().describe("Type of fasting (e.g., 'Intermittent')"),
+  // sleep
+  duration_seconds: z.coerce.number().min(0).optional().describe("Total sleep duration in seconds"),
+  sleep_score: z.coerce.number().int().min(0).max(100).optional().describe("Sleep quality score (0-100)"),
+  bedtime: z.string().optional().describe("Bedtime timestamp (ISO 8601)"),
+  wake_time: z.string().optional().describe("Wake-up timestamp (ISO 8601)"),
+  source: z.string().max(100).optional().describe("Source of data (e.g., 'manual', 'Garmin')"),
+  // history range
+  start_date: dateSchema.optional().describe("Start date for the history range"),
+  end_date: dateSchema.optional().describe("End date for the history range"),
+});

--- a/SparkyFitnessMCP/src/schemas/exercise.ts
+++ b/SparkyFitnessMCP/src/schemas/exercise.ts
@@ -91,3 +91,61 @@ export const manageExerciseSchema = z.discriminatedUnion("action", [
 ]);
 
 export type ManageExerciseInput = z.infer<typeof manageExerciseSchema>;
+
+
+// Flat input shape published to MCP clients as `inputSchema`. See comment on
+// manageFoodInput in ./food.js for the rationale (MCP TS SDK can't serialize
+// z.discriminatedUnion). Runtime validation still uses manageExerciseSchema
+// in the tool handler via safeParse.
+export const manageExerciseInput = z.object({
+  action: z.enum([
+    "search_exercises",
+    "create_exercise",
+    "log_exercise",
+    "list_exercise_diary",
+    "get_workout_presets",
+    "log_workout_preset",
+    "delete_exercise_entry",
+    "get_exercise_details",
+    "create_workout_preset",
+    "get_exercise_progress",
+  ]).describe("Action to perform. Each value selects a per-action signature; see the tool description for required fields per action."),
+  // identity
+  exercise_id: uuidSchema.optional().describe("Exercise UUID"),
+  exercise_name: z.string().min(1).max(200).optional().describe("Exercise name (alternative to exercise_id)"),
+  exercise_ids: z.array(uuidSchema).optional().describe("List of exercise UUIDs — for create_workout_preset"),
+  name: z.string().min(1).max(200).optional().describe("Name — for create_exercise / create_workout_preset"),
+  // search
+  searchTerm: z.string().min(1).max(200).optional().describe("Search term — required for search_exercises"),
+  muscleGroup: z.string().optional().describe("Muscle group filter (e.g., 'Chest')"),
+  equipment: z.string().optional().describe("Equipment filter (e.g., 'Dumbbell', 'None')"),
+  limit: z.coerce.number().int().min(1).max(100).optional().describe("Pagination limit"),
+  offset: z.coerce.number().int().min(0).optional().describe("Pagination offset"),
+  // create
+  category: z.string().optional().describe("Exercise category (e.g., 'Strength', 'Cardio')"),
+  calories_per_hour: z.coerce.number().min(0).optional().describe("Estimated calories burned per hour"),
+  description: z.string().max(1000).optional().describe("Description of the exercise"),
+  // log
+  entry_date: dateSchema.optional().describe("Date for the entry (YYYY-MM-DD)"),
+  duration_minutes: z.coerce.number().min(0).optional().describe("Duration in minutes"),
+  calories_burned: z.coerce.number().min(0).optional().describe("Calories burned"),
+  notes: z.string().max(2000).optional().describe("Additional notes"),
+  sets: z.union([
+    z.array(z.object({
+      reps: z.coerce.number().int().min(0).optional(),
+      weight: z.coerce.number().min(0).optional(),
+      duration: z.coerce.number().min(0).optional(),
+      rest_time: z.coerce.number().min(0).optional(),
+      set_type: setTypeEnum.optional(),
+    })),
+    z.string(),
+  ]).optional().describe("Set details as array of objects or JSON string"),
+  // presets
+  preset_id: uuidSchema.optional().describe("Workout preset UUID"),
+  preset_name: z.string().min(1).max(200).optional().describe("Workout preset name"),
+  // entry management
+  entry_id: uuidSchema.optional().describe("Exercise diary entry UUID — for delete_exercise_entry"),
+  // progress range
+  start_date: dateSchema.optional().describe("Start date for progress tracking"),
+  end_date: dateSchema.optional().describe("End date for progress tracking"),
+});

--- a/SparkyFitnessMCP/src/schemas/food.ts
+++ b/SparkyFitnessMCP/src/schemas/food.ts
@@ -168,3 +168,77 @@ export const manageFoodSchema = z.discriminatedUnion("action", [
 ]);
 
 export type ManageFoodInput = z.infer<typeof manageFoodSchema>;
+
+
+// Flat input shape published to MCP clients as `inputSchema`. The MCP TS SDK
+// (≤ 1.27) can serialize `z.object()` to JSON Schema but emits an empty
+// `{type:"object",properties:{}}` for `z.discriminatedUnion()`, which leaves
+// MCP clients with no way to know how to call the tool. Runtime validation
+// continues to use `manageFoodSchema` (the discriminated union) inside the
+// tool handler via `safeParse`, so strict per-action validation is preserved.
+export const manageFoodInput = z.object({
+  action: z.enum([
+    "search_food",
+    "log_food",
+    "create_food",
+    "search_meal",
+    "log_meal",
+    "list_diary",
+    "delete_entry",
+    "delete_food",
+    "update_entry",
+    "copy_from_yesterday",
+    "save_as_meal_template",
+    "log_water",
+    "get_nutritional_summary",
+    "get_water_history",
+  ]).describe("Action to perform. Each value selects a different per-action signature; see the tool description for required fields per action."),
+  // food identity
+  food_name: z.string().min(1).max(200).optional().describe("Food name — required for search_food/log_food/create_food/delete_food (alternative to food_id)"),
+  food_id: uuidSchema.optional().describe("Food UUID — alternative to food_name"),
+  variant_id: uuidSchema.optional().describe("Food variant UUID"),
+  brand: z.string().max(200).optional().describe("Brand name — for create_food"),
+  // serving
+  quantity: z.coerce.number().min(0).optional().describe("Amount consumed (units defined by 'unit')"),
+  unit: z.string().min(1).max(50).optional().describe("Unit of measurement ('g', 'serving', 'piece', etc.)"),
+  // meal / diary
+  meal_type: mealTypeEnum.optional().describe("breakfast | lunch | dinner | snacks"),
+  entry_date: dateSchema.optional().describe("Date for the entry (YYYY-MM-DD)"),
+  meal_id: uuidSchema.optional().describe("Meal template UUID"),
+  meal_name: z.string().min(1).max(200).optional().describe("Meal template name"),
+  // search
+  search_type: searchTypeEnum.optional().describe("exact | broad — for search_food"),
+  limit: z.coerce.number().int().min(1).max(100).optional().describe("Pagination limit"),
+  offset: z.coerce.number().int().min(0).optional().describe("Pagination offset"),
+  // macros (for create_food)
+  calories: z.coerce.number().min(0).optional().describe("Calories (kcal) — required for create_food"),
+  protein: z.coerce.number().min(0).optional().describe("Protein (g) — required for create_food"),
+  carbs: z.coerce.number().min(0).optional().describe("Carbohydrates (g) — required for create_food"),
+  fat: z.coerce.number().min(0).optional().describe("Total fat (g) — required for create_food"),
+  saturated_fat: z.coerce.number().min(0).optional().describe("Saturated fat (g)"),
+  polyunsaturated_fat: z.coerce.number().min(0).optional().describe("Polyunsaturated fat (g)"),
+  monounsaturated_fat: z.coerce.number().min(0).optional().describe("Monounsaturated fat (g)"),
+  trans_fat: z.coerce.number().min(0).optional().describe("Trans fat (g)"),
+  cholesterol: z.coerce.number().min(0).optional().describe("Cholesterol (mg)"),
+  sodium: z.coerce.number().min(0).optional().describe("Sodium (mg)"),
+  potassium: z.coerce.number().min(0).optional().describe("Potassium (mg)"),
+  fiber: z.coerce.number().min(0).optional().describe("Dietary fiber (g)"),
+  sugar: z.coerce.number().min(0).optional().describe("Sugars (g)"),
+  vitamin_a: z.coerce.number().min(0).optional().describe("Vitamin A (%)"),
+  vitamin_c: z.coerce.number().min(0).optional().describe("Vitamin C (%)"),
+  calcium: z.coerce.number().min(0).optional().describe("Calcium (%)"),
+  iron: z.coerce.number().min(0).optional().describe("Iron (%)"),
+  gi: giIndexEnum.optional().describe("Glycemic Index classification"),
+  // entry / diary management
+  entry_id: uuidSchema.optional().describe("Diary entry UUID"),
+  entry_type: entryTypeEnum.optional().describe("food_entry | food_entry_meal"),
+  description: z.string().max(1000).optional().describe("Description (for save_as_meal_template)"),
+  // copy_from_yesterday
+  target_date: optionalDateSchema.describe("Target date (defaults to today)"),
+  source_date: optionalDateSchema.describe("Source date (defaults to yesterday)"),
+  // water
+  amount_ml: z.coerce.number().min(0).optional().describe("Water amount in milliliters"),
+  // range queries
+  start_date: dateSchema.optional().describe("Start date for range queries"),
+  end_date: dateSchema.optional().describe("End date for range queries"),
+});

--- a/SparkyFitnessMCP/src/tools/checkin.ts
+++ b/SparkyFitnessMCP/src/tools/checkin.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { manageCheckinSchema, type ManageCheckinInput } from "../schemas/checkin.js";
+import { manageCheckinSchema, manageCheckinInput, type ManageCheckinInput } from "../schemas/checkin.js";
 import * as checkinService from "../services/checkinService.js";
 import { ERRORS } from "../utils/errors.js";
 import { formatList, formatConfirmation, formatSuccess } from "../utils/formatting.js";
@@ -28,7 +28,10 @@ Actions:
 - list_checkin_diary(entry_date?)
 - get_fasting_status() — returns the currently active fasting session if any
 - get_biometrics_history(start_date?, end_date?) — returns weight and measurements history`,
-      inputSchema: manageCheckinSchema,
+      // Publish the flat shape so MCP clients see the available fields.
+      // The SDK cannot serialize z.discriminatedUnion; manageCheckinSchema
+      // is still used below via safeParse for strict per-action validation.
+      inputSchema: manageCheckinInput,
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -37,7 +40,11 @@ Actions:
       },
     },
     async (rawArgs): Promise<ToolResponse> => {
-      const args = rawArgs as unknown as ManageCheckinInput;
+      const parsed = manageCheckinSchema.safeParse(rawArgs);
+      if (!parsed.success) {
+        return ERRORS.VALIDATION(parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; "));
+      }
+      const args: ManageCheckinInput = parsed.data;
       try {
         switch (args.action) {
           case "log_biometrics": {

--- a/SparkyFitnessMCP/src/tools/exercise.ts
+++ b/SparkyFitnessMCP/src/tools/exercise.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { manageExerciseSchema, type ManageExerciseInput } from "../schemas/exercise.js";
+import { manageExerciseSchema, manageExerciseInput, type ManageExerciseInput } from "../schemas/exercise.js";
 import * as exerciseService from "../services/exerciseService.js";
 import { ERRORS } from "../utils/errors.js";
 import { formatList, formatConfirmation } from "../utils/formatting.js";
@@ -25,7 +25,10 @@ Actions:
 - get_exercise_details(exercise_id?|exercise_name?)
 - create_workout_preset(name, exercise_ids)
 - get_exercise_progress(exercise_id?|exercise_name?, start_date?, end_date?) — returns performance history`,
-      inputSchema: manageExerciseSchema,
+      // Publish the flat shape so MCP clients see the available fields.
+      // The SDK cannot serialize z.discriminatedUnion; manageExerciseSchema
+      // is still used below via safeParse for strict per-action validation.
+      inputSchema: manageExerciseInput,
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -34,7 +37,11 @@ Actions:
       },
     },
     async (rawArgs): Promise<ToolResponse> => {
-      const args = rawArgs as unknown as ManageExerciseInput;
+      const parsed = manageExerciseSchema.safeParse(rawArgs);
+      if (!parsed.success) {
+        return ERRORS.VALIDATION(parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; "));
+      }
+      const args: ManageExerciseInput = parsed.data;
       try {
         switch (args.action) {
           case "search_exercises": {

--- a/SparkyFitnessMCP/src/tools/food.ts
+++ b/SparkyFitnessMCP/src/tools/food.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { manageFoodSchema, type ManageFoodInput } from "../schemas/food.js";
+import { manageFoodSchema, manageFoodInput, type ManageFoodInput } from "../schemas/food.js";
 import * as foodService from "../services/foodService.js";
 import { ERRORS } from "../utils/errors.js";
 import { formatList, formatConfirmation, formatSuccess } from "../utils/formatting.js";
@@ -33,7 +33,10 @@ Actions:
 - log_water(amount_ml, entry_date)
 - get_nutritional_summary(start_date, end_date) — returns macro breakdown for a range of dates
 - get_water_history(start_date?, end_date?)`,
-      inputSchema: manageFoodSchema,
+      // Publish the flat shape so MCP clients see the available fields.
+      // The SDK cannot serialize z.discriminatedUnion; manageFoodSchema is
+      // still used below via safeParse for strict per-action validation.
+      inputSchema: manageFoodInput,
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -42,7 +45,11 @@ Actions:
       },
     },
     async (rawArgs): Promise<ToolResponse> => {
-      const args = rawArgs as unknown as ManageFoodInput;
+      const parsed = manageFoodSchema.safeParse(rawArgs);
+      if (!parsed.success) {
+        return ERRORS.VALIDATION(parsed.error.issues.map(i => `${i.path.join(".")}: ${i.message}`).join("; "));
+      }
+      const args: ManageFoodInput = parsed.data;
       try {
         switch (args.action) {
           case "search_food": {


### PR DESCRIPTION
## Problem

The three `sparky_manage_*` tools publish empty `inputSchema` to MCP clients in `tools/list`:

```jsonc
"inputSchema": { "type": "object", "properties": {} }
```

Reproduction against any deployment (replace `$URL` / `$TOKEN`):

```bash
curl -sS -X POST $URL -H "Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' \
  | jq '.result.tools[] | {name, props: (.inputSchema.properties | length)}'
```

Result: `sparky_manage_food`, `sparky_manage_exercise`, `sparky_manage_checkin` all show `props: 0`. The other tools (e.g. `sparky_inspect_schema`, `sparky_get_health_summary`, `sparky_analyze_food_image`) all show populated properties and a `$schema` field.

## Cause

All three broken tools pass a `z.discriminatedUnion("action", [...])` to `server.registerTool({ inputSchema: ... })`. The MCP TypeScript SDK at `^1.27.1` converts `z.object()` to JSON Schema correctly — you can see `$schema` and populated `properties` on the working tools — but silently falls back to `{type:"object",properties:{}}` for any other Zod type.

Runtime validation still works (Zod errors come back via `isError:true`), but clients can't see fields. Models guess (`name` instead of `food_name`, `protein_g` instead of `protein`, `date` instead of `entry_date`, `snack` instead of `snacks`) and every call fails Zod validation upstream — opaque to most clients.

## Fix

For each of the three tools:

1. Add `export const manage*Input = z.object({...})` in the matching schemas file. The flat shape lists every field any action variant accepts, all optional, each with `.describe()` text indicating which actions need it.
2. In the tool file, import the new shape and pass it as `inputSchema`.
3. Replace the unchecked cast at the top of the handler with `manage*Schema.safeParse(rawArgs)`, returning the structured Zod error via `ERRORS.VALIDATION` if invalid.

The discriminated union still owns runtime correctness; the flat shape only exists to give MCP clients the schema they need.

## Files

| File | Change |
|---|---|
| `SparkyFitnessMCP/src/schemas/food.ts` | +74 — adds `manageFoodInput` |
| `SparkyFitnessMCP/src/schemas/exercise.ts` | +58 — adds `manageExerciseInput` |
| `SparkyFitnessMCP/src/schemas/checkin.ts` | +53 — adds `manageCheckinInput` |
| `SparkyFitnessMCP/src/tools/food.ts` | +10 / -3 — swap `inputSchema`, `safeParse` |
| `SparkyFitnessMCP/src/tools/exercise.ts` | +10 / -3 — same |
| `SparkyFitnessMCP/src/tools/checkin.ts` | +10 / -3 — same |

Total: 6 files, +215 / -9.

## Test plan

- [x] `npm install && npm run build` in `SparkyFitnessMCP/` (the submit script does this; PR will fail to push if it doesn't compile)
- [ ] Start the MCP server locally; hit `tools/list`; confirm all three `manage_*` tools now publish non-empty `inputSchema` with an `action` enum
- [ ] For each tool, call a valid per-action payload (e.g. `{"action":"create_food","food_name":"Test","calories":100,"protein":5,"carbs":10,"fat":3}`) — should succeed exactly as before
- [ ] Call with an invalid payload (missing required field, wrong type, unknown action) — `safeParse` returns the structured Zod error via `ERRORS.VALIDATION` instead of the previous default-fallback message
- [ ] Verify in an MCP client (Claude Desktop / Cline / Cursor / etc.) that the tools now expose their field structure on introspection
