### PR TITLE
fix(mobile): don't send etag to prevent cache issues

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/api/externalExerciseSearchApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/api/externalExerciseSearchApi.test.ts
@@ -135,7 +135,7 @@ describe('externalExerciseSearchApi', () => {
       );
     });
 
-    it('returns the imported exercise', async () => {
+    it('returns the imported exercise with id and name', async () => {
       const responseData = { id: 'new-ex-1', name: 'Bench Press', category: 'Strength' };
       mockGetActiveServerConfig.mockResolvedValue(testConfig);
       mockFetch.mockResolvedValue({
@@ -144,7 +144,66 @@ describe('externalExerciseSearchApi', () => {
       });
 
       const result = await importExercise('wger', '42');
-      expect(result).toEqual(responseData);
+      expect(result.id).toBe('new-ex-1');
+      expect(result.name).toBe('Bench Press');
+      expect(result.category).toBe('Strength');
+    });
+
+    // Regression: server stores `images` as a JSON-stringified array on import.
+    // Before the fix, importExercise returned the raw response, so
+    // `exercise.images[0]` resolved to the first character of the JSON string
+    // (e.g. `'['`) and the workout card requested `/api/uploads/exercises/%5B`.
+    it('parses JSON-stringified images returned by free-exercise-db import', async () => {
+      const responseData = {
+        id: 'ex-1',
+        name: 'One-Arm Kettlebell Clean',
+        source: 'free-exercise-db',
+        images: '["One-Arm_Kettlebell_Clean/0.jpg","One-Arm_Kettlebell_Clean/1.jpg"]',
+      };
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(responseData),
+      });
+
+      const result = await importExercise('free-exercise-db', 'One-Arm_Kettlebell_Clean');
+
+      expect(result.images).toEqual([
+        'One-Arm_Kettlebell_Clean/0.jpg',
+        'One-Arm_Kettlebell_Clean/1.jpg',
+      ]);
+      expect(result.images[0]).toBe('One-Arm_Kettlebell_Clean/0.jpg');
+    });
+
+    it('parses JSON-stringified images returned by wger import', async () => {
+      const responseData = {
+        id: 'ex-2',
+        name: 'Bench Press',
+        source: 'wger',
+        images: '["Bench_Press/0.jpg"]',
+      };
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(responseData),
+      });
+
+      const result = await importExercise('wger', '42');
+
+      expect(result.images).toEqual(['Bench_Press/0.jpg']);
+    });
+
+    it('returns empty images array when server response omits images', async () => {
+      const responseData = { id: 'ex-3', name: 'No Image Exercise' };
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(responseData),
+      });
+
+      const result = await importExercise('wger', '1');
+
+      expect(result.images).toEqual([]);
     });
   });
 });

--- a/SparkyFitnessMobile/src/components/SafeImage.tsx
+++ b/SparkyFitnessMobile/src/components/SafeImage.tsx
@@ -19,18 +19,36 @@ function getImageSourceSignature(
   return `${source.uri}|${headerSignature}`;
 }
 
+// Exercise images are downloaded on-demand by the server on first request, so
+// the initial fetch can race ahead of the server having the file on disk.
+// Retry a couple of times with backoff before giving up to the fallback.
+const MAX_RETRIES = 2;
+const RETRY_DELAY_MS = 1500;
+
 const SafeImage: React.FC<SafeImageProps> = ({ source, style, fallback = null }) => {
   const [error, setError] = useState(false);
+  const [attempt, setAttempt] = useState(0);
   const sourceSignature = getImageSourceSignature(source);
 
   useEffect(() => {
     setError(false);
+    setAttempt(0);
   }, [sourceSignature]);
 
-  if (!source || error) return fallback;
+  useEffect(() => {
+    if (!error || attempt >= MAX_RETRIES) return;
+    const timer = setTimeout(() => {
+      setError(false);
+      setAttempt((a) => a + 1);
+    }, RETRY_DELAY_MS * (attempt + 1));
+    return () => clearTimeout(timer);
+  }, [error, attempt]);
+
+  if (!source || (error && attempt >= MAX_RETRIES)) return fallback;
 
   return (
     <Image
+      key={attempt}
       source={{ uri: source.uri, headers: source.headers }}
       style={style}
       onError={() => setError(true)}

--- a/SparkyFitnessMobile/src/services/api/exerciseApi.ts
+++ b/SparkyFitnessMobile/src/services/api/exerciseApi.ts
@@ -196,7 +196,7 @@ const parseJsonArray = (raw: unknown): string[] => {
   return [];
 };
 
-const transformExerciseRow = (row: Record<string, unknown>): Exercise => ({
+export const transformExerciseRow = (row: Record<string, unknown>): Exercise => ({
   id: String(row.id),
   name: String(row.name),
   category: (row.category as string | null) ?? null,

--- a/SparkyFitnessMobile/src/services/api/externalExerciseSearchApi.ts
+++ b/SparkyFitnessMobile/src/services/api/externalExerciseSearchApi.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from './apiClient';
+import { transformExerciseRow } from './exerciseApi';
 import type { Exercise } from '../../types/exercise';
 import type { PaginatedExternalExerciseSearchResult } from '../../types/externalExercises';
 
@@ -28,24 +29,30 @@ export async function importExercise(
   source: string,
   externalId: string,
 ): Promise<Exercise> {
+  // Server stores `images` as a JSON-stringified array; transformExerciseRow
+  // parses it back so callers can index it as string[] (#1353 follow-up).
   switch (source) {
-    case 'wger':
-      return apiFetch<Exercise>({
+    case 'wger': {
+      const row = await apiFetch<Record<string, unknown>>({
         endpoint: '/api/exercises/add-external',
         serviceName: 'External Exercise Search',
         operation: 'import wger exercise',
         method: 'POST',
         body: { wgerExerciseId: Number(externalId) },
       });
+      return transformExerciseRow(row);
+    }
 
-    case 'free-exercise-db':
-      return apiFetch<Exercise>({
+    case 'free-exercise-db': {
+      const row = await apiFetch<Record<string, unknown>>({
         endpoint: '/api/freeexercisedb/add',
         serviceName: 'External Exercise Search',
         operation: 'import Free Exercise DB exercise',
         method: 'POST',
         body: { exerciseId: externalId },
       });
+      return transformExerciseRow(row);
+    }
 
     default:
       throw new Error(`Unsupported exercise source: ${source}`);

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -103,6 +103,8 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 app.set('trust proxy', 1); // Trust the first proxy immediately in front of me just internal nginx. external not required.
+// 304s from ETag revalidation break the iOS mobile app (#1353).
+app.set('etag', false);
 const PORT = process.env.SPARKY_FITNESS_SERVER_PORT || 3010;
 console.log(
   `DEBUG: SPARKY_FITNESS_FRONTEND_URL is: ${process.env.SPARKY_FITNESS_FRONTEND_URL}`
@@ -211,6 +213,11 @@ console.log('SparkyFitnessServer UPLOADS_BASE_DIR:', UPLOADS_BASE_DIR);
 // Mount at both paths for compatibility during transition
 app.use('/api/uploads', express.static(UPLOADS_BASE_DIR));
 app.use('/uploads', express.static(UPLOADS_BASE_DIR));
+// Mounted after uploads so static image Cache-Control isn't clobbered.
+app.use('/api', (_req, res, next) => {
+  res.setHeader('Cache-Control', 'no-store');
+  next();
+});
 // On-demand image serving route
 /**
  * @swagger

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -210,9 +210,13 @@ const UPLOADS_BASE_DIR = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
   : path.join(__dirname, 'uploads');
 
 console.log('SparkyFitnessServer UPLOADS_BASE_DIR:', UPLOADS_BASE_DIR);
-// Mount at both paths for compatibility during transition
-app.use('/api/uploads', express.static(UPLOADS_BASE_DIR));
-app.use('/uploads', express.static(UPLOADS_BASE_DIR));
+// Mount at both paths for compatibility during transition.
+// Disable etag/lastModified — iOS CFNetwork mis-handles the resulting 304s
+// on freshly uploaded images (#1353). Filenames embed Date.now() so URLs
+// are already effectively immutable; clients still cache by URL.
+const uploadsStaticOptions = { etag: false, lastModified: false };
+app.use('/api/uploads', express.static(UPLOADS_BASE_DIR, uploadsStaticOptions));
+app.use('/uploads', express.static(UPLOADS_BASE_DIR, uploadsStaticOptions));
 // Mounted after uploads so static image Cache-Control isn't clobbered.
 app.use('/api', (_req, res, next) => {
   res.setHeader('Cache-Control', 'no-store');
@@ -309,7 +313,7 @@ app.get(
     );
 
     if (resolvedStatus !== 'NOT_FOUND') {
-      return res.sendFile(localImagePath);
+      return res.sendFile(localImagePath, uploadsStaticOptions);
     }
     // If not found, attempt to re-download. Resolve image paths from the
     // upstream free-exercise-db record (the canonical source) rather than a
@@ -330,7 +334,7 @@ app.get(
         originalRelativeImagePath
       );
       await downloadImage(externalImageUrl, exerciseId);
-      res.sendFile(localImagePath);
+      res.sendFile(localImagePath, uploadsStaticOptions);
     } catch (error) {
       // @ts-expect-error TS18046
       log('error', `Error serving image: ${error.message}`);

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -218,8 +218,12 @@ const uploadsStaticOptions = { etag: false, lastModified: false };
 app.use('/api/uploads', express.static(UPLOADS_BASE_DIR, uploadsStaticOptions));
 app.use('/uploads', express.static(UPLOADS_BASE_DIR, uploadsStaticOptions));
 // Mounted after uploads so static image Cache-Control isn't clobbered.
-app.use('/api', (_req, res, next) => {
-  res.setHeader('Cache-Control', 'no-store');
+// Skip /api/uploads so the on-demand image route (which falls through static
+// on first download) doesn't get no-store applied to immutable image URLs.
+app.use('/api', (req, res, next) => {
+  if (!req.originalUrl.startsWith('/api/uploads')) {
+    res.setHeader('Cache-Control', 'no-store');
+  }
   next();
 });
 // On-demand image serving route


### PR DESCRIPTION
[!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
iOS users can experience cache issues when receiving 304s.

**How did you implement the solution?**
Don't send etag so there's cache validation. The real caching happens through react query on both the web and mobile apps.

Linked Issue: Closes #1353

## How to Test

1. Add food data
2. Refresh
3. Should not error

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
