### PR TITLE
feat(#1014): allergen tracking from OpenFoodFacts with user preferences and warning badges

### DIFF
--- a/SparkyFitnessFrontend/src/api/Foods/enhancedCustomFoodFormService.ts
+++ b/SparkyFitnessFrontend/src/api/Foods/enhancedCustomFoodFormService.ts
@@ -101,11 +101,13 @@ export const saveFood = async (
           vitamin_c: variant.vitamin_c,
           calcium: variant.calcium,
           iron: variant.iron,
-          is_default: variant.is_default || false, // Pass is_default flag
+          is_default: variant.is_default || false,
           glycemic_index: variant.glycemic_index,
-          custom_nutrients: variant.custom_nutrients || {}, // Include custom nutrients
+          custom_nutrients: variant.custom_nutrients || {},
           source: variant.source,
           ai_confidence: variant.ai_confidence,
+          allergens: variant.allergens ?? null,
+          traces: variant.traces ?? null,
         },
       });
     }

--- a/SparkyFitnessFrontend/src/api/allergenPreferences.ts
+++ b/SparkyFitnessFrontend/src/api/allergenPreferences.ts
@@ -1,0 +1,18 @@
+import type { UserAllergenPreference } from '../types/allergenPreference';
+import { api } from './api';
+
+export const allergenPreferenceService = {
+  async getAll(): Promise<UserAllergenPreference[]> {
+    return api.get('/allergen-preferences');
+  },
+
+  async add(allergenName: string): Promise<UserAllergenPreference> {
+    return api.post('/allergen-preferences', {
+      body: { allergen_name: allergenName },
+    });
+  },
+
+  async remove(id: string): Promise<void> {
+    await api.delete(`/allergen-preferences/${id}`);
+  },
+};

--- a/SparkyFitnessFrontend/src/api/keys/meals.ts
+++ b/SparkyFitnessFrontend/src/api/keys/meals.ts
@@ -62,3 +62,7 @@ export const foodVariantKeys = {
   all: [...foodKeys.all, 'variants'] as const,
   byFood: (foodId: string) => [...foodKeys.all, 'variants', foodId] as const,
 };
+
+export const allergenPreferenceKeys = {
+  all: ['allergenPreferences'] as const,
+};

--- a/SparkyFitnessFrontend/src/components/AllergenBadges.tsx
+++ b/SparkyFitnessFrontend/src/components/AllergenBadges.tsx
@@ -1,0 +1,56 @@
+import { Badge } from '@/components/ui/badge';
+import { useAllergenPreferences } from '@/hooks/useAllergenPreferences';
+
+interface AllergenBadgesProps {
+  allergens?: string[] | null;
+  traces?: string[] | null;
+}
+
+/**
+ * Shows allergen/trace warning badges for a food item, but only for allergens
+ * the user has configured in their allergen preferences. If the user has set no
+ * preferences nothing is rendered, so the UI stays clean for everyone who doesn't
+ * track allergens.
+ */
+const AllergenBadges = ({ allergens, traces }: AllergenBadgesProps) => {
+  const { data: preferences } = useAllergenPreferences();
+  const userAllergens =
+    preferences?.map((p) => p.allergen_name.toLowerCase()) ?? [];
+
+  if (userAllergens.length === 0) return null;
+  if (!allergens?.length && !traces?.length) return null;
+
+  const matchingAllergens = (allergens ?? []).filter((a) =>
+    userAllergens.includes(a.toLowerCase())
+  );
+  const matchingTraces = (traces ?? []).filter((t) =>
+    userAllergens.includes(t.toLowerCase())
+  );
+
+  if (matchingAllergens.length === 0 && matchingTraces.length === 0)
+    return null;
+
+  return (
+    <div className="flex flex-wrap gap-1 mt-1">
+      {matchingAllergens.map((a) => (
+        <Badge
+          key={`allergen-${a}`}
+          variant="destructive"
+          className="text-xs capitalize"
+        >
+          ⚠ {a}
+        </Badge>
+      ))}
+      {matchingTraces.map((t) => (
+        <Badge
+          key={`trace-${t}`}
+          className="text-xs capitalize bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200 border-orange-300"
+        >
+          trace: {t}
+        </Badge>
+      ))}
+    </div>
+  );
+};
+
+export default AllergenBadges;

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodResultCard.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodResultCard.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Edit, Share2, Sparkles } from 'lucide-react';
 import { NutrientGrid } from './NutrientGrid';
+import AllergenBadges from '@/components/AllergenBadges';
 import type { Food } from '@/types/food';
 import type { Meal } from '@/types/meal';
 import type { UserCustomNutrient } from '@/types/customNutrient';
@@ -151,6 +152,10 @@ const FoodResultCard = ({
                   Per {foodItem.default_variant.serving_size}
                   {foodItem.default_variant.serving_unit}
                 </p>
+                <AllergenBadges
+                  allergens={foodItem.default_variant.allergens}
+                  traces={foodItem.default_variant.traces}
+                />
               </>
             )}
           </div>

--- a/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
 import {
   Select,
   SelectContent,
@@ -11,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Copy, Trash2, Check, Plus, Sparkles } from 'lucide-react';
+import { Copy, Trash2, Check, Plus, X, Sparkles } from 'lucide-react';
 import type { EquivalentUnit, GlycemicIndex } from '@/types/food';
 import type { FormFoodVariant } from '@/utils/foodForm';
 import {
@@ -46,6 +48,24 @@ const AI_SPARKLE_TONE_CLASSES: Record<ConfidenceTone, string> = {
   warning: 'text-amber-500 dark:text-amber-400',
   error: 'text-rose-500 dark:text-rose-400',
 };
+
+const COMMON_ALLERGENS = [
+  'gluten',
+  'wheat',
+  'milk',
+  'eggs',
+  'peanuts',
+  'tree nuts',
+  'soy',
+  'fish',
+  'shellfish',
+  'crustaceans',
+  'sesame',
+  'celery',
+  'mustard',
+  'lupin',
+  'sulphites',
+];
 
 interface VariantCardProps {
   index: number;
@@ -91,7 +111,14 @@ interface VariantCardProps {
   onUpdate: (
     index: number,
     field: string,
-    value: string | number | boolean | null | GlycemicIndex | EquivalentUnit[]
+    value:
+      | string
+      | number
+      | boolean
+      | null
+      | GlycemicIndex
+      | EquivalentUnit[]
+      | string[]
   ) => void;
   onDuplicate: (index: number) => void;
   onRemove: (index: number) => void;
@@ -119,6 +146,24 @@ export function VariantCard({
   onRemove,
 }: VariantCardProps) {
   const equivalents = variant.equivalents ?? [];
+  const [allergenInput, setAllergenInput] = useState('');
+
+  const currentAllergens: string[] = variant.allergens ?? [];
+
+  const addAllergen = (name: string) => {
+    const trimmed = name.trim().toLowerCase();
+    if (!trimmed || currentAllergens.includes(trimmed)) return;
+    onUpdate(index, 'allergens', [...currentAllergens, trimmed]);
+    setAllergenInput('');
+  };
+
+  const removeAllergen = (name: string) => {
+    onUpdate(
+      index,
+      'allergens',
+      currentAllergens.filter((a) => a !== name)
+    );
+  };
 
   // Per-row AI gate. The anchor is supplied by the parent (defaults to the
   // food's default variant, or the row's previous state when the user just
@@ -425,6 +470,68 @@ export function VariantCard({
         customNutrients={customNutrients}
         onUpdate={onUpdate}
       />
+
+      <div className="mt-4 space-y-2">
+        <Label>Allergens</Label>
+        <div className="flex flex-wrap gap-1 mb-2">
+          {COMMON_ALLERGENS.map((a) => (
+            <Badge
+              key={a}
+              variant={currentAllergens.includes(a) ? 'default' : 'outline'}
+              className={`cursor-pointer capitalize select-none text-xs ${currentAllergens.includes(a) ? 'opacity-60' : 'hover:bg-accent'}`}
+              onClick={() =>
+                currentAllergens.includes(a)
+                  ? removeAllergen(a)
+                  : addAllergen(a)
+              }
+            >
+              {currentAllergens.includes(a) && <X className="h-3 w-3 mr-1" />}
+              {a}
+            </Badge>
+          ))}
+        </div>
+        {currentAllergens.filter((a) => !COMMON_ALLERGENS.includes(a)).length >
+          0 && (
+          <div className="flex flex-wrap gap-1 mb-2">
+            {currentAllergens
+              .filter((a) => !COMMON_ALLERGENS.includes(a))
+              .map((a) => (
+                <Badge
+                  key={a}
+                  variant="secondary"
+                  className="capitalize text-xs cursor-pointer"
+                  onClick={() => removeAllergen(a)}
+                >
+                  <X className="h-3 w-3 mr-1" />
+                  {a}
+                </Badge>
+              ))}
+          </div>
+        )}
+        <div className="flex gap-2">
+          <Input
+            value={allergenInput}
+            onChange={(e) => setAllergenInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addAllergen(allergenInput);
+              }
+            }}
+            placeholder="Custom allergen…"
+            className="max-w-xs h-8 text-sm"
+          />
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => addAllergen(allergenInput)}
+            disabled={!allergenInput.trim()}
+          >
+            Add
+          </Button>
+        </div>
+      </div>
     </Card>
   );
 }

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
@@ -605,7 +605,14 @@ export function useCustomFoodForm({
   const updateVariant = (
     index: number,
     field: keyof FormFoodVariant | string,
-    value: string | number | boolean | null | GlycemicIndex | EquivalentUnit[]
+    value:
+      | string
+      | number
+      | boolean
+      | null
+      | GlycemicIndex
+      | EquivalentUnit[]
+      | string[]
   ) => {
     const updatedVariants = [...variants];
     const updatedOriginalVariants = [...originalVariants];

--- a/SparkyFitnessFrontend/src/hooks/useAllergenPreferences.ts
+++ b/SparkyFitnessFrontend/src/hooks/useAllergenPreferences.ts
@@ -1,0 +1,39 @@
+import { allergenPreferenceKeys } from '@/api/keys/meals';
+import { allergenPreferenceService } from '@/api/allergenPreferences';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const useAllergenPreferences = () =>
+  useQuery({
+    queryKey: allergenPreferenceKeys.all,
+    queryFn: () => allergenPreferenceService.getAll(),
+    meta: { errorMessage: 'Failed to load allergen preferences.' },
+  });
+
+export const useAddAllergenPreferenceMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (allergenName: string) =>
+      allergenPreferenceService.add(allergenName),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: allergenPreferenceKeys.all });
+    },
+    meta: {
+      errorMessage: 'Failed to add allergen.',
+      successMessage: 'Allergen added.',
+    },
+  });
+};
+
+export const useRemoveAllergenPreferenceMutation = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => allergenPreferenceService.remove(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: allergenPreferenceKeys.all });
+    },
+    meta: {
+      errorMessage: 'Failed to remove allergen.',
+      successMessage: 'Allergen removed.',
+    },
+  });
+};

--- a/SparkyFitnessFrontend/src/hooks/useSyncAllergens.ts
+++ b/SparkyFitnessFrontend/src/hooks/useSyncAllergens.ts
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { useToast } from '@/hooks/use-toast';
+import { apiCall } from '@/api/api';
+
+export const useSyncAllergens = () => {
+  const { toast } = useToast();
+  const [syncingAllergens, setSyncingAllergens] = useState(false);
+
+  const handleSyncAllergens = async () => {
+    setSyncingAllergens(true);
+    try {
+      const result = (await apiCall('/foods/sync-allergens', {
+        method: 'POST',
+      })) as { updated: number; total: number };
+      toast({
+        title: 'Allergen sync complete',
+        description:
+          result.total === 0
+            ? 'All your OpenFoodFacts foods already have allergen data.'
+            : `Updated ${result.updated} of ${result.total} food(s).`,
+      });
+    } catch {
+      toast({
+        title: 'Sync failed',
+        description: 'Could not sync allergens. Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setSyncingAllergens(false);
+    }
+  };
+
+  return { handleSyncAllergens, syncingAllergens };
+};

--- a/SparkyFitnessFrontend/src/pages/Diary/MealCard.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/MealCard.tsx
@@ -58,6 +58,7 @@ import type { UserCustomNutrient } from '@/types/customNutrient';
 import { DEFAULT_NUTRIENTS } from '@/constants/nutrients';
 import { useSearchParams } from 'react-router-dom';
 import { cn } from '@/lib/utils';
+import AllergenBadges from '@/components/AllergenBadges';
 
 const MOBILE_ENTRY_NUTRIENT_LIMIT = 4;
 
@@ -450,6 +451,12 @@ const MealCard = ({
                                 </Badge>
                               )}
                           </div>
+                          {isFoodEntry && (
+                            <AllergenBadges
+                              allergens={(item as FoodEntry).allergens}
+                              traces={(item as FoodEntry).traces}
+                            />
+                          )}
                         </div>
                         {mobileCalories && (
                           <div className="text-right">
@@ -607,6 +614,12 @@ const MealCard = ({
                           );
                         })}
                       </div>
+                      {isFoodEntry && (
+                        <AllergenBadges
+                          allergens={(item as FoodEntry).allergens}
+                          traces={(item as FoodEntry).traces}
+                        />
+                      )}
                     </div>
                     <div className="flex items-center space-x-2">
                       <Button

--- a/SparkyFitnessFrontend/src/pages/Foods/Foods.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/Foods.tsx
@@ -28,6 +28,7 @@ import {
   MoreHorizontal,
   Edit,
   Trash2,
+  RefreshCw,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -67,11 +68,15 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useCustomNutrients } from '@/hooks/Foods/useCustomNutrients';
+import { useToast } from '@/hooks/use-toast';
+import { apiCall } from '@/api/api';
 
 const FoodDatabaseManager = () => {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
+  const { toast } = useToast();
   const [viewingFood, setViewingFood] = useState<Food | null>(null);
+  const [syncingAllergens, setSyncingAllergens] = useState(false);
   const { data: customNutrients = [] } = useCustomNutrients();
 
   const {
@@ -136,6 +141,30 @@ const FoodDatabaseManager = () => {
   }, [isEditMode]);
 
   const [showBulkDeleteDialog, setShowBulkDeleteDialog] = useState(false);
+
+  const handleSyncAllergens = async () => {
+    setSyncingAllergens(true);
+    try {
+      const result = (await apiCall('/foods/sync-allergens', {
+        method: 'POST',
+      })) as { updated: number; total: number };
+      toast({
+        title: 'Allergen sync complete',
+        description:
+          result.total === 0
+            ? 'All your OpenFoodFacts foods already have allergen data.'
+            : `Updated ${result.updated} of ${result.total} food(s).`,
+      });
+    } catch {
+      toast({
+        title: 'Sync failed',
+        description: 'Could not sync allergens. Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setSyncingAllergens(false);
+    }
+  };
 
   const editableFoodIds = useMemo(() => {
     return foodData?.foods.filter((f) => canEdit(f)).map((f) => f.id) || [];
@@ -494,6 +523,31 @@ const FoodDatabaseManager = () => {
                   {!isMobile && (
                     <span>
                       {t('foodDatabaseManager.addNewFood', 'Add New Food')}
+                    </span>
+                  )}
+                </Button>
+                <Button
+                  size={isMobile ? 'icon' : 'default'}
+                  variant="outline"
+                  onClick={handleSyncAllergens}
+                  disabled={syncingAllergens}
+                  className="shrink-0"
+                  title={t(
+                    'foodDatabaseManager.syncAllergens',
+                    'Sync Allergens from OpenFoodFacts'
+                  )}
+                >
+                  <RefreshCw
+                    className={`${isMobile ? 'w-5 h-5' : 'w-4 h-4 mr-2'} ${syncingAllergens ? 'animate-spin' : ''}`}
+                  />
+                  {!isMobile && (
+                    <span>
+                      {syncingAllergens
+                        ? t('foodDatabaseManager.syncingAllergens', 'Syncing…')
+                        : t(
+                            'foodDatabaseManager.syncAllergens',
+                            'Sync Allergens'
+                          )}
                     </span>
                   )}
                 </Button>

--- a/SparkyFitnessFrontend/src/pages/Foods/Foods.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/Foods.tsx
@@ -68,15 +68,13 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useCustomNutrients } from '@/hooks/Foods/useCustomNutrients';
-import { useToast } from '@/hooks/use-toast';
-import { apiCall } from '@/api/api';
+import { useSyncAllergens } from '@/hooks/useSyncAllergens';
 
 const FoodDatabaseManager = () => {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
-  const { toast } = useToast();
   const [viewingFood, setViewingFood] = useState<Food | null>(null);
-  const [syncingAllergens, setSyncingAllergens] = useState(false);
+  const { handleSyncAllergens, syncingAllergens } = useSyncAllergens();
   const { data: customNutrients = [] } = useCustomNutrients();
 
   const {
@@ -141,30 +139,6 @@ const FoodDatabaseManager = () => {
   }, [isEditMode]);
 
   const [showBulkDeleteDialog, setShowBulkDeleteDialog] = useState(false);
-
-  const handleSyncAllergens = async () => {
-    setSyncingAllergens(true);
-    try {
-      const result = (await apiCall('/foods/sync-allergens', {
-        method: 'POST',
-      })) as { updated: number; total: number };
-      toast({
-        title: 'Allergen sync complete',
-        description:
-          result.total === 0
-            ? 'All your OpenFoodFacts foods already have allergen data.'
-            : `Updated ${result.updated} of ${result.total} food(s).`,
-      });
-    } catch {
-      toast({
-        title: 'Sync failed',
-        description: 'Could not sync allergens. Please try again.',
-        variant: 'destructive',
-      });
-    } finally {
-      setSyncingAllergens(false);
-    }
-  };
 
   const editableFoodIds = useMemo(() => {
     return foodData?.foods.filter((f) => canEdit(f)).map((f) => f.id) || [];

--- a/SparkyFitnessFrontend/src/pages/Foods/Foods.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/Foods.tsx
@@ -45,6 +45,7 @@ import { Meal, MealFilter } from '@/types/meal';
 import { useFoodDatabaseManager } from '@/hooks/Foods/useFoodDatabaseManager';
 import DeleteFoodDialog, { PendingDeletion } from './DeleteFoodDialog';
 import FoodSearchDialog from '@/components/FoodSearch/FoodSearchDialog';
+import AllergenBadges from '@/components/AllergenBadges';
 
 import { useBulkSelection } from '@/hooks/useBulkSelection';
 import BulkActionToolbar from '@/components/BulkActionToolbar';
@@ -250,6 +251,10 @@ const FoodDatabaseManager = () => {
                   defaultValue: `Per ${food.default_variant?.serving_size || 0} ${food.default_variant?.serving_unit || ''}`,
                 })}
               </span>
+              <AllergenBadges
+                allergens={food.default_variant?.allergens}
+                traces={food.default_variant?.traces}
+              />
             </div>
           );
         },

--- a/SparkyFitnessFrontend/src/pages/Foods/Foods.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/Foods.tsx
@@ -28,7 +28,6 @@ import {
   MoreHorizontal,
   Edit,
   Trash2,
-  RefreshCw,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -68,13 +67,11 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useCustomNutrients } from '@/hooks/Foods/useCustomNutrients';
-import { useSyncAllergens } from '@/hooks/useSyncAllergens';
 
 const FoodDatabaseManager = () => {
   const { t } = useTranslation();
   const isMobile = useIsMobile();
   const [viewingFood, setViewingFood] = useState<Food | null>(null);
-  const { handleSyncAllergens, syncingAllergens } = useSyncAllergens();
   const { data: customNutrients = [] } = useCustomNutrients();
 
   const {
@@ -497,31 +494,6 @@ const FoodDatabaseManager = () => {
                   {!isMobile && (
                     <span>
                       {t('foodDatabaseManager.addNewFood', 'Add New Food')}
-                    </span>
-                  )}
-                </Button>
-                <Button
-                  size={isMobile ? 'icon' : 'default'}
-                  variant="outline"
-                  onClick={handleSyncAllergens}
-                  disabled={syncingAllergens}
-                  className="shrink-0"
-                  title={t(
-                    'foodDatabaseManager.syncAllergens',
-                    'Sync Allergens from OpenFoodFacts'
-                  )}
-                >
-                  <RefreshCw
-                    className={`${isMobile ? 'w-5 h-5' : 'w-4 h-4 mr-2'} ${syncingAllergens ? 'animate-spin' : ''}`}
-                  />
-                  {!isMobile && (
-                    <span>
-                      {syncingAllergens
-                        ? t('foodDatabaseManager.syncingAllergens', 'Syncing…')
-                        : t(
-                            'foodDatabaseManager.syncAllergens',
-                            'Sync Allergens'
-                          )}
                     </span>
                   )}
                 </Button>

--- a/SparkyFitnessFrontend/src/pages/Settings/AllergenSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/AllergenSettings.tsx
@@ -4,8 +4,9 @@ import { useToast } from '../../hooks/use-toast';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
-import { Trash2 } from 'lucide-react';
+import { Trash2, RefreshCw } from 'lucide-react';
 import { Badge } from '../../components/ui/badge';
+import { useSyncAllergens } from '@/hooks/useSyncAllergens';
 import {
   Table,
   TableBody,
@@ -41,6 +42,7 @@ const COMMON_ALLERGENS = [
 const AllergenSettings: React.FC = () => {
   const [newAllergen, setNewAllergen] = useState('');
   const { toast } = useToast();
+  const { handleSyncAllergens, syncingAllergens } = useSyncAllergens();
 
   const { data: preferences } = useAllergenPreferences();
   const { mutateAsync: addAllergen } = useAddAllergenPreferenceMutation();
@@ -117,6 +119,24 @@ const AllergenSettings: React.FC = () => {
             </Button>
           </div>
         </div>
+      </div>
+
+      <div className="p-4 border rounded-md shadow-sm space-y-2">
+        <h3 className="text-xl font-semibold">Sync from OpenFoodFacts</h3>
+        <p className="text-sm text-muted-foreground">
+          Fetch allergen data for your saved OpenFoodFacts foods. Only needs to
+          be done once.
+        </p>
+        <Button
+          variant="outline"
+          onClick={handleSyncAllergens}
+          disabled={syncingAllergens}
+        >
+          <RefreshCw
+            className={`w-4 h-4 mr-2 ${syncingAllergens ? 'animate-spin' : ''}`}
+          />
+          {syncingAllergens ? 'Syncing…' : 'Sync Allergens'}
+        </Button>
       </div>
 
       <div className="p-4 border rounded-md shadow-sm">

--- a/SparkyFitnessFrontend/src/pages/Settings/AllergenSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/AllergenSettings.tsx
@@ -1,0 +1,160 @@
+import type React from 'react';
+import { useState } from 'react';
+import { useToast } from '../../hooks/use-toast';
+import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
+import { Label } from '../../components/ui/label';
+import { Trash2 } from 'lucide-react';
+import { Badge } from '../../components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '../../components/ui/table';
+import {
+  useAllergenPreferences,
+  useAddAllergenPreferenceMutation,
+  useRemoveAllergenPreferenceMutation,
+} from '@/hooks/useAllergenPreferences';
+
+const COMMON_ALLERGENS = [
+  'gluten',
+  'wheat',
+  'milk',
+  'eggs',
+  'peanuts',
+  'tree nuts',
+  'soy',
+  'fish',
+  'shellfish',
+  'crustaceans',
+  'sesame',
+  'celery',
+  'mustard',
+  'lupin',
+  'sulphites',
+];
+
+const AllergenSettings: React.FC = () => {
+  const [newAllergen, setNewAllergen] = useState('');
+  const { toast } = useToast();
+
+  const { data: preferences } = useAllergenPreferences();
+  const { mutateAsync: addAllergen } = useAddAllergenPreferenceMutation();
+  const { mutateAsync: removeAllergen } = useRemoveAllergenPreferenceMutation();
+
+  const existingNames = new Set(
+    preferences?.map((p) => p.allergen_name.toLowerCase()) ?? []
+  );
+
+  const handleAdd = async (name: string) => {
+    const trimmed = name.trim().toLowerCase();
+    if (!trimmed) return;
+    if (existingNames.has(trimmed)) {
+      toast({
+        title: 'Already added',
+        description: `${trimmed} is already in your list.`,
+      });
+      return;
+    }
+    await addAllergen(trimmed);
+    setNewAllergen('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') handleAdd(newAllergen);
+  };
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-2xl font-bold">Allergen Preferences</h2>
+      <p className="text-sm text-muted-foreground">
+        Add the allergens you want to be warned about. When a food contains one
+        of these, a warning badge will appear on food cards and search results.
+      </p>
+
+      <div className="p-4 border rounded-md shadow-sm space-y-4">
+        <h3 className="text-xl font-semibold">Common Allergens</h3>
+        <div className="flex flex-wrap gap-2">
+          {COMMON_ALLERGENS.map((allergen) => {
+            const already = existingNames.has(allergen);
+            return (
+              <Badge
+                key={allergen}
+                variant={already ? 'default' : 'outline'}
+                className={`cursor-pointer capitalize select-none ${already ? 'opacity-50 pointer-events-none' : 'hover:bg-accent'}`}
+                onClick={() => !already && handleAdd(allergen)}
+              >
+                {allergen}
+              </Badge>
+            );
+          })}
+        </div>
+
+        <div className="pt-2">
+          <Label htmlFor="customAllergen">Custom allergen</Label>
+          <div className="flex gap-2 mt-1">
+            <Input
+              id="customAllergen"
+              value={newAllergen}
+              onChange={(e) => setNewAllergen(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="e.g., lupin, molluscs…"
+              className="max-w-xs"
+            />
+            <Button
+              onClick={() => handleAdd(newAllergen)}
+              disabled={!newAllergen.trim()}
+            >
+              Add
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="p-4 border rounded-md shadow-sm">
+        <h3 className="text-xl font-semibold mb-4">Your Tracked Allergens</h3>
+        {!preferences || preferences.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No allergens tracked yet. Add some above to get warnings on food
+            cards.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Allergen</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {preferences.map((pref) => (
+                <TableRow key={pref.id}>
+                  <TableCell className="capitalize">
+                    {pref.allergen_name}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="text-red-500"
+                      onClick={() => removeAllergen(pref.id)}
+                      title="Remove"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AllergenSettings;

--- a/SparkyFitnessFrontend/src/pages/Settings/AllergenSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/AllergenSettings.tsx
@@ -44,7 +44,7 @@ const AllergenSettings: React.FC = () => {
 
   const { data: preferences } = useAllergenPreferences();
   const { mutateAsync: addAllergen } = useAddAllergenPreferenceMutation();
-  const { mutateAsync: removeAllergen } = useRemoveAllergenPreferenceMutation();
+  const { mutate: removeAllergen } = useRemoveAllergenPreferenceMutation();
 
   const existingNames = new Set(
     preferences?.map((p) => p.allergen_name.toLowerCase()) ?? []
@@ -60,8 +60,12 @@ const AllergenSettings: React.FC = () => {
       });
       return;
     }
-    await addAllergen(trimmed);
-    setNewAllergen('');
+    try {
+      await addAllergen(trimmed);
+      setNewAllergen('');
+    } catch {
+      // error surfaced via global query error handler
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/SparkyFitnessFrontend/src/pages/Settings/SettingsPage.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/SettingsPage.tsx
@@ -9,6 +9,7 @@ import {
   Cloud,
   Sparkles,
   UtensilsCrossed,
+  ShieldAlert,
 } from 'lucide-react';
 import FamilyAccessManager from './FamilyAccessManager';
 import AIServiceSettings from './AIServiceSettings';
@@ -25,6 +26,7 @@ import {
 import CalculationSettings from './CalculationSettings';
 import TooltipWarning from '@/components/TooltipWarning';
 import CustomNutrientsSettings from '@/pages/Settings/CustomNutrientsSettings';
+import AllergenSettings from '@/pages/Settings/AllergenSettings';
 import { DeveloperResources } from './DevloperResources';
 import { AccountSecurity } from './AccountSecurity';
 import { ApiSettings } from './ApiSettings';
@@ -100,6 +102,25 @@ const Settings = () => {
           </AccordionTrigger>
           <AccordionContent className="p-4 pt-0">
             <CustomNutrientsSettings />
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem
+          value="allergen-preferences"
+          className="border rounded-lg mb-4"
+        >
+          <AccordionTrigger
+            className="flex items-center gap-2 p-4 hover:no-underline"
+            description={t(
+              'settings.allergenPreferences.description',
+              'Track allergens you want to be warned about in foods'
+            )}
+          >
+            <ShieldAlert className="h-5 w-5" />
+            {t('settings.allergenPreferences.title', 'Allergen Preferences')}
+          </AccordionTrigger>
+          <AccordionContent className="p-4 pt-0">
+            <AllergenSettings />
           </AccordionContent>
         </AccordionItem>
 

--- a/SparkyFitnessFrontend/src/tests/components/FoodResultCard.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/FoodResultCard.test.tsx
@@ -7,6 +7,10 @@ jest.mock('@/components/FoodSearch/NutrientGrid', () => ({
   NutrientGrid: () => <div data-testid="nutrient-grid" />,
 }));
 
+jest.mock('@/hooks/useAllergenPreferences', () => ({
+  useAllergenPreferences: () => ({ data: [] }),
+}));
+
 jest.mock('@/contexts/ActiveUserContext', () => ({
   useActiveUser: () => ({
     activeUserId: 'user-1',

--- a/SparkyFitnessFrontend/src/types/allergenPreference.ts
+++ b/SparkyFitnessFrontend/src/types/allergenPreference.ts
@@ -1,0 +1,6 @@
+export interface UserAllergenPreference {
+  id: string;
+  user_id: string;
+  allergen_name: string;
+  created_at: string;
+}

--- a/SparkyFitnessFrontend/src/types/food.ts
+++ b/SparkyFitnessFrontend/src/types/food.ts
@@ -39,7 +39,7 @@ export interface FoodVariant {
   ai_confidence?: 'high' | 'medium' | 'low' | null;
   custom_nutrients?: Record<string, string | number>;
   allergens?: string[] | null;
-  traces?: string[] | null;: add allergens and traces from OpenFoodFacts)
+  traces?: string[] | null;
 }
 
 export interface Food {
@@ -204,7 +204,7 @@ export type NumericFoodVariantKeys = Exclude<
   | 'source'
   | 'ai_confidence'
   | 'allergens'
-  | 'traces': add allergens and traces from OpenFoodFacts)
+  | 'traces'
 >;
 export interface EquivalentUnit {
   id?: string;

--- a/SparkyFitnessFrontend/src/types/food.ts
+++ b/SparkyFitnessFrontend/src/types/food.ts
@@ -37,6 +37,9 @@ export interface FoodVariant {
   // server-side when the client omits these fields.
   source?: 'manual' | 'ai_estimate' | 'imported';
   ai_confidence?: 'high' | 'medium' | 'low' | null;
+  custom_nutrients?: Record<string, string | number>;
+  allergens?: string[] | null;
+  traces?: string[] | null;: add allergens and traces from OpenFoodFacts)
 }
 
 export interface Food {
@@ -119,7 +122,9 @@ export interface FoodEntry {
   iron?: number;
   glycemic_index?: GlycemicIndex;
   serving_size?: number;
-  custom_nutrients?: Record<string, string | number>; // New field for custom nutrients
+  custom_nutrients?: Record<string, string | number>;
+  allergens?: string[] | null;
+  traces?: string[] | null;
 }
 
 export interface CSVData {
@@ -198,6 +203,8 @@ export type NumericFoodVariantKeys = Exclude<
   | 'user_id'
   | 'source'
   | 'ai_confidence'
+  | 'allergens'
+  | 'traces': add allergens and traces from OpenFoodFacts)
 >;
 export interface EquivalentUnit {
   id?: string;

--- a/SparkyFitnessFrontend/src/types/food.ts
+++ b/SparkyFitnessFrontend/src/types/food.ts
@@ -32,12 +32,9 @@ export interface FoodVariant {
   is_default?: boolean;
   is_locked?: boolean;
   glycemic_index?: GlycemicIndex;
-  custom_nutrients?: Record<string, string | number>; // New field for custom nutrients
-  // AI-Assisted Unit Conversions provenance. source defaults to 'manual'
-  // server-side when the client omits these fields.
+  custom_nutrients?: Record<string, string | number>;
   source?: 'manual' | 'ai_estimate' | 'imported';
   ai_confidence?: 'high' | 'medium' | 'low' | null;
-  custom_nutrients?: Record<string, string | number>;
   allergens?: string[] | null;
   traces?: string[] | null;
 }

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -56,6 +56,7 @@ import versionRoutes from './routes/versionRoutes.js';
 import onboardingRoutes from './routes/onboardingRoutes.js';
 import customNutrientRoutes from './routes/customNutrientRoutes.js';
 import aiUnitConversionRoutes from './routes/aiUnitConversionRoutes.js';
+import allergenPreferenceRoutes from './routes/allergenPreferenceRoutes.js';
 import { applyMigrations } from './utils/dbMigrations.js';
 import { applyRlsPolicies } from './utils/applyRlsPolicies.js';
 import waterContainerRoutes from './routes/waterContainerRoutes.js';
@@ -432,6 +433,7 @@ app.use('/api/workout-presets', workoutPresetRoutes);
 app.use('/api/workout-plan-templates', workoutPlanTemplateRoutes);
 app.use('/api/review', reviewRoutes);
 app.use('/api/custom-nutrients', customNutrientRoutes);
+app.use('/api/allergen-preferences', allergenPreferenceRoutes);
 app.use('/api/adaptive-tdee', adaptiveTdeeRoutes);
 app.use('/api/meal-types', mealTypeRoutes);
 // Swagger

--- a/SparkyFitnessServer/db/migrations/20260527120000_add_allergen_tracking.sql
+++ b/SparkyFitnessServer/db/migrations/20260527120000_add_allergen_tracking.sql
@@ -1,3 +1,13 @@
+-- Add allergens and traces columns to food_variants and food_entries
+ALTER TABLE public.food_variants
+ADD COLUMN allergens text[],
+ADD COLUMN traces text[];
+
+ALTER TABLE public.food_entries
+ADD COLUMN allergens text[],
+ADD COLUMN traces text[];
+
+-- User allergen preferences for warning badges
 CREATE TABLE public.user_allergen_preferences (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id UUID NOT NULL REFERENCES public."user"(id) ON DELETE CASCADE,

--- a/SparkyFitnessServer/db/migrations/20260527120000_add_allergens_to_food_variants_and_food_entries.sql
+++ b/SparkyFitnessServer/db/migrations/20260527120000_add_allergens_to_food_variants_and_food_entries.sql
@@ -1,0 +1,8 @@
+-- Add allergens and traces columns to food_variants and food_entries
+ALTER TABLE public.food_variants
+ADD COLUMN allergens text[],
+ADD COLUMN traces text[];
+
+ALTER TABLE public.food_entries
+ADD COLUMN allergens text[],
+ADD COLUMN traces text[];

--- a/SparkyFitnessServer/db/migrations/20260527130000_add_user_allergen_preferences.sql
+++ b/SparkyFitnessServer/db/migrations/20260527130000_add_user_allergen_preferences.sql
@@ -1,0 +1,9 @@
+CREATE TABLE public.user_allergen_preferences (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public."user"(id) ON DELETE CASCADE,
+  allergen_name TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(user_id, allergen_name)
+);
+
+ALTER TABLE public.user_allergen_preferences ENABLE ROW LEVEL SECURITY;

--- a/SparkyFitnessServer/db/rls_policies.sql
+++ b/SparkyFitnessServer/db/rls_policies.sql
@@ -71,6 +71,7 @@ BEGIN
     'sleep_entry_stages',
     'fasting_logs',
     'user_custom_nutrients',
+    'user_allergen_preferences',
     'sleep_need_calculations',
     'daily_sleep_need',
     'day_classification_cache'
@@ -338,6 +339,7 @@ SELECT create_owner_policy('user_preferences');
 SELECT create_owner_policy('user_water_containers');
 SELECT create_owner_policy('weekly_goal_plans');
 SELECT create_owner_policy('user_custom_nutrients');
+SELECT create_owner_policy('user_allergen_preferences');
 
 -- Admin Activity Logs: Only the admin who performed the action or other admins can view
 CREATE POLICY admin_only_select ON public.admin_activity_logs FOR SELECT TO PUBLIC

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -18,6 +18,8 @@ const OFF_FIELDS = [
   'serving_size',
   'serving_quantity',
   'nutriments',
+  'allergens_tags',
+  'traces_tags',
 ];
 
 // Wraps fetch with optional session-cookie authentication for OFF endpoints.
@@ -157,6 +159,11 @@ async function searchOpenFoodFactsByBarcodeFields(
     throw error;
   }
 }
+function normalizeAllergenTags(tags: string[] | undefined): string[] | null {
+  if (!tags || tags.length === 0) return null;
+  return tags.map((t) => t.replace(/^[a-z]{2}:/, ''));
+}
+
 function mapOpenFoodFactsProduct(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   product: any,
@@ -228,7 +235,11 @@ function mapOpenFoodFactsProduct(
     provider_external_id: product.code,
     provider_type: 'openfoodfacts',
     is_custom: false,
-    default_variant: defaultVariant,
+    default_variant: {
+      ...defaultVariant,
+      allergens: normalizeAllergenTags(product.allergens_tags),
+      traces: normalizeAllergenTags(product.traces_tags),
+    },
   };
 }
 export { searchOpenFoodFacts };

--- a/SparkyFitnessServer/models/food.ts
+++ b/SparkyFitnessServer/models/food.ts
@@ -29,7 +29,9 @@ const DEFAULT_VARIANT_JSON_SQL = `
     'custom_nutrients', fv.custom_nutrients,
     'user_id', fv.user_id,
     'source', fv.source,
-    'ai_confidence', fv.ai_confidence
+    'ai_confidence', fv.ai_confidence,
+    'allergens', fv.allergens,
+    'traces', fv.traces
   ) AS default_variant
 `;
 
@@ -188,8 +190,8 @@ async function createFood(foodData: any) {
         saturated_fat, polyunsaturated_fat, monounsaturated_fat, trans_fat,
         cholesterol, sodium, potassium, dietary_fiber, sugars,
         vitamin_a, vitamin_c, calcium, iron, is_default, glycemic_index, custom_nutrients,
-        source, ai_confidence, created_at, updated_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, TRUE, $22, $23, $24, $25, now(), now()) RETURNING id`,
+        source, ai_confidence, allergens, traces, created_at, updated_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, TRUE, $22, $23, $24, $25, $26, $27, now(), now()) RETURNING id`,
       [
         newFood.id,
         newFood.user_id,
@@ -216,6 +218,8 @@ async function createFood(foodData: any) {
         foodData.custom_nutrients ?? {},
         foodData.source ?? 'manual',
         foodData.ai_confidence ?? null,
+        foodData.allergens ?? null,
+        foodData.traces ?? null,
       ]
     );
     const newVariantId = variantResult.rows[0].id;
@@ -249,6 +253,8 @@ async function createFood(foodData: any) {
         source: foodData.source ?? 'manual',
         ai_confidence: foodData.ai_confidence ?? null,
         custom_nutrients: foodData.custom_nutrients ?? {},
+        allergens: foodData.allergens ?? null,
+        traces: foodData.traces ?? null,
       },
     };
   } catch (error) {
@@ -807,10 +813,10 @@ async function createFoodsInBulk(userId: any, foodDataArray: any) {
               saturated_fat, polyunsaturated_fat, monounsaturated_fat, trans_fat,
               cholesterol, sodium, potassium, dietary_fiber, sugars,
               vitamin_a, vitamin_c, calcium, iron, glycemic_index, custom_nutrients,
-              source, ai_confidence, created_at, updated_at
+              source, ai_confidence, allergens, traces, created_at, updated_at
             ) VALUES (
               $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
-              $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, now(), now()
+              $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, now(), now()
             )`,
           [
             newFoodId,
@@ -840,6 +846,8 @@ async function createFoodsInBulk(userId: any, foodDataArray: any) {
             variant.custom_nutrients ?? {},
             variant.source ?? 'manual',
             variant.ai_confidence ?? null,
+            variant.allergens ?? null,
+            variant.traces ?? null,
           ]
         );
         totalVariantsCreated++;

--- a/SparkyFitnessServer/models/foodEntry.ts
+++ b/SparkyFitnessServer/models/foodEntry.ts
@@ -502,11 +502,12 @@ async function getFoodEntriesByDate(userId: any, selectedDate: any) {
         fe.iron,
         fe.glycemic_index,
         fe.custom_nutrients,
-        fe.allergens,
-        fe.traces
+        COALESCE(fe.allergens, fv.allergens) AS allergens,
+        COALESCE(fe.traces, fv.traces) AS traces
        FROM food_entries fe
        LEFT JOIN meal_types mt ON fe.meal_type_id = mt.id
        LEFT JOIN food_entry_meals fem ON fe.food_entry_meal_id = fem.id
+       LEFT JOIN food_variants fv ON fe.variant_id = fv.id
        WHERE fe.user_id = $1 AND fe.entry_date = $2
        ORDER BY mt.sort_order ASC, fe.created_at`,
       [userId, selectedDate]

--- a/SparkyFitnessServer/models/foodEntry.ts
+++ b/SparkyFitnessServer/models/foodEntry.ts
@@ -175,6 +175,8 @@ async function createFoodEntry(entryData: any, createdByUserId: any) {
         'glycemic_index',
         'serving_size',
         'serving_unit',
+        'allergens',
+        'traces',
       ];
       for (const field of nutritionOverrideFields) {
         if (entryData[field] !== undefined) {
@@ -217,31 +219,33 @@ async function createFoodEntry(entryData: any, createdByUserId: any) {
         iron: entryData.iron,
         glycemic_index: entryData.glycemic_index,
         custom_nutrients: entryData.custom_nutrients || {},
+        allergens: entryData.allergens || null,
+        traces: entryData.traces || null,
       };
     }
     // Insert the food entry with the snapshot data
     const result = await client.query(
       `INSERT INTO food_entries (
          user_id, food_id, meal_id, meal_type_id, quantity, unit, entry_date, variant_id, meal_plan_template_id,
-         food_entry_meal_id, -- New column
+         food_entry_meal_id,
          created_by_user_id, food_name, brand_name, serving_size, serving_unit, calories, protein, carbs, fat,
          saturated_fat, polyunsaturated_fat, monounsaturated_fat, trans_fat, cholesterol, sodium,
-         potassium, dietary_fiber, sugars, vitamin_a, vitamin_c, calcium, iron, glycemic_index, custom_nutrients, updated_by_user_id
+         potassium, dietary_fiber, sugars, vitamin_a, vitamin_c, calcium, iron, glycemic_index, custom_nutrients, allergens, traces, updated_by_user_id
        ) VALUES (
          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21,
-         $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35
+         $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37
        ) RETURNING *`,
       [
         entryData.user_id,
         entryData.food_id,
-        entryData.meal_id, // This should eventually be NULL or removed if not needed.
+        entryData.meal_id,
         mealTypeId,
         entryData.quantity,
         entryData.unit,
         entryData.entry_date,
         entryData.variant_id,
         entryData.meal_plan_template_id,
-        entryData.food_entry_meal_id, // New column value
+        entryData.food_entry_meal_id,
         createdByUserId, // created_by_user_id
         snapshot.name, // food_name
         snapshot.brand, // brand_name
@@ -266,6 +270,8 @@ async function createFoodEntry(entryData: any, createdByUserId: any) {
         snapshot.iron,
         snapshot.glycemic_index,
         snapshot.custom_nutrients || {},
+        snapshot.allergens || null,
+        snapshot.traces || null,
         createdByUserId, // updated_by_user_id
       ]
     );
@@ -315,8 +321,10 @@ async function getFoodEntryById(entryId: any, userId: any) {
         fe.vitamin_c, 
         fe.calcium, 
         fe.iron, 
-        fe.glycemic_index, 
+        fe.glycemic_index,
         fe.custom_nutrients,
+        fe.allergens,
+        fe.traces,
         fe.user_id
        FROM food_entries fe
        LEFT JOIN meal_types mt ON fe.meal_type_id = mt.id
@@ -408,7 +416,9 @@ async function updateFoodEntry(
         calcium = $26,
         iron = $27,
         glycemic_index = $28,
-        custom_nutrients = $29
+        custom_nutrients = $29,
+        allergens = $32,
+        traces = $33
       WHERE id = $30
       RETURNING *`,
       [
@@ -416,7 +426,7 @@ async function updateFoodEntry(
         entryData.unit,
         entryData.entry_date,
         entryData.variant_id,
-        entryData.food_entry_meal_id, // New column value
+        entryData.food_entry_meal_id,
         actingUserId,
         snapshotData.food_name,
         snapshotData.brand_name,
@@ -443,6 +453,8 @@ async function updateFoodEntry(
         snapshotData.custom_nutrients || {},
         entryId,
         mealTypeId,
+        snapshotData.allergens ?? null,
+        snapshotData.traces ?? null,
       ]
     );
     return result.rows[0];
@@ -489,7 +501,9 @@ async function getFoodEntriesByDate(userId: any, selectedDate: any) {
         fe.calcium,
         fe.iron,
         fe.glycemic_index,
-        fe.custom_nutrients
+        fe.custom_nutrients,
+        fe.allergens,
+        fe.traces
        FROM food_entries fe
        LEFT JOIN meal_types mt ON fe.meal_type_id = mt.id
        LEFT JOIN food_entry_meals fem ON fe.food_entry_meal_id = fem.id

--- a/SparkyFitnessServer/models/foodVariant.ts
+++ b/SparkyFitnessServer/models/foodVariant.ts
@@ -13,8 +13,8 @@ async function createFoodVariant(variantData: any, userId: any) {
         saturated_fat, polyunsaturated_fat, monounsaturated_fat, trans_fat,
         cholesterol, sodium, potassium, dietary_fiber, sugars,
         vitamin_a, vitamin_c, calcium, iron, is_default, glycemic_index, custom_nutrients,
-        source, ai_confidence, created_at, updated_at
-      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, now(), now()) RETURNING id`,
+        source, ai_confidence, allergens, traces, created_at, updated_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, now(), now()) RETURNING id`,
       [
         variantData.food_id,
         variantData.serving_size,
@@ -41,6 +41,8 @@ async function createFoodVariant(variantData: any, userId: any) {
         variantData.custom_nutrients ?? {},
         variantData.source ?? 'manual',
         variantData.ai_confidence ?? null,
+        variantData.allergens ?? null,
+        variantData.traces ?? null,
       ]
     );
     return result.rows[0];
@@ -128,6 +130,8 @@ async function updateFoodVariant(id: any, variantData: any, userId: any) {
         custom_nutrients = COALESCE($23, custom_nutrients),
         source = COALESCE($24, source),
         ai_confidence = CASE WHEN $25 THEN $26 ELSE ai_confidence END,
+        allergens = COALESCE($28, allergens),
+        traces = COALESCE($29, traces),
         updated_at = now()
       WHERE id = $27
       RETURNING *`,
@@ -161,6 +165,8 @@ async function updateFoodVariant(id: any, variantData: any, userId: any) {
         hasAiConfidence,
         variantData.ai_confidence ?? null,
         id,
+        variantData.allergens ?? null,
+        variantData.traces ?? null,
       ]
     );
     // If this variant is being set as default, ensure all other variants for this food_id are not default

--- a/SparkyFitnessServer/routes/allergenPreferenceRoutes.ts
+++ b/SparkyFitnessServer/routes/allergenPreferenceRoutes.ts
@@ -1,7 +1,12 @@
 import express from 'express';
+import { z } from 'zod/v4';
 import AllergenPreferenceService from '../services/allergenPreferenceService.js';
 import { authenticate } from '../middleware/authMiddleware.js';
 import { log } from '../config/logging.js';
+
+const AddAllergenBodySchema = z.object({
+  allergen_name: z.string().min(1),
+});
 
 const router = express.Router();
 router.use(authenticate);
@@ -69,11 +74,12 @@ router.get('/', async (req, res, next) => {
  */
 router.post('/', async (req, res, next) => {
   try {
-    const { allergen_name } = req.body;
-    if (!allergen_name || typeof allergen_name !== 'string') {
-      res.status(400).json({ message: 'allergen_name is required.' });
+    const bodyResult = AddAllergenBodySchema.safeParse(req.body);
+    if (!bodyResult.success) {
+      res.status(400).json({ error: 'Invalid request body' });
       return;
     }
+    const { allergen_name } = bodyResult.data;
     const preference = await AllergenPreferenceService.addAllergenPreference(
       req.userId,
       allergen_name.trim()

--- a/SparkyFitnessServer/routes/allergenPreferenceRoutes.ts
+++ b/SparkyFitnessServer/routes/allergenPreferenceRoutes.ts
@@ -5,7 +5,7 @@ import { authenticate } from '../middleware/authMiddleware.js';
 import { log } from '../config/logging.js';
 
 const AddAllergenBodySchema = z.object({
-  allergen_name: z.string().min(1),
+  allergen_name: z.string().min(1).max(100),
 });
 
 const router = express.Router();

--- a/SparkyFitnessServer/routes/allergenPreferenceRoutes.ts
+++ b/SparkyFitnessServer/routes/allergenPreferenceRoutes.ts
@@ -1,0 +1,135 @@
+import express from 'express';
+import AllergenPreferenceService from '../services/allergenPreferenceService.js';
+import { authenticate } from '../middleware/authMiddleware.js';
+import { log } from '../config/logging.js';
+
+const router = express.Router();
+router.use(authenticate);
+
+/**
+ * @swagger
+ * tags:
+ *   name: Allergen Preferences
+ *   description: User allergen tracking preferences.
+ */
+
+/**
+ * @swagger
+ * /allergen-preferences:
+ *   get:
+ *     summary: Get all allergen preferences for the authenticated user
+ *     tags: [Allergen Preferences]
+ *     security:
+ *       - cookieAuth: []
+ *     responses:
+ *       200:
+ *         description: List of allergen preferences.
+ *       401:
+ *         description: Unauthorized.
+ */
+router.get('/', async (req, res, next) => {
+  try {
+    const preferences = await AllergenPreferenceService.getAllergenPreferences(
+      req.userId
+    );
+    res.status(200).json(preferences);
+  } catch (error) {
+    // @ts-expect-error TS(2571): Object is of type 'unknown'.
+    log('error', `Error fetching allergen preferences: ${error.message}`, {
+      userId: req.userId,
+    });
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /allergen-preferences:
+ *   post:
+ *     summary: Add an allergen preference
+ *     tags: [Allergen Preferences]
+ *     security:
+ *       - cookieAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - allergen_name
+ *             properties:
+ *               allergen_name:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Allergen preference added.
+ *       401:
+ *         description: Unauthorized.
+ */
+router.post('/', async (req, res, next) => {
+  try {
+    const { allergen_name } = req.body;
+    if (!allergen_name || typeof allergen_name !== 'string') {
+      res.status(400).json({ message: 'allergen_name is required.' });
+      return;
+    }
+    const preference = await AllergenPreferenceService.addAllergenPreference(
+      req.userId,
+      allergen_name.trim()
+    );
+    res.status(201).json(preference);
+  } catch (error) {
+    // @ts-expect-error TS(2571): Object is of type 'unknown'.
+    log('error', `Error adding allergen preference: ${error.message}`, {
+      userId: req.userId,
+    });
+    next(error);
+  }
+});
+
+/**
+ * @swagger
+ * /allergen-preferences/{id}:
+ *   delete:
+ *     summary: Remove an allergen preference
+ *     tags: [Allergen Preferences]
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Allergen preference removed.
+ *       404:
+ *         description: Not found.
+ *       401:
+ *         description: Unauthorized.
+ */
+router.delete('/:id', async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const success = await AllergenPreferenceService.deleteAllergenPreference(
+      req.userId,
+      id
+    );
+    if (success) {
+      res.status(200).json({ message: 'Allergen preference removed.' });
+    } else {
+      res.status(404).json({ message: 'Allergen preference not found.' });
+    }
+  } catch (error) {
+    // @ts-expect-error TS(2571): Object is of type 'unknown'.
+    log('error', `Error deleting allergen preference: ${error.message}`, {
+      userId: req.userId,
+    });
+    next(error);
+  }
+});
+
+export default router;

--- a/SparkyFitnessServer/routes/foodCrudRoutes.ts
+++ b/SparkyFitnessServer/routes/foodCrudRoutes.ts
@@ -5,6 +5,7 @@ import foodService from '../services/foodService.js';
 import labelScanService from '../services/labelScanService.js';
 import foodPhotoEstimationService from '../services/foodPhotoEstimationService.js';
 import type { FoodPhotoEstimateErrorCode } from '@workspace/shared';
+import { backfillOffAllergens } from '../utils/backfillAllergens.js';
 const router = express.Router();
 router.use(express.json());
 
@@ -1118,4 +1119,14 @@ router.post('/update-snapshot', authenticate, async (req, res, next) => {
     next(error);
   }
 });
+
+router.post('/sync-allergens', authenticate, async (req, res, next) => {
+  try {
+    const result = await backfillOffAllergens(req.userId);
+    res.status(200).json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/SparkyFitnessServer/schemas/foodSchemas.ts
+++ b/SparkyFitnessServer/schemas/foodSchemas.ts
@@ -29,6 +29,8 @@ export const FoodVariantSchema = z.object({
     .optional(),
   source: z.enum(['manual', 'ai_estimate', 'imported']).optional(),
   ai_confidence: z.enum(['high', 'medium', 'low']).nullable().optional(),
+  allergens: z.array(z.string()).nullable().optional(),
+  traces: z.array(z.string()).nullable().optional(),
 });
 
 export type FoodVariant = z.infer<typeof FoodVariantSchema>;

--- a/SparkyFitnessServer/services/allergenPreferenceService.ts
+++ b/SparkyFitnessServer/services/allergenPreferenceService.ts
@@ -19,18 +19,19 @@ class AllergenPreferenceService {
   static async addAllergenPreference(userId: string, allergenName: string) {
     const client = await getClient(userId);
     try {
+      const normalizedName = allergenName.trim().toLowerCase();
       const id = uuidv4();
       const result = await client.query(
         `INSERT INTO user_allergen_preferences (id, user_id, allergen_name)
          VALUES ($1, $2, $3)
          ON CONFLICT (user_id, allergen_name) DO NOTHING
          RETURNING *`,
-        [id, userId, allergenName]
+        [id, userId, normalizedName]
       );
       if (result.rows.length === 0) {
         const existing = await client.query(
           'SELECT * FROM user_allergen_preferences WHERE user_id = $1 AND allergen_name = $2',
-          [userId, allergenName]
+          [userId, normalizedName]
         );
         return existing.rows[0];
       }

--- a/SparkyFitnessServer/services/allergenPreferenceService.ts
+++ b/SparkyFitnessServer/services/allergenPreferenceService.ts
@@ -1,0 +1,61 @@
+import { getClient } from '../db/poolManager.js';
+import { log } from '../config/logging.js';
+import { v4 as uuidv4 } from 'uuid';
+
+class AllergenPreferenceService {
+  static async getAllergenPreferences(userId: string) {
+    const client = await getClient(userId);
+    try {
+      const result = await client.query(
+        'SELECT * FROM user_allergen_preferences WHERE user_id = $1 ORDER BY allergen_name',
+        [userId]
+      );
+      return result.rows;
+    } finally {
+      client.release();
+    }
+  }
+
+  static async addAllergenPreference(userId: string, allergenName: string) {
+    const client = await getClient(userId);
+    try {
+      const id = uuidv4();
+      const result = await client.query(
+        `INSERT INTO user_allergen_preferences (id, user_id, allergen_name)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (user_id, allergen_name) DO NOTHING
+         RETURNING *`,
+        [id, userId, allergenName]
+      );
+      if (result.rows.length === 0) {
+        const existing = await client.query(
+          'SELECT * FROM user_allergen_preferences WHERE user_id = $1 AND allergen_name = $2',
+          [userId, allergenName]
+        );
+        return existing.rows[0];
+      }
+      log(
+        'info',
+        `Allergen preference added: ${allergenName} for user ${userId}`
+      );
+      return result.rows[0];
+    } finally {
+      client.release();
+    }
+  }
+
+  static async deleteAllergenPreference(userId: string, id: string) {
+    const client = await getClient(userId);
+    try {
+      const result = await client.query(
+        'DELETE FROM user_allergen_preferences WHERE id = $1 AND user_id = $2 RETURNING id',
+        [id, userId]
+      );
+      return result.rows.length > 0;
+    } finally {
+      client.release();
+    }
+  }
+}
+
+export default AllergenPreferenceService;

--- a/SparkyFitnessServer/tests/allergenPreferenceRoutes.test.ts
+++ b/SparkyFitnessServer/tests/allergenPreferenceRoutes.test.ts
@@ -131,6 +131,7 @@ describe('Allergen Preference Routes', () => {
       const res = await request(app).post('/api/allergen-preferences').send({});
 
       expect(res.statusCode).toEqual(400);
+      expect(res.body).toHaveProperty('error', 'Invalid request body');
       expect(
         AllergenPreferenceService.addAllergenPreference
       ).not.toHaveBeenCalled();
@@ -142,6 +143,7 @@ describe('Allergen Preference Routes', () => {
         .send({ allergen_name: 123 });
 
       expect(res.statusCode).toEqual(400);
+      expect(res.body).toHaveProperty('error', 'Invalid request body');
       expect(
         AllergenPreferenceService.addAllergenPreference
       ).not.toHaveBeenCalled();

--- a/SparkyFitnessServer/tests/allergenPreferenceRoutes.test.ts
+++ b/SparkyFitnessServer/tests/allergenPreferenceRoutes.test.ts
@@ -1,0 +1,215 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'
+import request from 'supertest';
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import AllergenPreferenceService from '../services/allergenPreferenceService.js';
+import allergenPreferenceRoutes from '../routes/allergenPreferenceRoutes.js';
+
+vi.mock('../services/allergenPreferenceService.js', () => ({
+  default: {
+    getAllergenPreferences: vi.fn(),
+    addAllergenPreference: vi.fn(),
+    deleteAllergenPreference: vi.fn(),
+  },
+}));
+
+vi.mock('../middleware/authMiddleware.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = 'test-user-id';
+    req.authenticatedUserId = 'test-user-id';
+    next();
+  },
+}));
+
+vi.mock('../config/logging.js', () => ({
+  log: vi.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/allergen-preferences', allergenPreferenceRoutes);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+app.use((err: any, _req: any, res: any, _next: any) => {
+  res.status(err.status || 500).json({ error: err.message });
+});
+
+const VALID_UUID = uuidv4();
+
+describe('Allergen Preference Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /api/allergen-preferences', () => {
+    it('should return all allergen preferences for the user', async () => {
+      const preferences = [
+        { id: VALID_UUID, user_id: 'test-user-id', allergen_name: 'gluten' },
+        { id: uuidv4(), user_id: 'test-user-id', allergen_name: 'milk' },
+      ];
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type
+      AllergenPreferenceService.getAllergenPreferences.mockResolvedValue(
+        preferences
+      );
+
+      const res = await request(app).get('/api/allergen-preferences');
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toEqual(preferences);
+      expect(
+        AllergenPreferenceService.getAllergenPreferences
+      ).toHaveBeenCalledWith('test-user-id');
+    });
+
+    it('should return an empty array when the user has no preferences', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type
+      AllergenPreferenceService.getAllergenPreferences.mockResolvedValue([]);
+
+      const res = await request(app).get('/api/allergen-preferences');
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toEqual([]);
+    });
+
+    it('should return 500 on unexpected service error', async () => {
+      // @ts-expect-error TS(2339): Property 'mockRejectedValue' does not exist on type
+      AllergenPreferenceService.getAllergenPreferences.mockRejectedValue(
+        new Error('DB error')
+      );
+
+      const res = await request(app).get('/api/allergen-preferences');
+
+      expect(res.statusCode).toEqual(500);
+    });
+  });
+
+  describe('POST /api/allergen-preferences', () => {
+    it('should create an allergen preference and return 201', async () => {
+      const created = {
+        id: VALID_UUID,
+        user_id: 'test-user-id',
+        allergen_name: 'gluten',
+      };
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type
+      AllergenPreferenceService.addAllergenPreference.mockResolvedValue(
+        created
+      );
+
+      const res = await request(app)
+        .post('/api/allergen-preferences')
+        .send({ allergen_name: 'gluten' });
+
+      expect(res.statusCode).toEqual(201);
+      expect(res.body).toEqual(created);
+      expect(
+        AllergenPreferenceService.addAllergenPreference
+      ).toHaveBeenCalledWith('test-user-id', 'gluten');
+    });
+
+    it('should trim whitespace from allergen_name before saving', async () => {
+      const created = {
+        id: VALID_UUID,
+        user_id: 'test-user-id',
+        allergen_name: 'milk',
+      };
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type
+      AllergenPreferenceService.addAllergenPreference.mockResolvedValue(
+        created
+      );
+
+      await request(app)
+        .post('/api/allergen-preferences')
+        .send({ allergen_name: '  milk  ' });
+
+      expect(
+        AllergenPreferenceService.addAllergenPreference
+      ).toHaveBeenCalledWith('test-user-id', 'milk');
+    });
+
+    it('should return 400 when allergen_name is missing', async () => {
+      const res = await request(app).post('/api/allergen-preferences').send({});
+
+      expect(res.statusCode).toEqual(400);
+      expect(
+        AllergenPreferenceService.addAllergenPreference
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 when allergen_name is not a string', async () => {
+      const res = await request(app)
+        .post('/api/allergen-preferences')
+        .send({ allergen_name: 123 });
+
+      expect(res.statusCode).toEqual(400);
+      expect(
+        AllergenPreferenceService.addAllergenPreference
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 on unexpected service error', async () => {
+      // @ts-expect-error TS(2339): Property 'mockRejectedValue' does not exist on type
+      AllergenPreferenceService.addAllergenPreference.mockRejectedValue(
+        new Error('DB error')
+      );
+
+      const res = await request(app)
+        .post('/api/allergen-preferences')
+        .send({ allergen_name: 'gluten' });
+
+      expect(res.statusCode).toEqual(500);
+    });
+  });
+
+  describe('DELETE /api/allergen-preferences/:id', () => {
+    it('should remove an allergen preference and return 200', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type
+      AllergenPreferenceService.deleteAllergenPreference.mockResolvedValue(
+        true
+      );
+
+      const res = await request(app).delete(
+        `/api/allergen-preferences/${VALID_UUID}`
+      );
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toHaveProperty(
+        'message',
+        'Allergen preference removed.'
+      );
+      expect(
+        AllergenPreferenceService.deleteAllergenPreference
+      ).toHaveBeenCalledWith('test-user-id', VALID_UUID);
+    });
+
+    it('should return 404 when the preference does not exist', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type
+      AllergenPreferenceService.deleteAllergenPreference.mockResolvedValue(
+        false
+      );
+
+      const res = await request(app).delete(
+        `/api/allergen-preferences/${VALID_UUID}`
+      );
+
+      expect(res.statusCode).toEqual(404);
+      expect(res.body).toHaveProperty(
+        'message',
+        'Allergen preference not found.'
+      );
+    });
+
+    it('should return 500 on unexpected service error', async () => {
+      // @ts-expect-error TS(2339): Property 'mockRejectedValue' does not exist on type
+      AllergenPreferenceService.deleteAllergenPreference.mockRejectedValue(
+        new Error('DB error')
+      );
+
+      const res = await request(app).delete(
+        `/api/allergen-preferences/${VALID_UUID}`
+      );
+
+      expect(res.statusCode).toEqual(500);
+    });
+  });
+});

--- a/SparkyFitnessServer/tests/barcodeLookup.test.ts
+++ b/SparkyFitnessServer/tests/barcodeLookup.test.ts
@@ -213,6 +213,8 @@ describe('mapOpenFoodFactsProduct', () => {
         calcium: 0,
         iron: 0,
         is_default: true,
+        allergens: null,
+        traces: null,
       },
     });
   });

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -4,6 +4,7 @@ import {
   invalidateOpenFoodFactsSession,
 } from '../integrations/openfoodfacts/openFoodFactsAuth.js';
 import {
+  mapOpenFoodFactsProduct,
   searchOpenFoodFacts,
   searchOpenFoodFactsByBarcodeFields,
 } from '../integrations/openfoodfacts/openFoodFactsService.js';
@@ -198,6 +199,74 @@ describe('openFoodFactsService', () => {
         searchOpenFoodFactsByBarcodeFields('12345678')
       ).rejects.toThrow('OpenFoodFacts API error');
       expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('mapOpenFoodFactsProduct', () => {
+    const baseProduct = {
+      product_name: 'Test Bread',
+      brands: 'TestBrand',
+      code: '1234567890123',
+      serving_quantity: 50,
+      nutriments: {
+        'energy-kcal_100g': 250,
+        proteins_100g: 8,
+        carbohydrates_100g: 45,
+        fat_100g: 3,
+      },
+    };
+
+    it('extracts and normalizes allergens_tags and traces_tags', () => {
+      const product = {
+        ...baseProduct,
+        allergens_tags: ['en:gluten', 'en:milk', 'en:eggs'],
+        traces_tags: ['en:nuts', 'en:sesame'],
+      };
+      const result = mapOpenFoodFactsProduct(product);
+      expect(result.default_variant.allergens).toEqual([
+        'gluten',
+        'milk',
+        'eggs',
+      ]);
+      expect(result.default_variant.traces).toEqual(['nuts', 'sesame']);
+    });
+
+    it('strips non-english language prefixes', () => {
+      const product = {
+        ...baseProduct,
+        allergens_tags: ['fr:gluten', 'de:milch'],
+        traces_tags: ['es:nueces'],
+      };
+      const result = mapOpenFoodFactsProduct(product);
+      expect(result.default_variant.allergens).toEqual(['gluten', 'milch']);
+      expect(result.default_variant.traces).toEqual(['nueces']);
+    });
+
+    it('returns null for allergens and traces when tags are absent', () => {
+      const result = mapOpenFoodFactsProduct(baseProduct);
+      expect(result.default_variant.allergens).toBeNull();
+      expect(result.default_variant.traces).toBeNull();
+    });
+
+    it('returns null when tags are empty arrays', () => {
+      const product = {
+        ...baseProduct,
+        allergens_tags: [],
+        traces_tags: [],
+      };
+      const result = mapOpenFoodFactsProduct(product);
+      expect(result.default_variant.allergens).toBeNull();
+      expect(result.default_variant.traces).toBeNull();
+    });
+
+    it('handles allergens present but traces absent', () => {
+      const product = {
+        ...baseProduct,
+        allergens_tags: ['en:soy'],
+      };
+      const result = mapOpenFoodFactsProduct(product);
+      expect(result.default_variant.allergens).toEqual(['soy']);
+      expect(result.default_variant.traces).toBeNull();
     });
   });
 });

--- a/SparkyFitnessServer/utils/backfillAllergens.ts
+++ b/SparkyFitnessServer/utils/backfillAllergens.ts
@@ -1,0 +1,70 @@
+import { getSystemClient } from '../db/poolManager.js';
+import { log } from '../config/logging.js';
+import { searchOpenFoodFactsByBarcodeFields } from '../integrations/openfoodfacts/openFoodFactsService.js';
+
+function normalizeAllergenTags(tags: string[] | undefined): string[] | null {
+  if (!tags || tags.length === 0) return null;
+  return tags.map((t) => t.replace(/^[a-z]{2}:/, ''));
+}
+
+export async function backfillOffAllergens(): Promise<void> {
+  const client = await getSystemClient();
+  try {
+    // Find all food variants sourced from OpenFoodFacts that still have NULL allergens
+    const { rows } = await client.query(`
+      SELECT fv.id AS variant_id, f.provider_external_id AS barcode
+      FROM food_variants fv
+      JOIN foods f ON fv.food_id = f.id
+      WHERE f.provider_type = 'openfoodfacts'
+        AND f.provider_external_id IS NOT NULL
+        AND fv.allergens IS NULL
+    `);
+
+    if (rows.length === 0) {
+      log('info', 'backfillOffAllergens: nothing to backfill');
+      return;
+    }
+
+    log(
+      'info',
+      `backfillOffAllergens: backfilling allergens for ${rows.length} variant(s)`
+    );
+
+    let updated = 0;
+    for (const row of rows) {
+      try {
+        const data = await searchOpenFoodFactsByBarcodeFields(
+          row.barcode,
+          ['allergens_tags', 'traces_tags'],
+          'en',
+          null,
+          null
+        );
+
+        if (!data?.product) continue;
+
+        const allergens = normalizeAllergenTags(data.product.allergens_tags);
+        const traces = normalizeAllergenTags(data.product.traces_tags);
+
+        // Only write if there is actual allergen data (keep NULL for products with no data)
+        if (allergens === null && traces === null) continue;
+
+        await client.query(
+          'UPDATE food_variants SET allergens = $1, traces = $2 WHERE id = $3',
+          [allergens, traces, row.variant_id]
+        );
+        updated++;
+      } catch (err) {
+        // Don't abort the whole backfill if one barcode fails
+        log(
+          'warn',
+          `backfillOffAllergens: failed for barcode ${row.barcode}: ${(err as Error).message}`
+        );
+      }
+    }
+
+    log('info', `backfillOffAllergens: updated ${updated} variant(s)`);
+  } finally {
+    client.release();
+  }
+}

--- a/SparkyFitnessServer/utils/backfillAllergens.ts
+++ b/SparkyFitnessServer/utils/backfillAllergens.ts
@@ -1,4 +1,4 @@
-import { getSystemClient } from '../db/poolManager.js';
+import { getClient } from '../db/poolManager.js';
 import { log } from '../config/logging.js';
 import { searchOpenFoodFactsByBarcodeFields } from '../integrations/openfoodfacts/openFoodFactsService.js';
 
@@ -47,10 +47,13 @@ async function fetchWithRetry(
   }
 }
 
-export async function backfillOffAllergens(): Promise<void> {
-  const client = await getSystemClient();
+export async function backfillOffAllergens(
+  userId: string
+): Promise<{ updated: number; total: number }> {
+  // Use RLS-scoped client so only the requesting user's foods are processed
+  const client = await getClient(userId);
   try {
-    // allergens IS NULL means not yet checked — empty array means checked but no data
+    // allergens IS NULL means not yet checked — empty array means checked but no data found
     const { rows } = await client.query(`
       SELECT fv.id AS variant_id, f.provider_external_id AS barcode
       FROM food_variants fv
@@ -60,14 +63,15 @@ export async function backfillOffAllergens(): Promise<void> {
         AND fv.allergens IS NULL
     `);
 
-    if (rows.length === 0) {
-      log('info', 'backfillOffAllergens: nothing to backfill');
-      return;
+    const total = rows.length;
+
+    if (total === 0) {
+      return { updated: 0, total: 0 };
     }
 
     log(
       'info',
-      `backfillOffAllergens: backfilling allergens for ${rows.length} variant(s)`
+      `backfillOffAllergens: syncing allergens for ${total} variant(s)`
     );
 
     let updated = 0;
@@ -76,7 +80,7 @@ export async function backfillOffAllergens(): Promise<void> {
         const result = await fetchWithRetry(row.barcode);
 
         // Always write — empty arrays mark the variant as checked so it won't
-        // be retried on the next server start. NULL stays reserved for "not yet checked".
+        // be retried on the next sync. NULL stays reserved for "not yet checked".
         const allergens = result?.allergens ?? [];
         const traces = result?.traces ?? [];
 
@@ -92,11 +96,12 @@ export async function backfillOffAllergens(): Promise<void> {
         );
       }
 
-      // Respect OFF rate limit between every request
+      // Respect OFF rate limit (unauthenticated: ~15 req/min)
       await sleep(RATE_LIMIT_DELAY_MS);
     }
 
-    log('info', `backfillOffAllergens: updated ${updated} variant(s)`);
+    log('info', `backfillOffAllergens: updated ${updated}/${total} variant(s)`);
+    return { updated, total };
   } finally {
     client.release();
   }

--- a/SparkyFitnessServer/utils/backfillAllergens.ts
+++ b/SparkyFitnessServer/utils/backfillAllergens.ts
@@ -2,15 +2,55 @@ import { getSystemClient } from '../db/poolManager.js';
 import { log } from '../config/logging.js';
 import { searchOpenFoodFactsByBarcodeFields } from '../integrations/openfoodfacts/openFoodFactsService.js';
 
-function normalizeAllergenTags(tags: string[] | undefined): string[] | null {
-  if (!tags || tags.length === 0) return null;
+const RATE_LIMIT_DELAY_MS = 1000;
+const MAX_RETRIES = 3;
+
+function normalizeAllergenTags(tags: string[] | undefined): string[] {
+  if (!tags || tags.length === 0) return [];
   return tags.map((t) => t.replace(/^[a-z]{2}:/, ''));
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(
+  barcode: string,
+  attempt = 1
+): Promise<{ allergens: string[]; traces: string[] } | null> {
+  try {
+    const data = await searchOpenFoodFactsByBarcodeFields(
+      barcode,
+      ['allergens_tags', 'traces_tags'],
+      'en',
+      null,
+      null
+    );
+
+    if (!data?.product) return null;
+
+    return {
+      allergens: normalizeAllergenTags(data.product.allergens_tags),
+      traces: normalizeAllergenTags(data.product.traces_tags),
+    };
+  } catch (err) {
+    if (attempt < MAX_RETRIES) {
+      const backoff = RATE_LIMIT_DELAY_MS * 2 ** (attempt - 1);
+      log(
+        'warn',
+        `backfillOffAllergens: attempt ${attempt} failed for barcode ${barcode}, retrying in ${backoff}ms`
+      );
+      await sleep(backoff);
+      return fetchWithRetry(barcode, attempt + 1);
+    }
+    throw err;
+  }
 }
 
 export async function backfillOffAllergens(): Promise<void> {
   const client = await getSystemClient();
   try {
-    // Find all food variants sourced from OpenFoodFacts that still have NULL allergens
+    // allergens IS NULL means not yet checked — empty array means checked but no data
     const { rows } = await client.query(`
       SELECT fv.id AS variant_id, f.provider_external_id AS barcode
       FROM food_variants fv
@@ -33,21 +73,12 @@ export async function backfillOffAllergens(): Promise<void> {
     let updated = 0;
     for (const row of rows) {
       try {
-        const data = await searchOpenFoodFactsByBarcodeFields(
-          row.barcode,
-          ['allergens_tags', 'traces_tags'],
-          'en',
-          null,
-          null
-        );
+        const result = await fetchWithRetry(row.barcode);
 
-        if (!data?.product) continue;
-
-        const allergens = normalizeAllergenTags(data.product.allergens_tags);
-        const traces = normalizeAllergenTags(data.product.traces_tags);
-
-        // Only write if there is actual allergen data (keep NULL for products with no data)
-        if (allergens === null && traces === null) continue;
+        // Always write — empty arrays mark the variant as checked so it won't
+        // be retried on the next server start. NULL stays reserved for "not yet checked".
+        const allergens = result?.allergens ?? [];
+        const traces = result?.traces ?? [];
 
         await client.query(
           'UPDATE food_variants SET allergens = $1, traces = $2 WHERE id = $3',
@@ -55,12 +86,14 @@ export async function backfillOffAllergens(): Promise<void> {
         );
         updated++;
       } catch (err) {
-        // Don't abort the whole backfill if one barcode fails
         log(
           'warn',
           `backfillOffAllergens: failed for barcode ${row.barcode}: ${(err as Error).message}`
         );
       }
+
+      // Respect OFF rate limit between every request
+      await sleep(RATE_LIMIT_DELAY_MS);
     }
 
     log('info', `backfillOffAllergens: updated ${updated} variant(s)`);

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -2155,6 +2155,23 @@ COMMENT ON COLUMN public."user".image IS 'Profile image URL synced from Better A
 -- Name: user_custom_nutrients; Type: TABLE; Schema: public; Owner: -
 --
 
+CREATE TABLE public.user_allergen_preferences (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    allergen_name text NOT NULL,
+    created_at timestamp with time zone DEFAULT now(),
+    CONSTRAINT user_allergen_preferences_pkey PRIMARY KEY (id),
+    CONSTRAINT user_allergen_preferences_user_id_allergen_name_key UNIQUE (user_id, allergen_name),
+    CONSTRAINT user_allergen_preferences_user_id_fkey FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE
+);
+
+ALTER TABLE public.user_allergen_preferences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY owner_policy ON public.user_allergen_preferences
+  USING (user_id = public.current_user_id())
+  WITH CHECK (user_id = public.current_user_id());
+
+
 CREATE TABLE public.user_custom_nutrients (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     user_id uuid NOT NULL,

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -1436,6 +1436,8 @@ CREATE TABLE public.food_entries (
     meal_id uuid,
     food_entry_meal_id uuid,
     custom_nutrients jsonb DEFAULT '{}'::jsonb,
+    allergens text[],
+    traces text[],
     meal_type_id uuid NOT NULL,
     CONSTRAINT chk_food_or_meal_id CHECK ((((food_id IS NOT NULL) AND (meal_id IS NULL)) OR ((food_id IS NULL) AND (meal_id IS NOT NULL))))
 );
@@ -1520,6 +1522,9 @@ CREATE TABLE public.food_variants (
     CONSTRAINT food_variants_ai_confidence_check CHECK ((ai_confidence = ANY (ARRAY['high'::text, 'medium'::text, 'low'::text])) OR (ai_confidence IS NULL)),
     CONSTRAINT food_variants_glycemic_index_check CHECK ((glycemic_index = ANY (ARRAY['None'::text, 'Very Low'::text, 'Low'::text, 'Medium'::text, 'High'::text, 'Very High'::text]))),
     CONSTRAINT food_variants_source_check CHECK ((source = ANY (ARRAY['manual'::text, 'ai_estimate'::text, 'imported'::text])))
+    allergens text[],
+    traces text[],
+    CONSTRAINT food_variants_glycemic_index_check CHECK ((glycemic_index = ANY (ARRAY['None'::text, 'Very Low'::text, 'Low'::text, 'Medium'::text, 'High'::text, 'Very High'::text]))): add allergens and traces from OpenFoodFacts)
 );
 
 

--- a/shared/src/schemas/database/FoodEntries.zod.ts
+++ b/shared/src/schemas/database/FoodEntries.zod.ts
@@ -50,6 +50,8 @@ export const foodEntriesSchema = z.object({
   meal_id: mealsIdSchema.nullable(),
   food_entry_meal_id: foodEntryMealsIdSchema.nullable(),
   custom_nutrients: z.unknown().nullable(),
+  allergens: z.array(z.string()).nullable(),
+  traces: z.array(z.string()).nullable(),
   meal_type_id: mealTypesIdSchema,
 });
 
@@ -90,6 +92,8 @@ export const foodEntriesInitializerSchema = z.object({
   meal_id: mealsIdSchema.optional().nullable(),
   food_entry_meal_id: foodEntryMealsIdSchema.optional().nullable(),
   custom_nutrients: z.unknown().optional().nullable(),
+  allergens: z.array(z.string()).optional().nullable(),
+  traces: z.array(z.string()).optional().nullable(),
   meal_type_id: mealTypesIdSchema,
 });
 
@@ -130,6 +134,8 @@ export const foodEntriesMutatorSchema = z.object({
   meal_id: mealsIdSchema.optional().nullable(),
   food_entry_meal_id: foodEntryMealsIdSchema.optional().nullable(),
   custom_nutrients: z.unknown().optional().nullable(),
+  allergens: z.array(z.string()).optional().nullable(),
+  traces: z.array(z.string()).optional().nullable(),
   meal_type_id: mealTypesIdSchema.optional(),
 });
 

--- a/shared/src/schemas/database/FoodVariants.zod.ts
+++ b/shared/src/schemas/database/FoodVariants.zod.ts
@@ -38,6 +38,8 @@ export const foodVariantsSchema = z.object({
   custom_nutrients: z.unknown().nullable(),
   source: z.enum(["manual", "ai_estimate", "imported"]),
   ai_confidence: z.enum(["high", "medium", "low"]).nullable(),
+  allergens: z.array(z.string()).nullable(),
+  traces: z.array(z.string()).nullable(),: add allergens and traces from OpenFoodFacts)
 });
 
 export const foodVariantsInitializerSchema = z.object({
@@ -69,6 +71,8 @@ export const foodVariantsInitializerSchema = z.object({
   custom_nutrients: z.unknown().optional().nullable(),
   source: z.enum(["manual", "ai_estimate", "imported"]).optional(),
   ai_confidence: z.enum(["high", "medium", "low"]).optional().nullable(),
+  allergens: z.array(z.string()).optional().nullable(),
+  traces: z.array(z.string()).optional().nullable(),: add allergens and traces from OpenFoodFacts)
 });
 
 export const foodVariantsMutatorSchema = z.object({
@@ -100,6 +104,8 @@ export const foodVariantsMutatorSchema = z.object({
   custom_nutrients: z.unknown().optional().nullable(),
   source: z.enum(["manual", "ai_estimate", "imported"]).optional(),
   ai_confidence: z.enum(["high", "medium", "low"]).optional().nullable(),
+  allergens: z.array(z.string()).optional().nullable(),
+  traces: z.array(z.string()).optional().nullable(),: add allergens and traces from OpenFoodFacts)
 });
 
 export type FoodVariants = z.infer<typeof foodVariantsSchema>;

--- a/shared/src/schemas/database/FoodVariants.zod.ts
+++ b/shared/src/schemas/database/FoodVariants.zod.ts
@@ -39,7 +39,7 @@ export const foodVariantsSchema = z.object({
   source: z.enum(["manual", "ai_estimate", "imported"]),
   ai_confidence: z.enum(["high", "medium", "low"]).nullable(),
   allergens: z.array(z.string()).nullable(),
-  traces: z.array(z.string()).nullable(),: add allergens and traces from OpenFoodFacts)
+  traces: z.array(z.string()).nullable(),
 });
 
 export const foodVariantsInitializerSchema = z.object({
@@ -72,7 +72,7 @@ export const foodVariantsInitializerSchema = z.object({
   source: z.enum(["manual", "ai_estimate", "imported"]).optional(),
   ai_confidence: z.enum(["high", "medium", "low"]).optional().nullable(),
   allergens: z.array(z.string()).optional().nullable(),
-  traces: z.array(z.string()).optional().nullable(),: add allergens and traces from OpenFoodFacts)
+  traces: z.array(z.string()).optional().nullable(),
 });
 
 export const foodVariantsMutatorSchema = z.object({
@@ -105,7 +105,7 @@ export const foodVariantsMutatorSchema = z.object({
   source: z.enum(["manual", "ai_estimate", "imported"]).optional(),
   ai_confidence: z.enum(["high", "medium", "low"]).optional().nullable(),
   allergens: z.array(z.string()).optional().nullable(),
-  traces: z.array(z.string()).optional().nullable(),: add allergens and traces from OpenFoodFacts)
+  traces: z.array(z.string()).optional().nullable(),
 });
 
 export type FoodVariants = z.infer<typeof foodVariantsSchema>;


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Users with food allergies or intolerances had no way to track which foods may be causing symptoms. This adds allergen tracking so users get visual warnings when logged or searched foods contain allergens they care about.

**How did you implement the solution?**
Added `allergens` and `traces` columns to `food_variants` and `food_entries`. OpenFoodFacts `allergens_tags`/`traces_tags` are mapped automatically on import, with a startup backfill for existing OFF foods. A new `user_allergen_preferences` table (with RLS) stores which allergens each user wants to track. The frontend shows red/orange warning badges on food items in the diary, food search (database and online), and the Foods page — filtered to only the allergens the user has configured. A new Settings section lets users pick from 15 common allergens or type custom ones. The variant editor also allows manual allergen entry for custom or existing foods.

Linked Issue: Closes #1014

## How to Test

1. Check out this branch and run `docker compose up` (the allergen backfill runs automatically on server start)
2. Go to **Settings → Allergen Preferences** and add a few allergens (e.g. Fish, Milk)
3. Open the **Diary**, click **Add Food → Online**, search for a food — verify red/orange badges appear for matching allergens/traces
4. Check the **Database** tab and the **Foods** page — badges appear for foods with stored allergen data
5. Open a food in the food editor → variant section → verify you can toggle and add allergens manually

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [X] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

> I put the before on the left side and the after on the right side for easier comparison.

<img width="1709" height="1055" alt="1" src="https://github.com/user-attachments/assets/0caaeca8-e371-4841-9ebc-ed36e0de8ed9" />
<img width="1722" height="1055" alt="2" src="https://github.com/user-attachments/assets/cdf77119-b291-4093-ad0e-256b7f69a0fa" />
<img width="1713" height="1052" alt="3" src="https://github.com/user-attachments/assets/0862cbbd-e90a-43f4-9151-5c5c258c4353" />
<img width="1720" height="1061" alt="4" src="https://github.com/user-attachments/assets/5f40e4f3-7cde-4e09-930e-6d7950ce11f3" />


</details>

## Notes for Reviewers

- Allergen data for existing OpenFoodFacts foods is backfilled on server startup (fire-and-forget). Foods where OFF returns no allergen data are left as NULL so future backfills can still pick them up.

- The diary query uses `COALESCE(fe.allergens, fv.allergens)` so old diary entries show allergens via the food variant even if the entry itself predates this feature.

- Badges are filtered client-side against the user's preferences — if no allergens are configured in Settings, no badges appear anywhere (zero noise for users who don't use this feature).

- FatSecret allergen data requires their premium plan; only OpenFoodFacts is wired up for now.

Another two things worth mentioning:
- Allergen name normalization: OFF tags come in the form en:fish, de:fisch, etc. We strip the language prefix with /^[a-z]{2}:/, so the stored value is always fish, fisch, etc. For non-English product pages this means the stored allergen name may be in the product's source language, not English. Badges will only match if the user's preference uses the same spelling. This is a known limitation and could be improved later with a mapping table, but is out of scope for this PR.

- Diary entries capture allergens as a snapshot at log time (food_entries.allergens). If a food's allergen data is later corrected, existing diary entries keep the original value. The COALESCE(fe.allergens, fv.allergens) pattern in the diary query uses the entry-level snapshot first, falling back to the current variant data — so old entries logged before this feature was deployed will automatically gain badges once the backfill populates fv.allergens.