### PR TITLE
feat: add error handling for fatsecret

### DIFF
--- a/SparkyFitnessMobile/__tests__/screens/FoodScanScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodScanScreen.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import FoodScanScreen from '../../src/screens/FoodScanScreen';
 import { lookupBarcodeV2, scanNutritionLabel } from '../../src/services/api/externalFoodSearchApi';
+import { ApiError } from '../../src/services/api/errors';
 import { fireSuccessHaptic } from '../../src/services/haptics';
 import { useActiveAiServiceSetting } from '../../src/hooks/useActiveAiServiceSetting';
 import { hasSeenFoodPhotoIntro } from '../../src/services/foodPhotoIntro';
@@ -145,6 +146,50 @@ describe('FoodScanScreen', () => {
     });
     expect(mockFireSuccessHaptic).not.toHaveBeenCalled();
     expect(mockNavigation.replace).not.toHaveBeenCalled();
+  });
+
+  it('shows the lookup-failed recovery card with the server message when lookup throws', async () => {
+    mockLookupBarcodeV2.mockRejectedValue(
+      new ApiError(
+        'Bad Gateway',
+        502,
+        JSON.stringify({ error: 'FatSecret API error (code 21): Invalid IP address detected' }),
+      ),
+    );
+    const screen = renderScreen();
+
+    fireEvent(screen.getByTestId('camera-view'), 'onBarcodeScanned', {
+      data: '012345678905',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Lookup failed')).toBeTruthy();
+    });
+    expect(
+      screen.getByText('FatSecret API error (code 21): Invalid IP address detected'),
+    ).toBeTruthy();
+    // The misleading not-found copy is not shown for a real failure.
+    expect(screen.queryByText('No match for barcode')).toBeNull();
+    // The flow stays recoverable.
+    expect(screen.getByText('Scan Nutrition Label')).toBeTruthy();
+    expect(screen.getByText('Add Food Manually')).toBeTruthy();
+    expect(mockFireSuccessHaptic).not.toHaveBeenCalled();
+  });
+
+  it('falls back to generic copy when a thrown lookup carries no server message', async () => {
+    mockLookupBarcodeV2.mockRejectedValue(new Error('network down'));
+    const screen = renderScreen();
+
+    fireEvent(screen.getByTestId('camera-view'), 'onBarcodeScanned', {
+      data: '012345678905',
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Lookup failed')).toBeTruthy();
+    });
+    expect(
+      screen.getByText("Couldn't look up this barcode. Please try again."),
+    ).toBeTruthy();
   });
 
   it('does not retrigger haptics while a scan lookup is locked', async () => {

--- a/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import Toast from 'react-native-toast-message';
 import FoodSearchScreen from '../../src/screens/FoodSearchScreen';
+import { fetchExternalFoodDetails } from '../../src/services/api/externalFoodSearchApi';
+import { ApiError } from '../../src/services/api/errors';
 import {
   useExternalFoodSearch,
   useExternalProviders,
@@ -47,6 +50,8 @@ jest.mock('../../src/components/Icon', () => {
   };
 });
 
+const mockFetchExternalFoodDetails = fetchExternalFoodDetails as jest.MockedFunction<typeof fetchExternalFoodDetails>;
+const mockToastShow = Toast.show as jest.MockedFunction<typeof Toast.show>;
 const mockUseExternalFoodSearch = useExternalFoodSearch as jest.MockedFunction<typeof useExternalFoodSearch>;
 const mockUseExternalProviders = useExternalProviders as jest.MockedFunction<typeof useExternalProviders>;
 const mockUseFoodSearch = useFoodSearch as jest.MockedFunction<typeof useFoodSearch>;
@@ -214,6 +219,112 @@ describe('FoodSearchScreen', () => {
         </SafeAreaProvider>,
       );
       expect(screen.queryByText('Estimate from photo')).toBeNull();
+    });
+  });
+
+  describe('online search errors', () => {
+    const externalItem = {
+      id: 'ext-1',
+      name: 'Cheddar Cheese',
+      brand: 'FatSecret Brand',
+      source: 'fatsecret',
+      serving_size: 100,
+      serving_unit: 'g',
+      calories: 400,
+      protein: 25,
+      carbs: 1,
+      fat: 33,
+    } as any;
+
+    const openOnlineTab = () => {
+      mockUseExternalProviders.mockReturnValue({
+        providers: [{ id: 'p1', provider_type: 'fatsecret', provider_name: 'FatSecret' }],
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn(),
+      } as any);
+      const screen = render(
+        <SafeAreaProvider initialMetrics={{ insets, frame }}>
+          <FoodSearchScreen navigation={navigation} route={route} />
+        </SafeAreaProvider>,
+      );
+      fireEvent.press(screen.getByText('Online'));
+      return screen;
+    };
+
+    it('renders the server error message when the search hook surfaces one', () => {
+      mockUseExternalFoodSearch.mockReturnValue({
+        searchResults: [],
+        isSearching: false,
+        isSearchActive: true,
+        isSearchError: true,
+        searchErrorMessage: 'FatSecret API error (code 21): Invalid IP address detected',
+        isProviderSupported: true,
+        fetchNextPage: jest.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        isFetchNextPageError: false,
+      } as any);
+
+      const screen = openOnlineTab();
+
+      expect(
+        screen.getByText('FatSecret API error (code 21): Invalid IP address detected'),
+      ).toBeTruthy();
+      expect(screen.queryByText('Failed to search FatSecret')).toBeNull();
+    });
+
+    it('falls back to the generic message when no server message is available', () => {
+      mockUseExternalFoodSearch.mockReturnValue({
+        searchResults: [],
+        isSearching: false,
+        isSearchActive: true,
+        isSearchError: true,
+        searchErrorMessage: null,
+        isProviderSupported: true,
+        fetchNextPage: jest.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        isFetchNextPageError: false,
+      } as any);
+
+      const screen = openOnlineTab();
+
+      expect(screen.getByText('Failed to search FatSecret')).toBeTruthy();
+    });
+
+    it('toasts the error but still opens partial info when a detail fetch fails', async () => {
+      mockUseExternalFoodSearch.mockReturnValue({
+        searchResults: [externalItem],
+        isSearching: false,
+        isSearchActive: true,
+        isSearchError: false,
+        searchErrorMessage: null,
+        isProviderSupported: true,
+        fetchNextPage: jest.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        isFetchNextPageError: false,
+      } as any);
+      mockFetchExternalFoodDetails.mockRejectedValue(
+        new ApiError('Bad Gateway', 502, JSON.stringify({ error: 'FatSecret down' })),
+      );
+
+      const screen = openOnlineTab();
+
+      fireEvent.press(screen.getByText('Cheddar Cheese'));
+
+      await waitFor(() => {
+        expect(mockToastShow).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'error', text2: 'FatSecret down' }),
+        );
+      });
+      expect(navigation.navigate).toHaveBeenCalledWith(
+        'FoodEntryAdd',
+        expect.objectContaining({
+          item: expect.objectContaining({ id: 'ext-1', source: 'external' }),
+        }),
+      );
     });
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/api/errors.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/api/errors.test.ts
@@ -1,0 +1,44 @@
+import { ApiError, getApiErrorMessage } from '../../../src/services/api/errors';
+
+describe('getApiErrorMessage', () => {
+  it('returns the message from an ApiError with an { error } body', () => {
+    const error = new ApiError(
+      'Bad Gateway',
+      502,
+      JSON.stringify({ error: 'FatSecret API error (code 21): Invalid IP address detected' }),
+    );
+    expect(getApiErrorMessage(error)).toBe(
+      'FatSecret API error (code 21): Invalid IP address detected',
+    );
+  });
+
+  it('returns the message from an ApiError with a { message } body', () => {
+    const error = new ApiError('Bad Gateway', 502, JSON.stringify({ message: 'Something failed' }));
+    expect(getApiErrorMessage(error)).toBe('Something failed');
+  });
+
+  it('prefers the { error } field over { message } when both are present', () => {
+    const error = new ApiError(
+      'Bad Gateway',
+      502,
+      JSON.stringify({ error: 'primary', message: 'secondary' }),
+    );
+    expect(getApiErrorMessage(error)).toBe('primary');
+  });
+
+  it('returns null when the body is not JSON', () => {
+    const error = new ApiError('Bad Gateway', 502, 'not json');
+    expect(getApiErrorMessage(error)).toBeNull();
+  });
+
+  it('returns null when the ApiError has no body', () => {
+    const error = new ApiError('Bad Gateway', 502);
+    expect(getApiErrorMessage(error)).toBeNull();
+  });
+
+  it('returns null for a non-ApiError value', () => {
+    expect(getApiErrorMessage(new Error('plain error'))).toBeNull();
+    expect(getApiErrorMessage('a string')).toBeNull();
+    expect(getApiErrorMessage(null)).toBeNull();
+  });
+});

--- a/SparkyFitnessMobile/src/hooks/useExternalFoodSearch.ts
+++ b/SparkyFitnessMobile/src/hooks/useExternalFoodSearch.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useInfiniteQuery, keepPreviousData } from '@tanstack/react-query';
 import { searchExternalFoods } from '../services/api/externalFoodSearchApi';
+import { getApiErrorMessage } from '../services/api/errors';
 import { externalFoodSearchQueryKey } from './queryKeys';
 import { useDebounce } from './useDebounce';
 import { RateLimiter } from '../utils/rateLimiter';
@@ -53,6 +54,7 @@ export function useExternalFoodSearch(
     isSearching: query.isFetching && !query.isFetchingNextPage,
     isSearchActive,
     isSearchError: query.isError && !hasCurrentData,
+    searchErrorMessage: query.isError && !hasCurrentData ? getApiErrorMessage(query.error) : null,
     isProviderSupported,
     fetchNextPage: query.fetchNextPage,
     hasNextPage: query.hasNextPage,

--- a/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
@@ -24,6 +24,7 @@ import type { FoodInfoItem } from '../types/foodInfo';
 import { useCSSVariable } from 'uniwind';
 import { CameraView, useCameraPermissions, type BarcodeScanningResult } from 'expo-camera';
 import { lookupBarcodeV2, scanNutritionLabel } from '../services/api/externalFoodSearchApi';
+import { getApiErrorMessage } from '../services/api/errors';
 import { fireSuccessHaptic } from '../services/haptics';
 import { toFormString } from '../types/foodInfo';
 import { useActiveAiServiceSetting } from '../hooks/useActiveAiServiceSetting';
@@ -82,6 +83,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
     return requested;
   });
   const [notFoundBarcode, setNotFoundBarcode] = useState<string | null>(null);
+  const [lookupError, setLookupError] = useState<{ barcode: string; message: string } | null>(null);
   const [labelProcessing, setLabelProcessing] = useState(false);
   const [capturedPhoto, setCapturedPhoto] = useState<{ base64: string; uri: string } | null>(null);
   const [manualEntryVisible, setManualEntryVisible] = useState(false);
@@ -132,6 +134,8 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
     barcode: string,
     { shouldFireSuccessHaptic = false }: { shouldFireSuccessHaptic?: boolean } = {},
   ) => {
+    setNotFoundBarcode(null);
+    setLookupError(null);
     try {
       const result = await lookupBarcodeV2(barcode);
 
@@ -207,8 +211,10 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
           }),
         );
       }
-    } catch {
-      setNotFoundBarcode(barcode);
+    } catch (error) {
+      const message =
+        getApiErrorMessage(error) ?? "Couldn't look up this barcode. Please try again.";
+      setLookupError({ barcode, message });
     } finally {
       setLoading(false);
     }
@@ -297,7 +303,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
             vitaminA: toFormString(result.vitamin_a),
             vitaminC: toFormString(result.vitamin_c),
           },
-          barcode: notFoundBarcode ?? undefined,
+          barcode: lookupError?.barcode ?? notFoundBarcode ?? undefined,
           providerType: 'label_scan',
         }),
       );
@@ -326,6 +332,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
     }
     setScanMode(key);
     setNotFoundBarcode(null);
+    setLookupError(null);
     setCapturedPhoto(null);
     setScanned(false);
     scanLock.current = false;
@@ -439,7 +446,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
         enableTorch={flashlight}
       />
 
-      {scanMode === 'barcode' && !notFoundBarcode && !loading && !manualEntryVisible ? (
+      {scanMode === 'barcode' && !notFoundBarcode && !lookupError && !loading && !manualEntryVisible ? (
         <View pointerEvents="none" style={StyleSheet.absoluteFillObject} className="justify-center items-center">
           <View style={{ width: GUIDE_WIDTH, height: GUIDE_HEIGHT, marginBottom: 120 }}>
             <View style={{ ...CORNER_STYLE, top: 0, left: 0, borderTopWidth: CORNER_BORDER, borderLeftWidth: CORNER_BORDER, borderTopLeftRadius: 4 }} />
@@ -506,15 +513,19 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
         </View>
       ) : null}
 
-      {!isCaptureBarcodeMode && !capturedPhoto && !labelProcessing && !loading && !manualEntryVisible && scanMode === 'barcode' && notFoundBarcode ? (
+      {!isCaptureBarcodeMode && !capturedPhoto && !labelProcessing && !loading && !manualEntryVisible && scanMode === 'barcode' && (notFoundBarcode || lookupError) ? (
         <View
           className="absolute left-0 right-0 items-center px-8"
           style={{ bottom: Math.max(insets.bottom + 8, 24) + 76 }}
         >
           <View className="self-stretch bg-surface rounded-xl p-5 items-center gap-3">
-            <Text className="text-text-primary text-base font-semibold">No match for barcode</Text>
+            <Text className="text-text-primary text-base font-semibold">
+              {lookupError ? 'Lookup failed' : 'No match for barcode'}
+            </Text>
             <Text className="text-text-secondary text-sm text-center">
-              You can scan the nutrition label or enter it manually.
+              {lookupError
+                ? lookupError.message
+                : 'You can scan the nutrition label or enter it manually.'}
             </Text>
             <View className="gap-3 mt-2 self-stretch">
               <UIButton
@@ -530,7 +541,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
                 onPress={() => navigation.replace(
                   'FoodForm',
                   buildFoodFormParams({
-                    barcode: notFoundBarcode,
+                    barcode: lookupError?.barcode ?? notFoundBarcode ?? undefined,
                   }),
                 )}
                 className="rounded-lg"
@@ -613,7 +624,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
             />
           </View>
 
-          {!(scanMode === 'barcode' && notFoundBarcode) &&
+          {!(scanMode === 'barcode' && (notFoundBarcode || lookupError)) &&
           !(scanMode === 'photo' && photoGateVisible) ? (
             <View className="h-20 items-center justify-center self-stretch">
               {scanMode === 'barcode' ? (

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -25,7 +25,9 @@ import {
   useExternalFoodSearch,
   usePreferences,
 } from '../hooks';
+import Toast from 'react-native-toast-message';
 import { fetchExternalFoodDetails } from '../services/api/externalFoodSearchApi';
+import { getApiErrorMessage } from '../services/api/errors';
 import { getLastUsedTab, setLastUsedTab } from '../services/foodSearchPreferences';
 import type { FoodSearchTab } from '../services/foodSearchPreferences';
 import { FoodItem, TopFoodItem } from '../types/foods';
@@ -144,6 +146,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     isSearching: isOnlineSearching,
     isSearchActive: isOnlineSearchActive,
     isSearchError: isOnlineSearchError,
+    searchErrorMessage: onlineSearchErrorMessage,
     isProviderSupported,
     fetchNextPage,
     hasNextPage,
@@ -211,7 +214,9 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
       try {
         const detailed = await fetchExternalFoodDetails('fatsecret', item.id, selectedProvider);
         showFoodInfo(externalFoodItemToFoodInfo(detailed));
-      } catch {
+      } catch (error) {
+        const message = getApiErrorMessage(error) ?? "Couldn't load full nutrition details.";
+        Toast.show({ type: 'error', text1: 'Details unavailable', text2: message });
         showFoodInfo(externalFoodItemToFoodInfo(item));
       } finally {
         setLoadingFoodId(null);
@@ -725,7 +730,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
           <View className="flex-1 justify-center items-center px-6">
             <Icon name="alert-circle" size={48} color={accentColor} />
             <Text className="text-text-secondary text-base mt-4 text-center">
-              Failed to search {selectedProviderName}
+              {onlineSearchErrorMessage ?? `Failed to search ${selectedProviderName}`}
             </Text>
           </View>
         </>

--- a/SparkyFitnessMobile/src/services/api/errors.ts
+++ b/SparkyFitnessMobile/src/services/api/errors.ts
@@ -8,3 +8,15 @@ export class ApiError extends Error {
     this.name = 'ApiError';
   }
 }
+
+export function getApiErrorMessage(error: unknown): string | null {
+  if (!(error instanceof ApiError) || !error.body) return null;
+  try {
+    const parsed = JSON.parse(error.body);
+    if (typeof parsed?.error === 'string') return parsed.error;
+    if (typeof parsed?.message === 'string') return parsed.message;
+  } catch {
+    // body wasn't JSON — fall through
+  }
+  return null;
+}

--- a/SparkyFitnessServer/integrations/fatsecret/fatsecretService.ts
+++ b/SparkyFitnessServer/integrations/fatsecret/fatsecretService.ts
@@ -107,6 +107,30 @@ function evaluateFraction(fractionStr: any) {
   }
   return total || 0;
 }
+// FatSecret's REST endpoints return HTTP 200 even on failure, embedding the
+// error as { error: { code, message } } (e.g. code 21 "Invalid IP" when the
+// server IP isn't whitelisted). Surface it instead of letting it fall through
+// as empty "No results found".
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function assertNoFatSecretApiError(data: any) {
+  const apiError = data?.error;
+  const hasCode = apiError?.code !== undefined && apiError?.code !== null;
+  const hasMessage =
+    apiError?.message !== undefined && apiError?.message !== null;
+  if (!apiError || (!hasCode && !hasMessage)) {
+    return;
+  }
+  const code = apiError.code;
+  const message = apiError.message || 'Unknown FatSecret API error';
+  throw Object.assign(
+    new Error(
+      `FatSecret API error${hasCode ? ` (code ${code})` : ''}: ${message}`
+    ),
+    // `status` is honored by the v2 route handlers; `statusCode` by the
+    // centralized errorHandler middleware.
+    { status: 502, statusCode: 502, fatSecretErrorCode: code }
+  );
+}
 // Function to get FatSecret OAuth 2.0 Access Token
 async function getFatSecretAccessToken(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -221,9 +245,10 @@ async function searchFatSecretByBarcode(
       throw new Error(`FatSecret Barcode API error: ${errorText}`);
     }
     const data = await response.json();
-    if (data.error && data.error.code === '211') {
+    if (data.error && String(data.error.code) === '211') {
       return null; // No food item detected
     }
+    assertNoFatSecretApiError(data);
     return data;
   } catch (error) {
     log('error', `Error searching FatSecret by barcode ${barcode}:`, error);
@@ -465,6 +490,7 @@ function mapFatSecretSearchItem(item: any) {
   };
 }
 export { getFatSecretAccessToken };
+export { assertNoFatSecretApiError };
 export { searchFatSecretByBarcode };
 export { mapFatSecretFood };
 export { mapFatSecretSearchItem };
@@ -473,6 +499,7 @@ export { CACHE_DURATION_MS };
 export { FATSECRET_API_BASE_URL };
 export default {
   getFatSecretAccessToken,
+  assertNoFatSecretApiError,
   searchFatSecretByBarcode,
   mapFatSecretFood,
   mapFatSecretSearchItem,

--- a/SparkyFitnessServer/services/foodCoreService.ts
+++ b/SparkyFitnessServer/services/foodCoreService.ts
@@ -751,6 +751,18 @@ async function updateFoodEntriesSnapshot(
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function lookupBarcode(barcode: any, userId: any, providerId: any) {
+  // Providers are tried in turn, each failure caught so the next can run.
+  // Capture the first failure carrying an HTTP status (a surfaceable
+  // misconfiguration, e.g. FatSecret's IP error) to report instead of a
+  // misleading "not found" if every provider fails.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let surfaceableError: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const captureSurfaceable = (err: any) => {
+    if (!surfaceableError && err?.status) {
+      surfaceableError = err;
+    }
+  };
   try {
     const localFood = await foodRepository.findFoodByBarcode(barcode, userId);
     if (localFood) {
@@ -809,6 +821,7 @@ async function lookupBarcode(barcode: any, userId: any, providerId: any) {
         }
       } catch (fsError) {
         log('warn', `FatSecret barcode lookup failed for ${barcode}:`, fsError);
+        captureSurfaceable(fsError);
       }
     }
     // Try USDA if provider is configured
@@ -846,6 +859,7 @@ async function lookupBarcode(barcode: any, userId: any, providerId: any) {
         }
       } catch (usdaError) {
         log('warn', `USDA barcode lookup failed for ${barcode}:`, usdaError);
+        captureSurfaceable(usdaError);
       }
     }
     // Try OpenFoodFacts if it is the configured primary provider
@@ -878,6 +892,7 @@ async function lookupBarcode(barcode: any, userId: any, providerId: any) {
           `OpenFoodFacts barcode lookup failed for ${barcode}:`,
           error
         );
+        captureSurfaceable(error);
       }
     }
     // Fall back to OpenFoodFacts if not already tried and user preference allows it
@@ -932,7 +947,12 @@ async function lookupBarcode(barcode: any, userId: any, providerId: any) {
           `OpenFoodFacts lookup failed for barcode ${barcode}:`,
           error
         );
+        captureSurfaceable(error);
       }
+    }
+    // Every provider failed: report a misconfiguration rather than "not found".
+    if (surfaceableError) {
+      throw surfaceableError;
     }
     return { source: 'not_found', food: null };
   } catch (error) {

--- a/SparkyFitnessServer/services/foodIntegrationService.ts
+++ b/SparkyFitnessServer/services/foodIntegrationService.ts
@@ -1,6 +1,7 @@
 import { log } from '../config/logging.js';
 import {
   getFatSecretAccessToken,
+  assertNoFatSecretApiError,
   foodNutrientCache,
   CACHE_DURATION_MS,
   FATSECRET_API_BASE_URL,
@@ -41,6 +42,7 @@ async function searchFatSecretFoods(
       throw new Error(`FatSecret API error: ${errorText}`);
     }
     const data = await response.json();
+    assertNoFatSecretApiError(data);
     const foods = data.foods || {};
     const totalCount = Number(foods.total_results || 0);
     const pageNum = Number(foods.page_number || 0) + 1;
@@ -100,6 +102,7 @@ async function getFatSecretNutrients(
       throw new Error(`FatSecret API error: ${errorText}`);
     }
     const data = await response.json();
+    assertNoFatSecretApiError(data);
     // Store in cache
     foodNutrientCache.set(foodId, {
       data: data,

--- a/SparkyFitnessServer/tests/barcodeLookup.test.ts
+++ b/SparkyFitnessServer/tests/barcodeLookup.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../integrations/usda/usdaService.js';
 import externalProviderService from '../services/externalProviderService.js';
 import preferenceService from '../services/preferenceService.js';
+import { searchFatSecretByBarcode } from '../integrations/fatsecret/fatsecretService.js';
 import { lookupBarcode } from '../services/foodCoreService.js';
 import { normalizeBarcode } from '../utils/foodUtils.js';
 vi.mock('../models/foodRepository.js');
@@ -50,6 +51,24 @@ vi.mock('../integrations/usda/usdaService.js', async (importOriginal) => {
     },
   };
 });
+
+vi.mock(
+  '../integrations/fatsecret/fatsecretService.js',
+  async (importOriginal) => {
+    const actual = await importOriginal();
+    const mockSearch = vi.fn();
+    return {
+      // @ts-expect-error TS(2698): Spread types may only be created from object types... Remove this comment to see the full error message
+      ...actual,
+      searchFatSecretByBarcode: mockSearch, // Für Named Import im Test
+      default: {
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
+        ...actual.default,
+        searchFatSecretByBarcode: mockSearch, // Für Default Import im Service
+      },
+    };
+  }
+);
 describe('normalizeBarcode', () => {
   it('should pad a 12-digit UPC-A to 13-digit EAN-13', () => {
     expect(normalizeBarcode('094395000172')).toBe('0094395000172');
@@ -103,6 +122,22 @@ const makeUsdaProvider = (overrides = {}) => ({
   is_active: true,
   ...overrides,
 });
+const TEST_FATSECRET_PROVIDER_ID = 'provider-fatsecret-001';
+const makeFatSecretProvider = (overrides = {}) => ({
+  id: TEST_FATSECRET_PROVIDER_ID,
+  provider_type: 'fatsecret',
+  app_id: 'test-fatsecret-app-id',
+  app_key: 'test-fatsecret-app-key',
+  is_active: true,
+  ...overrides,
+});
+// Mimics the error thrown by assertNoFatSecretApiError for the IP-restriction
+// (code 21) misconfiguration: an HTTP-status-bearing error.
+const makeFatSecretIpError = () =>
+  Object.assign(
+    new Error('FatSecret API error (code 21): Invalid IP address detected'),
+    { status: 502, statusCode: 502, fatSecretErrorCode: 21 }
+  );
 const makeLocalFood = (overrides = {}) => ({
   id: 'food-abc-123',
   name: 'Peanut Butter',
@@ -940,5 +975,75 @@ describe('lookupBarcode', () => {
     expect(result.source).toBe('usda');
     expect(result.food.name).toBe('Direct Match');
     expect(searchUsdaFoodsByBarcode).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a FatSecret misconfiguration instead of not_found when no provider succeeds', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.findFoodByBarcode.mockResolvedValue(null);
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    preferenceService.getUserPreferences.mockResolvedValue({
+      default_barcode_provider_id: TEST_FATSECRET_PROVIDER_ID,
+      // Disable the OFF fallback so FatSecret is the only provider tried
+      barcode_fallback_open_food_facts: false,
+    });
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue(
+      makeFatSecretProvider()
+    );
+    // @ts-expect-error TS(2339): Property 'mockRejectedValue' does not exist on typ... Remove this comment to see the full error message
+    searchFatSecretByBarcode.mockRejectedValue(makeFatSecretIpError());
+    const promise = lookupBarcode(
+      '3017620422003',
+      TEST_USER_ID,
+      TEST_FATSECRET_PROVIDER_ID
+    );
+    await expect(promise).rejects.toThrow('Invalid IP address detected');
+    await expect(promise).rejects.toMatchObject({ statusCode: 502 });
+  });
+
+  it('still returns a fallback result (hiding the FatSecret error) when OFF succeeds', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.findFoodByBarcode.mockResolvedValue(null);
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    preferenceService.getUserPreferences.mockResolvedValue({
+      default_barcode_provider_id: TEST_FATSECRET_PROVIDER_ID,
+    });
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue(
+      makeFatSecretProvider()
+    );
+    // @ts-expect-error TS(2339): Property 'mockRejectedValue' does not exist on typ... Remove this comment to see the full error message
+    searchFatSecretByBarcode.mockRejectedValue(makeFatSecretIpError());
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    searchOpenFoodFactsByBarcodeFields.mockResolvedValue(makeOffResponse());
+    const result = await lookupBarcode(
+      '3017620422003',
+      TEST_USER_ID,
+      TEST_FATSECRET_PROVIDER_ID
+    );
+    expect(result.source).toBe('openfoodfacts');
+    expect(result.food.name).toBe('Nutella');
+  });
+
+  it('still degrades to not_found when FatSecret fails without an HTTP status (e.g. network error)', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.findFoodByBarcode.mockResolvedValue(null);
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    preferenceService.getUserPreferences.mockResolvedValue({
+      default_barcode_provider_id: TEST_FATSECRET_PROVIDER_ID,
+      barcode_fallback_open_food_facts: false,
+    });
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue(
+      makeFatSecretProvider()
+    );
+    // @ts-expect-error TS(2339): Property 'mockRejectedValue' does not exist on typ... Remove this comment to see the full error message
+    searchFatSecretByBarcode.mockRejectedValue(new Error('Network timeout'));
+    const result = await lookupBarcode(
+      '3017620422003',
+      TEST_USER_ID,
+      TEST_FATSECRET_PROVIDER_ID
+    );
+    expect(result).toEqual({ source: 'not_found', food: null });
   });
 });

--- a/SparkyFitnessServer/tests/fatsecretService.test.ts
+++ b/SparkyFitnessServer/tests/fatsecretService.test.ts
@@ -1,7 +1,37 @@
 import { describe, expect, it } from 'vitest';
 import { mapFatSecretSearchItem } from '../integrations/fatsecret/fatsecretService.js';
 import { mapFatSecretFood } from '../integrations/fatsecret/fatsecretService.js';
+import { assertNoFatSecretApiError } from '../integrations/fatsecret/fatsecretService.js';
 describe('FatSecret Service Mapping', () => {
+  describe('assertNoFatSecretApiError', () => {
+    it('throws a descriptive error for the IP restriction envelope', () => {
+      const data = {
+        error: { code: 21, message: 'Invalid IP address detected: 1.2.3.4' },
+      };
+      let thrown: unknown;
+      try {
+        assertNoFatSecretApiError(data);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toContain('code 21');
+      expect((thrown as Error).message).toContain('Invalid IP address');
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((thrown as any).status).toBe(502);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((thrown as any).fatSecretErrorCode).toBe(21);
+    });
+    it('does not throw for a successful response', () => {
+      expect(() =>
+        assertNoFatSecretApiError({ foods: { total_results: '0' } })
+      ).not.toThrow();
+    });
+    it('does not throw for null/undefined data', () => {
+      expect(() => assertNoFatSecretApiError(null)).not.toThrow();
+      expect(() => assertNoFatSecretApiError(undefined)).not.toThrow();
+    });
+  });
   describe('mapFatSecretSearchItem', () => {
     it('should map metric description correctly', () => {
       const item = {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

Fatsecret API Errors (such as not whitelisted ip) are either swallowed or surface as an empty result in search. This not only surfaces them from the API, but shows them on the mobile client. The web client already shows the error.

Linked Issue: Closes #1355

## How to Test

1. Scan a bad barcode
2. Get error

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
