### PR TITLE
feat(mobile): add gallery picker to food photo estimate

### DIFF
--- a/SparkyFitnessMobile/__tests__/screens/FoodScanScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodScanScreen.test.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import * as ImagePicker from 'expo-image-picker';
 import FoodScanScreen from '../../src/screens/FoodScanScreen';
 import { lookupBarcodeV2, scanNutritionLabel } from '../../src/services/api/externalFoodSearchApi';
 import { ApiError } from '../../src/services/api/errors';
 import { fireSuccessHaptic } from '../../src/services/haptics';
 import { useActiveAiServiceSetting } from '../../src/hooks/useActiveAiServiceSetting';
-import { hasSeenFoodPhotoIntro } from '../../src/services/foodPhotoIntro';
+import { hasSeenFoodPhotoIntro, markFoodPhotoIntroSeen } from '../../src/services/foodPhotoIntro';
 
 jest.mock('../../src/services/api/externalFoodSearchApi', () => ({
   lookupBarcodeV2: jest.fn(),
@@ -430,6 +431,112 @@ describe('FoodScanScreen', () => {
       // Re-tap Photo while still on Photo — should refetch.
       fireEvent.press(screen.getByText('Photo'));
       expect(refetch).toHaveBeenCalled();
+    });
+  });
+
+  describe('Photo library picker', () => {
+    const mockLaunchLibrary = ImagePicker.launchImageLibraryAsync as jest.MockedFunction<
+      typeof ImagePicker.launchImageLibraryAsync
+    >;
+    const mockMarkSeen = markFoodPhotoIntroSeen as jest.MockedFunction<
+      typeof markFoodPhotoIntroSeen
+    >;
+
+    beforeEach(() => {
+      mockLaunchLibrary.mockReset();
+    });
+
+    it('exposes the library button only in photo mode when AI is configured', async () => {
+      const screen = renderScreen();
+      // Not visible on barcode mode.
+      expect(screen.queryByLabelText('Choose photo from library')).toBeNull();
+
+      fireEvent.press(screen.getByText('Photo'));
+      await waitFor(() => {
+        expect(screen.getByLabelText('Choose photo from library')).toBeTruthy();
+      });
+    });
+
+    it('hides the library button when AI photo is not available', async () => {
+      mockUseActiveAiServiceSetting.mockReturnValue({
+        data: null,
+        isLoading: false,
+      } as any);
+      const screen = renderScreenWithRoute({ initialMode: 'photo' });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(/AI photo estimates aren.t set up/),
+        ).toBeTruthy();
+      });
+      expect(screen.queryByLabelText('Choose photo from library')).toBeNull();
+    });
+
+    it('routes a picked photo into the FoodPhotoFlow > Improve screen', async () => {
+      mockLaunchLibrary.mockResolvedValue({
+        canceled: false,
+        assets: [{ uri: 'file:///picked.jpg' } as any],
+      } as any);
+
+      const screen = renderScreenWithRoute({ initialMode: 'photo' });
+      await waitFor(() => {
+        expect(screen.getByLabelText('Choose photo from library')).toBeTruthy();
+      });
+
+      await act(async () => {
+        fireEvent.press(screen.getByLabelText('Choose photo from library'));
+      });
+
+      await waitFor(() => {
+        expect(mockLaunchLibrary).toHaveBeenCalledTimes(1);
+      });
+      expect(mockMarkSeen).toHaveBeenCalled();
+      expect(mockNavigation.replace).toHaveBeenCalledWith('FoodPhotoFlow', {
+        screen: 'Improve',
+        params: { date: undefined, photo: { uri: 'file:///picked.jpg' } },
+      });
+    });
+
+    it('does nothing when the user cancels the system picker', async () => {
+      mockLaunchLibrary.mockResolvedValue({ canceled: true } as any);
+
+      const screen = renderScreenWithRoute({ initialMode: 'photo' });
+      await waitFor(() => {
+        expect(screen.getByLabelText('Choose photo from library')).toBeTruthy();
+      });
+
+      await act(async () => {
+        fireEvent.press(screen.getByLabelText('Choose photo from library'));
+      });
+
+      await waitFor(() => {
+        expect(mockLaunchLibrary).toHaveBeenCalledTimes(1);
+      });
+      expect(mockNavigation.replace).not.toHaveBeenCalled();
+    });
+
+    it('ignores a second tap while the picker is still resolving', async () => {
+      let resolveLaunch: ((value: any) => void) | undefined;
+      mockLaunchLibrary.mockImplementation(
+        () => new Promise((resolve) => { resolveLaunch = resolve; }),
+      );
+
+      const screen = renderScreenWithRoute({ initialMode: 'photo' });
+      await waitFor(() => {
+        expect(screen.getByLabelText('Choose photo from library')).toBeTruthy();
+      });
+
+      const button = screen.getByLabelText('Choose photo from library');
+      await act(async () => {
+        fireEvent.press(button);
+        fireEvent.press(button);
+      });
+
+      expect(mockLaunchLibrary).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        resolveLaunch?.({ canceled: true });
+      });
     });
   });
 });

--- a/SparkyFitnessMobile/jest.setup.js
+++ b/SparkyFitnessMobile/jest.setup.js
@@ -148,6 +148,11 @@ jest.mock('expo-camera', () => {
   };
 });
 
+// Mock expo-image-picker
+jest.mock('expo-image-picker', () => ({
+  launchImageLibraryAsync: jest.fn().mockResolvedValue({ canceled: true }),
+}));
+
 // Mock expo-secure-store
 jest.mock('expo-secure-store', () => {
   const store = {};

--- a/SparkyFitnessMobile/package.json
+++ b/SparkyFitnessMobile/package.json
@@ -41,6 +41,7 @@
     "expo-font": "~55.0.8",
     "expo-haptics": "~55.0.14",
     "expo-health-connect": "^0.1.1",
+    "expo-image-picker": "~55.0.20",
     "expo-navigation-bar": "~55.0.13",
     "expo-notifications": "~55.0.23",
     "expo-secure-store": "~55.0.14",

--- a/SparkyFitnessMobile/src/components/Icon.tsx
+++ b/SparkyFitnessMobile/src/components/Icon.tsx
@@ -33,6 +33,7 @@ const ICON_MAP = {
   'radio-button-on': { sf: 'circle.inset.filled', ion: 'radio-button-on' },
   'radio-button-off': { sf: 'circle', ion: 'radio-button-off' },
   'camera-reverse': { sf: 'camera.rotate', ion: 'camera-reverse-outline' },
+  'photo-library': { sf: 'photo.on.rectangle', ion: 'images-outline' },
   'pencil': { sf: 'pencil', ion: 'create-outline' },
   'pause': { sf: 'pause.fill', ion: 'pause' },
   'play': { sf: 'play.fill', ion: 'play' },

--- a/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
@@ -23,6 +23,7 @@ import type { RootStackScreenProps } from '../types/navigation';
 import type { FoodInfoItem } from '../types/foodInfo';
 import { useCSSVariable } from 'uniwind';
 import { CameraView, useCameraPermissions, type BarcodeScanningResult } from 'expo-camera';
+import * as ImagePicker from 'expo-image-picker';
 import { lookupBarcodeV2, scanNutritionLabel } from '../services/api/externalFoodSearchApi';
 import { getApiErrorMessage } from '../services/api/errors';
 import { fireSuccessHaptic } from '../services/haptics';
@@ -64,6 +65,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
   const [loading, setLoading] = useState(false);
   const [flashlight, setFlashlight] = useState(false);
   const scanLock = useRef(false);
+  const pickerLock = useRef(false);
   const params = route.params;
   const captureParams = params?.mode === 'capture-barcode' ? params : undefined;
   const lookupParams = params?.mode === 'capture-barcode' ? undefined : params;
@@ -387,6 +389,35 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
     }
   };
 
+  const handlePhotoPickFromLibrary = async () => {
+    // Guard against rapid double-taps re-entering the system picker.
+    if (pickerLock.current) return;
+    pickerLock.current = true;
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: 'images',
+        quality: 0.7,
+        allowsMultipleSelection: false,
+      });
+      if (result.canceled) return;
+      const asset = result.assets?.[0];
+      if (!asset?.uri) {
+        Toast.show({ type: 'error', text1: 'Error', text2: 'No photo returned by picker.' });
+        return;
+      }
+      await markFoodPhotoIntroSeen();
+      navigation.replace('FoodPhotoFlow', {
+        screen: 'Improve',
+        params: { date, photo: { uri: asset.uri } },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load photo.';
+      Toast.show({ type: 'error', text1: 'Error', text2: msg });
+    } finally {
+      pickerLock.current = false;
+    }
+  };
+
   const handleDismissPhotoGate = () => {
     setPhotoGateVisible(false);
     setScanMode('barcode');
@@ -664,6 +695,28 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
                       <View className="w-16 h-16 rounded-full bg-white" />
                     </TouchableOpacity>
                   )}
+                  {/* Centered between the capture button and the segmented control's left edge. */}
+                  {photoModeAvailable && !photoModeLoading ? (
+                    <TouchableOpacity
+                      onPress={() => {
+                        void handlePhotoPickFromLibrary();
+                      }}
+                      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+                      accessibilityLabel="Choose photo from library"
+                      accessibilityRole="button"
+                      className="bg-black/50 rounded-full items-center justify-center"
+                      style={{
+                        position: 'absolute',
+                        left: '25%',
+                        top: 18,
+                        width: 44,
+                        height: 44,
+                        transform: [{ translateX: -26 }],
+                      }}
+                    >
+                      <Icon name="photo-library" size={26} color="#fff" />
+                    </TouchableOpacity>
+                  ) : null}
                   {/* Centered between the capture button and the segmented control's right edge. */}
                   <TouchableOpacity
                     onPress={() => navigation.navigate('FoodPhotoIntro', { date })}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -454,6 +454,9 @@ importers:
       expo-health-connect:
         specifier: ^0.1.1
         version: 0.1.1(expo@55.0.26)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      expo-image-picker:
+        specifier: ~55.0.20
+        version: 55.0.20(expo@55.0.26)
       expo-navigation-bar:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.26)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -8568,6 +8571,16 @@ packages:
     peerDependenciesMeta:
       expo:
         optional: true
+
+  expo-image-loader@55.0.1:
+    resolution: {integrity: sha512-o8gCo1j59XpXDh0/llgNYPcnfecYQhafQAO0yw5pb+kukPizvNoEqea8tFQIIQmNYqxd6Ljgs7lLXed0gXpOdQ==}
+    peerDependencies:
+      expo: '*'
+
+  expo-image-picker@55.0.20:
+    resolution: {integrity: sha512-lfWt/0rPWdKz8AdDEGmGHZIJSNlVc720Dlx5bfou10FU16ZV5wAbTU63nm2jkXd8hbXke4a/2Ha1dzxCVA+LQQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-json-utils@55.0.2:
     resolution: {integrity: sha512-QJMOZOPOG7CTnKcrdVaiummn2va1MCO56z++eyWkDv3GBRODldM6MFMDf/jTREWthFc2Nxo6TuyWRrEV9S6n/Q==}
@@ -23943,6 +23956,15 @@ snapshots:
       react-native: 0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0)
     optionalDependencies:
       expo: 55.0.26(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.4(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+
+  expo-image-loader@55.0.1(expo@55.0.26):
+    dependencies:
+      expo: 55.0.26(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.4(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+
+  expo-image-picker@55.0.20(expo@55.0.26):
+    dependencies:
+      expo: 55.0.26(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.4(react@19.2.0))(react-native-worklets@0.7.4(@babel/core@7.29.0)(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-image-loader: 55.0.1(expo@55.0.26)
 
   expo-json-utils@55.0.2: {}
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The food-photo estimate flow in the Android app is camera-only. Users can't log meals from photos already in their gallery, which is the common case for restaurant meals.

**How did you implement the solution?**

Adds a "Choose from Library" button to the photo-mode action row in `FoodScanScreen`, left of the shutter. Tapping it launches the system photo picker via `expo-image-picker@~55.0.20` and routes the picked image into the existing `FoodPhotoFlow > Improve` screen using the same `{ uri }` payload the camera path delivers. A `useRef`-based lock guards against rapid double-taps re-entering the picker. No backend changes, no other screens touched.

Linked Issue: Closes #1371

## How to Test

1. Check out this branch and run `pnpm install` from the repo root.
2. Build a release APK (`cd SparkyFitnessMobile && pnpm expo prebuild --platform android && cd android && ./gradlew assembleRelease`) and sideload, or run on iOS via `pnpm expo run:ios`.
3. Open the app, navigate to **Add → Scan → Photo**.
4. Confirm three controls in the photo-mode row: gallery button on the left, shutter centered, help button on the right.
5. Tap the gallery button. The system photo picker should open without a permission prompt (SDK 55's out-of-process picker doesn't require media library permissions on iOS 14+ / Android 13+).
6. Pick a meal photo. You should land on the **Improve** screen with the photo preloaded.
7. Run an estimate end-to-end and confirm it logs.
8. Re-test the camera capture path to confirm no regression.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="1440" height="935" alt="Screenshot_20260528_192315_SparkyFitness" src="https://github.com/user-attachments/assets/28395255-2b95-4e8a-b570-02c56111c4ef" />

### After

<img width="1440" height="955" alt="Screenshot_20260528_192041_SparkyFitness" src="https://github.com/user-attachments/assets/19baa843-2688-40b3-8223-488200269559" />

</details>

## Notes for Reviewers

- Mobile-only change. Frontend/Backend mandatory checklist items don't apply (no files touched in `SparkyFitnessFrontend/` or `SparkyFitnessServer/`).
- Tested on Android (Galaxy S26 Ultra) via release APK. iOS untested (no device). Same code path on both platforms; `expo-image-picker@~55.0.20` matches Expo SDK 55's `bundledNativeModules.json`.
- No `app.json` plugin config or `photosPermission` string is needed: SDK 55's `launchImageLibraryAsync` uses the system out-of-process picker (iOS 14+ / Android 13+) which requires no media library permissions.
- The picker is gated on `photoModeAvailable` (same gate as the shutter), so the button is hidden when AI photo is not configured.
- Branch is rebased onto current `main` (head `4d7caf1`), cleanly merges the recent fatsecret error-surfacing changes that touch the same `FoodScanScreen.tsx`.
- A follow-up for multi-image upload is being considered separately to keep this PR focused on the picker.
