### PR TITLE
feat(mobile): add Camera shutter toggle in App Settings

### DIFF
--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -88,6 +88,7 @@ import {
 } from './src/services/autoSyncCoordinator';
 import { initializeTheme } from './src/services/themeService';
 import { initializeHaptics } from './src/services/haptics';
+import { initializeSounds } from './src/services/sounds';
 import { loadActiveDraft, clearDraft } from './src/services/workoutDraftService';
 import { addLog, initLogService } from './src/services/LogService';
 import { initNotifications } from './src/services/notifications';
@@ -430,6 +431,7 @@ function AppContent() {
     // Initialize theme from storage on app start
     initializeTheme();
     initializeHaptics();
+    initializeSounds();
 
     // Reset the auto-open flag on every app start
     const initializeApp = async () => {

--- a/SparkyFitnessMobile/__tests__/services/sounds.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/sounds.test.ts
@@ -61,4 +61,18 @@ describe('sounds service', () => {
 
     expect(getSoundsEnabled()).toBe(false);
   });
+
+  it('does not let initializeSounds overwrite a user toggle that lands mid-flight', async () => {
+    // Storage has "true". Start init but don't await it yet — it is now sitting
+    // on `await AsyncStorage.getItem(...)`.
+    await AsyncStorage.setItem(STORAGE_KEY, 'true');
+    const initPromise = initializeSounds();
+
+    // While the storage read is in flight, the user toggles off.
+    await setSoundsEnabled(false);
+
+    // Now let initializeSounds resolve. It must not clobber the user value.
+    await initPromise;
+    expect(getSoundsEnabled()).toBe(false);
+  });
 });

--- a/SparkyFitnessMobile/__tests__/services/sounds.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/sounds.test.ts
@@ -1,8 +1,11 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { renderHook, act } from '@testing-library/react-native';
 import {
   initializeSounds,
   setSoundsEnabled,
   getSoundsEnabled,
+  useSoundsEnabled,
+  __resetSoundsStateForTests,
 } from '../../src/services/sounds';
 
 const STORAGE_KEY = '@HealthConnect:soundsEnabled';
@@ -10,9 +13,7 @@ const STORAGE_KEY = '@HealthConnect:soundsEnabled';
 describe('sounds service', () => {
   beforeEach(async () => {
     await AsyncStorage.clear();
-    // Reset module-level state to default (enabled) before each test.
-    await setSoundsEnabled(true);
-    await AsyncStorage.clear();
+    __resetSoundsStateForTests();
   });
 
   it('defaults to enabled when nothing is persisted', async () => {
@@ -34,5 +35,30 @@ describe('sounds service', () => {
     await setSoundsEnabled(true);
     expect(getSoundsEnabled()).toBe(true);
     expect(await AsyncStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+
+  it('notifies already-mounted hook subscribers when initializeSounds loads from storage', async () => {
+    await AsyncStorage.setItem(STORAGE_KEY, 'false');
+
+    const { result } = renderHook(() => useSoundsEnabled());
+    expect(result.current).toBe(true); // default before init resolves
+
+    await act(async () => {
+      await initializeSounds();
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('does not let initializeSounds overwrite an explicit user toggle made first', async () => {
+    // Storage has "true" from a previous session.
+    await AsyncStorage.setItem(STORAGE_KEY, 'true');
+
+    // User toggles off before initializeSounds gets a chance to run.
+    await setSoundsEnabled(false);
+
+    // Then initializeSounds finally runs.
+    await initializeSounds();
+
+    expect(getSoundsEnabled()).toBe(false);
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/sounds.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/sounds.test.ts
@@ -1,0 +1,38 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  initializeSounds,
+  setSoundsEnabled,
+  getSoundsEnabled,
+} from '../../src/services/sounds';
+
+const STORAGE_KEY = '@HealthConnect:soundsEnabled';
+
+describe('sounds service', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    // Reset module-level state to default (enabled) before each test.
+    await setSoundsEnabled(true);
+    await AsyncStorage.clear();
+  });
+
+  it('defaults to enabled when nothing is persisted', async () => {
+    await initializeSounds();
+    expect(getSoundsEnabled()).toBe(true);
+  });
+
+  it('restores the saved disabled value on init', async () => {
+    await AsyncStorage.setItem(STORAGE_KEY, 'false');
+    await initializeSounds();
+    expect(getSoundsEnabled()).toBe(false);
+  });
+
+  it('persists the value when toggled', async () => {
+    await setSoundsEnabled(false);
+    expect(getSoundsEnabled()).toBe(false);
+    expect(await AsyncStorage.getItem(STORAGE_KEY)).toBe('false');
+
+    await setSoundsEnabled(true);
+    expect(getSoundsEnabled()).toBe(true);
+    expect(await AsyncStorage.getItem(STORAGE_KEY)).toBe('true');
+  });
+});

--- a/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
@@ -13,6 +13,7 @@ import {
   type ThemePreference,
 } from '../services/themeService';
 import { useHapticsEnabled, setHapticsEnabled } from '../services/haptics';
+import { useSoundsEnabled, setSoundsEnabled } from '../services/sounds';
 import type { RootStackScreenProps } from '../types/navigation';
 
 type AppSettingsScreenProps = RootStackScreenProps<'AppSettings'>;
@@ -35,6 +36,7 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = ({ navigation }) => 
 
   const appTheme = useThemePreference();
   const hapticsEnabled = useHapticsEnabled();
+  const soundsEnabled = useSoundsEnabled();
 
   return (
     <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
@@ -82,6 +84,21 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = ({ navigation }) => 
           </View>
           <Text className="text-text-secondary text-sm mt-2">
             Light vibrations for timers and confirmations.
+          </Text>
+        </View>
+
+        <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
+          <View className="flex-row justify-between items-center">
+            <Text className="text-base text-text-primary">Camera shutter</Text>
+            <Switch
+              value={soundsEnabled}
+              onValueChange={setSoundsEnabled}
+              trackColor={{ false: formDisabled, true: formEnabled }}
+              thumbColor="#FFFFFF"
+            />
+          </View>
+          <Text className="text-text-secondary text-sm mt-2">
+            Play a sound when capturing photos.
           </Text>
         </View>
       </ScrollView>

--- a/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
@@ -26,6 +26,7 @@ import { CameraView, useCameraPermissions, type BarcodeScanningResult } from 'ex
 import { lookupBarcodeV2, scanNutritionLabel } from '../services/api/externalFoodSearchApi';
 import { getApiErrorMessage } from '../services/api/errors';
 import { fireSuccessHaptic } from '../services/haptics';
+import { useSoundsEnabled } from '../services/sounds';
 import { toFormString } from '../types/foodInfo';
 import { useActiveAiServiceSetting } from '../hooks/useActiveAiServiceSetting';
 import { isFoodPhotoAvailable } from '../services/api/aiSettingsApi';
@@ -60,6 +61,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
   const insets = useSafeAreaInsets();
   const accentPrimary = String(useCSSVariable('--color-accent-primary'));
   const [permission, requestPermission] = useCameraPermissions();
+  const soundsEnabled = useSoundsEnabled();
   const [scanned, setScanned] = useState(false);
   const [loading, setLoading] = useState(false);
   const [flashlight, setFlashlight] = useState(false);
@@ -263,7 +265,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
   const handleLabelCapture = async () => {
     if (!cameraRef.current) return;
     try {
-      const photo = await cameraRef.current.takePictureAsync({ base64: true, quality: 0.7 });
+      const photo = await cameraRef.current.takePictureAsync({ base64: true, quality: 0.7, shutterSound: soundsEnabled });
       if (!photo?.base64) {
         Toast.show({ type: 'error', text1: 'Error', text2: 'Failed to capture photo.' });
         return;
@@ -371,7 +373,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
   const handlePhotoCapture = async () => {
     if (!cameraRef.current) return;
     try {
-      const photo = await cameraRef.current.takePictureAsync({ base64: false, quality: 0.7 });
+      const photo = await cameraRef.current.takePictureAsync({ base64: false, quality: 0.7, shutterSound: soundsEnabled });
       if (!photo?.uri) {
         Toast.show({ type: 'error', text1: 'Error', text2: 'Failed to capture photo.' });
         return;

--- a/SparkyFitnessMobile/src/services/sounds.ts
+++ b/SparkyFitnessMobile/src/services/sounds.ts
@@ -4,18 +4,25 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 const SOUNDS_KEY = '@HealthConnect:soundsEnabled';
 
 let soundsEnabled = true;
+let initialized = false;
 const listeners = new Set<(enabled: boolean) => void>();
 
 export async function initializeSounds(): Promise<void> {
+  if (initialized) return;
   try {
     const saved = await AsyncStorage.getItem(SOUNDS_KEY);
     if (saved !== null) soundsEnabled = saved === 'true';
   } catch {
     // fall back to default (enabled)
+  } finally {
+    initialized = true;
+    listeners.forEach((l) => l(soundsEnabled));
   }
 }
 
 export async function setSoundsEnabled(enabled: boolean): Promise<void> {
+  // An explicit user toggle wins over any still-pending initializeSounds().
+  initialized = true;
   soundsEnabled = enabled;
   listeners.forEach((l) => l(enabled));
   try {
@@ -29,9 +36,6 @@ export function useSoundsEnabled(): boolean {
   const [enabled, setEnabled] = useState<boolean>(soundsEnabled);
   useEffect(() => {
     listeners.add(setEnabled);
-    AsyncStorage.getItem(SOUNDS_KEY).then((saved) => {
-      if (saved !== null) setEnabled(saved === 'true');
-    });
     return () => {
       listeners.delete(setEnabled);
     };
@@ -41,4 +45,11 @@ export function useSoundsEnabled(): boolean {
 
 export function getSoundsEnabled(): boolean {
   return soundsEnabled;
+}
+
+/** Test-only helper — resets module-level state. */
+export function __resetSoundsStateForTests(): void {
+  soundsEnabled = true;
+  initialized = false;
+  listeners.clear();
 }

--- a/SparkyFitnessMobile/src/services/sounds.ts
+++ b/SparkyFitnessMobile/src/services/sounds.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const SOUNDS_KEY = '@HealthConnect:soundsEnabled';
@@ -11,12 +11,18 @@ export async function initializeSounds(): Promise<void> {
   if (initialized) return;
   try {
     const saved = await AsyncStorage.getItem(SOUNDS_KEY);
-    if (saved !== null) soundsEnabled = saved === 'true';
+    // A user toggle that landed during the await above already set
+    // `initialized = true`; don't clobber their choice with stored state.
+    if (!initialized && saved !== null) {
+      soundsEnabled = saved === 'true';
+    }
   } catch {
     // fall back to default (enabled)
   } finally {
-    initialized = true;
-    listeners.forEach((l) => l(soundsEnabled));
+    if (!initialized) {
+      initialized = true;
+      listeners.forEach((l) => l(soundsEnabled));
+    }
   }
 }
 
@@ -33,14 +39,15 @@ export async function setSoundsEnabled(enabled: boolean): Promise<void> {
 }
 
 export function useSoundsEnabled(): boolean {
-  const [enabled, setEnabled] = useState<boolean>(soundsEnabled);
-  useEffect(() => {
-    listeners.add(setEnabled);
-    return () => {
-      listeners.delete(setEnabled);
-    };
-  }, []);
-  return enabled;
+  return useSyncExternalStore(
+    (callback) => {
+      listeners.add(callback);
+      return () => {
+        listeners.delete(callback);
+      };
+    },
+    () => soundsEnabled,
+  );
 }
 
 export function getSoundsEnabled(): boolean {

--- a/SparkyFitnessMobile/src/services/sounds.ts
+++ b/SparkyFitnessMobile/src/services/sounds.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const SOUNDS_KEY = '@HealthConnect:soundsEnabled';
+
+let soundsEnabled = true;
+const listeners = new Set<(enabled: boolean) => void>();
+
+export async function initializeSounds(): Promise<void> {
+  try {
+    const saved = await AsyncStorage.getItem(SOUNDS_KEY);
+    if (saved !== null) soundsEnabled = saved === 'true';
+  } catch {
+    // fall back to default (enabled)
+  }
+}
+
+export async function setSoundsEnabled(enabled: boolean): Promise<void> {
+  soundsEnabled = enabled;
+  listeners.forEach((l) => l(enabled));
+  try {
+    await AsyncStorage.setItem(SOUNDS_KEY, String(enabled));
+  } catch {
+    // ignore — in-memory value still updates so the camera responds immediately
+  }
+}
+
+export function useSoundsEnabled(): boolean {
+  const [enabled, setEnabled] = useState<boolean>(soundsEnabled);
+  useEffect(() => {
+    listeners.add(setEnabled);
+    AsyncStorage.getItem(SOUNDS_KEY).then((saved) => {
+      if (saved !== null) setEnabled(saved === 'true');
+    });
+    return () => {
+      listeners.delete(setEnabled);
+    };
+  }, []);
+  return enabled;
+}
+
+export function getSoundsEnabled(): boolean {
+  return soundsEnabled;
+}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The Android camera shutter fires a loud system click when capturing food photos. Resolves #1372 by adding an opt-out under Settings → App Settings.

**How did you implement the solution?**

New `src/services/sounds.ts` (storage key `@HealthConnect:soundsEnabled`, default on) following the same shape as `src/services/haptics.ts`. A "Camera shutter" Switch row is added to `AppSettingsScreen` directly under Haptic Feedback. `FoodScanScreen` reads the preference via `useSoundsEnabled()` and passes `shutterSound: soundsEnabled` into `expo-camera`'s `takePictureAsync` at both capture call sites (label scan + food photo).

`shutterSound` is the documented `expo-camera` knob for the capture sound and works on both iOS and Android (on iOS it invokes Apple's private `AudioServicesDisposeSystemSoundID(1108)` path inside `expo-camera`; on Android it disables the `MediaActionSound` the OS plays on capture).

Linked Issue: Closes #1372

## How to Test

1. Check out this branch and run `pnpm install && pnpm start` from `SparkyFitnessMobile/`.
2. Open the app, go to Settings → App Settings. You should see a new "Camera shutter" row directly under Haptic Feedback. Default is on.
3. Open Add → Scan, then take a photo in either Label or Photo mode. With the toggle on you hear the normal shutter sound. With the toggle off the shutter is silent.
4. Force-quit the app and reopen. The toggle state persists.

## PR Type

- [x] New Feature
- [ ] Issue (bug fix)
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. (Issue #1372, acknowledged by @apedley.)

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. - Verified on Samsung Galaxy S26 Ultra: shutter audible when toggle is on, silent when toggle is off, state persists across force-quit. Changes should also work on iOS – `expo-camera`'s `shutterSound: false` triggers `AudioServicesDisposeSystemSoundID(1108)` in `CameraPhotoCapture.swift` – but I do not have iOS hardware to verify directly. Note that iOS shutter mute is region-restricted by Apple in Japan and South Korea regardless of the flag.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="1440" height="1316" alt="Screenshot_20260530_122753_SparkyFitness" src="https://github.com/user-attachments/assets/483c754f-32f1-4ba3-a757-714d8983bfd6" />

### After

<img width="1440" height="1329" alt="Screenshot_20260530_122846_SparkyFitness" src="https://github.com/user-attachments/assets/ae488133-2b23-4a02-8c60-3d6446c45c26" />

</details>

## Notes for Reviewers

### Why camera-only and not a full app-sounds toggle

The issue thread (#1372) framed this as both silencing the camera shutter *and* the rest-timer notification. I initially attempted a broader "App sounds" toggle that would also cover rest-timer notification audio, but ran into a foreground-delivery limitation I could not reliably solve from the JS layer.

What I found, on Samsung One UI 7 (S26 Ultra) and an older S6 tablet, both on the public v0.16.6.3 release with no modifications:

- The workout rest-timer notification fires correctly when the app is **backgrounded** (sound + haptic).
- When the app is in the **foreground**, only the haptic fires. The configured channel sound never plays.

This reproduces against the unmodified release and is independent of any changes in this PR – it appears to be an Android foreground-delivery behaviour rather than something a per-call `sound: true` flag on the scheduled notification can override from JS. Properly fixing it likely means either an in-process audio playback path (e.g. `expo-av`) layered onto the existing notification flow, or letting the OS handle it via the notification channel and accepting current foreground behaviour.

Rather than ship a sounds toggle that visually claims to silence the rest timer while the rest timer was *already* not audible in the foreground, I narrowed scope to the one place a user can clearly hear a sound today: the camera shutter. Labeling the toggle "Camera shutter" keeps the UI honest about what it does, and leaves the foreground notification audio question for a future, focused PR.

If you would prefer a different name (e.g. "Mute camera shutter") or want this nested under a future "Sounds" group, happy to adjust.
