### PR TITLE
fix: preserve model name on AI Service

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Settings/AIServiceSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/AIServiceSettings.tsx
@@ -435,11 +435,6 @@ const AIServiceSettings = () => {
     }
 
     try {
-      const isCustomModel = originalService.model_name
-        ? !getModelOptions(originalService.service_type ?? '').includes(
-            originalService.model_name
-          )
-        : false;
       const serviceData = updateAiServiceSettingsFormSchema.parse({
         service_name: originalService.service_name,
         service_type: originalService.service_type,
@@ -447,9 +442,9 @@ const AIServiceSettings = () => {
         custom_url: originalService.custom_url ?? '',
         system_prompt: originalService.system_prompt ?? '',
         is_active: isActive,
-        model_name: isCustomModel ? '' : (originalService.model_name ?? ''),
-        showCustomModelInput: isCustomModel,
-        custom_model_name: originalService.model_name ?? '',
+        model_name: originalService.model_name ?? '',
+        showCustomModelInput: false,
+        custom_model_name: '',
       });
       if (serviceData.api_key === '') delete serviceData.api_key;
       await updateService({ serviceId, serviceData });

--- a/SparkyFitnessFrontend/src/pages/Settings/AIServiceSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/AIServiceSettings.tsx
@@ -435,7 +435,24 @@ const AIServiceSettings = () => {
     }
 
     try {
-      await updateService({ serviceId, serviceData: { is_active: isActive } });
+      const isCustomModel = originalService.model_name
+        ? !getModelOptions(originalService.service_type ?? '').includes(
+            originalService.model_name
+          )
+        : false;
+      const serviceData = updateAiServiceSettingsFormSchema.parse({
+        service_name: originalService.service_name,
+        service_type: originalService.service_type,
+        api_key: '',
+        custom_url: originalService.custom_url ?? '',
+        system_prompt: originalService.system_prompt ?? '',
+        is_active: isActive,
+        model_name: isCustomModel ? '' : (originalService.model_name ?? ''),
+        showCustomModelInput: isCustomModel,
+        custom_model_name: originalService.model_name ?? '',
+      });
+      if (serviceData.api_key === '') delete serviceData.api_key;
+      await updateService({ serviceId, serviceData });
       toast({
         title: t('settings.aiService.userSettings.success'),
         description: isActive

--- a/SparkyFitnessFrontend/src/tests/components/AIServiceSettings.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/AIServiceSettings.test.tsx
@@ -579,4 +579,43 @@ describe('AIServiceSettings', () => {
       expect(screen.getByText('Custom prompt')).toBeInTheDocument();
     });
   });
+
+  it('toggle sends full service payload so model_name and other fields are not overwritten', async () => {
+    const serviceWithCustomModel: AiServiceSettingsResponse = {
+      id: 'user-service2',
+      user_id: 'user1',
+      service_name: 'My Custom Service',
+      service_type: 'openai',
+      custom_url: 'https://my-proxy.example.com',
+      is_active: true,
+      system_prompt: 'Be concise.',
+      model_name: 'my-fine-tuned-model',
+      is_public: false,
+      source: 'user',
+    };
+    mockGetAIServices.mockResolvedValue([serviceWithCustomModel]);
+    mockUpdateAIService.mockResolvedValue({
+      ...serviceWithCustomModel,
+      is_active: false,
+    });
+
+    renderWithClient(<AIServiceSettings />);
+
+    await screen.findByText('My Custom Service');
+
+    const toggleSwitch = await screen.findByRole('switch');
+    fireEvent.click(toggleSwitch);
+
+    await waitFor(() => {
+      expect(mockUpdateAIService).toHaveBeenCalledWith(
+        'user-service2',
+        expect.objectContaining({
+          is_active: false,
+          model_name: 'my-fine-tuned-model',
+          custom_url: 'https://my-proxy.example.com',
+          system_prompt: 'Be concise.',
+        })
+      );
+    });
+  });
 });

--- a/SparkyFitnessServer/tests/chatRepository.test.ts
+++ b/SparkyFitnessServer/tests/chatRepository.test.ts
@@ -24,11 +24,8 @@ describe('chatRepository.upsertAiServiceSetting', () => {
       query: vi.fn(),
       release: vi.fn(),
     };
-    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type
-    getClient.mockResolvedValue(mockClient);
     vi.clearAllMocks();
-    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type
-    getClient.mockResolvedValue(mockClient);
+    vi.mocked(getClient).mockResolvedValue(mockClient);
   });
 
   it('omitting model_name/custom_url/system_prompt sends undefined to SQL (documents why callers must send full payload)', async () => {

--- a/SparkyFitnessServer/tests/chatRepository.test.ts
+++ b/SparkyFitnessServer/tests/chatRepository.test.ts
@@ -1,0 +1,74 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import chatRepository from '../models/chatRepository.js';
+import { getClient } from '../db/poolManager.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+vi.mock('../security/encryption', () => ({
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  ENCRYPTION_KEY: 'test-key',
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+describe('chatRepository.upsertAiServiceSetting', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type
+    getClient.mockResolvedValue(mockClient);
+    vi.clearAllMocks();
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type
+    getClient.mockResolvedValue(mockClient);
+  });
+
+  it('omitting model_name/custom_url/system_prompt sends undefined to SQL (documents why callers must send full payload)', async () => {
+    // upsertAiServiceSetting has no COALESCE for model_name, custom_url, or system_prompt.
+    // Sending a partial update (e.g. only is_active) will pass undefined for those params,
+    // which PostgreSQL coerces to NULL — overwriting stored values.
+    // This is why handleToggleActive in AIServiceSettings.tsx must send the full payload.
+    mockClient.query.mockResolvedValue({ rows: [{ id: 'service-1' }] });
+
+    await chatRepository.upsertAiServiceSetting({
+      id: 'service-1',
+      user_id: 'user-1',
+      is_active: false,
+    });
+
+    const [, params] = mockClient.query.mock.calls[0];
+    expect(params[2]).toBeUndefined(); // $3 → custom_url → becomes NULL without COALESCE
+    expect(params[3]).toBeUndefined(); // $4 → system_prompt → becomes NULL without COALESCE
+    expect(params[5]).toBeUndefined(); // $6 → model_name → becomes NULL without COALESCE
+  });
+
+  it('explicit null clears fields — intentional clearing still works via direct API', async () => {
+    mockClient.query.mockResolvedValue({
+      rows: [{ id: 'service-1', model_name: null }],
+    });
+
+    await chatRepository.upsertAiServiceSetting({
+      id: 'service-1',
+      user_id: 'user-1',
+      service_name: 'My Service',
+      service_type: 'openai',
+      model_name: null,
+      custom_url: null,
+      system_prompt: null,
+      is_active: true,
+    });
+
+    const [, params] = mockClient.query.mock.calls[0];
+    expect(params[2]).toBeNull(); // $3 → custom_url explicitly cleared
+    expect(params[3]).toBeNull(); // $4 → system_prompt explicitly cleared
+    expect(params[5]).toBeNull(); // $6 → model_name explicitly cleared
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Fixes a bug where toggling off an AI service would remove the  custom model name and url if you had one

**How did you implement the solution?**
The toggle was only sending `{ is_active }` to the server, which caused the SQL UPDATE to overwrite `model_name`, `custom_url`, and `system_prompt` with NULL. The fix makes the toggle include all the exisitng service data.


Linked Issue: Closes #

## How to Test

1. Go to AI Service
2. Set a custom model 
3. toggle it on and off

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
