### PR TITLE
Fix Health Connect body fat sync mapping

### DIFF
--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -521,8 +521,7 @@ async function processHealthData(
           processedResults.push({ type, status: 'success', data: result });
           break;
         }
-        case 'weight':
-        case 'body_fat_percentage': {
+        case 'weight': {
           const numericValue = parseFloat(value);
           if (isNaN(numericValue) || numericValue <= 0) {
             errors.push({
@@ -531,12 +530,30 @@ async function processHealthData(
             });
             break;
           }
-          const checkInMeasurements = { [type]: numericValue };
           result = await measurementRepository.upsertCheckInMeasurements(
             userId,
             actingUserId,
             parsedDate,
-            checkInMeasurements
+            { weight: numericValue }
+          );
+          processedResults.push({ type, status: 'success', data: result });
+          break;
+        }
+        case 'body_fat_percentage':
+        case 'body_fat': {
+          const numericValue = parseFloat(value);
+          if (isNaN(numericValue) || numericValue < 0 || numericValue > 100) {
+            errors.push({
+              error: `Invalid value for ${type}. Must be between 0 and 100.`,
+              entry: dataEntry,
+            });
+            break;
+          }
+          result = await measurementRepository.upsertCheckInMeasurements(
+            userId,
+            actingUserId,
+            parsedDate,
+            { body_fat_percentage: numericValue }
           );
           processedResults.push({ type, status: 'success', data: result });
           break;

--- a/SparkyFitnessServer/tests/measurementService.healthDataUnits.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.healthDataUnits.test.ts
@@ -169,6 +169,37 @@ describe('processHealthData default units (#567)', () => {
       measurementRepository.upsertCustomMeasurement
     ).not.toHaveBeenCalled();
   });
+
+  it('stores Health Connect body_fat in check-in measurements as body_fat_percentage', async () => {
+    measurementRepository.upsertCheckInMeasurements = vi
+      .fn()
+      .mockResolvedValue({ id: 'check-in-1', body_fat_percentage: 18.4 });
+
+    const result = await measurementService.processHealthData(
+      [
+        {
+          type: 'body_fat',
+          value: 18.4,
+          date: '2025-02-01',
+          source: 'HealthConnect',
+          unit: '%',
+        },
+      ],
+      userId,
+      actingUserId
+    );
+
+    expect(result.processed).toHaveLength(1);
+    expect(
+      measurementRepository.upsertCheckInMeasurements
+    ).toHaveBeenCalledWith(userId, actingUserId, '2025-02-01', {
+      body_fat_percentage: 18.4,
+    });
+    expect(measurementRepository.createCustomCategory).not.toHaveBeenCalled();
+    expect(
+      measurementRepository.upsertCustomMeasurement
+    ).not.toHaveBeenCalled();
+  });
 });
 describe('Aggregated health metric default units', () => {
   const userId = 'user-123';


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

  **What problem does this PR solve?**
  Android Health Connect body fat sync was creating a duplicate custom measurement
  instead of updating the built-in body fat check-in value.

  **How did you implement the solution?**
  Updated server health data processing to treat the mobile health sync type
  `body_fat` as the built-in `body_fat_percentage` check-in field, with a focused
  regression test.

Linked Issue: Closes #1378

## How to Test

1. Check out this branch and run server.
2. Navigate on android mobile app and run health connect sync.
3. Verify that body fat was correctly synced and no custom measurement was created.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**Backend changes (`SparkyFitnessServer/`):**

- [X] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [X] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**Mobile changes (`SparkyFitnessMobile/`):**

- [X] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Notes for Reviewers
  This is a backend-only fix. No database schema, RLS, frontend, or mobile code
  changes were made.
