### PR TITLE
[Feature]: Allow multiple images per AI food photo estimate

### DIFF
--- a/SparkyFitnessMobile/__tests__/screens/FoodPhotoImproveScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodPhotoImproveScreen.test.tsx
@@ -97,7 +97,7 @@ describe('FoodPhotoImproveScreen', () => {
     expect(mockMutate).not.toHaveBeenCalled();
   });
 
-  it('Generate with empty fields sends only image+mimeType, base64 is read once', async () => {
+  it('Generate with empty fields sends a single-image images[] payload, base64 is read once', async () => {
     const screen = renderScreen();
 
     fireEvent.press(screen.getByText('Generate estimate'));
@@ -109,8 +109,7 @@ describe('FoodPhotoImproveScreen', () => {
     const [input] = mockMutate.mock.calls[0];
     expect(input).toEqual(
       expect.objectContaining({
-        base64Image: 'AAAA-base64',
-        mimeType: 'image/jpeg',
+        images: [{ base64Image: 'AAAA-base64', mimeType: 'image/jpeg' }],
         description: undefined,
         totalWeight: undefined,
         weightUnit: undefined,
@@ -158,8 +157,7 @@ describe('FoodPhotoImproveScreen', () => {
     const [input] = mockMutate.mock.calls[0];
     expect(input).toEqual(
       expect.objectContaining({
-        base64Image: 'AAAA-base64',
-        mimeType: 'image/jpeg',
+        images: [{ base64Image: 'AAAA-base64', mimeType: 'image/jpeg' }],
         description: 'yogurt and berries',
         totalWeight: 250,
         weightUnit: 'g',

--- a/SparkyFitnessMobile/__tests__/services/externalFoodSearchApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/externalFoodSearchApi.test.ts
@@ -2003,8 +2003,7 @@ describe('externalFoodSearchApi', () => {
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({
-            image: 'AAAA',
-            mime_type: 'image/jpeg',
+            images: [{ image: 'AAAA', mime_type: 'image/jpeg' }],
             description: 'yogurt and berries',
             total_weight: 250,
             weight_unit: 'g',
@@ -2026,7 +2025,37 @@ describe('externalFoodSearchApi', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          body: JSON.stringify({ image: 'AAAA', mime_type: 'image/jpeg' }),
+          body: JSON.stringify({
+            images: [{ image: 'AAAA', mime_type: 'image/jpeg' }],
+          }),
+        }),
+      );
+    });
+
+    test('serializes a multi-image images[] payload in request order', async () => {
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(happyResponse),
+      });
+
+      await estimateFoodPhoto({
+        images: [
+          { base64Image: 'AAAA', mimeType: 'image/jpeg' },
+          { base64Image: 'BBBB', mimeType: 'image/png' },
+        ],
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify({
+            images: [
+              { image: 'AAAA', mime_type: 'image/jpeg' },
+              { image: 'BBBB', mime_type: 'image/png' },
+            ],
+          }),
         }),
       );
     });

--- a/SparkyFitnessMobile/src/components/Icon.tsx
+++ b/SparkyFitnessMobile/src/components/Icon.tsx
@@ -33,6 +33,7 @@ const ICON_MAP = {
   'radio-button-on': { sf: 'circle.inset.filled', ion: 'radio-button-on' },
   'radio-button-off': { sf: 'circle', ion: 'radio-button-off' },
   'camera-reverse': { sf: 'camera.rotate', ion: 'camera-reverse-outline' },
+  'camera': { sf: 'camera', ion: 'camera-outline' },
   'photo-library': { sf: 'photo.on.rectangle', ion: 'images-outline' },
   'pencil': { sf: 'pencil', ion: 'create-outline' },
   'pause': { sf: 'pause.fill', ion: 'pause' },

--- a/SparkyFitnessMobile/src/screens/FoodPhotoImproveScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodPhotoImproveScreen.tsx
@@ -1,7 +1,17 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { View, Text, ActivityIndicator, Image, Platform } from 'react-native';
+import {
+  View,
+  Text,
+  ActivityIndicator,
+  Image,
+  Platform,
+  Pressable,
+  ScrollView,
+  Modal,
+} from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { File } from 'expo-file-system';
+import * as ImagePicker from 'expo-image-picker';
 import { KeyboardAwareScrollView, KeyboardStickyView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
@@ -32,6 +42,52 @@ const WEIGHT_UNITS: Segment<'g' | 'oz'>[] = [
 
 const DESCRIPTION_MAX = 500;
 
+// Client-side cap on images per estimate. Mirrors the server default
+// (AI_PHOTO_ESTIMATE_MAX_IMAGES); the server is the source of truth and will
+// reject anything above its own configured limit.
+const MAX_IMAGES = 6;
+
+type StagedImage = { uri: string; mimeType?: string };
+
+const SUPPORTED_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+
+// Prefer the mime type the picker reports; fall back to the URI extension, then
+// JPEG. Avoids mislabelling PNG/WebP/HEIC library picks as JPEG.
+function resolveMimeType(img: StagedImage): string {
+  // Normalize the non-standard image/jpg up front so it is never emitted: the
+  // server allow-list only has image/jpeg and would reject image/jpg at the
+  // route before the service's normalization runs.
+  const mime = img.mimeType === 'image/jpg' ? 'image/jpeg' : img.mimeType;
+  if (mime && SUPPORTED_MIME_TYPES.has(mime)) {
+    return mime;
+  }
+  const ext = img.uri.split('?')[0].split('.').pop()?.toLowerCase();
+  switch (ext) {
+    case 'png':
+      return 'image/png';
+    case 'webp':
+      return 'image/webp';
+    case 'heic':
+      return 'image/heic';
+    case 'heif':
+      return 'image/heif';
+    case 'jpg':
+    case 'jpeg':
+      return 'image/jpeg';
+    default:
+      // Unknown extension: prefer the picker's reported type so an unsupported
+      // format (e.g. image/gif) reaches the server and gets a clean
+      // UNSUPPORTED_MIME_TYPE rejection instead of being mislabelled as JPEG.
+      return mime || 'image/jpeg';
+  }
+}
+
 const FADE_IN_MS = 200;
 const FADE_OUT_MS = 150;
 
@@ -43,10 +99,14 @@ const PENDING_MESSAGES: { startsAt: number; text: string }[] = [
   { startsAt: 45, text: 'Almost there…' },
 ];
 
-function pendingMessageFor(elapsedSec: number): string {
+function pendingMessageFor(elapsedSec: number, imageCount: number): string {
   let current = PENDING_MESSAGES[0].text;
   for (const m of PENDING_MESSAGES) {
     if (elapsedSec >= m.startsAt) current = m.text;
+  }
+  // Pluralize the first ("Reading your photo…") message for multi-image sets.
+  if (imageCount > 1 && current === PENDING_MESSAGES[0].text) {
+    return 'Reading your photos…';
   }
   return current;
 }
@@ -61,6 +121,14 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
   ]) as [string, string, string];
 
   const { date, photo } = route.params;
+
+  // The scan screen hands off a single photo; the user composes the rest of the
+  // image set here. Seeded from the handoff photo.
+  // `photo` is a required nav param, but guard against a restored/deep-linked
+  // route that arrives without it so the thumbnail map can't hit undefined.
+  const [images, setImages] = useState<StagedImage[]>(photo ? [photo] : []);
+  const [sheetVisible, setSheetVisible] = useState(false);
+  const pickerLock = useRef(false);
 
   const [totalWeight, setTotalWeight] = useState<string>(
     route.params.initialTotalWeight ?? '',
@@ -99,6 +167,97 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
   const handleWeightChange = (text: string) => {
     if (text === '' || DECIMAL_INPUT_REGEX.test(text)) {
       setTotalWeight(text);
+    }
+  };
+
+  const atImageCap = images.length >= MAX_IMAGES;
+
+  const appendImage = (uri: string, mimeType?: string) => {
+    // Fail fast on the client when the active provider can't read HEIC/HEIF,
+    // rather than reading base64 and round-tripping to a guaranteed server
+    // rejection. The service-side guard remains the backstop.
+    const provider = aiSetting?.service_type;
+    const resolved = resolveMimeType({ uri, mimeType });
+    if (
+      (provider === 'openai' || provider === 'anthropic') &&
+      (resolved === 'image/heic' || resolved === 'image/heif')
+    ) {
+      Toast.show({
+        type: 'error',
+        text1: 'Unsupported format',
+        text2: `${provider === 'openai' ? 'OpenAI' : 'Anthropic'} can't read HEIC/HEIF images. Please pick a JPEG or PNG.`,
+      });
+      return;
+    }
+    setImages((prev) =>
+      prev.length >= MAX_IMAGES ? prev : [...prev, { uri, mimeType }],
+    );
+  };
+
+  const removeImage = (index: number) => {
+    const next = images.filter((_, i) => i !== index);
+    setImages(next);
+    // Removing the last image is equivalent to abandoning the flow. Kept out of
+    // the state updater so the updater stays pure (no navigation side-effects).
+    if (next.length === 0) {
+      navigation
+        .getParent<NativeStackNavigationProp<RootStackParamList>>()
+        ?.replace('FoodScan', { date, initialMode: 'photo' });
+    }
+  };
+
+  const addFromCamera = async () => {
+    setSheetVisible(false);
+    if (pickerLock.current) return;
+    pickerLock.current = true;
+    try {
+      const permission = await ImagePicker.requestCameraPermissionsAsync();
+      if (!permission.granted) {
+        Toast.show({
+          type: 'error',
+          text1: 'Camera permission needed',
+          text2: 'Enable camera access to add a photo.',
+        });
+        return;
+      }
+      const result = await ImagePicker.launchCameraAsync({
+        mediaTypes: 'images',
+        quality: 0.7,
+      });
+      if (result.canceled) return;
+      const asset = result.assets?.[0];
+      if (asset?.uri) appendImage(asset.uri, asset.mimeType);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      addLog(`[Food Photo Improve] Camera capture failed: ${message}`, 'ERROR');
+      Toast.show({ type: 'error', text1: 'Could not take photo' });
+    } finally {
+      pickerLock.current = false;
+    }
+  };
+
+  const addFromLibrary = async () => {
+    setSheetVisible(false);
+    if (pickerLock.current) return;
+    pickerLock.current = true;
+    try {
+      const remaining = MAX_IMAGES - images.length;
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: 'images',
+        quality: 0.7,
+        allowsMultipleSelection: true,
+        selectionLimit: Math.max(1, remaining),
+      });
+      if (result.canceled) return;
+      for (const asset of result.assets ?? []) {
+        if (asset?.uri) appendImage(asset.uri, asset.mimeType);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      addLog(`[Food Photo Improve] Library pick failed: ${message}`, 'ERROR');
+      Toast.show({ type: 'error', text1: 'Could not load photo' });
+    } finally {
+      pickerLock.current = false;
     }
   };
 
@@ -148,9 +307,46 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
       payloadDescription = trimmedDescription;
     }
 
-    let base64: string;
+    if (images.length === 0) {
+      Toast.show({
+        type: 'error',
+        text1: 'No images',
+        text2: 'Add at least one photo to generate an estimate.',
+      });
+      return;
+    }
+
+    // Fail fast before the memory-intensive base64 reads if any staged image is
+    // HEIC/HEIF and the active provider can't read it. Catches the seed image
+    // from the scan screen, which never passes through appendImage.
+    const provider = aiSetting?.service_type;
+    if (provider === 'openai' || provider === 'anthropic') {
+      const hasUnsupported = images.some((img) => {
+        const resolved = resolveMimeType(img);
+        return resolved === 'image/heic' || resolved === 'image/heif';
+      });
+      if (hasUnsupported) {
+        Toast.show({
+          type: 'error',
+          text1: 'Unsupported format',
+          text2: `${provider === 'openai' ? 'OpenAI' : 'Anthropic'} can't read HEIC/HEIF images. Please remove them or switch to JPEG/PNG.`,
+        });
+        return;
+      }
+    }
+
+    const imagePayloads: { base64Image: string; mimeType: string }[] = [];
     try {
-      base64 = await new File(photo.uri).base64();
+      // Sequential rather than Promise.all: converting several images to base64
+      // concurrently spikes peak memory on the RN bridge and can OOM low-end
+      // devices. Local-file reads are fast, so the cost of going one at a time
+      // is negligible.
+      for (const img of images) {
+        imagePayloads.push({
+          base64Image: await new File(img.uri).base64(),
+          mimeType: resolveMimeType(img),
+        });
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       addLog(`[Food Photo Improve] Failed to read photo: ${message}`, 'ERROR');
@@ -168,8 +364,7 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
 
     mutation.mutate(
       {
-        base64Image: base64,
-        mimeType: 'image/jpeg',
+        images: imagePayloads,
         description: payloadDescription,
         totalWeight: payloadWeight,
         weightUnit: payloadWeight !== undefined ? weightUnit : undefined,
@@ -216,7 +411,7 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
   };
 
   const isPending = mutation.isPending;
-  const pendingMessage = pendingMessageFor(elapsedSec);
+  const pendingMessage = pendingMessageFor(elapsedSec, images.length);
 
   return (
     <View
@@ -248,12 +443,48 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
         bottomOffset={80}
         keyboardShouldPersistTaps="handled"
       >
-        <View className="rounded-xl overflow-hidden bg-raised mb-4">
-          <Image
-            source={{ uri: photo.uri }}
-            style={{ width: '100%', aspectRatio: 4 / (3 * 0.85) }}
-            resizeMode="cover"
-          />
+        <View className="mb-4">
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={{ gap: 8, paddingVertical: 2 }}
+            keyboardShouldPersistTaps="handled"
+          >
+            {images.map((img, index) => (
+              <View
+                key={`${img.uri}-${index}`}
+                className="rounded-xl overflow-hidden bg-raised"
+                style={{ width: 96, height: 96 }}
+              >
+                <Image
+                  source={{ uri: img.uri }}
+                  style={{ width: 96, height: 96 }}
+                  resizeMode="cover"
+                />
+                {!isPending ? (
+                  <Pressable
+                    onPress={() => removeImage(index)}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    accessibilityLabel={`Remove image ${index + 1}`}
+                    className="absolute top-1 right-1 rounded-full bg-background/80 p-0.5"
+                  >
+                    <Icon name="close" size={16} color={textPrimary} />
+                  </Pressable>
+                ) : null}
+              </View>
+            ))}
+            {!isPending && !atImageCap ? (
+              <Pressable
+                onPress={() => setSheetVisible(true)}
+                accessibilityLabel="Add another image"
+                className="rounded-xl items-center justify-center border border-dashed border-border-subtle"
+                style={{ width: 96, height: 96 }}
+              >
+                <Icon name="add" size={28} color={accentPrimary} />
+                <Text className="text-text-secondary text-xs mt-1">Add</Text>
+              </Pressable>
+            ) : null}
+          </ScrollView>
         </View>
 
         {isPending ? (
@@ -283,7 +514,8 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
             exiting={FadeOut.duration(FADE_OUT_MS)}
           >
             <Text className="text-text-secondary text-sm mb-4 leading-5">
-              Add anything the photo might not make obvious.
+              Add anything the {images.length > 1 ? 'photos' : 'photo'} might not
+              make obvious.
             </Text>
 
             <Text className="text-text-primary text-base font-semibold mb-2">
@@ -379,6 +611,60 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
           )}
         </View>
       </KeyboardStickyView>
+
+      <Modal
+        visible={sheetVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setSheetVisible(false)}
+      >
+        <Pressable
+          className="flex-1 justify-end bg-black/50"
+          onPress={() => setSheetVisible(false)}
+          accessibilityLabel="Dismiss"
+        >
+          <Pressable
+            // Tap-absorbing wrapper only; hide it from screen readers so they
+            // focus the real buttons inside instead of an empty container button.
+            accessible={false}
+            className="bg-surface rounded-t-2xl px-4 pt-3"
+            style={{ paddingBottom: Math.max(insets.bottom, 16) }}
+            // Absorb the tap so it doesn't fall through to the backdrop. RN
+            // press events have no stopPropagation(); a nested Pressable with a
+            // no-op onPress already prevents the backdrop's onPress from firing.
+            onPress={() => {}}
+          >
+            <View className="items-center mb-3">
+              <View className="h-1 w-10 rounded-full bg-border-subtle" />
+            </View>
+            <Text className="text-text-primary text-base font-semibold mb-2 px-1">
+              Add another image
+            </Text>
+            <Button
+              variant="outline"
+              className="flex-row items-center justify-start gap-3 mb-2"
+              onPress={() => {
+                void addFromCamera();
+              }}
+            >
+              <Icon name="camera" size={22} color={accentPrimary} />
+              <Text className="text-text-primary text-base">Take photo</Text>
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-row items-center justify-start gap-3"
+              onPress={() => {
+                void addFromLibrary();
+              }}
+            >
+              <Icon name="photo-library" size={22} color={accentPrimary} />
+              <Text className="text-text-primary text-base">
+                Choose from library
+              </Text>
+            </Button>
+          </Pressable>
+        </Pressable>
+      </Modal>
     </View>
   );
 };

--- a/SparkyFitnessMobile/src/services/api/externalFoodSearchApi.ts
+++ b/SparkyFitnessMobile/src/services/api/externalFoodSearchApi.ts
@@ -627,9 +627,18 @@ export async function scanNutritionLabel(base64Image: string, mimeType: string):
   });
 }
 
-export interface EstimateFoodPhotoInput {
+export interface ImagePayload {
   base64Image: string;
   mimeType: string;
+}
+
+export interface EstimateFoodPhotoInput {
+  /** One or more images for a single estimate. Preferred over base64Image/mimeType. */
+  images?: ImagePayload[];
+  /** Legacy single-image field; use images[]. Still accepted during transition. */
+  base64Image?: string;
+  /** Legacy single-image field; use images[]. Still accepted during transition. */
+  mimeType?: string;
   description?: string;
   totalWeight?: number;
   weightUnit?: 'g' | 'oz';
@@ -664,9 +673,21 @@ export async function estimateFoodPhoto(
     );
   }
 
+  const images: ImagePayload[] =
+    input.images && input.images.length > 0
+      ? input.images
+      : input.base64Image && input.mimeType
+        ? [{ base64Image: input.base64Image, mimeType: input.mimeType }]
+        : [];
+  if (images.length === 0) {
+    throw new FoodPhotoEstimateError('INVALID_REQUEST', 'At least one image is required.');
+  }
+
   const body: Record<string, unknown> = {
-    image: input.base64Image,
-    mime_type: input.mimeType,
+    images: images.map((img) => ({
+      image: img.base64Image,
+      mime_type: img.mimeType,
+    })),
   };
   if (input.description !== undefined) body.description = input.description;
   if (input.totalWeight !== undefined) body.total_weight = input.totalWeight;

--- a/SparkyFitnessServer/routes/foodCrudRoutes.ts
+++ b/SparkyFitnessServer/routes/foodCrudRoutes.ts
@@ -671,6 +671,15 @@ const ALLOWED_PHOTO_MIME_TYPES = new Set([
 const MAX_BASE64_IMAGE_LENGTH = 8 * 1024 * 1024;
 const MAX_DESCRIPTION_LENGTH = 500;
 const OZ_TO_GRAMS = 28.3495;
+const MAX_PHOTO_IMAGES = (() => {
+  const raw = Number(process.env.AI_PHOTO_ESTIMATE_MAX_IMAGES);
+  return Number.isInteger(raw) && raw > 0 ? raw : 6;
+})();
+// Cap the combined base64 payload across all images. The per-image 8MB limit
+// alone allows up to MAX_PHOTO_IMAGES * 8MB, which (parsed, mapped, and
+// re-stringified for the provider) can spike memory enough to OOM a small box
+// under concurrent load.
+const MAX_TOTAL_BASE64_LENGTH = 24 * 1024 * 1024;
 
 const PHOTO_ESTIMATION_ERROR_HTTP_STATUS: Record<
   FoodPhotoEstimateErrorCode,
@@ -693,31 +702,74 @@ router.post(
   authenticate,
   checkPermissionMiddleware('diary'),
   async (req, res, next) => {
-    const { image, mime_type, description, total_weight, weight_unit } =
+    const { image, mime_type, images, description, total_weight, weight_unit } =
       req.body ?? {};
 
-    if (typeof image !== 'string' || image.length === 0) {
+    // Normalize to an array of { image, mime_type } entries. Accepts the
+    // multi-image `images[]` shape or the legacy single `image`/`mime_type`
+    // fields (kept for backward compatibility).
+    let rawImages: unknown[];
+    if (images !== undefined) {
+      if (!Array.isArray(images) || images.length === 0) {
+        return res.status(400).json({
+          error: 'images must be a non-empty array.',
+          code: 'INVALID_REQUEST',
+        });
+      }
+      rawImages = images;
+    } else if (image !== undefined || mime_type !== undefined) {
+      rawImages = [{ image, mime_type }];
+    } else {
       return res
         .status(400)
         .json({ error: 'image is required.', code: 'INVALID_REQUEST' });
     }
-    if (typeof mime_type !== 'string' || mime_type.length === 0) {
-      return res
-        .status(400)
-        .json({ error: 'mime_type is required.', code: 'INVALID_REQUEST' });
-    }
-    if (image.length > MAX_BASE64_IMAGE_LENGTH) {
+
+    if (rawImages.length > MAX_PHOTO_IMAGES) {
       return res.status(400).json({
-        error: 'image exceeds the maximum allowed size of 8MB (base64).',
-        code: 'IMAGE_TOO_LARGE',
+        error: `A maximum of ${MAX_PHOTO_IMAGES} images is allowed per estimate.`,
+        code: 'INVALID_REQUEST',
       });
     }
-    if (!ALLOWED_PHOTO_MIME_TYPES.has(mime_type)) {
-      return res.status(400).json({
-        error: `Unsupported mime_type '${mime_type}'. Allowed: ${[...ALLOWED_PHOTO_MIME_TYPES].join(', ')}.`,
-        code: 'UNSUPPORTED_MIME_TYPE',
-      });
+
+    const photoImages: { base64: string; mimeType: string }[] = [];
+    let totalBase64Length = 0;
+    for (const entry of rawImages) {
+      const img = (entry as { image?: unknown } | null)?.image;
+      const mt = (entry as { mime_type?: unknown } | null)?.mime_type;
+      if (typeof img !== 'string' || img.length === 0) {
+        return res
+          .status(400)
+          .json({ error: 'image is required.', code: 'INVALID_REQUEST' });
+      }
+      if (typeof mt !== 'string' || mt.length === 0) {
+        return res
+          .status(400)
+          .json({ error: 'mime_type is required.', code: 'INVALID_REQUEST' });
+      }
+      if (img.length > MAX_BASE64_IMAGE_LENGTH) {
+        return res.status(400).json({
+          error: 'image exceeds the maximum allowed size of 8MB (base64).',
+          code: 'IMAGE_TOO_LARGE',
+        });
+      }
+      totalBase64Length += img.length;
+      if (totalBase64Length > MAX_TOTAL_BASE64_LENGTH) {
+        return res.status(400).json({
+          error:
+            'The combined size of all images exceeds the allowed limit of 24MB (base64).',
+          code: 'IMAGE_TOO_LARGE',
+        });
+      }
+      if (!ALLOWED_PHOTO_MIME_TYPES.has(mt)) {
+        return res.status(400).json({
+          error: `Unsupported mime_type '${mt}'. Allowed: ${[...ALLOWED_PHOTO_MIME_TYPES].join(', ')}.`,
+          code: 'UNSUPPORTED_MIME_TYPE',
+        });
+      }
+      photoImages.push({ base64: img, mimeType: mt });
     }
+
     if (description !== undefined) {
       if (
         typeof description !== 'string' ||
@@ -768,8 +820,7 @@ router.post(
     try {
       const result =
         await foodPhotoEstimationService.estimateFoodPhotoNutrition({
-          base64Image: image,
-          mimeType: mime_type,
+          images: photoImages,
           userId: req.userId,
           description: typeof description === 'string' ? description : '',
           weightSlot,

--- a/SparkyFitnessServer/services/foodPhotoEstimationService.ts
+++ b/SparkyFitnessServer/services/foodPhotoEstimationService.ts
@@ -234,9 +234,23 @@ function toStrictJsonSchema(input: unknown): JsonSchemaNode {
   return clone;
 }
 
-function buildPrompt(description: string, weight: string): string {
-  return `You are a nutrition estimation assistant. Analyze the meal photo and return
-structured nutrition data.
+function buildPrompt(
+  description: string,
+  weight: string,
+  imageCount: number
+): string {
+  const multiImage = imageCount > 1;
+  const intro = multiImage
+    ? `You are a nutrition estimation assistant. Analyze the ${imageCount} provided photos and return
+structured nutrition data. The photos all show ONE meal, not separate meals. They may include
+several angles of the same dish plus supporting context such as a menu or item description, or the
+packaging or nutrition label of an ingredient. Use every photo together to identify items and
+portions, prefer label or menu text when it is more specific than the plate, and do not count the
+same item twice when it appears in more than one photo.`
+    : `You are a nutrition estimation assistant. Analyze the meal photo and return
+structured nutrition data.`;
+  const visualSource = multiImage ? 'photos' : 'image';
+  return `${intro}
 
 User description (optional): "${description}"
 
@@ -245,7 +259,7 @@ User-provided total weight (optional): "${weight}"
 Rules:
 
   - If the user provided a description, treat it as authoritative over what you
-    see in the image when they conflict.
+    see in the ${visualSource} when they conflict.
   - If the user provided a total weight, distribute it across items
     proportionally to your visual estimate, then recalculate nutrition.
   - Break mixed dishes into component ingredients when reasonable (e.g. a
@@ -603,7 +617,7 @@ async function estimateFoodPhotoNutrition(
     };
   }
   const apiKey = aiService.api_key;
-  const prompt = buildPrompt(description, weightSlot);
+  const prompt = buildPrompt(description, weightSlot, images.length);
   const providerType = aiService.service_type;
   const model = aiService.model_name || getDefaultVisionModel(providerType);
 

--- a/SparkyFitnessServer/services/foodPhotoEstimationService.ts
+++ b/SparkyFitnessServer/services/foodPhotoEstimationService.ts
@@ -17,6 +17,12 @@ const REQUEST_TIMEOUT_MS = 90_000;
 
 const SUPPORTED_PROVIDERS = new Set(['google', 'openai', 'anthropic']);
 
+// Providers whose vision APIs reject HEIC/HEIF (only Gemini accepts them).
+// Caught here so the user gets a clean UNSUPPORTED_MIME_TYPE instead of an
+// opaque upstream 400 surfaced as a 502.
+const HEIC_MIME_TYPES = new Set(['image/heic', 'image/heif']);
+const HEIC_UNSUPPORTED_PROVIDERS = new Set(['openai', 'anthropic']);
+
 const RESPONSE_SCHEMA = {
   type: 'object',
   properties: {
@@ -249,12 +255,49 @@ Rules:
   - Only ask clarifying questions that would materially change the estimate.`;
 }
 
-export interface EstimateFoodPhotoNutritionInput {
-  base64Image: string;
+export interface PhotoImage {
+  base64: string;
   mimeType: string;
+}
+
+export interface EstimateFoodPhotoNutritionInput {
+  /** One or more images for a single estimate. Preferred over base64Image/mimeType. */
+  images?: PhotoImage[];
+  /** Legacy single-image field; use images[]. Still accepted for backward compatibility. */
+  base64Image?: string;
+  /** Legacy single-image field; use images[]. Still accepted for backward compatibility. */
+  mimeType?: string;
   userId: string;
   description?: string;
   weightSlot?: string;
+}
+
+// Anthropic's Messages API rejects the non-standard 'image/jpg'; normalize it
+// to the canonical 'image/jpeg'. The route already rejects 'image/jpg' via its
+// allow-list, so this is defense-in-depth for the independently-exported
+// service rather than a currently-reachable path.
+function normalizeMimeType(mimeType: string): string {
+  return mimeType === 'image/jpg' ? 'image/jpeg' : mimeType;
+}
+
+function resolveImages(input: EstimateFoodPhotoNutritionInput): PhotoImage[] {
+  const raw =
+    input.images && input.images.length > 0
+      ? input.images
+      : input.base64Image && input.mimeType
+        ? [{ base64: input.base64Image, mimeType: input.mimeType }]
+        : [];
+  return raw
+    .filter(
+      (img): img is PhotoImage =>
+        !!img &&
+        typeof img.base64 === 'string' &&
+        typeof img.mimeType === 'string'
+    )
+    .map((img) => ({
+      base64: img.base64,
+      mimeType: normalizeMimeType(img.mimeType),
+    }));
 }
 
 export type EstimateFoodPhotoNutritionResult =
@@ -273,8 +316,7 @@ type ProviderExtractResult =
 
 function buildGoogleRequest(
   apiKey: string,
-  base64Image: string,
-  mimeType: string,
+  images: PhotoImage[],
   prompt: string,
   model: string
 ): ProviderRequest {
@@ -289,7 +331,9 @@ function buildGoogleRequest(
         {
           role: 'user',
           parts: [
-            { inline_data: { mime_type: mimeType, data: base64Image } },
+            ...images.map((img) => ({
+              inline_data: { mime_type: img.mimeType, data: img.base64 },
+            })),
             { text: prompt },
           ],
         },
@@ -329,8 +373,7 @@ function extractGoogleResponse(data: unknown): ProviderExtractResult {
 
 function buildOpenAiRequest(
   apiKey: string,
-  base64Image: string,
-  mimeType: string,
+  images: PhotoImage[],
   prompt: string,
   strictSchema: JsonSchemaNode,
   model: string
@@ -347,10 +390,10 @@ function buildOpenAiRequest(
         {
           role: 'user',
           content: [
-            {
+            ...images.map((img) => ({
               type: 'image_url',
-              image_url: { url: `data:${mimeType};base64,${base64Image}` },
-            },
+              image_url: { url: `data:${img.mimeType};base64,${img.base64}` },
+            })),
             { type: 'text', text: prompt },
           ],
         },
@@ -419,8 +462,7 @@ function extractOpenAiResponse(data: unknown): ProviderExtractResult {
 
 function buildAnthropicRequest(
   apiKey: string,
-  base64Image: string,
-  mimeType: string,
+  images: PhotoImage[],
   prompt: string,
   strictSchema: JsonSchemaNode,
   model: string
@@ -449,14 +491,14 @@ function buildAnthropicRequest(
         {
           role: 'user',
           content: [
-            {
+            ...images.map((img) => ({
               type: 'image',
               source: {
                 type: 'base64',
-                media_type: mimeType,
-                data: base64Image,
+                media_type: img.mimeType,
+                data: img.base64,
               },
-            },
+            })),
             { type: 'text', text: prompt },
           ],
         },
@@ -517,13 +559,15 @@ function extractAnthropicResponse(data: unknown): ProviderExtractResult {
 async function estimateFoodPhotoNutrition(
   input: EstimateFoodPhotoNutritionInput
 ): Promise<EstimateFoodPhotoNutritionResult> {
-  const {
-    base64Image,
-    mimeType,
-    userId,
-    description = '',
-    weightSlot = '',
-  } = input;
+  const { userId, description = '', weightSlot = '' } = input;
+  const images = resolveImages(input);
+  if (images.length === 0) {
+    return {
+      success: false,
+      code: 'INVALID_REQUEST',
+      error: 'At least one image is required.',
+    };
+  }
 
   const setting = await chatRepository.getActiveAiServiceSetting(userId);
   if (!setting) {
@@ -563,22 +607,26 @@ async function estimateFoodPhotoNutrition(
   const providerType = aiService.service_type;
   const model = aiService.model_name || getDefaultVisionModel(providerType);
 
+  if (
+    HEIC_UNSUPPORTED_PROVIDERS.has(providerType) &&
+    images.some((img) => HEIC_MIME_TYPES.has(img.mimeType))
+  ) {
+    return {
+      success: false,
+      code: 'UNSUPPORTED_MIME_TYPE',
+      error: `The active AI provider (${providerType}) does not support HEIC/HEIF images. Please use JPEG, PNG, or WebP.`,
+    };
+  }
+
   let request: ProviderRequest;
   switch (providerType) {
     case 'google':
-      request = buildGoogleRequest(
-        apiKey,
-        base64Image,
-        mimeType,
-        prompt,
-        model
-      );
+      request = buildGoogleRequest(apiKey, images, prompt, model);
       break;
     case 'openai':
       request = buildOpenAiRequest(
         apiKey,
-        base64Image,
-        mimeType,
+        images,
         prompt,
         toStrictJsonSchema(RESPONSE_SCHEMA),
         model
@@ -587,8 +635,7 @@ async function estimateFoodPhotoNutrition(
     case 'anthropic':
       request = buildAnthropicRequest(
         apiKey,
-        base64Image,
-        mimeType,
+        images,
         prompt,
         toStrictJsonSchema(RESPONSE_SCHEMA),
         model

--- a/SparkyFitnessServer/tests/foodPhotoEstimationRoute.test.ts
+++ b/SparkyFitnessServer/tests/foodPhotoEstimationRoute.test.ts
@@ -222,8 +222,7 @@ describe('POST /food-crud/estimate-food-photo', () => {
     ).toHaveBeenCalledWith(
       expect.objectContaining({
         weightSlot: '16 oz (approximately 454 g)',
-        base64Image: 'aGVsbG8=',
-        mimeType: 'image/jpeg',
+        images: [{ base64: 'aGVsbG8=', mimeType: 'image/jpeg' }],
         userId: 'user-123',
       })
     );
@@ -266,6 +265,107 @@ describe('POST /food-crud/estimate-food-photo', () => {
       .post('/food-crud/estimate-food-photo')
       .send({ image: 'aGVsbG8=', mime_type: 'image/jpeg' });
     expect(res.statusCode).toBe(401);
+    expect(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).not.toHaveBeenCalled();
+  });
+
+  it('accepts a multi-image images[] payload and passes it through', async () => {
+    // @ts-expect-error mocked
+    foodPhotoEstimationService.estimateFoodPhotoNutrition.mockResolvedValue({
+      success: true,
+      estimate: sampleEstimate,
+    });
+    const res = await request(app)
+      .post('/food-crud/estimate-food-photo')
+      .send({
+        images: [
+          { image: 'aGVsbG8=', mime_type: 'image/jpeg' },
+          { image: 'd29ybGQ=', mime_type: 'image/png' },
+        ],
+      });
+    expect(res.statusCode).toBe(200);
+    expect(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        images: [
+          { base64: 'aGVsbG8=', mimeType: 'image/jpeg' },
+          { base64: 'd29ybGQ=', mimeType: 'image/png' },
+        ],
+      })
+    );
+  });
+
+  it('returns 400 INVALID_REQUEST when images is an empty array', async () => {
+    const res = await request(app)
+      .post('/food-crud/estimate-food-photo')
+      .send({ images: [] });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
+    expect(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 INVALID_REQUEST when images exceeds the cap', async () => {
+    const images = Array.from({ length: 7 }, () => ({
+      image: 'aGVsbG8=',
+      mime_type: 'image/jpeg',
+    }));
+    const res = await request(app)
+      .post('/food-crud/estimate-food-photo')
+      .send({ images });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.code).toBe('INVALID_REQUEST');
+    expect(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 UNSUPPORTED_MIME_TYPE when one image in the set is invalid', async () => {
+    const res = await request(app)
+      .post('/food-crud/estimate-food-photo')
+      .send({
+        images: [
+          { image: 'aGVsbG8=', mime_type: 'image/jpeg' },
+          { image: 'aGVsbG8=', mime_type: 'application/pdf' },
+        ],
+      });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.code).toBe('UNSUPPORTED_MIME_TYPE');
+    expect(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 IMAGE_TOO_LARGE when one image in the set is too large', async () => {
+    const huge = 'a'.repeat(8 * 1024 * 1024 + 1);
+    const res = await request(app)
+      .post('/food-crud/estimate-food-photo')
+      .send({
+        images: [
+          { image: 'aGVsbG8=', mime_type: 'image/jpeg' },
+          { image: huge, mime_type: 'image/jpeg' },
+        ],
+      });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.code).toBe('IMAGE_TOO_LARGE');
+  });
+
+  it('returns 400 IMAGE_TOO_LARGE when the combined image size exceeds the cap', async () => {
+    // Each image is within the 8MB per-image limit, but four of them together
+    // exceed the 24MB cumulative cap.
+    const sevenMb = 'a'.repeat(7 * 1024 * 1024);
+    const images = Array.from({ length: 4 }, () => ({
+      image: sevenMb,
+      mime_type: 'image/jpeg',
+    }));
+    const res = await request(app)
+      .post('/food-crud/estimate-food-photo')
+      .send({ images });
+    expect(res.statusCode).toBe(400);
+    expect(res.body.code).toBe('IMAGE_TOO_LARGE');
     expect(
       foodPhotoEstimationService.estimateFoodPhotoNutrition
     ).not.toHaveBeenCalled();

--- a/SparkyFitnessServer/tests/foodPhotoEstimationService.test.ts
+++ b/SparkyFitnessServer/tests/foodPhotoEstimationService.test.ts
@@ -186,6 +186,43 @@ describe('estimateFoodPhotoNutrition', () => {
     }
   });
 
+  it('rejects HEIC with UNSUPPORTED_MIME_TYPE for openai before any upstream call', async () => {
+    // @ts-expect-error mocked
+    chatRepository.getActiveAiServiceSetting.mockResolvedValue(
+      makeSetting({ service_type: 'openai' })
+    );
+    // @ts-expect-error mocked
+    chatRepository.getAiServiceSettingForBackend.mockResolvedValue(
+      makeServiceDetail({ service_type: 'openai', api_key: 'oai-key' })
+    );
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy;
+    const result = await estimateFoodPhotoNutrition({
+      images: [{ base64: 'aGVsbG8=', mimeType: 'image/heic' }],
+      userId: TEST_USER_ID,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.code).toBe('UNSUPPORTED_MIME_TYPE');
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows HEIC for google (Gemini supports it)', async () => {
+    // @ts-expect-error mocked
+    chatRepository.getActiveAiServiceSetting.mockResolvedValue(makeSetting());
+    // @ts-expect-error mocked
+    chatRepository.getAiServiceSettingForBackend.mockResolvedValue(
+      makeServiceDetail()
+    );
+    mockGoogleSuccess(sampleEstimate);
+    const result = await estimateFoodPhotoNutrition({
+      images: [{ base64: 'aGVsbG8=', mimeType: 'image/heic' }],
+      userId: TEST_USER_ID,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it('returns the parsed estimate on Google happy path', async () => {
     // @ts-expect-error mocked
     chatRepository.getActiveAiServiceSetting.mockResolvedValue(makeSetting());
@@ -451,6 +488,56 @@ describe('estimateFoodPhotoNutrition', () => {
       expect(imagePart).toBeDefined();
       expect(imagePart.inline_data.data).toBe(TEST_BASE64);
       expect(imagePart.inline_data.mime_type).toBe(TEST_MIME);
+    });
+
+    it('emits one inline_data part per image when given multiple images, prompt last', async () => {
+      await estimateFoodPhotoNutrition({
+        images: [
+          { base64: 'aW1nMQ==', mimeType: 'image/jpeg' },
+          { base64: 'aW1nMg==', mimeType: 'image/png' },
+        ],
+        userId: TEST_USER_ID,
+      });
+      // @ts-expect-error mock typing
+      const [, options] = global.fetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+      const parts = body.contents[0].parts;
+      const imageParts = parts.filter(
+        (p: { inline_data?: unknown }) => p.inline_data !== undefined
+      );
+      expect(imageParts).toHaveLength(2);
+      expect(imageParts[0].inline_data.data).toBe('aW1nMQ==');
+      expect(imageParts[0].inline_data.mime_type).toBe('image/jpeg');
+      expect(imageParts[1].inline_data.data).toBe('aW1nMg==');
+      expect(imageParts[1].inline_data.mime_type).toBe('image/png');
+      // Prompt text part comes after the images.
+      expect(typeof parts[parts.length - 1].text).toBe('string');
+    });
+
+    it('returns INVALID_REQUEST when no image is supplied', async () => {
+      const result = await estimateFoodPhotoNutrition({
+        images: [],
+        userId: TEST_USER_ID,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.code).toBe('INVALID_REQUEST');
+      }
+    });
+
+    it("normalizes 'image/jpg' to 'image/jpeg' before sending to the provider", async () => {
+      await estimateFoodPhotoNutrition({
+        images: [{ base64: 'aW1n', mimeType: 'image/jpg' }],
+        userId: TEST_USER_ID,
+      });
+      // @ts-expect-error mock typing
+      const [, options] = global.fetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+      const imagePart = body.contents[0].parts.find(
+        (p: { inline_data?: { mime_type?: string } }) =>
+          p.inline_data !== undefined
+      );
+      expect(imagePart.inline_data.mime_type).toBe('image/jpeg');
     });
 
     it("renders weight slot as '<n> g' for gram input", async () => {

--- a/SparkyFitnessServer/tests/foodPhotoEstimationService.test.ts
+++ b/SparkyFitnessServer/tests/foodPhotoEstimationService.test.ts
@@ -514,6 +514,39 @@ describe('estimateFoodPhotoNutrition', () => {
       expect(typeof parts[parts.length - 1].text).toBe('string');
     });
 
+    it('tells the model multiple images are one meal when given several', async () => {
+      await estimateFoodPhotoNutrition({
+        images: [
+          { base64: 'aW1nMQ==', mimeType: 'image/jpeg' },
+          { base64: 'aW1nMg==', mimeType: 'image/jpeg' },
+        ],
+        userId: TEST_USER_ID,
+      });
+      // @ts-expect-error mock typing
+      const [, options] = global.fetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+      const promptPart = body.contents[0].parts.find(
+        (p: { text?: string }) => typeof p.text === 'string'
+      );
+      expect(promptPart.text).toContain('2 provided photos');
+      expect(promptPart.text).toContain('ONE meal');
+    });
+
+    it('keeps the singular prompt for a single image', async () => {
+      await estimateFoodPhotoNutrition({
+        images: [{ base64: 'aW1n', mimeType: 'image/jpeg' }],
+        userId: TEST_USER_ID,
+      });
+      // @ts-expect-error mock typing
+      const [, options] = global.fetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+      const promptPart = body.contents[0].parts.find(
+        (p: { text?: string }) => typeof p.text === 'string'
+      );
+      expect(promptPart.text).toContain('Analyze the meal photo');
+      expect(promptPart.text).not.toContain('ONE meal');
+    });
+
     it('returns INVALID_REQUEST when no image is supplied', async () => {
       const result = await estimateFoodPhotoNutrition({
         images: [],


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The AI food-photo estimate accepts only one image per request, but real meals are often best captured across several (a plate plus the menu, or a dish plus a packaging nutrition panel). This lets a single estimate draw on multiple images for richer context while still producing one aggregate diary entry.

**How did you implement the solution?**
The estimate endpoint and all three provider builders (Gemini, OpenAI, Anthropic) now accept an `images[]` array and emit one image content block per image ahead of the prompt. The legacy single `image`/`mime_type` shape is still accepted at the route and service layers for backward compatibility. The per-request cap is configurable via `AI_PHOTO_ESTIMATE_MAX_IMAGES` (default 6), with per-image size, cumulative-size, and mime validation, and the response shape is unchanged. On mobile, the Improve screen becomes the staging surface: a thumbnail strip, an Add-another sheet (camera via `launchCameraAsync`, library via `launchImageLibraryAsync` with multi-select), per-thumbnail removal, and a client-side cap. Unsupported formats are handled (HEIC/HEIF is rejected early for OpenAI and Anthropic, which cannot read it, while Gemini accepts it). The scan screen stays single-shot.

Linked Issue: Closes #1398

## How to Test

1. Run the server (`SparkyFitnessServer`) and the mobile app (`SparkyFitnessMobile`) from this branch.
2. Start a food-photo estimate, then on the Improve screen tap "Add another" and add more images (camera, or library with multi-select). Confirm thumbnails appear, can be removed, and the count caps at the limit.
3. Submit and verify the estimate reflects all images and still saves as a single diary entry. The restaurant plate-plus-menu case is the strongest example.
4. Backend only: POST to `/api/foods/estimate-food-photo` with an `images` array of two `{ image, mime_type }` objects and confirm a 200 with one rolled-up estimate. Confirm the legacy single `image`/`mime_type` body still works, that exceeding `AI_PHOTO_ESTIMATE_MAX_IMAGES` returns 400, and that a combined payload over the cumulative limit returns 400.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the License terms.

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: Raised and discussed in #1398; approved proceeding with the PR.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: typecheck, lint, and the full server test suite pass, with added route and service tests for the multi-image path. No new endpoint or table was added; the extended endpoint follows the file's existing manual-validation pattern (this route does not use Zod).
- [x] **[MANDATORY for Backend changes] Database Security**: no new tables; `rls_policies.sql` is unchanged.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: Before/After attached below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: verified on an Android device (Samsung Galaxy S26 Ultra) against a self-hosted instance.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="480" height="976" alt="Screenshot_20260531_223328_SparkyFitness" src="https://github.com/user-attachments/assets/11db50e0-004e-49a9-b085-1296ee292696" />

### After

<img width="480" height="976" alt="Screenshot_20260531_223156_SparkyFitness" src="https://github.com/user-attachments/assets/b655aa7f-a700-4d67-b5ed-d0d4cd1a64bf" />

</details>

## Notes for Reviewers

Tested on a self-hosted instance and on an Android device: staged two to six images on the Improve screen, generated, and confirmed the estimate draws on all of them into a single diary entry, including the restaurant plate-plus-menu case.

The change is additive and backward-compatible: single-image requests are unchanged, the response shape is unchanged, there are no new endpoints, and no new tables. The extended endpoint reuses the file's existing manual request validation rather than Zod, matching the surrounding code. Per-request count, per-image size, and cumulative payload size are all bounded to protect the server, and HEIC/HEIF is rejected early for providers that cannot read it.
