### PR TITLE
Fix empty MCP input schema on discriminated-union tools (manage_goals, etc.)

### DIFF
--- a/SparkyFitnessMCP/src/schemas/goals.ts
+++ b/SparkyFitnessMCP/src/schemas/goals.ts
@@ -28,3 +28,21 @@ export const manageGoalsSchema = z.discriminatedUnion("action", [
 ]);
 
 export type ManageGoalsInput = z.infer<typeof manageGoalsSchema>;
+
+// Flat shape published to MCP clients as `inputSchema`. The MCP TS SDK serializes
+// `z.object()` to JSON Schema but emits an empty object for `z.discriminatedUnion()`,
+// so clients can't see `action` or the per-action fields. Strict per-action
+// validation still runs in the tool handler via `manageGoalsSchema.safeParse`.
+export const manageGoalsInput = z.object({
+  action: z
+    .enum(["get_goals", "set_goals", "list_goal_timeline"])
+    .describe("Action to perform; see the tool description for the fields each action needs."),
+  target_date: optionalDateSchema.describe("get_goals: date to fetch goals for (defaults to today)"),
+  start_date: dateSchema.optional().describe("set_goals: date when these goals take effect"),
+  calories: z.coerce.number().min(0).optional().describe("set_goals: daily calorie goal"),
+  protein: z.coerce.number().min(0).optional().describe("set_goals: daily protein goal (g)"),
+  carbs: z.coerce.number().min(0).optional().describe("set_goals: daily carbohydrate goal (g)"),
+  fat: z.coerce.number().min(0).optional().describe("set_goals: daily fat goal (g)"),
+  water_goal_ml: z.coerce.number().min(0).optional().describe("set_goals: daily water intake goal (ml)"),
+  weight: z.coerce.number().min(0).optional().describe("set_goals: target body weight"),
+});

--- a/SparkyFitnessMCP/src/schemas/habits.ts
+++ b/SparkyFitnessMCP/src/schemas/habits.ts
@@ -26,3 +26,18 @@ export const manageHabitsSchema = z.discriminatedUnion("action", [
 ]);
 
 export type ManageHabitsInput = z.infer<typeof manageHabitsSchema>;
+
+// Flat shape published to MCP clients as `inputSchema`. The MCP TS SDK serializes
+// `z.object()` to JSON Schema but emits an empty object for `z.discriminatedUnion()`,
+// so clients can't see `action` or the per-action fields. Strict per-action
+// validation still runs in the tool handler via `manageHabitsSchema.safeParse`.
+export const manageHabitsInput = z.object({
+  action: z
+    .enum(["list_habits", "log_habit", "get_habit_history"])
+    .describe("Action to perform; see the tool description for the fields each action needs."),
+  habit_id: uuidSchema.optional().describe("log_habit / get_habit_history: UUID of the habit"),
+  entry_date: dateSchema.optional().describe("log_habit: date to log the habit for"),
+  completed: z.boolean().optional().describe("log_habit: whether the habit was completed"),
+  start_date: optionalDateSchema.describe("get_habit_history: range start date"),
+  end_date: optionalDateSchema.describe("get_habit_history: range end date"),
+});

--- a/SparkyFitnessMCP/src/schemas/profile.ts
+++ b/SparkyFitnessMCP/src/schemas/profile.ts
@@ -34,3 +34,22 @@ export const manageProfileSchema = z.discriminatedUnion("action", [
 ]);
 
 export type ManageProfileInput = z.infer<typeof manageProfileSchema>;
+
+// Flat shape published to MCP clients as `inputSchema`. The MCP TS SDK serializes
+// `z.object()` to JSON Schema but emits an empty object for `z.discriminatedUnion()`,
+// so clients can't see `action` or the per-action fields. Strict per-action
+// validation still runs in the tool handler via `manageProfileSchema.safeParse`.
+export const manageProfileInput = z.object({
+  action: z
+    .enum(["get_profile", "update_profile", "get_preferences", "update_preferences"])
+    .describe("Action to perform; see the tool description for the fields each action needs."),
+  display_name: z.string().min(1).max(200).optional().describe("update_profile: user's display name"),
+  email: z.string().email().optional().describe("update_profile: user's email address"),
+  image: z.string().url().optional().describe("update_profile: profile image URL"),
+  timezone: z.string().optional().describe("update_preferences: timezone (e.g., 'UTC', 'America/New_York')"),
+  energy_unit: z.enum(["kcal", "kJ"]).optional().describe("update_preferences: unit for energy"),
+  default_weight_unit: z.enum(["kg", "lbs"]).optional().describe("update_preferences: default weight unit"),
+  default_measurement_unit: z.enum(["cm", "in"]).optional().describe("update_preferences: default measurement unit"),
+  default_distance_unit: z.enum(["km", "miles"]).optional().describe("update_preferences: default distance unit"),
+  water_display_unit: z.enum(["ml", "oz"]).optional().describe("update_preferences: default water unit"),
+});

--- a/SparkyFitnessMCP/src/schemas/wizard.ts
+++ b/SparkyFitnessMCP/src/schemas/wizard.ts
@@ -11,3 +11,16 @@ export const manageWizardSchema = z.discriminatedUnion("action", [
 ]);
 
 export type ManageWizardInput = z.infer<typeof manageWizardSchema>;
+
+// Flat shape published to MCP clients as `inputSchema`. The MCP TS SDK serializes
+// `z.object()` to JSON Schema but emits an empty object for `z.discriminatedUnion()`,
+// so clients can't see `action` or the fields. Strict validation still runs in the
+// tool handler via `manageWizardSchema.safeParse`.
+export const manageWizardInput = z.object({
+  action: z.enum(["daily_checkin"]).describe("Action to perform."),
+  step: z
+    .enum(["start", "weight", "steps", "sleep", "mood", "habits", "complete"])
+    .optional()
+    .describe("The current step in the check-in process (defaults to 'start')"),
+  answer: z.string().optional().describe("User's answer to the current question"),
+});

--- a/SparkyFitnessMCP/src/tools/goals.ts
+++ b/SparkyFitnessMCP/src/tools/goals.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { manageGoalsSchema, type ManageGoalsInput } from "../schemas/goals.js";
+import { manageGoalsSchema, manageGoalsInput, type ManageGoalsInput } from "../schemas/goals.js";
 import * as goalService from "../services/goalService.js";
 import { ERRORS } from "../utils/errors.js";
 import { formatList, formatConfirmation, formatSuccess } from "../utils/formatting.js";
@@ -18,10 +18,14 @@ Actions:
 - get_goals(target_date?) — returns the goals active on a specific date
 - set_goals(start_date, calories?, protein?, carbs?, fat?, water_goal_ml?, weight?) — sets new goals from a start date
 - list_goal_timeline() — lists all goal changes over time`,
-      inputSchema: manageGoalsSchema,
+      inputSchema: manageGoalsInput,
     },
     async (rawArgs): Promise<ToolResponse> => {
-      const args = rawArgs as unknown as ManageGoalsInput;
+      const parsed = manageGoalsSchema.safeParse(rawArgs);
+      if (!parsed.success) {
+        return ERRORS.VALIDATION(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+      }
+      const args: ManageGoalsInput = parsed.data;
       try {
         switch (args.action) {
           case "get_goals": {

--- a/SparkyFitnessMCP/src/tools/goals.ts
+++ b/SparkyFitnessMCP/src/tools/goals.ts
@@ -23,7 +23,7 @@ Actions:
     async (rawArgs): Promise<ToolResponse> => {
       const parsed = manageGoalsSchema.safeParse(rawArgs);
       if (!parsed.success) {
-        return ERRORS.VALIDATION(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+        return ERRORS.VALIDATION(parsed.error.issues.map((i) => (i.path.length > 0 ? `${i.path.join(".")}: ${i.message}` : i.message)).join("; "));
       }
       const args: ManageGoalsInput = parsed.data;
       try {

--- a/SparkyFitnessMCP/src/tools/habits.ts
+++ b/SparkyFitnessMCP/src/tools/habits.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { manageHabitsSchema, type ManageHabitsInput } from "../schemas/habits.js";
+import { manageHabitsSchema, manageHabitsInput, type ManageHabitsInput } from "../schemas/habits.js";
 import * as habitService from "../services/habitService.js";
 import { ERRORS } from "../utils/errors.js";
 import { formatList, formatConfirmation, formatSuccess } from "../utils/formatting.js";
@@ -18,10 +18,14 @@ Actions:
 - list_habits() — returns all habits (custom categories with boolean type)
 - log_habit(habit_id, entry_date, completed) — logs whether a habit was done on a specific date
 - get_habit_history(habit_id, start_date?, end_date?) — returns completion history for a habit`,
-      inputSchema: manageHabitsSchema,
+      inputSchema: manageHabitsInput,
     },
     async (rawArgs): Promise<ToolResponse> => {
-      const args = rawArgs as unknown as ManageHabitsInput;
+      const parsed = manageHabitsSchema.safeParse(rawArgs);
+      if (!parsed.success) {
+        return ERRORS.VALIDATION(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+      }
+      const args: ManageHabitsInput = parsed.data;
       try {
         switch (args.action) {
           case "list_habits": {

--- a/SparkyFitnessMCP/src/tools/habits.ts
+++ b/SparkyFitnessMCP/src/tools/habits.ts
@@ -23,7 +23,7 @@ Actions:
     async (rawArgs): Promise<ToolResponse> => {
       const parsed = manageHabitsSchema.safeParse(rawArgs);
       if (!parsed.success) {
-        return ERRORS.VALIDATION(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+        return ERRORS.VALIDATION(parsed.error.issues.map((i) => (i.path.length > 0 ? `${i.path.join(".")}: ${i.message}` : i.message)).join("; "));
       }
       const args: ManageHabitsInput = parsed.data;
       try {

--- a/SparkyFitnessMCP/src/tools/profile.ts
+++ b/SparkyFitnessMCP/src/tools/profile.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { manageProfileSchema, type ManageProfileInput } from "../schemas/profile.js";
+import { manageProfileSchema, manageProfileInput, type ManageProfileInput } from "../schemas/profile.js";
 import * as profileService from "../services/profileService.js";
 import { ERRORS } from "../utils/errors.js";
 import { formatList, formatConfirmation, formatSuccess } from "../utils/formatting.js";
@@ -19,10 +19,14 @@ Actions:
 - update_profile(display_name?, email?, image?) — updates account details
 - get_preferences() — returns user preferences (timezone, units)
 - update_preferences(timezone?, energy_unit?, default_weight_unit?, default_distance_unit?) — updates preferences`,
-      inputSchema: manageProfileSchema,
+      inputSchema: manageProfileInput,
     },
     async (rawArgs): Promise<ToolResponse> => {
-      const args = rawArgs as unknown as ManageProfileInput;
+      const parsed = manageProfileSchema.safeParse(rawArgs);
+      if (!parsed.success) {
+        return ERRORS.VALIDATION(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+      }
+      const args: ManageProfileInput = parsed.data;
       try {
         switch (args.action) {
           case "get_profile": {

--- a/SparkyFitnessMCP/src/tools/profile.ts
+++ b/SparkyFitnessMCP/src/tools/profile.ts
@@ -24,7 +24,7 @@ Actions:
     async (rawArgs): Promise<ToolResponse> => {
       const parsed = manageProfileSchema.safeParse(rawArgs);
       if (!parsed.success) {
-        return ERRORS.VALIDATION(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+        return ERRORS.VALIDATION(parsed.error.issues.map((i) => (i.path.length > 0 ? `${i.path.join(".")}: ${i.message}` : i.message)).join("; "));
       }
       const args: ManageProfileInput = parsed.data;
       try {

--- a/SparkyFitnessMCP/src/tools/report.ts
+++ b/SparkyFitnessMCP/src/tools/report.ts
@@ -32,7 +32,7 @@ export function registerReportTools(server: McpServer, userId: string): void {
     async (rawArgs): Promise<ToolResponse> => {
       const parsed = manageReportSchema.safeParse(rawArgs);
       if (!parsed.success) {
-        return ERRORS.VALIDATION(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+        return ERRORS.VALIDATION(parsed.error.issues.map((i) => (i.path.length > 0 ? `${i.path.join(".")}: ${i.message}` : i.message)).join("; "));
       }
       const args: ManageReportInput = parsed.data;
       try {

--- a/SparkyFitnessMCP/src/tools/report.ts
+++ b/SparkyFitnessMCP/src/tools/report.ts
@@ -13,16 +13,28 @@ const getWeeklyReportSchema = z.object({
 const manageReportSchema = z.discriminatedUnion("action", [getWeeklyReportSchema]);
 type ManageReportInput = z.infer<typeof manageReportSchema>;
 
+// Flat shape published to MCP clients as `inputSchema`. The MCP TS SDK serializes
+// `z.object()` to JSON Schema but emits an empty object for `z.discriminatedUnion()`.
+// Strict validation still runs in the handler via `manageReportSchema.safeParse`.
+const manageReportInput = z.object({
+  action: z.enum(["get_weekly_report"]).describe("Action to perform."),
+  end_date: optionalDateSchema.describe("get_weekly_report: end date for the weekly report (YYYY-MM-DD)"),
+});
+
 export function registerReportTools(server: McpServer, userId: string): void {
   server.registerTool(
     "sparky_get_report",
     {
       title: "Get Health Report",
       description: "Generates consolidated health and fitness reports.",
-      inputSchema: manageReportSchema,
+      inputSchema: manageReportInput,
     },
     async (rawArgs): Promise<ToolResponse> => {
-      const args = rawArgs as unknown as ManageReportInput;
+      const parsed = manageReportSchema.safeParse(rawArgs);
+      if (!parsed.success) {
+        return ERRORS.VALIDATION(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+      }
+      const args: ManageReportInput = parsed.data;
       try {
         switch (args.action) {
           case "get_weekly_report": {

--- a/SparkyFitnessMCP/src/tools/wizard.ts
+++ b/SparkyFitnessMCP/src/tools/wizard.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { manageWizardSchema, type ManageWizardInput } from "../schemas/wizard.js";
+import { manageWizardSchema, manageWizardInput, type ManageWizardInput } from "../schemas/wizard.js";
+import { ERRORS } from "../utils/errors.js";
 import type { ToolResponse } from "../types.js";
 
 const STEPS = {
@@ -39,10 +40,14 @@ export function registerWizardTools(server: McpServer, userId: string): void {
     {
       title: "Daily Check-in Wizard",
       description: "A guided, step-by-step interactive assistant for your daily health check-in. Use 'daily_checkin' action and pass the current step.",
-      inputSchema: manageWizardSchema,
+      inputSchema: manageWizardInput,
     },
     async (rawArgs): Promise<ToolResponse> => {
-      const args = rawArgs as unknown as ManageWizardInput;
+      const parsed = manageWizardSchema.safeParse(rawArgs);
+      if (!parsed.success) {
+        return ERRORS.VALIDATION(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+      }
+      const args: ManageWizardInput = parsed.data;
       
       const currentStep = args.step || "start";
       const stepInfo = (STEPS as any)[currentStep];

--- a/SparkyFitnessMCP/src/tools/wizard.ts
+++ b/SparkyFitnessMCP/src/tools/wizard.ts
@@ -45,7 +45,7 @@ export function registerWizardTools(server: McpServer, userId: string): void {
     async (rawArgs): Promise<ToolResponse> => {
       const parsed = manageWizardSchema.safeParse(rawArgs);
       if (!parsed.success) {
-        return ERRORS.VALIDATION(parsed.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "));
+        return ERRORS.VALIDATION(parsed.error.issues.map((i) => (i.path.length > 0 ? `${i.path.join(".")}: ${i.message}` : i.message)).join("; "));
       }
       const args: ManageWizardInput = parsed.data;
       


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Five MCP tools (`manage_goals`, `manage_habits`, `manage_profile`, `get_report`, `daily_checkin_wizard`) expose an empty input schema, so clients never see the `action` field and every call fails with `invalid_union_discriminator`.

**How did you implement the solution?**
They passed a `z.discriminatedUnion` straight to `registerTool` as `inputSchema`; the MCP SDK serializes that to an empty object. Switched them to a flat `z.object` (`manage*Input`) — the same approach `food.ts`/`exercise.ts`/`checkin.ts` already use — and kept the union for strict `safeParse` validation in the handler.

Linked Issue: none (found while integrating the MCP server with a client — happy to open one if you'd prefer)

## How to Test

1. Run the MCP server and call `tools/list`.
2. `sparky_manage_goals` (and the other four) now publish `action` plus the per-action fields instead of `{"properties":{}}`.
3. Call e.g. `sparky_manage_goals` with `{ "action": "get_goals" }` — it returns the goals instead of a discriminator error.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

## Notes for Reviewers

- `tsc --noEmit` passes. No behaviour change beyond the published schema — runtime validation still goes through the discriminated unions.
- Second commit addresses the gemini-code-assist note (leading colon on root-level validation errors).

Disclaimer: I worked this out together with Claude while setting up the SparkyFitness MCP server as a Claude connector. `manage_goals` was where the empty schema surfaced, so I traced it and this is the fix I landed on. Happy to adjust the approach.
