### PR TITLE
fix(#1417): round set duration to the nearest minute

### DIFF
--- a/SparkyFitnessServer/integrations/hevy/hevyDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/hevy/hevyDataProcessor.ts
@@ -139,7 +139,9 @@ async function processSingleWorkout(
         set_type: mapSetType(set.type),
         weight: set.weight_kg,
         reps: set.reps,
-        duration: set.duration_seconds ? set.duration_seconds / 60 : null,
+        duration: set.duration_seconds
+          ? Math.round(set.duration_seconds / 60)
+          : null,
         rpe: set.rpe,
       })),
     };


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Fixes Hevy synchronization failing when a timed set has a `duration_seconds`
value that is not divisible by 60.

**How did you implement the solution?**
Rounds timed set durations to the nearest minute before inserting them into the
integer database column.

Linked Issue: Closes #1417

## How to Test

1. Sync a Hevy workout containing a timed set that is not an exact number of
   minutes, such as `duration_seconds: 275`.
2. Verify that the workout sync completes successfully.
3. Verify that the stored set duration is rounded to the nearest minute
   (`275` seconds becomes `5` minutes).

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.


