### PR TITLE
fix: add missing $27 placeholder for traces column in bulk food import

### DIFF
--- a/SparkyFitnessServer/models/food.ts
+++ b/SparkyFitnessServer/models/food.ts
@@ -810,7 +810,7 @@ async function createFoodsInBulk(userId: any, foodDataArray: any) {
               source, ai_confidence, allergens, traces, created_at, updated_at
             ) VALUES (
               $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
-              $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, now(), now()
+              $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, now(), now()
             )`,
           [
             newFoodId,


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The `createFoodsInBulk` INSERT query for `food_variants` listed 29 target columns but only 28 value expressions, causing PostgreSQL error: *INSERT a plus de colonnes cibles que d expressions*.

**How did you implement the solution?**
Added the missing `$27` placeholder for the `traces` column in the VALUES clause.

Linked Issue: N/A (bug found during usage)

## How to Test

1. Check out this branch and run `pnpm run validate` in `SparkyFitnessServer/`
2. Import foods via CSV using the bulk import feature
3. Verify that the import completes without SQL errors

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

## Notes for Reviewers

> Single-character fix: the parameter array already provided `variant.traces` as the 27th element, but the SQL VALUES clause jumped from `$26` directly to `now(), now()`, skipping the `traces` column entirely. No schema or logic changes needed.