### PR TITLE
Add update_exercise_entry action to MCP exercise tool

### DIFF
--- a/SparkyFitnessMCP/src/schemas/exercise.ts
+++ b/SparkyFitnessMCP/src/schemas/exercise.ts
@@ -52,6 +52,16 @@ const logWorkoutPresetSchema = z.object({
   entry_date: dateSchema,
 }).strict();
 
+const updateExerciseEntrySchema = z.object({
+  action: z.literal("update_exercise_entry"),
+  entry_id: uuidSchema.describe("UUID of the exercise entry to update"),
+  entry_date: dateSchema.optional().describe("New date for the entry (YYYY-MM-DD)"),
+  duration_minutes: z.coerce.number().min(0).optional().describe("Duration in minutes"),
+  calories_burned: z.coerce.number().min(0).optional().describe("Calories burned"),
+  notes: z.string().max(2000).optional().describe("Additional notes"),
+  sets: z.union([z.array(exerciseSetSchema), z.string()]).optional().describe("Replacement set details as array or JSON string; replaces all existing sets when provided"),
+}).strict();
+
 const deleteExerciseEntrySchema = z.object({
   action: z.literal("delete_exercise_entry"),
   entry_id: uuidSchema.describe("UUID of the exercise entry to delete"),
@@ -84,6 +94,7 @@ export const manageExerciseSchema = z.discriminatedUnion("action", [
   listExerciseDiarySchema,
   getWorkoutPresetsSchema,
   logWorkoutPresetSchema,
+  updateExerciseEntrySchema,
   deleteExerciseEntrySchema,
   getExerciseDetailsSchema,
   createWorkoutPresetSchema,
@@ -105,6 +116,7 @@ export const manageExerciseInput = z.object({
     "list_exercise_diary",
     "get_workout_presets",
     "log_workout_preset",
+    "update_exercise_entry",
     "delete_exercise_entry",
     "get_exercise_details",
     "create_workout_preset",
@@ -144,7 +156,7 @@ export const manageExerciseInput = z.object({
   preset_id: uuidSchema.optional().describe("Workout preset UUID"),
   preset_name: z.string().min(1).max(200).optional().describe("Workout preset name"),
   // entry management
-  entry_id: uuidSchema.optional().describe("Exercise diary entry UUID — for delete_exercise_entry"),
+  entry_id: uuidSchema.optional().describe("Exercise diary entry UUID — for update_exercise_entry / delete_exercise_entry"),
   // progress range
   start_date: dateSchema.optional().describe("Start date for progress tracking"),
   end_date: dateSchema.optional().describe("End date for progress tracking"),

--- a/SparkyFitnessMCP/src/services/exerciseService.ts
+++ b/SparkyFitnessMCP/src/services/exerciseService.ts
@@ -493,7 +493,7 @@ export async function updateExerciseEntry(
           await client.query(
             `INSERT INTO exercise_entry_sets (exercise_entry_id, set_number, set_type, reps, weight, duration, rest_time, created_at, updated_at)
              VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())`,
-            [params.entry_id, i + 1, s.set_type || "Working Set", s.reps || null, s.weight || null, s.duration || null, s.rest_time || null]
+            [params.entry_id, i + 1, s.set_type || "Working Set", s.reps ?? null, s.weight ?? null, s.duration ?? null, s.rest_time ?? null]
           );
         }
       }

--- a/SparkyFitnessMCP/src/services/exerciseService.ts
+++ b/SparkyFitnessMCP/src/services/exerciseService.ts
@@ -444,6 +444,69 @@ export async function logWorkoutPreset(
   });
 }
 
+export async function updateExerciseEntry(
+  userId: string,
+  params: {
+    entry_id: string;
+    entry_date?: string;
+    duration_minutes?: number;
+    calories_burned?: number;
+    notes?: string;
+    sets?: ExerciseSet[];
+  }
+): Promise<boolean> {
+  return withClient(userId, async (client) => {
+    await client.query("BEGIN");
+    try {
+      // Build a partial UPDATE from the fields that were actually provided.
+      const setClauses: string[] = [];
+      const values: unknown[] = [];
+      let idx = 1;
+
+      if (params.entry_date !== undefined) { setClauses.push(`entry_date = $${idx++}`); values.push(params.entry_date); }
+      if (params.duration_minutes !== undefined) { setClauses.push(`duration_minutes = $${idx++}`); values.push(params.duration_minutes); }
+      if (params.calories_burned !== undefined) { setClauses.push(`calories_burned = $${idx++}`); values.push(params.calories_burned); }
+      if (params.notes !== undefined) { setClauses.push(`notes = $${idx++}`); values.push(params.notes); }
+
+      // Always touch the audit columns; this also guarantees at least one
+      // assignment so the statement is valid even for a sets-only update.
+      setClauses.push(`updated_by_user_id = $${idx++}`); values.push(userId);
+      setClauses.push("updated_at = NOW()");
+
+      values.push(params.entry_id);
+      const result = await client.query(
+        `UPDATE exercise_entries SET ${setClauses.join(", ")} WHERE id = $${idx} RETURNING id`,
+        values
+      );
+
+      // RLS scopes the row to the current user; an absent/foreign id updates nothing.
+      if ((result.rowCount ?? 0) === 0) {
+        await client.query("ROLLBACK");
+        return false;
+      }
+
+      // When sets are provided, fully replace the existing sets (mirrors logExercise inserts).
+      if (params.sets !== undefined) {
+        await client.query("DELETE FROM exercise_entry_sets WHERE exercise_entry_id = $1", [params.entry_id]);
+        for (let i = 0; i < params.sets.length; i++) {
+          const s = params.sets[i];
+          await client.query(
+            `INSERT INTO exercise_entry_sets (exercise_entry_id, set_number, set_type, reps, weight, duration, rest_time, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())`,
+            [params.entry_id, i + 1, s.set_type || "Working Set", s.reps || null, s.weight || null, s.duration || null, s.rest_time || null]
+          );
+        }
+      }
+
+      await client.query("COMMIT");
+      return true;
+    } catch (error) {
+      await client.query("ROLLBACK");
+      throw error;
+    }
+  });
+}
+
 export async function deleteExerciseEntry(userId: string, entryId: string): Promise<boolean> {
   return withClient(userId, async (client) => {
     // exercise_entry_sets should cascade delete, but delete explicitly to be safe

--- a/SparkyFitnessMCP/src/tools/exercise.ts
+++ b/SparkyFitnessMCP/src/tools/exercise.ts
@@ -135,7 +135,11 @@ Actions:
             // Parse sets if it arrives as a JSON string (MCP serialisation quirk), matching log_exercise.
             let parsedSets: ExerciseSet[] | undefined;
             if (typeof args.sets === "string") {
-              try { parsedSets = JSON.parse(args.sets); } catch { parsedSets = undefined; }
+              try {
+                parsedSets = JSON.parse(args.sets);
+              } catch {
+                return ERRORS.VALIDATION("Invalid JSON format for sets");
+              }
             } else {
               parsedSets = args.sets as ExerciseSet[] | undefined;
             }

--- a/SparkyFitnessMCP/src/tools/exercise.ts
+++ b/SparkyFitnessMCP/src/tools/exercise.ts
@@ -5,7 +5,7 @@ import { ERRORS } from "../utils/errors.js";
 import { formatList, formatConfirmation } from "../utils/formatting.js";
 import type { ToolResponse, Exercise, ExerciseEntry, ExerciseSet } from "../types.js";
 
-const VALID_ACTIONS = ["search_exercises", "create_exercise", "log_exercise", "list_exercise_diary", "get_workout_presets", "log_workout_preset", "delete_exercise_entry", "get_exercise_details", "create_workout_preset", "get_exercise_progress"];
+const VALID_ACTIONS = ["search_exercises", "create_exercise", "log_exercise", "list_exercise_diary", "get_workout_presets", "log_workout_preset", "update_exercise_entry", "delete_exercise_entry", "get_exercise_details", "create_workout_preset", "get_exercise_progress"];
 
 export function registerExerciseTools(server: McpServer, userId: string): void {
   server.registerTool(
@@ -21,6 +21,7 @@ Actions:
 - list_exercise_diary(entry_date)
 - get_workout_presets()
 - log_workout_preset(entry_date, preset_id?|preset_name?)
+- update_exercise_entry(entry_id, entry_date?, duration_minutes?, calories_burned?, notes?, sets?) — only the provided fields change; sets, when provided, replace all existing sets
 - delete_exercise_entry(entry_id)
 - get_exercise_details(exercise_id?|exercise_name?)
 - create_workout_preset(name, exercise_ids)
@@ -128,6 +129,26 @@ Actions:
               `Workout preset logged for ${args.entry_date}. ${entries.length} exercises added.`,
               { entries_count: entries.length, entry_date: args.entry_date }
             );
+          }
+
+          case "update_exercise_entry": {
+            // Parse sets if it arrives as a JSON string (MCP serialisation quirk), matching log_exercise.
+            let parsedSets: ExerciseSet[] | undefined;
+            if (typeof args.sets === "string") {
+              try { parsedSets = JSON.parse(args.sets); } catch { parsedSets = undefined; }
+            } else {
+              parsedSets = args.sets as ExerciseSet[] | undefined;
+            }
+            const updated = await exerciseService.updateExerciseEntry(userId, {
+              entry_id: args.entry_id,
+              entry_date: args.entry_date,
+              duration_minutes: args.duration_minutes,
+              calories_burned: args.calories_burned,
+              notes: args.notes,
+              sets: parsedSets,
+            });
+            if (!updated) return ERRORS.NOT_FOUND("Exercise Entry", args.entry_id);
+            return formatConfirmation(`Exercise entry updated.`, { entry_id: args.entry_id });
           }
 
           case "delete_exercise_entry": {


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The MCP exercise tool (`sparky_manage_exercise`) can `log_exercise` and `delete_exercise_entry`, but there's no way to edit an existing diary entry. To fix a typo, adjust a weight, or add a note after the fact, you have to delete the entry and log it again.

**How did you implement the solution?**
Added an `update_exercise_entry` action. It does a partial update of `exercise_entries` — only the fields you pass (`entry_date`, `duration_minutes`, `calories_burned`, `notes`) change — and, when `sets` are supplied, it replaces the entry's sets in `exercise_entry_sets`. The update and the set replacement run inside one transaction. Row ownership is enforced by the existing RLS context (`withClient`), and a missing/foreign `entry_id` returns the standard not-found error — same model as `delete_exercise_entry`.

No new fields were needed on the published (flat) input schema — `entry_id`, `notes`, `duration_minutes`, `calories_burned`, `sets` and `entry_date` already exist there; only the new action value was added. No DB migration (the `notes` column already exists).

Linked Issue: none (came up while using the MCP server as a Claude connector — happy to open one if you'd prefer).

## How to Test

1. `log_exercise` an entry and note its `entry_id` (or grab it from `list_exercise_diary`).
2. `sparky_manage_exercise` with `{ "action": "update_exercise_entry", "entry_id": "<id>", "notes": "felt strong, last set was a grinder" }` — only the note changes; sets/date/duration are untouched.
3. Call again with `sets` (array or JSON string) — the entry's sets are fully replaced.
4. Call with a random UUID for `entry_id` — returns not-found.
5. Confirm a second user cannot update another user's entry (RLS → not-found).

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

## Notes for Reviewers

- `tsc --noEmit` passes.
- `sets` is parsed from a JSON string on the way in and the set replacement mirrors the existing `log_exercise` insert logic (`set_number`, `Working Set` default, null fallbacks).
- Passing `sets: []` clears the entry's sets; omitting `sets` leaves them as-is.

Disclaimer: I built this with Claude while using the SparkyFitness MCP server as a connector. I wanted to be able to add notes to / fix a workout entry without deleting and re-logging it, noticed there was no update action, and this is the implementation I landed on. Happy to adjust the approach.
