### PR TITLE
Expose RPE, per-set notes, and cardio fields over the MCP exercise tool

### DIFF
--- a/SparkyFitnessMCP/src/schemas/exercise.ts
+++ b/SparkyFitnessMCP/src/schemas/exercise.ts
@@ -7,6 +7,8 @@ const exerciseSetSchema = z.object({
   duration: z.coerce.number().min(0).optional().describe("Duration in seconds"),
   rest_time: z.coerce.number().min(0).optional().describe("Rest time in seconds"),
   set_type: setTypeEnum.default("Working Set"),
+  rpe: z.coerce.number().min(0).max(10).optional().describe("Rate of Perceived Exertion (0-10 scale, one decimal allowed)"),
+  notes: z.string().max(1000).optional().describe("Note for this set"),
 }).strict();
 
 const searchExercisesSchema = z.object({
@@ -33,6 +35,9 @@ const logExerciseSchema = z.object({
   duration_minutes: z.coerce.number().min(0).optional().describe("Duration in minutes"),
   calories_burned: z.coerce.number().min(0).optional().describe("Calories burned"),
   notes: z.string().max(2000).optional().describe("Additional notes"),
+  distance: z.coerce.number().min(0).optional().describe("Distance covered, in the user's distance unit (e.g. km) — for cardio"),
+  avg_heart_rate: z.coerce.number().int().min(0).max(300).optional().describe("Average heart rate in bpm — for cardio"),
+  steps: z.coerce.number().int().min(0).optional().describe("Step count for the activity"),
   sets: z.union([z.array(exerciseSetSchema), z.string()]).optional().describe("Set details as array or JSON string"),
 }).strict();
 
@@ -59,6 +64,9 @@ const updateExerciseEntrySchema = z.object({
   duration_minutes: z.coerce.number().min(0).optional().describe("Duration in minutes"),
   calories_burned: z.coerce.number().min(0).optional().describe("Calories burned"),
   notes: z.string().max(2000).optional().describe("Additional notes"),
+  distance: z.coerce.number().min(0).optional().describe("Distance covered, in the user's distance unit (e.g. km) — for cardio"),
+  avg_heart_rate: z.coerce.number().int().min(0).max(300).optional().describe("Average heart rate in bpm — for cardio"),
+  steps: z.coerce.number().int().min(0).optional().describe("Step count for the activity"),
   sets: z.union([z.array(exerciseSetSchema), z.string()]).optional().describe("Replacement set details as array or JSON string; replaces all existing sets when provided"),
 }).strict();
 
@@ -142,6 +150,9 @@ export const manageExerciseInput = z.object({
   duration_minutes: z.coerce.number().min(0).optional().describe("Duration in minutes"),
   calories_burned: z.coerce.number().min(0).optional().describe("Calories burned"),
   notes: z.string().max(2000).optional().describe("Additional notes"),
+  distance: z.coerce.number().min(0).optional().describe("Distance covered, in the user's distance unit (e.g. km) — cardio, for log/update"),
+  avg_heart_rate: z.coerce.number().int().min(0).max(300).optional().describe("Average heart rate in bpm — cardio, for log/update"),
+  steps: z.coerce.number().int().min(0).optional().describe("Step count for the activity — for log/update"),
   sets: z.union([
     z.array(z.object({
       reps: z.coerce.number().int().min(0).optional(),
@@ -149,9 +160,11 @@ export const manageExerciseInput = z.object({
       duration: z.coerce.number().min(0).optional(),
       rest_time: z.coerce.number().min(0).optional(),
       set_type: setTypeEnum.optional(),
+      rpe: z.coerce.number().min(0).max(10).optional(),
+      notes: z.string().max(1000).optional(),
     })),
     z.string(),
-  ]).optional().describe("Set details as array of objects or JSON string"),
+  ]).optional().describe("Set details as array of objects or JSON string; per-set fields include rpe and notes"),
   // presets
   preset_id: uuidSchema.optional().describe("Workout preset UUID"),
   preset_name: z.string().min(1).max(200).optional().describe("Workout preset name"),

--- a/SparkyFitnessMCP/src/services/exerciseService.ts
+++ b/SparkyFitnessMCP/src/services/exerciseService.ts
@@ -117,6 +117,9 @@ export async function logExercise(
     duration_minutes?: number;
     calories_burned?: number;
     notes?: string;
+    distance?: number;
+    avg_heart_rate?: number;
+    steps?: number;
     sets?: ExerciseSet[];
   }
 ): Promise<ExerciseEntry> {
@@ -165,10 +168,10 @@ export async function logExercise(
     // exercise_entries does NOT have a sets jsonb column.
     // Sets are stored in the exercise_entry_sets table.
     const result = await client.query(
-      `INSERT INTO exercise_entries (user_id, exercise_id, entry_date, duration_minutes, calories_burned, notes, exercise_name, category, source, created_by_user_id, updated_by_user_id, created_at, updated_at)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'manual', $1, $1, NOW(), NOW())
-       RETURNING id, user_id, exercise_id, entry_date, duration_minutes, calories_burned, notes, created_at`,
-      [userId, exerciseId, params.entry_date, params.duration_minutes || 0, params.calories_burned || 0, params.notes || null, exerciseName, exerciseCategory]
+      `INSERT INTO exercise_entries (user_id, exercise_id, entry_date, duration_minutes, calories_burned, notes, distance, avg_heart_rate, steps, exercise_name, category, source, created_by_user_id, updated_by_user_id, created_at, updated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, 'manual', $1, $1, NOW(), NOW())
+       RETURNING id, user_id, exercise_id, entry_date, duration_minutes, calories_burned, notes, distance, avg_heart_rate, steps, created_at`,
+      [userId, exerciseId, params.entry_date, params.duration_minutes || 0, params.calories_burned || 0, params.notes || null, params.distance ?? null, params.avg_heart_rate ?? null, params.steps ?? null, exerciseName, exerciseCategory]
     );
 
     const row = result.rows[0];
@@ -180,9 +183,9 @@ export async function logExercise(
       for (let i = 0; i < params.sets.length; i++) {
         const s = params.sets[i];
         await client.query(
-          `INSERT INTO exercise_entry_sets (exercise_entry_id, set_number, set_type, reps, weight, duration, rest_time, created_at, updated_at)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())`,
-          [entryId, i + 1, s.set_type || "Working Set", s.reps || null, s.weight || null, s.duration || null, s.rest_time || null]
+          `INSERT INTO exercise_entry_sets (exercise_entry_id, set_number, set_type, reps, weight, duration, rest_time, rpe, notes, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())`,
+          [entryId, i + 1, s.set_type || "Working Set", s.reps ?? null, s.weight ?? null, s.duration ?? null, s.rest_time ?? null, s.rpe ?? null, s.notes ?? null]
         );
         sets.push(s);
       }
@@ -198,6 +201,9 @@ export async function logExercise(
       duration_minutes: row.duration_minutes,
       calories_burned: row.calories_burned,
       notes: row.notes,
+      distance: row.distance != null ? Number(row.distance) : undefined,
+      avg_heart_rate: row.avg_heart_rate ?? undefined,
+      steps: row.steps ?? undefined,
       created_at: row.created_at,
     };
   });
@@ -207,7 +213,7 @@ export async function listExerciseDiary(userId: string, entryDate: string): Prom
   return withClient(userId, async (client) => {
     const result = await client.query(
       `SELECT ee.id, ee.user_id, ee.exercise_id, e.name AS exercise_name, ee.entry_date,
-              ee.duration_minutes, ee.calories_burned, ee.notes, ee.created_at
+              ee.duration_minutes, ee.calories_burned, ee.notes, ee.distance, ee.avg_heart_rate, ee.steps, ee.created_at
        FROM exercise_entries ee
        JOIN exercises e ON ee.exercise_id = e.id
        WHERE ee.entry_date = $1
@@ -221,7 +227,7 @@ export async function listExerciseDiary(userId: string, entryDate: string): Prom
 
     // Fetch all sets for all entries in a single query
     const setsResult = await client.query(
-      `SELECT exercise_entry_id, set_number, set_type, reps, weight, duration, rest_time
+      `SELECT exercise_entry_id, set_number, set_type, reps, weight, duration, rest_time, rpe, notes
        FROM exercise_entry_sets
        WHERE exercise_entry_id = ANY($1)
        ORDER BY exercise_entry_id, set_number ASC`,
@@ -240,6 +246,8 @@ export async function listExerciseDiary(userId: string, entryDate: string): Prom
         weight: s.weight ? Number(s.weight) : undefined,
         duration: s.duration,
         rest_time: s.rest_time,
+        rpe: s.rpe != null ? Number(s.rpe) : undefined,
+        notes: s.notes ?? undefined,
       });
     }
 
@@ -253,6 +261,9 @@ export async function listExerciseDiary(userId: string, entryDate: string): Prom
       duration_minutes: row.duration_minutes,
       calories_burned: row.calories_burned,
       notes: row.notes,
+      distance: row.distance != null ? Number(row.distance) : undefined,
+      avg_heart_rate: row.avg_heart_rate ?? undefined,
+      steps: row.steps ?? undefined,
       created_at: row.created_at,
     }));
   });
@@ -452,6 +463,9 @@ export async function updateExerciseEntry(
     duration_minutes?: number;
     calories_burned?: number;
     notes?: string;
+    distance?: number;
+    avg_heart_rate?: number;
+    steps?: number;
     sets?: ExerciseSet[];
   }
 ): Promise<boolean> {
@@ -467,6 +481,9 @@ export async function updateExerciseEntry(
       if (params.duration_minutes !== undefined) { setClauses.push(`duration_minutes = $${idx++}`); values.push(params.duration_minutes); }
       if (params.calories_burned !== undefined) { setClauses.push(`calories_burned = $${idx++}`); values.push(params.calories_burned); }
       if (params.notes !== undefined) { setClauses.push(`notes = $${idx++}`); values.push(params.notes); }
+      if (params.distance !== undefined) { setClauses.push(`distance = $${idx++}`); values.push(params.distance); }
+      if (params.avg_heart_rate !== undefined) { setClauses.push(`avg_heart_rate = $${idx++}`); values.push(params.avg_heart_rate); }
+      if (params.steps !== undefined) { setClauses.push(`steps = $${idx++}`); values.push(params.steps); }
 
       // Always touch the audit columns; this also guarantees at least one
       // assignment so the statement is valid even for a sets-only update.
@@ -491,9 +508,9 @@ export async function updateExerciseEntry(
         for (let i = 0; i < params.sets.length; i++) {
           const s = params.sets[i];
           await client.query(
-            `INSERT INTO exercise_entry_sets (exercise_entry_id, set_number, set_type, reps, weight, duration, rest_time, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())`,
-            [params.entry_id, i + 1, s.set_type || "Working Set", s.reps ?? null, s.weight ?? null, s.duration ?? null, s.rest_time ?? null]
+            `INSERT INTO exercise_entry_sets (exercise_entry_id, set_number, set_type, reps, weight, duration, rest_time, rpe, notes, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())`,
+            [params.entry_id, i + 1, s.set_type || "Working Set", s.reps ?? null, s.weight ?? null, s.duration ?? null, s.rest_time ?? null, s.rpe ?? null, s.notes ?? null]
           );
         }
       }

--- a/SparkyFitnessMCP/src/tools/exercise.ts
+++ b/SparkyFitnessMCP/src/tools/exercise.ts
@@ -17,11 +17,11 @@ export function registerExerciseTools(server: McpServer, userId: string): void {
 Actions:
 - search_exercises(searchTerm, muscleGroup?, equipment?, limit?, offset?)
 - create_exercise(name, category?, calories_per_hour?, description?)
-- log_exercise(entry_date, exercise_id?|exercise_name?, duration_minutes?, calories_burned?, notes?, sets?:JSON string or array of [{reps,weight,duration,rest_time,set_type}])
+- log_exercise(entry_date, exercise_id?|exercise_name?, duration_minutes?, calories_burned?, notes?, distance?, avg_heart_rate?, steps?, sets?:JSON string or array of [{reps,weight,duration,rest_time,set_type,rpe,notes}]) — distance/avg_heart_rate/steps are for cardio
 - list_exercise_diary(entry_date)
 - get_workout_presets()
 - log_workout_preset(entry_date, preset_id?|preset_name?)
-- update_exercise_entry(entry_id, entry_date?, duration_minutes?, calories_burned?, notes?, sets?) — only the provided fields change; sets, when provided, replace all existing sets
+- update_exercise_entry(entry_id, entry_date?, duration_minutes?, calories_burned?, notes?, distance?, avg_heart_rate?, steps?, sets?) — only the provided fields change; sets, when provided, replace all existing sets
 - delete_exercise_entry(entry_id)
 - get_exercise_details(exercise_id?|exercise_name?)
 - create_workout_preset(name, exercise_ids)
@@ -82,6 +82,9 @@ Actions:
               duration_minutes: args.duration_minutes,
               calories_burned: args.calories_burned,
               notes: args.notes,
+              distance: args.distance,
+              avg_heart_rate: args.avg_heart_rate,
+              steps: args.steps,
               sets: parsedSets,
             });
             return formatConfirmation(
@@ -100,6 +103,24 @@ Actions:
                 if (e.sets.length > 0) text += ` — ${e.sets.length} sets`;
                 if (e.duration_minutes) text += ` | ${e.duration_minutes} min`;
                 if (e.calories_burned) text += ` | ${e.calories_burned} kcal`;
+                if (e.distance != null) text += ` | ${e.distance} dist`;
+                if (e.avg_heart_rate != null) text += ` | ${e.avg_heart_rate} bpm`;
+                if (e.steps != null) text += ` | ${e.steps} steps`;
+                if (e.sets.length > 0) {
+                  const setLine = e.sets
+                    .map((s) => {
+                      const parts: string[] = [];
+                      if (s.reps != null) parts.push(`${s.reps}r`);
+                      if (s.weight != null) parts.push(`${s.weight}kg`);
+                      if (s.rpe != null) parts.push(`RPE ${s.rpe}`);
+                      let str = parts.join("×");
+                      if (s.notes) str += ` (${s.notes})`;
+                      return str;
+                    })
+                    .filter(Boolean)
+                    .join("; ");
+                  if (setLine) text += `\n  Sets: ${setLine}`;
+                }
                 if (e.notes) text += `\n  Notes: ${e.notes}`;
                 text += `\n  ID: ${e.id}`;
                 return text;
@@ -149,6 +170,9 @@ Actions:
               duration_minutes: args.duration_minutes,
               calories_burned: args.calories_burned,
               notes: args.notes,
+              distance: args.distance,
+              avg_heart_rate: args.avg_heart_rate,
+              steps: args.steps,
               sets: parsedSets,
             });
             if (!updated) return ERRORS.NOT_FOUND("Exercise Entry", args.entry_id);

--- a/SparkyFitnessMCP/src/tools/exercise.ts
+++ b/SparkyFitnessMCP/src/tools/exercise.ts
@@ -112,8 +112,10 @@ Actions:
                       const parts: string[] = [];
                       if (s.reps != null) parts.push(`${s.reps}r`);
                       if (s.weight != null) parts.push(`${s.weight}kg`);
+                      if (s.duration != null) parts.push(`${s.duration}s`);
                       if (s.rpe != null) parts.push(`RPE ${s.rpe}`);
                       let str = parts.join("×");
+                      if (s.rest_time != null) str += ` (rest ${s.rest_time}s)`;
                       if (s.notes) str += ` (${s.notes})`;
                       return str;
                     })

--- a/SparkyFitnessMCP/src/types.ts
+++ b/SparkyFitnessMCP/src/types.ts
@@ -38,6 +38,8 @@ export interface ExerciseSet {
   duration?: number;
   rest_time?: number;
   set_type: "Working Set" | "Warmup" | "Drop Set" | "Failure";
+  rpe?: number;
+  notes?: string;
 }
 
 export interface ExerciseEntry {
@@ -50,6 +52,9 @@ export interface ExerciseEntry {
   duration_minutes?: number;
   calories_burned?: number;
   notes?: string;
+  distance?: number;
+  avg_heart_rate?: number;
+  steps?: number;
   created_at: string;
 }
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The MCP exercise tool stored only `reps/weight/duration/rest_time/set_type` per set and `duration/calories/notes` per entry — but the app and DB already track more: per-set **RPE** and **notes**, and entry-level **distance**, **average heart rate**, and **steps**. So a cardio session logged through the connector lost its core metrics, and strength sets couldn't record effort or per-set notes.

**How did you implement the solution?**
Added `rpe` + `notes` to the set shape and `distance` / `avg_heart_rate` / `steps` to the entry shape, wired through:
- `log_exercise` and `update_exercise_entry` (write — including the transactional set replacement)
- `list_exercise_diary` (read), so entries round-trip fully

The fields were added to both the discriminated-union variant (used for `safeParse`) and the flat `manageExerciseInput` shape published to clients. Numeric set fields use nullish coalescing so a valid `0` (bodyweight, zero rest) is stored rather than coerced to null. No DB migration — all columns already exist (`exercise_entry_sets.rpe/notes`, `exercise_entries.distance/avg_heart_rate/steps`).

Linked Issue: none (found while completing MCP coverage as a Claude connector).

## How to Test

1. `log_exercise` a strength entry with `sets: [{reps, weight, rpe, notes}, ...]` → the RPE and per-set note are stored.
2. `log_exercise` a cardio entry with `distance`, `avg_heart_rate`, `steps` → all three persist.
3. `list_exercise_diary(entry_date)` → the entry comes back with rpe / per-set notes / distance / HR / steps.
4. `update_exercise_entry(entry_id, distance?, avg_heart_rate?, steps?, sets?)` → only the provided fields change; sets (with rpe/notes) replace the existing sets.
5. Log a set with `reps: 0, weight: 0` → stored as `0`, not null.

Verified end-to-end against a live instance: write → read → update → delete round-trip, with 0-values, RPE, per-set notes, and all three cardio fields persisting at the DB level.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

## Notes for Reviewers

- Builds on #1428 (`update_exercise_entry`); the new fields are wired into both write paths and the read path.
- `tsc --noEmit` passes.
- Per-set numeric fields use `??` (not `||`) so a valid `0` survives, consistent with the earlier fix in #1428.

Disclaimer: I built this with Claude while using the SparkyFitness MCP server as a connector. After adding update support I noticed the tool couldn't capture RPE, per-set notes, or cardio metrics (distance/HR/steps) that the app already stores, so I wired those through. Happy to adjust the approach.
