### PR TITLE
update swagger-jsdoc apis globs to scan TypeScript sources and nested…

### DIFF
--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -353,6 +353,7 @@ app.use((req, res, next) => {
   const publicRoutes = [
     '/api/auth/settings',
     '/api/auth/mfa-factors',
+    '/api/api-docs',
     '/api/health',
     '/api/version',
     '/api/uploads',

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -350,16 +350,20 @@ app.get(
 );
 // Apply authentication middleware to all protected routes
 app.use((req, res, next) => {
+  const isPublicApiDocsEnabled =
+    process.env.SPARKY_FITNESS_PUBLIC_API_DOCS === 'true';
   const publicRoutes = [
     '/api/auth/settings',
     '/api/auth/mfa-factors',
-    '/api/api-docs',
     '/api/health',
     '/api/version',
     '/api/uploads',
     '/uploads',
     '/api/ping',
   ];
+  if (isPublicApiDocsEnabled) {
+    publicRoutes.push('/api/api-docs');
+  }
   const isPublic = publicRoutes.some((route) => {
     // Exact match or subpath match with trailing slash to prevent partial matches
     // e.g. "/api/health" matches "/api/health" and "/api/health/" but NOT "/api/health-data"

--- a/SparkyFitnessServer/config/swagger.ts
+++ b/SparkyFitnessServer/config/swagger.ts
@@ -1423,9 +1423,11 @@ const options = {
     ],
   },
   apis: [
-    './routes/*.js',
-    './routes/auth/*.js',
-    './models/*.js',
+    './routes/**/*.ts',
+    './models/**/*.ts',
+    './SparkyFitnessServer.ts',
+    './routes/**/*.js',
+    './models/**/*.js',
     './SparkyFitnessServer.js',
   ], // Paths to files containing OpenAPI definitions
 };

--- a/SparkyFitnessServer/config/swagger.ts
+++ b/SparkyFitnessServer/config/swagger.ts
@@ -1,5 +1,18 @@
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'swag... Remove this comment to see the full error message
 import swaggerJsdoc from 'swagger-jsdoc';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const swaggerScanPaths = [
+  path.join(__dirname, '../routes/**/*.ts'),
+  path.join(__dirname, '../models/**/*.ts'),
+  path.join(__dirname, '../SparkyFitnessServer.ts'),
+  path.join(__dirname, '../routes/**/*.js'),
+  path.join(__dirname, '../models/**/*.js'),
+  path.join(__dirname, '../SparkyFitnessServer.js'),
+];
+
 const options = {
   definition: {
     openapi: '3.0.0',
@@ -1422,14 +1435,7 @@ const options = {
       },
     ],
   },
-  apis: [
-    './routes/**/*.ts',
-    './models/**/*.ts',
-    './SparkyFitnessServer.ts',
-    './routes/**/*.js',
-    './models/**/*.js',
-    './SparkyFitnessServer.js',
-  ], // Paths to files containing OpenAPI definitions
+  apis: swaggerScanPaths, // Paths to files containing OpenAPI definitions
 };
 const specs = swaggerJsdoc(options);
 export default specs;


### PR DESCRIPTION
… routes (including v2)

## Description

**What problem does this PR solve?**  
Public API documentation was incomplete and inaccessible without authentication. Swagger was scanning only JavaScript files while the backend is TypeScript-first, so many endpoints (including v2) were missing from generated docs.

**How did you implement the solution?**  
Updated Swagger `apis` globs to include nested TypeScript routes and models, while keeping JavaScript globs as fallback for compiled/runtime compatibility. Also added `/api/api-docs` to the global public-route allowlist so Swagger UI, ReDoc, and docs JSON can be accessed without login.

Linked Issue: Closes #

## How to Test

1. Check out this branch.
2. Ensure backend env + local Postgres are running, then start backend:
   - `cd SparkyFitnessServer && pnpm start`
3. Open:
   - `http://localhost:3010/api/api-docs/swagger`
   - `http://localhost:3010/api/api-docs/redoc`
   - `http://localhost:3010/api/api-docs/json`
4. Verify:
   - docs JSON endpoint returns HTTP 200
   - docs endpoints are reachable without authentication
   - v2 routes are present in the spec
   - current run shows about 260 total paths

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I validated the backend change by running the server and verifying docs endpoint behavior (`200`, public access, v2 coverage).
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. *(Not applicable: no schema/table changes.)*

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. *(Not applicable.)*

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. *(Not applicable.)*

## Screenshots

<details>
<summary>Click to expand</summary>

No UI changes.

</details>

## Notes for Reviewers

This PR includes two focused fixes:

1. Swagger generation now scans TypeScript route/model sources (including v2) with JS fallback preserved.
2. API docs endpoints are treated as public routes so documentation can be accessed without login.

Manual verification in this branch/environment:
- `GET /api/api-docs/json` returns `200`
- generated spec includes v2 routes
- total generated paths currently: `260`keep JavaScript globs as fallback for compiled/runtime compatibility allow /api/api-docs routes through the global auth middleware so Swagger, ReDoc, and JSON are reachable without login verify docs endpoint returns 200 and includes v2 paths (260 total paths in current run)

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes Part of #893 

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
