### PR TITLE
fix: add cache: 'no-store' to all fetch to prevent empty 304

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/api/apiClient.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/api/apiClient.test.ts
@@ -65,4 +65,27 @@ describe('apiFetch error handling', () => {
     await expect(promise).rejects.toBeInstanceOf(ApiError);
     await expect(promise).rejects.toMatchObject({ statusCode: 503 });
   });
+
+  // Regression (#1353): the native HTTP cache (iOS CFNetwork / Android OkHttp)
+  // silently replays If-None-Match/If-Modified-Since and the server answers 304
+  // with an empty body, which the app reports as "Failed to Load". Passing
+  // `cache: 'no-store'` makes RN's whatwg-fetch rewrite the GET URL with a
+  // cache-buster so the request misses the native cache. We assert only that
+  // the fetch option is passed — whatwg-fetch owns the actual URL rewrite.
+  test('passes cache: no-store so whatwg-fetch busts the native cache', async () => {
+    const mockFetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
+    global.fetch = mockFetch as never;
+
+    await apiFetch({ endpoint: '/api/x', serviceName: 's', operation: 'get' });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.invalid/api/x',
+      expect.objectContaining({ cache: 'no-store' })
+    );
+  });
 });

--- a/SparkyFitnessMobile/__tests__/services/api/apiClient.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/api/apiClient.test.ts
@@ -72,7 +72,7 @@ describe('apiFetch error handling', () => {
   // `cache: 'no-store'` makes RN's whatwg-fetch rewrite the GET URL with a
   // cache-buster so the request misses the native cache. We assert only that
   // the fetch option is passed — whatwg-fetch owns the actual URL rewrite.
-  test('passes cache: no-store so whatwg-fetch busts the native cache', async () => {
+  test('passes cache: no-store on GET so whatwg-fetch busts the native cache', async () => {
     const mockFetch = jest.fn().mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -86,6 +86,32 @@ describe('apiFetch error handling', () => {
     expect(mockFetch).toHaveBeenCalledWith(
       'https://example.invalid/api/x',
       expect.objectContaining({ cache: 'no-store' })
+    );
+  });
+
+  // whatwg-fetch appends the `_=<timestamp>` cache-buster for *any* method when
+  // `cache: 'no-store'` is set, so we scope it to GET — mutating requests are
+  // not cacheable and should not carry the buster onto their URLs (#1353).
+  test('omits cache: no-store on non-GET requests', async () => {
+    const mockFetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
+    global.fetch = mockFetch as never;
+
+    await apiFetch({
+      endpoint: '/api/y',
+      serviceName: 's',
+      operation: 'post',
+      method: 'POST',
+      body: {},
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.invalid/api/y',
+      expect.not.objectContaining({ cache: 'no-store' })
     );
   });
 });

--- a/SparkyFitnessMobile/src/components/ServerConfigModal.tsx
+++ b/SparkyFitnessMobile/src/components/ServerConfigModal.tsx
@@ -311,6 +311,7 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
     try {
       const response = await fetch(`${url}/api/identity/user`, {
         method: 'GET',
+        cache: 'no-store', // skip native HTTP cache to avoid 304 empty bodies (#1353)
         headers: {
           ...proxyHeadersToRecord(cleanedHeaders()),
           Authorization: `Bearer ${apiKey.trim()}`,

--- a/SparkyFitnessMobile/src/screens/OnboardingScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/OnboardingScreen.tsx
@@ -51,6 +51,7 @@ const checkReachability = async (url: string): Promise<boolean> => {
     const timeout = setTimeout(() => controller.abort(), 5000);
     const response = await fetch(`${normalizeUrl(url)}/api/auth/settings`, {
       signal: controller.signal,
+      cache: 'no-store', // skip native HTTP cache to avoid 304 empty bodies (#1353)
     });
     clearTimeout(timeout);
     return response.ok;
@@ -239,6 +240,7 @@ export default function OnboardingScreen({ navigation }: Props) {
     try {
       const response = await fetch(`${url}/api/identity/user`, {
         method: 'GET',
+        cache: 'no-store', // skip native HTTP cache to avoid 304 empty bodies (#1353)
         headers: {
           Authorization: `Bearer ${apiKey.trim()}`,
         },

--- a/SparkyFitnessMobile/src/services/api/aiSettingsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/aiSettingsApi.ts
@@ -25,6 +25,7 @@ export async function fetchUserAiConfigAllowed(): Promise<boolean> {
   try {
     const response = await fetch(`${baseUrl}/api/global-settings/allow-user-ai-config`, {
       method: 'GET',
+      cache: 'no-store', // skip native HTTP cache to avoid 304 empty bodies (#1353)
       headers: {
         ...proxyHeadersToRecord(config.proxyHeaders),
         ...getAuthHeaders(config),
@@ -67,6 +68,7 @@ export async function fetchActiveAiServiceSetting(): Promise<ActiveAiServiceSett
   try {
     const response = await fetch(`${baseUrl}/api/chat/ai-service-settings/active`, {
       method: 'GET',
+      cache: 'no-store', // skip native HTTP cache to avoid 304 empty bodies (#1353)
       headers: {
         ...proxyHeadersToRecord(config.proxyHeaders),
         ...getAuthHeaders(config),

--- a/SparkyFitnessMobile/src/services/api/apiClient.ts
+++ b/SparkyFitnessMobile/src/services/api/apiClient.ts
@@ -41,8 +41,10 @@ export async function apiFetch<T>(options: ApiFetchOptions): Promise<T> {
       // not forward a fetch cache policy; instead RN's whatwg-fetch polyfill
       // rewrites the GET URL with a `_=<timestamp>` cache-buster when this is
       // set, so every request misses the native cache. React Query owns all
-      // caching here, so the HTTP layer should never revalidate.
-      cache: 'no-store',
+      // caching here, so the HTTP layer should never revalidate. Only GET is
+      // cacheable, and the polyfill appends the cache-buster regardless of
+      // method, so we scope this to GET to avoid pinning `_` onto mutating URLs.
+      ...(method === 'GET' ? { cache: 'no-store' as const } : {}),
       headers: {
         ...proxyHeadersToRecord(config.proxyHeaders),
         ...getAuthHeaders(config),

--- a/SparkyFitnessMobile/src/services/api/apiClient.ts
+++ b/SparkyFitnessMobile/src/services/api/apiClient.ts
@@ -33,6 +33,16 @@ export async function apiFetch<T>(options: ApiFetchOptions): Promise<T> {
   try {
     const response = await fetch(`${baseUrl}${endpoint}`, {
       method,
+      // Defeat the native HTTP cache (iOS NSURLCache/CFNetwork, Android OkHttp).
+      // Left cacheable, it stores GET responses and silently replays
+      // If-None-Match/If-Modified-Since on the next request, so the server (or a
+      // reverse proxy in front of it) answers 304 with an empty body — which
+      // surfaces in the app as "Failed to Load" (#1353). The native bridge does
+      // not forward a fetch cache policy; instead RN's whatwg-fetch polyfill
+      // rewrites the GET URL with a `_=<timestamp>` cache-buster when this is
+      // set, so every request misses the native cache. React Query owns all
+      // caching here, so the HTTP layer should never revalidate.
+      cache: 'no-store',
       headers: {
         ...proxyHeadersToRecord(config.proxyHeaders),
         ...getAuthHeaders(config),

--- a/SparkyFitnessMobile/src/services/api/authService.ts
+++ b/SparkyFitnessMobile/src/services/api/authService.ts
@@ -141,6 +141,7 @@ const getTrustedAuthOrigin = async (serverUrl: string): Promise<string | undefin
     const response = await fetch(`${baseUrl}/api/auth/settings`, {
       method: 'GET',
       credentials: 'omit',
+      cache: 'no-store', // skip native HTTP cache to avoid 304 empty bodies (#1353)
       headers: { ...pendingProxyHeaders },
     });
 
@@ -279,6 +280,7 @@ export const fetchMfaFactors = async (
     `${baseUrl}/api/auth/mfa-factors?email=${encodeURIComponent(email)}`,
     {
       credentials: 'omit',
+      cache: 'no-store', // skip native HTTP cache to avoid 304 empty bodies (#1353)
       headers: { ...pendingProxyHeaders },
     },
   );

--- a/SparkyFitnessMobile/src/services/api/healthDataApi.ts
+++ b/SparkyFitnessMobile/src/services/api/healthDataApi.ts
@@ -303,6 +303,7 @@ export const checkServerConnection = async (): Promise<boolean> => {
   try {
     const response = await fetch(`${url}/api/identity/user`, {
       method: 'GET',
+      cache: 'no-store', // skip native HTTP cache to avoid 304 empty bodies (#1353)
       headers: {
         ...proxyHeadersToRecord(config.proxyHeaders),
         ...getAuthHeaders(config),

--- a/SparkyFitnessServer/tests/exerciseEntriesApiSchemas.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntriesApiSchemas.test.ts
@@ -209,4 +209,20 @@ describe('Exercise entry API schemas', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  // #1353: RN's whatwg-fetch appends `_=<timestamp>` to GET URLs when callers
+  // pass `cache: 'no-store'`. The strict history query schema must tolerate it.
+  it('accepts the whatwg-fetch `_` cache-buster param', () => {
+    const result = runSchema('exerciseHistoryQuerySchema', {
+      page: '2',
+      _: '1733419200000',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // Keeping `.strict()` so genuine client typos still fail loudly.
+  it('still rejects unknown keys like a misspelled param', () => {
+    const result = runSchema('exerciseHistoryQuerySchema', { pageSzie: '50' });
+    expect(result.success).toBe(false);
+  });
 });

--- a/SparkyFitnessServer/tests/exercisesApiSchemas.test.ts
+++ b/SparkyFitnessServer/tests/exercisesApiSchemas.test.ts
@@ -58,6 +58,23 @@ describe('Exercises API schemas', () => {
     expect(result.success).toBe(false);
   });
 
+  // #1353: RN's whatwg-fetch appends `_=<timestamp>` to GET URLs when callers
+  // pass `cache: 'no-store'`. The strict schema must tolerate that one key.
+  it('accepts the whatwg-fetch `_` cache-buster param', () => {
+    const result = runSchema('exerciseSearchQuerySchema', {
+      searchTerm: 'squat',
+      _: '1733419200000',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  // Keeping `.strict()` (rather than `.loose()`) so genuine client typos still
+  // fail loudly instead of being silently dropped.
+  it('still rejects unknown keys like a misspelled param', () => {
+    const result = runSchema('exerciseSearchQuerySchema', { pageSzie: '50' });
+    expect(result.success).toBe(false);
+  });
+
   it('round-trips a fully populated library item', () => {
     const item = {
       id: 'ex-1',

--- a/shared/src/schemas/api/ExerciseEntries.api.zod.ts
+++ b/shared/src/schemas/api/ExerciseEntries.api.zod.ts
@@ -13,6 +13,9 @@ export const exerciseHistoryQuerySchema = z
     page: z.coerce.number().int().min(1).default(1),
     pageSize: z.coerce.number().int().min(1).max(100).default(20),
     userId: z.string().uuid().optional(),
+    // RN's fetch (whatwg-fetch) appends `_=<timestamp>` to GET URLs when a
+    // caller passes `cache: 'no-store'`, so the strict schema must tolerate it.
+    _: z.string().optional(),
   })
   .strict();
 

--- a/shared/src/schemas/api/Exercises.api.zod.ts
+++ b/shared/src/schemas/api/Exercises.api.zod.ts
@@ -11,6 +11,9 @@ export const exerciseSearchQuerySchema = z
     muscleGroupFilter: z.string().optional(),
     page: z.coerce.number().int().min(1).default(1),
     pageSize: z.coerce.number().int().min(1).max(100).default(20),
+    // RN's fetch (whatwg-fetch) appends `_=<timestamp>` to GET URLs when a
+    // caller passes `cache: 'no-store'`, so the strict schema must tolerate it.
+    _: z.string().optional(),
   })
   .strict();
 


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

Fixes an issue where the iOS app could show 'Failed to Load.' This adds cache: 'no-store' to every GET requst which makes the polyfill append a timestamp query parameter for cache busting. This required me to add the parameter to the two strict zod schemas we have (exercise related.)

Linked Issue: Closes #1353 again

## How to Test

1. Don't strip cache headers
2. Try to reload mobile app

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
