### PR TITLE
feat(mobile): YAZIO provider support for mobile app

### DIFF
--- a/SparkyFitnessMobile/__tests__/hooks/useExternalFoodSearch.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useExternalFoodSearch.test.ts
@@ -312,6 +312,36 @@ describe('useExternalFoodSearch', () => {
     });
   });
 
+  test('fetches for yazio provider type with providerId', async () => {
+    mockSearchExternalFoods.mockResolvedValue(
+      makePaginatedResult([
+        {
+          id: 'yazio-1',
+          name: 'Protein Yogurt',
+          brand: 'Yazio Brand',
+          calories: 92,
+          protein: 10,
+          carbs: 8,
+          fat: 2,
+          serving_size: 100,
+          serving_unit: 'g',
+          source: 'yazio',
+        },
+      ]),
+    );
+
+    const { result } = renderHook(
+      () => useExternalFoodSearch('yogurt', 'yazio', { providerId: 'provider-yazio' }),
+      { wrapper: createQueryWrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(mockSearchExternalFoods).toHaveBeenCalledWith('yazio', 'yogurt', 1, 'provider-yazio', undefined);
+      expect(result.current.searchResults).toHaveLength(1);
+      expect(result.current.searchResults[0].source).toBe('yazio');
+    });
+  });
+
   test('fatsecret returns empty when no providerId', async () => {
     const { result } = renderHook(
       () => useExternalFoodSearch('chicken', 'fatsecret'),
@@ -328,6 +358,19 @@ describe('useExternalFoodSearch', () => {
   test('mealie returns empty when no providerId', async () => {
     const { result } = renderHook(
       () => useExternalFoodSearch('chicken', 'mealie'),
+      { wrapper: createQueryWrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.searchResults).toEqual([]);
+    });
+
+    expect(mockSearchExternalFoods).not.toHaveBeenCalled();
+  });
+
+  test('yazio returns empty when no providerId', async () => {
+    const { result } = renderHook(
+      () => useExternalFoodSearch('yogurt', 'yazio'),
       { wrapper: createQueryWrapper(queryClient) },
     );
 
@@ -372,6 +415,15 @@ describe('useExternalFoodSearch', () => {
   test('reports mealie as a supported provider', () => {
     const { result } = renderHook(
       () => useExternalFoodSearch('chicken', 'mealie'),
+      { wrapper: createQueryWrapper(queryClient) },
+    );
+
+    expect(result.current.isProviderSupported).toBe(true);
+  });
+
+  test('reports yazio as a supported provider', () => {
+    const { result } = renderHook(
+      () => useExternalFoodSearch('yogurt', 'yazio'),
       { wrapper: createQueryWrapper(queryClient) },
     );
 

--- a/SparkyFitnessMobile/__tests__/hooks/useExternalProviders.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useExternalProviders.test.ts
@@ -105,6 +105,28 @@ describe('useExternalProviders', () => {
 
       expect(result.current.providers).toHaveLength(foodTypes.length);
     });
+
+    test('keeps active yazio providers in the food provider list', async () => {
+      mockFetchExternalProviders.mockResolvedValue([
+        makeProvider({ id: '1', provider_name: 'Yazio', provider_type: 'yazio' }),
+      ]);
+
+      const { result } = renderHook(() => useExternalProviders(), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.providers).toEqual([
+        expect.objectContaining({
+          id: '1',
+          provider_name: 'Yazio',
+          provider_type: 'yazio',
+        }),
+      ]);
+    });
   });
 
   describe('query behavior', () => {

--- a/SparkyFitnessMobile/__tests__/screens/FoodScanScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodScanScreen.test.tsx
@@ -241,6 +241,38 @@ describe('FoodScanScreen', () => {
     expect(mockFireSuccessHaptic).not.toHaveBeenCalled();
   });
 
+  it('passes the route barcodeProviderId to scanned barcode lookups', async () => {
+    mockLookupBarcodeV2.mockResolvedValue(existingFoodResult);
+    const screen = renderScreenWithRoute({ barcodeProviderId: 'provider-1' });
+
+    fireEvent(screen.getByTestId('camera-view'), 'onBarcodeScanned', {
+      data: '012345678905',
+    });
+
+    await waitFor(() => {
+      expect(mockLookupBarcodeV2).toHaveBeenCalledWith(
+        '012345678905',
+        'provider-1',
+      );
+    });
+  });
+
+  it('passes the route barcodeProviderId to manual barcode lookups', async () => {
+    mockLookupBarcodeV2.mockResolvedValue(existingFoodResult);
+    const screen = renderScreenWithRoute({ barcodeProviderId: 'provider-1' });
+
+    fireEvent.press(screen.getByText('Type Barcode Instead'));
+    fireEvent.changeText(screen.getByPlaceholderText('Barcode number'), '012345678905');
+    fireEvent.press(screen.getByText('Look Up'));
+
+    await waitFor(() => {
+      expect(mockLookupBarcodeV2).toHaveBeenCalledWith(
+        '012345678905',
+        'provider-1',
+      );
+    });
+  });
+
   describe('Photo segment gating', () => {
     it('shows the setup gate when AI is unconfigured (after switching to Photo)', async () => {
       mockUseActiveAiServiceSetting.mockReturnValue({

--- a/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
@@ -177,6 +177,45 @@ describe('FoodSearchScreen', () => {
     );
   });
 
+  it('passes the selected online provider to FoodScan barcode lookups', async () => {
+    mockUsePreferences.mockReturnValue({
+      preferences: { default_food_data_provider_id: 'yazio-provider' },
+    } as any);
+    mockUseExternalProviders.mockReturnValue({
+      providers: [
+        { id: 'off-provider', provider_type: 'openfoodfacts', provider_name: 'OpenFoodFacts' },
+        { id: 'yazio-provider', provider_type: 'yazio', provider_name: 'YAZIO' },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    } as any);
+    const dateRoute = {
+      key: 'FoodSearch-key',
+      name: 'FoodSearch' as const,
+      params: { date: '2026-05-18' },
+    };
+    const screen = render(
+      <SafeAreaProvider initialMetrics={{ insets, frame }}>
+        <FoodSearchScreen navigation={navigation} route={dateRoute} />
+      </SafeAreaProvider>,
+    );
+
+    fireEvent.press(screen.getByText('Online'));
+    await waitFor(() => {
+      expect(screen.getByText('Search YAZIO for foods')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByLabelText('Scan Food'));
+
+    expect(navigation.navigate).toHaveBeenCalledWith('FoodScan', {
+      date: '2026-05-18',
+      pickerMode: undefined,
+      returnDepth: undefined,
+      barcodeProviderId: 'yazio-provider',
+    });
+  });
+
   describe('empty-results CTA', () => {
     beforeEach(() => {
       mockUseFoodSearch.mockReturnValue({
@@ -291,6 +330,125 @@ describe('FoodSearchScreen', () => {
       const screen = openOnlineTab();
 
       expect(screen.getByText('Failed to search FatSecret')).toBeTruthy();
+    });
+
+    it('renders Yazio as an online provider and searches with its provider id', async () => {
+      mockUseExternalProviders.mockReturnValue({
+        providers: [
+          { id: 'p-mealie', provider_type: 'mealie', provider_name: 'Mealie' },
+          { id: 'p-off', provider_type: 'openfoodfacts', provider_name: 'Open Food Facts' },
+          { id: 'p-yazio', provider_type: 'yazio', provider_name: 'Yazio' },
+        ],
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn(),
+      } as any);
+
+      const screen = render(
+        <SafeAreaProvider initialMetrics={{ insets, frame }}>
+          <FoodSearchScreen navigation={navigation} route={route} />
+        </SafeAreaProvider>,
+      );
+
+      fireEvent.press(screen.getByText('Online'));
+      expect(screen.getByText('Yazio')).toBeTruthy();
+
+      fireEvent.press(screen.getByText('Yazio'));
+
+      await waitFor(() => {
+        expect(mockUseExternalFoodSearch).toHaveBeenCalledWith(
+          '',
+          'yazio',
+          expect.objectContaining({
+            enabled: true,
+            providerId: 'p-yazio',
+          }),
+        );
+      });
+    });
+
+    it('fetches full Yazio details before opening the selected food', async () => {
+      const yazioItem = {
+        id: 'yz-1',
+        name: 'Protein Yogurt',
+        brand: 'Yazio Brand',
+        source: 'yazio',
+        serving_size: 100,
+        serving_unit: 'g',
+        calories: 92,
+        protein: 10,
+        carbs: 8,
+        fat: 2,
+      } as any;
+      mockUseExternalProviders.mockReturnValue({
+        providers: [{ id: 'p-yazio', provider_type: 'yazio', provider_name: 'Yazio' }],
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn(),
+      } as any);
+      mockUseExternalFoodSearch.mockReturnValue({
+        searchResults: [yazioItem],
+        isSearching: false,
+        isSearchActive: true,
+        isSearchError: false,
+        searchErrorMessage: null,
+        isProviderSupported: true,
+        fetchNextPage: jest.fn(),
+        hasNextPage: false,
+        isFetchingNextPage: false,
+        isFetchNextPageError: false,
+      } as any);
+      mockFetchExternalFoodDetails.mockResolvedValue({
+        ...yazioItem,
+        calories: 95,
+        variants: [
+          {
+            serving_size: 100,
+            serving_unit: 'g',
+            serving_description: '100 g',
+            calories: 95,
+            protein: 11,
+            carbs: 8,
+            fat: 2,
+          },
+        ],
+      });
+
+      const screen = render(
+        <SafeAreaProvider initialMetrics={{ insets, frame }}>
+          <FoodSearchScreen navigation={navigation} route={route} />
+        </SafeAreaProvider>,
+      );
+
+      fireEvent.press(screen.getByText('Online'));
+
+      await waitFor(() => {
+        expect(mockUseExternalFoodSearch).toHaveBeenCalledWith(
+          '',
+          'yazio',
+          expect.objectContaining({ providerId: 'p-yazio' }),
+        );
+      });
+
+      fireEvent.press(screen.getByText('Protein Yogurt'));
+
+      await waitFor(() => {
+        expect(mockFetchExternalFoodDetails).toHaveBeenCalledWith(
+          'yazio',
+          'yz-1',
+          'p-yazio',
+        );
+      });
+      expect(navigation.navigate).toHaveBeenCalledWith(
+        'FoodEntryAdd',
+        expect.objectContaining({
+          item: expect.objectContaining({
+            id: 'yz-1',
+            source: 'external',
+            calories: 95,
+          }),
+        }),
+      );
     });
 
     it('toasts the error but still opens partial info when a detail fetch fails', async () => {

--- a/SparkyFitnessMobile/__tests__/services/externalFoodSearchApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/externalFoodSearchApi.test.ts
@@ -1785,6 +1785,21 @@ describe('externalFoodSearchApi', () => {
         );
       });
 
+      test('includes providerId in query params when provided', async () => {
+        mockGetActiveServerConfig.mockResolvedValue(testConfig);
+        mockFetch.mockResolvedValue({
+          ok: true,
+          json: () => Promise.resolve({ source: 'not_found', food: null }),
+        });
+
+        await lookupBarcodeV2('123', 'provider-1');
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.stringContaining('/api/v2/foods/barcode/123?providerId=provider-1'),
+          expect.anything(),
+        );
+      });
+
       test('returns not_found when food is null', async () => {
         mockGetActiveServerConfig.mockResolvedValue(testConfig);
         mockFetch.mockResolvedValue({

--- a/SparkyFitnessMobile/src/hooks/useExternalFoodSearch.ts
+++ b/SparkyFitnessMobile/src/hooks/useExternalFoodSearch.ts
@@ -2,11 +2,10 @@ import { useMemo } from 'react';
 import { useInfiniteQuery, keepPreviousData } from '@tanstack/react-query';
 import { searchExternalFoods } from '../services/api/externalFoodSearchApi';
 import { getApiErrorMessage } from '../services/api/errors';
+import { FOOD_PROVIDER_TYPES } from '../types/externalProviders';
 import { externalFoodSearchQueryKey } from './queryKeys';
 import { useDebounce } from './useDebounce';
 import { RateLimiter } from '../utils/rateLimiter';
-
-const SUPPORTED_PROVIDERS = new Set(['openfoodfacts', 'usda', 'fatsecret', 'mealie', 'tandoor']);
 
 // Open Food Facts allows 10 req/min; use 8 for headroom
 const offRateLimiter = new RateLimiter(8, 60_000);
@@ -19,7 +18,7 @@ export function useExternalFoodSearch(
   const { enabled = true, providerId, autoScale } = options ?? {};
   const debouncedSearch = useDebounce(searchText.trim(), 600);
   const isSearchActive = debouncedSearch.length >= 3;
-  const isProviderSupported = SUPPORTED_PROVIDERS.has(providerType);
+  const isProviderSupported = FOOD_PROVIDER_TYPES.has(providerType);
 
   const query = useInfiniteQuery({
     queryKey: externalFoodSearchQueryKey(providerType, debouncedSearch, providerId, autoScale),

--- a/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
@@ -98,6 +98,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
   const date = lookupParams?.date;
   const pickerMode = lookupParams?.pickerMode ?? 'log-entry';
   const returnDepth = lookupParams?.returnDepth;
+  const barcodeProviderId = lookupParams?.barcodeProviderId;
   const isMealBuilderMode = pickerMode === 'meal-builder';
 
   // Photo estimation always logs to the diary; hide it for meal-builder
@@ -141,7 +142,7 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
     setNotFoundBarcode(null);
     setLookupError(null);
     try {
-      const result = await lookupBarcodeV2(barcode);
+      const result = await lookupBarcodeV2(barcode, barcodeProviderId);
 
       if (!result.food) {
         setNotFoundBarcode(barcode);

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -192,10 +192,13 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   };
 
   const openFoodScan = () => {
+    const barcodeProviderId =
+      activeTab === 'online' && selectedProvider ? selectedProvider : undefined;
     navigation.navigate('FoodScan', {
       date,
       pickerMode: isMealBuilderMode ? 'meal-builder' : undefined,
       returnDepth: isMealBuilderMode ? 2 : undefined,
+      barcodeProviderId,
     });
   };
 
@@ -209,10 +212,17 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   };
 
   const handleExternalFoodTap = async (item: ExternalFoodItem) => {
-    if (item.source === 'fatsecret' && selectedProvider) {
+    if (
+      (item.source === 'fatsecret' || item.source === 'yazio') &&
+      selectedProvider
+    ) {
       setLoadingFoodId(item.id);
       try {
-        const detailed = await fetchExternalFoodDetails('fatsecret', item.id, selectedProvider);
+        const detailed = await fetchExternalFoodDetails(
+          item.source,
+          item.id,
+          selectedProvider,
+        );
         showFoodInfo(externalFoodItemToFoodInfo(detailed));
       } catch (error) {
         const message = getApiErrorMessage(error) ?? "Couldn't load full nutrition details.";
@@ -651,7 +661,15 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     >
       <View className="flex-row justify-between items-center">
         <View className="flex-1 mr-3">
-          <Text className="text-text-primary text-base font-medium">{item.name}</Text>
+          <View className="flex-row items-center flex-wrap gap-x-2">
+            <Text className="text-text-primary text-base font-medium">{item.name}</Text>
+            {item.provider_verified ? (
+              <View className="flex-row items-center rounded px-1.5 py-0.5 bg-green-50">
+                <Icon name="shield-checkmark" size={12} color="#047857" />
+                <Text className="text-[11px] font-semibold text-green-700 ml-1">Verified</Text>
+              </View>
+            ) : null}
+          </View>
           {item.brand ? (
             <Text className="text-text-secondary text-sm mt-0.5">{item.brand}</Text>
           ) : null}

--- a/SparkyFitnessMobile/src/services/api/externalFoodSearchApi.ts
+++ b/SparkyFitnessMobile/src/services/api/externalFoodSearchApi.ts
@@ -6,7 +6,12 @@ import type {
 import { addLog } from '../LogService';
 import { getActiveServerConfig, proxyHeadersToRecord } from '../storage';
 import { getAuthHeaders, notifySessionExpired } from './authService';
-import type { ExternalFoodItem, ExternalFoodVariant, ExternalFoodSearchPagination, PaginatedExternalFoodSearchResult } from '../../types/externalFoods';
+import type {
+  ExternalFoodItem,
+  ExternalFoodVariant,
+  ExternalFoodSearchPagination,
+  PaginatedExternalFoodSearchResult,
+} from '../../types/externalFoods';
 
 interface OpenFoodFactsProduct {
   product_name: string;
@@ -30,7 +35,9 @@ interface OpenFoodFactsResponse {
   pagination: ExternalFoodSearchPagination;
 }
 
-export function transformOpenFoodFactsProduct(product: OpenFoodFactsProduct): ExternalFoodItem {
+export function transformOpenFoodFactsProduct(
+  product: OpenFoodFactsProduct,
+): ExternalFoodItem {
   const n = product.nutriments;
   return {
     id: product.code,
@@ -85,7 +92,9 @@ export type BarcodeLookupResult =
   | { source: string; food: BarcodeFood }
   | { source: 'not_found'; food: null };
 
-export async function lookupBarcode(barcode: string): Promise<BarcodeLookupResult> {
+export async function lookupBarcode(
+  barcode: string,
+): Promise<BarcodeLookupResult> {
   return apiFetch<BarcodeLookupResult>({
     endpoint: `/api/foods/barcode/${barcode}`,
     serviceName: 'External Food Search',
@@ -93,7 +102,10 @@ export async function lookupBarcode(barcode: string): Promise<BarcodeLookupResul
   });
 }
 
-export async function searchOpenFoodFacts(query: string, page = 1): Promise<PaginatedExternalFoodSearchResult> {
+export async function searchOpenFoodFacts(
+  query: string,
+  page = 1,
+): Promise<PaginatedExternalFoodSearchResult> {
   const params = new URLSearchParams({ query, page: String(page) });
   const response = await apiFetch<OpenFoodFactsResponse>({
     endpoint: `/api/foods/openfoodfacts/search?${params.toString()}`,
@@ -103,7 +115,7 @@ export async function searchOpenFoodFacts(query: string, page = 1): Promise<Pagi
 
   return {
     items: response.products
-      .filter((p) => p.product_name)
+      .filter(p => p.product_name)
       .map(transformOpenFoodFactsProduct),
     pagination: response.pagination,
   };
@@ -143,8 +155,11 @@ const USDA_NUTRIENT_IDS = {
   SATURATED_FAT: 1258,
 } as const;
 
-function getUsdaNutrientValue(nutrients: UsdaFoodNutrient[], nutrientId: number): number {
-  return nutrients.find((n) => n.nutrientId === nutrientId)?.value ?? 0;
+function getUsdaNutrientValue(
+  nutrients: UsdaFoodNutrient[],
+  nutrientId: number,
+): number {
+  return nutrients.find(n => n.nutrientId === nutrientId)?.value ?? 0;
 }
 
 /** Title-case a string only if it looks like ALL CAPS (e.g. USDA data). */
@@ -152,10 +167,12 @@ function autoTitleCase(text: string): string {
   if (text !== text.toUpperCase()) return text;
   return text
     .toLowerCase()
-    .replace(/(?:^|\s|[-/(])\S/g, (ch) => ch.toUpperCase());
+    .replace(/(?:^|\s|[-/(])\S/g, ch => ch.toUpperCase());
 }
 
-export function transformUsdaFoodItem(item: UsdaFoodSearchItem): ExternalFoodItem {
+export function transformUsdaFoodItem(
+  item: UsdaFoodSearchItem,
+): ExternalFoodItem {
   const n = item.foodNutrients;
   return {
     id: String(item.fdcId),
@@ -165,7 +182,9 @@ export function transformUsdaFoodItem(item: UsdaFoodSearchItem): ExternalFoodIte
     protein: Math.round(getUsdaNutrientValue(n, USDA_NUTRIENT_IDS.PROTEIN)),
     carbs: Math.round(getUsdaNutrientValue(n, USDA_NUTRIENT_IDS.CARBS)),
     fat: Math.round(getUsdaNutrientValue(n, USDA_NUTRIENT_IDS.FAT)),
-    saturated_fat: Math.round(getUsdaNutrientValue(n, USDA_NUTRIENT_IDS.SATURATED_FAT)),
+    saturated_fat: Math.round(
+      getUsdaNutrientValue(n, USDA_NUTRIENT_IDS.SATURATED_FAT),
+    ),
     sodium: Math.round(getUsdaNutrientValue(n, USDA_NUTRIENT_IDS.SODIUM)),
     fiber: Math.round(getUsdaNutrientValue(n, USDA_NUTRIENT_IDS.FIBER)),
     sugars: Math.round(getUsdaNutrientValue(n, USDA_NUTRIENT_IDS.SUGARS)),
@@ -175,7 +194,11 @@ export function transformUsdaFoodItem(item: UsdaFoodSearchItem): ExternalFoodIte
   };
 }
 
-export async function searchUsda(query: string, providerId: string, page = 1): Promise<PaginatedExternalFoodSearchResult> {
+export async function searchUsda(
+  query: string,
+  providerId: string,
+  page = 1,
+): Promise<PaginatedExternalFoodSearchResult> {
   const params = new URLSearchParams({ query, page: String(page) });
   const response = await apiFetch<UsdaFoodSearchResponse>({
     endpoint: `/api/foods/usda/search?${params.toString()}`,
@@ -186,7 +209,7 @@ export async function searchUsda(query: string, providerId: string, page = 1): P
 
   return {
     items: response.foods
-      .filter((item) => item.description)
+      .filter(item => item.description)
       .map(transformUsdaFoodItem),
     pagination: response.pagination,
   };
@@ -253,7 +276,9 @@ export function parseFatSecretDescription(description: string): {
   };
 }
 
-export function transformFatSecretSearchItem(item: FatSecretSearchFood): ExternalFoodItem {
+export function transformFatSecretSearchItem(
+  item: FatSecretSearchFood,
+): ExternalFoodItem {
   const parsed = parseFatSecretDescription(item.food_description);
   return {
     id: item.food_id,
@@ -269,14 +294,20 @@ export function transformFatSecretSearchItem(item: FatSecretSearchFood): Externa
   };
 }
 
-export function selectFatSecretServing(servings: FatSecretServing[]): FatSecretServing {
-  const preferred = servings.find((s) =>
+export function selectFatSecretServing(
+  servings: FatSecretServing[],
+): FatSecretServing {
+  const preferred = servings.find(s =>
     s.measurement_description.toLowerCase().includes('serving'),
   );
   return preferred ?? servings[0];
 }
 
-export async function searchFatSecret(query: string, providerId: string, page = 1): Promise<PaginatedExternalFoodSearchResult> {
+export async function searchFatSecret(
+  query: string,
+  providerId: string,
+  page = 1,
+): Promise<PaginatedExternalFoodSearchResult> {
   const params = new URLSearchParams({ query, page: String(page) });
   const response = await apiFetch<FatSecretSearchResponse>({
     endpoint: `/api/foods/fatsecret/search?${params.toString()}`,
@@ -286,11 +317,12 @@ export async function searchFatSecret(query: string, providerId: string, page = 
   });
 
   const rawFood = response.foods?.food;
-  const foods = rawFood == null ? [] : Array.isArray(rawFood) ? rawFood : [rawFood];
+  const foods =
+    rawFood == null ? [] : Array.isArray(rawFood) ? rawFood : [rawFood];
 
   return {
     items: foods
-      .filter((item) => item.food_name)
+      .filter(item => item.food_name)
       .map(transformFatSecretSearchItem),
     pagination: response.pagination,
   };
@@ -300,7 +332,9 @@ export function hasMetricServing(serving: FatSecretServing): boolean {
   return !!(serving.metric_serving_amount && serving.metric_serving_unit);
 }
 
-export function transformFatSecretServing(serving: FatSecretServing): ExternalFoodVariant {
+export function transformFatSecretServing(
+  serving: FatSecretServing,
+): ExternalFoodVariant {
   return {
     serving_size: Math.round(parseFloat(serving.metric_serving_amount!)),
     serving_unit: serving.metric_serving_unit!,
@@ -316,7 +350,10 @@ export function transformFatSecretServing(serving: FatSecretServing): ExternalFo
   };
 }
 
-export async function fetchFatSecretNutrients(foodId: string, providerId: string): Promise<ExternalFoodItem> {
+export async function fetchFatSecretNutrients(
+  foodId: string,
+  providerId: string,
+): Promise<ExternalFoodItem> {
   const params = new URLSearchParams({ foodId });
   const response = await apiFetch<FatSecretNutrientsResponse>({
     endpoint: `/api/foods/fatsecret/nutrients?${params.toString()}`,
@@ -332,24 +369,27 @@ export async function fetchFatSecretNutrients(foodId: string, providerId: string
   const preferred = selectFatSecretServing(servings);
 
   // Order variants with preferred serving first, skip non-metric servings
-  const orderedServings = [preferred, ...servings.filter((s) => s !== preferred)];
-  const variants = orderedServings.filter(hasMetricServing).map(transformFatSecretServing);
+  const orderedServings = [preferred, ...servings.filter(s => s !== preferred)];
+  const variants = orderedServings
+    .filter(hasMetricServing)
+    .map(transformFatSecretServing);
 
   // Primary fields from first variant, or fall back to preferred serving raw values
-  const primary = variants.length > 0
-    ? variants[0]
-    : {
-        serving_size: 1,
-        serving_unit: 'serving',
-        calories: Math.round(parseFloat(preferred.calories)),
-        protein: Math.round(parseFloat(preferred.protein)),
-        carbs: Math.round(parseFloat(preferred.carbohydrate)),
-        fat: Math.round(parseFloat(preferred.fat)),
-        saturated_fat: Math.round(parseFloat(preferred.saturated_fat ?? '0')),
-        sodium: Math.round(parseFloat(preferred.sodium ?? '0')),
-        fiber: Math.round(parseFloat(preferred.fiber ?? '0')),
-        sugars: Math.round(parseFloat(preferred.sugar ?? '0')),
-      };
+  const primary =
+    variants.length > 0
+      ? variants[0]
+      : {
+          serving_size: 1,
+          serving_unit: 'serving',
+          calories: Math.round(parseFloat(preferred.calories)),
+          protein: Math.round(parseFloat(preferred.protein)),
+          carbs: Math.round(parseFloat(preferred.carbohydrate)),
+          fat: Math.round(parseFloat(preferred.fat)),
+          saturated_fat: Math.round(parseFloat(preferred.saturated_fat ?? '0')),
+          sodium: Math.round(parseFloat(preferred.sodium ?? '0')),
+          fiber: Math.round(parseFloat(preferred.fiber ?? '0')),
+          sugars: Math.round(parseFloat(preferred.sugar ?? '0')),
+        };
 
   return {
     id: response.food.food_id,
@@ -405,7 +445,8 @@ export function transformMealieItem(item: MealieSearchItem): ExternalFoodItem {
     protein: Math.round(v.protein),
     carbs: Math.round(v.carbs),
     fat: Math.round(v.fat),
-    saturated_fat: v.saturated_fat != null ? Math.round(v.saturated_fat) : undefined,
+    saturated_fat:
+      v.saturated_fat != null ? Math.round(v.saturated_fat) : undefined,
     sodium: v.sodium != null ? Math.round(v.sodium) : undefined,
     fiber: v.dietary_fiber != null ? Math.round(v.dietary_fiber) : undefined,
     sugars: v.sugars != null ? Math.round(v.sugars) : undefined,
@@ -415,7 +456,11 @@ export function transformMealieItem(item: MealieSearchItem): ExternalFoodItem {
   };
 }
 
-export async function searchMealie(query: string, providerId: string, page = 1): Promise<PaginatedExternalFoodSearchResult> {
+export async function searchMealie(
+  query: string,
+  providerId: string,
+  page = 1,
+): Promise<PaginatedExternalFoodSearchResult> {
   const params = new URLSearchParams({ query, page: String(page) });
   const response = await apiFetch<MealieSearchResponse>({
     endpoint: `/api/foods/mealie/search?${params.toString()}`,
@@ -425,9 +470,7 @@ export async function searchMealie(query: string, providerId: string, page = 1):
   });
 
   return {
-    items: response.items
-      .filter((item) => item.name)
-      .map(transformMealieItem),
+    items: response.items.filter(item => item.name).map(transformMealieItem),
     pagination: response.pagination,
   };
 }
@@ -438,6 +481,9 @@ interface NormalizedFoodVariant {
   id?: string;
   serving_size: number;
   serving_unit: string;
+  serving_description?: string;
+  serving_weight?: number;
+  serving_weight_unit?: string;
   calories: number;
   protein: number;
   carbs: number;
@@ -467,39 +513,62 @@ interface NormalizedFood {
   barcode?: string;
   provider_external_id?: string;
   provider_type?: string;
+  provider_verified?: boolean;
   is_custom: boolean;
   default_variant: NormalizedFoodVariant;
   variants?: NormalizedFoodVariant[];
 }
 
-export function transformNormalizedFood(food: NormalizedFood, providerType: string): ExternalFoodItem {
+export function transformNormalizedFood(
+  food: NormalizedFood,
+  providerType: string,
+): ExternalFoodItem {
   const dv = food.default_variant;
 
-  const mapVariant = (v: NormalizedFoodVariant): ExternalFoodVariant => ({
-    serving_size: v.serving_size,
-    serving_unit: v.serving_unit,
-    serving_description: `${v.serving_size} ${v.serving_unit}`,
-    calories: v.calories,
-    protein: v.protein,
-    carbs: v.carbs,
-    fat: v.fat,
-    saturated_fat: v.saturated_fat,
-    sodium: v.sodium,
-    fiber: v.dietary_fiber,
-    sugars: v.sugars,
-    trans_fat: v.trans_fat,
-    cholesterol: v.cholesterol,
-    potassium: v.potassium,
-    calcium: v.calcium,
-    iron: v.iron,
-    vitamin_a: v.vitamin_a,
-    vitamin_c: v.vitamin_c,
-  });
+  const mapVariant = (v: NormalizedFoodVariant): ExternalFoodVariant => {
+    const mapped: ExternalFoodVariant = {
+      serving_size: v.serving_size,
+      serving_unit: v.serving_unit,
+      serving_description:
+        v.serving_description ?? `${v.serving_size} ${v.serving_unit}`,
+      calories: v.calories,
+      protein: v.protein,
+      carbs: v.carbs,
+      fat: v.fat,
+      saturated_fat: v.saturated_fat,
+      sodium: v.sodium,
+      fiber: v.dietary_fiber,
+      sugars: v.sugars,
+      trans_fat: v.trans_fat,
+      cholesterol: v.cholesterol,
+      potassium: v.potassium,
+      calcium: v.calcium,
+      iron: v.iron,
+      vitamin_a: v.vitamin_a,
+      vitamin_c: v.vitamin_c,
+    };
+
+    if (v.serving_weight !== undefined) {
+      mapped.serving_weight = v.serving_weight;
+    }
+    if (v.serving_weight_unit !== undefined) {
+      mapped.serving_weight_unit = v.serving_weight_unit;
+    }
+
+    return mapped;
+  };
 
   // FoodEntryAddScreen selects ext-0 (first variant) by default, so the
   // default variant must come first to keep search/add calories consistent.
+  const isSameVariant = (a: NormalizedFoodVariant, b: NormalizedFoodVariant) =>
+    a.serving_size === b.serving_size &&
+    a.serving_unit === b.serving_unit &&
+    a.calories === b.calories &&
+    a.protein === b.protein &&
+    a.carbs === b.carbs &&
+    a.fat === b.fat;
   const defaultFirst = food.variants
-    ? [dv, ...food.variants.filter((v) => v !== dv)]
+    ? [dv, ...food.variants.filter(v => !isSameVariant(v, dv))]
     : undefined;
   const variants = defaultFirst?.map(mapVariant);
 
@@ -509,6 +578,7 @@ export function transformNormalizedFood(food: NormalizedFood, providerType: stri
     brand: food.brand,
     ...mapVariant(dv),
     source: food.provider_type ?? providerType,
+    provider_verified: food.provider_verified,
     variants: variants && variants.length > 0 ? variants : undefined,
   };
 }
@@ -536,7 +606,7 @@ export async function searchExternalFoods(
   });
 
   return {
-    items: response.foods.map((f) => transformNormalizedFood(f, providerType)),
+    items: response.foods.map(f => transformNormalizedFood(f, providerType)),
     pagination: response.pagination,
   };
 }
@@ -564,9 +634,16 @@ interface V2BarcodeResponse {
   food: NormalizedFood | null;
 }
 
-export async function lookupBarcodeV2(barcode: string): Promise<BarcodeLookupResult> {
+export async function lookupBarcodeV2(
+  barcode: string,
+  providerId?: string,
+): Promise<BarcodeLookupResult> {
+  const params = new URLSearchParams();
+  if (providerId) params.set('providerId', providerId);
+  const qs = params.toString();
+
   const response = await apiFetch<V2BarcodeResponse>({
-    endpoint: `/api/v2/foods/barcode/${barcode}`,
+    endpoint: `/api/v2/foods/barcode/${barcode}${qs ? `?${qs}` : ''}`,
     serviceName: 'External Food Search',
     operation: 'barcode lookup (v2)',
   });
@@ -588,7 +665,10 @@ export async function lookupBarcodeV2(barcode: string): Promise<BarcodeLookupRes
   };
 
   if (response.source === 'local') {
-    return { source: 'local', food: barcodeFood as BarcodeFood & { id: string } };
+    return {
+      source: 'local',
+      food: barcodeFood as BarcodeFood & { id: string },
+    };
   }
   return { source: response.source, food: barcodeFood };
 }
@@ -617,7 +697,10 @@ export interface LabelScanResult {
   vitamin_c: number | null;
 }
 
-export async function scanNutritionLabel(base64Image: string, mimeType: string): Promise<LabelScanResult> {
+export async function scanNutritionLabel(
+  base64Image: string,
+  mimeType: string,
+): Promise<LabelScanResult> {
   return apiFetch<LabelScanResult>({
     endpoint: '/api/foods/scan-label',
     serviceName: 'Label Scan',
@@ -653,7 +736,10 @@ export async function estimateFoodPhoto(
 ): Promise<FoodPhotoEstimateResponse> {
   const config = await getActiveServerConfig();
   if (!config) {
-    throw new FoodPhotoEstimateError('UPSTREAM_ERROR', 'Server configuration not found.');
+    throw new FoodPhotoEstimateError(
+      'UPSTREAM_ERROR',
+      'Server configuration not found.',
+    );
   }
 
   const baseUrl = normalizeUrl(config.url);
@@ -714,6 +800,9 @@ export async function estimateFoodPhoto(
   } catch {
     // Non-JSON error body — fall through with UPSTREAM_ERROR + raw text.
   }
-  addLog(`[Food Photo Estimate] Failed (${response.status} / ${code}): ${message}`, 'ERROR');
+  addLog(
+    `[Food Photo Estimate] Failed (${response.status} / ${code}): ${message}`,
+    'ERROR',
+  );
   throw new FoodPhotoEstimateError(code, message);
 }

--- a/SparkyFitnessMobile/src/types/externalFoods.ts
+++ b/SparkyFitnessMobile/src/types/externalFoods.ts
@@ -2,6 +2,8 @@ export interface ExternalFoodVariant {
   serving_size: number;
   serving_unit: string;
   serving_description: string;
+  serving_weight?: number;
+  serving_weight_unit?: string;
   calories: number;
   protein: number;
   carbs: number;
@@ -53,5 +55,6 @@ export interface ExternalFoodItem {
   serving_size: number;
   serving_unit: string;
   source: string;
+  provider_verified?: boolean;
   variants?: ExternalFoodVariant[];
 }

--- a/SparkyFitnessMobile/src/types/externalProviders.ts
+++ b/SparkyFitnessMobile/src/types/externalProviders.ts
@@ -3,17 +3,26 @@ export interface ExternalProvider {
   provider_name: string;
   provider_type: string;
   is_active: boolean;
+  availability_error?: string;
 }
 
 // Allowlist of provider_type values relevant to food search
 export const FOOD_PROVIDER_TYPES = new Set([
-  'openfoodfacts', 'fatsecret', 'usda', 'mealie', 'tandoor',
+  'openfoodfacts',
+  'fatsecret',
+  'usda',
+  'mealie',
+  'tandoor',
+  'yazio',
 ]);
 
 // Allowlist of provider_type values that support barcode lookup
-export const BARCODE_PROVIDER_TYPES = new Set(['usda', 'openfoodfacts', 'fatsecret']);
+export const BARCODE_PROVIDER_TYPES = new Set([
+  'usda',
+  'openfoodfacts',
+  'fatsecret',
+  'yazio',
+]);
 
 // Allowlist of provider_type values relevant to exercise search
-export const EXERCISE_PROVIDER_TYPES = new Set([
-  'wger', 'free-exercise-db',
-]);
+export const EXERCISE_PROVIDER_TYPES = new Set(['wger', 'free-exercise-db']);

--- a/SparkyFitnessMobile/src/types/navigation.ts
+++ b/SparkyFitnessMobile/src/types/navigation.ts
@@ -113,6 +113,7 @@ export type RootStackParamList = {
         pickerMode?: FoodPickerMode;
         returnDepth?: number;
         initialMode?: 'barcode' | 'label' | 'photo';
+        barcodeProviderId?: string;
       }
     | {
         mode: 'capture-barcode';


### PR DESCRIPTION
## Description

**What problem does this Solve?**
Adds YAZIO provider support to the mobile app (React Native/Expo) so users can search and scan YAZIO foods on iOS and Android.

**How did you implement the solution?**
- Added YAZIO to mobile provider types and navigation types
- Extended `useExternalFoodSearch` hook to handle YAZIO provider
- Updated `FoodSearchScreen` and `FoodScanScreen` to show YAZIO provider chip
- Added `externalFoodSearchApi` service for YAZIO API calls
- Added targeted tests for hooks, screens, and API service

Linked Issue: Closes #1442 (mobile part)

## How to Test

1. Run mobile tests:
   ```bash
   cd SparkyFitnessMobile
   pnpm run test:run -- --watchman=false --runInBand __tests__/hooks/useExternalFoodSearch.test.ts __tests__/hooks/useExternalProviders.test.ts __tests__/screens/FoodSearchScreen.test.tsx __tests__/screens/FoodScanScreen.test.tsx __tests__/services/externalFoodSearchApi.test.ts
   ```
2. Configure an active YAZIO external food provider on the backend
3. Verify the Online food-search source chips show YAZIO alongside other active providers on mobile

## PR Type

- [x] New Feature

## Checklist

**All PRs:**
- [x] Integrity & License

**New features only:**
- [x] Alignment

**Mobile changes:**
- [x] Tested via automated screen/hook coverage

## Notes for Reviewers

- This is the mobile-only companion PR to #1442 (web+server)
- No platform-specific iOS/Android changes needed; uses shared provider type list
- Requires the backend changes from #1442 to be merged first
- Mobile app reads active providers from the existing provider API