### PR TITLE
fix: mobile banner and healthconnect source fixes

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/whatsNewBanner.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/whatsNewBanner.test.ts
@@ -1,14 +1,10 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
+  WHATS_NEW_CONTENT_VERSION,
   getLastSeenWhatsNewVersion,
   markCurrentVersionSeen,
   markWhatsNewVersionSeen,
 } from '../../src/services/whatsNewBanner';
-
-jest.mock('expo-constants', () => ({
-  __esModule: true,
-  default: { expoConfig: { version: '1.4.0' } },
-}));
 
 jest.mock('../../src/services/LogService', () => ({
   addLog: jest.fn(),
@@ -42,8 +38,10 @@ describe('whatsNewBanner', () => {
     ).resolves.toBe('1.4.0');
   });
 
-  test('markCurrentVersionSeen stamps the Expo config version', async () => {
+  test('markCurrentVersionSeen stamps the current content version', async () => {
     await markCurrentVersionSeen();
-    await expect(getLastSeenWhatsNewVersion()).resolves.toBe('1.4.0');
+    await expect(getLastSeenWhatsNewVersion()).resolves.toBe(
+      String(WHATS_NEW_CONTENT_VERSION),
+    );
   });
 });

--- a/SparkyFitnessMobile/src/components/WhatsNewBanner.tsx
+++ b/SparkyFitnessMobile/src/components/WhatsNewBanner.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
-import Constants from 'expo-constants';
 import { useCSSVariable } from 'uniwind';
 
 import Icon from './Icon';
 import { navigationRef } from './ActiveWorkoutBar';
 import { useActiveWorkoutStore } from '../stores/activeWorkoutStore';
 import {
+  WHATS_NEW_CONTENT_VERSION,
   getLastSeenWhatsNewVersion,
   markWhatsNewVersionSeen,
   subscribeToWhatsNewBannerReset,
@@ -24,7 +24,7 @@ const WhatsNewBanner: React.FC = () => {
   const workoutActive = useActiveWorkoutStore((s) => s.sessionId !== null);
   const [phase, setPhase] = useState<Phase>('evaluating');
   const [resetTick, setResetTick] = useState(0);
-  const currentVersion = Constants.expoConfig?.version ?? null;
+  const contentVersion = String(WHATS_NEW_CONTENT_VERSION);
 
   // Dev Tools can clear `lastSeenVersion` at runtime — bump the tick so the
   // evaluation effect below re-runs and the banner can re-appear without
@@ -40,16 +40,21 @@ const WhatsNewBanner: React.FC = () => {
   ]) as [string, string];
 
   useEffect(() => {
-    if (!currentVersion) {
-      setPhase('ineligible');
-      return;
-    }
     setPhase('evaluating');
     let cancelled = false;
     void (async () => {
       const lastSeen = await getLastSeenWhatsNewVersion();
       if (cancelled) return;
-      if (lastSeen === currentVersion) {
+      if (lastSeen === contentVersion) {
+        setPhase('ineligible');
+        return;
+      }
+      // Pre-marker builds stamped the app version here (e.g. "1.4.0"); markers
+      // are plain integers, so a "." means this user has already seen the
+      // current cards. Migrate their stamp (so future content bumps still reach
+      // them) and suppress this time.
+      if (lastSeen?.includes('.')) {
+        void markWhatsNewVersionSeen(contentVersion);
         setPhase('ineligible');
         return;
       }
@@ -62,7 +67,7 @@ const WhatsNewBanner: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [currentVersion, resetTick]);
+  }, [contentVersion, resetTick]);
 
   // Mark the version seen as soon as the banner actually renders — a banner
   // the user ignores still consumes the prompt, so we don't re-pester next
@@ -70,10 +75,10 @@ const WhatsNewBanner: React.FC = () => {
   // workout doesn't burn the prompt without ever displaying.
   const shouldRender = phase === 'eligible' && !workoutActive;
   useEffect(() => {
-    if (shouldRender && currentVersion) {
-      void markWhatsNewVersionSeen(currentVersion);
+    if (shouldRender) {
+      void markWhatsNewVersionSeen(contentVersion);
     }
-  }, [shouldRender, currentVersion]);
+  }, [shouldRender, contentVersion]);
 
   if (!shouldRender) return null;
 

--- a/SparkyFitnessMobile/src/screens/WhatsNewScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WhatsNewScreen.tsx
@@ -215,6 +215,8 @@ const WhatsNewScreen: React.FC<WhatsNewScreenProps> = ({ navigation }) => {
 
   const accentPrimary = useCSSVariable('--color-accent-primary') as string;
 
+  // Added or changed a card below? Bump WHATS_NEW_CONTENT_VERSION in
+  // services/whatsNewBanner.ts so the banner re-appears for existing users.
   const features: Feature[] = [
     {
       eyebrow: 'HOME SCREEN WIDGET',

--- a/SparkyFitnessMobile/src/services/whatsNewBanner.ts
+++ b/SparkyFitnessMobile/src/services/whatsNewBanner.ts
@@ -1,6 +1,10 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import Constants from 'expo-constants';
 import { addLog } from './LogService';
+
+// Bump this whenever you add or change the cards shown in WhatsNewScreen. The
+// banner is gated on this marker rather than the app version, so a release that
+// ships no new What's New content no longer re-triggers the banner.
+export const WHATS_NEW_CONTENT_VERSION = 1;
 
 const LAST_SEEN_VERSION_KEY = '@WhatsNew:lastSeenVersion';
 
@@ -29,14 +33,12 @@ export async function markWhatsNewVersionSeen(version: string): Promise<void> {
   }
 }
 
-// Stamps the current app version as already-seen. Called from the onboarding
-// completion paths so that fresh installs never see the banner — by contrast,
-// users upgrading from a pre-banner build never pass through onboarding, so
-// their `lastSeenVersion` stays null and the banner fires for them.
+// Stamps the current content version as already-seen. Called from the
+// onboarding completion paths so that fresh installs never see the banner — by
+// contrast, users upgrading from a pre-banner build never pass through
+// onboarding, so their stored value stays null and the banner fires for them.
 export async function markCurrentVersionSeen(): Promise<void> {
-  const version = Constants.expoConfig?.version;
-  if (!version) return;
-  await markWhatsNewVersionSeen(version);
+  await markWhatsNewVersionSeen(String(WHATS_NEW_CONTENT_VERSION));
 }
 
 // Dev-only: subscribers fire after `resetWhatsNewBanner` clears storage so the

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -14,9 +14,14 @@ async function upsertExerciseEntryData(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   caloriesBurned: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  date: any
+  date: any,
+  source = 'Health Data'
 ) {
   log('info', 'upsertExerciseEntryData received date parameter:', date);
+  // HealthKit is shown to users as "Apple Health"; other sources display as-is.
+  // Fall back to 'Health Data' for falsy sources (e.g. an explicit null bypasses the default param).
+  const sourceLabel =
+    (source === 'HealthKit' ? 'Apple Health' : source) || 'Health Data';
   const client = await getClient(userId);
   let existingEntry;
   let exerciseName = 'Unknown Exercise'; // Default value
@@ -69,7 +74,7 @@ async function upsertExerciseEntryData(
         'UPDATE exercise_entries SET calories_burned = $1, notes = $2, updated_by_user_id = $3, exercise_name = $4 WHERE id = $5 RETURNING *',
         [
           caloriesBurned,
-          'Active calories logged from Apple Health (updated).',
+          `Active calories logged from ${sourceLabel} (updated).`,
           createdByUserId,
           exerciseName,
           existingEntry.id,
@@ -102,7 +107,7 @@ async function upsertExerciseEntryData(
           date,
           caloriesBurned,
           0,
-          'Active calories logged from Apple Health.',
+          `Active calories logged from ${sourceLabel}.`,
           createdByUserId,
           exerciseName,
         ]

--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -516,7 +516,8 @@ async function processHealthData(
             actingUserId,
             exerciseId,
             activeCaloriesValue,
-            parsedDate
+            parsedDate,
+            exerciseSource
           );
           processedResults.push({ type, status: 'success', data: result });
           break;

--- a/SparkyFitnessServer/tests/exerciseEntryActiveCaloriesNotes.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntryActiveCaloriesNotes.test.ts
@@ -1,0 +1,142 @@
+import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import exerciseEntryDb from '../models/exerciseEntry.js';
+import { getClient } from '../db/poolManager.js';
+import exerciseRepository from '../models/exercise.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('../models/exercise', () => ({
+  default: {
+    getExerciseById: vi.fn(),
+  },
+}));
+
+vi.mock('../models/activityDetailsRepository', () => ({
+  default: {},
+}));
+
+// Reproduces the bug where active calories synced from Android Health Connect
+// were stamped with "Apple Health" in the entry notes regardless of platform.
+describe('upsertExerciseEntryData active-calories notes', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = { query: vi.fn(), release: vi.fn() };
+    // @ts-expect-error mock typing
+    getClient.mockResolvedValue(mockClient);
+    // @ts-expect-error mock typing
+    exerciseRepository.getExerciseById.mockResolvedValue({
+      name: 'Active Calories',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('records the synced source in the notes on insert (Health Connect, not Apple Health)', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [] }) // no existing entry
+      .mockResolvedValueOnce({ rows: [{ id: 'entry-1' }] }); // insert
+
+    await exerciseEntryDb.upsertExerciseEntryData(
+      'user-1',
+      'user-1',
+      'exercise-1',
+      300,
+      '2024-01-15',
+      'Health Connect'
+    );
+
+    const [sql, params] = mockClient.query.mock.calls[1];
+    expect(sql).toContain('INSERT INTO exercise_entries');
+    expect(params[5]).toBe('Active calories logged from Health Connect.');
+    expect(params[5]).not.toContain('Apple Health');
+  });
+
+  it('records the synced source in the notes on update', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({
+        rows: [{ id: 'entry-1', calories_burned: 100 }],
+      }) // existing entry
+      .mockResolvedValueOnce({ rows: [{ id: 'entry-1' }] }); // update
+
+    await exerciseEntryDb.upsertExerciseEntryData(
+      'user-1',
+      'user-1',
+      'exercise-1',
+      300,
+      '2024-01-15',
+      'Health Connect'
+    );
+
+    const [sql, params] = mockClient.query.mock.calls[1];
+    expect(sql).toContain('UPDATE exercise_entries');
+    expect(params[1]).toBe(
+      'Active calories logged from Health Connect (updated).'
+    );
+    expect(params[1]).not.toContain('Apple Health');
+  });
+
+  it('maps the HealthKit source to the friendly "Apple Health" label', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 'entry-1' }] });
+
+    await exerciseEntryDb.upsertExerciseEntryData(
+      'user-1',
+      'user-1',
+      'exercise-1',
+      300,
+      '2024-01-15',
+      'HealthKit'
+    );
+
+    const [, params] = mockClient.query.mock.calls[1];
+    expect(params[5]).toBe('Active calories logged from Apple Health.');
+  });
+
+  it('falls back to a generic source label when none is provided', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 'entry-1' }] });
+
+    await exerciseEntryDb.upsertExerciseEntryData(
+      'user-1',
+      'user-1',
+      'exercise-1',
+      300,
+      '2024-01-15'
+    );
+
+    const [, params] = mockClient.query.mock.calls[1];
+    expect(params[5]).toBe('Active calories logged from Health Data.');
+  });
+
+  it('falls back to a generic source label when source is explicitly null', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 'entry-1' }] });
+
+    await exerciseEntryDb.upsertExerciseEntryData(
+      'user-1',
+      'user-1',
+      'exercise-1',
+      300,
+      '2024-01-15',
+      // Simulates an untyped (`any`) caller passing null, which bypasses the default param.
+      null as unknown as string
+    );
+
+    const [, params] = mockClient.query.mock.calls[1];
+    expect(params[5]).toBe('Active calories logged from Health Data.');
+    expect(params[5]).not.toContain('null');
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
What's new banner showing too often
Health Connect data attributed to healthkit
**How did you implement the solution?**
Banner only fires when a counter is manually incremented
Changed label

Linked Issue: Closes #1461 

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
