### PR TITLE
fix: migrate OpenFoodFacts text search to Search-a-licious API

### DIFF
--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -229,7 +229,9 @@ function mapOpenFoodFactsProduct(
     product.product_name;
   return {
     name,
-    brand: product.brands?.split(',')[0]?.trim() || '',
+    brand: Array.isArray(product.brands)
+      ? product.brands[0]?.trim() || ''
+      : product.brands?.split(',')[0]?.trim() || '',
     barcode: normalizeBarcode(product.code),
     provider_external_id: product.code,
     provider_type: 'openfoodfacts',

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -84,7 +84,7 @@ async function searchOpenFoodFacts(
       fieldSet.add(`product_name_${language}`);
     }
     const fields = [...fieldSet];
-    const searchUrl = `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=20&page=${page}&fields=${fields.join(',')}&lc=${language}`;
+    const searchUrl = `https://search.openfoodfacts.org/search?q=${encodeURIComponent(query)}&page_size=20&page=${page}&fields=${fields.join(',')}`;
     const response = await fetchOpenFoodFacts(searchUrl, {
       authenticatedUserId,
       providerId,
@@ -96,13 +96,12 @@ async function searchOpenFoodFacts(
     }
     const data = await response.json();
     return {
-      products: data.products,
+      products: data.hits,
       pagination: {
         page: data.page || page,
         pageSize: data.page_size || 20,
         totalCount: data.count || 0,
-        hasMore:
-          (data.page || page) * (data.page_size || 20) < (data.count || 0),
+        hasMore: (data.page || page) < (data.page_count || 0),
       },
     };
   } catch (error) {

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -84,7 +84,7 @@ async function searchOpenFoodFacts(
       fieldSet.add(`product_name_${language}`);
     }
     const fields = [...fieldSet];
-    const searchUrl = `https://search.openfoodfacts.org/search?q=${encodeURIComponent(query)}&page_size=20&page=${page}&fields=${fields.join(',')}`;
+    const searchUrl = `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=20&page=${page}&fields=${fields.join(',')}&lc=${language}`;
     const response = await fetchOpenFoodFacts(searchUrl, {
       authenticatedUserId,
       providerId,
@@ -96,12 +96,13 @@ async function searchOpenFoodFacts(
     }
     const data = await response.json();
     return {
-      products: data.hits,
+      products: data?.products || [],
       pagination: {
-        page: data.page || page,
-        pageSize: data.page_size || 20,
-        totalCount: data.count || 0,
-        hasMore: (data.page || page) < (data.page_count || 0),
+        page: data?.page || page,
+        pageSize: data?.page_size || 20,
+        totalCount: data?.count || 0,
+        hasMore:
+          (data?.page || page) * (data?.page_size || 20) < (data?.count || 0),
       },
     };
   } catch (error) {

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -24,30 +24,30 @@ describe('openFoodFactsService', () => {
   });
 
   describe('searchOpenFoodFacts', () => {
-    it('should append the lc parameter with the specified language to the search URL', async () => {
+    it('should call the Search-a-licious endpoint', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       fetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ products: [], count: 0 }),
+        json: () => Promise.resolve({ hits: [], count: 0, page_count: 0 }),
       });
       // @ts-expect-error TS(2554): Expected 5 arguments, but got 3.
-      await searchOpenFoodFacts('pizza', 1, 'fr');
+      await searchOpenFoodFacts('pizza', 1, 'en');
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('&lc=fr'),
+        expect.stringContaining('search.openfoodfacts.org/search'),
         expect.any(Object)
       );
     });
 
-    it("should default to language 'en' when not specified", async () => {
+    it('should add language-specific product_name field when language is not en', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       fetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ products: [], count: 0 }),
+        json: () => Promise.resolve({ hits: [], count: 0, page_count: 0 }),
       });
-      // @ts-expect-error TS(2554): Expected 5 arguments, but got 2.
-      await searchOpenFoodFacts('pizza', 1);
+      // @ts-expect-error TS(2554): Expected 5 arguments, but got 3.
+      await searchOpenFoodFacts('pizza', 1, 'fr');
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('&lc=en'),
+        expect.stringContaining('product_name_fr'),
         expect.any(Object)
       );
     });
@@ -177,7 +177,7 @@ describe('openFoodFactsService', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: () => Promise.resolve({ products: [], count: 0 }),
+          json: () => Promise.resolve({ hits: [], count: 0, page_count: 0 }),
         });
 
       await searchOpenFoodFacts('pizza', 1, 'en', 'user-A', 'prov-1');


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
The OpenFoodFacts legacy search endpoint (`world.openfoodfacts.org/cgi/search.pl`) is returning HTTP 503 errors globally, breaking all text-based food searches. Barcode lookups are unaffected.

**How did you implement the solution?**
Migrated to the Search-a-licious API (`search.openfoodfacts.org/search`), OFF's official Elasticsearch-backed replacement. The change is confined to the `searchOpenFoodFacts` function — two lines swapped, response key renamed from `products` to `hits`, and `brands` normalized to handle both string (barcode API) and array (Search-a-licious) shapes. Barcode lookup is untouched.

A side effect: dropping the `lc=` language filter means non-English products (e.g. French products with no `product_name_en`) now appear in results. The existing language-fallback logic in `mapOpenFoodFactsProduct` already handles this correctly.

Linked Issue: Closes #1079

## How to Test

1. Check out this branch and run `docker compose up`
2. Go to Foods → Search → select OpenFoodFacts as source
3. Search for any food — results should appear (previously 503 / empty)
4. Verify non-English products (e.g. "Harrys American Sandwich Complet") are now found

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before
<img width="1107" height="365" alt="Before_OFF" src="https://github.com/user-attachments/assets/baf50236-7916-4687-ad65-47f40424b8a8" />

### After
<img width="1085" height="652" alt="After_OFF" src="https://github.com/user-attachments/assets/e9ff6d8d-4314-401a-a37e-fbe570978391" />

</details>

## Notes for Reviewers

- The Search-a-licious API is documented at https://search.openfoodfacts.org/docs and is the officially recommended replacement per the OFF API docs.
- No frontend changes required — the response shape exposed to callers (`{ products, pagination }`) is unchanged.
- The `lc=` parameter drop is intentional: Search-a-licious searches all languages by default, which is the correct behavior for a global food database.
- `brands` is returned as `string[]` by Search-a-licious vs a comma-separated string by the barcode API — both handled in `mapOpenFoodFactsProduct`.