### PR TITLE
feat(mobile): edit ingredients of a logged meal

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/SwipeableIngredientRow.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/SwipeableIngredientRow.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+import SwipeableIngredientRow from '../../src/components/SwipeableIngredientRow';
+
+type AlertButton = { text: string; style?: string; onPress?: () => void };
+
+const baseProps = {
+  foodName: 'Chicken',
+  quantityLabel: '100 g',
+  caloriesLabel: '165 Cal',
+  showBottomBorder: false,
+  isLastIngredient: false,
+  onConfirmDelete: jest.fn(),
+  onPress: jest.fn(),
+};
+
+describe('SwipeableIngredientRow', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('long-press opens an Edit / Delete / Cancel menu', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const screen = render(<SwipeableIngredientRow {...baseProps} />);
+
+    fireEvent(screen.getByText('Chicken'), 'longPress');
+
+    expect(alertSpy).toHaveBeenCalled();
+    const [title, message, buttons] = alertSpy.mock.calls[0];
+    expect(title).toBe('Chicken');
+    expect(message).toBeUndefined();
+    const labels = (buttons as AlertButton[]).map((b) => b.text);
+    expect(labels).toEqual(expect.arrayContaining(['Edit', 'Delete', 'Cancel']));
+
+    alertSpy.mockRestore();
+  });
+
+  it('long-press Edit fires onPress and Delete fires onConfirmDelete', () => {
+    const onPress = jest.fn();
+    const onConfirmDelete = jest.fn();
+    let buttons: AlertButton[] = [];
+    const alertSpy = jest
+      .spyOn(Alert, 'alert')
+      .mockImplementation((_t, _m, b) => {
+        buttons = b as AlertButton[];
+      });
+
+    const screen = render(
+      <SwipeableIngredientRow {...baseProps} onPress={onPress} onConfirmDelete={onConfirmDelete} />,
+    );
+    fireEvent(screen.getByText('Chicken'), 'longPress');
+
+    buttons.find((b) => b.text === 'Edit')?.onPress?.();
+    buttons.find((b) => b.text === 'Delete')?.onPress?.();
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onConfirmDelete).toHaveBeenCalledTimes(1);
+
+    alertSpy.mockRestore();
+  });
+
+  it('warns when removing the last ingredient that another is needed to save', () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const screen = render(<SwipeableIngredientRow {...baseProps} isLastIngredient />);
+
+    fireEvent(screen.getByText('Chicken'), 'longPress');
+
+    expect(alertSpy.mock.calls[0][1]).toMatch(/last ingredient/i);
+
+    alertSpy.mockRestore();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/screens/EditLoggedMealScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/EditLoggedMealScreen.test.tsx
@@ -1,12 +1,29 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import EditLoggedMealScreen from '../../src/screens/EditLoggedMealScreen';
 import { useFoodEntryMealDetails } from '../../src/hooks/useFoodEntryMealDetails';
 import { useUpdateFoodEntryMeal } from '../../src/hooks/useUpdateFoodEntryMeal';
 import { useDeleteFoodEntryMeal } from '../../src/hooks/useDeleteFoodEntryMeal';
 import { useMealTypes } from '../../src/hooks';
-import type { FoodEntryMeal } from '../../src/types/foodEntryMeals';
+import { consumePendingMealIngredientSelection } from '../../src/services/mealBuilderSelection';
+import type { FoodEntryMeal, FoodEntryMealFood } from '../../src/types/foodEntryMeals';
+import type { MealIngredientDraft } from '../../src/types/meals';
+
+let focusCallback: (() => void) | undefined;
+const mockUseFocusEffect = jest.fn();
+
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useFocusEffect: (callback: () => void) => mockUseFocusEffect(callback),
+  };
+});
+
+jest.mock('../../src/services/mealBuilderSelection', () => ({
+  consumePendingMealIngredientSelection: jest.fn(),
+}));
 
 jest.mock('../../src/hooks/useFoodEntryMealDetails', () => ({
   useFoodEntryMealDetails: jest.fn(),
@@ -50,6 +67,25 @@ jest.mock('../../src/components/NutritionMacroCard', () => {
       <View>
         <Text>{Math.round(calories)} calories</Text>
       </View>
+    ),
+  };
+});
+
+// Render the ingredient rows as plain buttons so the screen's edit/remove
+// wiring can be exercised without the swipe gesture/Alert layer.
+jest.mock('../../src/components/SwipeableIngredientRow', () => {
+  const { Text, Pressable } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ foodName, onPress, onConfirmDelete }: any) => (
+      <>
+        <Pressable testID={`edit-${foodName}`} onPress={onPress}>
+          <Text>{foodName}</Text>
+        </Pressable>
+        <Pressable testID={`remove-${foodName}`} onPress={onConfirmDelete}>
+          <Text>remove {foodName}</Text>
+        </Pressable>
+      </>
     ),
   };
 });
@@ -124,9 +160,40 @@ const mockUseFoodEntryMealDetails = useFoodEntryMealDetails as jest.MockedFuncti
 const mockUseUpdateFoodEntryMeal = useUpdateFoodEntryMeal as jest.MockedFunction<typeof useUpdateFoodEntryMeal>;
 const mockUseDeleteFoodEntryMeal = useDeleteFoodEntryMeal as jest.MockedFunction<typeof useDeleteFoodEntryMeal>;
 const mockUseMealTypes = useMealTypes as jest.MockedFunction<typeof useMealTypes>;
+const mockConsume = consumePendingMealIngredientSelection as jest.MockedFunction<
+  typeof consumePendingMealIngredientSelection
+>;
 
 const insets = { top: 0, bottom: 0, left: 0, right: 0 };
 const frame = { x: 0, y: 0, width: 390, height: 844 };
+
+const chicken: FoodEntryMealFood = {
+  food_id: 'food-1',
+  food_name: 'Chicken',
+  variant_id: 'var-1',
+  quantity: 100,
+  unit: 'g',
+  serving_size: 100,
+  serving_unit: 'g',
+  calories: 165,
+  protein: 31,
+  carbs: 0,
+  fat: 4,
+};
+
+const rice: FoodEntryMealFood = {
+  food_id: 'food-2',
+  food_name: 'Rice',
+  variant_id: 'var-2',
+  quantity: 150,
+  unit: 'g',
+  serving_size: 100,
+  serving_unit: 'g',
+  calories: 130,
+  protein: 2.7,
+  carbs: 28,
+  fat: 0.3,
+};
 
 const baseMeal: FoodEntryMeal = {
   id: 'fem-1',
@@ -139,46 +206,58 @@ const baseMeal: FoodEntryMeal = {
   description: null,
   quantity: 1,
   unit: 'serving',
-  foods: [
-    {
-      food_id: 'food-1',
-      food_name: 'Chicken',
-      variant_id: 'var-1',
-      quantity: 100,
-      unit: 'g',
-      serving_size: 100,
-      serving_unit: 'g',
-      calories: 165,
-      protein: 31,
-      carbs: 0,
-      fat: 4,
-    },
-  ],
+  foods: [chicken],
   calories: 200,
   protein: 30,
   carbs: 5,
   fat: 5,
 };
 
+const buildIngredient = (overrides: Partial<MealIngredientDraft> = {}): MealIngredientDraft => ({
+  food_id: 'food-9',
+  variant_id: 'var-9',
+  quantity: 50,
+  unit: 'g',
+  brand: null,
+  food_name: 'Almonds',
+  serving_size: 100,
+  serving_unit: 'g',
+  calories: 579,
+  protein: 21,
+  carbs: 22,
+  fat: 50,
+  ...overrides,
+});
+
 describe('EditLoggedMealScreen', () => {
   const navigation = {
     goBack: jest.fn(),
     navigate: jest.fn(),
+    push: jest.fn(),
     setParams: jest.fn(),
   } as any;
 
   const mockUpdateMeal = jest.fn();
   const mockConfirmAndDelete = jest.fn();
+  const mockDeleteEntry = jest.fn();
 
-  beforeEach(() => {
-    jest.clearAllMocks();
+  const mockMeal = (meal: FoodEntryMeal) =>
     mockUseFoodEntryMealDetails.mockReturnValue({
-      meal: baseMeal,
+      meal,
       isLoading: false,
       isError: false,
       error: null,
       refetch: jest.fn(),
     } as any);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    focusCallback = undefined;
+    mockUseFocusEffect.mockImplementation((callback: () => void) => {
+      focusCallback = callback;
+    });
+    mockConsume.mockReturnValue(null);
+    mockMeal(baseMeal);
     mockUseUpdateFoodEntryMeal.mockReturnValue({
       updateMeal: mockUpdateMeal,
       isPending: false,
@@ -186,7 +265,7 @@ describe('EditLoggedMealScreen', () => {
     });
     mockUseDeleteFoodEntryMeal.mockReturnValue({
       confirmAndDelete: mockConfirmAndDelete,
-      deleteEntry: jest.fn(),
+      deleteEntry: mockDeleteEntry,
       isPending: false,
       invalidateCache: jest.fn(),
     });
@@ -235,16 +314,12 @@ describe('EditLoggedMealScreen', () => {
         unit: 'g',
       }),
     ]);
+    // brand is a draft-only field and must not leak into the wire payload.
+    expect(payload.foods[0]).not.toHaveProperty('brand');
   });
 
   it('scales component food quantities client-side when meal has no template', () => {
-    mockUseFoodEntryMealDetails.mockReturnValue({
-      meal: { ...baseMeal, meal_template_id: null },
-      isLoading: false,
-      isError: false,
-      error: null,
-      refetch: jest.fn(),
-    } as any);
+    mockMeal({ ...baseMeal, meal_template_id: null });
 
     const screen = renderScreen();
     fireEvent.changeText(screen.getByTestId('quantity-input'), '2');
@@ -266,5 +341,110 @@ describe('EditLoggedMealScreen', () => {
     const screen = renderScreen();
     fireEvent.press(screen.getByText('Save'));
     expect(mockUpdateMeal).not.toHaveBeenCalled();
+  });
+
+  it('opens the meal-builder picker when Add Food is pressed', () => {
+    const screen = renderScreen();
+    fireEvent.press(screen.getByText('Add Food'));
+    expect(navigation.push).toHaveBeenCalledWith('FoodSearch', { pickerMode: 'meal-builder' });
+  });
+
+  it('appends a food picked via the meal builder to the saved payload', () => {
+    // Non-template so displayScale is 1 and the picked 50 g is stored as-is.
+    mockMeal({ ...baseMeal, meal_template_id: null });
+    const screen = renderScreen();
+
+    mockConsume.mockReturnValueOnce({ ingredient: buildIngredient() });
+    act(() => {
+      focusCallback?.();
+    });
+
+    fireEvent.press(screen.getByText('Save'));
+
+    const payload = mockUpdateMeal.mock.calls[0][0];
+    expect(payload.foods).toHaveLength(2);
+    expect(payload.foods[1]).toEqual(
+      expect.objectContaining({ food_id: 'food-9', variant_id: 'var-9', quantity: 50, unit: 'g' }),
+    );
+  });
+
+  it('navigates to the meal builder to edit an ingredient on row tap', () => {
+    const screen = renderScreen();
+    fireEvent.press(screen.getByTestId('edit-Chicken'));
+    expect(navigation.navigate).toHaveBeenCalledWith(
+      'FoodEntryAdd',
+      expect.objectContaining({ pickerMode: 'meal-builder', ingredientIndex: 0, returnDepth: 1 }),
+    );
+  });
+
+  it('replaces an edited ingredient at its index on return', () => {
+    // Non-template so displayScale is 1 and the edited 250 g is stored as-is.
+    mockMeal({ ...baseMeal, meal_template_id: null });
+    const screen = renderScreen();
+
+    mockConsume.mockReturnValueOnce({
+      ingredient: buildIngredient({ food_id: 'food-1', variant_id: 'var-1', food_name: 'Chicken', quantity: 250 }),
+      ingredientIndex: 0,
+    });
+    act(() => {
+      focusCallback?.();
+    });
+
+    fireEvent.press(screen.getByText('Save'));
+
+    const payload = mockUpdateMeal.mock.calls[0][0];
+    expect(payload.foods).toHaveLength(1);
+    expect(payload.foods[0].quantity).toBe(250);
+  });
+
+  it('unscales a picked food by the servings multiplier before storing', () => {
+    // Non-template, servings bumped to 2 -> displayScale 2. The picker returns
+    // consumed amounts, so a 100 g pick is stored at base 50 and saved back to
+    // the consumed 100 (base 50 x scaleFactor 2).
+    mockMeal({ ...baseMeal, meal_template_id: null });
+    const screen = renderScreen();
+    fireEvent.changeText(screen.getByTestId('quantity-input'), '2');
+
+    mockConsume.mockReturnValueOnce({ ingredient: buildIngredient({ quantity: 100 }) });
+    act(() => {
+      focusCallback?.();
+    });
+
+    fireEvent.press(screen.getByText('Save'));
+
+    const payload = mockUpdateMeal.mock.calls[0][0];
+    expect(payload.foods[1]).toEqual(expect.objectContaining({ food_id: 'food-9', quantity: 100 }));
+  });
+
+  it('stages removal of a non-last ingredient until Save (no immediate delete)', () => {
+    mockMeal({ ...baseMeal, foods: [chicken, rice] });
+    const screen = renderScreen();
+
+    fireEvent.press(screen.getByTestId('remove-Rice'));
+
+    expect(mockDeleteEntry).not.toHaveBeenCalled();
+
+    fireEvent.press(screen.getByText('Save'));
+    const payload = mockUpdateMeal.mock.calls[0][0];
+    expect(payload.foods).toHaveLength(1);
+    expect(payload.foods[0].food_id).toBe('food-1');
+  });
+
+  it('stages removal of the last ingredient instead of deleting the meal', () => {
+    const screen = renderScreen();
+    fireEvent.press(screen.getByTestId('remove-Chicken'));
+    // No immediate server action; the meal entry is preserved.
+    expect(mockDeleteEntry).not.toHaveBeenCalled();
+    expect(mockConfirmAndDelete).not.toHaveBeenCalled();
+    // An empty meal cannot be saved.
+    fireEvent.press(screen.getByText('Save'));
+    expect(mockUpdateMeal).not.toHaveBeenCalled();
+  });
+
+  it('scales a template meal to the consumed total on the nutrition card', () => {
+    // baseMeal is template-linked: foods sum to 165 base cal, but meal.calories
+    // is the consumed total (200). The card must show 200, not the base 165.
+    const screen = renderScreen();
+    expect(screen.getByText('200 calories')).toBeTruthy();
   });
 });

--- a/SparkyFitnessMobile/src/components/SwipeableIngredientRow.tsx
+++ b/SparkyFitnessMobile/src/components/SwipeableIngredientRow.tsx
@@ -1,0 +1,135 @@
+import React, { useRef } from 'react';
+import { Alert, View, Text, TouchableOpacity } from 'react-native';
+import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
+
+interface SwipeableIngredientRowProps {
+  foodName: string;
+  quantityLabel: string;
+  caloriesLabel: string;
+  showBottomBorder: boolean;
+  isLastIngredient: boolean;
+  disabled?: boolean;
+  onConfirmDelete: () => void;
+  // Optional tap handler for editing the ingredient. When provided, the row
+  // body becomes a button; swipe-to-delete still works alongside it.
+  onPress?: () => void;
+}
+
+const DELETE_ACTION_WIDTH = 80;
+
+const SwipeableIngredientRow: React.FC<SwipeableIngredientRowProps> = ({
+  foodName,
+  quantityLabel,
+  caloriesLabel,
+  showBottomBorder,
+  isLastIngredient,
+  disabled = false,
+  onConfirmDelete,
+  onPress,
+}) => {
+  // Matches the existing `SwipeableFoodRow` convention in this codebase. A more
+  // specific ref type (e.g. `React.ComponentRef<typeof ReanimatedSwipeable>`)
+  // resolves to `{}` and breaks `.close()` under the current Expo SDK 55 React
+  // types; until upstream tightens this, `any` is what the rest of the project
+  // uses for the same ref.
+  const swipeableRef = useRef<any>(null);
+
+  const handleDeletePress = () => {
+    const message = isLastIngredient
+      ? 'This is the last ingredient. Add another before you can save, or use Delete Meal to remove the whole meal.'
+      : undefined;
+    Alert.alert(
+      `Remove ${foodName}?`,
+      message,
+      [
+        { text: 'Cancel', style: 'cancel', onPress: () => swipeableRef.current?.close() },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: () => {
+            swipeableRef.current?.close();
+            onConfirmDelete();
+          },
+        },
+      ],
+      // Android lets the user dismiss by tapping outside; close the row so it
+      // does not stay stuck in the swiped-open state.
+      { cancelable: true, onDismiss: () => swipeableRef.current?.close() },
+    );
+  };
+
+  // Long-press menu: a discoverable path for users who don't think to swipe
+  // (per contributor feedback on #1473), matching MealAddScreen's row menu. The
+  // menu itself is the confirmation, so Delete fires onConfirmDelete directly;
+  // the last-ingredient warning is surfaced in the message instead.
+  const handleLongPress = () => {
+    const buttons: {
+      text: string;
+      style?: 'cancel' | 'destructive';
+      onPress?: () => void;
+    }[] = [];
+    if (onPress) buttons.push({ text: 'Edit', onPress });
+    buttons.push({ text: 'Delete', style: 'destructive', onPress: onConfirmDelete });
+    buttons.push({ text: 'Cancel', style: 'cancel' });
+    const message = isLastIngredient
+      ? 'This is the last ingredient. Add another before you can save, or use Delete Meal to remove the whole meal.'
+      : undefined;
+    Alert.alert(foodName, message, buttons);
+  };
+
+  // RN TouchableOpacity + className here, matching SwipeableFoodRow /
+  // SwipeableExerciseRow: NativeWind styles it reliably (the red background) and
+  // it works inside ReanimatedSwipeable, as those shipped rows demonstrate.
+  const renderRightActions = () => (
+    <TouchableOpacity
+      className="bg-bg-danger justify-center items-center"
+      style={{ width: DELETE_ACTION_WIDTH }}
+      onPress={handleDeletePress}
+      activeOpacity={0.7}
+      disabled={disabled}
+    >
+      <Text className="text-text-danger font-semibold text-sm">Delete</Text>
+    </TouchableOpacity>
+  );
+
+  const rowBody = (
+    <View
+      className={`flex-row items-center px-3 py-2 bg-surface ${showBottomBorder ? 'border-b border-border-subtle' : ''}`}
+    >
+      <View className="flex-1 mr-2">
+        <Text className="text-text-primary text-base" numberOfLines={1}>
+          {foodName}
+        </Text>
+        <Text className="text-text-secondary text-xs mt-0.5">{quantityLabel}</Text>
+      </View>
+      <Text className="text-text-secondary text-sm font-medium">{caloriesLabel}</Text>
+    </View>
+  );
+
+  return (
+    <ReanimatedSwipeable
+      ref={swipeableRef}
+      renderRightActions={renderRightActions}
+      overshootRight={false}
+      rightThreshold={40}
+      enabled={!disabled}
+    >
+      {onPress ? (
+        <TouchableOpacity
+          activeOpacity={0.7}
+          onPress={onPress}
+          onLongPress={handleLongPress}
+          disabled={disabled}
+          accessibilityLabel={`Edit ${foodName}`}
+          accessibilityRole="button"
+        >
+          {rowBody}
+        </TouchableOpacity>
+      ) : (
+        rowBody
+      )}
+    </ReanimatedSwipeable>
+  );
+};
+
+export default SwipeableIngredientRow;

--- a/SparkyFitnessMobile/src/screens/EditLoggedMealScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/EditLoggedMealScreen.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { View, Text, TouchableOpacity, ScrollView, ActivityIndicator } from 'react-native';
 import Animated, { LinearTransition } from 'react-native-reanimated';
+import { useFocusEffect } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
 import Button from '../components/ui/Button';
@@ -10,19 +11,57 @@ import StepperInput from '../components/StepperInput';
 import BottomSheetPicker from '../components/BottomSheetPicker';
 import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarSheet';
 import NutritionMacroCard from '../components/NutritionMacroCard';
+import SwipeableIngredientRow from '../components/SwipeableIngredientRow';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { useMealTypes, usePreferences } from '../hooks';
 import { useFoodEntryMealDetails } from '../hooks/useFoodEntryMealDetails';
 import { useUpdateFoodEntryMeal } from '../hooks/useUpdateFoodEntryMeal';
 import { useDeleteFoodEntryMeal } from '../hooks/useDeleteFoodEntryMeal';
+import { consumePendingMealIngredientSelection } from '../services/mealBuilderSelection';
 import { formatDateLabel, normalizeDate } from '../utils/dateUtils';
 import { getMealTypeLabel } from '../constants/meals';
-import { toMealFoodPayload } from '../utils/mealBuilderDraft';
+import { buildMealIngredientDraftFromEntryMealFood } from '../utils/mealBuilderDraft';
+import { formatCaloriesDisplay, formatServingSizeDisplay } from '../utils/foodDetails';
 import { DECIMAL_INPUT_REGEX, parseDecimalInput } from '../utils/numericInput';
+import { mealIngredientDraftToFoodInfo } from '../types/foodInfo';
+import type { MealIngredientDraft } from '../types/meals';
 import type { FoodEntryMealUpdateData } from '../types/foodEntryMeals';
 import type { RootStackScreenProps } from '../types/navigation';
 
 type EditLoggedMealScreenProps = RootStackScreenProps<'EditLoggedMeal'>;
+
+interface IngredientTotals {
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  fiber?: number;
+}
+
+// Sum nutrition across the ingredient drafts at their stored quantities (each
+// food scaled by its own quantity / serving_size). The meal-level servings
+// factor is applied by the caller. Recomputing here (rather than reading
+// meal.calories) keeps totals correct after foods are added/removed/edited.
+function computeBaseTotals(ingredients: MealIngredientDraft[]): IngredientTotals {
+  let calories = 0;
+  let protein = 0;
+  let carbs = 0;
+  let fat = 0;
+  let fiber = 0;
+  let hasFiber = false;
+  for (const food of ingredients) {
+    const scale = food.serving_size > 0 ? food.quantity / food.serving_size : 0;
+    calories += (food.calories ?? 0) * scale;
+    protein += (food.protein ?? 0) * scale;
+    carbs += (food.carbs ?? 0) * scale;
+    fat += (food.fat ?? 0) * scale;
+    if (food.dietary_fiber != null) {
+      hasFiber = true;
+      fiber += food.dietary_fiber * scale;
+    }
+  }
+  return { calories, protein, carbs, fat, fiber: hasFiber ? fiber : undefined };
+}
 
 const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation, route }) => {
   const { foodEntryMealId, initialMeal } = route.params;
@@ -39,13 +78,68 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedMealId, setSelectedMealId] = useState<string | undefined>(undefined);
   const [quantityText, setQuantityText] = useState<string | null>(null);
+  const [ingredients, setIngredients] = useState<MealIngredientDraft[]>([]);
+  const [initializedMealId, setInitializedMealId] = useState<string | null>(null);
+  const [foodsTouched, setFoodsTouched] = useState(false);
+  // Latest displayScale, read inside useFocusEffect without re-creating it.
+  const displayScaleRef = useRef(1);
+
+  // Seed the editable ingredient list once the meal loads. meal.foods come back
+  // at their stored quantities: for non-template meals that is the consumed
+  // amount at the meal's logged servings (server multiplier is 1.0); for
+  // template meals it is the recipe base, which the server rescales. Either way
+  // the Servings stepper rescales via scaleFactor (defined below). Guard on
+  // meal.id so returning from the food picker (which re-focuses and may refetch)
+  // never clobbers in-progress edits.
+  useEffect(() => {
+    if (!meal || initializedMealId === meal.id) return;
+    setIngredients(meal.foods.map(buildMealIngredientDraftFromEntryMealFood));
+    setInitializedMealId(meal.id);
+  }, [meal, initializedMealId]);
+
+  // Consume a food chosen via the meal-builder picker flow: append on add, or
+  // replace at index on edit. Mirrors MealAddScreen's selection handoff.
+  useFocusEffect(
+    useCallback(() => {
+      const selection = consumePendingMealIngredientSelection();
+      if (!selection) return;
+      // The picker works in CONSUMED amounts (what the user sees on the row), so
+      // unscale back to the base quantity we store and save.
+      const scale = displayScaleRef.current;
+      const ingredient = {
+        ...selection.ingredient,
+        quantity:
+          scale > 0 ? selection.ingredient.quantity / scale : selection.ingredient.quantity,
+      };
+      setIngredients((current) => {
+        const next = [...current];
+        if (
+          selection.ingredientIndex != null &&
+          selection.ingredientIndex >= 0 &&
+          selection.ingredientIndex < next.length
+        ) {
+          next[selection.ingredientIndex] = ingredient;
+          return next;
+        }
+        next.push(ingredient);
+        return next;
+      });
+      setFoodsTouched(true);
+    }, []),
+  );
 
   const effectiveName = name ?? meal?.name ?? '';
   const effectiveDate = selectedDate ?? (meal ? normalizeDate(meal.entry_date) : null);
   const effectiveMealId = selectedMealId ?? meal?.meal_type_id ?? undefined;
   const effectiveQuantityText = quantityText ?? (meal ? String(meal.quantity) : '');
   const quantity = parseDecimalInput(effectiveQuantityText) || 0;
-  const originalQuantity = meal?.quantity ?? 1;
+  const originalQuantity = meal?.quantity && meal.quantity > 0 ? meal.quantity : 1;
+  // Rescale stored component quantities by the CHANGE in servings, not the raw
+  // servings count: meal.foods are already at the logged-servings amount
+  // (originalQuantity), so the factor is newServings / loadedServings. This
+  // matches the server, which persists non-template components verbatim
+  // (multiplier 1.0). Multiplying by `quantity` directly would double-count
+  // whenever the meal was logged at servings != 1.
   const scaleFactor = originalQuantity > 0 ? quantity / originalQuantity : 0;
 
   const selectedMealType = mealTypes.find((mt) => mt.id === effectiveMealId);
@@ -61,7 +155,8 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
       (name !== null && name !== meal.name) ||
       (selectedDate !== null && selectedDate !== initialDate) ||
       (selectedMealId !== undefined && selectedMealId !== meal.meal_type_id) ||
-      (quantityText !== null && quantity !== meal.quantity)
+      (quantityText !== null && quantity !== meal.quantity) ||
+      foodsTouched
     );
 
   const { updateMeal, isPending: isSavePending, invalidateCache: invalidateUpdateCache } = useUpdateFoodEntryMeal({
@@ -73,14 +168,35 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
     },
   });
 
-  const { confirmAndDelete, isPending: isDeletePending, invalidateCache: invalidateDeleteCache } = useDeleteFoodEntryMeal({
-    mealId: foodEntryMealId,
-    entryDate: meal?.entry_date ?? '',
-    onSuccess: () => {
-      invalidateDeleteCache();
-      navigation.goBack();
-    },
-  });
+  const { confirmAndDelete, isPending: isDeletePending, invalidateCache: invalidateDeleteCache } =
+    useDeleteFoodEntryMeal({
+      mealId: foodEntryMealId,
+      entryDate: meal?.entry_date ?? '',
+      onSuccess: () => {
+        invalidateDeleteCache();
+        navigation.goBack();
+      },
+    });
+
+  const isRowBusy = isSavePending || isDeletePending;
+
+  const baseTotals = useMemo(() => computeBaseTotals(ingredients), [ingredients]);
+
+  // Template-linked meals come back with component foods at recipe BASE
+  // quantities but meal.calories as the CONSUMED total (server divides foods by
+  // the storage multiplier on read, foodEntryService.ts). Base totals alone
+  // would therefore understate the meal, so recover that multiplier (consumed /
+  // base) from the loaded snapshot and fold it into all display scaling.
+  // Non-template meals already store consumed amounts, so this is 1 for them.
+  const templateScale = useMemo(() => {
+    // Guard null/zero calories: without it a template meal with no aggregate
+    // calories would yield templateScale 0 and zero out the whole display.
+    if (!meal?.meal_template_id || !meal.calories) return 1;
+    const base = computeBaseTotals(
+      meal.foods.map(buildMealIngredientDraftFromEntryMealFood),
+    ).calories;
+    return base > 0 ? meal.calories / base : 1;
+  }, [meal]);
 
   const [accentColor, textPrimary] = useCSSVariable([
     '--color-accent-primary',
@@ -105,7 +221,44 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
     setQuantityText(String(Math.max(step, next)));
   };
 
-  const canSave = dirty && quantity > 0 && !!meal && meal.foods.length > 0 && !!effectiveDate;
+  const openIngredientPicker = () => {
+    navigation.push('FoodSearch', { pickerMode: 'meal-builder' });
+  };
+
+  const editIngredient = (index: number) => {
+    const ingredient = ingredients[index];
+    if (!ingredient) return;
+    // Open the editor on the CONSUMED quantity the user sees on the row; the
+    // return path (useFocusEffect) unscales it back to base.
+    const scaledIngredient = {
+      ...ingredient,
+      quantity: ingredient.quantity * displayScaleRef.current,
+    };
+    navigation.navigate('FoodEntryAdd', {
+      item: mealIngredientDraftToFoodInfo(scaledIngredient),
+      pickerMode: 'meal-builder',
+      ingredientIndex: index,
+      returnDepth: 1,
+    });
+  };
+
+  // SwipeableIngredientRow confirms before invoking this. Removal is always
+  // staged and committed on Save, including the last ingredient: canSave blocks
+  // saving an empty meal, so the user can swap the final food (remove, Add Food)
+  // without losing the meal entry. Deleting the whole meal is the dedicated
+  // "Delete Meal" button.
+  const handleRemoveIngredient = (index: number) => {
+    setIngredients((current) => current.filter((_, i) => i !== index));
+    setFoodsTouched(true);
+  };
+
+  const canSave =
+    dirty &&
+    quantity > 0 &&
+    !!meal &&
+    ingredients.length > 0 &&
+    ingredients.every((food) => !!food.variant_id && food.quantity > 0) &&
+    !!effectiveDate;
 
   const handleSave = () => {
     if (!meal || !canSave || !effectiveDate) return;
@@ -118,9 +271,11 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
       quantity,
       unit: meal.unit,
       meal_template_id: meal.meal_template_id,
-      foods: meal.foods.map((f) => ({
-        ...toMealFoodPayload(f),
-        quantity: meal.meal_template_id ? f.quantity : f.quantity * scaleFactor,
+      foods: ingredients.map(({ brand: _brand, ...food }) => ({
+        ...food,
+        // Non-template meals persist consumed (scaled) component quantities;
+        // template-linked meals are rescaled server-side, so send base values.
+        quantity: meal.meal_template_id ? food.quantity : food.quantity * scaleFactor,
       })),
     };
 
@@ -139,12 +294,18 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
     throw error instanceof Error ? error : new Error('Failed to load meal');
   }
 
-  const scaledCalories = (meal.calories ?? 0) * scaleFactor;
-  const scaledProtein = (meal.protein ?? 0) * scaleFactor;
-  const scaledCarbs = (meal.carbs ?? 0) * scaleFactor;
-  const scaledFat = (meal.fat ?? 0) * scaleFactor;
+  // displayScale converts a draft's stored quantity to the consumed amount:
+  // templateScale (base -> consumed for template meals) x scaleFactor (the
+  // change in servings). Used by both the nutrition card and the rows so they
+  // always agree with each other and with the saved payload.
+  const displayScale = templateScale * scaleFactor;
+  displayScaleRef.current = displayScale;
+  const scaledCalories = baseTotals.calories * displayScale;
+  const scaledProtein = baseTotals.protein * displayScale;
+  const scaledCarbs = baseTotals.carbs * displayScale;
+  const scaledFat = baseTotals.fat * displayScale;
   const scaledFiber =
-    meal.dietary_fiber != null ? meal.dietary_fiber * scaleFactor : undefined;
+    baseTotals.fiber != null ? baseTotals.fiber * displayScale : undefined;
 
   return (
     <View className="flex-1 bg-background" style={{ paddingTop: insets.top }}>
@@ -161,7 +322,7 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
           <Button
             variant="ghost"
             onPress={handleSave}
-            disabled={!canSave || isSavePending}
+            disabled={!canSave || isRowBusy}
             hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
             textClassName="font-medium"
           >
@@ -261,35 +422,47 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
           </View>
         </Animated.View>
 
-        {/* Component foods (read-only) */}
+        {/* Component foods: tap a row to edit, swipe to remove, button to add. */}
         <View className="mt-2">
           <Text className="text-text-secondary text-sm mb-2">Foods in this meal</Text>
-          <View className="bg-surface rounded-xl">
-            {meal.foods.map((food, index) => {
-              const ratio = food.serving_size > 0 ? food.quantity / food.serving_size : food.quantity;
-              const foodCals = Math.round((food.calories ?? 0) * ratio * scaleFactor);
-              return (
-                <View
-                  key={`${food.food_id}-${index}`}
-                  className={`flex-row items-center px-3 py-2 ${index < meal.foods.length - 1 ? 'border-b border-border-subtle' : ''}`}
-                >
-                  <View className="flex-1 mr-2">
-                    <Text className="text-text-primary text-base" numberOfLines={1}>
-                      {food.food_name}
-                    </Text>
-                    <Text className="text-text-secondary text-xs mt-0.5">
-                      {food.quantity * scaleFactor % 1 === 0
-                        ? food.quantity * scaleFactor
-                        : parseFloat((food.quantity * scaleFactor).toFixed(2))}{' '}
-                      {food.unit}
-                    </Text>
-                  </View>
-                  <Text className="text-text-secondary text-sm font-medium">
-                    {foodCals} Cal
-                  </Text>
-                </View>
-              );
-            })}
+          {ingredients.length > 0 ? (
+            <View className="bg-surface rounded-xl overflow-hidden">
+              {ingredients.map((food, index) => {
+                // Show consumed amounts (stored quantity x servings change), so
+                // rows stay consistent with the nutrition card and the payload.
+                const scaledQty = food.quantity * displayScale;
+                const scale = food.serving_size > 0 ? scaledQty / food.serving_size : 0;
+                const foodCals = formatCaloriesDisplay((food.calories ?? 0) * scale);
+                return (
+                  <SwipeableIngredientRow
+                    key={`${food.food_id}-${food.variant_id}-${index}`}
+                    foodName={food.food_name ?? 'Food'}
+                    quantityLabel={`${formatServingSizeDisplay(scaledQty)} ${food.unit}`}
+                    caloriesLabel={`${foodCals} Cal`}
+                    showBottomBorder={index < ingredients.length - 1}
+                    isLastIngredient={ingredients.length === 1}
+                    disabled={isRowBusy}
+                    onPress={() => editIngredient(index)}
+                    onConfirmDelete={() => handleRemoveIngredient(index)}
+                  />
+                );
+              })}
+            </View>
+          ) : (
+            <Text className="text-text-muted text-sm">No foods in this meal yet.</Text>
+          )}
+
+          <View className="items-center pt-3">
+            <Button
+              variant="ghost"
+              onPress={openIngredientPicker}
+              disabled={isRowBusy}
+              className="min-h-11 flex-row items-center gap-1.5 rounded-xl px-3 py-2"
+              accessibilityLabel="Add Food"
+            >
+              <Icon name="add" size={16} color={accentColor} />
+              <Text className="text-accent-primary text-sm font-semibold">Add Food</Text>
+            </Button>
           </View>
         </View>
 
@@ -297,7 +470,7 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
         <Button
           variant="ghost"
           onPress={confirmAndDelete}
-          disabled={isDeletePending}
+          disabled={isRowBusy}
           className="mt-2"
           textClassName="text-bg-danger font-medium"
         >

--- a/SparkyFitnessMobile/src/utils/mealBuilderDraft.ts
+++ b/SparkyFitnessMobile/src/utils/mealBuilderDraft.ts
@@ -166,6 +166,24 @@ export function toMealFoodPayload(food: FoodEntryMealFood): MealFoodPayload {
   };
 }
 
+// Logged-meal component foods (FoodEntryMealFood) carry no brand and arrive at
+// BASE (unscaled) quantities from the server, which is exactly the shape the
+// ingredient editor works in. Spread-then-normalize so the full nutrient
+// snapshot (poly/mono fat, glycemic index, custom nutrients) survives a round
+// trip rather than being dropped.
+export function buildMealIngredientDraftFromEntryMealFood(
+  food: FoodEntryMealFood,
+): MealIngredientDraft {
+  return normalizeMealIngredientDraft({
+    ...food,
+    brand: null,
+    calories: food.calories ?? 0,
+    protein: food.protein ?? 0,
+    carbs: food.carbs ?? 0,
+    fat: food.fat ?? 0,
+  });
+}
+
 export function buildMealIngredientDraftFromMealFood(food: MealFood): MealIngredientDraft {
   return normalizeMealIngredientDraft({
     food_id: food.food_id,


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
On mobile the foods inside a logged meal were read-only, so correcting a meal meant deleting and re-logging it. This makes a logged meal's component foods fully editable, matching the web MealBuilder.

**How did you implement the solution?**
`EditLoggedMealScreen` now holds the component foods in local state seeded from the loaded meal. Add uses the existing meal-builder picker ("Add Food"), edit opens that picker pre-filled by tapping a row, and remove uses the swipe action or a long-press Edit / Delete menu (a discoverable path for users who don't reach for swipe, matching `MealAddScreen` and `SwipeableFoodRow`). All changes are staged and committed together on Save via `PUT /api/food-entry-meals/:id`, which already replaces the foods array, so there is no server change. Removing the last food stages like any other change rather than deleting the meal; Save is disabled until a food remains, and the Delete Meal button removes the whole meal. Component quantities are edited at base values and `meal_template_id` is preserved; for template-linked meals the screen recovers the storage multiplier so the card and rows show consumed totals, and the server rescales on save.

Linked Issue: Closes #1473

## How to Test

1. Open the diary and tap a logged meal to open the Edit Meal screen.
2. Tap "Add Food", pick a food and set a quantity, confirm, then Save and reopen to verify it persisted.
3. Tap an existing ingredient row, change quantity, unit, or serving, confirm, then Save and reopen to verify.
4. Swipe a non-last ingredient and Delete, or long-press a row and choose Delete. It leaves the list but only persists on Save (back out without saving to confirm it returns).
5. Swipe or long-press the last remaining ingredient and Delete. It is removed and Save is disabled until you add a food; use the Delete Meal button to remove the whole meal.
6. On a meal saved from a template and on a meal with servings set above 1, edit an ingredient, Save, reopen, and confirm the per-row amounts, the nutrition card, and the totals are all consistent.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):** _N/A - no frontend changes in this PR._

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):** _N/A - no backend changes in this PR._

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="480" height="976" alt="Screenshot_20260608_114049_SparkyFitness" src="https://github.com/user-attachments/assets/c3a0ffc9-832e-41f8-874c-9a2b29d06bcf" />

### After

<img width="480" height="976" alt="Screenshot_20260608_113955_SparkyFitness" src="https://github.com/user-attachments/assets/e1bf5f58-d0b4-439a-9d54-27667f0f251d" />

<img width="480" height="976" alt="Screenshot_20260608_114002_SparkyFitness" src="https://github.com/user-attachments/assets/4acc1b45-1d9e-41ad-b116-0f56ebc657cf" />

<img width="480" height="976" alt="Screenshot_20260608_114012_SparkyFitness" src="https://github.com/user-attachments/assets/0d57d44c-c7a2-4a29-826c-3d3fbda6c074" />

</details>

## Notes for Reviewers

No server change: the existing `PUT /api/food-entry-meals/:id` already replaces the foods array. Removal is staged and committed on Save (not an immediate write), so add, edit, and remove share one Save and one persistence model. For template-linked meals the screen derives the storage multiplier from the loaded snapshot so displayed totals match the consumed amounts while the saved payload stays in base units for the server to rescale.

Tested on a physical Android device. I do not have an iOS device to test on, but this is shared React Native code with no platform-specific branches, so it should behave identically on iOS.
