### PR TITLE
refactor: add chatbot tool registry

### DIFF
--- a/SparkyFitnessServer/AGENTS.md
+++ b/SparkyFitnessServer/AGENTS.md
@@ -185,7 +185,7 @@ When searching, ignore noisy/generated directories unless you explicitly need th
 - `ai/config.ts` holds default model and vision-model selection per provider; `ai/providerDispatch.ts` is the unified dispatch helper used by chat, food-photo analysis, nutrition-label scan, and unit conversion
 - Prefer routing new AI features through `providerDispatch.ts` instead of calling provider SDKs directly
 - Chatbot tool calls run in-process through the registry in `ai/tools/`; the chat path does not use the external `SparkyFitnessMCP/` server (that package now serves external MCP clients only)
-- `ai/tools/index.ts` exposes `buildChatbotTools(userId)`, composing the per-domain builders (`build<Domain>Tools` in `ai/tools/<domain>Tools.ts`); handlers close over the authenticated user, so two-actor services receive `(userId, userId, ...)`
+- `ai/tools/index.ts` exposes `buildChatbotTools(userId, tz)`, composing the per-domain builders (`build<Domain>Tools` in `ai/tools/<domain>Tools.ts`); handlers close over the authenticated user — so two-actor services receive `(userId, userId, ...)` — and the user's IANA timezone, used for "today" defaults and day bucketing
 - Tool handlers follow a fixed contract: publish a flat Zod schema, validate with a strict union `safeParse` inside `execute`, orchestrate through existing services and repositories, and never throw - errors come back as `ERRORS.*` strings from `ai/tools/errors.ts`
 - Tool output text is a parity contract with the MCP tool set; golden tests in `tests/chatbotTools*.test.ts` assert exact returned strings, so do not reword tool output casually
 

--- a/SparkyFitnessServer/AGENTS.md
+++ b/SparkyFitnessServer/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-_Last updated: 2026-06-10_
+_Last updated: 2026-06-11_
 
 SparkyFitness Server is the backend API package for the SparkyFitness monorepo. Use this file as the primary guide for work inside `SparkyFitnessServer/`.
 
@@ -64,7 +64,7 @@ pnpm exec eslint routes/v2/foodRoutes.ts services/foodCoreService.ts
 - `db/` - pool management, grants, migrations, and RLS policies
 - `config/` - logging and Swagger config
 - `utils/` - startup helpers, CORS, permissions, timezone loading, OIDC helpers, migration helpers
-- `ai/` - AI provider configuration (`config.ts`) and the unified provider-dispatch helper (`providerDispatch.ts`)
+- `ai/` - AI provider configuration (`config.ts`), the unified provider-dispatch helper (`providerDispatch.ts`), and the in-process chatbot tool registry (`ai/tools/`)
 - `security/` - encryption utilities (`encryption.ts`)
 - `validation/` - legacy express-validator rules for a few older routes (new routes use Zod schemas)
 - `constants/` - shared constants and supporting package data
@@ -184,6 +184,10 @@ When searching, ignore noisy/generated directories unless you explicitly need th
 - AI calls go through the Vercel `ai` SDK (v6) with provider adapters for OpenAI, Anthropic, and Google, plus OpenAI-compatible, Mistral, Groq, OpenRouter, and Ollama service types
 - `ai/config.ts` holds default model and vision-model selection per provider; `ai/providerDispatch.ts` is the unified dispatch helper used by chat, food-photo analysis, nutrition-label scan, and unit conversion
 - Prefer routing new AI features through `providerDispatch.ts` instead of calling provider SDKs directly
+- Chatbot tool calls run in-process through the registry in `ai/tools/`; the chat path does not use the external `SparkyFitnessMCP/` server (that package now serves external MCP clients only)
+- `ai/tools/index.ts` exposes `buildChatbotTools(userId)`, composing the per-domain builders (`build<Domain>Tools` in `ai/tools/<domain>Tools.ts`); handlers close over the authenticated user, so two-actor services receive `(userId, userId, ...)`
+- Tool handlers follow a fixed contract: publish a flat Zod schema, validate with a strict union `safeParse` inside `execute`, orchestrate through existing services and repositories, and never throw - errors come back as `ERRORS.*` strings from `ai/tools/errors.ts`
+- Tool output text is a parity contract with the MCP tool set; golden tests in `tests/chatbotTools*.test.ts` assert exact returned strings, so do not reword tool output casually
 
 ## Testing and Validation
 
@@ -209,6 +213,8 @@ When searching, ignore noisy/generated directories unless you explicitly need th
   inspect the relevant `integrations/*` code, then the matching service and repository files
 - Health data or date bucketing issue:
   inspect `integrations/healthData/healthDataRoutes.ts`, `services/measurementService.ts`, and `utils/timezoneLoader.ts`
+- AI chat or chatbot tool issue:
+  inspect `services/chatService.ts`, `ai/tools/`, and the matching domain service and repository
 
 ## Working Rules
 

--- a/SparkyFitnessServer/ai/tools/checkinTools.ts
+++ b/SparkyFitnessServer/ai/tools/checkinTools.ts
@@ -33,6 +33,47 @@ function isSet<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined;
 }
 
+// Biometrics rows converted into the user's preferred units, oldest-first —
+// MCP's getBiometricsHistory row shape. Shared with the report tools.
+export async function getBiometricsHistoryRows(
+  userId: string,
+  startDate?: string,
+  endDate?: string
+) {
+  const prefs = await preferenceService.getUserPreferences(userId, userId);
+  const wUnit = prefs.default_weight_unit || 'kg';
+  const mUnit = prefs.default_measurement_unit || 'cm';
+
+  const rows = await measurementService.getCheckInMeasurementsByDateRange(
+    userId,
+    userId,
+    startDate || '1970-01-01',
+    endDate || '9999-12-31'
+  );
+  // The repository returns newest-first; MCP rendered oldest-first.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return [...rows].reverse().map((row: any) => ({
+    ...row,
+    weight: isSet(row.weight)
+      ? convertWeight(Number(row.weight), 'kg', wUnit)
+      : null,
+    height: isSet(row.height)
+      ? convertMeasurement(Number(row.height), 'cm', mUnit)
+      : null,
+    neck: isSet(row.neck)
+      ? convertMeasurement(Number(row.neck), 'cm', mUnit)
+      : null,
+    waist: isSet(row.waist)
+      ? convertMeasurement(Number(row.waist), 'cm', mUnit)
+      : null,
+    hips: isSet(row.hips)
+      ? convertMeasurement(Number(row.hips), 'cm', mUnit)
+      : null,
+    weight_unit: wUnit,
+    measurement_unit: mUnit,
+  }));
+}
+
 export function buildCheckinTools(userId: string) {
   return {
     sparky_manage_checkin: tool({
@@ -491,41 +532,11 @@ Actions:
             }
 
             case 'get_biometrics_history': {
-              const prefs = await preferenceService.getUserPreferences(
+              const history = await getBiometricsHistoryRows(
                 userId,
-                userId
+                args.start_date,
+                args.end_date
               );
-              const wUnit = prefs.default_weight_unit || 'kg';
-              const mUnit = prefs.default_measurement_unit || 'cm';
-
-              const rows =
-                await measurementService.getCheckInMeasurementsByDateRange(
-                  userId,
-                  userId,
-                  args.start_date || '1970-01-01',
-                  args.end_date || '9999-12-31'
-                );
-              // The repository returns newest-first; MCP rendered oldest-first.
-              const history = [...rows].reverse().map((row: any) => ({
-                ...row,
-                weight: isSet(row.weight)
-                  ? convertWeight(Number(row.weight), 'kg', wUnit)
-                  : null,
-                height: isSet(row.height)
-                  ? convertMeasurement(Number(row.height), 'cm', mUnit)
-                  : null,
-                neck: isSet(row.neck)
-                  ? convertMeasurement(Number(row.neck), 'cm', mUnit)
-                  : null,
-                waist: isSet(row.waist)
-                  ? convertMeasurement(Number(row.waist), 'cm', mUnit)
-                  : null,
-                hips: isSet(row.hips)
-                  ? convertMeasurement(Number(row.hips), 'cm', mUnit)
-                  : null,
-                weight_unit: wUnit,
-                measurement_unit: mUnit,
-              }));
               return formatList(history, 'Biometrics History', (h: any) => {
                 const hw = h.weight_unit || 'kg';
                 let text = `**${h.entry_date}**: `;

--- a/SparkyFitnessServer/ai/tools/checkinTools.ts
+++ b/SparkyFitnessServer/ai/tools/checkinTools.ts
@@ -309,8 +309,9 @@ Actions:
                 const mins = Math.floor((args.duration_seconds % 3600) / 60);
                 parts.push(`${hours}h ${mins}m`);
               }
-              if (isSet(args.sleep_score))
-                parts.push(`score: ${args.sleep_score}/100`);
+              // args.sleep_score is accepted for schema parity but never
+              // stored — processSleepEntry always computes its own score —
+              // so it must not be echoed in the confirmation either.
               if (args.source) parts.push(`source: ${args.source}`);
               const summary = parts.length > 0 ? parts.join(', ') : 'recorded';
               return formatConfirmation(

--- a/SparkyFitnessServer/ai/tools/checkinTools.ts
+++ b/SparkyFitnessServer/ai/tools/checkinTools.ts
@@ -1,0 +1,556 @@
+import { tool } from 'ai';
+import { todayInZone } from '@workspace/shared';
+import { log } from '../../config/logging.js';
+import measurementService from '../../services/measurementService.js';
+import preferenceService from '../../services/preferenceService.js';
+import moodRepository from '../../models/moodRepository.js';
+import fastingRepository from '../../models/fastingRepository.js';
+import sleepRepository from '../../models/sleepRepository.js';
+import { ERRORS, formatZodError } from './errors.js';
+import { formatConfirmation, formatList, formatSuccess } from './formatting.js';
+import { convertWeight, convertMeasurement } from './unitConversion.js';
+import {
+  manageCheckinSchema,
+  manageCheckinInput,
+  type ManageCheckinInput,
+} from './schemas/checkin.js';
+
+const VALID_ACTIONS = [
+  'log_biometrics',
+  'log_custom_metric',
+  'list_categories',
+  'create_category',
+  'log_mood',
+  'log_fasting',
+  'log_sleep',
+  'list_checkin_diary',
+  'get_fasting_status',
+  'get_biometrics_history',
+];
+
+// Optional inputs and nullable DB columns are treated alike: absent.
+function isSet<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+export function buildCheckinTools(userId: string) {
+  return {
+    sparky_manage_checkin: tool({
+      description: `Health tracking: weight, steps, body measurements, mood, sleep, fasting, custom metrics.
+
+Actions:
+- log_biometrics(entry_date, weight?, steps?, height?, neck?, waist?, hips?, body_fat?, weight_unit?:"kg"|"lbs", height_unit?:"cm"|"in", measurements_unit?:"cm"|"in")
+- log_mood(entry_date, mood_value:1-10, notes?)
+- log_sleep(entry_date, duration_seconds?, sleep_score?:0-100, bedtime?, wake_time?, source?)
+- log_fasting(start_time:ISO8601, end_time?, fasting_status?:"ACTIVE"|"COMPLETED"|"CANCELLED", fasting_type?)
+- log_custom_metric(entry_date, category_name, value:string|number, unit?, notes?)
+- create_category(category_name, unit?)
+- list_categories()
+- list_checkin_diary(entry_date?)
+- get_fasting_status() — returns the currently active fasting session if any
+- get_biometrics_history(start_date?, end_date?) — returns weight and measurements history`,
+      inputSchema: manageCheckinInput,
+      execute: async (rawArgs) => {
+        const parsed = manageCheckinSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        const args: ManageCheckinInput = parsed.data;
+        try {
+          switch (args.action) {
+            case 'log_biometrics': {
+              const prefs = await preferenceService.getUserPreferences(
+                userId,
+                userId
+              );
+              const defaultWeightUnit = prefs.default_weight_unit || 'kg';
+              const defaultMeasurementUnit =
+                prefs.default_measurement_unit || 'cm';
+
+              // Convert to standard units (kg, cm) for storage
+              const mUnit = args.measurements_unit || defaultMeasurementUnit;
+              const measurements: Record<string, number> = {};
+              if (isSet(args.weight)) {
+                measurements.weight = convertWeight(
+                  args.weight,
+                  args.weight_unit || defaultWeightUnit,
+                  'kg'
+                );
+              }
+              if (isSet(args.height)) {
+                measurements.height = convertMeasurement(
+                  args.height,
+                  args.height_unit || defaultMeasurementUnit,
+                  'cm'
+                );
+              }
+              if (isSet(args.body_fat)) {
+                measurements.body_fat_percentage = args.body_fat;
+              }
+              if (isSet(args.neck)) {
+                measurements.neck = convertMeasurement(args.neck, mUnit, 'cm');
+              }
+              if (isSet(args.waist)) {
+                measurements.waist = convertMeasurement(
+                  args.waist,
+                  mUnit,
+                  'cm'
+                );
+              }
+              if (isSet(args.hips)) {
+                measurements.hips = convertMeasurement(args.hips, mUnit, 'cm');
+              }
+              if (isSet(args.steps)) {
+                measurements.steps = args.steps;
+              }
+
+              await measurementService.upsertCheckInMeasurements(
+                userId,
+                userId,
+                args.entry_date,
+                measurements
+              );
+
+              const parts: string[] = [];
+              if (isSet(args.weight))
+                parts.push(`weight: ${args.weight}${args.weight_unit || 'kg'}`);
+              if (isSet(args.steps)) parts.push(`steps: ${args.steps}`);
+              if (isSet(args.height))
+                parts.push(`height: ${args.height}${args.height_unit || 'cm'}`);
+              if (isSet(args.body_fat))
+                parts.push(`body fat: ${args.body_fat}%`);
+              if (isSet(args.neck))
+                parts.push(
+                  `neck: ${args.neck}${args.measurements_unit || 'cm'}`
+                );
+              if (isSet(args.waist))
+                parts.push(
+                  `waist: ${args.waist}${args.measurements_unit || 'cm'}`
+                );
+              if (isSet(args.hips))
+                parts.push(
+                  `hips: ${args.hips}${args.measurements_unit || 'cm'}`
+                );
+              const summary =
+                parts.length > 0 ? parts.join(', ') : 'no changes';
+              return formatConfirmation(
+                `Biometrics logged for ${args.entry_date} (${summary}).`
+              );
+            }
+
+            case 'log_custom_metric': {
+              const categories = await measurementService.getCustomCategories(
+                userId,
+                userId
+              );
+              const category = categories.find(
+                (cat: any) =>
+                  String(cat.name).toLowerCase() ===
+                  args.category_name.toLowerCase()
+              );
+              if (!category) {
+                return ERRORS.VALIDATION(
+                  `Category "${args.category_name}" not found. Create it first using the create_category action.`
+                );
+              }
+              await measurementService.upsertCustomMeasurementEntry(
+                userId,
+                userId,
+                {
+                  category_id: category.id,
+                  value: String(args.value),
+                  entry_date: args.entry_date,
+                  notes: args.notes,
+                }
+              );
+              return formatConfirmation(
+                `Custom metric "${args.category_name}" logged: ${args.value}${args.unit ? ' ' + args.unit : ''} on ${args.entry_date}.`
+              );
+            }
+
+            case 'list_categories': {
+              const rows = await measurementService.getCustomCategories(
+                userId,
+                userId
+              );
+              const categories = rows
+                .map((row: any) => ({
+                  id: row.id,
+                  category_name: row.name,
+                  measurement_type: row.measurement_type,
+                  created_at: row.created_at,
+                }))
+                .sort((a: any, b: any) =>
+                  String(a.category_name).localeCompare(String(b.category_name))
+                );
+              return formatList(
+                categories,
+                'Custom Measurement Categories',
+                (c: any) => `**${c.category_name}**\n  ID: ${c.id}`
+              );
+            }
+
+            case 'create_category': {
+              await measurementService.createCustomCategory(userId, userId, {
+                name: args.category_name,
+                measurement_type: args.unit || 'unit',
+                data_type: args.data_type || 'numeric',
+                frequency: 'Daily',
+              });
+              return formatConfirmation(
+                `Category "${args.category_name}" created${args.unit ? ` with measurement type "${args.unit}"` : ''}.`
+              );
+            }
+
+            case 'log_mood': {
+              await moodRepository.createOrUpdateMoodEntry(
+                userId,
+                args.mood_value,
+                args.notes || null,
+                args.entry_date
+              );
+              return formatConfirmation(
+                `Mood logged for ${args.entry_date}: ${args.mood_value}/10${args.notes ? ' — ' + args.notes : ''}.`
+              );
+            }
+
+            case 'log_fasting': {
+              const created = await fastingRepository.createFastingLog(
+                userId,
+                args.start_time,
+                null,
+                args.fasting_type || null
+              );
+              const status = args.fasting_status || 'ACTIVE';
+              const updates: Record<string, string> = {};
+              if (args.end_time) updates.end_time = args.end_time;
+              if (status !== 'ACTIVE') updates.status = status;
+              if (Object.keys(updates).length > 0) {
+                await fastingRepository.updateFast(created.id, userId, updates);
+              }
+              return formatConfirmation(
+                `Fasting window logged (${status})${args.fasting_type ? ' — ' + args.fasting_type : ''}.`
+              );
+            }
+
+            case 'log_sleep': {
+              let bedtime = args.bedtime;
+              let wakeTime = args.wake_time;
+              const duration = args.duration_seconds ?? 28800; // Default 8h
+
+              if (!bedtime && !wakeTime) {
+                // Default: wake time is 7 AM on entry_date, bedtime is 8h before
+                const wake = new Date(`${args.entry_date}T07:00:00Z`);
+                const bed = new Date(wake.getTime() - duration * 1000);
+                wakeTime = wake.toISOString();
+                bedtime = bed.toISOString();
+              } else if (!bedtime && wakeTime) {
+                const wake = new Date(wakeTime);
+                const bed = new Date(wake.getTime() - duration * 1000);
+                bedtime = bed.toISOString();
+              } else if (bedtime && !wakeTime) {
+                const bed = new Date(bedtime);
+                const wake = new Date(bed.getTime() + duration * 1000);
+                wakeTime = wake.toISOString();
+              }
+
+              await measurementService.processSleepEntry(userId, userId, {
+                entry_date: args.entry_date,
+                bedtime,
+                wake_time: wakeTime,
+                duration_in_seconds: duration,
+                source: args.source || 'manual',
+              });
+
+              const parts: string[] = [];
+              if (isSet(args.duration_seconds)) {
+                const hours = Math.floor(args.duration_seconds / 3600);
+                const mins = Math.floor((args.duration_seconds % 3600) / 60);
+                parts.push(`${hours}h ${mins}m`);
+              }
+              if (isSet(args.sleep_score))
+                parts.push(`score: ${args.sleep_score}/100`);
+              if (args.source) parts.push(`source: ${args.source}`);
+              const summary = parts.length > 0 ? parts.join(', ') : 'recorded';
+              return formatConfirmation(
+                `Sleep logged for ${args.entry_date} (${summary}).`
+              );
+            }
+
+            case 'list_checkin_diary': {
+              const date = args.entry_date || todayInZone('UTC');
+              const dateLabel = args.entry_date || 'today';
+
+              const bioRow = await measurementService.getCheckInMeasurements(
+                userId,
+                userId,
+                date
+              );
+              const moodEntry = await moodRepository.getMoodEntryByDate(
+                userId,
+                date
+              );
+              const sleepRows =
+                await sleepRepository.getSleepEntriesByUserIdAndDateRange(
+                  userId,
+                  date,
+                  date
+                );
+              const fastRows =
+                await fastingRepository.getFastingLogsOverlappingDay(
+                  userId,
+                  date
+                );
+              const customRows =
+                await measurementService.getCustomMeasurementEntriesByDate(
+                  userId,
+                  userId,
+                  date
+                );
+              const prefs = await preferenceService.getUserPreferences(
+                userId,
+                userId
+              );
+              const wUnit = prefs.default_weight_unit || 'kg';
+              const mUnit = prefs.default_measurement_unit || 'cm';
+
+              let bio: Record<string, any> | null =
+                bioRow && Object.keys(bioRow).length > 0 ? bioRow : null;
+              if (bio) {
+                bio = {
+                  ...bio,
+                  weight: isSet(bio.weight)
+                    ? convertWeight(Number(bio.weight), 'kg', wUnit)
+                    : null,
+                  height: isSet(bio.height)
+                    ? convertMeasurement(Number(bio.height), 'cm', mUnit)
+                    : null,
+                  neck: isSet(bio.neck)
+                    ? convertMeasurement(Number(bio.neck), 'cm', mUnit)
+                    : null,
+                  waist: isSet(bio.waist)
+                    ? convertMeasurement(Number(bio.waist), 'cm', mUnit)
+                    : null,
+                  hips: isSet(bio.hips)
+                    ? convertMeasurement(Number(bio.hips), 'cm', mUnit)
+                    : null,
+                  weight_unit: wUnit,
+                  measurement_unit: mUnit,
+                };
+              }
+
+              const moods = moodEntry ? [moodEntry] : [];
+              const sleeps = [...sleepRows]
+                .sort(
+                  (a: any, b: any) =>
+                    new Date(a.created_at).getTime() -
+                    new Date(b.created_at).getTime()
+                )
+                .map((row: any) => ({
+                  ...row,
+                  duration_seconds: row.duration_in_seconds,
+                  bedtime: row.bedtime
+                    ? new Date(row.bedtime).toISOString()
+                    : null,
+                  wake_time: row.wake_time
+                    ? new Date(row.wake_time).toISOString()
+                    : null,
+                }));
+              const fasts = fastRows.map((row: any) => ({
+                id: row.id,
+                start_time: row.start_time,
+                end_time: row.end_time,
+                fasting_status: row.status,
+                fasting_type: row.fasting_type,
+              }));
+              const customs = [...customRows]
+                .map((row: any) => ({
+                  id: row.id,
+                  category_name: row.custom_categories?.name,
+                  value: row.value,
+                  measurement_type: row.custom_categories?.measurement_type,
+                  notes: row.notes,
+                  entry_date: row.entry_date,
+                  created_at: row.created_at,
+                }))
+                .sort(
+                  (a: any, b: any) =>
+                    String(a.category_name).localeCompare(
+                      String(b.category_name)
+                    ) ||
+                    new Date(a.created_at).getTime() -
+                      new Date(b.created_at).getTime()
+                );
+
+              let text = `### Check-in Diary: ${dateLabel}\n\n`;
+
+              // Biometrics
+              if (bio) {
+                const b = bio;
+                const bw = b.weight_unit || 'kg';
+                const bm = b.measurement_unit || 'cm';
+
+                text += '#### Biometrics\n';
+                if (b.weight) text += `- **Weight:** ${b.weight} ${bw}\n`;
+                if (b.height) text += `- **Height:** ${b.height} ${bm}\n`;
+                if (b.steps) text += `- **Steps:** ${b.steps}\n`;
+                if (b.body_fat_percentage)
+                  text += `- **Body Fat:** ${b.body_fat_percentage}%\n`;
+                if (b.neck) text += `- **Neck:** ${b.neck} ${bm}\n`;
+                if (b.waist) text += `- **Waist:** ${b.waist} ${bm}\n`;
+                if (b.hips) text += `- **Hips:** ${b.hips} ${bm}\n`;
+                text += '\n';
+              }
+
+              // Mood
+              if (moods.length > 0) {
+                text += '## Mood\n';
+                for (const m of moods) {
+                  text += `- ${m.mood_value}/10`;
+                  if (m.notes) text += ` — ${m.notes}`;
+                  text += '\n';
+                }
+                text += '\n';
+              }
+
+              // Sleep
+              if (sleeps.length > 0) {
+                text += '## Sleep\n';
+                for (const s of sleeps) {
+                  const parts: string[] = [];
+                  if (isSet(s.duration_seconds)) {
+                    const hours = Math.floor(s.duration_seconds / 3600);
+                    const mins = Math.floor((s.duration_seconds % 3600) / 60);
+                    parts.push(`${hours}h ${mins}m`);
+                  }
+                  if (isSet(s.sleep_score))
+                    parts.push(`score: ${s.sleep_score}/100`);
+                  if (s.bedtime) parts.push(`bed: ${s.bedtime}`);
+                  if (s.wake_time) parts.push(`wake: ${s.wake_time}`);
+                  if (s.source) parts.push(`(${s.source})`);
+                  text += `- ${parts.join(' | ')}\n`;
+                }
+                text += '\n';
+              }
+
+              // Fasting
+              if (fasts.length > 0) {
+                text += '## Fasting\n';
+                for (const f of fasts) {
+                  let line = `- ${f.fasting_status || 'ACTIVE'}`;
+                  if (f.fasting_type) line += ` (${f.fasting_type})`;
+                  line += `: ${f.start_time}`;
+                  if (f.end_time) line += ` → ${f.end_time}`;
+                  text += line + '\n';
+                }
+                text += '\n';
+              }
+
+              // Custom metrics
+              if (customs.length > 0) {
+                text += '## Custom Metrics\n';
+                for (const c of customs) {
+                  let line = `- **${c.category_name}**: ${c.value}`;
+                  if (c.notes) line += ` — ${c.notes}`;
+                  text += line + '\n';
+                }
+                text += '\n';
+              }
+
+              // Check if empty
+              if (
+                !bio &&
+                moods.length === 0 &&
+                sleeps.length === 0 &&
+                fasts.length === 0 &&
+                customs.length === 0
+              ) {
+                text += 'No check-in data found for this date.\n';
+              }
+
+              return text;
+            }
+
+            case 'get_fasting_status': {
+              const fast = await fastingRepository.getCurrentFast(userId);
+              if (!fast) {
+                return 'No active fasting session.';
+              }
+              return formatSuccess(
+                {
+                  id: fast.id,
+                  user_id: fast.user_id,
+                  start_time: fast.start_time,
+                  end_time: fast.end_time,
+                  fasting_status: fast.status,
+                  fasting_type: fast.fasting_type,
+                  created_at: fast.created_at,
+                },
+                'Fasting Status'
+              );
+            }
+
+            case 'get_biometrics_history': {
+              const prefs = await preferenceService.getUserPreferences(
+                userId,
+                userId
+              );
+              const wUnit = prefs.default_weight_unit || 'kg';
+              const mUnit = prefs.default_measurement_unit || 'cm';
+
+              const rows =
+                await measurementService.getCheckInMeasurementsByDateRange(
+                  userId,
+                  userId,
+                  args.start_date || '1970-01-01',
+                  args.end_date || '9999-12-31'
+                );
+              // The repository returns newest-first; MCP rendered oldest-first.
+              const history = [...rows].reverse().map((row: any) => ({
+                ...row,
+                weight: isSet(row.weight)
+                  ? convertWeight(Number(row.weight), 'kg', wUnit)
+                  : null,
+                height: isSet(row.height)
+                  ? convertMeasurement(Number(row.height), 'cm', mUnit)
+                  : null,
+                neck: isSet(row.neck)
+                  ? convertMeasurement(Number(row.neck), 'cm', mUnit)
+                  : null,
+                waist: isSet(row.waist)
+                  ? convertMeasurement(Number(row.waist), 'cm', mUnit)
+                  : null,
+                hips: isSet(row.hips)
+                  ? convertMeasurement(Number(row.hips), 'cm', mUnit)
+                  : null,
+                weight_unit: wUnit,
+                measurement_unit: mUnit,
+              }));
+              return formatList(history, 'Biometrics History', (h: any) => {
+                const hw = h.weight_unit || 'kg';
+                let text = `**${h.entry_date}**: `;
+                if (h.weight) text += `Weight: ${h.weight}${hw} `;
+                if (h.body_fat_percentage)
+                  text += `| BF: ${h.body_fat_percentage}% `;
+                if (h.steps) text += `| Steps: ${h.steps}`;
+                return text;
+              });
+            }
+
+            default:
+              return ERRORS.INVALID_ACTION(
+                String((args as any).action),
+                VALID_ACTIONS
+              );
+          }
+        } catch (error) {
+          log('error', '[Checkin Tool] Error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.VALIDATION(error.message);
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/checkinTools.ts
+++ b/SparkyFitnessServer/ai/tools/checkinTools.ts
@@ -1,5 +1,5 @@
 import { tool } from 'ai';
-import { todayInZone } from '@workspace/shared';
+import { dayToUtcRange, todayInZone } from '@workspace/shared';
 import { log } from '../../config/logging.js';
 import measurementService from '../../services/measurementService.js';
 import preferenceService from '../../services/preferenceService.js';
@@ -74,7 +74,7 @@ export async function getBiometricsHistoryRows(
   }));
 }
 
-export function buildCheckinTools(userId: string) {
+export function buildCheckinTools(userId: string, tz: string) {
   return {
     sparky_manage_checkin: tool({
       description: `Health tracking: weight, steps, body measurements, mood, sleep, fasting, custom metrics.
@@ -280,8 +280,14 @@ Actions:
               const duration = args.duration_seconds ?? 28800; // Default 8h
 
               if (!bedtime && !wakeTime) {
-                // Default: wake time is 7 AM on entry_date, bedtime is 8h before
-                const wake = new Date(`${args.entry_date}T07:00:00Z`);
+                // Default: wake time is 7 AM on entry_date in the user's
+                // timezone, bedtime is 8h before. Local midnight + 7h is off
+                // by the shifted hour on DST-transition days — acceptable for
+                // a sleep-log default.
+                const wake = new Date(
+                  dayToUtcRange(args.entry_date, tz).start.getTime() +
+                    7 * 3600 * 1000
+                );
                 const bed = new Date(wake.getTime() - duration * 1000);
                 wakeTime = wake.toISOString();
                 bedtime = bed.toISOString();
@@ -320,7 +326,7 @@ Actions:
             }
 
             case 'list_checkin_diary': {
-              const date = args.entry_date || todayInZone('UTC');
+              const date = args.entry_date || todayInZone(tz);
               const dateLabel = args.entry_date || 'today';
 
               const bioRow = await measurementService.getCheckInMeasurements(
@@ -341,7 +347,8 @@ Actions:
               const fastRows =
                 await fastingRepository.getFastingLogsOverlappingDay(
                   userId,
-                  date
+                  date,
+                  tz
                 );
               const customRows =
                 await measurementService.getCustomMeasurementEntriesByDate(
@@ -400,8 +407,12 @@ Actions:
                 }));
               const fasts = fastRows.map((row: any) => ({
                 id: row.id,
-                start_time: row.start_time,
-                end_time: row.end_time,
+                start_time: row.start_time
+                  ? new Date(row.start_time).toISOString()
+                  : null,
+                end_time: row.end_time
+                  ? new Date(row.end_time).toISOString()
+                  : null,
                 fasting_status: row.status,
                 fasting_type: row.fasting_type,
               }));

--- a/SparkyFitnessServer/ai/tools/coachTools.ts
+++ b/SparkyFitnessServer/ai/tools/coachTools.ts
@@ -1,0 +1,438 @@
+import { tool } from 'ai';
+import { todayInZone } from '@workspace/shared';
+import { log } from '../../config/logging.js';
+import coachRepository from '../../models/coachRepository.js';
+import { ERRORS, formatZodError } from './errors.js';
+import { formatSuccess } from './formatting.js';
+import {
+  GetHealthSummarySchema,
+  AnalyzeTrendsSchema,
+  Get30DayTrendsSchema,
+  DetectPatternsSchema,
+  GenerateCoachingPlanSchema,
+} from './schemas/coach.js';
+
+// Trend math and pattern classification ported from MCP's coachService; the
+// SQL lives in models/coachRepository.ts.
+
+async function getHealthSummary(
+  userId: string,
+  startDate: string,
+  endDate?: string
+): Promise<Record<string, unknown>> {
+  const end = endDate || startDate;
+
+  const nutrition = await coachRepository.getNutritionAggregates(
+    userId,
+    startDate,
+    end
+  );
+  const exercise = await coachRepository.getExerciseAggregates(
+    userId,
+    startDate,
+    end
+  );
+  const weight = await coachRepository.getLatestWeightInRange(
+    userId,
+    startDate,
+    end
+  );
+  const water = await coachRepository.getWaterIntakeTotal(
+    userId,
+    startDate,
+    end
+  );
+
+  return {
+    period: { start_date: startDate, end_date: end },
+    nutrition: {
+      total_calories: Number(nutrition.total_calories),
+      avg_protein: Number(Number(nutrition.avg_protein).toFixed(1)),
+      avg_carbs: Number(Number(nutrition.avg_carbs).toFixed(1)),
+      avg_fat: Number(Number(nutrition.avg_fat).toFixed(1)),
+      entry_count: nutrition.entry_count,
+    },
+    fitness: {
+      total_calories_burned: Number(exercise.total_calories_burned),
+      workout_count: exercise.workout_count,
+    },
+    vitals: {
+      latest_weight: weight
+        ? { weight: Number(weight.weight), date: weight.entry_date }
+        : null,
+    },
+    hydration: {
+      total_water_ml: Number(water.total_water),
+    },
+  };
+}
+
+async function analyzeTrends(userId: string, days: number) {
+  const weightRows = await coachRepository.getWeightSeries(userId, days);
+  const calorieRows = await coachRepository.getDailyCalorieSeries(userId, days);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const weights = weightRows.map((r: any) => ({
+    date: r.entry_date,
+    weight: Number(r.weight),
+  }));
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const calories = calorieRows.map((r: any) => ({
+    date: r.entry_date,
+    calories: Number(r.daily_calories),
+  }));
+
+  let weightTrend:
+    | 'increasing'
+    | 'decreasing'
+    | 'stable'
+    | 'insufficient_data' = 'insufficient_data';
+  if (weights.length >= 2) {
+    const first = weights[0].weight;
+    const last = weights[weights.length - 1].weight;
+    const diff = last - first;
+    if (Math.abs(diff) < 0.5) {
+      weightTrend = 'stable';
+    } else if (diff > 0) {
+      weightTrend = 'increasing';
+    } else {
+      weightTrend = 'decreasing';
+    }
+  }
+
+  const avgCalories =
+    calories.length > 0
+      ? Number(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (
+            calories.reduce((sum: number, c: any) => sum + c.calories, 0) /
+            calories.length
+          ).toFixed(0)
+        )
+      : 0;
+
+  return {
+    period_days: days,
+    weight: {
+      trend: weightTrend,
+      data_points: weights.length,
+      entries: weights,
+    },
+    calories: {
+      average_daily: avgCalories,
+      data_points: calories.length,
+      entries: calories,
+    },
+  };
+}
+
+async function get30DayTrends(
+  userId: string,
+  endDate?: string
+): Promise<Record<string, unknown>> {
+  const end = endDate || todayInZone('UTC');
+
+  const food = await coachRepository.get30DayFoodAggregates(userId, end);
+  const exercise = await coachRepository.get30DayExerciseAggregates(
+    userId,
+    end
+  );
+  const mood = await coachRepository.get30DayMoodAggregates(userId, end);
+  const sleep = await coachRepository.get30DaySleepAggregates(userId, end);
+  const weightRows = await coachRepository.get30DayWeightSeries(userId, end);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const weights = weightRows.map((r: any) => ({
+    date: r.entry_date,
+    weight: Number(r.weight),
+  }));
+
+  return {
+    period: { end_date: end, days: 30 },
+    food: {
+      days_logged: food.days_logged,
+      avg_daily_calories: Number(Number(food.avg_daily_calories).toFixed(0)),
+      avg_daily_protein: Number(Number(food.avg_daily_protein).toFixed(1)),
+    },
+    exercise: {
+      total_workouts: exercise.total_workouts,
+      active_days: exercise.active_days,
+      total_calories_burned: Number(exercise.total_calories_burned),
+    },
+    mood: {
+      entries: mood.entries,
+      avg_mood: Number(Number(mood.avg_mood).toFixed(1)),
+    },
+    sleep: {
+      entries: sleep.entries,
+      avg_duration_hours: Number(
+        (Number(sleep.avg_duration_seconds) / 3600).toFixed(1)
+      ),
+      avg_sleep_score: Number(Number(sleep.avg_sleep_score).toFixed(0)),
+    },
+    biometrics: {
+      weight_entries: weights.length,
+      weights,
+    },
+  };
+}
+
+async function detectPatterns(
+  userId: string,
+  days: number
+): Promise<Record<string, unknown>> {
+  const data = await coachRepository.getDailyCorrelationRows(userId, days);
+  const patterns: string[] = [];
+
+  if (data.length >= 7) {
+    // 1. High Sugar vs Sleep Score
+    const highSugarDays = data.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (r: any) => Number(r.sugars) > 50 && r.sleep_score
+    );
+    if (highSugarDays.length >= 3) {
+      const avgHighSugarSleep =
+        highSugarDays.reduce(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (sum: number, r: any) => sum + Number(r.sleep_score),
+          0
+        ) / highSugarDays.length;
+      const avgNormalSleep =
+        data
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .filter((r: any) => Number(r.sugars) <= 50 && r.sleep_score)
+          .reduce(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (sum: number, r: any) => sum + Number(r.sleep_score),
+            0
+          ) /
+        (data.length - highSugarDays.length);
+
+      if (avgHighSugarSleep < avgNormalSleep - 5) {
+        patterns.push(
+          'High sugar intake (>50g) correlates with a lower sleep score.'
+        );
+      }
+    }
+
+    // 2. Calories vs Mood
+    const highCalDays = data.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (r: any) => Number(r.calories) > 2500 && r.mood_value
+    );
+    if (highCalDays.length >= 3) {
+      const avgHighCalMood =
+        highCalDays.reduce(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (sum: number, r: any) => sum + Number(r.mood_value),
+          0
+        ) / highCalDays.length;
+      if (avgHighCalMood > 7)
+        patterns.push(
+          'High calorie days (>2500) are associated with higher reported mood.'
+        );
+    }
+
+    // 3. Sodium vs Sleep (High sodium can cause nighttime thirst/disruption)
+    const highSodiumDays = data.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (r: any) => Number(r.sodium) > 2300 && r.sleep_score
+    );
+    if (highSodiumDays.length >= 3) {
+      patterns.push(
+        'Frequent high sodium intake (>2300mg) detected; this may impact morning weight fluctuations.'
+      );
+    }
+  }
+
+  return {
+    period_days: days,
+    data_points: data.length,
+    detected_patterns:
+      patterns.length > 0
+        ? patterns
+        : ['No strong patterns detected in the current data range.'],
+    raw_correlations: data
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .map((r: any) => ({
+        date: r.entry_date,
+        nutrition: {
+          calories: Number(r.calories),
+          protein: Number(r.protein),
+          carbs: Number(r.carbs),
+          fat: Number(r.fat),
+          sugars: Number(r.sugars),
+          sodium: Number(r.sodium),
+          fiber: Number(r.fiber),
+          saturated_fat: Number(r.sat_fat),
+          cholesterol: Number(r.cholesterol),
+          potassium: Number(r.potassium),
+          vitamin_a: Number(r.vit_a),
+          vitamin_c: Number(r.vit_c),
+          calcium: Number(r.calcium),
+          iron: Number(r.iron),
+        },
+        sleep_score: r.sleep_score,
+        mood_value: r.mood_value,
+      }))
+      .slice(0, 7),
+  };
+}
+
+async function generateCoachingPlan(
+  userId: string,
+  goal: 'weight_loss' | 'muscle_gain' | 'maintenance'
+): Promise<Record<string, unknown>> {
+  // 1. Get recent trends to calculate TDEE
+  const trends = await analyzeTrends(userId, 14);
+  const weightData = trends.weight.entries;
+  const calorieData = trends.calories.entries;
+
+  let estimatedTdee = 2200; // Fallback
+  if (weightData.length >= 2 && calorieData.length >= 7) {
+    const weightChange =
+      weightData[weightData.length - 1].weight - weightData[0].weight;
+    const totalCals = calorieData.reduce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sum: number, c: any) => sum + c.calories,
+      0
+    );
+    const avgCals = totalCals / calorieData.length;
+
+    // 1kg of fat ~ 7700 cals. Weight change over 14 days.
+    const dailyCaloricBalance = (weightChange * 7700) / 14;
+    estimatedTdee = Math.round(avgCals - dailyCaloricBalance);
+  }
+
+  // 2. Set targets
+  let targetCals = estimatedTdee;
+  if (goal === 'weight_loss') targetCals -= 500;
+  if (goal === 'muscle_gain') targetCals += 300;
+
+  // 3. Find favorite high-protein foods for the shopping list
+  const favorites = await coachRepository.getFrequentHighProteinFoods(userId);
+
+  return {
+    goal,
+    current_estimated_tdee: estimatedTdee,
+    recommended_targets: {
+      daily_calories: targetCals,
+      protein_grams: Math.round((targetCals * 0.3) / 4), // 30% protein
+      carbs_grams: Math.round((targetCals * 0.4) / 4), // 40% carbs
+      fat_grams: Math.round((targetCals * 0.3) / 9), // 30% fat
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    shopping_list_suggestions: favorites.map((r: any) => r.food_name),
+    coaching_insight:
+      goal === 'weight_loss' && trends.weight.trend === 'increasing'
+        ? 'Your weight is currently trending up. To hit your weight loss goal, we need to bring daily calories down to ' +
+          targetCals +
+          '.'
+        : 'You are on the right track for your ' + goal + ' goal.',
+  };
+}
+
+export function buildCoachTools(userId: string) {
+  return {
+    sparky_get_health_summary: tool({
+      description:
+        "Get a summary of the user's health status (Nutrition, Fitness, Vitals, Hydration) for a specific date range.",
+      inputSchema: GetHealthSummarySchema,
+      execute: async (rawArgs) => {
+        const parsed = GetHealthSummarySchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const result = await getHealthSummary(
+            userId,
+            parsed.data.start_date,
+            parsed.data.end_date
+          );
+          return formatSuccess(result, 'Health Summary');
+        } catch (error) {
+          log('error', '[Coach Tool] getHealthSummary error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_analyze_trends: tool({
+      description:
+        'Analyze weight trends vs. calorie intake to identify plateaus or progress over a specified number of days.',
+      inputSchema: AnalyzeTrendsSchema,
+      execute: async (rawArgs) => {
+        const parsed = AnalyzeTrendsSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const result = await analyzeTrends(userId, parsed.data.days);
+          return formatSuccess(result, 'Trend Analysis');
+        } catch (error) {
+          log('error', '[Coach Tool] analyzeTrends error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_30_day_trends: tool({
+      description:
+        'Get comprehensive trends for the last 30 days including food, exercise, mood, sleep, and biometrics.',
+      inputSchema: Get30DayTrendsSchema,
+      execute: async (rawArgs) => {
+        const parsed = Get30DayTrendsSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const result = await get30DayTrends(userId, parsed.data.end_date);
+          return formatSuccess(result, '30-Day Trends');
+        } catch (error) {
+          log('error', '[Coach Tool] get30DayTrends error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_detect_patterns: tool({
+      description:
+        'Health Detective: Scans historical data for correlations between nutrition, sleep, and mood.',
+      inputSchema: DetectPatternsSchema,
+      execute: async (rawArgs) => {
+        const parsed = DetectPatternsSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const result = await detectPatterns(userId, parsed.data.days);
+          return formatSuccess(result, 'Pattern Detection');
+        } catch (error) {
+          log('error', '[Coach Tool] detectPatterns error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_generate_coaching_plan: tool({
+      description:
+        'Auto-Coach: Generates a 7-day macro plan and shopping list based on your goal and weight trends.',
+      inputSchema: GenerateCoachingPlanSchema,
+      execute: async (rawArgs) => {
+        const parsed = GenerateCoachingPlanSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          // target_weight is accepted by the schema but unused, as in MCP.
+          const result = await generateCoachingPlan(userId, parsed.data.goal);
+          return formatSuccess(result, 'Coaching Plan');
+        } catch (error) {
+          log('error', '[Coach Tool] generateCoachingPlan error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/coachTools.ts
+++ b/SparkyFitnessServer/ai/tools/coachTools.ts
@@ -3,7 +3,7 @@ import { todayInZone } from '@workspace/shared';
 import { log } from '../../config/logging.js';
 import coachRepository from '../../models/coachRepository.js';
 import { ERRORS, formatZodError } from './errors.js';
-import { formatSuccess } from './formatting.js';
+import { dayString, formatSuccess } from './formatting.js';
 import {
   GetHealthSummarySchema,
   AnalyzeTrendsSchema,
@@ -58,7 +58,7 @@ async function getHealthSummary(
     },
     vitals: {
       latest_weight: weight
-        ? { weight: Number(weight.weight), date: weight.entry_date }
+        ? { weight: Number(weight.weight), date: dayString(weight.entry_date) }
         : null,
     },
     hydration: {
@@ -67,19 +67,24 @@ async function getHealthSummary(
   };
 }
 
-async function analyzeTrends(userId: string, days: number) {
-  const weightRows = await coachRepository.getWeightSeries(userId, days);
-  const calorieRows = await coachRepository.getDailyCalorieSeries(userId, days);
+async function analyzeTrends(userId: string, tz: string, days: number) {
+  const today = todayInZone(tz);
+  const weightRows = await coachRepository.getWeightSeries(userId, days, today);
+  const calorieRows = await coachRepository.getDailyCalorieSeries(
+    userId,
+    days,
+    today
+  );
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const weights = weightRows.map((r: any) => ({
-    date: r.entry_date,
+    date: dayString(r.entry_date),
     weight: Number(r.weight),
   }));
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const calories = calorieRows.map((r: any) => ({
-    date: r.entry_date,
+    date: dayString(r.entry_date),
     calories: Number(r.daily_calories),
   }));
 
@@ -129,9 +134,10 @@ async function analyzeTrends(userId: string, days: number) {
 
 async function get30DayTrends(
   userId: string,
+  tz: string,
   endDate?: string
 ): Promise<Record<string, unknown>> {
-  const end = endDate || todayInZone('UTC');
+  const end = endDate || todayInZone(tz);
 
   const food = await coachRepository.get30DayFoodAggregates(userId, end);
   const exercise = await coachRepository.get30DayExerciseAggregates(
@@ -144,7 +150,7 @@ async function get30DayTrends(
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const weights = weightRows.map((r: any) => ({
-    date: r.entry_date,
+    date: dayString(r.entry_date),
     weight: Number(r.weight),
   }));
 
@@ -180,9 +186,14 @@ async function get30DayTrends(
 
 async function detectPatterns(
   userId: string,
+  tz: string,
   days: number
 ): Promise<Record<string, unknown>> {
-  const data = await coachRepository.getDailyCorrelationRows(userId, days);
+  const data = await coachRepository.getDailyCorrelationRows(
+    userId,
+    days,
+    todayInZone(tz)
+  );
   const patterns: string[] = [];
 
   if (data.length >= 7) {
@@ -256,7 +267,7 @@ async function detectPatterns(
     raw_correlations: data
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .map((r: any) => ({
-        date: r.entry_date,
+        date: dayString(r.entry_date),
         nutrition: {
           calories: Number(r.calories),
           protein: Number(r.protein),
@@ -282,10 +293,11 @@ async function detectPatterns(
 
 async function generateCoachingPlan(
   userId: string,
+  tz: string,
   goal: 'weight_loss' | 'muscle_gain' | 'maintenance'
 ): Promise<Record<string, unknown>> {
   // 1. Get recent trends to calculate TDEE
-  const trends = await analyzeTrends(userId, 14);
+  const trends = await analyzeTrends(userId, tz, 14);
   const weightData = trends.weight.entries;
   const calorieData = trends.calories.entries;
 
@@ -333,7 +345,7 @@ async function generateCoachingPlan(
   };
 }
 
-export function buildCoachTools(userId: string) {
+export function buildCoachTools(userId: string, tz: string) {
   return {
     sparky_get_health_summary: tool({
       description:
@@ -368,7 +380,7 @@ export function buildCoachTools(userId: string) {
           return formatZodError(parsed.error);
         }
         try {
-          const result = await analyzeTrends(userId, parsed.data.days);
+          const result = await analyzeTrends(userId, tz, parsed.data.days);
           return formatSuccess(result, 'Trend Analysis');
         } catch (error) {
           log('error', '[Coach Tool] analyzeTrends error:', error);
@@ -387,7 +399,7 @@ export function buildCoachTools(userId: string) {
           return formatZodError(parsed.error);
         }
         try {
-          const result = await get30DayTrends(userId, parsed.data.end_date);
+          const result = await get30DayTrends(userId, tz, parsed.data.end_date);
           return formatSuccess(result, '30-Day Trends');
         } catch (error) {
           log('error', '[Coach Tool] get30DayTrends error:', error);
@@ -406,7 +418,7 @@ export function buildCoachTools(userId: string) {
           return formatZodError(parsed.error);
         }
         try {
-          const result = await detectPatterns(userId, parsed.data.days);
+          const result = await detectPatterns(userId, tz, parsed.data.days);
           return formatSuccess(result, 'Pattern Detection');
         } catch (error) {
           log('error', '[Coach Tool] detectPatterns error:', error);
@@ -426,7 +438,11 @@ export function buildCoachTools(userId: string) {
         }
         try {
           // target_weight is accepted by the schema but unused, as in MCP.
-          const result = await generateCoachingPlan(userId, parsed.data.goal);
+          const result = await generateCoachingPlan(
+            userId,
+            tz,
+            parsed.data.goal
+          );
           return formatSuccess(result, 'Coaching Plan');
         } catch (error) {
           log('error', '[Coach Tool] generateCoachingPlan error:', error);

--- a/SparkyFitnessServer/ai/tools/engagementTools.ts
+++ b/SparkyFitnessServer/ai/tools/engagementTools.ts
@@ -1,0 +1,211 @@
+import { tool } from 'ai';
+import { log } from '../../config/logging.js';
+import engagementRepository from '../../models/engagementRepository.js';
+import { ERRORS } from './errors.js';
+import { formatSuccess } from './formatting.js';
+import {
+  CheckEngagementSchema,
+  GetLoggingStreakSchema,
+  GetContextualNudgeSchema,
+} from './schemas/engagement.js';
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+export function buildEngagementTools(userId: string) {
+  return {
+    sparky_check_engagement: tool({
+      description:
+        "Scans the user's data for moments that require a proactive nudge (e.g., missed workout, plateau, achievement).",
+      inputSchema: CheckEngagementSchema,
+      execute: async () => {
+        try {
+          const triggers: Array<{ type: string; message: string }> = [];
+
+          // Missed workouts (no exercise in 3+ days)
+          const lastExerciseDate =
+            await engagementRepository.getLastExerciseDate(userId);
+          if (lastExerciseDate !== null) {
+            const lastDate = new Date(lastExerciseDate);
+            const daysSince = Math.floor(
+              (Date.now() - lastDate.getTime()) / MS_PER_DAY
+            );
+            if (daysSince >= 3) {
+              triggers.push({
+                type: 'missed_workout',
+                message: `No workout logged in ${daysSince} days. Time to get moving!`,
+              });
+            }
+          } else {
+            triggers.push({
+              type: 'no_workouts',
+              message:
+                'No workouts logged yet. Start your fitness journey today!',
+            });
+          }
+
+          // Weight plateau (no change across the last 7 weigh-ins)
+          const recentWeights =
+            await engagementRepository.getRecentWeights(userId);
+          if (recentWeights.length >= 2) {
+            const weights = recentWeights.map((r: any) => Number(r.weight));
+            const min = Math.min(...weights);
+            const max = Math.max(...weights);
+            if (max - min < 0.3) {
+              triggers.push({
+                type: 'weight_plateau',
+                message:
+                  "Your weight has been stable for the past week. Consider adjusting your routine if you're trying to change.",
+              });
+            }
+          }
+
+          // Achievements (logged days in the past week)
+          const streakDays =
+            await engagementRepository.getWeeklyLoggedDayCount(userId);
+          if (streakDays >= 7) {
+            triggers.push({
+              type: 'achievement',
+              message:
+                "Amazing! You've logged data every day for the past week. Keep it up!",
+            });
+          } else if (streakDays >= 3) {
+            triggers.push({
+              type: 'streak_building',
+              message: `You're on a ${streakDays}-day logging streak. Keep going!`,
+            });
+          }
+
+          return formatSuccess(
+            {
+              triggers,
+              trigger_count: triggers.length,
+              checked_at: new Date().toISOString(),
+            },
+            'Engagement Triggers'
+          );
+        } catch (error) {
+          log('error', '[Engagement Tool] checkEngagement error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_logging_streak: tool({
+      description:
+        "Retrieves the user's current consecutive logging streak for any health or fitness data.",
+      inputSchema: GetLoggingStreakSchema,
+      execute: async () => {
+        try {
+          const rows = await engagementRepository.getLoggedDates(userId);
+          if (rows.length === 0) {
+            return formatSuccess(
+              { current_streak: 0, last_logged: null },
+              'Logging Streak'
+            );
+          }
+
+          // Count consecutive days, allowing the streak to start from
+          // yesterday if nothing is logged today yet.
+          let streak = 0;
+          const today = new Date();
+          today.setHours(0, 0, 0, 0);
+
+          for (let i = 0; i < rows.length; i++) {
+            const entryDate = new Date(rows[i].entry_date);
+            entryDate.setHours(0, 0, 0, 0);
+
+            if (i === 0) {
+              const yesterday = new Date(today);
+              yesterday.setDate(yesterday.getDate() - 1);
+              if (
+                entryDate.getTime() !== today.getTime() &&
+                entryDate.getTime() !== yesterday.getTime()
+              ) {
+                break;
+              }
+            } else {
+              const firstEntry = new Date(rows[0].entry_date);
+              firstEntry.setHours(0, 0, 0, 0);
+              const daysSinceFirst = Math.round(
+                (firstEntry.getTime() - entryDate.getTime()) / MS_PER_DAY
+              );
+              if (daysSinceFirst !== i) {
+                break;
+              }
+            }
+
+            streak++;
+          }
+
+          return formatSuccess(
+            {
+              current_streak: streak,
+              last_logged: rows[0].entry_date,
+            },
+            'Logging Streak'
+          );
+        } catch (error) {
+          log('error', '[Engagement Tool] getLoggingStreak error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_contextual_nudge: tool({
+      description:
+        'Generates a context-aware nudge based on recent user activity or inactivity.',
+      inputSchema: GetContextualNudgeSchema,
+      execute: async () => {
+        try {
+          const counts =
+            await engagementRepository.getTodayActivityCounts(userId);
+          const foodCount = counts.food_count;
+          const exerciseCount = counts.exercise_count;
+          const checkinCount = counts.checkin_count;
+
+          let nudge: string;
+          let nudge_type: string;
+
+          if (foodCount === 0 && exerciseCount === 0 && checkinCount === 0) {
+            nudge =
+              "You haven't logged anything today yet. Start with a quick check-in or log your breakfast!";
+            nudge_type = 'start_day';
+          } else if (foodCount > 0 && exerciseCount === 0) {
+            nudge =
+              "You've logged your meals but no exercise today. Even a short walk counts!";
+            nudge_type = 'suggest_exercise';
+          } else if (exerciseCount > 0 && foodCount === 0) {
+            nudge =
+              "Great workout! Don't forget to log your meals to track your nutrition.";
+            nudge_type = 'suggest_food';
+          } else if (checkinCount === 0) {
+            nudge =
+              "You're doing great with logging today! Consider a quick check-in to track your weight or mood.";
+            nudge_type = 'suggest_checkin';
+          } else {
+            nudge =
+              "Excellent! You've been thorough with your logging today. Keep up the great work!";
+            nudge_type = 'encouragement';
+          }
+
+          return formatSuccess(
+            {
+              nudge,
+              nudge_type,
+              today_summary: {
+                food_entries: foodCount,
+                exercise_entries: exerciseCount,
+                checkin_entries: checkinCount,
+              },
+              generated_at: new Date().toISOString(),
+            },
+            'Contextual Nudge'
+          );
+        } catch (error) {
+          log('error', '[Engagement Tool] getContextualNudge error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/engagementTools.ts
+++ b/SparkyFitnessServer/ai/tools/engagementTools.ts
@@ -1,8 +1,9 @@
 import { tool } from 'ai';
+import { addDays, todayInZone } from '@workspace/shared';
 import { log } from '../../config/logging.js';
 import engagementRepository from '../../models/engagementRepository.js';
 import { ERRORS } from './errors.js';
-import { formatSuccess } from './formatting.js';
+import { dayString, formatSuccess } from './formatting.js';
 import {
   CheckEngagementSchema,
   GetLoggingStreakSchema,
@@ -11,7 +12,13 @@ import {
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
-export function buildEngagementTools(userId: string) {
+// Whole days between two day strings. Day strings parse as UTC midnight per
+// the ES spec, so the difference is exact and DST-free.
+function daysBetween(from: string, to: string): number {
+  return Math.round((Date.parse(to) - Date.parse(from)) / MS_PER_DAY);
+}
+
+export function buildEngagementTools(userId: string, tz: string) {
   return {
     sparky_check_engagement: tool({
       description:
@@ -25,9 +32,9 @@ export function buildEngagementTools(userId: string) {
           const lastExerciseDate =
             await engagementRepository.getLastExerciseDate(userId);
           if (lastExerciseDate !== null) {
-            const lastDate = new Date(lastExerciseDate);
-            const daysSince = Math.floor(
-              (Date.now() - lastDate.getTime()) / MS_PER_DAY
+            const daysSince = daysBetween(
+              dayString(lastExerciseDate),
+              todayInZone(tz)
             );
             if (daysSince >= 3) {
               triggers.push({
@@ -60,8 +67,10 @@ export function buildEngagementTools(userId: string) {
           }
 
           // Achievements (logged days in the past week)
-          const streakDays =
-            await engagementRepository.getWeeklyLoggedDayCount(userId);
+          const streakDays = await engagementRepository.getWeeklyLoggedDayCount(
+            userId,
+            todayInZone(tz)
+          );
           if (streakDays >= 7) {
             triggers.push({
               type: 'achievement',
@@ -105,42 +114,27 @@ export function buildEngagementTools(userId: string) {
           }
 
           // Count consecutive days, allowing the streak to start from
-          // yesterday if nothing is logged today yet.
+          // yesterday if nothing is logged today yet. Rows arrive newest
+          // first with no duplicate days (SELECT DISTINCT).
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const days = rows.map((r: any) => dayString(r.entry_date));
+          const today = todayInZone(tz);
           let streak = 0;
-          const today = new Date();
-          today.setHours(0, 0, 0, 0);
-
-          for (let i = 0; i < rows.length; i++) {
-            const entryDate = new Date(rows[i].entry_date);
-            entryDate.setHours(0, 0, 0, 0);
-
-            if (i === 0) {
-              const yesterday = new Date(today);
-              yesterday.setDate(yesterday.getDate() - 1);
-              if (
-                entryDate.getTime() !== today.getTime() &&
-                entryDate.getTime() !== yesterday.getTime()
-              ) {
-                break;
-              }
-            } else {
-              const firstEntry = new Date(rows[0].entry_date);
-              firstEntry.setHours(0, 0, 0, 0);
-              const daysSinceFirst = Math.round(
-                (firstEntry.getTime() - entryDate.getTime()) / MS_PER_DAY
-              );
-              if (daysSinceFirst !== i) {
-                break;
-              }
+          if (days[0] === today || days[0] === addDays(today, -1)) {
+            streak = 1;
+            for (
+              let i = 1;
+              i < days.length && days[i] === addDays(days[0], -i);
+              i++
+            ) {
+              streak++;
             }
-
-            streak++;
           }
 
           return formatSuccess(
             {
               current_streak: streak,
-              last_logged: rows[0].entry_date,
+              last_logged: days[0],
             },
             'Logging Streak'
           );
@@ -157,8 +151,11 @@ export function buildEngagementTools(userId: string) {
       inputSchema: GetContextualNudgeSchema,
       execute: async () => {
         try {
-          const counts =
-            await engagementRepository.getTodayActivityCounts(userId);
+          const counts = await engagementRepository.getTodayActivityCounts(
+            userId,
+            todayInZone(tz),
+            tz
+          );
           const foodCount = counts.food_count;
           const exerciseCount = counts.exercise_count;
           const checkinCount = counts.checkin_count;

--- a/SparkyFitnessServer/ai/tools/errors.ts
+++ b/SparkyFitnessServer/ai/tools/errors.ts
@@ -1,0 +1,58 @@
+/**
+ * Creates a standardized error message for a chatbot tool result.
+ * Security: Never exposes internal details (stack traces, SQL errors).
+ */
+export function toolError(
+  code: string,
+  message: string,
+  suggestion?: string
+): string {
+  return suggestion
+    ? `Error [${code}]: ${message}\n\nSuggestion: ${suggestion}`
+    : `Error [${code}]: ${message}`;
+}
+
+// Standard error builders
+export const ERRORS = {
+  INVALID_DATE: (val: string) =>
+    toolError(
+      'INVALID_DATE',
+      `'${val}' is not a valid date. Use YYYY-MM-DD format.`,
+      'Example: 2025-01-15'
+    ),
+
+  NOT_FOUND: (resource: string, id: string) =>
+    toolError(
+      'NOT_FOUND',
+      `${resource} with ID '${id}' not found.`,
+      'Check the ID and try again.'
+    ),
+
+  VALIDATION: (details: string) => toolError('VALIDATION', details),
+
+  MISSING_PARAMS: (params: string[]) =>
+    toolError(
+      'MISSING_PARAMS',
+      `Missing required parameters: ${params.join(', ')}`,
+      'Provide all required parameters and try again.'
+    ),
+
+  DB_ERROR: () =>
+    toolError(
+      'DB_ERROR',
+      'A database error occurred. Please try again.',
+      'If the issue persists, contact support.'
+    ),
+
+  UNAUTHORIZED: () =>
+    toolError('UNAUTHORIZED', 'Authentication required. Please reconnect.'),
+
+  FORBIDDEN: (reason: string) => toolError('FORBIDDEN', reason),
+
+  INVALID_ACTION: (action: string, validActions: string[]) =>
+    toolError(
+      'INVALID_ACTION',
+      `Unknown action '${action}'.`,
+      `Valid actions: ${validActions.join(', ')}`
+    ),
+};

--- a/SparkyFitnessServer/ai/tools/errors.ts
+++ b/SparkyFitnessServer/ai/tools/errors.ts
@@ -1,3 +1,5 @@
+import type { ZodError } from 'zod';
+
 /**
  * Creates a standardized error message for a chatbot tool result.
  * Security: Never exposes internal details (stack traces, SQL errors).
@@ -56,3 +58,17 @@ export const ERRORS = {
       `Valid actions: ${validActions.join(', ')}`
     ),
 };
+
+/**
+ * Renders a zod parse failure as a chat-visible VALIDATION error,
+ * formatted as "path: message; path2: message2".
+ */
+export function formatZodError(error: ZodError): string {
+  return ERRORS.VALIDATION(
+    error.issues
+      .map((i) =>
+        i.path.length > 0 ? `${i.path.join('.')}: ${i.message}` : i.message
+      )
+      .join('; ')
+  );
+}

--- a/SparkyFitnessServer/ai/tools/exerciseTools.ts
+++ b/SparkyFitnessServer/ai/tools/exerciseTools.ts
@@ -1,0 +1,964 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { todayInZone } from '@workspace/shared';
+import { log } from '../../config/logging.js';
+import exerciseService from '../../services/exerciseService.js';
+import workoutPresetService from '../../services/workoutPresetService.js';
+import exerciseDb from '../../models/exercise.js';
+import exerciseEntryDb from '../../models/exerciseEntry.js';
+import workoutPresetRepository from '../../models/workoutPresetRepository.js';
+import { ERRORS, formatZodError } from './errors.js';
+import { formatConfirmation, formatList } from './formatting.js';
+import {
+  normalizePagination,
+  buildPaginatedResult,
+  type PaginatedResult,
+} from './pagination.js';
+import {
+  manageExerciseSchema,
+  manageExerciseInput,
+  type ManageExerciseInput,
+} from './schemas/exercise.js';
+
+const VALID_ACTIONS = [
+  'search_exercises',
+  'create_exercise',
+  'log_exercise',
+  'list_exercise_diary',
+  'get_workout_presets',
+  'log_workout_preset',
+  'update_exercise_entry',
+  'delete_exercise_entry',
+  'get_exercise_details',
+  'create_workout_preset',
+  'get_exercise_progress',
+];
+
+// Optional inputs and nullable DB columns are treated alike: absent.
+function isSet<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+// Text columns may hold JSON arrays, comma-separated values, or plain strings.
+function safeParseJson(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value);
+    } catch {
+      /* not JSON */
+    }
+    if (value.includes(',')) {
+      return value
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+    return value ? [value] : [];
+  }
+  return [];
+}
+
+interface ExerciseSetInput {
+  reps?: number;
+  weight?: number;
+  duration?: number;
+  rest_time?: number;
+  set_type?: string;
+  rpe?: number;
+  notes?: string;
+}
+
+// The set rows the exercise-entry repository expects: 1-based set_number plus
+// explicit nulls for absent fields (mirrors MCP's per-set INSERT defaults).
+function toRepoSets(sets: ExerciseSetInput[]) {
+  return sets.map((s, i) => ({
+    set_number: i + 1,
+    set_type: s.set_type || 'Working Set',
+    reps: s.reps ?? null,
+    weight: s.weight ?? null,
+    duration: s.duration ?? null,
+    rest_time: s.rest_time ?? null,
+    rpe: s.rpe ?? null,
+    notes: s.notes ?? null,
+  }));
+}
+
+// MCP's date-range defaults: a single `date` overrides start/end; otherwise
+// the range defaults to today (UTC) / the start date.
+function exerciseDateRange(query: {
+  date?: string;
+  start_date?: string;
+  end_date?: string;
+}): { startDate: string; endDate: string } {
+  const today = todayInZone('UTC');
+  const date = query.date || undefined;
+  const startDate = date || query.start_date || today;
+  const endDate = date || query.end_date || startDate;
+  return { startDate, endDate };
+}
+
+// The column set MCP's exercise search exposed; richer server rows are
+// projected down to it so the chat-visible output stays identical.
+function projectExercise(row: any) {
+  return {
+    id: row.id,
+    name: row.name,
+    category: row.category,
+    muscle_groups: row.primary_muscles,
+    equipment: row.equipment,
+    level: row.level,
+    calories_per_hour: row.calories_per_hour,
+    description: row.description,
+    is_custom: row.is_custom,
+  };
+}
+
+// Case-insensitive exact name lookup (MCP's `name ILIKE $1` without
+// wildcards). The server search returns substring matches; the exact match,
+// when present, is always among them.
+async function findExerciseByExactName(userId: string, name: string) {
+  const rows = await exerciseService.searchExercises(
+    userId,
+    name,
+    userId,
+    undefined,
+    undefined
+  );
+  return rows.find(
+    (e: any) => String(e.name).toLowerCase() === name.toLowerCase()
+  );
+}
+
+// Full details for one exercise by id or name, projected to MCP's shape.
+// Throws "not found" errors for the callers' catch blocks to map.
+async function getExerciseDetails(
+  userId: string,
+  params: { exercise_id?: string; exercise_name?: string }
+) {
+  let row: any;
+  if (params.exercise_id) {
+    row = await exerciseService.getExerciseById(userId, params.exercise_id);
+  } else if (params.exercise_name) {
+    row = await findExerciseByExactName(userId, params.exercise_name);
+  } else {
+    throw new Error('Either exercise_id or exercise_name must be provided');
+  }
+  if (!row) {
+    throw new Error('Exercise not found');
+  }
+  return {
+    id: row.id,
+    name: row.name,
+    category: row.category,
+    muscle_groups: safeParseJson(row.primary_muscles),
+    equipment: safeParseJson(row.equipment),
+    level: row.level,
+    calories_per_hour: row.calories_per_hour,
+    description: row.description,
+    is_custom: row.is_custom,
+    instructions: safeParseJson(row.instructions),
+    images: safeParseJson(row.images),
+  };
+}
+
+interface ProgressDay {
+  entry_date: unknown;
+  max_weight: number | null;
+  max_reps: number | null;
+  total_volume: number | null;
+}
+
+// Per-date set aggregates for one exercise, paginated over the grouped days.
+// Mirrors MCP's GROUP BY query: days whose entries have no sets are excluded,
+// MAX/SUM skip null reps/weights, and volume counts null weights as 0.
+async function getExerciseProgress(
+  userId: string,
+  params: {
+    exercise_id?: string;
+    exercise_name?: string;
+    start_date?: string;
+    end_date?: string;
+    limit?: number;
+    offset?: number;
+  }
+): Promise<PaginatedResult<ProgressDay>> {
+  let exerciseId = params.exercise_id;
+  if (!exerciseId && params.exercise_name) {
+    const exercise = await findExerciseByExactName(
+      userId,
+      params.exercise_name
+    );
+    exerciseId = exercise?.id;
+  }
+  if (!exerciseId) throw new Error('Exercise not found');
+
+  const entries = await exerciseService.getExerciseProgressData(
+    userId,
+    exerciseId,
+    params.start_date || '1970-01-01',
+    params.end_date || '9999-12-31'
+  );
+
+  // Repository rows arrive in entry_date ASC order; the Map keeps it.
+  const byDate = new Map<string, ProgressDay>();
+  for (const entry of entries) {
+    const sets: ExerciseSetInput[] = entry.sets ?? [];
+    if (sets.length === 0) continue;
+    const key = String(entry.entry_date);
+    let day = byDate.get(key);
+    if (!day) {
+      day = {
+        entry_date: entry.entry_date,
+        max_weight: null,
+        max_reps: null,
+        total_volume: null,
+      };
+      byDate.set(key, day);
+    }
+    for (const s of sets) {
+      if (isSet(s.weight)) {
+        const weight = Number(s.weight);
+        day.max_weight = isSet(day.max_weight)
+          ? Math.max(day.max_weight, weight)
+          : weight;
+      }
+      if (isSet(s.reps)) {
+        day.max_reps = isSet(day.max_reps)
+          ? Math.max(day.max_reps, s.reps)
+          : s.reps;
+        day.total_volume =
+          (day.total_volume ?? 0) +
+          s.reps * (isSet(s.weight) ? Number(s.weight) : 0);
+      }
+    }
+  }
+
+  const days = [...byDate.values()];
+  const { limit, offset } = normalizePagination(params.limit, params.offset);
+  return buildPaginatedResult(
+    days.slice(offset, offset + limit),
+    days.length,
+    offset
+  );
+}
+
+// Standalone domain tools.
+const exerciseDateRangeSchema = z.object({
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  start_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  end_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+});
+
+const exercisePaginationSchema = z.object({
+  limit: z.number().int().min(1).max(500).optional(),
+  offset: z.number().int().min(0).optional(),
+});
+
+const listExercisesSchema = exercisePaginationSchema.extend({
+  search: z.string().optional(),
+});
+
+const getExerciseDetailsSchema = z.object({
+  exercise_id: z.string().optional(),
+  exercise_name: z.string().optional(),
+});
+
+const searchExercisesSchema = exercisePaginationSchema.extend({
+  query: z.string().min(1),
+  muscle_group: z.string().optional(),
+  equipment: z.string().optional(),
+});
+
+const recentExerciseEntriesSchema = z.object({
+  limit: z.number().int().min(1).max(200).optional(),
+});
+
+const exerciseUsageSchema = exerciseDateRangeSchema
+  .merge(exercisePaginationSchema)
+  .extend({
+    exercise_id: z.string().min(1),
+  });
+
+const exerciseProgressSchema = exerciseDateRangeSchema
+  .merge(exercisePaginationSchema)
+  .extend({
+    exercise_id: z.string().optional(),
+    exercise_name: z.string().optional(),
+  });
+
+export function buildExerciseTools(userId: string) {
+  return {
+    sparky_manage_exercise: tool({
+      description: `Fitness tracking: search exercises, log workouts with sets, manage presets.
+
+Actions:
+- search_exercises(searchTerm, muscleGroup?, equipment?, limit?, offset?)
+- create_exercise(name, category?, calories_per_hour?, description?)
+- log_exercise(entry_date, exercise_id?|exercise_name?, duration_minutes?, calories_burned?, notes?, distance?, avg_heart_rate?, steps?, sets?:JSON string or array of [{reps,weight,duration,rest_time,set_type,rpe,notes}]) — distance/avg_heart_rate/steps are for cardio
+- list_exercise_diary(entry_date)
+- get_workout_presets()
+- log_workout_preset(entry_date, preset_id?|preset_name?)
+- update_exercise_entry(entry_id, entry_date?, duration_minutes?, calories_burned?, notes?, distance?, avg_heart_rate?, steps?, sets?) — only the provided fields change; sets, when provided, replace all existing sets
+- delete_exercise_entry(entry_id)
+- get_exercise_details(exercise_id?|exercise_name?)
+- create_workout_preset(name, exercise_ids)
+- get_exercise_progress(exercise_id?|exercise_name?, start_date?, end_date?, limit?, offset?) — returns paginated performance history`,
+      inputSchema: manageExerciseInput,
+      execute: async (rawArgs) => {
+        const parsed = manageExerciseSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        const args: ManageExerciseInput = parsed.data;
+        try {
+          switch (args.action) {
+            case 'search_exercises': {
+              const { limit, offset } = normalizePagination(
+                args.limit,
+                args.offset
+              );
+              const { exercises, totalCount } =
+                await exerciseService.searchExercisesPaginated(
+                  userId,
+                  args.searchTerm,
+                  userId,
+                  args.equipment ? [args.equipment] : undefined,
+                  args.muscleGroup ? [args.muscleGroup] : undefined,
+                  limit,
+                  offset
+                );
+              const result = buildPaginatedResult(
+                exercises.map(projectExercise),
+                totalCount,
+                offset
+              );
+              return formatList(
+                result.data,
+                `Exercise Search: "${args.searchTerm}"`,
+                (e: any) =>
+                  `**${e.name}** (${e.category || 'Uncategorized'})\n  Muscles: ${e.muscle_groups?.join(', ') || 'N/A'} | Equipment: ${e.equipment?.join(', ') || 'None'}\n  ID: ${e.id}`,
+                {
+                  total_count: result.total_count,
+                  has_more: result.has_more,
+                  next_offset: result.next_offset,
+                }
+              );
+            }
+
+            case 'create_exercise': {
+              // MCP returned the existing exercise (same confirmation text)
+              // when one already matched the name case-insensitively.
+              const existing = await findExerciseByExactName(userId, args.name);
+              const exercise =
+                existing ??
+                (await exerciseService.createExercise(userId, {
+                  name: args.name,
+                  category: args.category || 'custom',
+                  calories_per_hour: args.calories_per_hour || 300,
+                  description: args.description || null,
+                  is_custom: true,
+                  shared_with_public: false,
+                  source: 'manual',
+                }));
+              return formatConfirmation(`Exercise "${exercise.name}" created.`);
+            }
+
+            case 'log_exercise': {
+              if (!args.exercise_id && !args.exercise_name) {
+                return ERRORS.VALIDATION(
+                  'Either exercise_id or exercise_name must be provided'
+                );
+              }
+              // Parse sets if it arrives as a JSON string (LLM serialisation quirk)
+              let parsedSets: ExerciseSetInput[] | undefined;
+              if (typeof args.sets === 'string') {
+                try {
+                  parsedSets = JSON.parse(args.sets);
+                } catch {
+                  parsedSets = undefined;
+                }
+              } else {
+                parsedSets = args.sets;
+              }
+              let exerciseId = args.exercise_id;
+              if (!exerciseId && args.exercise_name) {
+                // Exact match first, then fuzzy, then auto-create — MCP's
+                // resolution order.
+                const rows = await exerciseService.searchExercises(
+                  userId,
+                  args.exercise_name,
+                  userId,
+                  undefined,
+                  undefined
+                );
+                const name = args.exercise_name.toLowerCase();
+                const found =
+                  rows.find(
+                    (e: any) => String(e.name).toLowerCase() === name
+                  ) ?? rows[0];
+                if (found) {
+                  exerciseId = found.id;
+                } else {
+                  const created = await exerciseService.createExercise(userId, {
+                    name: args.exercise_name,
+                    category: 'custom',
+                    calories_per_hour: 300,
+                    is_custom: true,
+                    shared_with_public: false,
+                    source: 'manual',
+                  });
+                  exerciseId = created.id;
+                }
+              }
+              // skipDuplicateCheck: logging the same exercise twice in a day
+              // must create two entries (MCP always inserted), not merge into
+              // the server's manual same-exercise/same-date upsert.
+              await exerciseService.createExerciseEntry(
+                userId,
+                userId,
+                {
+                  exercise_id: exerciseId,
+                  entry_date: args.entry_date,
+                  duration_minutes: args.duration_minutes,
+                  calories_burned: args.calories_burned,
+                  notes: args.notes,
+                  distance: args.distance,
+                  avg_heart_rate: args.avg_heart_rate,
+                  steps: args.steps,
+                  sets: parsedSets ? toRepoSets(parsedSets) : undefined,
+                },
+                { skipDuplicateCheck: true }
+              );
+              return formatConfirmation(
+                `Exercise logged for ${args.entry_date}.`
+              );
+            }
+
+            case 'list_exercise_diary': {
+              const grouped = await exerciseService.getExerciseEntriesByDate(
+                userId,
+                userId,
+                args.entry_date
+              );
+              // Flatten preset sessions into their member entries and render
+              // the flat per-entry list MCP produced (created_at ASC).
+              const entries = grouped
+                .flatMap((item: any) =>
+                  item.type === 'preset' ? item.exercises : [item]
+                )
+                .sort(
+                  (a: any, b: any) =>
+                    new Date(a.created_at).getTime() -
+                    new Date(b.created_at).getTime()
+                );
+              return formatList(
+                entries,
+                `Exercise Diary: ${args.entry_date}`,
+                (e: any) => {
+                  let text = `**${e.name}**`;
+                  const sets: ExerciseSetInput[] = e.sets ?? [];
+                  if (sets.length > 0) text += ` — ${sets.length} sets`;
+                  if (e.duration_minutes)
+                    text += ` | ${e.duration_minutes} min`;
+                  if (e.calories_burned) text += ` | ${e.calories_burned} kcal`;
+                  if (isSet(e.distance)) text += ` | ${e.distance} dist`;
+                  if (isSet(e.avg_heart_rate))
+                    text += ` | ${e.avg_heart_rate} bpm`;
+                  if (isSet(e.steps)) text += ` | ${e.steps} steps`;
+                  if (sets.length > 0) {
+                    const setLine = sets
+                      .map((s) => {
+                        const parts: string[] = [];
+                        if (isSet(s.reps)) parts.push(`${s.reps}r`);
+                        if (isSet(s.weight)) parts.push(`${s.weight}kg`);
+                        if (isSet(s.duration)) parts.push(`${s.duration}s`);
+                        if (isSet(s.rpe)) parts.push(`RPE ${s.rpe}`);
+                        let str = parts.join('×');
+                        if (isSet(s.rest_time))
+                          str += ` (rest ${s.rest_time}s)`;
+                        if (s.notes) str += ` (${s.notes})`;
+                        return str;
+                      })
+                      .filter(Boolean)
+                      .join('; ');
+                    if (setLine) text += `\n  Sets: ${setLine}`;
+                  }
+                  if (e.notes) text += `\n  Notes: ${e.notes}`;
+                  text += `\n  ID: ${e.id}`;
+                  return text;
+                }
+              );
+            }
+
+            case 'get_workout_presets': {
+              const { presets } = await workoutPresetService.getWorkoutPresets(
+                userId,
+                1,
+                1000
+              );
+              return formatList(
+                presets,
+                'Workout Presets',
+                (p: any) =>
+                  `**${p.name}** — ${p.exercises.length} exercises\n  ID: ${p.id}`
+              );
+            }
+
+            case 'log_workout_preset': {
+              if (!args.preset_id && !args.preset_name) {
+                return ERRORS.VALIDATION(
+                  'Either preset_id or preset_name must be provided'
+                );
+              }
+              let presetId = args.preset_id;
+              if (!presetId && args.preset_name) {
+                const preset =
+                  await workoutPresetRepository.getWorkoutPresetByName(
+                    userId,
+                    args.preset_name
+                  );
+                if (!preset) {
+                  return ERRORS.NOT_FOUND('Resource', 'unknown');
+                }
+                presetId = preset.id;
+              }
+              const session = await exerciseService.logWorkoutPresetGrouped(
+                userId,
+                userId,
+                presetId,
+                args.entry_date
+              );
+              return formatConfirmation(
+                `Workout preset logged for ${args.entry_date}. ${session?.exercises.length ?? 0} exercises added.`
+              );
+            }
+
+            case 'update_exercise_entry': {
+              // Parse sets if it arrives as a JSON string, matching log_exercise.
+              let parsedSets: ExerciseSetInput[] | undefined;
+              if (typeof args.sets === 'string') {
+                try {
+                  parsedSets = JSON.parse(args.sets);
+                } catch {
+                  return ERRORS.VALIDATION('Invalid JSON format for sets');
+                }
+              } else {
+                parsedSets = args.sets;
+              }
+              try {
+                await exerciseService.updateExerciseEntry(
+                  userId,
+                  userId,
+                  args.entry_id,
+                  {
+                    entry_date: args.entry_date,
+                    duration_minutes: args.duration_minutes,
+                    calories_burned: args.calories_burned,
+                    notes: args.notes,
+                    distance: args.distance,
+                    avg_heart_rate: args.avg_heart_rate,
+                    steps: args.steps,
+                    sets: parsedSets ? toRepoSets(parsedSets) : undefined,
+                  }
+                );
+              } catch (error) {
+                if (
+                  error instanceof Error &&
+                  error.message.includes('not found')
+                ) {
+                  return ERRORS.NOT_FOUND('Exercise Entry', args.entry_id);
+                }
+                throw error;
+              }
+              return formatConfirmation('Exercise entry updated.');
+            }
+
+            case 'delete_exercise_entry': {
+              try {
+                await exerciseService.deleteExerciseEntry(
+                  userId,
+                  args.entry_id
+                );
+              } catch (error) {
+                if (
+                  error instanceof Error &&
+                  error.message.includes('not found')
+                ) {
+                  return ERRORS.NOT_FOUND('Exercise Entry', args.entry_id);
+                }
+                throw error;
+              }
+              return formatConfirmation('Exercise entry deleted.');
+            }
+
+            case 'get_exercise_details': {
+              const exercise = await getExerciseDetails(userId, {
+                exercise_id: args.exercise_id,
+                exercise_name: args.exercise_name,
+              });
+              let text = `### ${exercise.name}\n\n`;
+              if (exercise.description) text += `*${exercise.description}*\n\n`;
+              text += `**Category:** ${exercise.category}\n`;
+              text += `**Equipment:** ${exercise.equipment?.join(', ') || 'None'}\n`;
+              text += `**Muscles:** ${exercise.muscle_groups?.join(', ') || 'N/A'}\n\n`;
+
+              if (exercise.instructions && exercise.instructions.length > 0) {
+                text += '#### Instructions\n';
+                exercise.instructions.forEach((ins, i) => {
+                  text += `${i + 1}. ${ins}\n`;
+                });
+              }
+
+              return text;
+            }
+
+            case 'create_workout_preset': {
+              const preset = await workoutPresetService.createWorkoutPreset(
+                userId,
+                {
+                  user_id: userId,
+                  name: args.name,
+                  description: null,
+                  is_public: false,
+                  exercises: args.exercise_ids.map((exerciseId, i) => ({
+                    exercise_id: exerciseId,
+                    sort_order: i,
+                  })),
+                }
+              );
+              return formatConfirmation(
+                `Workout preset "${preset.name}" created with ${preset.exercises.length} exercises.`
+              );
+            }
+
+            case 'get_exercise_progress': {
+              const progress = await getExerciseProgress(userId, {
+                exercise_id: args.exercise_id,
+                exercise_name: args.exercise_name,
+                start_date: args.start_date,
+                end_date: args.end_date,
+                limit: args.limit,
+                offset: args.offset,
+              });
+              return formatList(
+                progress.data,
+                `Exercise Progress: ${args.exercise_name || args.exercise_id}`,
+                (p: any) =>
+                  `**${p.entry_date}**: Max Weight: ${p.max_weight}kg | Max Reps: ${p.max_reps} | Volume: ${p.total_volume}kg`,
+                {
+                  total_count: progress.total_count,
+                  has_more: progress.has_more,
+                  next_offset: progress.next_offset,
+                }
+              );
+            }
+
+            default:
+              return ERRORS.INVALID_ACTION(
+                String((args as any).action),
+                VALID_ACTIONS
+              );
+          }
+        } catch (error) {
+          log('error', '[Exercise Tool] Error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND('Resource', 'unknown');
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_list_exercises: tool({
+      description:
+        'Returns a paginated exercise catalog for the authenticated user.',
+      inputSchema: listExercisesSchema,
+      execute: async (rawArgs) => {
+        const parsed = listExercisesSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const { limit, offset } = normalizePagination(
+            parsed.data.limit,
+            parsed.data.offset
+          );
+          const search = parsed.data.search?.trim() || undefined;
+          const [rows, totalCount] = await Promise.all([
+            exerciseDb.getExercisesWithPagination(
+              userId,
+              search,
+              null,
+              null,
+              null,
+              null,
+              limit,
+              offset
+            ),
+            exerciseDb.countExercises(userId, search, null, null, null, null),
+          ]);
+          const data = buildPaginatedResult(rows, totalCount, offset);
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log('error', '[Exercise Tool] sparky_list_exercises error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND('Exercise', 'unknown');
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_exercise_details: tool({
+      description:
+        'Returns full details for one exercise by exercise_id or exercise_name.',
+      inputSchema: getExerciseDetailsSchema,
+      execute: async (rawArgs) => {
+        const parsed = getExerciseDetailsSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const data = await getExerciseDetails(userId, parsed.data);
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log(
+            'error',
+            '[Exercise Tool] sparky_get_exercise_details error:',
+            error
+          );
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND(
+              'Exercise',
+              parsed.data.exercise_id || parsed.data.exercise_name || 'unknown'
+            );
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_search_exercises: tool({
+      description: 'Searches exercises by name and optional filters.',
+      inputSchema: searchExercisesSchema,
+      execute: async (rawArgs) => {
+        const parsed = searchExercisesSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const args = parsed.data;
+          const { limit, offset } = normalizePagination(
+            args.limit,
+            args.offset
+          );
+          const { exercises, totalCount } =
+            await exerciseService.searchExercisesPaginated(
+              userId,
+              args.query,
+              userId,
+              args.equipment ? [args.equipment] : undefined,
+              args.muscle_group ? [args.muscle_group] : undefined,
+              limit,
+              offset
+            );
+          const data = buildPaginatedResult(
+            exercises.map(projectExercise),
+            totalCount,
+            offset
+          );
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log('error', '[Exercise Tool] sparky_search_exercises error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND('Exercise', parsed.data.query);
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_exercise_diary: tool({
+      description:
+        'Returns entry-level exercise diary data for a specific date or date range.',
+      inputSchema: exerciseDateRangeSchema,
+      execute: async (rawArgs) => {
+        const parsed = exerciseDateRangeSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const { startDate, endDate } = exerciseDateRange(parsed.data);
+          const { entries, sets } = await exerciseEntryDb.getExerciseDiaryRange(
+            userId,
+            startDate,
+            endDate
+          );
+          const data = {
+            start_date: startDate,
+            end_date: endDate,
+            entries,
+            sets,
+          };
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log(
+            'error',
+            '[Exercise Tool] sparky_get_exercise_diary error:',
+            error
+          );
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND(
+              'Exercise diary',
+              parsed.data.date || parsed.data.start_date || 'unknown'
+            );
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_daily_exercise_totals: tool({
+      description: 'Returns daily exercise totals for a date or range.',
+      inputSchema: exerciseDateRangeSchema,
+      execute: async (rawArgs) => {
+        const parsed = exerciseDateRangeSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const { startDate, endDate } = exerciseDateRange(parsed.data);
+          const rows = await exerciseEntryDb.getDailyExerciseTotalsRange(
+            userId,
+            startDate,
+            endDate
+          );
+          const data = { start_date: startDate, end_date: endDate, rows };
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log(
+            'error',
+            '[Exercise Tool] sparky_get_daily_exercise_totals error:',
+            error
+          );
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND(
+              'Exercise totals',
+              parsed.data.date || parsed.data.start_date || 'unknown'
+            );
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_recent_exercise_entries: tool({
+      description:
+        'Returns recent entry-level exercise diary rows for the authenticated user.',
+      inputSchema: recentExerciseEntriesSchema,
+      execute: async (rawArgs) => {
+        const parsed = recentExerciseEntriesSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const limit = Math.min(Math.max(parsed.data.limit ?? 50, 1), 200);
+          const data = await exerciseEntryDb.getRecentExerciseEntries(
+            userId,
+            limit
+          );
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log(
+            'error',
+            '[Exercise Tool] sparky_get_recent_exercise_entries error:',
+            error
+          );
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND('Exercise entries', 'recent');
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_exercise_usage: tool({
+      description:
+        'Shows where a specific exercise_id was used in the exercise diary.',
+      inputSchema: exerciseUsageSchema,
+      execute: async (rawArgs) => {
+        const parsed = exerciseUsageSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const { exercise_id, ...query } = parsed.data;
+          const { startDate, endDate } = exerciseDateRange(query);
+          const { limit, offset } = normalizePagination(
+            query.limit,
+            query.offset
+          );
+          const { rows, totalCount } = await exerciseEntryDb.getExerciseUsage(
+            userId,
+            exercise_id,
+            startDate,
+            endDate,
+            limit,
+            offset
+          );
+          const data = buildPaginatedResult(rows, totalCount, offset);
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log(
+            'error',
+            '[Exercise Tool] sparky_get_exercise_usage error:',
+            error
+          );
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND('Exercise', parsed.data.exercise_id);
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_exercise_progress: tool({
+      description: 'Returns paginated performance history for an exercise.',
+      inputSchema: exerciseProgressSchema,
+      execute: async (rawArgs) => {
+        const parsed = exerciseProgressSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const data = await getExerciseProgress(userId, parsed.data);
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log(
+            'error',
+            '[Exercise Tool] sparky_get_exercise_progress error:',
+            error
+          );
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND(
+              'Exercise',
+              parsed.data.exercise_id || parsed.data.exercise_name || 'unknown'
+            );
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/exerciseTools.ts
+++ b/SparkyFitnessServer/ai/tools/exerciseTools.ts
@@ -8,7 +8,7 @@ import exerciseDb from '../../models/exercise.js';
 import exerciseEntryDb from '../../models/exerciseEntry.js';
 import workoutPresetRepository from '../../models/workoutPresetRepository.js';
 import { ERRORS, formatZodError } from './errors.js';
-import { formatConfirmation, formatList } from './formatting.js';
+import { dayString, formatConfirmation, formatList } from './formatting.js';
 import {
   normalizePagination,
   buildPaginatedResult,
@@ -86,17 +86,27 @@ function toRepoSets(sets: ExerciseSetInput[]) {
 }
 
 // MCP's date-range defaults: a single `date` overrides start/end; otherwise
-// the range defaults to today (UTC) / the start date.
-function exerciseDateRange(query: {
-  date?: string;
-  start_date?: string;
-  end_date?: string;
-}): { startDate: string; endDate: string } {
-  const today = todayInZone('UTC');
+// the range defaults to today (user timezone) / the start date.
+function exerciseDateRange(
+  query: {
+    date?: string;
+    start_date?: string;
+    end_date?: string;
+  },
+  tz: string
+): { startDate: string; endDate: string } {
+  const today = todayInZone(tz);
   const date = query.date || undefined;
   const startDate = date || query.start_date || today;
   const endDate = date || query.end_date || startDate;
   return { startDate, endDate };
+}
+
+// Renders a row's bare-DATE entry_date as a calendar-day string for JSON
+// output. entry_date is nullable; NULL stays JSON null, not the string "null".
+function projectEntryDate<T extends { entry_date?: unknown }>(row: T) {
+  if (!isSet(row.entry_date)) return row;
+  return { ...row, entry_date: dayString(row.entry_date) };
 }
 
 // The column set MCP's exercise search exposed; richer server rows are
@@ -164,7 +174,7 @@ async function getExerciseDetails(
 }
 
 interface ProgressDay {
-  entry_date: unknown;
+  entry_date: string;
   max_weight: number | null;
   max_reps: number | null;
   total_volume: number | null;
@@ -206,11 +216,11 @@ async function getExerciseProgress(
   for (const entry of entries) {
     const sets: ExerciseSetInput[] = entry.sets ?? [];
     if (sets.length === 0) continue;
-    const key = String(entry.entry_date);
+    const key = dayString(entry.entry_date);
     let day = byDate.get(key);
     if (!day) {
       day = {
-        entry_date: entry.entry_date,
+        entry_date: key,
         max_weight: null,
         max_reps: null,
         total_volume: null,
@@ -297,7 +307,7 @@ const exerciseProgressSchema = exerciseDateRangeSchema
     exercise_name: z.string().optional(),
   });
 
-export function buildExerciseTools(userId: string) {
+export function buildExerciseTools(userId: string, tz: string) {
   return {
     sparky_manage_exercise: tool({
       description: `Fitness tracking: search exercises, log workouts with sets, manage presets.
@@ -799,7 +809,7 @@ Actions:
           return formatZodError(parsed.error);
         }
         try {
-          const { startDate, endDate } = exerciseDateRange(parsed.data);
+          const { startDate, endDate } = exerciseDateRange(parsed.data, tz);
           const { entries, sets } = await exerciseEntryDb.getExerciseDiaryRange(
             userId,
             startDate,
@@ -808,7 +818,7 @@ Actions:
           const data = {
             start_date: startDate,
             end_date: endDate,
-            entries,
+            entries: entries.map(projectEntryDate),
             sets,
           };
           return JSON.stringify(data, null, 2);
@@ -838,13 +848,17 @@ Actions:
           return formatZodError(parsed.error);
         }
         try {
-          const { startDate, endDate } = exerciseDateRange(parsed.data);
+          const { startDate, endDate } = exerciseDateRange(parsed.data, tz);
           const rows = await exerciseEntryDb.getDailyExerciseTotalsRange(
             userId,
             startDate,
             endDate
           );
-          const data = { start_date: startDate, end_date: endDate, rows };
+          const data = {
+            start_date: startDate,
+            end_date: endDate,
+            rows: rows.map(projectEntryDate),
+          };
           return JSON.stringify(data, null, 2);
         } catch (error) {
           log(
@@ -874,11 +888,11 @@ Actions:
         }
         try {
           const limit = Math.min(Math.max(parsed.data.limit ?? 50, 1), 200);
-          const data = await exerciseEntryDb.getRecentExerciseEntries(
+          const rows = await exerciseEntryDb.getRecentExerciseEntries(
             userId,
             limit
           );
-          return JSON.stringify(data, null, 2);
+          return JSON.stringify(rows.map(projectEntryDate), null, 2);
         } catch (error) {
           log(
             'error',
@@ -904,7 +918,7 @@ Actions:
         }
         try {
           const { exercise_id, ...query } = parsed.data;
-          const { startDate, endDate } = exerciseDateRange(query);
+          const { startDate, endDate } = exerciseDateRange(query, tz);
           const { limit, offset } = normalizePagination(
             query.limit,
             query.offset
@@ -917,7 +931,11 @@ Actions:
             limit,
             offset
           );
-          const data = buildPaginatedResult(rows, totalCount, offset);
+          const data = buildPaginatedResult(
+            rows.map(projectEntryDate),
+            totalCount,
+            offset
+          );
           return JSON.stringify(data, null, 2);
         } catch (error) {
           log(

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -1,0 +1,1424 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { addDays, localDateToDay, todayInZone } from '@workspace/shared';
+import { log } from '../../config/logging.js';
+import foodCoreService from '../../services/foodCoreService.js';
+import foodEntryService from '../../services/foodEntryService.js';
+import mealService from '../../services/mealService.js';
+import preferenceService from '../../services/preferenceService.js';
+import {
+  searchProviderFoods,
+  type ProviderType,
+} from '../../services/externalFoodSearchService.js';
+import foodRepository from '../../models/foodRepository.js';
+import foodEntryMealRepository from '../../models/foodEntryMealRepository.js';
+import measurementRepository from '../../models/measurementRepository.js';
+import reportRepository from '../../models/reportRepository.js';
+import externalProviderRepository from '../../models/externalProviderRepository.js';
+import { ERRORS, formatZodError } from './errors.js';
+import { formatConfirmation, formatList } from './formatting.js';
+import {
+  normalizePagination,
+  buildPaginatedResult,
+  type PaginatedResult,
+} from './pagination.js';
+import { convertEnergy } from './unitConversion.js';
+import {
+  manageFoodSchema,
+  manageFoodInput,
+  type ManageFoodInput,
+} from './schemas/food.js';
+
+const VALID_ACTIONS = [
+  'search_food',
+  'lookup_food_nutrition',
+  'log_food',
+  'create_food',
+  'search_meal',
+  'log_meal',
+  'list_diary',
+  'delete_entry',
+  'delete_food',
+  'update_entry',
+  'update_food_variant',
+  'copy_from_yesterday',
+  'save_as_meal_template',
+  'log_water',
+  'get_nutritional_summary',
+  'get_water_history',
+];
+
+// Provider types the no-provider cascade may search (exercise/health
+// providers are excluded).
+const FOOD_PROVIDER_TYPES = [
+  'fatsecret',
+  'mealie',
+  'tandoor',
+  'norish',
+  'usda',
+  'openfoodfacts',
+];
+
+// Units where an omitted create_food quantity defaults to 1 instead of 100.
+const COUNT_BASED_UNITS = [
+  'serving',
+  'piece',
+  'slice',
+  'portion',
+  'unit',
+  'can',
+  'bottle',
+  'item',
+  'pack',
+];
+
+// Window for tool-layer exact-name matching over the server's substring
+// search. An exact match could fall outside it only when more than this many
+// foods contain the searched name as a substring.
+const NAME_RESOLUTION_WINDOW = 500;
+
+// Optional inputs and nullable DB columns are treated alike: absent.
+function isSet<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined;
+}
+
+// pg returns DATE columns as local-midnight Date objects; render them as
+// calendar-day strings.
+function dayString(value: unknown): string {
+  return value instanceof Date ? localDateToDay(value) : String(value);
+}
+
+// MCP's date-range defaults: a single `date` overrides start/end; otherwise
+// the range defaults to today (UTC) / the start date.
+function foodDateRange(query: {
+  date?: string;
+  start_date?: string;
+  end_date?: string;
+}): { startDate: string; endDate: string } {
+  const today = todayInZone('UTC');
+  const date = query.date || undefined;
+  const startDate = date || query.start_date || today;
+  const endDate = date || query.end_date || startDate;
+  return { startDate, endDate };
+}
+
+// The variant column set MCP's food search exposed; the server's
+// default_variant JSON is projected down to it.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function projectVariant(foodId: string, v: any) {
+  return {
+    id: v.id,
+    food_id: foodId,
+    serving_size: v.serving_size,
+    serving_unit: v.serving_unit,
+    calories: v.calories,
+    protein: v.protein,
+    carbs: v.carbs,
+    fat: v.fat,
+    saturated_fat: v.saturated_fat,
+    polyunsaturated_fat: v.polyunsaturated_fat,
+    monounsaturated_fat: v.monounsaturated_fat,
+    trans_fat: v.trans_fat,
+    cholesterol: v.cholesterol,
+    sodium: v.sodium,
+    potassium: v.potassium,
+    dietary_fiber: v.dietary_fiber,
+    sugars: v.sugars,
+    vitamin_a: v.vitamin_a,
+    vitamin_c: v.vitamin_c,
+    calcium: v.calcium,
+    iron: v.iron,
+    glycemic_index: v.glycemic_index,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function projectFoodItem(row: any) {
+  return {
+    id: row.id,
+    name: row.name,
+    brand: row.brand || undefined,
+    variants: row.default_variant?.id
+      ? [projectVariant(row.id, row.default_variant)]
+      : [],
+  };
+}
+
+// Catalog row for the JSON helpers: the server's default_variant JSON is
+// folded into MCP's `variants` array shape.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function projectCatalogFood(row: any) {
+  const { default_variant: defaultVariant, ...rest } = row;
+  return { ...rest, variants: defaultVariant?.id ? [defaultVariant] : [] };
+}
+
+// Internal food search mirroring MCP's searchFood: "broad" is a substring
+// match, "exact" a case-insensitive name-equality filter applied in the tool
+// layer over the server's substring search.
+async function searchFoodInternal(
+  userId: string,
+  foodName: string,
+  searchType: 'exact' | 'broad',
+  limitArg?: number,
+  offsetArg?: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<PaginatedResult<any>> {
+  const { limit, offset } = normalizePagination(limitArg, offsetArg);
+  if (searchType === 'exact') {
+    const rows = await foodRepository.getFoodsWithPagination(
+      foodName,
+      null,
+      userId,
+      NAME_RESOLUTION_WINDOW,
+      0,
+      null
+    );
+    const matches = rows.filter(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (r: any) => String(r.name).toLowerCase() === foodName.toLowerCase()
+    );
+    return buildPaginatedResult(
+      matches.slice(offset, offset + limit).map(projectFoodItem),
+      matches.length,
+      offset
+    );
+  }
+  const [rows, totalCount] = await Promise.all([
+    foodRepository.getFoodsWithPagination(
+      foodName,
+      null,
+      userId,
+      limit,
+      offset,
+      null
+    ),
+    foodRepository.countFoods(foodName, null, userId),
+  ]);
+  return buildPaginatedResult(rows.map(projectFoodItem), totalCount, offset);
+}
+
+// Case-insensitive exact name lookup (MCP's `name ILIKE $1` without
+// wildcards). Returns the raw catalog row including default_variant.
+async function findFoodByExactName(userId: string, name: string) {
+  const rows = await foodRepository.getFoodsWithPagination(
+    name,
+    null,
+    userId,
+    NAME_RESOLUTION_WINDOW,
+    0,
+    null
+  );
+  return rows.find(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (r: any) => String(r.name).toLowerCase() === name.toLowerCase()
+  );
+}
+
+// Per-day nutrition totals with the user's energy-unit conversion applied —
+// MCP's getNutritionalSummary row shape (fiber/sugar aliases included).
+async function getNutritionalSummaryRows(
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
+  const prefs = await preferenceService.getUserPreferences(userId, userId);
+  const energyUnit = (prefs?.energy_unit as string) || 'kcal';
+  const rows = await reportRepository.getDailyNutritionTotalsRange(
+    userId,
+    startDate,
+    endDate
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return rows.map((row: any) => {
+    const calories = Number(row.calories || 0);
+    return {
+      entry_date: dayString(row.entry_date),
+      calories:
+        energyUnit === 'kJ' ? convertEnergy(calories, 'kcal', 'kJ') : calories,
+      protein: Number(row.protein || 0),
+      carbs: Number(row.carbs || 0),
+      fat: Number(row.fat || 0),
+      saturated_fat: Number(row.saturated_fat || 0),
+      polyunsaturated_fat: Number(row.polyunsaturated_fat || 0),
+      monounsaturated_fat: Number(row.monounsaturated_fat || 0),
+      trans_fat: Number(row.trans_fat || 0),
+      cholesterol: Number(row.cholesterol || 0),
+      sodium: Number(row.sodium || 0),
+      potassium: Number(row.potassium || 0),
+      fiber: Number(row.fiber || 0),
+      sugar: Number(row.sugar || 0),
+      vitamin_a: Number(row.vitamin_a || 0),
+      vitamin_c: Number(row.vitamin_c || 0),
+      calcium: Number(row.calcium || 0),
+      iron: Number(row.iron || 0),
+      energy_unit: energyUnit,
+    };
+  });
+}
+
+/**
+ * Cascade lookup for food nutrition: internal DB, then the user's active
+ * configured external providers (sort_order first), then free OpenFoodFacts.
+ * `source: 'ai_estimate'` with a null food signals the AI-estimation fallback.
+ */
+async function lookupFoodNutrition(
+  userId: string,
+  foodName: string,
+  providerType?: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<{ source: string; food: any | null; alternatives?: any[] }> {
+  // Internal DB search (unless another provider was explicitly requested)
+  if (!providerType || providerType === 'internal') {
+    const internalExact = await searchFoodInternal(userId, foodName, 'exact');
+    if (internalExact.data.length > 0) {
+      return {
+        source: 'internal',
+        food: internalExact.data[0],
+        alternatives: internalExact.data.slice(1),
+      };
+    }
+    const internalBroad = await searchFoodInternal(userId, foodName, 'broad');
+    if (internalBroad.data.length > 0) {
+      return {
+        source: 'internal',
+        food: internalBroad.data[0],
+        alternatives: internalBroad.data.slice(1),
+      };
+    }
+    // "internal" explicitly requested and not found: stop here
+    if (providerType === 'internal') {
+      return { source: 'internal', food: null };
+    }
+  }
+
+  let targetProviders: {
+    id?: string;
+    provider_type: string;
+    provider_name: string;
+  }[] = [];
+
+  if (providerType) {
+    if (providerType === 'openfoodfacts') {
+      targetProviders.push({
+        provider_type: 'openfoodfacts',
+        provider_name: 'OpenFoodFacts',
+      });
+    } else {
+      const rows = await externalProviderRepository.getActiveProvidersByTypes(
+        userId,
+        [providerType]
+      );
+      if (rows.length > 0) {
+        targetProviders.push(rows[0]);
+      } else {
+        // Explicitly requested but unconfigured: the per-provider search
+        // below fails (no credentials) and the cascade falls through to the
+        // AI-estimate response — MCP behavior, pinned by test.
+        targetProviders.push({
+          provider_type: providerType,
+          provider_name: providerType,
+        });
+      }
+    }
+  } else {
+    targetProviders =
+      await externalProviderRepository.getActiveProvidersByTypes(
+        userId,
+        FOOD_PROVIDER_TYPES
+      );
+    if (!targetProviders.some((p) => p.provider_type === 'openfoodfacts')) {
+      targetProviders.push({
+        provider_type: 'openfoodfacts',
+        provider_name: 'OpenFoodFacts',
+      });
+    }
+  }
+
+  for (const provider of targetProviders) {
+    try {
+      log(
+        'debug',
+        `[Food Tool] Lookup cascade querying provider: ${provider.provider_name} (${provider.provider_type})`
+      );
+      const result = await searchProviderFoods(
+        userId,
+        provider.provider_type as ProviderType,
+        foodName,
+        { providerId: provider.id }
+      );
+      if (result.foods.length > 0) {
+        return {
+          source: provider.provider_type,
+          food: result.foods[0],
+          alternatives: result.foods.slice(1),
+        };
+      }
+    } catch (error) {
+      log(
+        'warn',
+        `[Food Tool] Lookup cascade provider ${provider.provider_name} failed:`,
+        error
+      );
+    }
+  }
+
+  return { source: 'ai_estimate', food: null };
+}
+
+// Standalone domain tools.
+const foodDateRangeSchema = z.object({
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  start_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+  end_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+});
+
+const foodPaginationSchema = z.object({
+  limit: z.number().int().min(1).max(500).optional(),
+  offset: z.number().int().min(0).optional(),
+});
+
+const listFoodsSchema = foodPaginationSchema.extend({
+  search: z.string().optional(),
+});
+
+const getFoodDetailsSchema = z.object({
+  food_id: z.string().min(1),
+});
+
+const searchFoodsSchema = foodPaginationSchema.extend({
+  query: z.string().min(1),
+});
+
+const recentFoodEntriesSchema = z.object({
+  limit: z.number().int().min(1).max(200).optional(),
+});
+
+const foodUsageSchema = foodDateRangeSchema.merge(foodPaginationSchema).extend({
+  food_id: z.string().min(1),
+});
+
+export function buildFoodTools(userId: string) {
+  return {
+    sparky_manage_food: tool({
+      description: `Nutrition tracking: search food, log meals, create foods, manage diary.
+
+Actions:
+- search_food(food_name, search_type:"exact"|"broad", limit?, offset?)
+- lookup_food_nutrition(food_name, provider_type?) — AI MUST call this cascade lookup first before creating or estimating a food. Bypasses regular cascade to search specific provider (e.g. openfoodfacts, usda) if provider_type given.
+- log_food(food_name, quantity, unit, meal_type:"breakfast"|"lunch"|"dinner"|"snacks", entry_date, food_id?, variant_id?)
+- create_food(food_name, calories, protein, carbs, fat, brand?, quantity?, unit?, saturated_fat?, fiber?, sugar?, sodium?, ...) — AI clients should search the web and populate as many micro-nutrients, GI classification, and brand ('Homemade' or 'Traditional' if generic) as possible rather than just core macros. ONLY call this if lookup_food_nutrition returns source='ai_estimate'.
+- search_meal(meal_name)
+- log_meal(meal_type, entry_date, meal_id?, meal_name?, quantity?)
+- list_diary(entry_date?)
+- delete_entry(entry_id, entry_type:"food_entry"|"food_entry_meal")
+- delete_food(food_id?|food_name?) — deletes food + variants + all diary entries referencing it
+- update_entry(entry_id, entry_type, quantity, unit)
+- update_food_variant(food_id?|variant_id?, serving_size?, serving_unit?, calories?, protein?, carbs?, fat?, saturated_fat?, fiber?, sugar?, sodium?, ..., update_existing_entries?) — updates an existing food variant without deleting the food. Defaults to leaving existing diary entries unchanged.
+- copy_from_yesterday(target_date?, source_date?, meal_type?)
+- save_as_meal_template(entry_date, meal_type, meal_name, description?)
+- log_water(amount_ml, entry_date)
+- get_nutritional_summary(start_date, end_date) — returns macro breakdown for a range of dates
+- get_water_history(start_date?, end_date?)`,
+      inputSchema: manageFoodInput,
+      execute: async (rawArgs) => {
+        const parsed = manageFoodSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        const args: ManageFoodInput = parsed.data;
+        try {
+          switch (args.action) {
+            case 'search_food': {
+              const result = await searchFoodInternal(
+                userId,
+                args.food_name,
+                args.search_type,
+                args.limit,
+                args.offset
+              );
+              return formatList(
+                result.data,
+                `Food Search: "${args.food_name}" (${args.search_type})`,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (f: any) => {
+                  const v = f.variants[0];
+                  let text = `**${f.name}**`;
+                  if (f.brand) text += ` (${f.brand})`;
+                  if (v) {
+                    text += `\n  ${v.serving_size}${v.serving_unit}: ${v.calories} kcal | P: ${v.protein}g | C: ${v.carbs}g | F: ${v.fat}g`;
+                  }
+                  text += `\n  ID: ${f.id}`;
+                  if (v) text += ` | Variant: ${v.id}`;
+                  return text;
+                },
+                {
+                  total_count: result.total_count,
+                  has_more: result.has_more,
+                  next_offset: result.next_offset,
+                }
+              );
+            }
+
+            case 'lookup_food_nutrition': {
+              const result = await lookupFoodNutrition(
+                userId,
+                args.food_name,
+                args.provider_type
+              );
+
+              if (result.source === 'ai_estimate') {
+                return `No matches found in internal DB or configured external databases/OpenFoodFacts for "${args.food_name}". You may estimate the nutrition using AI and save it using create_food.`;
+              }
+              if (!result.food) {
+                // MCP quirk: an explicit provider_type='internal' miss
+                // crashed its renderer on the null food and surfaced as a
+                // DB error — ported as-is.
+                return ERRORS.DB_ERROR();
+              }
+
+              const f = result.food;
+              let text = `### Found match in **${result.source}**:\n`;
+              text += `**${f.name}**`;
+              if (f.brand) text += ` (${f.brand})`;
+
+              const v = f.default_variant || f.variants?.[0];
+              if (v) {
+                text += `\n  Serving Size: ${v.serving_size} ${v.serving_unit}`;
+                text += `\n  Energy: ${v.calories ?? v.energy ?? 0} kcal`;
+                text += `\n  Macros: Protein: ${v.protein}g | Carbs: ${v.carbs}g | Fat: ${v.fat}g`;
+                if (
+                  isSet(v.saturated_fat) ||
+                  isSet(v.dietary_fiber) ||
+                  isSet(v.sugars) ||
+                  isSet(v.sodium)
+                ) {
+                  text += `\n  Details: Fiber: ${v.dietary_fiber ?? 0}g | Sugar: ${v.sugars ?? 0}g | Sodium: ${v.sodium ?? 0}mg | SatFat: ${v.saturated_fat ?? 0}g`;
+                }
+                if (f.provider_external_id) {
+                  text += `\n  External ID: ${f.provider_external_id}`;
+                }
+              }
+
+              if (result.alternatives && result.alternatives.length > 0) {
+                text += '\n\n**Other Alternatives found:**';
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                result.alternatives.slice(0, 5).forEach((alt: any) => {
+                  const altV = alt.default_variant || alt.variants?.[0];
+                  text += `\n- **${alt.name}**`;
+                  if (alt.brand) text += ` (${alt.brand})`;
+                  if (altV) {
+                    text += ` (${altV.serving_size}${altV.serving_unit}: ${altV.calories ?? altV.energy ?? 0} kcal)`;
+                  }
+                });
+              }
+
+              return text;
+            }
+
+            case 'log_food': {
+              let foodId = args.food_id;
+              let variantId = args.variant_id;
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              let foodRow: any;
+              if (!foodId) {
+                foodRow = await findFoodByExactName(userId, args.food_name);
+                if (!foodRow) {
+                  return ERRORS.VALIDATION(
+                    `Food "${args.food_name}" not found. Create it first using create_food action.`
+                  );
+                }
+                foodId = foodRow.id;
+              }
+              if (!variantId) {
+                const food =
+                  foodRow ?? (await foodRepository.getFoodById(foodId, userId));
+                variantId = food?.default_variant?.id;
+              }
+              const entry = await foodEntryService.createFoodEntry(
+                userId,
+                userId,
+                {
+                  user_id: userId,
+                  food_id: foodId,
+                  variant_id: variantId,
+                  entry_date: args.entry_date,
+                  quantity: args.quantity,
+                  unit: args.unit,
+                  meal_type: args.meal_type,
+                }
+              );
+              return formatConfirmation(
+                `Logged "${entry.food_name}" (${args.quantity} ${args.unit}) for ${args.meal_type} on ${args.entry_date}.`
+              );
+            }
+
+            case 'create_food': {
+              const targetUnit = args.unit || 'serving';
+              const isCountUnit = COUNT_BASED_UNITS.includes(
+                targetUnit.toLowerCase()
+              );
+              const targetQuantity = args.quantity || (isCountUnit ? 1 : 100);
+              // The `|| null` on optional fields is MCP's storage quirk
+              // (an explicit 0 is stored as null), ported as-is.
+              const food = await foodCoreService.createFood(userId, {
+                user_id: userId,
+                name: args.food_name,
+                brand: args.brand || null,
+                serving_size: targetQuantity,
+                serving_unit: targetUnit,
+                calories: args.calories,
+                protein: args.protein,
+                carbs: args.carbs,
+                fat: args.fat,
+                saturated_fat: args.saturated_fat || null,
+                polyunsaturated_fat: args.polyunsaturated_fat || null,
+                monounsaturated_fat: args.monounsaturated_fat || null,
+                trans_fat: args.trans_fat || null,
+                cholesterol: args.cholesterol || null,
+                sodium: args.sodium || null,
+                potassium: args.potassium || null,
+                dietary_fiber: args.fiber || null,
+                sugars: args.sugar || null,
+                vitamin_a: args.vitamin_a || null,
+                vitamin_c: args.vitamin_c || null,
+                calcium: args.calcium || null,
+                iron: args.iron || null,
+                glycemic_index: args.gi || null,
+              });
+              const v = food.default_variant;
+              let msg = `Food "${food.name}" created with ${v?.calories || 0} kcal per ${v?.serving_size || 100}${v?.serving_unit || 'g'}.`;
+              if (args.meal_type) {
+                const entryDate = args.entry_date || todayInZone('UTC');
+                await foodEntryService.createFoodEntry(userId, userId, {
+                  user_id: userId,
+                  food_id: food.id,
+                  variant_id: v?.id,
+                  entry_date: entryDate,
+                  quantity: targetQuantity,
+                  unit: targetUnit,
+                  meal_type: args.meal_type,
+                });
+                msg += ` Also logged to ${args.meal_type} for ${entryDate}.`;
+              }
+              return formatConfirmation(msg);
+            }
+
+            case 'search_meal': {
+              const meals = await mealService.searchMeals(
+                userId,
+                args.meal_name
+              );
+              return formatList(
+                meals,
+                `Meal Search: "${args.meal_name}"`,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (m: any) => {
+                  let text = `**${m.name}**`;
+                  if (m.description) text += ` — ${m.description}`;
+                  text += `\n  Foods: ${m.foods.length} items`;
+                  if (m.foods.length > 0) {
+                    text += ` (${m.foods
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      .map((f: any) => f.food_name)
+                      .join(', ')})`;
+                  }
+                  text += `\n  ID: ${m.id}`;
+                  return text;
+                }
+              );
+            }
+
+            case 'log_meal': {
+              if (!args.meal_id && !args.meal_name) {
+                return ERRORS.VALIDATION(
+                  'Either meal_id or meal_name must be provided'
+                );
+              }
+              let mealId = args.meal_id;
+              let mealName = args.meal_name || '';
+              if (!mealId && args.meal_name) {
+                // Exact-insensitive name match over the server's substring
+                // search (MCP's `name ILIKE $1 LIMIT 1`).
+                const meals = await mealService.searchMeals(
+                  userId,
+                  args.meal_name
+                );
+                const name = args.meal_name.toLowerCase();
+                const match = meals.find(
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  (m: any) => String(m.name).toLowerCase() === name
+                );
+                if (!match) {
+                  return ERRORS.VALIDATION(
+                    `Meal "${args.meal_name}" not found.`
+                  );
+                }
+                mealId = match.id;
+                mealName = match.name;
+              } else if (mealId) {
+                try {
+                  const meal = await mealService.getMealById(userId, mealId);
+                  mealName = meal.name;
+                } catch (error) {
+                  if (
+                    error instanceof Error &&
+                    error.message.includes('not found')
+                  ) {
+                    return ERRORS.VALIDATION(
+                      `Meal with ID "${mealId}" not found.`
+                    );
+                  }
+                  throw error;
+                }
+              }
+              await foodEntryService.createFoodEntryMeal(userId, userId, {
+                user_id: userId,
+                meal_template_id: mealId,
+                meal_type: args.meal_type,
+                entry_date: args.entry_date,
+                name: mealName,
+                quantity: args.quantity || 1,
+                unit: args.unit || 'serving',
+                _clientMealModelVersion: 2,
+              });
+              return formatConfirmation(
+                `Meal "${mealName}" logged for ${args.meal_type} on ${args.entry_date}.`
+              );
+            }
+
+            case 'list_diary': {
+              const date = args.entry_date || todayInZone('UTC');
+              const prefs = await preferenceService.getUserPreferences(
+                userId,
+                userId
+              );
+              const eUnit = (prefs?.energy_unit as string) || 'kcal';
+              const foodRows = await foodEntryService.getFoodEntriesByDate(
+                userId,
+                userId,
+                date
+              );
+              const mealRows =
+                await foodEntryMealRepository.getFoodEntryMealsByDate(
+                  userId,
+                  date
+                );
+
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const foodEntries = foodRows.map((row: any) => {
+                const servingSize = Number(row.serving_size) || 1;
+                const servingUnit = (
+                  row.serving_unit || 'serving'
+                ).toLowerCase();
+                const unit = (row.unit || 'serving').toLowerCase();
+                const quantity = Number(row.quantity);
+
+                // Unit-compatibility multiplier: "serving" or a unit other
+                // than the variant's is treated as absolute servings.
+                const multiplier =
+                  unit === 'serving' || unit !== servingUnit
+                    ? quantity
+                    : quantity / servingSize;
+
+                const scale = (val: unknown) => {
+                  const n = Number(val);
+                  return isNaN(n) ? 0 : Math.round(n * multiplier * 10) / 10;
+                };
+
+                const scaledCalories = scale(row.calories);
+                const displayCalories =
+                  eUnit === 'kJ'
+                    ? convertEnergy(scaledCalories, 'kcal', 'kJ')
+                    : scaledCalories;
+
+                return {
+                  id: row.id,
+                  food_name: row.food_name,
+                  quantity,
+                  unit: row.unit || 'g',
+                  meal_type: row.meal_type
+                    ? String(row.meal_type).toLowerCase()
+                    : 'snacks',
+                  entry_type: 'food_entry' as const,
+                  nutritional_values: isSet(row.calories)
+                    ? {
+                        calories: Math.round(displayCalories),
+                        protein: scale(row.protein),
+                        carbs: scale(row.carbs),
+                        fat: scale(row.fat),
+                      }
+                    : undefined,
+                };
+              });
+
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const mealEntries = mealRows.map((row: any) => ({
+                id: row.id,
+                meal_name: row.name,
+                quantity: Number(row.quantity),
+                meal_type: row.meal_type
+                  ? String(row.meal_type).toLowerCase()
+                  : 'snacks',
+                entry_type: 'food_entry_meal' as const,
+              }));
+
+              const allEntries = [...foodEntries, ...mealEntries];
+              const dateLabel = args.entry_date || 'Today';
+              let text = `# Food Diary: ${dateLabel}\n\n`;
+
+              if (allEntries.length === 0) {
+                text += 'No entries found for this date.';
+              } else {
+                const grouped: Record<string, typeof allEntries> = {};
+                for (const entry of allEntries) {
+                  const mt = entry.meal_type || 'other';
+                  if (!grouped[mt]) grouped[mt] = [];
+                  grouped[mt].push(entry);
+                }
+
+                let totalEnergy = 0;
+                for (const [mealType, entries] of Object.entries(grouped)) {
+                  text += `## ${mealType.charAt(0).toUpperCase() + mealType.slice(1)}\n`;
+                  for (const entry of entries) {
+                    if (entry.entry_type === 'food_entry') {
+                      text += `- **${entry.food_name}** — ${entry.quantity} ${entry.unit}`;
+                      if (entry.nutritional_values?.calories) {
+                        text += ` (${entry.nutritional_values.calories} ${eUnit})`;
+                        totalEnergy += entry.nutritional_values.calories;
+                      }
+                      text += `\n  ID: ${entry.id} | Type: food_entry\n`;
+                    } else {
+                      text += `- **${entry.meal_name}** (meal template) — ${entry.quantity}x`;
+                      text += `\n  ID: ${entry.id} | Type: food_entry_meal\n`;
+                    }
+                  }
+                  text += '\n';
+                }
+
+                if (totalEnergy > 0) {
+                  text += `---\n**Total Energy:** ${totalEnergy} ${eUnit}`;
+                }
+              }
+
+              return text;
+            }
+
+            case 'delete_entry': {
+              try {
+                if (args.entry_type === 'food_entry') {
+                  await foodEntryService.deleteFoodEntry(userId, args.entry_id);
+                } else {
+                  await foodEntryService.deleteFoodEntryMeal(
+                    userId,
+                    args.entry_id
+                  );
+                }
+              } catch (error) {
+                if (
+                  error instanceof Error &&
+                  error.message.includes('not found')
+                ) {
+                  return ERRORS.NOT_FOUND('Entry', args.entry_id);
+                }
+                throw error;
+              }
+              return formatConfirmation('Entry deleted.');
+            }
+
+            case 'delete_food': {
+              if (!args.food_id && !args.food_name) {
+                return ERRORS.VALIDATION(
+                  'Either food_id or food_name must be provided'
+                );
+              }
+              let foodId = args.food_id;
+              let name = args.food_name;
+              if (!foodId) {
+                const row = await findFoodByExactName(
+                  userId,
+                  args.food_name ?? ''
+                );
+                if (!row) {
+                  return ERRORS.VALIDATION(
+                    `Food "${args.food_name}" not found.`
+                  );
+                }
+                foodId = row.id;
+                name = row.name;
+              } else {
+                const row = await foodRepository.getFoodById(foodId, userId);
+                if (!row) {
+                  return ERRORS.NOT_FOUND(
+                    'Food',
+                    args.food_id || args.food_name || 'unknown'
+                  );
+                }
+                name = row.name;
+              }
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              let result: any;
+              try {
+                result = await foodCoreService.deleteFood(userId, foodId, true);
+              } catch (error) {
+                if (
+                  error instanceof Error &&
+                  (error.message.includes('not found') ||
+                    error.message.includes('Forbidden'))
+                ) {
+                  return ERRORS.NOT_FOUND(
+                    'Food',
+                    args.food_id || args.food_name || 'unknown'
+                  );
+                }
+                throw error;
+              }
+              if (result.status === 'hidden') {
+                // Named drift: other users still reference this food, so the
+                // server hides it instead of deleting (MCP hit an FK
+                // violation here and returned a DB error).
+                return formatConfirmation(
+                  `Food "${name}" hidden (marked as quick food). Existing references remain.`
+                );
+              }
+              return formatConfirmation(
+                `Food "${name}" deleted (including variants and diary entries).`
+              );
+            }
+
+            case 'update_entry': {
+              try {
+                if (args.entry_type === 'food_entry') {
+                  await foodEntryService.updateFoodEntry(
+                    userId,
+                    userId,
+                    args.entry_id,
+                    { quantity: args.quantity, unit: args.unit }
+                  );
+                } else {
+                  // Round-trip the template link and component foods so the
+                  // server's edit path rescales components instead of
+                  // detaching them.
+                  const existing =
+                    await foodEntryService.getFoodEntryMealWithComponents(
+                      userId,
+                      args.entry_id
+                    );
+                  if (!existing) {
+                    return ERRORS.NOT_FOUND('Entry', args.entry_id);
+                  }
+                  await foodEntryService.updateFoodEntryMeal(
+                    userId,
+                    userId,
+                    args.entry_id,
+                    {
+                      meal_template_id: existing.meal_template_id,
+                      entry_date: dayString(existing.entry_date),
+                      quantity: args.quantity,
+                      unit: args.unit,
+                      foods: existing.foods,
+                    }
+                  );
+                }
+              } catch (error) {
+                if (
+                  error instanceof Error &&
+                  error.message.includes('not found')
+                ) {
+                  return ERRORS.NOT_FOUND('Entry', args.entry_id);
+                }
+                throw error;
+              }
+              return formatConfirmation(
+                `Entry updated to ${args.quantity} ${args.unit}.`
+              );
+            }
+
+            case 'update_food_variant': {
+              if (!args.food_id && !args.variant_id) {
+                // MCP quirk: this guard threw a plain error whose message
+                // does not contain 'not found', so it surfaced as a DB
+                // error — ported as-is.
+                return ERRORS.DB_ERROR();
+              }
+              let variantId = args.variant_id;
+              if (!variantId) {
+                const food = await foodRepository.getFoodById(
+                  args.food_id,
+                  userId
+                );
+                if (
+                  !food ||
+                  food.user_id !== userId ||
+                  !food.default_variant?.id
+                ) {
+                  return ERRORS.VALIDATION(
+                    `Default variant for food_id "${args.food_id}" not found or not editable.`
+                  );
+                }
+                variantId = food.default_variant.id;
+              }
+              const variant = await foodRepository.getFoodVariantById(
+                variantId,
+                userId
+              );
+              const parentFood = variant
+                ? await foodRepository.getFoodById(variant.food_id, userId)
+                : null;
+              if (!variant || !parentFood || parentFood.user_id !== userId) {
+                return ERRORS.VALIDATION(
+                  `Food variant "${variantId}" not found or not editable.`
+                );
+              }
+              if (args.food_id && variant.food_id !== args.food_id) {
+                // MCP quirk: "does not belong" threw and surfaced as a DB
+                // error — ported as-is.
+                return ERRORS.DB_ERROR();
+              }
+
+              const updates: Record<string, unknown> = {};
+              const fieldMap: Record<string, string> = {
+                serving_size: 'serving_size',
+                serving_unit: 'serving_unit',
+                calories: 'calories',
+                protein: 'protein',
+                carbs: 'carbs',
+                fat: 'fat',
+                saturated_fat: 'saturated_fat',
+                polyunsaturated_fat: 'polyunsaturated_fat',
+                monounsaturated_fat: 'monounsaturated_fat',
+                trans_fat: 'trans_fat',
+                cholesterol: 'cholesterol',
+                sodium: 'sodium',
+                potassium: 'potassium',
+                fiber: 'dietary_fiber',
+                sugar: 'sugars',
+                vitamin_a: 'vitamin_a',
+                vitamin_c: 'vitamin_c',
+                calcium: 'calcium',
+                iron: 'iron',
+                gi: 'glycemic_index',
+              };
+              for (const [inputField, dbField] of Object.entries(fieldMap)) {
+                const value = (args as Record<string, unknown>)[inputField];
+                if (value !== undefined) {
+                  updates[dbField] = value;
+                }
+              }
+              if (Object.keys(updates).length === 0) {
+                // MCP quirk: "at least one field" threw and surfaced as a
+                // DB error — ported as-is.
+                return ERRORS.DB_ERROR();
+              }
+
+              const updated = await foodRepository.updateFoodVariant(
+                variantId,
+                updates,
+                userId
+              );
+              if (args.update_existing_entries) {
+                await foodCoreService.updateFoodEntriesSnapshot(
+                  userId,
+                  variant.food_id,
+                  variantId
+                );
+              }
+              return formatConfirmation(
+                `Food variant updated for "${parentFood.name}" (${updated.calories ?? 0} kcal per ${updated.serving_size ?? '?'}${updated.serving_unit ?? ''}).`
+              );
+            }
+
+            case 'copy_from_yesterday': {
+              // MCP's defaults: target falls back to today, source to
+              // yesterday-of-today (not yesterday-of-target).
+              const targetDate = args.target_date || todayInZone('UTC');
+              const sourceDate =
+                args.source_date || addDays(todayInZone('UTC'), -1);
+              const copied = args.meal_type
+                ? await foodEntryService.copyFoodEntries(
+                    userId,
+                    userId,
+                    sourceDate,
+                    args.meal_type,
+                    targetDate,
+                    args.meal_type
+                  )
+                : await foodEntryService.copyAllFoodEntries(
+                    userId,
+                    userId,
+                    sourceDate,
+                    targetDate
+                  );
+              if (copied.length === 0) {
+                return formatConfirmation(
+                  'No entries found to copy from the source date.'
+                );
+              }
+              return formatConfirmation(
+                `Copied ${copied.length} entries to ${targetDate}.`
+              );
+            }
+
+            case 'save_as_meal_template': {
+              const meal = await mealService.createMealFromDiaryEntries(
+                userId,
+                args.entry_date,
+                args.meal_type,
+                args.meal_name,
+                args.description ?? null
+              );
+              // createMealFromDiaryEntries returns the meal without its
+              // foods; re-fetch for the item count.
+              const saved = await mealService.getMealById(userId, meal.id);
+              return formatConfirmation(
+                `Meal template "${meal.name}" saved with ${saved.foods.length} food items.`
+              );
+            }
+
+            case 'log_water': {
+              await measurementRepository.insertWaterIntakeLog(
+                userId,
+                userId,
+                args.entry_date,
+                args.amount_ml,
+                null,
+                null
+              );
+              return formatConfirmation(
+                `Logged ${args.amount_ml}ml water for ${args.entry_date}.`
+              );
+            }
+
+            case 'get_nutritional_summary': {
+              const summary = await getNutritionalSummaryRows(
+                userId,
+                args.start_date,
+                args.end_date
+              );
+              const eUnit =
+                summary.length > 0 ? summary[0].energy_unit : 'kcal';
+              return formatList(
+                summary,
+                `Nutritional Summary (${args.start_date} to ${args.end_date})`,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (s: any) => {
+                  let text = `**${s.entry_date}**:\n`;
+                  text += `  Macros: ${s.calories} ${eUnit} | P: ${s.protein}g | C: ${s.carbs}g | F: ${s.fat}g\n`;
+                  text += `  Fiber: ${s.fiber}g | Sugar: ${s.sugar}g | Sodium: ${s.sodium}mg\n`;
+                  if (s.saturated_fat || s.cholesterol || s.potassium) {
+                    text += `  Other: SatFat: ${s.saturated_fat}g | Chol: ${s.cholesterol}mg | Potas: ${s.potassium}mg`;
+                  }
+                  return text;
+                }
+              );
+            }
+
+            case 'get_water_history': {
+              const prefs = await preferenceService.getUserPreferences(
+                userId,
+                userId
+              );
+              const waterUnit = (prefs?.water_display_unit as string) || 'ml';
+              const rows =
+                await measurementRepository.getWaterTotalsByDateRange(
+                  userId,
+                  args.start_date,
+                  args.end_date
+                );
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const history = rows.map((row: any) => {
+                const ml = Number(row.total_ml || 0);
+                return {
+                  entry_date: dayString(row.entry_date),
+                  amount:
+                    waterUnit === 'oz'
+                      ? Math.round((ml / 29.5735) * 10) / 10
+                      : ml,
+                  unit: waterUnit,
+                };
+              });
+              return formatList(
+                history,
+                'Water Intake History',
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (h: any) => `**${h.entry_date}**: ${h.amount} ${h.unit}`
+              );
+            }
+
+            default:
+              return ERRORS.INVALID_ACTION(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                String((args as any).action),
+                VALID_ACTIONS
+              );
+          }
+        } catch (error) {
+          log('error', '[Food Tool] Error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.VALIDATION(error.message);
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_list_foods: tool({
+      description:
+        'Returns a paginated food catalog for the authenticated user, including variants.',
+      inputSchema: listFoodsSchema,
+      execute: async (rawArgs) => {
+        const parsed = listFoodsSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const { limit, offset } = normalizePagination(
+            parsed.data.limit,
+            parsed.data.offset
+          );
+          const search = parsed.data.search?.trim() || undefined;
+          const [rows, totalCount] = await Promise.all([
+            foodRepository.getFoodsWithPagination(
+              search,
+              null,
+              userId,
+              limit,
+              offset,
+              null
+            ),
+            foodRepository.countFoods(search, null, userId),
+          ]);
+          const data = buildPaginatedResult(
+            rows.map(projectCatalogFood),
+            totalCount,
+            offset
+          );
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log('error', '[Food Tool] sparky_list_foods error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND('Food', 'unknown');
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_food_details: tool({
+      description:
+        'Returns full details for one food by food_id, including available variants.',
+      inputSchema: getFoodDetailsSchema,
+      execute: async (rawArgs) => {
+        const parsed = getFoodDetailsSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const food = await foodCoreService.getFoodById(
+            userId,
+            parsed.data.food_id
+          );
+          const variants = await foodRepository.getFoodVariantsByFoodId(
+            parsed.data.food_id,
+            userId
+          );
+          const { default_variant: _defaultVariant, ...rest } = food;
+          return JSON.stringify({ ...rest, variants }, null, 2);
+        } catch (error) {
+          log('error', '[Food Tool] sparky_get_food_details error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND('Food', parsed.data.food_id);
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_search_foods: tool({
+      description: 'Searches foods by name for the authenticated user.',
+      inputSchema: searchFoodsSchema,
+      execute: async (rawArgs) => {
+        const parsed = searchFoodsSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const { limit, offset } = normalizePagination(
+            parsed.data.limit,
+            parsed.data.offset
+          );
+          const [rows, totalCount] = await Promise.all([
+            foodRepository.getFoodsWithPagination(
+              parsed.data.query,
+              null,
+              userId,
+              limit,
+              offset,
+              null
+            ),
+            foodRepository.countFoods(parsed.data.query, null, userId),
+          ]);
+          const data = buildPaginatedResult(
+            rows.map(projectCatalogFood),
+            totalCount,
+            offset
+          );
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log('error', '[Food Tool] sparky_search_foods error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND('Food', parsed.data.query);
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_food_diary: tool({
+      description:
+        'Returns entry-level food diary data for a specific date or date range.',
+      inputSchema: foodDateRangeSchema,
+      execute: async (rawArgs) => {
+        const parsed = foodDateRangeSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const { startDate, endDate } = foodDateRange(parsed.data);
+          const foodEntries = await foodEntryService.getFoodEntriesByDateRange(
+            userId,
+            userId,
+            startDate,
+            endDate
+          );
+          const mealEntries =
+            await foodEntryMealRepository.getFoodEntryMealsByDateRange(
+              userId,
+              startDate,
+              endDate
+            );
+          const data = {
+            start_date: startDate,
+            end_date: endDate,
+            food_entries: foodEntries,
+            meal_entries: mealEntries,
+          };
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log('error', '[Food Tool] sparky_get_food_diary error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND(
+              'Food diary',
+              parsed.data.date || parsed.data.start_date || 'unknown'
+            );
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_nutrition_summary: tool({
+      description:
+        'Returns nutrition summary rows for a specific date or date range.',
+      inputSchema: foodDateRangeSchema,
+      execute: async (rawArgs) => {
+        const parsed = foodDateRangeSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const { startDate, endDate } = foodDateRange(parsed.data);
+          const data = await getNutritionalSummaryRows(
+            userId,
+            startDate,
+            endDate
+          );
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log(
+            'error',
+            '[Food Tool] sparky_get_nutrition_summary error:',
+            error
+          );
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND(
+              'Nutrition summary',
+              parsed.data.date || parsed.data.start_date || 'unknown'
+            );
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_recent_food_entries: tool({
+      description:
+        'Returns recent entry-level food diary rows for the authenticated user.',
+      inputSchema: recentFoodEntriesSchema,
+      execute: async (rawArgs) => {
+        const parsed = recentFoodEntriesSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const limit = Math.min(Math.max(parsed.data.limit ?? 50, 1), 200);
+          const data = await foodRepository.getRecentFoodEntries(userId, limit);
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log(
+            'error',
+            '[Food Tool] sparky_get_recent_food_entries error:',
+            error
+          );
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND('Food entries', 'recent');
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_food_usage: tool({
+      description: 'Shows where a specific food_id was used in the diary.',
+      inputSchema: foodUsageSchema,
+      execute: async (rawArgs) => {
+        const parsed = foodUsageSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const { food_id, ...query } = parsed.data;
+          const { startDate, endDate } = foodDateRange(query);
+          const { limit, offset } = normalizePagination(
+            query.limit,
+            query.offset
+          );
+          const { rows, totalCount } = await foodRepository.getFoodUsage(
+            userId,
+            food_id,
+            startDate,
+            endDate,
+            limit,
+            offset
+          );
+          const data = buildPaginatedResult(rows, totalCount, offset);
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log('error', '[Food Tool] sparky_get_food_usage error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND('Food', parsed.data.food_id);
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -216,7 +216,8 @@ async function findFoodByExactName(userId: string, name: string) {
 
 // Per-day nutrition totals with the user's energy-unit conversion applied —
 // MCP's getNutritionalSummary row shape (fiber/sugar aliases included).
-async function getNutritionalSummaryRows(
+// Shared with the report tools.
+export async function getNutritionalSummaryRows(
   userId: string,
   startDate: string,
   endDate: string
@@ -252,6 +253,31 @@ async function getNutritionalSummaryRows(
       calcium: Number(row.calcium || 0),
       iron: Number(row.iron || 0),
       energy_unit: energyUnit,
+    };
+  });
+}
+
+// Per-day water totals converted into the user's display unit — MCP's
+// getWaterHistory row shape. Shared with the report tools.
+export async function getWaterHistoryRows(
+  userId: string,
+  startDate?: string,
+  endDate?: string
+) {
+  const prefs = await preferenceService.getUserPreferences(userId, userId);
+  const waterUnit = (prefs?.water_display_unit as string) || 'ml';
+  const rows = await measurementRepository.getWaterTotalsByDateRange(
+    userId,
+    startDate,
+    endDate
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return rows.map((row: any) => {
+    const ml = Number(row.total_ml || 0);
+    return {
+      entry_date: dayString(row.entry_date),
+      amount: waterUnit === 'oz' ? Math.round((ml / 29.5735) * 10) / 10 : ml,
+      unit: waterUnit,
     };
   });
 }
@@ -1122,29 +1148,11 @@ Actions:
             }
 
             case 'get_water_history': {
-              const prefs = await preferenceService.getUserPreferences(
+              const history = await getWaterHistoryRows(
                 userId,
-                userId
+                args.start_date,
+                args.end_date
               );
-              const waterUnit = (prefs?.water_display_unit as string) || 'ml';
-              const rows =
-                await measurementRepository.getWaterTotalsByDateRange(
-                  userId,
-                  args.start_date,
-                  args.end_date
-                );
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const history = rows.map((row: any) => {
-                const ml = Number(row.total_ml || 0);
-                return {
-                  entry_date: dayString(row.entry_date),
-                  amount:
-                    waterUnit === 'oz'
-                      ? Math.round((ml / 29.5735) * 10) / 10
-                      : ml,
-                  unit: waterUnit,
-                };
-              });
               return formatList(
                 history,
                 'Water Intake History',

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -1,6 +1,6 @@
 import { tool } from 'ai';
 import { z } from 'zod';
-import { addDays, localDateToDay, todayInZone } from '@workspace/shared';
+import { addDays, todayInZone } from '@workspace/shared';
 import { log } from '../../config/logging.js';
 import foodCoreService from '../../services/foodCoreService.js';
 import foodEntryService from '../../services/foodEntryService.js';
@@ -16,7 +16,7 @@ import measurementRepository from '../../models/measurementRepository.js';
 import reportRepository from '../../models/reportRepository.js';
 import externalProviderRepository from '../../models/externalProviderRepository.js';
 import { ERRORS, formatZodError } from './errors.js';
-import { formatConfirmation, formatList } from './formatting.js';
+import { dayString, formatConfirmation, formatList } from './formatting.js';
 import {
   normalizePagination,
   buildPaginatedResult,
@@ -82,20 +82,17 @@ function isSet<T>(value: T | null | undefined): value is T {
   return value !== null && value !== undefined;
 }
 
-// pg returns DATE columns as local-midnight Date objects; render them as
-// calendar-day strings.
-function dayString(value: unknown): string {
-  return value instanceof Date ? localDateToDay(value) : String(value);
-}
-
 // MCP's date-range defaults: a single `date` overrides start/end; otherwise
-// the range defaults to today (UTC) / the start date.
-function foodDateRange(query: {
-  date?: string;
-  start_date?: string;
-  end_date?: string;
-}): { startDate: string; endDate: string } {
-  const today = todayInZone('UTC');
+// the range defaults to today (user timezone) / the start date.
+function foodDateRange(
+  query: {
+    date?: string;
+    start_date?: string;
+    end_date?: string;
+  },
+  tz: string
+): { startDate: string; endDate: string } {
+  const today = todayInZone(tz);
   const date = query.date || undefined;
   const startDate = date || query.start_date || today;
   const endDate = date || query.end_date || startDate;
@@ -432,7 +429,7 @@ const foodUsageSchema = foodDateRangeSchema.merge(foodPaginationSchema).extend({
   food_id: z.string().min(1),
 });
 
-export function buildFoodTools(userId: string) {
+export function buildFoodTools(userId: string, tz: string) {
   return {
     sparky_manage_food: tool({
       description: `Nutrition tracking: search food, log meals, create foods, manage diary.
@@ -623,7 +620,7 @@ Actions:
               const v = food.default_variant;
               let msg = `Food "${food.name}" created with ${v?.calories || 0} kcal per ${v?.serving_size || 100}${v?.serving_unit || 'g'}.`;
               if (args.meal_type) {
-                const entryDate = args.entry_date || todayInZone('UTC');
+                const entryDate = args.entry_date || todayInZone(tz);
                 await foodEntryService.createFoodEntry(userId, userId, {
                   user_id: userId,
                   food_id: food.id,
@@ -722,7 +719,7 @@ Actions:
             }
 
             case 'list_diary': {
-              const date = args.entry_date || todayInZone('UTC');
+              const date = args.entry_date || todayInZone(tz);
               const prefs = await preferenceService.getUserPreferences(
                 userId,
                 userId
@@ -1065,9 +1062,9 @@ Actions:
             case 'copy_from_yesterday': {
               // MCP's defaults: target falls back to today, source to
               // yesterday-of-today (not yesterday-of-target).
-              const targetDate = args.target_date || todayInZone('UTC');
+              const targetDate = args.target_date || todayInZone(tz);
               const sourceDate =
-                args.source_date || addDays(todayInZone('UTC'), -1);
+                args.source_date || addDays(todayInZone(tz), -1);
               const copied = args.meal_type
                 ? await foodEntryService.copyFoodEntries(
                     userId,
@@ -1300,7 +1297,7 @@ Actions:
           return formatZodError(parsed.error);
         }
         try {
-          const { startDate, endDate } = foodDateRange(parsed.data);
+          const { startDate, endDate } = foodDateRange(parsed.data, tz);
           const foodEntries = await foodEntryService.getFoodEntriesByDateRange(
             userId,
             userId,
@@ -1343,7 +1340,7 @@ Actions:
           return formatZodError(parsed.error);
         }
         try {
-          const { startDate, endDate } = foodDateRange(parsed.data);
+          const { startDate, endDate } = foodDateRange(parsed.data, tz);
           const data = await getNutritionalSummaryRows(
             userId,
             startDate,
@@ -1404,7 +1401,7 @@ Actions:
         }
         try {
           const { food_id, ...query } = parsed.data;
-          const { startDate, endDate } = foodDateRange(query);
+          const { startDate, endDate } = foodDateRange(query, tz);
           const { limit, offset } = normalizePagination(
             query.limit,
             query.offset

--- a/SparkyFitnessServer/ai/tools/formatting.ts
+++ b/SparkyFitnessServer/ai/tools/formatting.ts
@@ -1,4 +1,11 @@
+import { localDateToDay } from '@workspace/shared';
 import { truncateIfNeeded } from './truncation.js';
+
+// pg returns DATE columns as local-midnight Date objects; render them as
+// calendar-day strings.
+export function dayString(value: unknown): string {
+  return value instanceof Date ? localDateToDay(value) : String(value);
+}
 
 /**
  * Formats successful tool result data as text, with optional truncation.

--- a/SparkyFitnessServer/ai/tools/formatting.ts
+++ b/SparkyFitnessServer/ai/tools/formatting.ts
@@ -1,0 +1,54 @@
+import { truncateIfNeeded } from './truncation.js';
+
+/**
+ * Formats successful tool result data as text, with optional truncation.
+ */
+export function formatSuccess(data: unknown, title?: string): string {
+  let text: string;
+
+  if (typeof data === 'string') {
+    text = data;
+  } else {
+    text = JSON.stringify(data, null, 2);
+  }
+
+  if (title) {
+    text = `# ${title}\n\n${text}`;
+  }
+
+  return truncateIfNeeded(text);
+}
+
+/**
+ * Formats a list of items as readable text.
+ */
+export function formatList<T>(
+  items: T[],
+  title: string,
+  formatItem: (item: T) => string,
+  meta?: { total_count: number; has_more: boolean; next_offset: number | null }
+): string {
+  let text = `# ${title}\n\n`;
+
+  if (items.length === 0) {
+    text += 'No results found.';
+  } else {
+    text += items.map(formatItem).join('\n\n');
+  }
+
+  if (meta) {
+    text += `\n\n---\nShowing ${items.length} of ${meta.total_count} results.`;
+    if (meta.has_more) {
+      text += ` Use offset=${meta.next_offset} to see more.`;
+    }
+  }
+
+  return truncateIfNeeded(text);
+}
+
+/**
+ * Formats a simple confirmation message.
+ */
+export function formatConfirmation(message: string): string {
+  return `✅ ${message}`;
+}

--- a/SparkyFitnessServer/ai/tools/goalTools.ts
+++ b/SparkyFitnessServer/ai/tools/goalTools.ts
@@ -5,7 +5,7 @@ import { log } from '../../config/logging.js';
 import goalService from '../../services/goalService.js';
 import goalRepository from '../../models/goalRepository.js';
 import { ERRORS, formatZodError } from './errors.js';
-import { formatConfirmation, formatList } from './formatting.js';
+import { dayString, formatConfirmation, formatList } from './formatting.js';
 import {
   manageGoalsSchema,
   manageGoalsInput,
@@ -44,7 +44,7 @@ const goalSnapshotSchema = z.object({
     .optional(),
 });
 
-export function buildGoalTools(userId: string) {
+export function buildGoalTools(userId: string, tz: string) {
   return {
     sparky_manage_goals: tool({
       description: `Target management: set and view calorie, macro, water, and weight goals.
@@ -65,7 +65,7 @@ Actions:
             case 'get_goals': {
               const goals = (await goalService.getUserGoals(
                 userId,
-                args.target_date || todayInZone('UTC')
+                args.target_date || todayInZone(tz)
               )) as Record<string, unknown>;
               let text = `### Goals for ${args.target_date || 'today'}\n\n`;
               text += `- **Calories:** ${goals.calories || 2000} kcal\n`;
@@ -99,7 +99,7 @@ Actions:
                 timeline,
                 'Goal Timeline',
                 (g: any) =>
-                  `**${g.goal_date}**: ${g.calories} kcal | P: ${g.protein}g | C: ${g.carbs}g | F: ${g.fat}g | W: ${g.water_goal_ml}ml`
+                  `**${dayString(g.goal_date)}**: ${g.calories} kcal | P: ${g.protein}g | C: ${g.carbs}g | F: ${g.fat}g | W: ${g.water_goal_ml}ml`
               );
             }
 
@@ -127,7 +127,7 @@ Actions:
         try {
           const goals = (await goalService.getUserGoals(
             userId,
-            parsed.data.target_date || todayInZone('UTC')
+            parsed.data.target_date || todayInZone(tz)
           )) as Record<string, unknown>;
           const data: Record<string, unknown> = {};
           for (const field of GOAL_SNAPSHOT_FIELDS) {

--- a/SparkyFitnessServer/ai/tools/goalTools.ts
+++ b/SparkyFitnessServer/ai/tools/goalTools.ts
@@ -1,0 +1,152 @@
+import { tool } from 'ai';
+import { z } from 'zod';
+import { todayInZone } from '@workspace/shared';
+import { log } from '../../config/logging.js';
+import goalService from '../../services/goalService.js';
+import goalRepository from '../../models/goalRepository.js';
+import { ERRORS, formatZodError } from './errors.js';
+import { formatConfirmation, formatList } from './formatting.js';
+import {
+  manageGoalsSchema,
+  manageGoalsInput,
+  type ManageGoalsInput,
+} from './schemas/goals.js';
+
+const VALID_ACTIONS = ['get_goals', 'set_goals', 'list_goal_timeline'];
+
+// The column set MCP's goal queries exposed; richer server goal objects are
+// projected down to it so the chat-visible JSON stays identical.
+const GOAL_SNAPSHOT_FIELDS = [
+  'calories',
+  'protein',
+  'carbs',
+  'fat',
+  'water_goal_ml',
+  'saturated_fat',
+  'polyunsaturated_fat',
+  'monounsaturated_fat',
+  'trans_fat',
+  'cholesterol',
+  'sodium',
+  'potassium',
+  'dietary_fiber',
+  'sugars',
+  'vitamin_a',
+  'vitamin_c',
+  'calcium',
+  'iron',
+] as const;
+
+const goalSnapshotSchema = z.object({
+  target_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional(),
+});
+
+export function buildGoalTools(userId: string) {
+  return {
+    sparky_manage_goals: tool({
+      description: `Target management: set and view calorie, macro, water, and weight goals.
+      
+Actions:
+- get_goals(target_date?) — returns the goals active on a specific date
+- set_goals(start_date, calories?, protein?, carbs?, fat?, water_goal_ml?, weight?) — sets new goals from a start date
+- list_goal_timeline() — lists all goal changes over time`,
+      inputSchema: manageGoalsInput,
+      execute: async (rawArgs) => {
+        const parsed = manageGoalsSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        const args: ManageGoalsInput = parsed.data;
+        try {
+          switch (args.action) {
+            case 'get_goals': {
+              const goals = (await goalService.getUserGoals(
+                userId,
+                args.target_date || todayInZone('UTC')
+              )) as Record<string, unknown>;
+              let text = `### Goals for ${args.target_date || 'today'}\n\n`;
+              text += `- **Calories:** ${goals.calories || 2000} kcal\n`;
+              text += `- **Protein:** ${goals.protein || 150}g\n`;
+              text += `- **Carbs:** ${goals.carbs || 250}g\n`;
+              text += `- **Fat:** ${goals.fat || 67}g\n`;
+              text += `- **Water:** ${goals.water_goal_ml || 2000}ml\n`;
+              return text;
+            }
+
+            case 'set_goals': {
+              // MCP's defaults; manageGoalTimeline stores 0 for omitted
+              // numeric fields, so they must be applied here.
+              await goalService.manageGoalTimeline(userId, {
+                p_start_date: args.start_date,
+                p_cascade: true,
+                p_calories: args.calories ?? 2000,
+                p_protein: args.protein ?? 150,
+                p_carbs: args.carbs ?? 250,
+                p_fat: args.fat ?? 67,
+                p_water_goal_ml: args.water_goal_ml ?? 2000,
+              });
+              return formatConfirmation(
+                `Goals set successfully starting from ${args.start_date}.`
+              );
+            }
+
+            case 'list_goal_timeline': {
+              const timeline = await goalRepository.getGoalTimeline(userId);
+              return formatList(
+                timeline,
+                'Goal Timeline',
+                (g: any) =>
+                  `**${g.goal_date}**: ${g.calories} kcal | P: ${g.protein}g | C: ${g.carbs}g | F: ${g.fat}g | W: ${g.water_goal_ml}ml`
+              );
+            }
+
+            default:
+              return ERRORS.INVALID_ACTION(
+                String((args as any).action),
+                VALID_ACTIONS
+              );
+          }
+        } catch (error) {
+          log('error', '[Goal Tool] Error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_goal_snapshot: tool({
+      description: 'Returns the goals active on a specific date.',
+      inputSchema: goalSnapshotSchema,
+      execute: async (rawArgs) => {
+        const parsed = goalSnapshotSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const goals = (await goalService.getUserGoals(
+            userId,
+            parsed.data.target_date || todayInZone('UTC')
+          )) as Record<string, unknown>;
+          const data: Record<string, unknown> = {};
+          for (const field of GOAL_SNAPSHOT_FIELDS) {
+            if (field in goals) {
+              data[field] = goals[field];
+            }
+          }
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log('error', '[Goal Tool] sparky_get_goal_snapshot error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND(
+              'Goal',
+              parsed.data.target_date || 'unknown'
+            );
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/habitTools.ts
+++ b/SparkyFitnessServer/ai/tools/habitTools.ts
@@ -2,7 +2,7 @@ import { tool } from 'ai';
 import { log } from '../../config/logging.js';
 import habitRepository from '../../models/habitRepository.js';
 import { ERRORS, formatZodError } from './errors.js';
-import { formatConfirmation, formatList } from './formatting.js';
+import { dayString, formatConfirmation, formatList } from './formatting.js';
 import {
   manageHabitsSchema,
   manageHabitsInput,
@@ -60,7 +60,7 @@ Actions:
               const history = rows.map((row: any) => ({
                 id: row.id,
                 completed: row.value === 'true',
-                entry_date: row.entry_date,
+                entry_date: dayString(row.entry_date),
                 created_at: row.created_at,
               }));
               return formatList(

--- a/SparkyFitnessServer/ai/tools/habitTools.ts
+++ b/SparkyFitnessServer/ai/tools/habitTools.ts
@@ -1,0 +1,87 @@
+import { tool } from 'ai';
+import { log } from '../../config/logging.js';
+import habitRepository from '../../models/habitRepository.js';
+import { ERRORS, formatZodError } from './errors.js';
+import { formatConfirmation, formatList } from './formatting.js';
+import {
+  manageHabitsSchema,
+  manageHabitsInput,
+  type ManageHabitsInput,
+} from './schemas/habits.js';
+
+const VALID_ACTIONS = ['list_habits', 'log_habit', 'get_habit_history'];
+
+export function buildHabitTools(userId: string) {
+  return {
+    sparky_manage_habits: tool({
+      description: `Habit tracking: list habits, log completions, and view history.
+      
+Actions:
+- list_habits() — returns all habits (custom categories with boolean type)
+- log_habit(habit_id, entry_date, completed) — logs whether a habit was done on a specific date
+- get_habit_history(habit_id, start_date?, end_date?) — returns completion history for a habit`,
+      inputSchema: manageHabitsInput,
+      execute: async (rawArgs) => {
+        const parsed = manageHabitsSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        const args: ManageHabitsInput = parsed.data;
+        try {
+          switch (args.action) {
+            case 'list_habits': {
+              const habits = await habitRepository.listHabits(userId);
+              return formatList(
+                habits,
+                'Available Habits',
+                (h: any) => `**${h.display_name || h.name}**\n  ID: ${h.id}`
+              );
+            }
+
+            case 'log_habit': {
+              await habitRepository.upsertHabitLog(
+                userId,
+                args.habit_id,
+                args.entry_date,
+                args.completed ? 'true' : 'false'
+              );
+              return formatConfirmation(
+                `Habit ${args.completed ? 'completed' : 'not completed'} for ${args.entry_date}.`
+              );
+            }
+
+            case 'get_habit_history': {
+              const rows = await habitRepository.getHabitHistory(
+                userId,
+                args.habit_id,
+                args.start_date,
+                args.end_date
+              );
+              const history = rows.map((row: any) => ({
+                id: row.id,
+                completed: row.value === 'true',
+                entry_date: row.entry_date,
+                created_at: row.created_at,
+              }));
+              return formatList(
+                history,
+                'Habit History',
+                (h: any) =>
+                  `${h.entry_date}: ${h.completed ? '✅ Completed' : '❌ Missed'}`
+              );
+            }
+
+            default:
+              return ERRORS.INVALID_ACTION(
+                String((args as any).action),
+                VALID_ACTIONS
+              );
+          }
+        } catch (error) {
+          log('error', '[Habit Tool] Error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/index.ts
+++ b/SparkyFitnessServer/ai/tools/index.ts
@@ -1,0 +1,35 @@
+import { buildCheckinTools } from './checkinTools.js';
+import { buildCoachTools } from './coachTools.js';
+import { buildEngagementTools } from './engagementTools.js';
+import { buildExerciseTools } from './exerciseTools.js';
+import { buildFoodTools } from './foodTools.js';
+import { buildGoalTools } from './goalTools.js';
+import { buildHabitTools } from './habitTools.js';
+import { buildProfileTools } from './profileTools.js';
+import { buildReportTools } from './reportTools.js';
+import { buildVisionTools } from './visionTools.js';
+import { buildWizardTools } from './wizardTools.js';
+
+/**
+ * Composes the full in-process chatbot tool set for generateText/streamText.
+ * Handlers close over the authenticated userId — chat tools always act as the
+ * session user, so two-actor services receive (userId, userId, …).
+ *
+ * Domain order mirrors MCP's registerAllTools; the MCP-only dev tools are
+ * intentionally not part of the chat surface.
+ */
+export function buildChatbotTools(userId: string) {
+  return {
+    ...buildExerciseTools(userId),
+    ...buildFoodTools(userId),
+    ...buildCheckinTools(userId),
+    ...buildCoachTools(userId),
+    ...buildEngagementTools(userId),
+    ...buildVisionTools(userId),
+    ...buildGoalTools(userId),
+    ...buildProfileTools(userId),
+    ...buildHabitTools(userId),
+    ...buildWizardTools(userId),
+    ...buildReportTools(userId),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/index.ts
+++ b/SparkyFitnessServer/ai/tools/index.ts
@@ -20,7 +20,7 @@ import { buildWizardTools } from './wizardTools.js';
  * intentionally not part of the chat surface.
  */
 export function buildChatbotTools(userId: string, tz: string) {
-  return {
+  const tools = {
     ...buildExerciseTools(userId, tz),
     ...buildFoodTools(userId, tz),
     ...buildCheckinTools(userId, tz),
@@ -33,4 +33,13 @@ export function buildChatbotTools(userId: string, tz: string) {
     ...buildWizardTools(userId),
     ...buildReportTools(userId, tz),
   };
+  // The published flat schemas are advisory; real validation is the strict
+  // per-action union inside each handler. Strict provider-side mode must stay
+  // off: OpenAI's Responses API treats an omitted flag as "attempt strict
+  // mode" and then forces models to emit every published property, producing
+  // placeholder junk that the per-action validation rejects.
+  for (const tool of Object.values(tools)) {
+    tool.strict = false;
+  }
+  return tools;
 }

--- a/SparkyFitnessServer/ai/tools/index.ts
+++ b/SparkyFitnessServer/ai/tools/index.ts
@@ -13,23 +13,24 @@ import { buildWizardTools } from './wizardTools.js';
 /**
  * Composes the full in-process chatbot tool set for generateText/streamText.
  * Handlers close over the authenticated userId — chat tools always act as the
- * session user, so two-actor services receive (userId, userId, …).
+ * session user, so two-actor services receive (userId, userId, …) — and the
+ * user's IANA timezone, used for "today" defaults and day bucketing.
  *
  * Domain order mirrors MCP's registerAllTools; the MCP-only dev tools are
  * intentionally not part of the chat surface.
  */
-export function buildChatbotTools(userId: string) {
+export function buildChatbotTools(userId: string, tz: string) {
   return {
-    ...buildExerciseTools(userId),
-    ...buildFoodTools(userId),
-    ...buildCheckinTools(userId),
-    ...buildCoachTools(userId),
-    ...buildEngagementTools(userId),
+    ...buildExerciseTools(userId, tz),
+    ...buildFoodTools(userId, tz),
+    ...buildCheckinTools(userId, tz),
+    ...buildCoachTools(userId, tz),
+    ...buildEngagementTools(userId, tz),
     ...buildVisionTools(userId),
-    ...buildGoalTools(userId),
+    ...buildGoalTools(userId, tz),
     ...buildProfileTools(userId),
     ...buildHabitTools(userId),
     ...buildWizardTools(userId),
-    ...buildReportTools(userId),
+    ...buildReportTools(userId, tz),
   };
 }

--- a/SparkyFitnessServer/ai/tools/pagination.ts
+++ b/SparkyFitnessServer/ai/tools/pagination.ts
@@ -1,0 +1,39 @@
+export const DEFAULT_PAGE_SIZE = 20;
+export const MAX_PAGE_SIZE = 50;
+
+export interface PaginatedResult<T> {
+  data: T[];
+  has_more: boolean;
+  next_offset: number | null;
+  total_count: number;
+}
+
+/**
+ * Normalizes pagination parameters to safe defaults.
+ */
+export function normalizePagination(
+  limit?: number,
+  offset?: number
+): { limit: number; offset: number } {
+  return {
+    limit: Math.min(Math.max(limit ?? DEFAULT_PAGE_SIZE, 1), MAX_PAGE_SIZE),
+    offset: Math.max(offset ?? 0, 0),
+  };
+}
+
+/**
+ * Builds a PaginatedResult from query results and total count.
+ */
+export function buildPaginatedResult<T>(
+  data: T[],
+  totalCount: number,
+  offset: number
+): PaginatedResult<T> {
+  const hasMore = totalCount > offset + data.length;
+  return {
+    data,
+    has_more: hasMore,
+    next_offset: hasMore ? offset + data.length : null,
+    total_count: totalCount,
+  };
+}

--- a/SparkyFitnessServer/ai/tools/profileTools.ts
+++ b/SparkyFitnessServer/ai/tools/profileTools.ts
@@ -1,0 +1,122 @@
+import { tool } from 'ai';
+import { log } from '../../config/logging.js';
+import userRepository from '../../models/userRepository.js';
+import preferenceService from '../../services/preferenceService.js';
+import { ERRORS, formatZodError } from './errors.js';
+import { formatConfirmation } from './formatting.js';
+import {
+  manageProfileSchema,
+  manageProfileInput,
+  type ManageProfileInput,
+} from './schemas/profile.js';
+
+const VALID_ACTIONS = [
+  'get_profile',
+  'update_profile',
+  'get_preferences',
+  'update_preferences',
+];
+
+export function buildProfileTools(userId: string) {
+  return {
+    sparky_manage_profile: tool({
+      description: `User settings: update display name, timezone, and measurement units.
+      
+Actions:
+- get_profile() — returns user account details
+- update_profile(display_name?, email?, image?) — updates account details
+- get_preferences() — returns user preferences (timezone, units)
+- update_preferences(timezone?, energy_unit?, default_weight_unit?, default_distance_unit?) — updates preferences`,
+      inputSchema: manageProfileInput,
+      execute: async (rawArgs) => {
+        const parsed = manageProfileSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        const args: ManageProfileInput = parsed.data;
+        try {
+          switch (args.action) {
+            case 'get_profile': {
+              const profile =
+                (await userRepository.getAuthUserProfile(userId)) || {};
+              let text = '### User Profile\n\n';
+              text += `- **Name:** ${profile.name || 'N/A'}\n`;
+              text += `- **Email:** ${profile.email}\n`;
+              text += `- **ID:** ${profile.id}\n`;
+              return text;
+            }
+
+            case 'update_profile': {
+              await userRepository.updateAuthUserProfile(
+                userId,
+                args.display_name ?? null,
+                args.email ?? null,
+                args.image ?? null
+              );
+              return formatConfirmation('Profile updated.');
+            }
+
+            case 'get_preferences': {
+              const prefs = await preferenceService.getUserPreferences(
+                userId,
+                userId
+              );
+              let text = '### User Preferences\n\n';
+              text += `- **Timezone:** ${prefs.timezone || 'UTC'}\n`;
+              text += `- **Energy Unit:** ${prefs.energy_unit || 'kcal'}\n`;
+              text += `- **Weight Unit:** ${prefs.default_weight_unit || 'kg'}\n`;
+              text += `- **Distance Unit:** ${prefs.default_distance_unit || 'km'}\n`;
+              return text;
+            }
+
+            case 'update_preferences': {
+              const preferenceData = {
+                timezone: args.timezone ?? null,
+                energy_unit: args.energy_unit ?? null,
+                default_weight_unit: args.default_weight_unit ?? null,
+                default_measurement_unit: args.default_measurement_unit ?? null,
+                default_distance_unit: args.default_distance_unit ?? null,
+                water_display_unit: args.water_display_unit ?? null,
+              };
+              try {
+                await preferenceService.updateUserPreferences(
+                  userId,
+                  userId,
+                  preferenceData
+                );
+              } catch (error) {
+                if (
+                  error instanceof Error &&
+                  error.message.startsWith('Invalid timezone:')
+                ) {
+                  return ERRORS.VALIDATION(error.message);
+                }
+                if (
+                  error instanceof Error &&
+                  error.message.includes('not found')
+                ) {
+                  // No preferences row yet; create one with the given fields.
+                  await preferenceService.upsertUserPreferences(userId, {
+                    ...preferenceData,
+                  });
+                  return formatConfirmation('Preferences updated.');
+                }
+                throw error;
+              }
+              return formatConfirmation('Preferences updated.');
+            }
+
+            default:
+              return ERRORS.INVALID_ACTION(
+                String((args as any).action),
+                VALID_ACTIONS
+              );
+          }
+        } catch (error) {
+          log('error', '[Profile Tool] Error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/reportTools.ts
+++ b/SparkyFitnessServer/ai/tools/reportTools.ts
@@ -1,0 +1,195 @@
+import { tool } from 'ai';
+import { addDays, todayInZone } from '@workspace/shared';
+import { log } from '../../config/logging.js';
+import preferenceService from '../../services/preferenceService.js';
+import exerciseEntryDb from '../../models/exerciseEntry.js';
+import measurementRepository from '../../models/measurementRepository.js';
+import reportRepository from '../../models/reportRepository.js';
+import { ERRORS, formatZodError } from './errors.js';
+import { getNutritionalSummaryRows, getWaterHistoryRows } from './foodTools.js';
+import { getBiometricsHistoryRows } from './checkinTools.js';
+import {
+  manageReportSchema,
+  manageReportInput,
+  dailyReportSchema,
+  type ManageReportInput,
+} from './schemas/report.js';
+
+async function getWeeklyReport(
+  userId: string,
+  endDate?: string
+): Promise<string> {
+  const end = endDate || todayInZone('UTC');
+  const start = addDays(end, -6);
+
+  const nutrition = await getNutritionalSummaryRows(userId, start, end);
+  const water = await getWaterHistoryRows(userId, start, end);
+  const bio = await getBiometricsHistoryRows(userId, start, end);
+  const prefs = await preferenceService.getUserPreferences(userId, userId);
+  const energyUnit = (prefs?.energy_unit as string) || 'kcal';
+
+  let report = `# Weekly Performance Report (${start} to ${end})\n\n`;
+
+  // Nutrition & Energy
+  report += '## Nutrition & Energy\n';
+  if (nutrition.length === 0) {
+    report += '_No nutrition data logged this week._\n';
+  } else {
+    report += `| Date | Calories (${energyUnit}) | P (g) | C (g) | F (g) |\n`;
+    report += '| :--- | :--- | :--- | :--- | :--- |\n';
+    for (const n of nutrition) {
+      report += `| ${n.entry_date} | ${n.calories} | ${n.protein} | ${n.carbs} | ${n.fat} |\n`;
+    }
+  }
+  report += '\n';
+
+  // Water
+  report += '## Water Intake\n';
+  if (water.length === 0) {
+    report += '_No water intake logged this week._\n';
+  } else {
+    const wUnit = water[0]?.unit || 'ml';
+    report += `| Date | Amount (${wUnit}) |\n`;
+    report += '| :--- | :--- |\n';
+    for (const w of water) {
+      report += `| ${w.entry_date} | ${w.amount} |\n`;
+    }
+  }
+  report += '\n';
+
+  // Biometrics
+  report += '## Biometrics Trend\n';
+  if (bio.length === 0) {
+    report += '_No biometric data logged this week._\n';
+  } else {
+    const weightUnit = bio[0]?.weight_unit || 'kg';
+    report += `| Date | Weight (${weightUnit}) | BF % | Steps |\n`;
+    report += '| :--- | :--- | :--- | :--- |\n';
+    for (const b of bio) {
+      report += `| ${b.entry_date} | ${b.weight || '-'} | ${b.body_fat_percentage || '-'} | ${b.steps || '-'} |\n`;
+    }
+  }
+
+  return report;
+}
+
+// MCP's date-range defaults: a single `date` overrides start/end; otherwise
+// the range defaults to today (UTC) / the start date.
+function reportDateRange(query: {
+  date?: string;
+  start_date?: string;
+  end_date?: string;
+}): { startDate: string; endDate: string } {
+  const today = todayInZone('UTC');
+  const date = query.date || undefined;
+  const startDate = date || query.start_date || today;
+  const endDate = date || query.end_date || startDate;
+  return { startDate, endDate };
+}
+
+async function getDailyReport(
+  userId: string,
+  params: { date?: string; start_date?: string; end_date?: string }
+): Promise<Record<string, unknown>> {
+  const { startDate, endDate } = reportDateRange(params);
+
+  const nutritionRows = await reportRepository.getDailyNutritionTotalsRange(
+    userId,
+    startDate,
+    endDate
+  );
+  const exerciseRows = await exerciseEntryDb.getDailyExerciseTotalsRange(
+    userId,
+    startDate,
+    endDate
+  );
+  const waterRows = await measurementRepository.getWaterTotalsByDateRange(
+    userId,
+    startDate,
+    endDate
+  );
+
+  // Projections down to MCP's per-day column sets.
+  return {
+    start_date: startDate,
+    end_date: endDate,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    nutrition: nutritionRows.map((r: any) => ({
+      entry_date: r.entry_date,
+      calories: r.calories,
+      protein: r.protein,
+      carbs: r.carbs,
+      fat: r.fat,
+      fiber: r.fiber,
+    })),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    exercise: exerciseRows.map((r: any) => ({
+      entry_date: r.entry_date,
+      exercise_calories: r.calories_burned,
+      exercise_minutes: r.duration_minutes,
+      steps: r.steps,
+    })),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    water: waterRows.map((r: any) => ({
+      entry_date: r.entry_date,
+      water_ml: r.total_ml,
+    })),
+  };
+}
+
+export function buildReportTools(userId: string) {
+  return {
+    sparky_get_report: tool({
+      description: 'Generates consolidated health and fitness reports.',
+      inputSchema: manageReportInput,
+      execute: async (rawArgs) => {
+        const parsed = manageReportSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        const args: ManageReportInput = parsed.data;
+        try {
+          switch (args.action) {
+            case 'get_weekly_report': {
+              return await getWeeklyReport(userId, args.end_date);
+            }
+            default:
+              return ERRORS.INVALID_ACTION(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                String((args as any).action),
+                ['get_weekly_report']
+              );
+          }
+        } catch (error) {
+          log('error', '[Report Tool] Error:', error);
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+
+    sparky_get_daily_report: tool({
+      description:
+        'Returns daily report data across nutrition, exercise, and water for a specific date or range.',
+      inputSchema: dailyReportSchema,
+      execute: async (rawArgs) => {
+        const parsed = dailyReportSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const data = await getDailyReport(userId, parsed.data);
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          log('error', '[Report Tool] sparky_get_daily_report error:', error);
+          if (error instanceof Error && error.message.includes('not found')) {
+            return ERRORS.NOT_FOUND(
+              'Daily report',
+              parsed.data.date || parsed.data.start_date || 'unknown'
+            );
+          }
+          return ERRORS.DB_ERROR();
+        }
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/reportTools.ts
+++ b/SparkyFitnessServer/ai/tools/reportTools.ts
@@ -6,6 +6,7 @@ import exerciseEntryDb from '../../models/exerciseEntry.js';
 import measurementRepository from '../../models/measurementRepository.js';
 import reportRepository from '../../models/reportRepository.js';
 import { ERRORS, formatZodError } from './errors.js';
+import { dayString } from './formatting.js';
 import { getNutritionalSummaryRows, getWaterHistoryRows } from './foodTools.js';
 import { getBiometricsHistoryRows } from './checkinTools.js';
 import {
@@ -17,9 +18,10 @@ import {
 
 async function getWeeklyReport(
   userId: string,
+  tz: string,
   endDate?: string
 ): Promise<string> {
-  const end = endDate || todayInZone('UTC');
+  const end = endDate || todayInZone(tz);
   const start = addDays(end, -6);
 
   const nutrition = await getNutritionalSummaryRows(userId, start, end);
@@ -74,13 +76,16 @@ async function getWeeklyReport(
 }
 
 // MCP's date-range defaults: a single `date` overrides start/end; otherwise
-// the range defaults to today (UTC) / the start date.
-function reportDateRange(query: {
-  date?: string;
-  start_date?: string;
-  end_date?: string;
-}): { startDate: string; endDate: string } {
-  const today = todayInZone('UTC');
+// the range defaults to today (user timezone) / the start date.
+function reportDateRange(
+  query: {
+    date?: string;
+    start_date?: string;
+    end_date?: string;
+  },
+  tz: string
+): { startDate: string; endDate: string } {
+  const today = todayInZone(tz);
   const date = query.date || undefined;
   const startDate = date || query.start_date || today;
   const endDate = date || query.end_date || startDate;
@@ -89,9 +94,10 @@ function reportDateRange(query: {
 
 async function getDailyReport(
   userId: string,
+  tz: string,
   params: { date?: string; start_date?: string; end_date?: string }
 ): Promise<Record<string, unknown>> {
-  const { startDate, endDate } = reportDateRange(params);
+  const { startDate, endDate } = reportDateRange(params, tz);
 
   const nutritionRows = await reportRepository.getDailyNutritionTotalsRange(
     userId,
@@ -115,7 +121,7 @@ async function getDailyReport(
     end_date: endDate,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     nutrition: nutritionRows.map((r: any) => ({
-      entry_date: r.entry_date,
+      entry_date: dayString(r.entry_date),
       calories: r.calories,
       protein: r.protein,
       carbs: r.carbs,
@@ -124,20 +130,20 @@ async function getDailyReport(
     })),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     exercise: exerciseRows.map((r: any) => ({
-      entry_date: r.entry_date,
+      entry_date: dayString(r.entry_date),
       exercise_calories: r.calories_burned,
       exercise_minutes: r.duration_minutes,
       steps: r.steps,
     })),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     water: waterRows.map((r: any) => ({
-      entry_date: r.entry_date,
+      entry_date: dayString(r.entry_date),
       water_ml: r.total_ml,
     })),
   };
 }
 
-export function buildReportTools(userId: string) {
+export function buildReportTools(userId: string, tz: string) {
   return {
     sparky_get_report: tool({
       description: 'Generates consolidated health and fitness reports.',
@@ -151,7 +157,7 @@ export function buildReportTools(userId: string) {
         try {
           switch (args.action) {
             case 'get_weekly_report': {
-              return await getWeeklyReport(userId, args.end_date);
+              return await getWeeklyReport(userId, tz, args.end_date);
             }
             default:
               return ERRORS.INVALID_ACTION(
@@ -177,7 +183,7 @@ export function buildReportTools(userId: string) {
           return formatZodError(parsed.error);
         }
         try {
-          const data = await getDailyReport(userId, parsed.data);
+          const data = await getDailyReport(userId, tz, parsed.data);
           return JSON.stringify(data, null, 2);
         } catch (error) {
           log('error', '[Report Tool] sparky_get_daily_report error:', error);

--- a/SparkyFitnessServer/ai/tools/schemas/checkin.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/checkin.ts
@@ -1,0 +1,296 @@
+import { z } from 'zod';
+import {
+  dateSchema,
+  optionalDateSchema,
+  weightUnitEnum,
+  heightUnitEnum,
+  measurementsUnitEnum,
+  fastingStatusEnum,
+} from './common.js';
+
+const logBiometricsSchema = z
+  .object({
+    action: z.literal('log_biometrics'),
+    entry_date: dateSchema,
+    weight: z.coerce.number().min(0).optional().describe('Weight value'),
+    weight_unit: weightUnitEnum
+      .optional()
+      .describe('Unit for weight (defaults to kg)'),
+    steps: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Daily step count'),
+    height: z.coerce.number().min(0).optional().describe('Height value'),
+    height_unit: heightUnitEnum.optional().describe('Unit for height'),
+    neck: z.coerce.number().min(0).optional().describe('Neck measurement'),
+    waist: z.coerce.number().min(0).optional().describe('Waist measurement'),
+    hips: z.coerce.number().min(0).optional().describe('Hips measurement'),
+    measurements_unit: measurementsUnitEnum
+      .optional()
+      .describe('Unit for body measurements'),
+    body_fat: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Body fat percentage'),
+  })
+  .strict();
+
+const logCustomMetricSchema = z
+  .object({
+    action: z.literal('log_custom_metric'),
+    category_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .describe("Name of the custom category (e.g., 'Blood Pressure')"),
+    value: z
+      .union([z.string(), z.coerce.number()])
+      .describe('The value to record'),
+    unit: z.string().max(50).optional().describe('Unit for the recorded value'),
+    notes: z
+      .string()
+      .max(2000)
+      .optional()
+      .describe('Optional notes for the entry'),
+    entry_date: dateSchema,
+  })
+  .strict();
+
+const listCategoriesSchema = z
+  .object({
+    action: z.literal('list_categories'),
+  })
+  .strict();
+
+const createCategorySchema = z
+  .object({
+    action: z.literal('create_category'),
+    category_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .describe('Name of the custom category'),
+    unit: z
+      .string()
+      .max(50)
+      .optional()
+      .describe("Unit for the new category (e.g., 'kg', 'ml')"),
+    data_type: z
+      .enum(['numeric', 'boolean'])
+      .optional()
+      .describe(
+        "Type of data: 'numeric' for measurements, 'boolean' for habits (defaults to 'numeric')"
+      ),
+  })
+  .strict();
+
+const logMoodSchema = z
+  .object({
+    action: z.literal('log_mood'),
+    mood_value: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(10)
+      .describe('Mood score (1-10)'),
+    notes: z
+      .string()
+      .max(2000)
+      .optional()
+      .describe('Optional notes about the mood'),
+    entry_date: dateSchema,
+  })
+  .strict();
+
+const logFastingSchema = z
+  .object({
+    action: z.literal('log_fasting'),
+    start_time: z
+      .string()
+      .describe('Start timestamp of the fasting window (ISO 8601)'),
+    end_time: z
+      .string()
+      .optional()
+      .describe('End timestamp of the fasting window (ISO 8601)'),
+    fasting_status: fastingStatusEnum
+      .optional()
+      .describe('Current status of the fast'),
+    fasting_type: z
+      .string()
+      .max(100)
+      .optional()
+      .describe("Type of fasting (e.g., 'Intermittent')"),
+  })
+  .strict();
+
+const logSleepSchema = z
+  .object({
+    action: z.literal('log_sleep'),
+    entry_date: dateSchema,
+    duration_seconds: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Total sleep duration in seconds'),
+    sleep_score: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .max(100)
+      .optional()
+      .describe('Sleep quality score (0-100)'),
+    bedtime: z.string().optional().describe('Bedtime timestamp (ISO 8601)'),
+    wake_time: z.string().optional().describe('Wake up timestamp (ISO 8601)'),
+    source: z
+      .string()
+      .max(100)
+      .optional()
+      .describe("Source of data (e.g., 'manual', 'Garmin', 'Fitbit')"),
+  })
+  .strict();
+
+const listCheckinDiarySchema = z
+  .object({
+    action: z.literal('list_checkin_diary'),
+    entry_date: optionalDateSchema,
+  })
+  .strict();
+
+const getFastingStatusSchema = z
+  .object({
+    action: z.literal('get_fasting_status'),
+  })
+  .strict();
+
+const getBiometricsHistorySchema = z
+  .object({
+    action: z.literal('get_biometrics_history'),
+    start_date: dateSchema
+      .optional()
+      .describe('Start date for the history range'),
+    end_date: dateSchema.optional().describe('End date for the history range'),
+  })
+  .strict();
+
+export const manageCheckinSchema = z.discriminatedUnion('action', [
+  logBiometricsSchema,
+  logCustomMetricSchema,
+  listCategoriesSchema,
+  createCategorySchema,
+  logMoodSchema,
+  logFastingSchema,
+  logSleepSchema,
+  listCheckinDiarySchema,
+  getFastingStatusSchema,
+  getBiometricsHistorySchema,
+]);
+
+export type ManageCheckinInput = z.infer<typeof manageCheckinSchema>;
+
+// Flat input shape published to the LLM as `inputSchema`. See comment on
+// manageFoodInput in ./food.js for the rationale. Runtime validation still
+// uses manageCheckinSchema in the tool handler via safeParse.
+export const manageCheckinInput = z.object({
+  action: z
+    .enum([
+      'log_biometrics',
+      'log_custom_metric',
+      'list_categories',
+      'create_category',
+      'log_mood',
+      'log_fasting',
+      'log_sleep',
+      'list_checkin_diary',
+      'get_fasting_status',
+      'get_biometrics_history',
+    ])
+    .describe(
+      'Action to perform. Each value selects a per-action signature; see the tool description for required fields per action.'
+    ),
+  entry_date: dateSchema.optional().describe('Date for the entry (YYYY-MM-DD)'),
+  // biometrics
+  weight: z.coerce.number().min(0).optional().describe('Weight value'),
+  weight_unit: weightUnitEnum
+    .optional()
+    .describe('Unit for weight (defaults to kg)'),
+  steps: z.coerce.number().int().min(0).optional().describe('Daily step count'),
+  height: z.coerce.number().min(0).optional().describe('Height value'),
+  height_unit: heightUnitEnum.optional().describe('Unit for height'),
+  neck: z.coerce.number().min(0).optional().describe('Neck measurement'),
+  waist: z.coerce.number().min(0).optional().describe('Waist measurement'),
+  hips: z.coerce.number().min(0).optional().describe('Hips measurement'),
+  measurements_unit: measurementsUnitEnum
+    .optional()
+    .describe('Unit for body measurements'),
+  body_fat: z.coerce.number().min(0).optional().describe('Body fat percentage'),
+  // custom metrics / categories
+  category_name: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe('Name of the custom category'),
+  value: z
+    .union([z.string(), z.coerce.number()])
+    .optional()
+    .describe('Value to record (numeric or string)'),
+  unit: z.string().max(50).optional().describe('Unit for the recorded value'),
+  notes: z.string().max(2000).optional().describe('Optional notes'),
+  data_type: z
+    .enum(['numeric', 'boolean'])
+    .optional()
+    .describe('Type of data for create_category'),
+  // mood
+  mood_value: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(10)
+    .optional()
+    .describe('Mood score (1-10)'),
+  // fasting
+  start_time: z
+    .string()
+    .optional()
+    .describe('Start timestamp (ISO 8601) — for log_fasting'),
+  end_time: z
+    .string()
+    .optional()
+    .describe('End timestamp (ISO 8601) — for log_fasting'),
+  fasting_status: fastingStatusEnum
+    .optional()
+    .describe('Fasting session status'),
+  fasting_type: z
+    .string()
+    .max(100)
+    .optional()
+    .describe("Type of fasting (e.g., 'Intermittent')"),
+  // sleep
+  duration_seconds: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('Total sleep duration in seconds'),
+  sleep_score: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe('Sleep quality score (0-100)'),
+  bedtime: z.string().optional().describe('Bedtime timestamp (ISO 8601)'),
+  wake_time: z.string().optional().describe('Wake-up timestamp (ISO 8601)'),
+  source: z
+    .string()
+    .max(100)
+    .optional()
+    .describe("Source of data (e.g., 'manual', 'Garmin')"),
+  // history range
+  start_date: dateSchema
+    .optional()
+    .describe('Start date for the history range'),
+  end_date: dateSchema.optional().describe('End date for the history range'),
+});

--- a/SparkyFitnessServer/ai/tools/schemas/coach.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/coach.ts
@@ -1,0 +1,56 @@
+import { z } from 'zod';
+import { dateSchema, optionalDateSchema } from './common.js';
+
+export const GetHealthSummarySchema = z
+  .object({
+    start_date: dateSchema,
+    end_date: optionalDateSchema,
+  })
+  .strict();
+
+export const DaysRangeSchema = z
+  .object({
+    days: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(90)
+      .default(7)
+      .describe('Number of days to analyze (1-90)'),
+  })
+  .strict();
+
+export const AnalyzeTrendsSchema = DaysRangeSchema;
+
+export const Get30DayTrendsSchema = z
+  .object({
+    end_date: optionalDateSchema,
+  })
+  .strict();
+
+export const DetectPatternsSchema = DaysRangeSchema.extend({
+  days: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(90)
+    .default(30)
+    .describe('Number of days to analyze for patterns (1-90)'),
+}).strict();
+
+export const GenerateCoachingPlanSchema = z
+  .object({
+    goal: z
+      .enum(['weight_loss', 'muscle_gain', 'maintenance'])
+      .default('maintenance'),
+    target_weight: z.number().optional().describe("User's target weight in kg"),
+  })
+  .strict();
+
+export type GetHealthSummaryInput = z.infer<typeof GetHealthSummarySchema>;
+export type AnalyzeTrendsInput = z.infer<typeof AnalyzeTrendsSchema>;
+export type Get30DayTrendsInput = z.infer<typeof Get30DayTrendsSchema>;
+export type DetectPatternsInput = z.infer<typeof DetectPatternsSchema>;
+export type GenerateCoachingPlanInput = z.infer<
+  typeof GenerateCoachingPlanSchema
+>;

--- a/SparkyFitnessServer/ai/tools/schemas/common.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/common.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+
+// Date validation (YYYY-MM-DD)
+export const dateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
+  .describe('Date in YYYY-MM-DD format');
+
+// Pagination
+export const paginationSchema = z.object({
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .default(20)
+    .describe('Maximum results to return (1-50)'),
+  offset: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .default(0)
+    .describe('Number of results to skip for pagination'),
+});
+
+// Enums
+export const mealTypeEnum = z
+  .enum(['breakfast', 'lunch', 'dinner', 'snacks'])
+  .describe('Meal type category');
+
+export const setTypeEnum = z
+  .enum(['Working Set', 'Warmup', 'Drop Set', 'Failure'])
+  .describe('Type of exercise set');
+
+export const fastingStatusEnum = z
+  .enum(['ACTIVE', 'COMPLETED', 'CANCELLED'])
+  .describe('Current status of a fasting window');
+
+export const giIndexEnum = z
+  .enum(['None', 'Very Low', 'Low', 'Medium', 'High', 'Very High'])
+  .describe('Glycemic Index classification');
+
+export const weightUnitEnum = z
+  .enum(['kg', 'lbs', 'lb', 'g'])
+  .describe('Unit for weight measurement');
+
+export const heightUnitEnum = z
+  .enum(['cm', 'in', 'inch', 'ft'])
+  .describe('Unit for height measurement');
+
+export const measurementsUnitEnum = z
+  .enum(['cm', 'in', 'inch'])
+  .describe('Unit for body measurements');
+
+export const searchTypeEnum = z
+  .enum(['exact', 'broad'])
+  .describe('Type of search to perform');
+
+export const entryTypeEnum = z
+  .enum(['food_entry', 'food_entry_meal'])
+  .describe('Type of diary entry');
+
+// UUID validation
+export const uuidSchema = z
+  .string()
+  .uuid('Must be a valid UUID')
+  .describe('UUID identifier');
+
+// Optional date with today default
+export const optionalDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date must be in YYYY-MM-DD format')
+  .optional()
+  .describe('Date in YYYY-MM-DD format (defaults to today)');

--- a/SparkyFitnessServer/ai/tools/schemas/engagement.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/engagement.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const CheckEngagementSchema = z.object({}).strict();
+
+export const GetLoggingStreakSchema = z.object({}).strict();
+
+export const GetContextualNudgeSchema = z.object({}).strict();
+
+export type CheckEngagementInput = z.infer<typeof CheckEngagementSchema>;
+export type GetLoggingStreakInput = z.infer<typeof GetLoggingStreakSchema>;
+export type GetContextualNudgeInput = z.infer<typeof GetContextualNudgeSchema>;

--- a/SparkyFitnessServer/ai/tools/schemas/exercise.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/exercise.ts
@@ -1,0 +1,420 @@
+import { z } from 'zod';
+import {
+  dateSchema,
+  setTypeEnum,
+  paginationSchema,
+  uuidSchema,
+} from './common.js';
+
+const exerciseSetSchema = z
+  .object({
+    reps: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Number of repetitions'),
+    weight: z.coerce.number().min(0).optional().describe('Weight in kg'),
+    duration: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Duration in seconds'),
+    rest_time: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Rest time in seconds'),
+    set_type: setTypeEnum.default('Working Set'),
+    rpe: z.coerce
+      .number()
+      .min(0)
+      .max(10)
+      .optional()
+      .describe('Rate of Perceived Exertion (0-10 scale, one decimal allowed)'),
+    notes: z.string().max(1000).optional().describe('Note for this set'),
+  })
+  .strict();
+
+const searchExercisesSchema = z
+  .object({
+    action: z.literal('search_exercises'),
+    searchTerm: z
+      .string()
+      .min(1)
+      .max(200)
+      .describe('Name or part of exercise name'),
+    muscleGroup: z
+      .string()
+      .optional()
+      .describe("Muscle group filter (e.g., 'Chest', 'Biceps')"),
+    equipment: z
+      .string()
+      .optional()
+      .describe("Equipment filter (e.g., 'Dumbbell', 'None')"),
+    ...paginationSchema.shape,
+  })
+  .strict();
+
+const createExerciseSchema = z
+  .object({
+    action: z.literal('create_exercise'),
+    name: z.string().min(1).max(200).describe('Full name for the exercise'),
+    category: z
+      .string()
+      .optional()
+      .describe("Category (e.g., 'Strength', 'Cardio')"),
+    calories_per_hour: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Estimated calories burned per hour'),
+    description: z
+      .string()
+      .max(1000)
+      .optional()
+      .describe('Description of the exercise'),
+  })
+  .strict();
+
+const logExerciseSchema = z
+  .object({
+    action: z.literal('log_exercise'),
+    exercise_id: uuidSchema.optional().describe('UUID of the exercise'),
+    exercise_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Name of the exercise (alternative to ID)'),
+    entry_date: dateSchema,
+    duration_minutes: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Duration in minutes'),
+    calories_burned: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Calories burned'),
+    notes: z.string().max(2000).optional().describe('Additional notes'),
+    distance: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        "Distance covered, in the user's distance unit (e.g. km) — for cardio"
+      ),
+    avg_heart_rate: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .max(300)
+      .optional()
+      .describe('Average heart rate in bpm — for cardio'),
+    steps: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Step count for the activity'),
+    sets: z
+      .union([z.array(exerciseSetSchema), z.string()])
+      .optional()
+      .describe('Set details as array or JSON string'),
+  })
+  .strict();
+
+const listExerciseDiarySchema = z
+  .object({
+    action: z.literal('list_exercise_diary'),
+    entry_date: dateSchema,
+  })
+  .strict();
+
+const getWorkoutPresetsSchema = z
+  .object({
+    action: z.literal('get_workout_presets'),
+  })
+  .strict();
+
+const logWorkoutPresetSchema = z
+  .object({
+    action: z.literal('log_workout_preset'),
+    preset_id: uuidSchema.optional().describe('UUID of the workout preset'),
+    preset_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Name of the preset (alternative to ID)'),
+    entry_date: dateSchema,
+  })
+  .strict();
+
+const updateExerciseEntrySchema = z
+  .object({
+    action: z.literal('update_exercise_entry'),
+    entry_id: uuidSchema.describe('UUID of the exercise entry to update'),
+    entry_date: dateSchema
+      .optional()
+      .describe('New date for the entry (YYYY-MM-DD)'),
+    duration_minutes: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Duration in minutes'),
+    calories_burned: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Calories burned'),
+    notes: z.string().max(2000).optional().describe('Additional notes'),
+    distance: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        "Distance covered, in the user's distance unit (e.g. km) — for cardio"
+      ),
+    avg_heart_rate: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .max(300)
+      .optional()
+      .describe('Average heart rate in bpm — for cardio'),
+    steps: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Step count for the activity'),
+    sets: z
+      .union([z.array(exerciseSetSchema), z.string()])
+      .optional()
+      .describe(
+        'Replacement set details as array or JSON string; replaces all existing sets when provided'
+      ),
+  })
+  .strict();
+
+const deleteExerciseEntrySchema = z
+  .object({
+    action: z.literal('delete_exercise_entry'),
+    entry_id: uuidSchema.describe('UUID of the exercise entry to delete'),
+  })
+  .strict();
+
+const getExerciseDetailsSchema = z
+  .object({
+    action: z.literal('get_exercise_details'),
+    exercise_id: uuidSchema.optional().describe('UUID of the exercise'),
+    exercise_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Name of the exercise (alternative to ID)'),
+  })
+  .strict();
+
+const createWorkoutPresetSchema = z
+  .object({
+    action: z.literal('create_workout_preset'),
+    name: z.string().min(1).max(200).describe('Name of the workout preset'),
+    exercise_ids: z
+      .array(uuidSchema)
+      .describe('List of exercise UUIDs to include in the preset'),
+  })
+  .strict();
+
+const getExerciseProgressSchema = z
+  .object({
+    action: z.literal('get_exercise_progress'),
+    exercise_id: uuidSchema.optional().describe('UUID of the exercise'),
+    exercise_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Name of the exercise (alternative to ID)'),
+    start_date: dateSchema
+      .optional()
+      .describe('Start date for progress tracking'),
+    end_date: dateSchema.optional().describe('End date for progress tracking'),
+    ...paginationSchema.shape,
+  })
+  .strict();
+
+export const manageExerciseSchema = z.discriminatedUnion('action', [
+  searchExercisesSchema,
+  createExerciseSchema,
+  logExerciseSchema,
+  listExerciseDiarySchema,
+  getWorkoutPresetsSchema,
+  logWorkoutPresetSchema,
+  updateExerciseEntrySchema,
+  deleteExerciseEntrySchema,
+  getExerciseDetailsSchema,
+  createWorkoutPresetSchema,
+  getExerciseProgressSchema,
+]);
+
+export type ManageExerciseInput = z.infer<typeof manageExerciseSchema>;
+
+// Flat input shape published to the LLM as `inputSchema`. See comment on
+// manageFoodInput in ./food.js for the rationale. Runtime validation still
+// uses manageExerciseSchema in the tool handler via safeParse.
+export const manageExerciseInput = z.object({
+  action: z
+    .enum([
+      'search_exercises',
+      'create_exercise',
+      'log_exercise',
+      'list_exercise_diary',
+      'get_workout_presets',
+      'log_workout_preset',
+      'update_exercise_entry',
+      'delete_exercise_entry',
+      'get_exercise_details',
+      'create_workout_preset',
+      'get_exercise_progress',
+    ])
+    .describe(
+      'Action to perform. Each value selects a per-action signature; see the tool description for required fields per action.'
+    ),
+  // identity
+  exercise_id: uuidSchema.optional().describe('Exercise UUID'),
+  exercise_name: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe('Exercise name (alternative to exercise_id)'),
+  exercise_ids: z
+    .array(uuidSchema)
+    .optional()
+    .describe('List of exercise UUIDs — for create_workout_preset'),
+  name: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe('Name — for create_exercise / create_workout_preset'),
+  // search
+  searchTerm: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe('Search term — required for search_exercises'),
+  muscleGroup: z
+    .string()
+    .optional()
+    .describe("Muscle group filter (e.g., 'Chest')"),
+  equipment: z
+    .string()
+    .optional()
+    .describe("Equipment filter (e.g., 'Dumbbell', 'None')"),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe('Pagination limit'),
+  offset: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe('Pagination offset'),
+  // create
+  category: z
+    .string()
+    .optional()
+    .describe("Exercise category (e.g., 'Strength', 'Cardio')"),
+  calories_per_hour: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('Estimated calories burned per hour'),
+  description: z
+    .string()
+    .max(1000)
+    .optional()
+    .describe('Description of the exercise'),
+  // log
+  entry_date: dateSchema.optional().describe('Date for the entry (YYYY-MM-DD)'),
+  duration_minutes: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('Duration in minutes'),
+  calories_burned: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('Calories burned'),
+  notes: z.string().max(2000).optional().describe('Additional notes'),
+  distance: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      "Distance covered, in the user's distance unit (e.g. km) — cardio, for log/update"
+    ),
+  avg_heart_rate: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(300)
+    .optional()
+    .describe('Average heart rate in bpm — cardio, for log/update'),
+  steps: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe('Step count for the activity — for log/update'),
+  sets: z
+    .union([
+      z.array(
+        z.object({
+          reps: z.coerce.number().int().min(0).optional(),
+          weight: z.coerce.number().min(0).optional(),
+          duration: z.coerce.number().min(0).optional(),
+          rest_time: z.coerce.number().min(0).optional(),
+          set_type: setTypeEnum.optional(),
+          rpe: z.coerce.number().min(0).max(10).optional(),
+          notes: z.string().max(1000).optional(),
+        })
+      ),
+      z.string(),
+    ])
+    .optional()
+    .describe(
+      'Set details as array of objects or JSON string; per-set fields include rpe and notes'
+    ),
+  // presets
+  preset_id: uuidSchema.optional().describe('Workout preset UUID'),
+  preset_name: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe('Workout preset name'),
+  // entry management
+  entry_id: uuidSchema
+    .optional()
+    .describe(
+      'Exercise diary entry UUID — for update_exercise_entry / delete_exercise_entry'
+    ),
+  // progress range
+  start_date: dateSchema
+    .optional()
+    .describe('Start date for progress tracking'),
+  end_date: dateSchema.optional().describe('End date for progress tracking'),
+});

--- a/SparkyFitnessServer/ai/tools/schemas/food.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/food.ts
@@ -1,0 +1,725 @@
+import { z } from 'zod';
+import {
+  dateSchema,
+  optionalDateSchema,
+  uuidSchema,
+  mealTypeEnum,
+  searchTypeEnum,
+  entryTypeEnum,
+  giIndexEnum,
+  paginationSchema,
+} from './common.js';
+
+const searchFoodSchema = z
+  .object({
+    action: z.literal('search_food'),
+    food_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .describe('Name or part of food name to search'),
+    search_type: searchTypeEnum.describe('Type of search: exact or broad'),
+    ...paginationSchema.shape,
+  })
+  .strict();
+
+const lookupFoodNutritionSchema = z
+  .object({
+    action: z.literal('lookup_food_nutrition'),
+    food_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .describe('Name of the food to lookup'),
+    provider_type: z
+      .enum([
+        'internal',
+        'openfoodfacts',
+        'usda',
+        'fatsecret',
+        'mealie',
+        'tandoor',
+        'yazio',
+        'norish',
+      ])
+      .optional()
+      .describe(
+        'Optional: Force a specific provider search, bypassing the cascade lookup'
+      ),
+  })
+  .strict();
+
+const logFoodSchema = z
+  .object({
+    action: z.literal('log_food'),
+    food_name: z.string().min(1).max(200).describe('Name of the food item'),
+    food_id: uuidSchema.optional().describe('UUID of the food item (if known)'),
+    variant_id: uuidSchema
+      .optional()
+      .describe('UUID of the food variant (if known)'),
+    quantity: z.coerce.number().min(0).describe('Amount consumed'),
+    unit: z
+      .string()
+      .min(1)
+      .max(50)
+      .describe("Unit of measurement (e.g., 'g', 'piece', 'serving')"),
+    meal_type: mealTypeEnum.describe('Meal type category'),
+    entry_date: dateSchema,
+  })
+  .strict();
+
+const createFoodSchema = z
+  .object({
+    action: z
+      .literal('create_food')
+      .describe(
+        "Create a food. AI clients: you MUST search the web and populate as many micro-nutrients (fat details, fiber, sugar, sodium, potassium, calcium, iron, vitamins), GI classification, and brand ('Homemade' or 'Traditional' if generic) as possible rather than just core macros."
+      ),
+    food_name: z.string().min(1).max(200).describe('Name of the new food item'),
+    brand: z.string().max(200).optional().describe('Brand name of the food'),
+    calories: z.coerce.number().min(0).describe('Calories (kcal)'),
+    protein: z.coerce.number().min(0).describe('Protein (g)'),
+    carbs: z.coerce.number().min(0).describe('Carbohydrates (g)'),
+    fat: z.coerce.number().min(0).describe('Total fat (g)'),
+    saturated_fat: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Saturated fat (g). MANDATORY: Estimate and populate this if total fat > 0 based on typical profile (e.g. animal fats vs plant oils); do not default to 0/empty.'
+      ),
+    polyunsaturated_fat: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Polyunsaturated fat (g). MANDATORY: Estimate and populate this if total fat > 0 based on typical profile; do not default to 0/empty.'
+      ),
+    monounsaturated_fat: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Monounsaturated fat (g). MANDATORY: Estimate and populate this if total fat > 0 based on typical profile; do not default to 0/empty.'
+      ),
+    trans_fat: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Trans fat (g). MANDATORY: Estimate and populate this if total fat > 0 based on typical profile; do not default to 0/empty.'
+      ),
+    cholesterol: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Cholesterol (mg). MANDATORY: Estimate and populate this if food is animal-based or has fat; do not default to 0/empty.'
+      ),
+    sodium: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Sodium (mg). MANDATORY: Estimate and populate based on food type and processing; do not default to 0/empty.'
+      ),
+    potassium: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Potassium (mg). MANDATORY: Estimate and populate based on typical food composition; do not default to 0/empty.'
+      ),
+    fiber: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Dietary fiber (g). MANDATORY: Estimate and populate if plant-based or contains carbs; do not default to 0/empty.'
+      ),
+    sugar: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Sugars (g). MANDATORY: Estimate and populate if food contains carbs; do not default to 0/empty.'
+      ),
+    vitamin_a: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Vitamin A (% Daily Value). MANDATORY: Estimate and populate based on typical food composition; do not default to 0/empty.'
+      ),
+    vitamin_c: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Vitamin C (% Daily Value). MANDATORY: Estimate and populate based on typical food composition; do not default to 0/empty.'
+      ),
+    calcium: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Calcium (% Daily Value). MANDATORY: Estimate and populate based on typical food composition; do not default to 0/empty.'
+      ),
+    iron: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        'Iron (% Daily Value). MANDATORY: Estimate and populate based on typical food composition; do not default to 0/empty.'
+      ),
+    gi: giIndexEnum
+      .optional()
+      .describe(
+        'Glycemic Index classification. MANDATORY: Classify as low, medium, or high based on carb composition.'
+      ),
+    quantity: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Default serving size value'),
+    unit: z.string().max(50).optional().describe('Default serving size unit'),
+    meal_type: mealTypeEnum
+      .optional()
+      .describe('Optional: Automatically log this food to a meal'),
+    entry_date: optionalDateSchema.describe(
+      'Optional: Date for automatic log (YYYY-MM-DD)'
+    ),
+  })
+  .strict();
+
+const searchMealSchema = z
+  .object({
+    action: z.literal('search_meal'),
+    meal_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .describe('Name or part of meal template name to search'),
+  })
+  .strict();
+
+const logMealSchema = z
+  .object({
+    action: z.literal('log_meal'),
+    meal_id: uuidSchema
+      .optional()
+      .describe('UUID of the meal template (if known)'),
+    meal_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Name of the meal template (alternative to ID)'),
+    meal_type: mealTypeEnum.describe('Meal type category'),
+    entry_date: dateSchema,
+    quantity: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Multiplier for the meal template'),
+    unit: z
+      .string()
+      .max(50)
+      .optional()
+      .describe('Unit for the meal template multiplier'),
+  })
+  .strict();
+
+const listDiarySchema = z
+  .object({
+    action: z.literal('list_diary'),
+    entry_date: optionalDateSchema,
+  })
+  .strict();
+
+const deleteEntrySchema = z
+  .object({
+    action: z.literal('delete_entry'),
+    entry_id: uuidSchema.describe('UUID of the entry to delete'),
+    entry_type: entryTypeEnum.describe('Type of diary entry'),
+  })
+  .strict();
+
+const updateEntrySchema = z
+  .object({
+    action: z.literal('update_entry'),
+    entry_id: uuidSchema.describe('UUID of the entry to update'),
+    entry_type: entryTypeEnum.describe('Type of diary entry'),
+    quantity: z.coerce.number().min(0).describe('New amount'),
+    unit: z.string().min(1).max(50).describe('New unit of measurement'),
+  })
+  .strict();
+
+const updateFoodVariantSchema = z
+  .object({
+    action: z.literal('update_food_variant'),
+    food_id: uuidSchema
+      .optional()
+      .describe(
+        'Food UUID. Used to find the default variant when variant_id is not provided.'
+      ),
+    variant_id: uuidSchema
+      .optional()
+      .describe(
+        'Food variant UUID to update. If omitted, the default variant for food_id is updated.'
+      ),
+    serving_size: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated serving size value'),
+    serving_unit: z
+      .string()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe('Updated serving unit'),
+    calories: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated calories (kcal)'),
+    protein: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated protein (g)'),
+    carbs: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated carbohydrates (g)'),
+    fat: z.coerce.number().min(0).optional().describe('Updated total fat (g)'),
+    saturated_fat: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated saturated fat (g)'),
+    polyunsaturated_fat: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated polyunsaturated fat (g)'),
+    monounsaturated_fat: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated monounsaturated fat (g)'),
+    trans_fat: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated trans fat (g)'),
+    cholesterol: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated cholesterol (mg)'),
+    sodium: z.coerce.number().min(0).optional().describe('Updated sodium (mg)'),
+    potassium: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated potassium (mg)'),
+    fiber: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated dietary fiber (g)'),
+    sugar: z.coerce.number().min(0).optional().describe('Updated sugars (g)'),
+    vitamin_a: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated Vitamin A (% Daily Value)'),
+    vitamin_c: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated Vitamin C (% Daily Value)'),
+    calcium: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated calcium (% Daily Value)'),
+    iron: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Updated iron (% Daily Value)'),
+    gi: giIndexEnum
+      .optional()
+      .describe('Updated Glycemic Index classification'),
+    update_existing_entries: z.coerce
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        'If true, also updates existing diary food entries referencing this variant. Defaults to false.'
+      ),
+  })
+  .strict();
+
+const copyFromYesterdaySchema = z
+  .object({
+    action: z.literal('copy_from_yesterday'),
+    target_date: optionalDateSchema.describe(
+      'Date to copy entries to (defaults to today)'
+    ),
+    source_date: optionalDateSchema.describe(
+      'Date to copy entries from (defaults to yesterday)'
+    ),
+    meal_type: z
+      .string()
+      .max(50)
+      .optional()
+      .describe("Specific meal type to copy (e.g., 'breakfast')"),
+  })
+  .strict();
+
+const saveAsMealTemplateSchema = z
+  .object({
+    action: z.literal('save_as_meal_template'),
+    entry_date: dateSchema,
+    meal_type: z
+      .string()
+      .min(1)
+      .max(50)
+      .describe("Meal type to save (e.g., 'lunch')"),
+    meal_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .describe('Name for the new meal template'),
+    description: z
+      .string()
+      .max(1000)
+      .optional()
+      .describe('Description for the meal template'),
+  })
+  .strict();
+
+const deleteFoodSchema = z
+  .object({
+    action: z.literal('delete_food'),
+    food_id: uuidSchema.optional().describe('UUID of the food to delete'),
+    food_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe('Name of the food to delete (alternative to ID)'),
+  })
+  .strict();
+
+const logWaterSchema = z
+  .object({
+    action: z.literal('log_water'),
+    amount_ml: z.coerce
+      .number()
+      .min(0)
+      .describe('Amount of water in milliliters'),
+    entry_date: dateSchema.describe('Date to log the water for'),
+  })
+  .strict();
+
+const getNutritionalSummarySchema = z
+  .object({
+    action: z.literal('get_nutritional_summary'),
+    start_date: dateSchema.describe('Start date for the summary range'),
+    end_date: dateSchema.describe('End date for the summary range'),
+  })
+  .strict();
+
+const getWaterHistorySchema = z
+  .object({
+    action: z.literal('get_water_history'),
+    start_date: dateSchema
+      .optional()
+      .describe('Start date for the history range'),
+    end_date: dateSchema.optional().describe('End date for the history range'),
+  })
+  .strict();
+
+export const manageFoodSchema = z.discriminatedUnion('action', [
+  searchFoodSchema,
+  lookupFoodNutritionSchema,
+  logFoodSchema,
+  createFoodSchema,
+  searchMealSchema,
+  logMealSchema,
+  listDiarySchema,
+  deleteEntrySchema,
+  deleteFoodSchema,
+  updateEntrySchema,
+  updateFoodVariantSchema,
+  copyFromYesterdaySchema,
+  saveAsMealTemplateSchema,
+  logWaterSchema,
+  getNutritionalSummarySchema,
+  getWaterHistorySchema,
+]);
+
+export type ManageFoodInput = z.infer<typeof manageFoodSchema>;
+
+// Flat input shape published to the LLM as `inputSchema`. Runtime validation
+// uses `manageFoodSchema` (the discriminated union) inside the tool handler
+// via `safeParse`, so strict per-action validation is preserved while the
+// published schema stays a plain object the model can fill in.
+export const manageFoodInput = z.object({
+  action: z
+    .enum([
+      'search_food',
+      'lookup_food_nutrition',
+      'log_food',
+      'create_food',
+      'search_meal',
+      'log_meal',
+      'list_diary',
+      'delete_entry',
+      'delete_food',
+      'update_entry',
+      'update_food_variant',
+      'copy_from_yesterday',
+      'save_as_meal_template',
+      'log_water',
+      'get_nutritional_summary',
+      'get_water_history',
+    ])
+    .describe(
+      'Action to perform. Each value selects a different per-action signature; see the tool description for required fields per action.'
+    ),
+  // food identity
+  food_name: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe(
+      'Food name — required for search_food/log_food/create_food/delete_food (alternative to food_id)'
+    ),
+  food_id: uuidSchema
+    .optional()
+    .describe('Food UUID — alternative to food_name'),
+  variant_id: uuidSchema.optional().describe('Food variant UUID'),
+  update_existing_entries: z.coerce
+    .boolean()
+    .optional()
+    .describe(
+      'For update_food_variant: if true, also updates existing diary entries referencing this variant'
+    ),
+  serving_size: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('For update_food_variant: updated serving size value'),
+  serving_unit: z
+    .string()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe('For update_food_variant: updated serving unit'),
+  brand: z
+    .string()
+    .max(200)
+    .optional()
+    .describe('Brand name — for create_food'),
+  // serving
+  quantity: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe("Amount consumed (units defined by 'unit')"),
+  unit: z
+    .string()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe("Unit of measurement ('g', 'serving', 'piece', etc.)"),
+  // meal / diary
+  meal_type: mealTypeEnum
+    .optional()
+    .describe('breakfast | lunch | dinner | snacks'),
+  entry_date: dateSchema.optional().describe('Date for the entry (YYYY-MM-DD)'),
+  meal_id: uuidSchema.optional().describe('Meal template UUID'),
+  meal_name: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe('Meal template name'),
+  // search
+  search_type: searchTypeEnum
+    .optional()
+    .describe('exact | broad — for search_food'),
+  limit: z.coerce
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe('Pagination limit'),
+  offset: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe('Pagination offset'),
+  // macros (for create_food)
+  calories: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('Calories (kcal) — required for create_food'),
+  protein: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('Protein (g) — required for create_food'),
+  carbs: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('Carbohydrates (g) — required for create_food'),
+  fat: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('Total fat (g) — required for create_food'),
+  saturated_fat: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Saturated fat (g). MANDATORY: Estimate and populate this if total fat > 0 based on typical profile; do not default to 0/empty.'
+    ),
+  polyunsaturated_fat: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Polyunsaturated fat (g). MANDATORY: Estimate and populate this if total fat > 0 based on typical profile; do not default to 0/empty.'
+    ),
+  monounsaturated_fat: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Monounsaturated fat (g). MANDATORY: Estimate and populate this if total fat > 0 based on typical profile; do not default to 0/empty.'
+    ),
+  trans_fat: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Trans fat (g). MANDATORY: Estimate and populate this if total fat > 0 based on typical profile; do not default to 0/empty.'
+    ),
+  cholesterol: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Cholesterol (mg). MANDATORY: Estimate and populate this if food is animal-based or has fat; do not default to 0/empty.'
+    ),
+  sodium: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Sodium (mg). MANDATORY: Estimate and populate based on food type and processing; do not default to 0/empty.'
+    ),
+  potassium: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Potassium (mg). MANDATORY: Estimate and populate based on typical food composition; do not default to 0/empty.'
+    ),
+  fiber: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Dietary fiber (g). MANDATORY: Estimate and populate if plant-based or contains carbs; do not default to 0/empty.'
+    ),
+  sugar: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Sugars (g). MANDATORY: Estimate and populate if food contains carbs; do not default to 0/empty.'
+    ),
+  vitamin_a: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Vitamin A (% Daily Value). MANDATORY: Estimate and populate based on typical food composition; do not default to 0/empty.'
+    ),
+  vitamin_c: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Vitamin C (% Daily Value). MANDATORY: Estimate and populate based on typical food composition; do not default to 0/empty.'
+    ),
+  calcium: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Calcium (% Daily Value). MANDATORY: Estimate and populate based on typical food composition; do not default to 0/empty.'
+    ),
+  iron: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      'Iron (% Daily Value). MANDATORY: Estimate and populate based on typical food composition; do not default to 0/empty.'
+    ),
+  gi: giIndexEnum
+    .optional()
+    .describe(
+      'Glycemic Index classification. MANDATORY: Classify as low, medium, or high based on carb composition.'
+    ),
+  // entry / diary management
+  entry_id: uuidSchema.optional().describe('Diary entry UUID'),
+  entry_type: entryTypeEnum.optional().describe('food_entry | food_entry_meal'),
+  description: z
+    .string()
+    .max(1000)
+    .optional()
+    .describe('Description (for save_as_meal_template)'),
+  // copy_from_yesterday
+  target_date: optionalDateSchema.describe('Target date (defaults to today)'),
+  source_date: optionalDateSchema.describe(
+    'Source date (defaults to yesterday)'
+  ),
+  // water
+  amount_ml: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('Water amount in milliliters'),
+  // range queries
+  start_date: dateSchema.optional().describe('Start date for range queries'),
+  end_date: dateSchema.optional().describe('End date for range queries'),
+  // explicit search provider
+  provider_type: z
+    .enum([
+      'internal',
+      'openfoodfacts',
+      'usda',
+      'fatsecret',
+      'mealie',
+      'tandoor',
+      'norish',
+    ])
+    .optional()
+    .describe('Optional: Force a specific provider search (e.g. USDA)'),
+});

--- a/SparkyFitnessServer/ai/tools/schemas/goals.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/goals.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+import { dateSchema, optionalDateSchema } from './common.js';
+
+const getGoalsSchema = z
+  .object({
+    action: z.literal('get_goals'),
+    target_date: optionalDateSchema.describe(
+      'Date to fetch goals for (defaults to today)'
+    ),
+  })
+  .strict();
+
+const setGoalsSchema = z
+  .object({
+    action: z.literal('set_goals'),
+    start_date: dateSchema.describe('Date when these goals take effect'),
+    calories: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Daily calorie goal'),
+    protein: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Daily protein goal (g)'),
+    carbs: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Daily carbohydrate goal (g)'),
+    fat: z.coerce.number().min(0).optional().describe('Daily fat goal (g)'),
+    water_goal_ml: z.coerce
+      .number()
+      .min(0)
+      .optional()
+      .describe('Daily water intake goal (ml)'),
+    weight: z.coerce.number().min(0).optional().describe('Target body weight'),
+  })
+  .strict();
+
+const listGoalTimelineSchema = z
+  .object({
+    action: z.literal('list_goal_timeline'),
+  })
+  .strict();
+
+export const manageGoalsSchema = z.discriminatedUnion('action', [
+  getGoalsSchema,
+  setGoalsSchema,
+  listGoalTimelineSchema,
+]);
+
+export type ManageGoalsInput = z.infer<typeof manageGoalsSchema>;
+
+// Flat shape published to the LLM as `inputSchema`. Strict per-action
+// validation still runs in the tool handler via `manageGoalsSchema.safeParse`.
+export const manageGoalsInput = z.object({
+  action: z
+    .enum(['get_goals', 'set_goals', 'list_goal_timeline'])
+    .describe(
+      'Action to perform; see the tool description for the fields each action needs.'
+    ),
+  target_date: optionalDateSchema.describe(
+    'get_goals: date to fetch goals for (defaults to today)'
+  ),
+  start_date: dateSchema
+    .optional()
+    .describe('set_goals: date when these goals take effect'),
+  calories: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('set_goals: daily calorie goal'),
+  protein: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('set_goals: daily protein goal (g)'),
+  carbs: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('set_goals: daily carbohydrate goal (g)'),
+  fat: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('set_goals: daily fat goal (g)'),
+  water_goal_ml: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('set_goals: daily water intake goal (ml)'),
+  weight: z.coerce
+    .number()
+    .min(0)
+    .optional()
+    .describe('set_goals: target body weight'),
+});

--- a/SparkyFitnessServer/ai/tools/schemas/habits.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/habits.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod';
+import { dateSchema, optionalDateSchema, uuidSchema } from './common.js';
+
+const listHabitsSchema = z
+  .object({
+    action: z.literal('list_habits'),
+  })
+  .strict();
+
+const logHabitSchema = z
+  .object({
+    action: z.literal('log_habit'),
+    habit_id: uuidSchema.describe('UUID of the habit'),
+    entry_date: dateSchema.describe('Date to log the habit for'),
+    completed: z.boolean().describe('Whether the habit was completed'),
+  })
+  .strict();
+
+const getHabitHistorySchema = z
+  .object({
+    action: z.literal('get_habit_history'),
+    habit_id: uuidSchema.describe('UUID of the habit'),
+    start_date: optionalDateSchema,
+    end_date: optionalDateSchema,
+  })
+  .strict();
+
+export const manageHabitsSchema = z.discriminatedUnion('action', [
+  listHabitsSchema,
+  logHabitSchema,
+  getHabitHistorySchema,
+]);
+
+export type ManageHabitsInput = z.infer<typeof manageHabitsSchema>;
+
+// Flat shape published to the LLM as `inputSchema`. Strict per-action
+// validation still runs in the tool handler via `manageHabitsSchema.safeParse`.
+export const manageHabitsInput = z.object({
+  action: z
+    .enum(['list_habits', 'log_habit', 'get_habit_history'])
+    .describe(
+      'Action to perform; see the tool description for the fields each action needs.'
+    ),
+  habit_id: uuidSchema
+    .optional()
+    .describe('log_habit / get_habit_history: UUID of the habit'),
+  entry_date: dateSchema
+    .optional()
+    .describe('log_habit: date to log the habit for'),
+  completed: z
+    .boolean()
+    .optional()
+    .describe('log_habit: whether the habit was completed'),
+  start_date: optionalDateSchema.describe(
+    'get_habit_history: range start date'
+  ),
+  end_date: optionalDateSchema.describe('get_habit_history: range end date'),
+});

--- a/SparkyFitnessServer/ai/tools/schemas/profile.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/profile.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod';
+
+const getProfileSchema = z
+  .object({
+    action: z.literal('get_profile'),
+  })
+  .strict();
+
+const updateProfileSchema = z
+  .object({
+    action: z.literal('update_profile'),
+    display_name: z
+      .string()
+      .min(1)
+      .max(200)
+      .optional()
+      .describe("User's display name"),
+    email: z.string().email().optional().describe("User's email address"),
+    image: z.string().url().optional().describe('Profile image URL'),
+  })
+  .strict();
+
+const getPreferencesSchema = z
+  .object({
+    action: z.literal('get_preferences'),
+  })
+  .strict();
+
+const updatePreferencesSchema = z
+  .object({
+    action: z.literal('update_preferences'),
+    timezone: z
+      .string()
+      .optional()
+      .describe("User's timezone (e.g., 'UTC', 'America/New_York')"),
+    energy_unit: z
+      .enum(['kcal', 'kJ'])
+      .optional()
+      .describe('Unit for energy (kcal or kJ)'),
+    default_weight_unit: z
+      .enum(['kg', 'lbs'])
+      .optional()
+      .describe('Default unit for weight'),
+    default_measurement_unit: z
+      .enum(['cm', 'in'])
+      .optional()
+      .describe('Default unit for measurements (cm or in)'),
+    default_distance_unit: z
+      .enum(['km', 'miles'])
+      .optional()
+      .describe('Default unit for distance'),
+    water_display_unit: z
+      .enum(['ml', 'oz'])
+      .optional()
+      .describe('Default unit for water (ml or oz)'),
+  })
+  .strict();
+
+export const manageProfileSchema = z.discriminatedUnion('action', [
+  getProfileSchema,
+  updateProfileSchema,
+  getPreferencesSchema,
+  updatePreferencesSchema,
+]);
+
+export type ManageProfileInput = z.infer<typeof manageProfileSchema>;
+
+// Flat shape published to the LLM as `inputSchema`. Strict per-action
+// validation still runs in the tool handler via `manageProfileSchema.safeParse`.
+export const manageProfileInput = z.object({
+  action: z
+    .enum([
+      'get_profile',
+      'update_profile',
+      'get_preferences',
+      'update_preferences',
+    ])
+    .describe(
+      'Action to perform; see the tool description for the fields each action needs.'
+    ),
+  display_name: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe("update_profile: user's display name"),
+  email: z
+    .string()
+    .email()
+    .optional()
+    .describe("update_profile: user's email address"),
+  image: z
+    .string()
+    .url()
+    .optional()
+    .describe('update_profile: profile image URL'),
+  timezone: z
+    .string()
+    .optional()
+    .describe("update_preferences: timezone (e.g., 'UTC', 'America/New_York')"),
+  energy_unit: z
+    .enum(['kcal', 'kJ'])
+    .optional()
+    .describe('update_preferences: unit for energy'),
+  default_weight_unit: z
+    .enum(['kg', 'lbs'])
+    .optional()
+    .describe('update_preferences: default weight unit'),
+  default_measurement_unit: z
+    .enum(['cm', 'in'])
+    .optional()
+    .describe('update_preferences: default measurement unit'),
+  default_distance_unit: z
+    .enum(['km', 'miles'])
+    .optional()
+    .describe('update_preferences: default distance unit'),
+  water_display_unit: z
+    .enum(['ml', 'oz'])
+    .optional()
+    .describe('update_preferences: default water unit'),
+});

--- a/SparkyFitnessServer/ai/tools/schemas/report.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/report.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { optionalDateSchema } from './common.js';
+
+const getWeeklyReportSchema = z
+  .object({
+    action: z.literal('get_weekly_report'),
+    end_date: optionalDateSchema.describe(
+      'The end date for the weekly report (YYYY-MM-DD)'
+    ),
+  })
+  .strict();
+
+export const manageReportSchema = z.discriminatedUnion('action', [
+  getWeeklyReportSchema,
+]);
+
+export type ManageReportInput = z.infer<typeof manageReportSchema>;
+
+// Flat shape published to the LLM as `inputSchema`. Strict validation still
+// runs in the handler via `manageReportSchema.safeParse`.
+export const manageReportInput = z.object({
+  action: z.enum(['get_weekly_report']).describe('Action to perform.'),
+  end_date: optionalDateSchema.describe(
+    'get_weekly_report: end date for the weekly report (YYYY-MM-DD)'
+  ),
+});
+
+export const dailyReportSchema = z.object({
+  date: optionalDateSchema.optional(),
+  start_date: optionalDateSchema.optional(),
+  end_date: optionalDateSchema.optional(),
+});

--- a/SparkyFitnessServer/ai/tools/schemas/vision.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/vision.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const AnalyzeFoodImageSchema = z
+  .object({
+    image_url: z.string().min(1).describe('Base64 encoded image data or URL'),
+  })
+  .strict();
+
+export const ScanLabelSchema = z
+  .object({
+    image_url: z.string().min(1).describe('Base64 encoded image data or URL'),
+  })
+  .strict();
+
+export type AnalyzeFoodImageInput = z.infer<typeof AnalyzeFoodImageSchema>;
+export type ScanLabelInput = z.infer<typeof ScanLabelSchema>;

--- a/SparkyFitnessServer/ai/tools/schemas/wizard.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/wizard.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+const dailyCheckinSchema = z
+  .object({
+    action: z.literal('daily_checkin'),
+    step: z
+      .enum(['start', 'weight', 'steps', 'sleep', 'mood', 'habits', 'complete'])
+      .default('start')
+      .describe('The current step in the check-in process'),
+    answer: z
+      .string()
+      .optional()
+      .describe("User's answer to the current question"),
+  })
+  .strict();
+
+export const manageWizardSchema = z.discriminatedUnion('action', [
+  dailyCheckinSchema,
+]);
+
+export type ManageWizardInput = z.infer<typeof manageWizardSchema>;
+
+// Flat shape published to the LLM as `inputSchema`. Strict validation still
+// runs in the tool handler via `manageWizardSchema.safeParse`.
+export const manageWizardInput = z.object({
+  action: z.enum(['daily_checkin']).describe('Action to perform.'),
+  step: z
+    .enum(['start', 'weight', 'steps', 'sleep', 'mood', 'habits', 'complete'])
+    .optional()
+    .describe("The current step in the check-in process (defaults to 'start')"),
+  answer: z
+    .string()
+    .optional()
+    .describe("User's answer to the current question"),
+});

--- a/SparkyFitnessServer/ai/tools/truncation.ts
+++ b/SparkyFitnessServer/ai/tools/truncation.ts
@@ -1,0 +1,17 @@
+export const CHARACTER_LIMIT = 25_000;
+
+/**
+ * Truncates text if it exceeds CHARACTER_LIMIT.
+ * Appends a warning with a hint for the user to use pagination/filters.
+ */
+export function truncateIfNeeded(text: string, hint?: string): string {
+  if (text.length <= CHARACTER_LIMIT) return text;
+
+  const defaultHint =
+    "Use 'limit' and 'offset' parameters to paginate results, or add filters to narrow your search.";
+  const truncated = text.slice(0, CHARACTER_LIMIT - 200);
+  return (
+    truncated +
+    `\n\n---\n⚠️ Response truncated (exceeded ${CHARACTER_LIMIT} characters). ${hint || defaultHint}`
+  );
+}

--- a/SparkyFitnessServer/ai/tools/unitConversion.ts
+++ b/SparkyFitnessServer/ai/tools/unitConversion.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit conversion utilities for chatbot tool handlers.
+ */
+
+// Weight conversions
+export const LBS_TO_KG = 0.45359237;
+export const KG_TO_LBS = 2.20462262;
+
+// Measurement conversions
+export const INCH_TO_CM = 2.54;
+export const CM_TO_INCH = 1 / 2.54;
+
+// Energy conversions
+export const KCAL_TO_KJ = 4.184;
+export const KJ_TO_KCAL = 1 / 4.184;
+
+// Distance conversions
+export const MILES_TO_KM = 1.609344;
+export const KM_TO_MILES = 0.62137119;
+
+/**
+ * Converts a weight value to the target unit.
+ */
+export function convertWeight(value: number, from: string, to: string): number {
+  if (from.toLowerCase() === to.toLowerCase()) return value;
+
+  if (from.toLowerCase() === 'lbs' && to.toLowerCase() === 'kg') {
+    return value * LBS_TO_KG;
+  }
+  if (from.toLowerCase() === 'kg' && to.toLowerCase() === 'lbs') {
+    return value * KG_TO_LBS;
+  }
+  return value;
+}
+
+/**
+ * Converts a measurement value (height, neck, etc.) to the target unit.
+ */
+export function convertMeasurement(
+  value: number,
+  from: string,
+  to: string
+): number {
+  if (from.toLowerCase() === to.toLowerCase()) return value;
+
+  if (from.toLowerCase() === 'in' && to.toLowerCase() === 'cm') {
+    return value * INCH_TO_CM;
+  }
+  if (from.toLowerCase() === 'cm' && to.toLowerCase() === 'in') {
+    return value * CM_TO_INCH;
+  }
+  return value;
+}
+
+/**
+ * Converts energy values (calories/joules).
+ */
+export function convertEnergy(value: number, from: string, to: string): number {
+  const f = from.toLowerCase();
+  const t = to.toLowerCase();
+  if (f === t) return value;
+
+  if ((f === 'kcal' || f === 'calories') && t === 'kj') {
+    return value * KCAL_TO_KJ;
+  }
+  if (f === 'kj' && (t === 'kcal' || t === 'calories')) {
+    return value * KJ_TO_KCAL;
+  }
+  return value;
+}

--- a/SparkyFitnessServer/ai/tools/unitConversion.ts
+++ b/SparkyFitnessServer/ai/tools/unitConversion.ts
@@ -5,10 +5,12 @@
 // Weight conversions
 export const LBS_TO_KG = 0.45359237;
 export const KG_TO_LBS = 2.20462262;
+export const G_PER_KG = 1000;
 
 // Measurement conversions
 export const INCH_TO_CM = 2.54;
 export const CM_TO_INCH = 1 / 2.54;
+export const FT_TO_CM = 30.48;
 
 // Energy conversions
 export const KCAL_TO_KJ = 4.184;
@@ -18,17 +20,34 @@ export const KJ_TO_KCAL = 1 / 4.184;
 export const MILES_TO_KM = 1.609344;
 export const KM_TO_MILES = 0.62137119;
 
+// The published schemas accept alias spellings (`lb`, `inch`); fold them onto
+// the canonical unit names before branching.
+function normalizeWeightUnit(unit: string): string {
+  const u = unit.toLowerCase();
+  return u === 'lb' ? 'lbs' : u;
+}
+
+function normalizeMeasurementUnit(unit: string): string {
+  const u = unit.toLowerCase();
+  return u === 'inch' ? 'in' : u;
+}
+
 /**
  * Converts a weight value to the target unit.
  */
 export function convertWeight(value: number, from: string, to: string): number {
-  if (from.toLowerCase() === to.toLowerCase()) return value;
+  const f = normalizeWeightUnit(from);
+  const t = normalizeWeightUnit(to);
+  if (f === t) return value;
 
-  if (from.toLowerCase() === 'lbs' && to.toLowerCase() === 'kg') {
+  if (f === 'lbs' && t === 'kg') {
     return value * LBS_TO_KG;
   }
-  if (from.toLowerCase() === 'kg' && to.toLowerCase() === 'lbs') {
+  if (f === 'kg' && t === 'lbs') {
     return value * KG_TO_LBS;
+  }
+  if (f === 'g' && t === 'kg') {
+    return value / G_PER_KG;
   }
   return value;
 }
@@ -41,13 +60,18 @@ export function convertMeasurement(
   from: string,
   to: string
 ): number {
-  if (from.toLowerCase() === to.toLowerCase()) return value;
+  const f = normalizeMeasurementUnit(from);
+  const t = normalizeMeasurementUnit(to);
+  if (f === t) return value;
 
-  if (from.toLowerCase() === 'in' && to.toLowerCase() === 'cm') {
+  if (f === 'in' && t === 'cm') {
     return value * INCH_TO_CM;
   }
-  if (from.toLowerCase() === 'cm' && to.toLowerCase() === 'in') {
+  if (f === 'cm' && t === 'in') {
     return value * CM_TO_INCH;
+  }
+  if (f === 'ft' && t === 'cm') {
+    return value * FT_TO_CM;
   }
   return value;
 }

--- a/SparkyFitnessServer/ai/tools/visionTools.ts
+++ b/SparkyFitnessServer/ai/tools/visionTools.ts
@@ -1,0 +1,158 @@
+import { tool } from 'ai';
+import type { FoodPhotoEstimateResponse } from '@workspace/shared';
+import { log } from '../../config/logging.js';
+import foodPhotoEstimationService from '../../services/foodPhotoEstimationService.js';
+import labelScanService from '../../services/labelScanService.js';
+import { formatZodError } from './errors.js';
+import { AnalyzeFoodImageSchema, ScanLabelSchema } from './schemas/vision.js';
+
+const DATA_URL_PATTERN = /^data:(image\/[a-z0-9.+-]+);base64,(.+)$/i;
+
+// Base64 magic-byte prefixes for common image formats, used to infer the MIME
+// type of bare base64 input.
+const BASE64_MIME_PREFIXES: [string, string][] = [
+  ['/9j/', 'image/jpeg'],
+  ['iVBOR', 'image/png'],
+  ['R0lGOD', 'image/gif'],
+  ['UklGR', 'image/webp'],
+];
+
+type ParsedImage =
+  | { ok: true; base64: string; mimeType: string }
+  | { ok: false; reason: 'remote_url' | 'invalid' };
+
+// Accepts data: URLs and bare base64 only. Remote http(s) URLs are rejected
+// rather than fetched server-side (MCP passed them through to the AI
+// provider; named drift).
+function parseImageInput(imageUrl: string): ParsedImage {
+  const value = imageUrl.trim();
+  if (/^https?:\/\//i.test(value)) {
+    return { ok: false, reason: 'remote_url' };
+  }
+  if (value.startsWith('data:')) {
+    const match = DATA_URL_PATTERN.exec(value);
+    if (!match) {
+      return { ok: false, reason: 'invalid' };
+    }
+    return { ok: true, mimeType: match[1].toLowerCase(), base64: match[2] };
+  }
+  const mime = BASE64_MIME_PREFIXES.find(([prefix]) =>
+    value.startsWith(prefix)
+  );
+  return { ok: true, base64: value, mimeType: mime ? mime[1] : 'image/jpeg' };
+}
+
+function imageInputError(reason: 'remote_url' | 'invalid'): string {
+  return reason === 'remote_url'
+    ? 'Remote image URLs are not supported. Please attach the image directly to the chat.'
+    : 'The provided data: URL is not a valid base64-encoded image.';
+}
+
+function renderFoodPhotoEstimate(estimate: FoodPhotoEstimateResponse): string {
+  const lines: string[] = [];
+  lines.push(
+    `**${estimate.meal_summary}** (confidence: ${estimate.overall_confidence})`
+  );
+  if (estimate.confidence_reason) {
+    lines.push(`Confidence notes: ${estimate.confidence_reason}`);
+  }
+  lines.push('');
+  lines.push('Items:');
+  for (const item of estimate.items) {
+    const prep = item.preparation ? `, ${item.preparation}` : '';
+    lines.push(
+      `- ${item.name} (${item.portion_description}, ~${item.estimated_grams}g${prep}): ` +
+        `${item.calories_kcal} kcal | P: ${item.protein_g}g | C: ${item.carbs_g}g | F: ${item.fat_g}g | Fiber: ${item.fiber_g}g | Sugar: ${item.sugar_g}g`
+    );
+    if (item.assumptions.length > 0) {
+      lines.push(`  Assumptions: ${item.assumptions.join('; ')}`);
+    }
+  }
+  lines.push('');
+  const totals = estimate.totals;
+  lines.push(
+    `Total (~${totals.total_grams}g): ${totals.calories_kcal} kcal | P: ${totals.protein_g}g | C: ${totals.carbs_g}g | F: ${totals.fat_g}g | Fiber: ${totals.fiber_g}g | Sugar: ${totals.sugar_g}g`
+  );
+  if (estimate.user_weight_reconciliation) {
+    lines.push('');
+    lines.push(`Weight reconciliation: ${estimate.user_weight_reconciliation}`);
+  }
+  if (estimate.clarifying_questions.length > 0) {
+    lines.push('');
+    lines.push('To improve this estimate, the user could clarify:');
+    for (const question of estimate.clarifying_questions) {
+      lines.push(`- ${question}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export function buildVisionTools(userId: string) {
+  return {
+    sparky_analyze_food_image: tool({
+      description:
+        'Analyzes an image of food to estimate its nutritional content using advanced vision models.',
+      inputSchema: AnalyzeFoodImageSchema,
+      execute: async (rawArgs) => {
+        const parsed = AnalyzeFoodImageSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const image = parseImageInput(parsed.data.image_url);
+          if (!image.ok) {
+            return `❌ Error analyzing image: ${imageInputError(image.reason)}`;
+          }
+          const result =
+            await foodPhotoEstimationService.estimateFoodPhotoNutrition({
+              images: [{ base64: image.base64, mimeType: image.mimeType }],
+              userId,
+            });
+          if (!result.success) {
+            if (result.code === 'NO_AI_CONFIGURED') {
+              return '⚠️ Vision is not configured.\n\nNo AI service is configured. To enable food image analysis, configure an AI service in the chat settings.';
+            }
+            return `❌ Error analyzing image: ${result.error}`;
+          }
+          return `🔬 Food Image Analysis Result:\n\n${renderFoodPhotoEstimate(result.estimate)}`;
+        } catch (error) {
+          log('error', '[Vision Tool] analyzeFoodImage error:', error);
+          return `❌ Error analyzing image: ${error instanceof Error ? error.message : 'Unknown error'}`;
+        }
+      },
+    }),
+
+    sparky_scan_label: tool({
+      description:
+        'Scans a nutrition label from an image to extract detailed nutritional information using OCR.',
+      inputSchema: ScanLabelSchema,
+      execute: async (rawArgs) => {
+        const parsed = ScanLabelSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        try {
+          const image = parseImageInput(parsed.data.image_url);
+          if (!image.ok) {
+            return `❌ Error scanning label: ${imageInputError(image.reason)}`;
+          }
+          const result = await labelScanService.extractNutritionFromLabel(
+            image.base64,
+            image.mimeType,
+            userId
+          );
+          if (!result.success) {
+            if (result.category === 'no_ai_configured') {
+              return '⚠️ Vision is not configured.\n\nNo AI service is configured. To enable nutrition label scanning, configure an AI service in the chat settings.';
+            }
+            return `❌ Error scanning label: ${result.error}`;
+          }
+          return `🏷️ Nutrition Label Scan Result:\n\n${JSON.stringify(result.nutrition, null, 2)}`;
+        } catch (error) {
+          log('error', '[Vision Tool] scanLabel error:', error);
+          return `❌ Error scanning label: ${error instanceof Error ? error.message : 'Unknown error'}`;
+        }
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/ai/tools/wizardTools.ts
+++ b/SparkyFitnessServer/ai/tools/wizardTools.ts
@@ -1,0 +1,57 @@
+import { tool } from 'ai';
+import { formatZodError } from './errors.js';
+import { manageWizardSchema, manageWizardInput } from './schemas/wizard.js';
+
+const STEPS = {
+  start: {
+    question:
+      "Welcome to your daily check-in! Let's start with your **weight**. What is it today?",
+    next: 'weight',
+  },
+  weight: {
+    question: 'Got it. How many **steps** did you get in yesterday or today?',
+    next: 'steps',
+  },
+  steps: {
+    question:
+      'Nice! How was your **sleep**? (Duration and quality score 0-100)',
+    next: 'sleep',
+  },
+  sleep: {
+    question: 'And your **mood** today? (Scale of 1-10)',
+    next: 'mood',
+  },
+  mood: {
+    question:
+      "Finally, let's check your **habits**. Did you complete your daily goals?",
+    next: 'habits',
+  },
+  habits: {
+    question:
+      "All set! I've prepared a summary of your entries. Should I save everything?",
+    next: 'complete',
+  },
+  complete: {
+    question:
+      'Excellent. Your daily check-in is complete and saved. Have a great day!',
+    next: null,
+  },
+} as const;
+
+export function buildWizardTools(_userId: string) {
+  return {
+    sparky_daily_checkin_wizard: tool({
+      description:
+        "A guided, step-by-step interactive assistant for your daily health check-in. Use 'daily_checkin' action and pass the current step.",
+      inputSchema: manageWizardInput,
+      execute: async (rawArgs) => {
+        const parsed = manageWizardSchema.safeParse(rawArgs);
+        if (!parsed.success) {
+          return formatZodError(parsed.error);
+        }
+        const currentStep = parsed.data.step || 'start';
+        return STEPS[currentStep].question;
+      },
+    }),
+  };
+}

--- a/SparkyFitnessServer/models/coachRepository.ts
+++ b/SparkyFitnessServer/models/coachRepository.ts
@@ -1,0 +1,324 @@
+import { getClient } from '../db/poolManager.js';
+
+// Aggregate queries backing the chatbot coach tools (sparky_get_health_summary,
+// sparky_analyze_trends, sparky_get_30day_trends, sparky_detect_patterns,
+// sparky_generate_coaching_plan). Trend math and pattern classification live in
+// ai/tools/coachTools.ts; this file only holds the SQL.
+//
+// Snapshot nutrient columns on food_entries are stored unscaled (per serving),
+// so totals scale by quantity / serving_size.
+
+async function getNutritionAggregates(
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT
+        COALESCE(SUM(calories * quantity / NULLIF(serving_size, 0)), 0)::numeric AS total_calories,
+        COALESCE(AVG(protein * quantity / NULLIF(serving_size, 0)), 0)::numeric AS avg_protein,
+        COALESCE(AVG(carbs * quantity / NULLIF(serving_size, 0)), 0)::numeric AS avg_carbs,
+        COALESCE(AVG(fat * quantity / NULLIF(serving_size, 0)), 0)::numeric AS avg_fat,
+        COUNT(*)::int AS entry_count
+       FROM food_entries
+       WHERE user_id = $1 AND entry_date >= $2 AND entry_date <= $3`,
+      [userId, startDate, endDate]
+    );
+    return result.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function getExerciseAggregates(
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT
+        COALESCE(SUM(calories_burned), 0)::numeric AS total_calories_burned,
+        COUNT(*)::int AS workout_count
+       FROM exercise_entries
+       WHERE user_id = $1 AND entry_date >= $2 AND entry_date <= $3`,
+      [userId, startDate, endDate]
+    );
+    return result.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function getLatestWeightInRange(
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT weight, entry_date
+       FROM check_in_measurements
+       WHERE user_id = $1 AND weight IS NOT NULL AND entry_date >= $2 AND entry_date <= $3
+       ORDER BY entry_date DESC
+       LIMIT 1`,
+      [userId, startDate, endDate]
+    );
+    return result.rows[0] || null;
+  } finally {
+    client.release();
+  }
+}
+
+async function getWaterIntakeTotal(
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT COALESCE(SUM(water_ml), 0)::numeric AS total_water
+       FROM water_intake
+       WHERE user_id = $1 AND entry_date >= $2 AND entry_date <= $3`,
+      [userId, startDate, endDate]
+    );
+    return result.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function getWeightSeries(userId: string, days: number) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT weight, entry_date
+       FROM check_in_measurements
+       WHERE user_id = $1 AND weight IS NOT NULL AND entry_date >= (CURRENT_DATE - $2::int)
+       ORDER BY entry_date ASC`,
+      [userId, days]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+async function getDailyCalorieSeries(userId: string, days: number) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT entry_date, SUM(calories * quantity / NULLIF(serving_size, 0))::numeric AS daily_calories
+       FROM food_entries
+       WHERE user_id = $1 AND entry_date >= (CURRENT_DATE - $2::int)
+       GROUP BY entry_date
+       ORDER BY entry_date ASC`,
+      [userId, days]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+async function get30DayFoodAggregates(userId: string, endDate: string) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT
+        COUNT(DISTINCT entry_date)::int AS days_logged,
+        COALESCE(AVG(daily_cal), 0)::numeric AS avg_daily_calories,
+        COALESCE(AVG(daily_protein), 0)::numeric AS avg_daily_protein
+       FROM (
+         SELECT entry_date,
+                SUM(calories * quantity / NULLIF(serving_size, 0)) AS daily_cal,
+                SUM(protein * quantity / NULLIF(serving_size, 0)) AS daily_protein
+         FROM food_entries
+         WHERE user_id = $1 AND entry_date > ($2::date - INTERVAL '30 days') AND entry_date <= $2::date
+         GROUP BY entry_date
+       ) sub`,
+      [userId, endDate]
+    );
+    return result.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function get30DayExerciseAggregates(userId: string, endDate: string) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT
+        COUNT(*)::int AS total_workouts,
+        COUNT(DISTINCT entry_date)::int AS active_days,
+        COALESCE(SUM(calories_burned), 0)::numeric AS total_calories_burned
+       FROM exercise_entries
+       WHERE user_id = $1 AND entry_date > ($2::date - INTERVAL '30 days') AND entry_date <= $2::date`,
+      [userId, endDate]
+    );
+    return result.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function get30DayMoodAggregates(userId: string, endDate: string) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT
+        COUNT(*)::int AS entries,
+        COALESCE(AVG(mood_value), 0)::numeric AS avg_mood
+       FROM mood_entries
+       WHERE user_id = $1 AND entry_date > ($2::date - INTERVAL '30 days') AND entry_date <= $2::date`,
+      [userId, endDate]
+    );
+    return result.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function get30DaySleepAggregates(userId: string, endDate: string) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT
+        COUNT(*)::int AS entries,
+        COALESCE(AVG(duration_in_seconds), 0)::numeric AS avg_duration_seconds,
+        COALESCE(AVG(sleep_score), 0)::numeric AS avg_sleep_score
+       FROM sleep_entries
+       WHERE user_id = $1 AND entry_date > ($2::date - INTERVAL '30 days') AND entry_date <= $2::date`,
+      [userId, endDate]
+    );
+    return result.rows[0];
+  } finally {
+    client.release();
+  }
+}
+
+async function get30DayWeightSeries(userId: string, endDate: string) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT weight, entry_date
+       FROM check_in_measurements
+       WHERE user_id = $1 AND weight IS NOT NULL AND entry_date > ($2::date - INTERVAL '30 days') AND entry_date <= $2::date
+       ORDER BY entry_date ASC`,
+      [userId, endDate]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+// Daily nutrition totals joined with same-day sleep and mood, for pattern
+// detection (sparky_detect_patterns).
+async function getDailyCorrelationRows(userId: string, days: number) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `WITH daily_food AS (
+        SELECT
+          entry_date,
+          SUM(calories * quantity / NULLIF(serving_size, 0)) as calories,
+          SUM(protein * quantity / NULLIF(serving_size, 0)) as protein,
+          SUM(carbs * quantity / NULLIF(serving_size, 0)) as carbs,
+          SUM(fat * quantity / NULLIF(serving_size, 0)) as fat,
+          SUM(sugars * quantity / NULLIF(serving_size, 0)) as sugars,
+          SUM(sodium * quantity / NULLIF(serving_size, 0)) as sodium,
+          SUM(dietary_fiber * quantity / NULLIF(serving_size, 0)) as fiber,
+          SUM(saturated_fat * quantity / NULLIF(serving_size, 0)) as sat_fat,
+          SUM(cholesterol * quantity / NULLIF(serving_size, 0)) as cholesterol,
+          SUM(potassium * quantity / NULLIF(serving_size, 0)) as potassium,
+          SUM(vitamin_a * quantity / NULLIF(serving_size, 0)) as vit_a,
+          SUM(vitamin_c * quantity / NULLIF(serving_size, 0)) as vit_c,
+          SUM(calcium * quantity / NULLIF(serving_size, 0)) as calcium,
+          SUM(iron * quantity / NULLIF(serving_size, 0)) as iron
+        FROM food_entries
+        WHERE user_id = $1 AND entry_date >= CURRENT_DATE - $2::int
+        GROUP BY entry_date
+      ),
+      daily_sleep AS (
+        SELECT entry_date, duration_in_seconds, sleep_score
+        FROM sleep_entries
+        WHERE user_id = $1 AND entry_date >= CURRENT_DATE - $2::int
+      ),
+      daily_mood AS (
+        SELECT entry_date, mood_value
+        FROM mood_entries
+        WHERE user_id = $1 AND entry_date >= CURRENT_DATE - $2::int
+      )
+      SELECT
+        f.*,
+        s.duration_in_seconds, s.sleep_score,
+        m.mood_value
+      FROM daily_food f
+      LEFT JOIN daily_sleep s ON f.entry_date = s.entry_date
+      LEFT JOIN daily_mood m ON f.entry_date = m.entry_date
+      ORDER BY f.entry_date DESC`,
+      [userId, days]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+// Most frequently logged foods with >10g protein, for shopping-list
+// suggestions (sparky_generate_coaching_plan).
+async function getFrequentHighProteinFoods(userId: string) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT food_name, COUNT(*) as frequency
+       FROM food_entries
+       WHERE user_id = $1 AND protein > 10
+       GROUP BY food_name
+       ORDER BY frequency DESC
+       LIMIT 5`,
+      [userId]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+export {
+  getNutritionAggregates,
+  getExerciseAggregates,
+  getLatestWeightInRange,
+  getWaterIntakeTotal,
+  getWeightSeries,
+  getDailyCalorieSeries,
+  get30DayFoodAggregates,
+  get30DayExerciseAggregates,
+  get30DayMoodAggregates,
+  get30DaySleepAggregates,
+  get30DayWeightSeries,
+  getDailyCorrelationRows,
+  getFrequentHighProteinFoods,
+};
+export default {
+  getNutritionAggregates,
+  getExerciseAggregates,
+  getLatestWeightInRange,
+  getWaterIntakeTotal,
+  getWeightSeries,
+  getDailyCalorieSeries,
+  get30DayFoodAggregates,
+  get30DayExerciseAggregates,
+  get30DayMoodAggregates,
+  get30DaySleepAggregates,
+  get30DayWeightSeries,
+  getDailyCorrelationRows,
+  getFrequentHighProteinFoods,
+};

--- a/SparkyFitnessServer/models/coachRepository.ts
+++ b/SparkyFitnessServer/models/coachRepository.ts
@@ -93,15 +93,16 @@ async function getWaterIntakeTotal(
   }
 }
 
-async function getWeightSeries(userId: string, days: number) {
+// Trailing windows anchor on `today`, the caller's user-timezone day string.
+async function getWeightSeries(userId: string, days: number, today: string) {
   const client = await getClient(userId);
   try {
     const result = await client.query(
       `SELECT weight, entry_date
        FROM check_in_measurements
-       WHERE user_id = $1 AND weight IS NOT NULL AND entry_date >= (CURRENT_DATE - $2::int)
+       WHERE user_id = $1 AND weight IS NOT NULL AND entry_date >= ($3::date - $2::int)
        ORDER BY entry_date ASC`,
-      [userId, days]
+      [userId, days, today]
     );
     return result.rows;
   } finally {
@@ -109,16 +110,20 @@ async function getWeightSeries(userId: string, days: number) {
   }
 }
 
-async function getDailyCalorieSeries(userId: string, days: number) {
+async function getDailyCalorieSeries(
+  userId: string,
+  days: number,
+  today: string
+) {
   const client = await getClient(userId);
   try {
     const result = await client.query(
       `SELECT entry_date, SUM(calories * quantity / NULLIF(serving_size, 0))::numeric AS daily_calories
        FROM food_entries
-       WHERE user_id = $1 AND entry_date >= (CURRENT_DATE - $2::int)
+       WHERE user_id = $1 AND entry_date >= ($3::date - $2::int)
        GROUP BY entry_date
        ORDER BY entry_date ASC`,
-      [userId, days]
+      [userId, days, today]
     );
     return result.rows;
   } finally {
@@ -220,8 +225,13 @@ async function get30DayWeightSeries(userId: string, endDate: string) {
 }
 
 // Daily nutrition totals joined with same-day sleep and mood, for pattern
-// detection (sparky_detect_patterns).
-async function getDailyCorrelationRows(userId: string, days: number) {
+// detection (sparky_detect_patterns). The trailing window anchors on `today`,
+// the caller's user-timezone day string.
+async function getDailyCorrelationRows(
+  userId: string,
+  days: number,
+  today: string
+) {
   const client = await getClient(userId);
   try {
     const result = await client.query(
@@ -243,18 +253,18 @@ async function getDailyCorrelationRows(userId: string, days: number) {
           SUM(calcium * quantity / NULLIF(serving_size, 0)) as calcium,
           SUM(iron * quantity / NULLIF(serving_size, 0)) as iron
         FROM food_entries
-        WHERE user_id = $1 AND entry_date >= CURRENT_DATE - $2::int
+        WHERE user_id = $1 AND entry_date >= $3::date - $2::int
         GROUP BY entry_date
       ),
       daily_sleep AS (
         SELECT entry_date, duration_in_seconds, sleep_score
         FROM sleep_entries
-        WHERE user_id = $1 AND entry_date >= CURRENT_DATE - $2::int
+        WHERE user_id = $1 AND entry_date >= $3::date - $2::int
       ),
       daily_mood AS (
         SELECT entry_date, mood_value
         FROM mood_entries
-        WHERE user_id = $1 AND entry_date >= CURRENT_DATE - $2::int
+        WHERE user_id = $1 AND entry_date >= $3::date - $2::int
       )
       SELECT
         f.*,
@@ -264,7 +274,7 @@ async function getDailyCorrelationRows(userId: string, days: number) {
       LEFT JOIN daily_sleep s ON f.entry_date = s.entry_date
       LEFT JOIN daily_mood m ON f.entry_date = m.entry_date
       ORDER BY f.entry_date DESC`,
-      [userId, days]
+      [userId, days, today]
     );
     return result.rows;
   } finally {

--- a/SparkyFitnessServer/models/engagementRepository.ts
+++ b/SparkyFitnessServer/models/engagementRepository.ts
@@ -38,20 +38,24 @@ async function getRecentWeights(userId: string, limit = 7) {
   }
 }
 
-// Distinct days with any food/exercise/check-in entry in the last 7 days.
-async function getWeeklyLoggedDayCount(userId: string): Promise<number> {
+// Distinct days with any food/exercise/check-in entry in the 7 days before
+// `today`, the caller's user-timezone day string.
+async function getWeeklyLoggedDayCount(
+  userId: string,
+  today: string
+): Promise<number> {
   const client = await getClient(userId);
   try {
     const result = await client.query(
       `SELECT COUNT(DISTINCT d.entry_date)::int AS streak_days
        FROM (
-         SELECT entry_date FROM food_entries WHERE user_id = $1 AND entry_date >= (CURRENT_DATE - 7)
+         SELECT entry_date FROM food_entries WHERE user_id = $1 AND entry_date >= ($2::date - 7)
          UNION
-         SELECT entry_date FROM exercise_entries WHERE user_id = $1 AND entry_date >= (CURRENT_DATE - 7)
+         SELECT entry_date FROM exercise_entries WHERE user_id = $1 AND entry_date >= ($2::date - 7)
          UNION
-         SELECT entry_date FROM check_in_measurements WHERE user_id = $1 AND entry_date >= (CURRENT_DATE - 7)
+         SELECT entry_date FROM check_in_measurements WHERE user_id = $1 AND entry_date >= ($2::date - 7)
        ) d`,
-      [userId]
+      [userId, today]
     );
     return result.rows[0]?.streak_days ?? 0;
   } finally {
@@ -82,28 +86,35 @@ async function getLoggedDates(userId: string) {
   }
 }
 
-async function getTodayActivityCounts(userId: string) {
+// Counts for `today`, the caller's user-timezone day string. The fasting
+// branch counts fasts *started* today, bucketing start_time in the user's
+// timezone.
+async function getTodayActivityCounts(
+  userId: string,
+  today: string,
+  tz: string
+) {
   const client = await getClient(userId);
   try {
     const foodResult = await client.query(
-      'SELECT COUNT(*)::int AS count FROM food_entries WHERE user_id = $1 AND entry_date = CURRENT_DATE',
-      [userId]
+      'SELECT COUNT(*)::int AS count FROM food_entries WHERE user_id = $1 AND entry_date = $2::date',
+      [userId, today]
     );
     const exerciseResult = await client.query(
-      'SELECT COUNT(*)::int AS count FROM exercise_entries WHERE user_id = $1 AND entry_date = CURRENT_DATE',
-      [userId]
+      'SELECT COUNT(*)::int AS count FROM exercise_entries WHERE user_id = $1 AND entry_date = $2::date',
+      [userId, today]
     );
     const checkinResult = await client.query(
       `SELECT COUNT(*)::int AS count FROM (
-         SELECT id FROM check_in_measurements WHERE user_id = $1 AND entry_date = CURRENT_DATE
+         SELECT id FROM check_in_measurements WHERE user_id = $1 AND entry_date = $2::date
          UNION ALL
-         SELECT id FROM mood_entries WHERE user_id = $1 AND entry_date = CURRENT_DATE
+         SELECT id FROM mood_entries WHERE user_id = $1 AND entry_date = $2::date
          UNION ALL
-         SELECT id FROM sleep_entries WHERE user_id = $1 AND entry_date = CURRENT_DATE
+         SELECT id FROM sleep_entries WHERE user_id = $1 AND entry_date = $2::date
          UNION ALL
-         SELECT id FROM fasting_logs WHERE user_id = $1 AND start_time::date = CURRENT_DATE
+         SELECT id FROM fasting_logs WHERE user_id = $1 AND (start_time AT TIME ZONE $3)::date = $2::date
        ) all_checkins`,
-      [userId]
+      [userId, today, tz]
     );
 
     return {

--- a/SparkyFitnessServer/models/engagementRepository.ts
+++ b/SparkyFitnessServer/models/engagementRepository.ts
@@ -1,0 +1,129 @@
+import { getClient } from '../db/poolManager.js';
+
+// Queries backing the chatbot engagement tools (sparky_check_engagement,
+// sparky_get_logging_streak, sparky_get_contextual_nudge). Streak counting and
+// nudge selection live in ai/tools/engagementTools.ts; this file only holds
+// the SQL.
+
+async function getLastExerciseDate(userId: string): Promise<string | null> {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT entry_date FROM exercise_entries
+       WHERE user_id = $1
+       ORDER BY entry_date DESC LIMIT 1`,
+      [userId]
+    );
+    return result.rows[0]?.entry_date ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+async function getRecentWeights(userId: string, limit = 7) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT weight, entry_date FROM check_in_measurements
+       WHERE user_id = $1 AND weight IS NOT NULL
+       ORDER BY entry_date DESC LIMIT $2`,
+      [userId, limit]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+// Distinct days with any food/exercise/check-in entry in the last 7 days.
+async function getWeeklyLoggedDayCount(userId: string): Promise<number> {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT COUNT(DISTINCT d.entry_date)::int AS streak_days
+       FROM (
+         SELECT entry_date FROM food_entries WHERE user_id = $1 AND entry_date >= (CURRENT_DATE - 7)
+         UNION
+         SELECT entry_date FROM exercise_entries WHERE user_id = $1 AND entry_date >= (CURRENT_DATE - 7)
+         UNION
+         SELECT entry_date FROM check_in_measurements WHERE user_id = $1 AND entry_date >= (CURRENT_DATE - 7)
+       ) d`,
+      [userId]
+    );
+    return result.rows[0]?.streak_days ?? 0;
+  } finally {
+    client.release();
+  }
+}
+
+// All distinct days with any logged data, newest first. The streak walk over
+// these dates happens in the tool layer.
+async function getLoggedDates(userId: string) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT DISTINCT entry_date
+       FROM (
+         SELECT entry_date FROM food_entries WHERE user_id = $1
+         UNION
+         SELECT entry_date FROM exercise_entries WHERE user_id = $1
+         UNION
+         SELECT entry_date FROM check_in_measurements WHERE user_id = $1
+       ) all_entries
+       ORDER BY entry_date DESC`,
+      [userId]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+async function getTodayActivityCounts(userId: string) {
+  const client = await getClient(userId);
+  try {
+    const foodResult = await client.query(
+      'SELECT COUNT(*)::int AS count FROM food_entries WHERE user_id = $1 AND entry_date = CURRENT_DATE',
+      [userId]
+    );
+    const exerciseResult = await client.query(
+      'SELECT COUNT(*)::int AS count FROM exercise_entries WHERE user_id = $1 AND entry_date = CURRENT_DATE',
+      [userId]
+    );
+    const checkinResult = await client.query(
+      `SELECT COUNT(*)::int AS count FROM (
+         SELECT id FROM check_in_measurements WHERE user_id = $1 AND entry_date = CURRENT_DATE
+         UNION ALL
+         SELECT id FROM mood_entries WHERE user_id = $1 AND entry_date = CURRENT_DATE
+         UNION ALL
+         SELECT id FROM sleep_entries WHERE user_id = $1 AND entry_date = CURRENT_DATE
+         UNION ALL
+         SELECT id FROM fasting_logs WHERE user_id = $1 AND start_time::date = CURRENT_DATE
+       ) all_checkins`,
+      [userId]
+    );
+
+    return {
+      food_count: foodResult.rows[0]?.count ?? 0,
+      exercise_count: exerciseResult.rows[0]?.count ?? 0,
+      checkin_count: checkinResult.rows[0]?.count ?? 0,
+    };
+  } finally {
+    client.release();
+  }
+}
+
+export {
+  getLastExerciseDate,
+  getRecentWeights,
+  getWeeklyLoggedDayCount,
+  getLoggedDates,
+  getTodayActivityCounts,
+};
+export default {
+  getLastExerciseDate,
+  getRecentWeights,
+  getWeeklyLoggedDayCount,
+  getLoggedDates,
+  getTodayActivityCounts,
+};

--- a/SparkyFitnessServer/models/engagementRepository.ts
+++ b/SparkyFitnessServer/models/engagementRepository.ts
@@ -5,7 +5,10 @@ import { getClient } from '../db/poolManager.js';
 // nudge selection live in ai/tools/engagementTools.ts; this file only holds
 // the SQL.
 
-async function getLastExerciseDate(userId: string): Promise<string | null> {
+// pg returns DATE columns as Date objects; string covers custom type parsers.
+async function getLastExerciseDate(
+  userId: string
+): Promise<Date | string | null> {
   const client = await getClient(userId);
   try {
     const result = await client.query(

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -427,12 +427,15 @@ async function _createExerciseEntryWithClient(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createdByUserId: any,
   entrySource = 'Manual',
-  exercisePresetEntryId = null
+  exercisePresetEntryId = null,
+  options: { skipDuplicateCheck?: boolean } = {}
 ) {
   try {
     // Check for existing entry
     // treat entries without a preset ID as unique if their exercise_id, entry_date, and source match.
     // For entries within a preset, we always allow duplicates (no uniqueness check).
+    // Callers that must always insert (e.g. the chatbot, where logging the
+    // same exercise twice in a day means two workouts) pass skipDuplicateCheck.
     const syncDuplicateCheck = entryData.source_id ? true : false;
     const skipManualDuplicateCheck = [
       'HealthKit',
@@ -455,7 +458,8 @@ async function _createExerciseEntryWithClient(
       !existingEntryResult?.rows?.length &&
       !exercisePresetEntryId &&
       !skipManualDuplicateCheck &&
-      !syncDuplicateCheck
+      !syncDuplicateCheck &&
+      !options.skipDuplicateCheck
     ) {
       if (entryData.workout_plan_assignment_id) {
         // If it's linked to a workout plan assignment, it's unique by that assignment ID and date.
@@ -580,7 +584,8 @@ async function createExerciseEntry(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createdByUserId: any,
   entrySource = 'Manual',
-  exercisePresetEntryId = null
+  exercisePresetEntryId = null,
+  options: { skipDuplicateCheck?: boolean } = {}
 ) {
   const client = await getClient(userId);
   try {
@@ -591,7 +596,8 @@ async function createExerciseEntry(
       entryData,
       createdByUserId,
       entrySource,
-      exercisePresetEntryId
+      exercisePresetEntryId,
+      options
     );
     await client.query('COMMIT');
     return entry;
@@ -654,11 +660,12 @@ async function updateExerciseEntry(
         image_url = $7,
         distance = $8,
         avg_heart_rate = $9,
-        sort_order = $10,
-        exercise_name = $11,
-        updated_by_user_id = $12,
+        steps = $10,
+        sort_order = $11,
+        exercise_name = $12,
+        updated_by_user_id = $13,
         updated_at = now()
-      WHERE id = $13 AND user_id = $14
+      WHERE id = $14 AND user_id = $15
       RETURNING id`,
       [
         updateData.exercise_id ?? null,
@@ -670,6 +677,7 @@ async function updateExerciseEntry(
         updateData.image_url ?? null,
         updateData.distance ?? null,
         updateData.avg_heart_rate ?? null,
+        updateData.steps ?? null,
         updateData.sort_order ?? null,
         updateData.exercise_name ?? null,
         actingUserId,
@@ -1274,6 +1282,41 @@ async function getDailyExerciseTotalsRange(
   }
 }
 
+// Entry-level diary rows for a date range, plus all their sets, with catalog
+// name/category. Backs the chatbot sparky_get_exercise_diary tool.
+async function getExerciseDiaryRange(
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
+  const client = await getClient(userId);
+  try {
+    const entriesResult = await client.query(
+      `SELECT ee.*, e.name AS exercise_name_from_catalog, e.category AS exercise_category_from_catalog
+       FROM exercise_entries ee
+       LEFT JOIN exercises e ON e.id = ee.exercise_id
+       WHERE ee.user_id = $1 AND ee.entry_date BETWEEN $2 AND $3
+       ORDER BY ee.entry_date ASC, ee.created_at ASC`,
+      [userId, startDate, endDate]
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const entryIds = entriesResult.rows.map((row: any) => row.id);
+    let sets: Record<string, unknown>[] = [];
+    if (entryIds.length > 0) {
+      const setsResult = await client.query(
+        `SELECT * FROM exercise_entry_sets
+         WHERE exercise_entry_id = ANY($1)
+         ORDER BY exercise_entry_id, set_number ASC`,
+        [entryIds]
+      );
+      sets = setsResult.rows;
+    }
+    return { entries: entriesResult.rows, sets };
+  } finally {
+    client.release();
+  }
+}
+
 // Most recent exercise entries with catalog name/category. Backs the chatbot
 // sparky_get_recent_exercise_entries tool.
 async function getRecentExerciseEntries(userId: string, limit: number) {
@@ -1344,6 +1387,7 @@ export { getBestSetForExercise };
 export { getLastSetForExercise };
 export { deleteExerciseEntriesByEntrySourceAndDate };
 export { getDailyExerciseTotalsRange };
+export { getExerciseDiaryRange };
 export { getRecentExerciseEntries };
 export { getExerciseUsage };
 export default {
@@ -1366,6 +1410,7 @@ export default {
   getLastSetForExercise,
   deleteExerciseEntriesByEntrySourceAndDate,
   getDailyExerciseTotalsRange,
+  getExerciseDiaryRange,
   getRecentExerciseEntries,
   getExerciseUsage,
 };

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -1246,6 +1246,88 @@ async function deleteExerciseEntriesByEntrySourceAndDate(
     client.release();
   }
 }
+// Per-day exercise totals over a date range. Backs the chatbot
+// sparky_get_daily_exercise_totals tool.
+async function getDailyExerciseTotalsRange(
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT entry_date,
+              COUNT(*)::int AS entry_count,
+              SUM(COALESCE(duration_minutes, 0)) AS duration_minutes,
+              SUM(COALESCE(calories_burned, 0)) AS calories_burned,
+              SUM(COALESCE(distance, 0)) AS distance,
+              SUM(COALESCE(steps, 0)) AS steps
+       FROM exercise_entries
+       WHERE user_id = $1 AND entry_date BETWEEN $2 AND $3
+       GROUP BY entry_date
+       ORDER BY entry_date ASC`,
+      [userId, startDate, endDate]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+// Most recent exercise entries with catalog name/category. Backs the chatbot
+// sparky_get_recent_exercise_entries tool.
+async function getRecentExerciseEntries(userId: string, limit: number) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT ee.*, e.name AS exercise_name_from_catalog, e.category AS exercise_category_from_catalog
+       FROM exercise_entries ee
+       LEFT JOIN exercises e ON e.id = ee.exercise_id
+       WHERE ee.user_id = $1
+       ORDER BY ee.entry_date DESC, ee.created_at DESC
+       LIMIT $2`,
+      [userId, limit]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+// Paged entries for one exercise in a date range, plus the total count.
+// Backs the chatbot sparky_get_exercise_usage tool.
+async function getExerciseUsage(
+  userId: string,
+  exerciseId: string,
+  startDate: string,
+  endDate: string,
+  limit: number,
+  offset: number
+) {
+  const client = await getClient(userId);
+  try {
+    const countResult = await client.query(
+      `SELECT COUNT(*)::int AS count
+       FROM exercise_entries
+       WHERE user_id = $1 AND exercise_id = $2 AND entry_date BETWEEN $3 AND $4`,
+      [userId, exerciseId, startDate, endDate]
+    );
+    const dataResult = await client.query(
+      `SELECT * FROM exercise_entries
+       WHERE user_id = $1 AND exercise_id = $2 AND entry_date BETWEEN $3 AND $4
+       ORDER BY entry_date DESC, created_at DESC
+       LIMIT $5 OFFSET $6`,
+      [userId, exerciseId, startDate, endDate, limit, offset]
+    );
+    return {
+      rows: dataResult.rows,
+      totalCount: countResult.rows[0]?.count ?? 0,
+    };
+  } finally {
+    client.release();
+  }
+}
+
 export { upsertExerciseEntryData };
 export { _createExerciseEntryWithClient };
 export { createExerciseEntry };
@@ -1261,6 +1343,9 @@ export { getExerciseHistory };
 export { getBestSetForExercise };
 export { getLastSetForExercise };
 export { deleteExerciseEntriesByEntrySourceAndDate };
+export { getDailyExerciseTotalsRange };
+export { getRecentExerciseEntries };
+export { getExerciseUsage };
 export default {
   upsertExerciseEntryData,
   _createExerciseEntryWithClient,
@@ -1280,4 +1365,7 @@ export default {
   getBestSetForExercise,
   getLastSetForExercise,
   deleteExerciseEntriesByEntrySourceAndDate,
+  getDailyExerciseTotalsRange,
+  getRecentExerciseEntries,
+  getExerciseUsage,
 };

--- a/SparkyFitnessServer/models/externalProviderRepository.ts
+++ b/SparkyFitnessServer/models/externalProviderRepository.ts
@@ -592,8 +592,31 @@ async function getProvidersByType(providerType: any) {
     client.release();
   }
 }
+// A user's active providers of the given types, in cascade order (manual
+// sort_order first, then most recently created). Backs the chatbot
+// lookup_food_nutrition provider cascade.
+async function getActiveProvidersByTypes(
+  userId: string,
+  providerTypes: string[]
+) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT id, provider_type, provider_name
+       FROM external_data_providers
+       WHERE user_id = $1 AND is_active = TRUE
+         AND provider_type = ANY($2::text[])
+       ORDER BY sort_order ASC NULLS LAST, created_at DESC`,
+      [userId, providerTypes]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
 export { getExternalDataProviders };
 export { getExternalDataProvidersByUserId };
+export { getActiveProvidersByTypes };
 export { createExternalDataProvider };
 export { updateExternalDataProvider };
 export { getExternalDataProviderById };
@@ -605,6 +628,7 @@ export { getProvidersByType };
 export default {
   getExternalDataProviders,
   getExternalDataProvidersByUserId,
+  getActiveProvidersByTypes,
   createExternalDataProvider,
   updateExternalDataProvider,
   getExternalDataProviderById,

--- a/SparkyFitnessServer/models/fastingRepository.ts
+++ b/SparkyFitnessServer/models/fastingRepository.ts
@@ -214,6 +214,26 @@ async function getFastingLogsByDateRange(
     client.release();
   }
 }
+// Fasting logs whose window overlaps the given calendar day, including active
+// fasts with no end_time. Backs the chatbot check-in diary
+// (ai/tools/checkinTools.ts).
+async function getFastingLogsOverlappingDay(userId: string, date: string) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT id, start_time, end_time, status, fasting_type
+       FROM fasting_logs
+       WHERE user_id = $1
+         AND start_time::date <= $2::date
+         AND (end_time IS NULL OR end_time::date >= $2::date)
+       ORDER BY start_time ASC`,
+      [userId, date]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
 export { createFastingLog };
 export { endFast };
 export { getFastingById };
@@ -222,6 +242,7 @@ export { getFastingHistory };
 export { updateFast };
 export { getFastingStats };
 export { getFastingLogsByDateRange };
+export { getFastingLogsOverlappingDay };
 export default {
   createFastingLog,
   endFast,
@@ -231,4 +252,5 @@ export default {
   updateFast,
   getFastingStats,
   getFastingLogsByDateRange,
+  getFastingLogsOverlappingDay,
 };

--- a/SparkyFitnessServer/models/fastingRepository.ts
+++ b/SparkyFitnessServer/models/fastingRepository.ts
@@ -214,20 +214,24 @@ async function getFastingLogsByDateRange(
     client.release();
   }
 }
-// Fasting logs whose window overlaps the given calendar day, including active
-// fasts with no end_time. Backs the chatbot check-in diary
-// (ai/tools/checkinTools.ts).
-async function getFastingLogsOverlappingDay(userId: string, date: string) {
+// Fasting logs whose window overlaps the given calendar day in the user's
+// timezone, including active fasts with no end_time. Backs the chatbot
+// check-in diary (ai/tools/checkinTools.ts).
+async function getFastingLogsOverlappingDay(
+  userId: string,
+  date: string,
+  timezone: string
+) {
   const client = await getClient(userId);
   try {
     const result = await client.query(
       `SELECT id, start_time, end_time, status, fasting_type
        FROM fasting_logs
        WHERE user_id = $1
-         AND start_time::date <= $2::date
-         AND (end_time IS NULL OR end_time::date >= $2::date)
+         AND (start_time AT TIME ZONE $3)::date <= $2::date
+         AND (end_time IS NULL OR (end_time AT TIME ZONE $3)::date >= $2::date)
        ORDER BY start_time ASC`,
-      [userId, date]
+      [userId, date, timezone]
     );
     return result.rows;
   } finally {

--- a/SparkyFitnessServer/models/foodEntry.ts
+++ b/SparkyFitnessServer/models/foodEntry.ts
@@ -927,6 +927,63 @@ async function deleteFoodEntriesByProviderTypeAndDateRange(
   }
 }
 
+// Most recent food entries with catalog name/brand. Backs the chatbot
+// sparky_get_recent_food_entries tool.
+async function getRecentFoodEntries(userId: string, limit: number) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT fe.*, mt.name AS meal_type, f.name AS food_name_from_catalog, f.brand AS brand_from_catalog
+       FROM food_entries fe
+       LEFT JOIN meal_types mt ON mt.id = fe.meal_type_id
+       LEFT JOIN foods f ON f.id = fe.food_id
+       WHERE fe.user_id = $1
+       ORDER BY fe.entry_date DESC, fe.created_at DESC
+       LIMIT $2`,
+      [userId, limit]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+// Paged entries for one food in a date range, plus the total count. Backs the
+// chatbot sparky_get_food_usage tool.
+async function getFoodUsage(
+  userId: string,
+  foodId: string,
+  startDate: string,
+  endDate: string,
+  limit: number,
+  offset: number
+) {
+  const client = await getClient(userId);
+  try {
+    const countResult = await client.query(
+      `SELECT COUNT(*)::int AS count
+       FROM food_entries
+       WHERE user_id = $1 AND food_id = $2 AND entry_date BETWEEN $3 AND $4`,
+      [userId, foodId, startDate, endDate]
+    );
+    const dataResult = await client.query(
+      `SELECT fe.*, mt.name AS meal_type
+       FROM food_entries fe
+       LEFT JOIN meal_types mt ON mt.id = fe.meal_type_id
+       WHERE fe.user_id = $1 AND fe.food_id = $2 AND fe.entry_date BETWEEN $3 AND $4
+       ORDER BY fe.entry_date DESC, fe.created_at DESC
+       LIMIT $5 OFFSET $6`,
+      [userId, foodId, startDate, endDate, limit, offset]
+    );
+    return {
+      rows: dataResult.rows,
+      totalCount: countResult.rows[0]?.count ?? 0,
+    };
+  } finally {
+    client.release();
+  }
+}
+
 export { createFoodEntry };
 export { getFoodEntryOwnerId };
 export { updateFoodEntry };
@@ -941,6 +998,8 @@ export { getFoodEntryById };
 export { getFoodEntryComponentsByFoodEntryMealId };
 export { deleteFoodEntryComponentsByFoodEntryMealId };
 export { getFoodEntriesBatch };
+export { getRecentFoodEntries };
+export { getFoodUsage };
 export default {
   createFoodEntry,
   getFoodEntryOwnerId,
@@ -956,4 +1015,6 @@ export default {
   getFoodEntryComponentsByFoodEntryMealId,
   deleteFoodEntryComponentsByFoodEntryMealId,
   getFoodEntriesBatch,
+  getRecentFoodEntries,
+  getFoodUsage,
 };

--- a/SparkyFitnessServer/models/foodEntryMealRepository.ts
+++ b/SparkyFitnessServer/models/foodEntryMealRepository.ts
@@ -205,6 +205,28 @@ async function getFoodEntryMealsByDate(userId: any, selectedDate: any) {
     client.release();
   }
 }
+// Flat meal-container rows for a date range. Backs the chatbot
+// sparky_get_food_diary tool (per-date reads use getFoodEntryMealsByDate).
+async function getFoodEntryMealsByDateRange(
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT fem.*, mt.name AS meal_type
+       FROM food_entry_meals fem
+       LEFT JOIN meal_types mt ON fem.meal_type_id = mt.id
+       WHERE fem.user_id = $1 AND fem.entry_date BETWEEN $2 AND $3
+       ORDER BY fem.entry_date ASC, fem.created_at ASC`,
+      [userId, startDate, endDate]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function deleteFoodEntryMeal(foodEntryMealId: any, userId: any) {
   log(
@@ -235,11 +257,13 @@ export { createFoodEntryMeal };
 export { updateFoodEntryMeal };
 export { getFoodEntryMealById };
 export { getFoodEntryMealsByDate };
+export { getFoodEntryMealsByDateRange };
 export { deleteFoodEntryMeal };
 export default {
   createFoodEntryMeal,
   updateFoodEntryMeal,
   getFoodEntryMealById,
   getFoodEntryMealsByDate,
+  getFoodEntryMealsByDateRange,
   deleteFoodEntryMeal,
 };

--- a/SparkyFitnessServer/models/goalRepository.ts
+++ b/SparkyFitnessServer/models/goalRepository.ts
@@ -224,6 +224,24 @@ async function deleteDefaultGoal(userId: any) {
     client.release();
   }
 }
+// Compact goal history (one row per user_goals record, newest first). Backs
+// the chatbot list_goal_timeline action.
+async function getGoalTimeline(userId: string) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT id, goal_date, calories, protein, carbs, fat, water_goal_ml
+       FROM user_goals
+       WHERE user_id = $1
+       ORDER BY goal_date DESC`,
+      [userId]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
 export { getGoalByDate };
 export { getMostRecentGoalBeforeDate };
 export { getAllHistoricalGoals };
@@ -231,6 +249,7 @@ export { upsertGoal };
 export { deleteGoalsInRange };
 export { deleteDefaultGoal };
 export { getGoalsInRange };
+export { getGoalTimeline };
 export default {
   getGoalByDate,
   getMostRecentGoalBeforeDate,
@@ -239,4 +258,5 @@ export default {
   deleteGoalsInRange,
   deleteDefaultGoal,
   getGoalsInRange,
+  getGoalTimeline,
 };

--- a/SparkyFitnessServer/models/habitRepository.ts
+++ b/SparkyFitnessServer/models/habitRepository.ts
@@ -1,0 +1,92 @@
+import { getClient } from '../db/poolManager.js';
+
+// Habits are custom_categories rows with data_type = 'boolean'; completions
+// are custom_measurements rows with value 'true'/'false'. Used by the chatbot
+// habit tools (ai/tools/habitTools.ts).
+
+async function listHabits(userId: string) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT id, name, display_name, measurement_type, frequency, data_type
+       FROM custom_categories
+       WHERE user_id = $1 AND data_type = 'boolean'
+       ORDER BY name ASC`,
+      [userId]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+async function upsertHabitLog(
+  userId: string,
+  habitId: string,
+  entryDate: string,
+  value: string
+) {
+  const client = await getClient(userId);
+  try {
+    // Check if an entry exists first to avoid ON CONFLICT errors if the
+    // unique constraint is missing
+    const existing = await client.query(
+      'SELECT id FROM custom_measurements WHERE user_id = $1 AND category_id = $2 AND entry_date = $3 LIMIT 1',
+      [userId, habitId, entryDate]
+    );
+
+    if (existing.rows.length > 0) {
+      await client.query(
+        'UPDATE custom_measurements SET value = $1, updated_at = NOW() WHERE id = $2',
+        [value, existing.rows[0].id]
+      );
+    } else {
+      await client.query(
+        `INSERT INTO custom_measurements (user_id, category_id, value, entry_date, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, NOW(), NOW())`,
+        [userId, habitId, value, entryDate]
+      );
+    }
+  } finally {
+    client.release();
+  }
+}
+
+async function getHabitHistory(
+  userId: string,
+  habitId: string,
+  startDate?: string,
+  endDate?: string
+) {
+  const client = await getClient(userId);
+  try {
+    let query = `
+      SELECT id, value, entry_date, created_at
+      FROM custom_measurements
+      WHERE user_id = $1 AND category_id = $2
+    `;
+    const queryParams: unknown[] = [userId, habitId];
+    let paramIdx = 3;
+
+    if (startDate) {
+      query += ` AND entry_date >= $${paramIdx}`;
+      queryParams.push(startDate);
+      paramIdx++;
+    }
+    if (endDate) {
+      query += ` AND entry_date <= $${paramIdx}`;
+      queryParams.push(endDate);
+      paramIdx++;
+    }
+
+    query += ' ORDER BY entry_date ASC';
+
+    const result = await client.query(query, queryParams);
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
+export { listHabits, upsertHabitLog, getHabitHistory };
+export default { listHabits, upsertHabitLog, getHabitHistory };

--- a/SparkyFitnessServer/models/measurementRepository.ts
+++ b/SparkyFitnessServer/models/measurementRepository.ts
@@ -1048,6 +1048,44 @@ async function updateWaterIntakeLogTime(
   }
 }
 
+// Per-day water totals over an optional date range (both bounds optional;
+// no bounds returns the full history). Used by the chatbot get_water_history
+// action.
+async function getWaterTotalsByDateRange(
+  userId: string,
+  startDate?: string,
+  endDate?: string
+) {
+  const client = await getClient(userId);
+  try {
+    let query = `
+      SELECT entry_date, SUM(water_ml) as total_ml
+      FROM water_intake_entries
+      WHERE user_id = $1
+    `;
+    const queryParams: unknown[] = [userId];
+    let paramIdx = 2;
+
+    if (startDate) {
+      query += ` AND entry_date >= $${paramIdx}`;
+      queryParams.push(startDate);
+      paramIdx++;
+    }
+    if (endDate) {
+      query += ` AND entry_date <= $${paramIdx}`;
+      queryParams.push(endDate);
+      paramIdx++;
+    }
+
+    query += ' GROUP BY entry_date ORDER BY entry_date ASC';
+
+    const result = await client.query(query, queryParams);
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
 export default {
   upsertStepData,
   upsertWaterData,
@@ -1063,6 +1101,7 @@ export default {
   deleteWaterIntakeLog,
   getWaterIntakeLogEntryOwnerId,
   updateWaterIntakeLogTime,
+  getWaterTotalsByDateRange,
   upsertCheckInMeasurements,
   getCheckInMeasurementsByDate,
   updateCheckInMeasurements,

--- a/SparkyFitnessServer/models/reportRepository.ts
+++ b/SparkyFitnessServer/models/reportRepository.ts
@@ -592,6 +592,48 @@ async function getExerciseNames(userId: any, muscle: any, equipment: any) {
     client.release();
   }
 }
+// Per-day nutrition totals (macros + micros) over a date range, scaled by
+// quantity / serving_size since food_entries snapshots store unscaled
+// per-serving values. Backs the chatbot get_nutritional_summary action and
+// report tools.
+async function getDailyNutritionTotalsRange(
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT entry_date,
+              SUM(calories * quantity / NULLIF(serving_size, 0)) as calories,
+              SUM(protein * quantity / NULLIF(serving_size, 0)) as protein,
+              SUM(carbs * quantity / NULLIF(serving_size, 0)) as carbs,
+              SUM(fat * quantity / NULLIF(serving_size, 0)) as fat,
+              SUM(saturated_fat * quantity / NULLIF(serving_size, 0)) as saturated_fat,
+              SUM(polyunsaturated_fat * quantity / NULLIF(serving_size, 0)) as polyunsaturated_fat,
+              SUM(monounsaturated_fat * quantity / NULLIF(serving_size, 0)) as monounsaturated_fat,
+              SUM(trans_fat * quantity / NULLIF(serving_size, 0)) as trans_fat,
+              SUM(cholesterol * quantity / NULLIF(serving_size, 0)) as cholesterol,
+              SUM(sodium * quantity / NULLIF(serving_size, 0)) as sodium,
+              SUM(potassium * quantity / NULLIF(serving_size, 0)) as potassium,
+              SUM(dietary_fiber * quantity / NULLIF(serving_size, 0)) as fiber,
+              SUM(sugars * quantity / NULLIF(serving_size, 0)) as sugar,
+              SUM(vitamin_a * quantity / NULLIF(serving_size, 0)) as vitamin_a,
+              SUM(vitamin_c * quantity / NULLIF(serving_size, 0)) as vitamin_c,
+              SUM(calcium * quantity / NULLIF(serving_size, 0)) as calcium,
+              SUM(iron * quantity / NULLIF(serving_size, 0)) as iron
+       FROM food_entries
+       WHERE user_id = $1 AND entry_date >= $2 AND entry_date <= $3
+       GROUP BY entry_date
+       ORDER BY entry_date ASC`,
+      [userId, startDate, endDate]
+    );
+    return result.rows;
+  } finally {
+    client.release();
+  }
+}
+
 export { getNutritionData };
 export { getTabularFoodData };
 export { getMeasurementData };
@@ -599,6 +641,7 @@ export { getCustomMeasurementsData };
 export { getMiniNutritionTrends };
 export { getExerciseEntries };
 export { getExerciseNames };
+export { getDailyNutritionTotalsRange };
 export default {
   getNutritionData,
   getTabularFoodData,
@@ -607,4 +650,5 @@ export default {
   getMiniNutritionTrends,
   getExerciseEntries,
   getExerciseNames,
+  getDailyNutritionTotalsRange,
 };

--- a/SparkyFitnessServer/models/userRepository.ts
+++ b/SparkyFitnessServer/models/userRepository.ts
@@ -147,6 +147,46 @@ async function updateUserProfile(
     client.release();
   }
 }
+// Account fields on the Better Auth "user" table; backs the chatbot profile
+// tools (ai/tools/profileTools.ts).
+async function getAuthUserProfile(userId: string) {
+  const client = await getClient(userId); // User-specific operation
+  try {
+    const result = await client.query(
+      'SELECT id, email, name, image FROM "user" WHERE id = $1',
+      [userId]
+    );
+    return result.rows[0];
+  } finally {
+    client.release();
+  }
+}
+// Partial COALESCE update of the Better Auth "user" row. Note: unlike
+// updateUserEmail, an email change here does not update account.account_id
+// for credential logins.
+async function updateAuthUserProfile(
+  userId: string,
+  name: string | null,
+  email: string | null,
+  image: string | null
+) {
+  const client = await getClient(userId); // User-specific operation
+  try {
+    const result = await client.query(
+      `UPDATE "user"
+       SET name = COALESCE($2, name),
+           email = COALESCE($3, email),
+           image = COALESCE($4, image),
+           updated_at = now()
+       WHERE id = $1
+       RETURNING id, email, name, image`,
+      [userId, name, email, image]
+    );
+    return result.rows[0];
+  } finally {
+    client.release();
+  }
+}
 async function updateUserPassword(userId: string, hashedPassword: string) {
   const client = await getClient(userId); // User-specific operation
   try {
@@ -515,6 +555,8 @@ export { findUserIdByEmail };
 export { getAccessibleUsers };
 export { getUserProfile };
 export { updateUserProfile };
+export { getAuthUserProfile };
+export { updateAuthUserProfile };
 export { updateUserPassword };
 export { updateUserEmail };
 export { getUserRole };
@@ -543,6 +585,8 @@ export default {
   getAccessibleUsers,
   getUserProfile,
   updateUserProfile,
+  getAuthUserProfile,
+  updateAuthUserProfile,
   updateUserPassword,
   updateUserEmail,
   getUserRole,

--- a/SparkyFitnessServer/package.json
+++ b/SparkyFitnessServer/package.json
@@ -23,12 +23,10 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.79",
     "@ai-sdk/google": "^3.0.79",
-    "@ai-sdk/mcp": "^1.0.43",
     "@ai-sdk/openai": "^3.0.65",
     "@better-auth/api-key": "^1.5.6",
     "@better-auth/passkey": "^1.5.6",
     "@better-auth/sso": "^1.5.6",
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "@workspace/shared": "workspace:*",
     "ai": "^6.0.191",
     "axios": "^1.13.2",

--- a/SparkyFitnessServer/routes/chatRoutes.ts
+++ b/SparkyFitnessServer/routes/chatRoutes.ts
@@ -99,7 +99,7 @@ router.post('/', authenticate, async (req, res, next) => {
       messages,
       service_config_id,
       req.userId,
-      req.headers
+      req.authenticatedUserId
     );
     return res.status(200).json({ content, action: actionType, executedTools });
   } catch (error) {
@@ -153,18 +153,12 @@ router.post('/', authenticate, async (req, res, next) => {
 router.post('/stream', authenticate, async (req, res, next) => {
   const { messages, service_config_id } = req.body;
   try {
-    const { result, mcpClient } = await chatService.processChatMessageStream(
+    const { result } = await chatService.processChatMessageStream(
       messages,
       service_config_id,
       req.userId,
-      req.headers
+      req.authenticatedUserId
     );
-
-    res.on('close', () => {
-      if (mcpClient) {
-        mcpClient.close().catch(() => {});
-      }
-    });
 
     result.pipeUIMessageStreamToResponse(res);
   } catch (error) {

--- a/SparkyFitnessServer/routes/chatRoutes.ts
+++ b/SparkyFitnessServer/routes/chatRoutes.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { pipeUIMessageStreamToResponse } from 'ai';
 import { authenticate } from '../middleware/authMiddleware.js';
 import chatService from '../services/chatService.js';
 import type { FoodOptionsErrorCategory } from '../services/chatService.js';
@@ -153,14 +154,14 @@ router.post('/', authenticate, async (req, res, next) => {
 router.post('/stream', authenticate, async (req, res, next) => {
   const { messages, service_config_id } = req.body;
   try {
-    const { result } = await chatService.processChatMessageStream(
+    const { stream } = await chatService.processChatMessageStream(
       messages,
       service_config_id,
       req.userId,
       req.authenticatedUserId
     );
 
-    result.pipeUIMessageStreamToResponse(res);
+    pipeUIMessageStreamToResponse({ response: res, stream });
   } catch (error) {
     next(error);
   }

--- a/SparkyFitnessServer/routes/v2/foodRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/foodRoutes.ts
@@ -8,164 +8,34 @@ import {
 import { log } from '../../config/logging.js';
 import checkPermissionMiddleware from '../../middleware/checkPermissionMiddleware.js';
 import foodCoreService from '../../services/foodCoreService.js';
-import externalProviderService from '../../services/externalProviderService.js';
 import preferenceService from '../../services/preferenceService.js';
 import {
-  searchOpenFoodFacts,
+  isValidProviderType,
+  resolveOpenFoodFactsProviderId,
+  resolveProviderCredentials,
+  searchProviderFoods,
+} from '../../services/externalFoodSearchService.js';
+import {
   searchOpenFoodFactsByBarcodeFields,
   mapOpenFoodFactsProduct,
 } from '../../integrations/openfoodfacts/openFoodFactsService.js';
 import {
-  searchUsdaFoods,
   getUsdaFoodDetails,
   mapUsdaBarcodeProduct,
 } from '../../integrations/usda/usdaService.js';
+import { mapFatSecretFood } from '../../integrations/fatsecret/fatsecretService.js';
+import { getYazioFoodDetails } from '../../integrations/yazio/yazioService.js';
+import { getSwissFoodDetails } from '../../integrations/swissfood/swissFoodService.js';
 import {
-  mapFatSecretFood,
-  mapFatSecretSearchItem,
-} from '../../integrations/fatsecret/fatsecretService.js';
-import {
-  searchYazioFoods,
-  getYazioFoodDetails,
-} from '../../integrations/yazio/yazioService.js';
-import {
-  searchSwissFoods,
-  getSwissFoodDetails,
-} from '../../integrations/swissfood/swissFoodService.js';
-import {
-  searchFatSecretFoods,
   getFatSecretNutrients,
-  searchMealieFoods,
   getMealieFoodDetails,
-  searchTandoorFoods,
   getTandoorFoodDetails,
-  searchNorishFoods,
   getNorishFoodDetails,
 } from '../../services/foodIntegrationService.js';
 
 const router = express.Router();
 
 router.use(checkPermissionMiddleware('diary'));
-
-const VALID_PROVIDER_TYPES = [
-  'openfoodfacts',
-  'usda',
-  'fatsecret',
-  'mealie',
-  'tandoor',
-  'yazio',
-  'norish',
-  'swissfood',
-] as const;
-
-type ProviderType = (typeof VALID_PROVIDER_TYPES)[number];
-
-function isValidProviderType(value: string): value is ProviderType {
-  return (VALID_PROVIDER_TYPES as readonly string[]).includes(value);
-}
-
-interface ProviderCredentials {
-  app_id?: string;
-  app_key?: string;
-  base_url?: string;
-  is_active?: boolean;
-}
-
-// Resolve an OFF providerId for session-cookie auth. Unlike other providers,
-// OFF does not need credentials to function — this just opts into the
-// authenticated request path when the user has configured an OFF account.
-// Returns the provided id (validated for ownership) or the user's first
-// credentialed OFF provider, or null.
-async function resolveOpenFoodFactsProviderId(
-  userId: string,
-  providerId: string | undefined
-): Promise<string | null> {
-  if (providerId) {
-    try {
-      const details =
-        await externalProviderService.getExternalDataProviderDetails(
-          userId,
-          providerId
-        );
-      if (
-        details &&
-        details.is_active &&
-        details.provider_type === 'openfoodfacts' &&
-        details.app_id &&
-        details.app_key
-      ) {
-        return providerId;
-      }
-    } catch (error) {
-      log('debug', 'v2 OFF providerId validation failed:', error);
-    }
-    return null;
-  }
-  return externalProviderService.getActiveOpenFoodFactsProviderId(userId);
-}
-
-async function resolveProviderCredentials(
-  userId: string,
-  providerId: string | undefined,
-  providerType: ProviderType
-): Promise<ProviderCredentials> {
-  if (providerType === 'openfoodfacts') {
-    return {};
-  }
-
-  if (providerType === 'swissfood' && !providerId) {
-    return {};
-  }
-
-  if (!providerId) {
-    throw Object.assign(new Error('Missing providerId query parameter'), {
-      status: 400,
-    });
-  }
-
-  const details = await externalProviderService.getExternalDataProviderDetails(
-    userId,
-    providerId
-  );
-
-  if (!details || !details.is_active) {
-    throw Object.assign(new Error('Provider not found or is inactive'), {
-      status: 400,
-    });
-  }
-
-  // Guard against Tandoor misconfiguration where app_key contains a URL
-  if (providerType === 'tandoor' && typeof details.app_key === 'string') {
-    const key = details.app_key;
-    if (
-      key.startsWith('http://') ||
-      key.startsWith('https://') ||
-      key.includes('/settings') ||
-      key.includes('/api/')
-    ) {
-      throw Object.assign(
-        new Error(
-          'Tandoor provider configuration appears to have a URL in the app_key field. ' +
-            'Please set the actual Tandoor API token (e.g. tda_...) as the provider app_key.'
-        ),
-        { status: 400 }
-      );
-    }
-  }
-
-  return {
-    app_id: details.app_id ?? undefined,
-    app_key: details.app_key ?? undefined,
-    base_url: details.base_url ?? undefined,
-  };
-}
-
-const EMPTY_PAGINATION = (page: number, pageSize: number) => ({
-  page,
-  pageSize,
-  totalCount: 0,
-  hasMore: false,
-});
 
 function nullToUndefined<T>(value: T | null | undefined): T | undefined {
   return value === null ? undefined : value;
@@ -333,163 +203,15 @@ const searchHandler: RequestHandler<{ providerType: string }> = async (
   const page = Number(req.query.page) || 1;
   const pageSize = Number(req.query.pageSize) || 20;
   const providerId = req.query.providerId as string | undefined;
+  const autoScale = ((req.query.autoScale as string) ?? 'true') !== 'false';
 
   try {
-    const credentials = await resolveProviderCredentials(
+    const { foods, pagination } = await searchProviderFoods(
       req.userId,
-      providerId,
-      providerType
+      providerType,
+      query,
+      { page, pageSize, providerId, autoScale }
     );
-    const userPrefs = await preferenceService.getUserPreferences(
-      req.userId,
-
-      req.userId
-    );
-    const language = userPrefs?.language || 'en';
-
-    let foods: unknown[] = [];
-    let pagination = EMPTY_PAGINATION(page, pageSize);
-
-    switch (providerType) {
-      case 'openfoodfacts': {
-        const autoScale =
-          ((req.query.autoScale as string) ?? 'true') !== 'false';
-        const offProviderId = await resolveOpenFoodFactsProviderId(
-          req.userId,
-          providerId
-        );
-        const result = await searchOpenFoodFacts(
-          query,
-          page,
-          language,
-
-          offProviderId ? req.userId : undefined,
-          offProviderId || undefined
-        );
-        const products = (result.products || []).filter(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (p: Record<string, any>) =>
-            p.product_name || p[`product_name_${language}`] || p.product_name_en
-        );
-        foods = products
-          .map((p: Record<string, unknown>) =>
-            mapOpenFoodFactsProduct(p, { autoScale, language })
-          )
-          .filter(Boolean);
-        pagination = result.pagination;
-        break;
-      }
-
-      case 'usda': {
-        const result = await searchUsdaFoods(
-          query,
-          credentials.app_key,
-          page,
-          pageSize
-        );
-        const items = result.foods || [];
-        foods = items.map(mapUsdaBarcodeProduct).filter(Boolean);
-        pagination = result.pagination;
-        break;
-      }
-
-      case 'fatsecret': {
-        const result = await searchFatSecretFoods(
-          query,
-          credentials.app_id,
-          credentials.app_key,
-          page
-        );
-        const rawFoods = result.foods?.food;
-        const items = Array.isArray(rawFoods)
-          ? rawFoods
-          : rawFoods
-            ? [rawFoods]
-            : [];
-        foods = items.map(mapFatSecretSearchItem).filter(Boolean);
-        pagination = result.pagination;
-        break;
-      }
-
-      case 'mealie': {
-        const result = await searchMealieFoods(
-          query,
-          credentials.base_url,
-          credentials.app_key,
-
-          req.userId,
-          providerId,
-          page
-        );
-        foods = result.items || [];
-        pagination = result.pagination;
-        break;
-      }
-
-      case 'tandoor': {
-        const results = await searchTandoorFoods(
-          query,
-          credentials.base_url,
-          credentials.app_key,
-
-          req.userId,
-          providerId
-        );
-        foods = results || [];
-        pagination = {
-          page: 1,
-          pageSize: foods.length,
-          totalCount: foods.length,
-          hasMore: false,
-        };
-        break;
-      }
-
-      case 'norish': {
-        const results = await searchNorishFoods(
-          query,
-          credentials.base_url,
-          credentials.app_key,
-
-          req.userId,
-          providerId
-        );
-        foods = results || [];
-        pagination = {
-          page: 1,
-          pageSize: foods.length,
-          totalCount: foods.length,
-          hasMore: false,
-        };
-        break;
-      }
-
-      case 'yazio': {
-        const result = await searchYazioFoods(query, {
-          username: credentials.app_id,
-          password: credentials.app_key,
-          baseUrl: credentials.base_url,
-          page,
-          pageSize,
-        });
-        foods = result.foods || [];
-        pagination = result.pagination;
-        break;
-      }
-
-      case 'swissfood': {
-        const result = await searchSwissFoods(
-          query,
-          page,
-          pageSize,
-          language,
-          credentials.base_url || undefined
-        );
-        foods = result.foods || [];
-        pagination = result.pagination;
-        break;
-      }
-    }
 
     const normalizedFoods = foods.map((food) => normalizeFoodForResponse(food));
     const response = SearchResponseSchema.parse({

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -15,8 +15,6 @@ import {
   SparkyChatHistory,
   SparkyChatHistoryMutator,
 } from '@workspace/shared';
-import { IncomingHttpHeaders } from 'http';
-import { experimental_createMCPClient as createMCPClient } from '@ai-sdk/mcp';
 
 interface ChatMessagePart {
   type: 'text' | 'image' | 'image_url' | 'file';
@@ -41,12 +39,11 @@ interface ChatMessage {
   parts?: ChatMessagePart[];
 }
 
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { generateText, streamText, stepCountIs } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
-import path from 'path';
+import { buildChatbotTools } from '../ai/tools/index.js';
 
 async function handleAiServiceSettings(
   action: string,
@@ -314,74 +311,38 @@ async function saveSparkyChatHistory(
     throw error;
   }
 }
-async function getMcpClient(reqHeaders?: IncomingHttpHeaders) {
-  const mcpUrl = process.env.SPARKY_FITNESS_MCP_URL;
+/**
+ * Loads the per-user chat context shared by the blocking and streaming paths:
+ * the system prompt (custom categories + timezone) and the in-process tool
+ * registry. Everything is scoped to the authenticated user — chat tool calls
+ * always act as the logged-in actor, matching the previous MCP behavior.
+ */
+async function prepareChatContext(authenticatedUserId: string) {
+  const [customCategories, chatTz] = await Promise.all([
+    measurementRepository.getCustomCategories(authenticatedUserId),
+    loadUserTimezone(authenticatedUserId),
+  ]);
 
-  if (mcpUrl) {
-    const mcpEndpoint = mcpUrl.endsWith('/mcp') ? mcpUrl : `${mcpUrl}/mcp`;
-    // Forward the user's authorization and cookies to MCP
-    const headers: Record<string, string> = {};
-    if (reqHeaders?.authorization) {
-      headers['authorization'] = reqHeaders.authorization;
-    }
-    if (reqHeaders?.cookie) {
-      headers['cookie'] = reqHeaders.cookie;
-    }
-    // Forward proxy headers so Better Auth accepts secure cookies over internal HTTP
-    const isHttps =
-      process.env.SPARKY_FITNESS_FRONTEND_URL?.startsWith('https');
-    const protoHeader = reqHeaders?.['x-forwarded-proto'];
-    const resolvedProto = Array.isArray(protoHeader)
-      ? protoHeader[0]
-      : protoHeader;
-    headers['x-forwarded-proto'] =
-      resolvedProto || (isHttps ? 'https' : 'http');
-    const hostHeader = reqHeaders?.['x-forwarded-host'];
-    const resolvedHost = Array.isArray(hostHeader) ? hostHeader[0] : hostHeader;
-    if (resolvedHost) {
-      headers['x-forwarded-host'] = resolvedHost;
-    }
-    // If a server-level API key is configured, prefer it over session forwarding
-    // for the server→MCP internal call (useful when cookie auth fails over plain
-    // internal Docker HTTP). Mirrors the same priority logic in the stdio path.
-    if (process.env.SPARKY_FITNESS_API_KEY) {
-      headers['x-api-key'] = process.env.SPARKY_FITNESS_API_KEY;
-    }
-    log('info', `Connecting to MCP server over HTTP: ${mcpEndpoint}`);
-    return await createMCPClient({
-      transport: {
-        type: 'http',
-        url: mcpEndpoint,
-        headers,
-      },
-    });
-  } else {
-    // Fallback for local Stdio transport (CLI mode / developer convenience)
-    log('info', 'Connecting to MCP server via local Stdio transport');
-    const indexCjsPath = path.resolve(
-      process.cwd(),
-      '../SparkyFitnessMCP/dist/index.cjs'
-    );
-    return await createMCPClient({
-      transport: new StdioClientTransport({
-        command: 'node',
-        args: [indexCjsPath],
-        env: {
-          ...process.env,
-          // For n8n / external tools: use server-level API key if configured.
-          // For frontend sessions: forward the user's cookie so the MCP
-          // process can authenticate via the existing session.
-          ...(process.env.SPARKY_FITNESS_API_KEY
-            ? { SPARKY_FITNESS_API_KEY: process.env.SPARKY_FITNESS_API_KEY }
-            : {
-                Authorization: reqHeaders?.authorization || '',
-                Cookie: reqHeaders?.cookie || '',
-              }),
-          MCP_TRANSPORT: 'stdio',
-        },
-      }),
-    });
-  }
+  const customCategoriesList =
+    customCategories.length > 0
+      ? customCategories
+          .map(
+            (cat: DatabaseCustomCategories) =>
+              `- ${cat.name} (${cat.measurement_type}, ${cat.frequency})`
+          )
+          .join('\n')
+      : 'None';
+
+  const tools = buildChatbotTools(authenticatedUserId);
+  log(
+    'info',
+    `Loaded ${Object.keys(tools).length} tools for chatbot: ${Object.keys(tools).join(', ')}`
+  );
+
+  return {
+    systemPromptContent: getSystemPrompt(chatTz, customCategoriesList),
+    tools,
+  };
 }
 
 function getSystemPrompt(chatTz: string, customCategoriesList: string): string {
@@ -420,10 +381,9 @@ Be precise with data extraction and call the correct tools in the correct order.
 async function processChatMessage(
   messages: ChatMessage[],
   serviceConfigId: string,
-  authenticatedUserId: string,
-  reqHeaders?: IncomingHttpHeaders
+  userId: string,
+  authenticatedUserId: string
 ) {
-  let mcpClient: Awaited<ReturnType<typeof getMcpClient>> | undefined;
   try {
     if (!Array.isArray(messages) || messages.length === 0) {
       throw new Error('Invalid messages format.');
@@ -433,7 +393,7 @@ async function processChatMessage(
     }
     const aiService = await chatRepository.getAiServiceSettingForBackend(
       serviceConfigId,
-      authenticatedUserId
+      userId
     );
     if (!aiService) {
       throw new Error('AI service setting not found for the provided ID.');
@@ -442,7 +402,7 @@ async function processChatMessage(
     const source = aiService.source || 'unknown';
     log(
       'info',
-      `Processing chat message for user ${authenticatedUserId} using AI service from ${source} (ID: ${serviceConfigId})`
+      `Processing chat message for user ${userId} using AI service from ${source} (ID: ${serviceConfigId})`
     );
 
     if (aiService.service_type !== 'ollama' && !aiService.api_key) {
@@ -493,47 +453,8 @@ async function processChatMessage(
       throw new Error(`Unsupported service type: ${aiService.service_type}`);
     }
 
-    // Connect to MCP Server using helper function
-    mcpClient = await getMcpClient(reqHeaders);
-
-    // Load user context (categories, timezone)
-    const [customCategories, chatTz] = await Promise.all([
-      measurementRepository.getCustomCategories(authenticatedUserId),
-      loadUserTimezone(authenticatedUserId),
-    ]);
-
-    const customCategoriesList =
-      customCategories.length > 0
-        ? customCategories
-            .map(
-              (cat: DatabaseCustomCategories) =>
-                `- ${cat.name} (${cat.measurement_type}, ${cat.frequency})`
-            )
-            .join('\n')
-        : 'None';
-
-    const systemPromptContent = getSystemPrompt(chatTz, customCategoriesList);
-
-    // Retrieve and filter tools from MCP server
-    const allTools = await mcpClient.tools();
-
-    // Filter developer/test tools out
-    const chatbotTools: NonNullable<
-      Parameters<typeof generateText>[0]['tools']
-    > = {};
-    for (const [key, tool] of Object.entries(allTools)) {
-      const isBlocked = [
-        'sparky_run_project_tests',
-        'sparky_inspect_schema',
-      ].includes(key);
-      if (!isBlocked) {
-        chatbotTools[key] = tool;
-      }
-    }
-    log(
-      'info',
-      `Loaded ${Object.keys(chatbotTools).length} tools for chatbot: ${Object.keys(chatbotTools).join(', ')}`
-    );
+    const { systemPromptContent, tools } =
+      await prepareChatContext(authenticatedUserId);
 
     // Map conversation history messages to CoreMessage format
     const conversationMessages = messages.map((msg: ChatMessage) => {
@@ -662,22 +583,18 @@ async function processChatMessage(
       messages: conversationMessages as NonNullable<
         Parameters<typeof generateText>[0]['messages']
       >,
-      tools: chatbotTools,
+      tools,
       stopWhen: stepCountIs(50),
       onStepFinish({ toolCalls }) {
         if (toolCalls && toolCalls.length > 0) {
           toolCalls.forEach((call) => {
-            const toolCall = call as unknown as {
-              toolName: string;
-              args: Record<string, unknown>;
-            };
             log(
               'info',
-              `Agent executed tool call: ${toolCall.toolName} with args: ${JSON.stringify(toolCall.args)}`
+              `Agent executed tool call: ${call.toolName} with args: ${JSON.stringify(call.input)}`
             );
             executedToolsList.push({
-              name: toolCall.toolName,
-              args: toolCall.args,
+              name: call.toolName,
+              args: call.input as Record<string, unknown>,
             });
           });
         }
@@ -699,7 +616,7 @@ async function processChatMessage(
 
     await chatRepository
       .saveChatHistory({
-        user_id: authenticatedUserId,
+        user_id: userId,
         content: userMessageContent,
         messageType: 'user',
         parts: userMessageParts,
@@ -710,7 +627,7 @@ async function processChatMessage(
 
     await chatRepository
       .saveChatHistory({
-        user_id: authenticatedUserId,
+        user_id: userId,
         content: result.text,
         messageType: 'assistant',
         parts: [{ type: 'text', text: result.text }],
@@ -765,16 +682,8 @@ async function processChatMessage(
       executedTools: executedToolsList,
     };
   } catch (error) {
-    log(
-      'error',
-      `Error processing chat message for user ${authenticatedUserId}:`,
-      error
-    );
+    log('error', `Error processing chat message for user ${userId}:`, error);
     throw error;
-  } finally {
-    if (mcpClient) {
-      await mcpClient.close().catch(() => {});
-    }
   }
 }
 const FOOD_OPTIONS_PROMPT = `You are Sparky, an AI nutrition and wellness coach. Your task is to generate minimum 3 realistic food options in JSON format when requested. Respond ONLY with a JSON array of FoodOption objects, including detailed nutritional information for EVERY field (calories, protein, carbs, fat, saturated_fat, polyunsaturated_fat, monounsaturated_fat, trans_fat, cholesterol, sodium, potassium, dietary_fiber, sugars, vitamin_a, vitamin_c, calcium, iron). **CRITICAL: You MUST estimate and populate every single micro-nutritional field. Do NOT default to 0 or leave blank any nutritional field if a realistic scientific estimation can be made based on the food type. Use your biochemical and culinary knowledge to calculate typical distributions.** Do NOT include any other text.
@@ -857,10 +766,9 @@ async function processFoodOptionsRequest(
 async function processChatMessageStream(
   messages: ChatMessage[],
   serviceConfigId: string,
-  authenticatedUserId: string,
-  reqHeaders?: IncomingHttpHeaders
+  userId: string,
+  authenticatedUserId: string
 ) {
-  let mcpClient: Awaited<ReturnType<typeof getMcpClient>> | undefined;
   try {
     if (!Array.isArray(messages) || messages.length === 0) {
       throw new Error('Invalid messages format.');
@@ -870,7 +778,7 @@ async function processChatMessageStream(
     }
     const aiService = await chatRepository.getAiServiceSettingForBackend(
       serviceConfigId,
-      authenticatedUserId
+      userId
     );
     if (!aiService) {
       throw new Error('AI service setting not found for the provided ID.');
@@ -922,42 +830,8 @@ async function processChatMessageStream(
       throw new Error(`Unsupported service type: ${aiService.service_type}`);
     }
 
-    // Connect to MCP Server using helper function
-    mcpClient = await getMcpClient(reqHeaders);
-
-    const [customCategories, chatTz] = await Promise.all([
-      measurementRepository.getCustomCategories(authenticatedUserId),
-      loadUserTimezone(authenticatedUserId),
-    ]);
-
-    const customCategoriesList =
-      customCategories.length > 0
-        ? customCategories
-            .map(
-              (cat: DatabaseCustomCategories) =>
-                `- ${cat.name} (${cat.measurement_type}, ${cat.frequency})`
-            )
-            .join('\n')
-        : 'None';
-
-    const systemPromptContent = getSystemPrompt(chatTz, customCategoriesList);
-
-    const allTools = await mcpClient.tools();
-    const chatbotTools: NonNullable<Parameters<typeof streamText>[0]['tools']> =
-      {};
-    for (const [key, tool] of Object.entries(allTools)) {
-      const isBlocked = [
-        'sparky_run_project_tests',
-        'sparky_inspect_schema',
-      ].includes(key);
-      if (!isBlocked) {
-        chatbotTools[key] = tool;
-      }
-    }
-    log(
-      'info',
-      `Loaded ${Object.keys(chatbotTools).length} tools for chatbot: ${Object.keys(chatbotTools).join(', ')}`
-    );
+    const { systemPromptContent, tools } =
+      await prepareChatContext(authenticatedUserId);
 
     const conversationMessages = messages.map((msg: ChatMessage) => {
       // If parts or content is an array of parts (text + images), pass them through
@@ -1060,14 +934,9 @@ async function processChatMessageStream(
       messages: llmMessages as NonNullable<
         Parameters<typeof streamText>[0]['messages']
       >,
-      tools: chatbotTools,
+      tools,
       stopWhen: stepCountIs(50),
       onFinish: async ({ text }) => {
-        // Close MCP Client
-        if (mcpClient) {
-          await mcpClient.close().catch(() => {});
-        }
-
         // Get the last user message from conversationMessages to ensure parts are captured
         const lastUserMessage = [...conversationMessages]
           .reverse()
@@ -1085,7 +954,7 @@ async function processChatMessageStream(
         // Save to DB on completion
         await chatRepository
           .saveChatHistory({
-            user_id: authenticatedUserId,
+            user_id: userId,
             content: userMessageContent,
             messageType: 'user',
             parts: userMessageParts,
@@ -1096,7 +965,7 @@ async function processChatMessageStream(
 
         await chatRepository
           .saveChatHistory({
-            user_id: authenticatedUserId,
+            user_id: userId,
             content: text,
             messageType: 'assistant',
             parts: [{ type: 'text', text }],
@@ -1107,14 +976,11 @@ async function processChatMessageStream(
       },
     });
 
-    return { result, mcpClient };
+    return { result };
   } catch (error) {
-    if (mcpClient) {
-      await mcpClient.close().catch(() => {});
-    }
     log(
       'error',
-      `Error in processChatMessageStream for user ${authenticatedUserId}:`,
+      `Error in processChatMessageStream for user ${userId}:`,
       error
     );
     throw error;

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -333,7 +333,7 @@ async function prepareChatContext(authenticatedUserId: string) {
           .join('\n')
       : 'None';
 
-  const tools = buildChatbotTools(authenticatedUserId);
+  const tools = buildChatbotTools(authenticatedUserId, chatTz);
   log(
     'info',
     `Loaded ${Object.keys(tools).length} tools for chatbot: ${Object.keys(tools).join(', ')}`

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -40,6 +40,7 @@ interface ChatMessage {
 }
 
 import { generateText, streamText, stepCountIs } from 'ai';
+import type { UIMessageChunk } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
@@ -625,16 +626,23 @@ async function processChatMessage(
         log('error', 'Failed to save user chat history:', err)
       );
 
-    await chatRepository
-      .saveChatHistory({
-        user_id: userId,
-        content: result.text,
-        messageType: 'assistant',
-        parts: [{ type: 'text', text: result.text }],
-      })
-      .catch((err: unknown) =>
-        log('error', 'Failed to save assistant chat history:', err)
+    if (result.text.trim()) {
+      await chatRepository
+        .saveChatHistory({
+          user_id: userId,
+          content: result.text,
+          messageType: 'assistant',
+          parts: [{ type: 'text', text: result.text }],
+        })
+        .catch((err: unknown) =>
+          log('error', 'Failed to save assistant chat history:', err)
+        );
+    } else {
+      log(
+        'warn',
+        `Skipping empty assistant chat history for user ${userId} (finishReason: ${result.finishReason})`
       );
+    }
 
     // Determine the general action type based on executed tools
     let actionType = 'advice';
@@ -763,6 +771,42 @@ async function processFoodOptionsRequest(
   }
   return { success: true, content: result.text };
 }
+const EMPTY_RESPONSE_ERROR_TEXT =
+  'The AI service returned an empty response. Please try again.';
+
+// Some providers (notably Gemini via MALFORMED_FUNCTION_CALL) end a tool-calling
+// turn with finishReason 'error' and an empty completion instead of a thrown
+// error, so the stream closes cleanly and clients render nothing. Inject an
+// explicit error chunk so the UI surfaces a failure instead of staying silent.
+function withEmptyCompletionGuard(
+  stream: ReadableStream<UIMessageChunk>
+): ReadableStream<UIMessageChunk> {
+  let sawContent = false;
+  return stream.pipeThrough(
+    new TransformStream<UIMessageChunk, UIMessageChunk>({
+      transform(chunk, controller) {
+        if (
+          chunk.type === 'text-delta' ||
+          chunk.type === 'reasoning-delta' ||
+          chunk.type.startsWith('tool-')
+        ) {
+          sawContent = true;
+        }
+        if (
+          chunk.type === 'finish' &&
+          (chunk.finishReason === 'error' || !sawContent)
+        ) {
+          controller.enqueue({
+            type: 'error',
+            errorText: EMPTY_RESPONSE_ERROR_TEXT,
+          });
+        }
+        controller.enqueue(chunk);
+      },
+    })
+  );
+}
+
 async function processChatMessageStream(
   messages: ChatMessage[],
   serviceConfigId: string,
@@ -936,7 +980,7 @@ async function processChatMessageStream(
       >,
       tools,
       stopWhen: stepCountIs(50),
-      onFinish: async ({ text }) => {
+      onFinish: async ({ text, finishReason }) => {
         // Get the last user message from conversationMessages to ensure parts are captured
         const lastUserMessage = [...conversationMessages]
           .reverse()
@@ -963,6 +1007,14 @@ async function processChatMessageStream(
             log('error', 'Failed to save user chat history:', err)
           );
 
+        if (!text.trim()) {
+          log(
+            'warn',
+            `Skipping empty assistant chat history for user ${userId} (finishReason: ${finishReason})`
+          );
+          return;
+        }
+
         await chatRepository
           .saveChatHistory({
             user_id: userId,
@@ -976,7 +1028,7 @@ async function processChatMessageStream(
       },
     });
 
-    return { result };
+    return { stream: withEmptyCompletionGuard(result.toUIMessageStream()) };
   } catch (error) {
     log(
       'error',

--- a/SparkyFitnessServer/services/exerciseService.ts
+++ b/SparkyFitnessServer/services/exerciseService.ts
@@ -323,7 +323,8 @@ async function createExerciseEntry(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   actingUserId: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  entryData: any
+  entryData: any,
+  options: { skipDuplicateCheck?: boolean } = {}
 ) {
   try {
     const snapshotEntryData = await prepareExerciseEntryForCreate(
@@ -334,7 +335,10 @@ async function createExerciseEntry(
     const newEntry = await exerciseEntryDb.createExerciseEntry(
       authenticatedUserId,
       snapshotEntryData,
-      actingUserId
+      actingUserId,
+      'Manual',
+      null,
+      options
     );
     // If activity_details are provided, create them
     if (entryData.activity_details && entryData.activity_details.length > 0) {
@@ -478,6 +482,7 @@ async function updateExerciseEntry(
         distance: updateData.distance ?? existingEntry.distance,
         avg_heart_rate:
           updateData.avg_heart_rate ?? existingEntry.avg_heart_rate,
+        steps: updateData.steps ?? existingEntry.steps,
         sort_order: updateData.sort_order ?? existingEntry.sort_order,
         exercise_name: updateData.exercise_name ?? existingEntry.exercise_name,
       }

--- a/SparkyFitnessServer/services/externalFoodSearchService.ts
+++ b/SparkyFitnessServer/services/externalFoodSearchService.ts
@@ -1,0 +1,326 @@
+import { log } from '../config/logging.js';
+import externalProviderService from './externalProviderService.js';
+import preferenceService from './preferenceService.js';
+import {
+  searchOpenFoodFacts,
+  mapOpenFoodFactsProduct,
+} from '../integrations/openfoodfacts/openFoodFactsService.js';
+import {
+  searchUsdaFoods,
+  mapUsdaBarcodeProduct,
+} from '../integrations/usda/usdaService.js';
+import { mapFatSecretSearchItem } from '../integrations/fatsecret/fatsecretService.js';
+import { searchYazioFoods } from '../integrations/yazio/yazioService.js';
+import { searchSwissFoods } from '../integrations/swissfood/swissFoodService.js';
+import {
+  searchFatSecretFoods,
+  searchMealieFoods,
+  searchTandoorFoods,
+  searchNorishFoods,
+} from './foodIntegrationService.js';
+
+export const VALID_PROVIDER_TYPES = [
+  'openfoodfacts',
+  'usda',
+  'fatsecret',
+  'mealie',
+  'tandoor',
+  'yazio',
+  'norish',
+  'swissfood',
+] as const;
+
+export type ProviderType = (typeof VALID_PROVIDER_TYPES)[number];
+
+export function isValidProviderType(value: string): value is ProviderType {
+  return (VALID_PROVIDER_TYPES as readonly string[]).includes(value);
+}
+
+export interface ProviderCredentials {
+  app_id?: string;
+  app_key?: string;
+  base_url?: string;
+  is_active?: boolean;
+}
+
+// Resolve an OFF providerId for session-cookie auth. Unlike other providers,
+// OFF does not need credentials to function — this just opts into the
+// authenticated request path when the user has configured an OFF account.
+// Returns the provided id (validated for ownership) or the user's first
+// credentialed OFF provider, or null.
+export async function resolveOpenFoodFactsProviderId(
+  userId: string,
+  providerId: string | undefined
+): Promise<string | null> {
+  if (providerId) {
+    try {
+      const details =
+        await externalProviderService.getExternalDataProviderDetails(
+          userId,
+          providerId
+        );
+      if (
+        details &&
+        details.is_active &&
+        details.provider_type === 'openfoodfacts' &&
+        details.app_id &&
+        details.app_key
+      ) {
+        return providerId;
+      }
+    } catch (error) {
+      log('debug', 'v2 OFF providerId validation failed:', error);
+    }
+    return null;
+  }
+  return externalProviderService.getActiveOpenFoodFactsProviderId(userId);
+}
+
+export async function resolveProviderCredentials(
+  userId: string,
+  providerId: string | undefined,
+  providerType: ProviderType
+): Promise<ProviderCredentials> {
+  if (providerType === 'openfoodfacts') {
+    return {};
+  }
+
+  if (providerType === 'swissfood' && !providerId) {
+    return {};
+  }
+
+  if (!providerId) {
+    throw Object.assign(new Error('Missing providerId query parameter'), {
+      status: 400,
+    });
+  }
+
+  const details = await externalProviderService.getExternalDataProviderDetails(
+    userId,
+    providerId
+  );
+
+  if (!details || !details.is_active) {
+    throw Object.assign(new Error('Provider not found or is inactive'), {
+      status: 400,
+    });
+  }
+
+  // Guard against Tandoor misconfiguration where app_key contains a URL
+  if (providerType === 'tandoor' && typeof details.app_key === 'string') {
+    const key = details.app_key;
+    if (
+      key.startsWith('http://') ||
+      key.startsWith('https://') ||
+      key.includes('/settings') ||
+      key.includes('/api/')
+    ) {
+      throw Object.assign(
+        new Error(
+          'Tandoor provider configuration appears to have a URL in the app_key field. ' +
+            'Please set the actual Tandoor API token (e.g. tda_...) as the provider app_key.'
+        ),
+        { status: 400 }
+      );
+    }
+  }
+
+  return {
+    app_id: details.app_id ?? undefined,
+    app_key: details.app_key ?? undefined,
+    base_url: details.base_url ?? undefined,
+  };
+}
+
+export interface ProviderSearchPagination {
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  hasMore: boolean;
+}
+
+export interface ProviderSearchResult {
+  foods: unknown[];
+  pagination: ProviderSearchPagination;
+}
+
+export interface ProviderSearchOptions {
+  page?: number;
+  pageSize?: number;
+  providerId?: string;
+  autoScale?: boolean;
+}
+
+const EMPTY_PAGINATION = (
+  page: number,
+  pageSize: number
+): ProviderSearchPagination => ({
+  page,
+  pageSize,
+  totalCount: 0,
+  hasMore: false,
+});
+
+export async function searchProviderFoods(
+  userId: string,
+  providerType: ProviderType,
+  query: string,
+  opts: ProviderSearchOptions = {}
+): Promise<ProviderSearchResult> {
+  const page = opts.page ?? 1;
+  const pageSize = opts.pageSize ?? 20;
+  const providerId = opts.providerId;
+  const autoScale = opts.autoScale ?? true;
+
+  const credentials = await resolveProviderCredentials(
+    userId,
+    providerId,
+    providerType
+  );
+  const userPrefs = await preferenceService.getUserPreferences(userId, userId);
+  const language = userPrefs?.language || 'en';
+
+  let foods: unknown[] = [];
+  let pagination = EMPTY_PAGINATION(page, pageSize);
+
+  switch (providerType) {
+    case 'openfoodfacts': {
+      const offProviderId = await resolveOpenFoodFactsProviderId(
+        userId,
+        providerId
+      );
+      const result = await searchOpenFoodFacts(
+        query,
+        page,
+        language,
+
+        offProviderId ? userId : undefined,
+        offProviderId || undefined
+      );
+      const products = (result.products || []).filter(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (p: Record<string, any>) =>
+          p.product_name || p[`product_name_${language}`] || p.product_name_en
+      );
+      foods = products
+        .map((p: Record<string, unknown>) =>
+          mapOpenFoodFactsProduct(p, { autoScale, language })
+        )
+        .filter(Boolean);
+      pagination = result.pagination;
+      break;
+    }
+
+    case 'usda': {
+      const result = await searchUsdaFoods(
+        query,
+        credentials.app_key,
+        page,
+        pageSize
+      );
+      const items = result.foods || [];
+      foods = items.map(mapUsdaBarcodeProduct).filter(Boolean);
+      pagination = result.pagination;
+      break;
+    }
+
+    case 'fatsecret': {
+      const result = await searchFatSecretFoods(
+        query,
+        credentials.app_id,
+        credentials.app_key,
+        page
+      );
+      const rawFoods = result.foods?.food;
+      const items = Array.isArray(rawFoods)
+        ? rawFoods
+        : rawFoods
+          ? [rawFoods]
+          : [];
+      foods = items.map(mapFatSecretSearchItem).filter(Boolean);
+      pagination = result.pagination;
+      break;
+    }
+
+    case 'mealie': {
+      const result = await searchMealieFoods(
+        query,
+        credentials.base_url,
+        credentials.app_key,
+
+        userId,
+        providerId,
+        page
+      );
+      foods = result.items || [];
+      pagination = result.pagination;
+      break;
+    }
+
+    case 'tandoor': {
+      const results = await searchTandoorFoods(
+        query,
+        credentials.base_url,
+        credentials.app_key,
+
+        userId,
+        providerId
+      );
+      foods = results || [];
+      pagination = {
+        page: 1,
+        pageSize: foods.length,
+        totalCount: foods.length,
+        hasMore: false,
+      };
+      break;
+    }
+
+    case 'norish': {
+      const results = await searchNorishFoods(
+        query,
+        credentials.base_url,
+        credentials.app_key,
+
+        userId,
+        providerId
+      );
+      foods = results || [];
+      pagination = {
+        page: 1,
+        pageSize: foods.length,
+        totalCount: foods.length,
+        hasMore: false,
+      };
+      break;
+    }
+
+    case 'yazio': {
+      const result = await searchYazioFoods(query, {
+        username: credentials.app_id,
+        password: credentials.app_key,
+        baseUrl: credentials.base_url,
+        page,
+        pageSize,
+      });
+      foods = result.foods || [];
+      pagination = result.pagination;
+      break;
+    }
+
+    case 'swissfood': {
+      const result = await searchSwissFoods(
+        query,
+        page,
+        pageSize,
+        language,
+        credentials.base_url || undefined
+      );
+      foods = result.foods || [];
+      pagination = result.pagination;
+      break;
+    }
+  }
+
+  return { foods, pagination };
+}

--- a/SparkyFitnessServer/services/mealService.ts
+++ b/SparkyFitnessServer/services/mealService.ts
@@ -597,7 +597,7 @@ async function createMealFromDiaryEntries(
   mealType: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mealName: any,
-  description = null,
+  description: string | null = null,
   isPublic = false
 ) {
   try {

--- a/SparkyFitnessServer/tests/chatService.test.ts
+++ b/SparkyFitnessServer/tests/chatService.test.ts
@@ -1,5 +1,7 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
 import { MockLanguageModelV3 } from 'ai/test';
+import { simulateReadableStream } from 'ai';
+import type { UIMessageChunk } from 'ai';
 import chatService from '../services/chatService.js';
 import chatRepository from '../models/chatRepository.js';
 import measurementRepository from '../models/measurementRepository.js';
@@ -437,6 +439,169 @@ describe('chatService', () => {
       expect(model.doGenerateCalls).toHaveLength(2);
       expect(JSON.stringify(model.doGenerateCalls[1].prompt)).toContain(
         'Error [DB_ERROR]: A database error occurred.'
+      );
+    });
+  });
+
+  describe('processChatMessageStream (empty completion handling)', () => {
+    const activeUserId = 'user-123';
+    const actorUserId = 'actor-456';
+
+    const aiServiceSetting = {
+      id: 'svc-1',
+      service_type: 'openai',
+      api_key: 'sk-test',
+      model_name: 'gpt-test',
+      source: 'user',
+    };
+
+    const usage = {
+      inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+      outputTokens: { total: 5, text: 5, reasoning: 0 },
+    };
+
+    const streamModel = (parts: unknown[]) => {
+      const model = new MockLanguageModelV3({
+        doStream: async () => ({
+          stream: simulateReadableStream({
+            chunks: parts as never[],
+          }),
+        }),
+      });
+      mockModelHolder.current = model;
+      return model;
+    };
+
+    const drainStream = async (stream: ReadableStream<UIMessageChunk>) => {
+      const chunks: UIMessageChunk[] = [];
+      const reader = stream.getReader();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+      return chunks;
+    };
+
+    beforeEach(() => {
+      vi.mocked(chatRepository.getAiServiceSettingForBackend).mockResolvedValue(
+        aiServiceSetting
+      );
+      vi.mocked(chatRepository.saveChatHistory).mockResolvedValue(true);
+      vi.mocked(measurementRepository.getCustomCategories).mockResolvedValue(
+        []
+      );
+    });
+
+    it('injects an error chunk and skips the assistant save when the model errors out with an empty completion', async () => {
+      // Gemini's MALFORMED_FUNCTION_CALL surfaces as finishReason 'error' with
+      // no content instead of a thrown error.
+      streamModel([
+        { type: 'stream-start', warnings: [] },
+        {
+          type: 'finish',
+          finishReason: { unified: 'error', raw: 'MALFORMED_FUNCTION_CALL' },
+          usage,
+        },
+      ]);
+
+      const { stream } = await chatService.processChatMessageStream(
+        [{ role: 'user', content: 'Show my goal timeline' }],
+        'svc-1',
+        activeUserId,
+        actorUserId
+      );
+      const chunks = await drainStream(stream);
+
+      expect(chunks).toContainEqual({
+        type: 'error',
+        errorText:
+          'The AI service returned an empty response. Please try again.',
+      });
+
+      await vi.waitFor(() =>
+        expect(log).toHaveBeenCalledWith(
+          'warn',
+          expect.stringContaining('Skipping empty assistant chat history')
+        )
+      );
+      expect(chatRepository.saveChatHistory).toHaveBeenCalledTimes(1);
+      expect(chatRepository.saveChatHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: activeUserId,
+          messageType: 'user',
+          content: 'Show my goal timeline',
+        })
+      );
+    });
+
+    it('injects an error chunk when the stream finishes without any content even on a normal stop', async () => {
+      streamModel([
+        { type: 'stream-start', warnings: [] },
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: undefined },
+          usage,
+        },
+      ]);
+
+      const { stream } = await chatService.processChatMessageStream(
+        [{ role: 'user', content: 'Show my goal timeline' }],
+        'svc-1',
+        activeUserId,
+        actorUserId
+      );
+      const chunks = await drainStream(stream);
+
+      expect(chunks).toContainEqual({
+        type: 'error',
+        errorText:
+          'The AI service returned an empty response. Please try again.',
+      });
+    });
+
+    it('passes a normal completion through untouched and saves both history rows', async () => {
+      streamModel([
+        { type: 'stream-start', warnings: [] },
+        { type: 'text-start', id: 't1' },
+        { type: 'text-delta', id: 't1', delta: 'Here is your timeline.' },
+        { type: 'text-end', id: 't1' },
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: undefined },
+          usage,
+        },
+      ]);
+
+      const { stream } = await chatService.processChatMessageStream(
+        [{ role: 'user', content: 'Show my goal timeline' }],
+        'svc-1',
+        activeUserId,
+        actorUserId
+      );
+      const chunks = await drainStream(stream);
+
+      expect(chunks.some((chunk) => chunk.type === 'error')).toBe(false);
+      expect(chunks).toContainEqual(
+        expect.objectContaining({
+          type: 'text-delta',
+          delta: 'Here is your timeline.',
+        })
+      );
+
+      await vi.waitFor(() =>
+        expect(chatRepository.saveChatHistory).toHaveBeenCalledWith(
+          expect.objectContaining({
+            messageType: 'assistant',
+            content: 'Here is your timeline.',
+          })
+        )
+      );
+      expect(chatRepository.saveChatHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageType: 'user',
+          content: 'Show my goal timeline',
+        })
       );
     });
   });

--- a/SparkyFitnessServer/tests/chatService.test.ts
+++ b/SparkyFitnessServer/tests/chatService.test.ts
@@ -1,6 +1,10 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { MockLanguageModelV3 } from 'ai/test';
 import chatService from '../services/chatService.js';
 import chatRepository from '../models/chatRepository.js';
+import measurementRepository from '../models/measurementRepository.js';
+import foodRepository from '../models/foodRepository.js';
+import foodEntryService from '../services/foodEntryService.js';
 import { log } from '../config/logging.js';
 // Mock dependencies
 vi.mock('../models/chatRepository');
@@ -8,6 +12,41 @@ vi.mock('../models/userRepository');
 vi.mock('../models/measurementRepository');
 vi.mock('../config/logging', () => ({
   log: vi.fn(),
+}));
+vi.mock('../utils/timezoneLoader', () => ({
+  loadUserTimezone: vi.fn(async () => 'UTC'),
+}));
+// Loading the real foodEntryService trips on a deep '@workspace/shared'
+// subpath import under vitest; the stub doubles as the log_food seam.
+vi.mock('../services/foodEntryService', () => ({
+  default: {
+    createFoodEntry: vi.fn(),
+  },
+}));
+vi.mock('../models/foodRepository', () => ({
+  default: {
+    getFoodsWithPagination: vi.fn(),
+    countFoods: vi.fn(),
+    getFoodById: vi.fn(),
+  },
+}));
+vi.mock('../services/preferenceService', () => ({
+  default: {
+    getUserPreferences: vi.fn(),
+  },
+}));
+
+// processChatMessage builds its model from DB config via createOpenAI();
+// route the provider to a per-test scripted MockLanguageModelV3.
+const mockModelHolder = vi.hoisted(() => ({
+  current: undefined as unknown,
+}));
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: vi.fn(() =>
+    Object.assign(() => mockModelHolder.current, {
+      chat: () => mockModelHolder.current,
+    })
+  ),
 }));
 describe('chatService', () => {
   const mockUserId = 'user-123';
@@ -209,6 +248,196 @@ describe('chatService', () => {
         user_id: mockUserId,
       });
       expect(result).toEqual({ message: 'Chat history saved successfully.' });
+    });
+  });
+  describe('processChatMessage (in-process tool integration)', () => {
+    const FOOD_ID = '11111111-1111-4111-8111-111111111111';
+    const VARIANT_ID = '22222222-2222-4222-8222-222222222222';
+    // History is saved under the active user; tools act as the logged-in
+    // actor (the MCP path scoped tools to the session-authenticated user).
+    const activeUserId = 'user-123';
+    const actorUserId = 'actor-456';
+
+    const aiServiceSetting = {
+      id: 'svc-1',
+      service_type: 'openai',
+      api_key: 'sk-test',
+      model_name: 'gpt-test',
+      source: 'user',
+    };
+
+    const eggsRow = {
+      id: FOOD_ID,
+      name: 'Eggs',
+      brand: 'Farm Fresh',
+      user_id: actorUserId,
+      default_variant: {
+        id: VARIANT_ID,
+        serving_size: 100,
+        serving_unit: 'g',
+        calories: 155,
+        protein: 13,
+        carbs: 1.1,
+        fat: 11,
+      },
+    };
+
+    const usage = {
+      inputTokens: { total: 10, noCache: 10, cacheRead: 0, cacheWrite: 0 },
+      outputTokens: { total: 5, text: 5, reasoning: 0 },
+    };
+
+    const toolCallStep = (input: Record<string, unknown>) => ({
+      finishReason: { unified: 'tool-calls' as const, raw: undefined },
+      usage,
+      content: [
+        {
+          type: 'tool-call' as const,
+          toolCallId: 'call-1',
+          toolName: 'sparky_manage_food',
+          input: JSON.stringify(input),
+        },
+      ],
+      warnings: [],
+    });
+
+    const textStep = (text: string) => ({
+      finishReason: { unified: 'stop' as const, raw: undefined },
+      usage,
+      content: [{ type: 'text' as const, text }],
+      warnings: [],
+    });
+
+    const scriptModel = (
+      steps: Array<
+        ReturnType<typeof toolCallStep> | ReturnType<typeof textStep>
+      >
+    ) => {
+      const queue = [...steps];
+      const model = new MockLanguageModelV3({
+        doGenerate: async () => {
+          const step = queue.shift();
+          if (!step) {
+            throw new Error('MockLanguageModelV3: no scripted step left.');
+          }
+          return step;
+        },
+      });
+      mockModelHolder.current = model;
+      return model;
+    };
+
+    beforeEach(() => {
+      vi.mocked(chatRepository.getAiServiceSettingForBackend).mockResolvedValue(
+        aiServiceSetting
+      );
+      vi.mocked(chatRepository.saveChatHistory).mockResolvedValue(true);
+      vi.mocked(measurementRepository.getCustomCategories).mockResolvedValue(
+        []
+      );
+    });
+
+    it('executes a log_food tool call in-process, derives food_added from call input, and saves history', async () => {
+      vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([
+        eggsRow,
+      ]);
+      vi.mocked(foodEntryService.createFoodEntry).mockResolvedValue({
+        id: 'entry-1',
+        food_name: 'Eggs',
+      });
+      const logFoodArgs = {
+        action: 'log_food',
+        food_name: 'Eggs',
+        quantity: 2,
+        unit: 'serving',
+        meal_type: 'breakfast',
+        entry_date: '2026-06-10',
+      };
+      scriptModel([
+        toolCallStep(logFoodArgs),
+        textStep('Logged 2 eggs for breakfast!'),
+      ]);
+
+      const result = await chatService.processChatMessage(
+        [{ role: 'user', content: 'log 2 eggs for breakfast' }],
+        'svc-1',
+        activeUserId,
+        actorUserId
+      );
+
+      expect(result.content).toBe('Logged 2 eggs for breakfast!');
+      expect(result.action).toBe('food_added');
+      expect(result.executedTools).toEqual([
+        { name: 'sparky_manage_food', args: logFoodArgs },
+      ]);
+      // Tool handlers act as the authenticated user, not the active user.
+      expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
+        actorUserId,
+        actorUserId,
+        {
+          user_id: actorUserId,
+          food_id: FOOD_ID,
+          variant_id: VARIANT_ID,
+          entry_date: '2026-06-10',
+          quantity: 2,
+          unit: 'serving',
+          meal_type: 'breakfast',
+        }
+      );
+      expect(chatRepository.saveChatHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: activeUserId,
+          messageType: 'user',
+          content: 'log 2 eggs for breakfast',
+        })
+      );
+      expect(chatRepository.saveChatHistory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          user_id: activeUserId,
+          messageType: 'assistant',
+          content: 'Logged 2 eggs for breakfast!',
+        })
+      );
+    });
+
+    it('completes with an ERRORS string as the tool result when a backing service throws', async () => {
+      vi.mocked(foodRepository.getFoodsWithPagination).mockRejectedValue(
+        new Error('connection refused')
+      );
+      const model = scriptModel([
+        toolCallStep({
+          action: 'search_food',
+          food_name: 'egg',
+          search_type: 'broad',
+        }),
+        textStep('Sorry, I could not search foods right now.'),
+      ]);
+
+      const result = await chatService.processChatMessage(
+        [{ role: 'user', content: 'find eggs' }],
+        'svc-1',
+        activeUserId,
+        actorUserId
+      );
+
+      expect(result.content).toBe('Sorry, I could not search foods right now.');
+      expect(result.action).toBe('advice');
+      expect(result.executedTools).toEqual([
+        {
+          name: 'sparky_manage_food',
+          args: {
+            action: 'search_food',
+            food_name: 'egg',
+            search_type: 'broad',
+          },
+        },
+      ]);
+      // The handler never throws; the ERRORS string reaches the model as the
+      // tool result on the follow-up generation step.
+      expect(model.doGenerateCalls).toHaveLength(2);
+      expect(JSON.stringify(model.doGenerateCalls[1].prompt)).toContain(
+        'Error [DB_ERROR]: A database error occurred.'
+      );
     });
   });
 });

--- a/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
@@ -73,20 +73,33 @@ describe('coachRepository', () => {
     expect(result).toBeNull();
   });
 
-  it('getDailyCalorieSeries uses a CURRENT_DATE window of N days', async () => {
-    await coachRepository.getDailyCalorieSeries('user-1', 14);
+  it("getWeightSeries anchors the window on the caller's today", async () => {
+    await coachRepository.getWeightSeries('user-1', 14, '2026-06-11');
     const [sql, params] = mockClient.query.mock.calls[0];
-    expect(sql).toContain('CURRENT_DATE - $2::int');
-    expect(params).toEqual(['user-1', 14]);
+    expect(sql).toContain('entry_date >= ($3::date - $2::int)');
+    expect(sql).not.toContain('CURRENT_DATE');
+    expect(params).toEqual(['user-1', 14, '2026-06-11']);
   });
 
-  it('getDailyCorrelationRows joins food, sleep and mood by day', async () => {
-    await coachRepository.getDailyCorrelationRows('user-1', 30);
+  it("getDailyCalorieSeries anchors the window on the caller's today", async () => {
+    await coachRepository.getDailyCalorieSeries('user-1', 14, '2026-06-11');
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('entry_date >= ($3::date - $2::int)');
+    expect(sql).not.toContain('CURRENT_DATE');
+    expect(params).toEqual(['user-1', 14, '2026-06-11']);
+  });
+
+  it("getDailyCorrelationRows joins food, sleep and mood by day, all anchored on the caller's today", async () => {
+    await coachRepository.getDailyCorrelationRows('user-1', 30, '2026-06-11');
     const [sql, params] = mockClient.query.mock.calls[0];
     expect(sql).toContain('daily_food');
     expect(sql).toContain('daily_sleep');
     expect(sql).toContain('daily_mood');
-    expect(params).toEqual(['user-1', 30]);
+    // All three CTEs must carry the anchor — a single toContain would pass
+    // with a half-fixed query.
+    expect(sql.match(/entry_date >= \$3::date - \$2::int/g)).toHaveLength(3);
+    expect(sql).not.toContain('CURRENT_DATE');
+    expect(params).toEqual(['user-1', 30, '2026-06-11']);
   });
 
   it('releases the client when a query throws', async () => {
@@ -122,9 +135,19 @@ describe('engagementRepository', () => {
   });
 
   it('getWeeklyLoggedDayCount returns 0 when there are no rows', async () => {
-    expect(await engagementRepository.getWeeklyLoggedDayCount('user-1')).toBe(
-      0
-    );
+    expect(
+      await engagementRepository.getWeeklyLoggedDayCount('user-1', '2026-06-11')
+    ).toBe(0);
+  });
+
+  it("getWeeklyLoggedDayCount anchors all three UNION branches on the caller's today", async () => {
+    await engagementRepository.getWeeklyLoggedDayCount('user-1', '2026-06-11');
+    const [sql, params] = mockClient.query.mock.calls[0];
+    // All three UNION branches must carry the anchor — a single toContain
+    // would pass with a half-fixed query.
+    expect(sql.match(/entry_date >= \(\$2::date - 7\)/g)).toHaveLength(3);
+    expect(sql).not.toContain('CURRENT_DATE');
+    expect(params).toEqual(['user-1', '2026-06-11']);
   });
 
   it('getTodayActivityCounts maps the three count queries and defaults to 0', async () => {
@@ -133,7 +156,11 @@ describe('engagementRepository', () => {
       .mockResolvedValueOnce({ rows: [{ count: 1 }] })
       .mockResolvedValueOnce({ rows: [] });
 
-    const result = await engagementRepository.getTodayActivityCounts('user-1');
+    const result = await engagementRepository.getTodayActivityCounts(
+      'user-1',
+      '2026-06-11',
+      'UTC'
+    );
 
     expect(result).toEqual({
       food_count: 3,
@@ -142,6 +169,34 @@ describe('engagementRepository', () => {
     });
     expect(mockClient.query).toHaveBeenCalledTimes(3);
     expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("getTodayActivityCounts anchors every query on the caller's today, bucketing fasts in the user's timezone", async () => {
+    await engagementRepository.getTodayActivityCounts(
+      'user-1',
+      '2026-06-11',
+      'Asia/Tokyo'
+    );
+
+    const [foodSql, foodParams] = mockClient.query.mock.calls[0];
+    expect(foodSql).toContain('entry_date = $2::date');
+    expect(foodSql).not.toContain('CURRENT_DATE');
+    expect(foodParams).toEqual(['user-1', '2026-06-11']);
+
+    const [exerciseSql, exerciseParams] = mockClient.query.mock.calls[1];
+    expect(exerciseSql).toContain('entry_date = $2::date');
+    expect(exerciseSql).not.toContain('CURRENT_DATE');
+    expect(exerciseParams).toEqual(['user-1', '2026-06-11']);
+
+    const [checkinSql, checkinParams] = mockClient.query.mock.calls[2];
+    // All three entry_date branches plus the fasting branch must carry the
+    // anchor — a single toContain would pass with a half-fixed query.
+    expect(checkinSql.match(/entry_date = \$2::date/g)).toHaveLength(3);
+    expect(checkinSql).toContain(
+      '(start_time AT TIME ZONE $3)::date = $2::date'
+    );
+    expect(checkinSql).not.toContain('CURRENT_DATE');
+    expect(checkinParams).toEqual(['user-1', '2026-06-11', 'Asia/Tokyo']);
   });
 });
 
@@ -517,21 +572,27 @@ describe('externalProviderRepository.getActiveProvidersByTypes', () => {
 });
 
 describe('fastingRepository.getFastingLogsOverlappingDay', () => {
-  it('matches windows overlapping the day, including open-ended fasts', async () => {
+  it('matches windows overlapping the user-timezone day, including open-ended fasts', async () => {
     const rows = [{ id: 'f1', status: 'ACTIVE' }];
     mockClient.query.mockResolvedValue({ rows });
 
     const result = await fastingRepository.getFastingLogsOverlappingDay(
       'user-1',
-      '2026-06-01'
+      '2026-06-01',
+      'Pacific/Auckland'
     );
 
     expect(result).toBe(rows);
     const [sql, params] = mockClient.query.mock.calls[0];
-    expect(sql).toContain('start_time::date <= $2::date');
-    expect(sql).toContain('end_time IS NULL OR end_time::date >= $2::date');
+    expect(sql).toContain('(start_time AT TIME ZONE $3)::date <= $2::date');
+    expect(sql).toContain(
+      'end_time IS NULL OR (end_time AT TIME ZONE $3)::date >= $2::date'
+    );
+    // No bare ::date casts left — those bucket by the DB session timezone.
+    expect(sql).not.toContain('start_time::date');
+    expect(sql).not.toContain('end_time::date');
     expect(sql).toContain('ORDER BY start_time ASC');
-    expect(params).toEqual(['user-1', '2026-06-01']);
+    expect(params).toEqual(['user-1', '2026-06-01', 'Pacific/Auckland']);
     expect(mockClient.release).toHaveBeenCalled();
   });
 });

--- a/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
@@ -8,6 +8,7 @@ import reportRepository from '../models/reportRepository.js';
 import exerciseEntryRepository from '../models/exerciseEntry.js';
 import foodEntryRepository from '../models/foodEntry.js';
 import goalRepository from '../models/goalRepository.js';
+import fastingRepository from '../models/fastingRepository.js';
 
 vi.mock('../db/poolManager', () => ({
   getClient: vi.fn(),
@@ -350,5 +351,25 @@ describe('goalRepository.getGoalTimeline', () => {
     );
     expect(sql).toContain('ORDER BY goal_date DESC');
     expect(params).toEqual(['user-1']);
+  });
+});
+
+describe('fastingRepository.getFastingLogsOverlappingDay', () => {
+  it('matches windows overlapping the day, including open-ended fasts', async () => {
+    const rows = [{ id: 'f1', status: 'ACTIVE' }];
+    mockClient.query.mockResolvedValue({ rows });
+
+    const result = await fastingRepository.getFastingLogsOverlappingDay(
+      'user-1',
+      '2026-06-01'
+    );
+
+    expect(result).toBe(rows);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('start_time::date <= $2::date');
+    expect(sql).toContain('end_time IS NULL OR end_time::date >= $2::date');
+    expect(sql).toContain('ORDER BY start_time ASC');
+    expect(params).toEqual(['user-1', '2026-06-01']);
+    expect(mockClient.release).toHaveBeenCalled();
   });
 });

--- a/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
@@ -299,6 +299,110 @@ describe('exerciseEntry range/usage queries', () => {
       0,
     ]);
   });
+
+  it('getExerciseDiaryRange returns entries plus their sets', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [{ id: 'ee-1' }, { id: 'ee-2' }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: 's-1', exercise_entry_id: 'ee-1' }],
+      });
+
+    const result = await exerciseEntryRepository.getExerciseDiaryRange(
+      'user-1',
+      '2026-06-01',
+      '2026-06-11'
+    );
+
+    expect(result).toEqual({
+      entries: [{ id: 'ee-1' }, { id: 'ee-2' }],
+      sets: [{ id: 's-1', exercise_entry_id: 'ee-1' }],
+    });
+    const [entriesSql, entriesParams] = mockClient.query.mock.calls[0];
+    expect(entriesSql).toContain(
+      'LEFT JOIN exercises e ON e.id = ee.exercise_id'
+    );
+    expect(entriesSql).toContain('ee.entry_date BETWEEN $2 AND $3');
+    expect(entriesParams).toEqual(['user-1', '2026-06-01', '2026-06-11']);
+    const [setsSql, setsParams] = mockClient.query.mock.calls[1];
+    expect(setsSql).toContain('exercise_entry_id = ANY($1)');
+    expect(setsParams).toEqual([['ee-1', 'ee-2']]);
+  });
+
+  it('getExerciseDiaryRange skips the sets query when there are no entries', async () => {
+    const result = await exerciseEntryRepository.getExerciseDiaryRange(
+      'user-1',
+      '2026-06-01',
+      '2026-06-11'
+    );
+    expect(result).toEqual({ entries: [], sets: [] });
+    expect(mockClient.query).toHaveBeenCalledTimes(1);
+  });
+
+  // Answers the snapshot SELECT, the entry INSERT and the refetch so a
+  // createExerciseEntry call can run end to end; the dedup lookup, when it
+  // happens, finds nothing.
+  function mockEntryCreateQueries() {
+    mockClient.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT id FROM exercise_entries')) {
+        return { rows: [] };
+      }
+      if (sql.includes('FROM exercises WHERE id')) {
+        return {
+          rows: [
+            { name: 'Running', calories_per_hour: 300, category: 'custom' },
+          ],
+        };
+      }
+      return { rows: [{ id: 'ee-new' }] };
+    });
+  }
+
+  function findQueryCall(snippet: string) {
+    return mockClient.query.mock.calls.find((call: unknown[]) =>
+      String(call[0]).includes(snippet)
+    );
+  }
+
+  it('createExerciseEntry dedupes manual same-exercise/same-date entries by default', async () => {
+    mockEntryCreateQueries();
+    await exerciseEntryRepository.createExerciseEntry(
+      'user-1',
+      { exercise_id: 'ex-1', entry_date: '2026-06-11' },
+      'actor-1'
+    );
+    expect(findQueryCall('exercise_preset_entry_id IS NULL')).toBeDefined();
+    expect(findQueryCall('INSERT INTO exercise_entries')).toBeDefined();
+  });
+
+  it('createExerciseEntry always inserts when skipDuplicateCheck is set', async () => {
+    mockEntryCreateQueries();
+    await exerciseEntryRepository.createExerciseEntry(
+      'user-1',
+      { exercise_id: 'ex-1', entry_date: '2026-06-11' },
+      'actor-1',
+      'Manual',
+      null,
+      { skipDuplicateCheck: true }
+    );
+    expect(findQueryCall('exercise_preset_entry_id IS NULL')).toBeUndefined();
+    expect(findQueryCall('INSERT INTO exercise_entries')).toBeDefined();
+  });
+
+  it('updateExerciseEntry persists steps', async () => {
+    await exerciseEntryRepository.updateExerciseEntry(
+      'ee-1',
+      'user-1',
+      'actor-1',
+      { steps: 1234 }
+    );
+    const updateCall = mockClient.query.mock.calls.find((call: unknown[]) =>
+      String(call[0]).includes('UPDATE exercise_entries')
+    );
+    expect(updateCall).toBeDefined();
+    const [sql, params] = updateCall!;
+    expect(sql).toContain('steps = $10');
+    expect(params[9]).toBe(1234);
+  });
 });
 
 describe('foodEntry recent/usage queries', () => {

--- a/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
@@ -1,0 +1,354 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { getClient } from '../db/poolManager.js';
+import coachRepository from '../models/coachRepository.js';
+import engagementRepository from '../models/engagementRepository.js';
+import habitRepository from '../models/habitRepository.js';
+import measurementRepository from '../models/measurementRepository.js';
+import reportRepository from '../models/reportRepository.js';
+import exerciseEntryRepository from '../models/exerciseEntry.js';
+import foodEntryRepository from '../models/foodEntry.js';
+import goalRepository from '../models/goalRepository.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockClient: any;
+
+beforeEach(() => {
+  mockClient = {
+    query: vi.fn().mockResolvedValue({ rows: [] }),
+    release: vi.fn(),
+  };
+  vi.clearAllMocks();
+  vi.mocked(getClient).mockResolvedValue(mockClient);
+});
+
+describe('coachRepository', () => {
+  it('getNutritionAggregates scopes by user and date range and returns the aggregate row', async () => {
+    const row = {
+      total_calories: '2100',
+      avg_protein: '80.1',
+      avg_carbs: '210.5',
+      avg_fat: '70.2',
+      entry_count: 12,
+    };
+    mockClient.query.mockResolvedValue({ rows: [row] });
+
+    const result = await coachRepository.getNutritionAggregates(
+      'user-1',
+      '2026-06-01',
+      '2026-06-07'
+    );
+
+    expect(result).toBe(row);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('FROM food_entries');
+    expect(sql).toContain('NULLIF(serving_size, 0)');
+    expect(params).toEqual(['user-1', '2026-06-01', '2026-06-07']);
+    expect(mockClient.release).toHaveBeenCalled();
+  });
+
+  it('getLatestWeightInRange returns null when no weight is logged', async () => {
+    const result = await coachRepository.getLatestWeightInRange(
+      'user-1',
+      '2026-06-01',
+      '2026-06-07'
+    );
+    expect(result).toBeNull();
+  });
+
+  it('getDailyCalorieSeries uses a CURRENT_DATE window of N days', async () => {
+    await coachRepository.getDailyCalorieSeries('user-1', 14);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('CURRENT_DATE - $2::int');
+    expect(params).toEqual(['user-1', 14]);
+  });
+
+  it('getDailyCorrelationRows joins food, sleep and mood by day', async () => {
+    await coachRepository.getDailyCorrelationRows('user-1', 30);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('daily_food');
+    expect(sql).toContain('daily_sleep');
+    expect(sql).toContain('daily_mood');
+    expect(params).toEqual(['user-1', 30]);
+  });
+
+  it('releases the client when a query throws', async () => {
+    mockClient.query.mockRejectedValue(new Error('boom'));
+    await expect(
+      coachRepository.getNutritionAggregates(
+        'user-1',
+        '2026-06-01',
+        '2026-06-07'
+      )
+    ).rejects.toThrow('boom');
+    expect(mockClient.release).toHaveBeenCalled();
+  });
+});
+
+describe('engagementRepository', () => {
+  it('getLastExerciseDate returns the most recent entry_date or null', async () => {
+    mockClient.query.mockResolvedValueOnce({
+      rows: [{ entry_date: '2026-06-09' }],
+    });
+    expect(await engagementRepository.getLastExerciseDate('user-1')).toBe(
+      '2026-06-09'
+    );
+
+    mockClient.query.mockResolvedValueOnce({ rows: [] });
+    expect(await engagementRepository.getLastExerciseDate('user-1')).toBeNull();
+  });
+
+  it('getRecentWeights defaults to a limit of 7', async () => {
+    await engagementRepository.getRecentWeights('user-1');
+    const [, params] = mockClient.query.mock.calls[0];
+    expect(params).toEqual(['user-1', 7]);
+  });
+
+  it('getWeeklyLoggedDayCount returns 0 when there are no rows', async () => {
+    expect(await engagementRepository.getWeeklyLoggedDayCount('user-1')).toBe(
+      0
+    );
+  });
+
+  it('getTodayActivityCounts maps the three count queries and defaults to 0', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [{ count: 3 }] })
+      .mockResolvedValueOnce({ rows: [{ count: 1 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await engagementRepository.getTodayActivityCounts('user-1');
+
+    expect(result).toEqual({
+      food_count: 3,
+      exercise_count: 1,
+      checkin_count: 0,
+    });
+    expect(mockClient.query).toHaveBeenCalledTimes(3);
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('habitRepository', () => {
+  it('listHabits selects boolean custom categories for the user', async () => {
+    const rows = [{ id: 'habit-1', name: 'meditate', data_type: 'boolean' }];
+    mockClient.query.mockResolvedValue({ rows });
+
+    const result = await habitRepository.listHabits('user-1');
+
+    expect(result).toBe(rows);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain("data_type = 'boolean'");
+    expect(params).toEqual(['user-1']);
+  });
+
+  it('upsertHabitLog updates the existing row when one exists', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [{ id: 'cm-1' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await habitRepository.upsertHabitLog(
+      'user-1',
+      'habit-1',
+      '2026-06-11',
+      'true'
+    );
+
+    expect(mockClient.query).toHaveBeenCalledTimes(2);
+    const [updateSql, updateParams] = mockClient.query.mock.calls[1];
+    expect(updateSql).toContain('UPDATE custom_measurements');
+    expect(updateParams).toEqual(['true', 'cm-1']);
+  });
+
+  it('upsertHabitLog inserts when no row exists', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await habitRepository.upsertHabitLog(
+      'user-1',
+      'habit-1',
+      '2026-06-11',
+      'false'
+    );
+
+    const [insertSql, insertParams] = mockClient.query.mock.calls[1];
+    expect(insertSql).toContain('INSERT INTO custom_measurements');
+    expect(insertParams).toEqual(['user-1', 'habit-1', 'false', '2026-06-11']);
+  });
+
+  it('getHabitHistory adds range clauses only for provided bounds', async () => {
+    await habitRepository.getHabitHistory('user-1', 'habit-1');
+    let [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).not.toContain('entry_date >=');
+    expect(sql).not.toContain('entry_date <=');
+    expect(params).toEqual(['user-1', 'habit-1']);
+
+    await habitRepository.getHabitHistory(
+      'user-1',
+      'habit-1',
+      '2026-06-01',
+      '2026-06-11'
+    );
+    [sql, params] = mockClient.query.mock.calls[1];
+    expect(sql).toContain('entry_date >= $3');
+    expect(sql).toContain('entry_date <= $4');
+    expect(params).toEqual(['user-1', 'habit-1', '2026-06-01', '2026-06-11']);
+  });
+});
+
+describe('measurementRepository.getWaterTotalsByDateRange', () => {
+  it('sums per day over the optional range', async () => {
+    const rows = [{ entry_date: '2026-06-10', total_ml: '1500' }];
+    mockClient.query.mockResolvedValue({ rows });
+
+    const result = await measurementRepository.getWaterTotalsByDateRange(
+      'user-1',
+      '2026-06-01',
+      '2026-06-11'
+    );
+
+    expect(result).toBe(rows);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('SUM(water_ml)');
+    expect(sql).toContain('GROUP BY entry_date');
+    expect(params).toEqual(['user-1', '2026-06-01', '2026-06-11']);
+  });
+
+  it('omits range clauses when no bounds are given', async () => {
+    await measurementRepository.getWaterTotalsByDateRange('user-1');
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).not.toContain('entry_date >=');
+    expect(sql).not.toContain('entry_date <=');
+    expect(params).toEqual(['user-1']);
+  });
+});
+
+describe('reportRepository.getDailyNutritionTotalsRange', () => {
+  it('returns per-day scaled totals including micros', async () => {
+    const rows = [{ entry_date: '2026-06-10', calories: '1900', iron: '8' }];
+    mockClient.query.mockResolvedValue({ rows });
+
+    const result = await reportRepository.getDailyNutritionTotalsRange(
+      'user-1',
+      '2026-06-01',
+      '2026-06-11'
+    );
+
+    expect(result).toBe(rows);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain(
+      'SUM(dietary_fiber * quantity / NULLIF(serving_size, 0)) as fiber'
+    );
+    expect(sql).toContain(
+      'SUM(sugars * quantity / NULLIF(serving_size, 0)) as sugar'
+    );
+    expect(params).toEqual(['user-1', '2026-06-01', '2026-06-11']);
+  });
+});
+
+describe('exerciseEntry range/usage queries', () => {
+  it('getDailyExerciseTotalsRange groups totals by entry_date', async () => {
+    await exerciseEntryRepository.getDailyExerciseTotalsRange(
+      'user-1',
+      '2026-06-01',
+      '2026-06-11'
+    );
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('GROUP BY entry_date');
+    expect(sql).toContain('entry_date BETWEEN $2 AND $3');
+    expect(params).toEqual(['user-1', '2026-06-01', '2026-06-11']);
+  });
+
+  it('getRecentExerciseEntries joins the exercise catalog', async () => {
+    await exerciseEntryRepository.getRecentExerciseEntries('user-1', 50);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('LEFT JOIN exercises e ON e.id = ee.exercise_id');
+    expect(params).toEqual(['user-1', 50]);
+  });
+
+  it('getExerciseUsage returns rows with the total count', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [{ count: 9 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'entry-1' }] });
+
+    const result = await exerciseEntryRepository.getExerciseUsage(
+      'user-1',
+      'exercise-1',
+      '2026-06-01',
+      '2026-06-11',
+      20,
+      0
+    );
+
+    expect(result).toEqual({ rows: [{ id: 'entry-1' }], totalCount: 9 });
+    const [, dataParams] = mockClient.query.mock.calls[1];
+    expect(dataParams).toEqual([
+      'user-1',
+      'exercise-1',
+      '2026-06-01',
+      '2026-06-11',
+      20,
+      0,
+    ]);
+  });
+});
+
+describe('foodEntry recent/usage queries', () => {
+  it('getRecentFoodEntries joins meal types and the food catalog', async () => {
+    await foodEntryRepository.getRecentFoodEntries('user-1', 25);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('LEFT JOIN meal_types mt ON mt.id = fe.meal_type_id');
+    expect(sql).toContain('LEFT JOIN foods f ON f.id = fe.food_id');
+    expect(params).toEqual(['user-1', 25]);
+  });
+
+  it('getFoodUsage returns rows with the total count and defaults count to 0', async () => {
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 'entry-1' }] });
+
+    const result = await foodEntryRepository.getFoodUsage(
+      'user-1',
+      'food-1',
+      '2026-06-01',
+      '2026-06-11',
+      20,
+      40
+    );
+
+    expect(result).toEqual({ rows: [{ id: 'entry-1' }], totalCount: 0 });
+    const [, dataParams] = mockClient.query.mock.calls[1];
+    expect(dataParams).toEqual([
+      'user-1',
+      'food-1',
+      '2026-06-01',
+      '2026-06-11',
+      20,
+      40,
+    ]);
+  });
+});
+
+describe('goalRepository.getGoalTimeline', () => {
+  it('returns the compact goal history newest first', async () => {
+    const rows = [{ id: 'goal-1', goal_date: '2026-06-01', calories: 2200 }];
+    mockClient.query.mockResolvedValue({ rows });
+
+    const result = await goalRepository.getGoalTimeline('user-1');
+
+    expect(result).toBe(rows);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain(
+      'SELECT id, goal_date, calories, protein, carbs, fat, water_goal_ml'
+    );
+    expect(sql).toContain('ORDER BY goal_date DESC');
+    expect(params).toEqual(['user-1']);
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
@@ -9,6 +9,8 @@ import exerciseEntryRepository from '../models/exerciseEntry.js';
 import foodEntryRepository from '../models/foodEntry.js';
 import goalRepository from '../models/goalRepository.js';
 import fastingRepository from '../models/fastingRepository.js';
+import foodEntryMealRepository from '../models/foodEntryMealRepository.js';
+import externalProviderRepository from '../models/externalProviderRepository.js';
 
 vi.mock('../db/poolManager', () => ({
   getClient: vi.fn(),
@@ -16,6 +18,13 @@ vi.mock('../db/poolManager', () => ({
 }));
 vi.mock('../config/logging', () => ({
   log: vi.fn(),
+}));
+// externalProviderRepository imports the encryption module, which requires a
+// key from the environment at import time.
+vi.mock('../security/encryption', () => ({
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  ENCRYPTION_KEY: 'test-key',
 }));
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -455,6 +464,55 @@ describe('goalRepository.getGoalTimeline', () => {
     );
     expect(sql).toContain('ORDER BY goal_date DESC');
     expect(params).toEqual(['user-1']);
+  });
+});
+
+describe('foodEntryMealRepository.getFoodEntryMealsByDateRange', () => {
+  it('returns flat meal-container rows for the range in diary order', async () => {
+    const rows = [{ id: 'fem-1', name: 'Protein Shake' }];
+    mockClient.query.mockResolvedValue({ rows });
+
+    const result = await foodEntryMealRepository.getFoodEntryMealsByDateRange(
+      'user-1',
+      '2026-06-01',
+      '2026-06-11'
+    );
+
+    expect(result).toBe(rows);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('FROM food_entry_meals fem');
+    expect(sql).toContain(
+      'LEFT JOIN meal_types mt ON fem.meal_type_id = mt.id'
+    );
+    expect(sql).toContain('fem.entry_date BETWEEN $2 AND $3');
+    expect(sql).toContain('ORDER BY fem.entry_date ASC, fem.created_at ASC');
+    expect(params).toEqual(['user-1', '2026-06-01', '2026-06-11']);
+    expect(mockClient.release).toHaveBeenCalled();
+  });
+});
+
+describe('externalProviderRepository.getActiveProvidersByTypes', () => {
+  it('filters to active providers of the given types in cascade order', async () => {
+    const rows = [
+      { id: 'prov-1', provider_type: 'usda', provider_name: 'USDA' },
+    ];
+    mockClient.query.mockResolvedValue({ rows });
+
+    const result = await externalProviderRepository.getActiveProvidersByTypes(
+      'user-1',
+      ['usda', 'openfoodfacts']
+    );
+
+    expect(result).toBe(rows);
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).toContain('FROM external_data_providers');
+    expect(sql).toContain('is_active = TRUE');
+    expect(sql).toContain('provider_type = ANY($2::text[])');
+    expect(sql).toContain(
+      'ORDER BY sort_order ASC NULLS LAST, created_at DESC'
+    );
+    expect(params).toEqual(['user-1', ['usda', 'openfoodfacts']]);
+    expect(mockClient.release).toHaveBeenCalled();
   });
 });
 

--- a/SparkyFitnessServer/tests/chatbotToolSchemas.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolSchemas.test.ts
@@ -1,0 +1,482 @@
+import { describe, expect, it } from 'vitest';
+import { zodSchema } from 'ai';
+import type { z } from 'zod';
+import { manageFoodInput, manageFoodSchema } from '../ai/tools/schemas/food.js';
+import {
+  manageExerciseInput,
+  manageExerciseSchema,
+} from '../ai/tools/schemas/exercise.js';
+import {
+  manageCheckinInput,
+  manageCheckinSchema,
+} from '../ai/tools/schemas/checkin.js';
+import {
+  manageGoalsInput,
+  manageGoalsSchema,
+} from '../ai/tools/schemas/goals.js';
+import {
+  manageProfileInput,
+  manageProfileSchema,
+} from '../ai/tools/schemas/profile.js';
+import {
+  manageHabitsInput,
+  manageHabitsSchema,
+} from '../ai/tools/schemas/habits.js';
+import {
+  manageWizardInput,
+  manageWizardSchema,
+} from '../ai/tools/schemas/wizard.js';
+import {
+  manageReportInput,
+  manageReportSchema,
+  dailyReportSchema,
+} from '../ai/tools/schemas/report.js';
+import {
+  GetHealthSummarySchema,
+  AnalyzeTrendsSchema,
+  Get30DayTrendsSchema,
+  DetectPatternsSchema,
+  GenerateCoachingPlanSchema,
+} from '../ai/tools/schemas/coach.js';
+import {
+  CheckEngagementSchema,
+  GetLoggingStreakSchema,
+  GetContextualNudgeSchema,
+} from '../ai/tools/schemas/engagement.js';
+import {
+  AnalyzeFoodImageSchema,
+  ScanLabelSchema,
+} from '../ai/tools/schemas/vision.js';
+
+interface JsonSchemaObject {
+  type?: string;
+  properties?: Record<string, { enum?: string[] }>;
+  required?: string[];
+}
+
+function toJson(schema: z.ZodType): JsonSchemaObject {
+  return zodSchema(schema).jsonSchema as JsonSchemaObject;
+}
+
+describe('published (flat) chatbot tool schemas', () => {
+  const flatCases: Array<{
+    name: string;
+    schema: z.ZodType;
+    properties: string[];
+    actions?: string[];
+  }> = [
+    {
+      name: 'manageFoodInput',
+      schema: manageFoodInput,
+      properties: [
+        'action',
+        'food_name',
+        'food_id',
+        'variant_id',
+        'update_existing_entries',
+        'serving_size',
+        'serving_unit',
+        'brand',
+        'quantity',
+        'unit',
+        'meal_type',
+        'entry_date',
+        'meal_id',
+        'meal_name',
+        'search_type',
+        'limit',
+        'offset',
+        'calories',
+        'protein',
+        'carbs',
+        'fat',
+        'saturated_fat',
+        'polyunsaturated_fat',
+        'monounsaturated_fat',
+        'trans_fat',
+        'cholesterol',
+        'sodium',
+        'potassium',
+        'fiber',
+        'sugar',
+        'vitamin_a',
+        'vitamin_c',
+        'calcium',
+        'iron',
+        'gi',
+        'entry_id',
+        'entry_type',
+        'description',
+        'target_date',
+        'source_date',
+        'amount_ml',
+        'start_date',
+        'end_date',
+        'provider_type',
+      ],
+      actions: [
+        'search_food',
+        'lookup_food_nutrition',
+        'log_food',
+        'create_food',
+        'search_meal',
+        'log_meal',
+        'list_diary',
+        'delete_entry',
+        'delete_food',
+        'update_entry',
+        'update_food_variant',
+        'copy_from_yesterday',
+        'save_as_meal_template',
+        'log_water',
+        'get_nutritional_summary',
+        'get_water_history',
+      ],
+    },
+    {
+      name: 'manageExerciseInput',
+      schema: manageExerciseInput,
+      properties: [
+        'action',
+        'exercise_id',
+        'exercise_name',
+        'exercise_ids',
+        'name',
+        'searchTerm',
+        'muscleGroup',
+        'equipment',
+        'limit',
+        'offset',
+        'category',
+        'calories_per_hour',
+        'description',
+        'entry_date',
+        'duration_minutes',
+        'calories_burned',
+        'notes',
+        'distance',
+        'avg_heart_rate',
+        'steps',
+        'sets',
+        'preset_id',
+        'preset_name',
+        'entry_id',
+        'start_date',
+        'end_date',
+      ],
+      actions: [
+        'search_exercises',
+        'create_exercise',
+        'log_exercise',
+        'list_exercise_diary',
+        'get_workout_presets',
+        'log_workout_preset',
+        'update_exercise_entry',
+        'delete_exercise_entry',
+        'get_exercise_details',
+        'create_workout_preset',
+        'get_exercise_progress',
+      ],
+    },
+    {
+      name: 'manageCheckinInput',
+      schema: manageCheckinInput,
+      properties: [
+        'action',
+        'entry_date',
+        'weight',
+        'weight_unit',
+        'steps',
+        'height',
+        'height_unit',
+        'neck',
+        'waist',
+        'hips',
+        'measurements_unit',
+        'body_fat',
+        'category_name',
+        'value',
+        'unit',
+        'notes',
+        'data_type',
+        'mood_value',
+        'start_time',
+        'end_time',
+        'fasting_status',
+        'fasting_type',
+        'duration_seconds',
+        'sleep_score',
+        'bedtime',
+        'wake_time',
+        'source',
+        'start_date',
+        'end_date',
+      ],
+      actions: [
+        'log_biometrics',
+        'log_custom_metric',
+        'list_categories',
+        'create_category',
+        'log_mood',
+        'log_fasting',
+        'log_sleep',
+        'list_checkin_diary',
+        'get_fasting_status',
+        'get_biometrics_history',
+      ],
+    },
+    {
+      name: 'manageGoalsInput',
+      schema: manageGoalsInput,
+      properties: [
+        'action',
+        'target_date',
+        'start_date',
+        'calories',
+        'protein',
+        'carbs',
+        'fat',
+        'water_goal_ml',
+        'weight',
+      ],
+      actions: ['get_goals', 'set_goals', 'list_goal_timeline'],
+    },
+    {
+      name: 'manageProfileInput',
+      schema: manageProfileInput,
+      properties: [
+        'action',
+        'display_name',
+        'email',
+        'image',
+        'timezone',
+        'energy_unit',
+        'default_weight_unit',
+        'default_measurement_unit',
+        'default_distance_unit',
+        'water_display_unit',
+      ],
+      actions: [
+        'get_profile',
+        'update_profile',
+        'get_preferences',
+        'update_preferences',
+      ],
+    },
+    {
+      name: 'manageHabitsInput',
+      schema: manageHabitsInput,
+      properties: [
+        'action',
+        'habit_id',
+        'entry_date',
+        'completed',
+        'start_date',
+        'end_date',
+      ],
+      actions: ['list_habits', 'log_habit', 'get_habit_history'],
+    },
+    {
+      name: 'manageWizardInput',
+      schema: manageWizardInput,
+      properties: ['action', 'step', 'answer'],
+      actions: ['daily_checkin'],
+    },
+    {
+      name: 'manageReportInput',
+      schema: manageReportInput,
+      properties: ['action', 'end_date'],
+      actions: ['get_weekly_report'],
+    },
+    {
+      name: 'dailyReportSchema',
+      schema: dailyReportSchema,
+      properties: ['date', 'start_date', 'end_date'],
+    },
+    {
+      name: 'GetHealthSummarySchema',
+      schema: GetHealthSummarySchema,
+      properties: ['start_date', 'end_date'],
+    },
+    {
+      name: 'AnalyzeTrendsSchema',
+      schema: AnalyzeTrendsSchema,
+      properties: ['days'],
+    },
+    {
+      name: 'Get30DayTrendsSchema',
+      schema: Get30DayTrendsSchema,
+      properties: ['end_date'],
+    },
+    {
+      name: 'DetectPatternsSchema',
+      schema: DetectPatternsSchema,
+      properties: ['days'],
+    },
+    {
+      name: 'GenerateCoachingPlanSchema',
+      schema: GenerateCoachingPlanSchema,
+      properties: ['goal', 'target_weight'],
+    },
+    {
+      name: 'CheckEngagementSchema',
+      schema: CheckEngagementSchema,
+      properties: [],
+    },
+    {
+      name: 'GetLoggingStreakSchema',
+      schema: GetLoggingStreakSchema,
+      properties: [],
+    },
+    {
+      name: 'GetContextualNudgeSchema',
+      schema: GetContextualNudgeSchema,
+      properties: [],
+    },
+    {
+      name: 'AnalyzeFoodImageSchema',
+      schema: AnalyzeFoodImageSchema,
+      properties: ['image_url'],
+    },
+    {
+      name: 'ScanLabelSchema',
+      schema: ScanLabelSchema,
+      properties: ['image_url'],
+    },
+  ];
+
+  it.each(flatCases)(
+    '$name converts to a JSON schema with the expected properties',
+    ({ schema, properties, actions }) => {
+      const json = toJson(schema);
+
+      expect(json.type).toBe('object');
+      expect(Object.keys(json.properties ?? {})).toEqual(properties);
+
+      if (actions) {
+        expect(json.properties?.action?.enum).toEqual(actions);
+      }
+    }
+  );
+});
+
+describe('strict discriminated-union validation schemas', () => {
+  it('manageFoodSchema accepts a valid log_food input', () => {
+    const result = manageFoodSchema.safeParse({
+      action: 'log_food',
+      food_name: 'Eggs',
+      quantity: 2,
+      unit: 'piece',
+      meal_type: 'breakfast',
+      entry_date: '2026-06-11',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('manageFoodSchema rejects fields that do not belong to the action', () => {
+    const result = manageFoodSchema.safeParse({
+      action: 'list_diary',
+      entry_date: '2026-06-11',
+      quantity: 2,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('manageFoodSchema rejects an unknown action', () => {
+    const result = manageFoodSchema.safeParse({ action: 'bogus' });
+    expect(result.success).toBe(false);
+  });
+
+  it('manageExerciseSchema accepts sets as an array or a JSON string', () => {
+    const base = {
+      action: 'log_exercise',
+      exercise_name: 'Bench Press',
+      entry_date: '2026-06-11',
+    };
+    expect(
+      manageExerciseSchema.safeParse({
+        ...base,
+        sets: [{ reps: 10, weight: 60, set_type: 'Working Set' }],
+      }).success
+    ).toBe(true);
+    expect(
+      manageExerciseSchema.safeParse({
+        ...base,
+        sets: '[{"reps":10,"weight":60}]',
+      }).success
+    ).toBe(true);
+  });
+
+  it('manageCheckinSchema accepts a valid log_biometrics input and coerces numbers', () => {
+    const result = manageCheckinSchema.safeParse({
+      action: 'log_biometrics',
+      entry_date: '2026-06-11',
+      weight: '80.5',
+      weight_unit: 'kg',
+    });
+    expect(result.success).toBe(true);
+    if (result.success && result.data.action === 'log_biometrics') {
+      expect(result.data.weight).toBe(80.5);
+    }
+  });
+
+  it('manageGoalsSchema requires start_date for set_goals', () => {
+    expect(
+      manageGoalsSchema.safeParse({ action: 'set_goals', calories: 2200 })
+        .success
+    ).toBe(false);
+    expect(
+      manageGoalsSchema.safeParse({
+        action: 'set_goals',
+        start_date: '2026-06-11',
+        calories: 2200,
+      }).success
+    ).toBe(true);
+  });
+
+  it('manageProfileSchema rejects update_preferences with an invalid enum value', () => {
+    expect(
+      manageProfileSchema.safeParse({
+        action: 'update_preferences',
+        energy_unit: 'joules',
+      }).success
+    ).toBe(false);
+  });
+
+  it('manageHabitsSchema requires a UUID habit_id for log_habit', () => {
+    expect(
+      manageHabitsSchema.safeParse({
+        action: 'log_habit',
+        habit_id: 'not-a-uuid',
+        entry_date: '2026-06-11',
+        completed: true,
+      }).success
+    ).toBe(false);
+  });
+
+  it('manageWizardSchema defaults step to start', () => {
+    const result = manageWizardSchema.safeParse({ action: 'daily_checkin' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.step).toBe('start');
+    }
+  });
+
+  it('manageReportSchema accepts get_weekly_report with an optional end_date', () => {
+    expect(
+      manageReportSchema.safeParse({ action: 'get_weekly_report' }).success
+    ).toBe(true);
+    expect(
+      manageReportSchema.safeParse({
+        action: 'get_weekly_report',
+        end_date: '2026-06-11',
+      }).success
+    ).toBe(true);
+    expect(
+      manageReportSchema.safeParse({
+        action: 'get_weekly_report',
+        end_date: 'June 11',
+      }).success
+    ).toBe(false);
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolUnitConversion.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolUnitConversion.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import {
+  convertWeight,
+  convertMeasurement,
+  convertEnergy,
+  LBS_TO_KG,
+  KG_TO_LBS,
+  INCH_TO_CM,
+  CM_TO_INCH,
+  FT_TO_CM,
+  G_PER_KG,
+  KCAL_TO_KJ,
+  KJ_TO_KCAL,
+} from '../ai/tools/unitConversion.js';
+
+describe('convertWeight', () => {
+  it('converts lbs to kg', () => {
+    expect(convertWeight(10, 'lbs', 'kg')).toBe(10 * LBS_TO_KG);
+  });
+
+  it('converts kg to lbs', () => {
+    expect(convertWeight(10, 'kg', 'lbs')).toBe(10 * KG_TO_LBS);
+  });
+
+  it("treats the 'lb' alias as lbs", () => {
+    expect(convertWeight(10, 'lb', 'kg')).toBe(10 * 0.45359237);
+  });
+
+  it('converts g to kg', () => {
+    expect(convertWeight(500, 'g', 'kg')).toBe(500 / G_PER_KG);
+  });
+
+  it('returns the value unchanged when units match', () => {
+    expect(convertWeight(70, 'kg', 'kg')).toBe(70);
+    expect(convertWeight(150, 'lb', 'lbs')).toBe(150);
+  });
+
+  it('passes unknown units through unchanged', () => {
+    expect(convertWeight(12, 'stone', 'kg')).toBe(12);
+  });
+
+  it('is case-insensitive at the converter level', () => {
+    expect(convertWeight(10, 'LB', 'KG')).toBe(10 * LBS_TO_KG);
+  });
+});
+
+describe('convertMeasurement', () => {
+  it('converts in to cm', () => {
+    expect(convertMeasurement(10, 'in', 'cm')).toBe(10 * INCH_TO_CM);
+  });
+
+  it('converts cm to in', () => {
+    expect(convertMeasurement(10, 'cm', 'in')).toBe(10 * CM_TO_INCH);
+  });
+
+  it("treats the 'inch' alias as in", () => {
+    expect(convertMeasurement(10, 'inch', 'cm')).toBe(10 * 2.54);
+  });
+
+  it('converts ft to cm', () => {
+    expect(convertMeasurement(6, 'ft', 'cm')).toBe(6 * FT_TO_CM);
+  });
+
+  it('returns the value unchanged when units match', () => {
+    expect(convertMeasurement(90, 'cm', 'cm')).toBe(90);
+    expect(convertMeasurement(36, 'inch', 'in')).toBe(36);
+  });
+
+  it('passes unknown units through unchanged', () => {
+    expect(convertMeasurement(2, 'm', 'cm')).toBe(2);
+  });
+
+  it('is case-insensitive at the converter level', () => {
+    expect(convertMeasurement(10, 'INCH', 'CM')).toBe(10 * INCH_TO_CM);
+  });
+});
+
+describe('convertEnergy', () => {
+  it('converts kcal to kJ', () => {
+    expect(convertEnergy(100, 'kcal', 'kj')).toBe(100 * KCAL_TO_KJ);
+  });
+
+  it('converts kJ to kcal', () => {
+    expect(convertEnergy(100, 'kj', 'kcal')).toBe(100 * KJ_TO_KCAL);
+  });
+
+  it("treats 'calories' as kcal", () => {
+    expect(convertEnergy(100, 'calories', 'kj')).toBe(100 * KCAL_TO_KJ);
+  });
+
+  it('passes unknown units through unchanged', () => {
+    expect(convertEnergy(100, 'cal', 'kj')).toBe(100);
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsCheckin.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsCheckin.test.ts
@@ -421,9 +421,9 @@ describe('log_sleep', () => {
       opts
     );
 
-    expect(result).toBe(
-      '✅ Sleep logged for 2026-06-01 (7h 30m, score: 85/100).'
-    );
+    // The provided sleep_score must not be echoed: it is never stored
+    // (processSleepEntry computes its own score).
+    expect(result).toBe('✅ Sleep logged for 2026-06-01 (7h 30m).');
     expect(measurementService.processSleepEntry).toHaveBeenCalledWith(
       'user-1',
       'user-1',

--- a/SparkyFitnessServer/tests/chatbotToolsCheckin.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsCheckin.test.ts
@@ -70,7 +70,7 @@ function mockEmptyDiary() {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({});
-  tools = buildCheckinTools('user-1');
+  tools = buildCheckinTools('user-1', 'UTC');
 });
 
 describe('log_biometrics', () => {
@@ -103,6 +103,37 @@ describe('log_biometrics', () => {
         weight: 180 * 0.45359237,
         waist: 32 * 2.54,
         steps: 9000,
+      }
+    );
+  });
+
+  it("converts the 'lb' and 'ft' alias units for storage", async () => {
+    vi.mocked(measurementService.upsertCheckInMeasurements).mockResolvedValue({
+      id: 'ci-1',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_biometrics',
+        entry_date: '2026-06-01',
+        weight: 150,
+        weight_unit: 'lb',
+        height: 6,
+        height_unit: 'ft',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Biometrics logged for 2026-06-01 (weight: 150lb, height: 6ft).'
+    );
+    expect(measurementService.upsertCheckInMeasurements).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      '2026-06-01',
+      {
+        weight: 150 * 0.45359237,
+        height: 6 * 30.48,
       }
     );
   });
@@ -437,6 +468,35 @@ describe('log_sleep', () => {
     );
   });
 
+  it("anchors the default wake time at 7 AM in the user's timezone", async () => {
+    vi.mocked(measurementService.processSleepEntry).mockResolvedValue({
+      id: 's1',
+    });
+    const tokyoTools = buildCheckinTools('user-1', 'Asia/Tokyo');
+
+    await tokyoTools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_sleep',
+        entry_date: '2026-06-01',
+        duration_seconds: 27000,
+      },
+      opts
+    );
+
+    // 7 AM in Tokyo on 2026-06-01 is 22:00 UTC the previous day.
+    expect(measurementService.processSleepEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      {
+        entry_date: '2026-06-01',
+        bedtime: '2026-05-31T14:30:00.000Z',
+        wake_time: '2026-05-31T22:00:00.000Z',
+        duration_in_seconds: 27000,
+        source: 'manual',
+      }
+    );
+  });
+
   it('derives wake time from bedtime using the default 8h duration', async () => {
     vi.mocked(measurementService.processSleepEntry).mockResolvedValue({
       id: 's1',
@@ -551,6 +611,38 @@ describe('list_checkin_diary', () => {
         '## Custom Metrics\n' +
         '- **Blood Pressure**: 120\n' +
         '\n'
+    );
+  });
+
+  it('renders fasting timestamps from pg Date objects as ISO-8601 strings', async () => {
+    mockEmptyDiary();
+    vi.mocked(fastingRepository.getFastingLogsOverlappingDay).mockResolvedValue(
+      [
+        {
+          id: 'f1',
+          start_time: new Date('2026-06-01T20:00:00Z'),
+          end_time: new Date('2026-06-02T12:00:00Z'),
+          status: 'COMPLETED',
+          fasting_type: '16:8',
+        },
+      ]
+    );
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'list_checkin_diary', entry_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### Check-in Diary: 2026-06-01\n\n' +
+        '## Fasting\n' +
+        '- COMPLETED (16:8): 2026-06-01T20:00:00.000Z → 2026-06-02T12:00:00.000Z\n' +
+        '\n'
+    );
+    expect(fastingRepository.getFastingLogsOverlappingDay).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-01',
+      'UTC'
     );
   });
 

--- a/SparkyFitnessServer/tests/chatbotToolsCheckin.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsCheckin.test.ts
@@ -1,0 +1,713 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { todayInZone } from '@workspace/shared';
+import { buildCheckinTools } from '../ai/tools/checkinTools.js';
+import measurementService from '../services/measurementService.js';
+import preferenceService from '../services/preferenceService.js';
+import moodRepository from '../models/moodRepository.js';
+import fastingRepository from '../models/fastingRepository.js';
+import sleepRepository from '../models/sleepRepository.js';
+
+vi.mock('../services/measurementService', () => ({
+  default: {
+    upsertCheckInMeasurements: vi.fn(),
+    getCheckInMeasurements: vi.fn(),
+    getCheckInMeasurementsByDateRange: vi.fn(),
+    getCustomCategories: vi.fn(),
+    createCustomCategory: vi.fn(),
+    upsertCustomMeasurementEntry: vi.fn(),
+    getCustomMeasurementEntriesByDate: vi.fn(),
+    processSleepEntry: vi.fn(),
+  },
+}));
+vi.mock('../services/preferenceService', () => ({
+  default: {
+    getUserPreferences: vi.fn(),
+  },
+}));
+vi.mock('../models/moodRepository', () => ({
+  default: {
+    createOrUpdateMoodEntry: vi.fn(),
+    getMoodEntryByDate: vi.fn(),
+  },
+}));
+vi.mock('../models/fastingRepository', () => ({
+  default: {
+    createFastingLog: vi.fn(),
+    updateFast: vi.fn(),
+    getCurrentFast: vi.fn(),
+    getFastingLogsOverlappingDay: vi.fn(),
+  },
+}));
+vi.mock('../models/sleepRepository', () => ({
+  default: {
+    getSleepEntriesByUserIdAndDateRange: vi.fn(),
+  },
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+const DB_ERROR_TEXT =
+  'Error [DB_ERROR]: A database error occurred. Please try again.\n\nSuggestion: If the issue persists, contact support.';
+
+let tools: ReturnType<typeof buildCheckinTools>;
+
+function mockEmptyDiary() {
+  vi.mocked(measurementService.getCheckInMeasurements).mockResolvedValue({});
+  vi.mocked(moodRepository.getMoodEntryByDate).mockResolvedValue(undefined);
+  vi.mocked(
+    sleepRepository.getSleepEntriesByUserIdAndDateRange
+  ).mockResolvedValue([]);
+  vi.mocked(fastingRepository.getFastingLogsOverlappingDay).mockResolvedValue(
+    []
+  );
+  vi.mocked(
+    measurementService.getCustomMeasurementEntriesByDate
+  ).mockResolvedValue([]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({});
+  tools = buildCheckinTools('user-1');
+});
+
+describe('log_biometrics', () => {
+  it('converts explicit units to kg/cm for storage and echoes the input units', async () => {
+    vi.mocked(measurementService.upsertCheckInMeasurements).mockResolvedValue({
+      id: 'ci-1',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_biometrics',
+        entry_date: '2026-06-01',
+        weight: 180,
+        weight_unit: 'lbs',
+        waist: 32,
+        measurements_unit: 'in',
+        steps: 9000,
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Biometrics logged for 2026-06-01 (weight: 180lbs, steps: 9000, waist: 32in).'
+    );
+    expect(measurementService.upsertCheckInMeasurements).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      '2026-06-01',
+      {
+        weight: 180 * 0.45359237,
+        waist: 32 * 2.54,
+        steps: 9000,
+      }
+    );
+  });
+
+  it("falls back to the user's preferred units for conversion (text still defaults to kg)", async () => {
+    vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+      default_weight_unit: 'lbs',
+    });
+    vi.mocked(measurementService.upsertCheckInMeasurements).mockResolvedValue({
+      id: 'ci-1',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'log_biometrics', entry_date: '2026-06-01', weight: 180 },
+      opts
+    );
+
+    expect(result).toBe('✅ Biometrics logged for 2026-06-01 (weight: 180kg).');
+    expect(measurementService.upsertCheckInMeasurements).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      '2026-06-01',
+      { weight: 180 * 0.45359237 }
+    );
+  });
+
+  it("reports 'no changes' when no measurements are provided", async () => {
+    vi.mocked(measurementService.upsertCheckInMeasurements).mockResolvedValue(
+      null
+    );
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'log_biometrics', entry_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe('✅ Biometrics logged for 2026-06-01 (no changes).');
+    expect(measurementService.upsertCheckInMeasurements).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      '2026-06-01',
+      {}
+    );
+  });
+
+  it('rejects an unknown weight unit', async () => {
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_biometrics',
+        entry_date: '2026-06-01',
+        weight: 80,
+        weight_unit: 'stone',
+      } as any,
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: weight_unit: Invalid option: expected one of "kg"|"lbs"|"lb"|"g"'
+    );
+  });
+});
+
+describe('log_custom_metric', () => {
+  it('logs against a case-insensitively matched category', async () => {
+    vi.mocked(measurementService.getCustomCategories).mockResolvedValue([
+      {
+        id: 'c1',
+        name: 'Blood Pressure',
+        measurement_type: 'mmHg',
+        frequency: 'Daily',
+      },
+    ]);
+    vi.mocked(
+      measurementService.upsertCustomMeasurementEntry
+    ).mockResolvedValue({ id: 'm1' });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_custom_metric',
+        category_name: 'blood pressure',
+        value: 120,
+        unit: 'mmHg',
+        entry_date: '2026-06-01',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Custom metric "blood pressure" logged: 120 mmHg on 2026-06-01.'
+    );
+    expect(
+      measurementService.upsertCustomMeasurementEntry
+    ).toHaveBeenCalledWith('user-1', 'user-1', {
+      category_id: 'c1',
+      value: '120',
+      entry_date: '2026-06-01',
+      notes: undefined,
+    });
+  });
+
+  it('asks for create_category when the category does not exist', async () => {
+    vi.mocked(measurementService.getCustomCategories).mockResolvedValue([]);
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_custom_metric',
+        category_name: 'Hydration',
+        value: 5,
+        entry_date: '2026-06-01',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: Category "Hydration" not found. Create it first using the create_category action.'
+    );
+    expect(
+      measurementService.upsertCustomMeasurementEntry
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe('list_categories / create_category', () => {
+  it('lists categories sorted by name', async () => {
+    vi.mocked(measurementService.getCustomCategories).mockResolvedValue([
+      { id: 'c2', name: 'Steps Goal', measurement_type: 'steps' },
+      { id: 'c1', name: 'Blood Pressure', measurement_type: 'mmHg' },
+    ]);
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'list_categories' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Custom Measurement Categories\n\n' +
+        '**Blood Pressure**\n  ID: c1\n\n' +
+        '**Steps Goal**\n  ID: c2'
+    );
+    expect(measurementService.getCustomCategories).toHaveBeenCalledWith(
+      'user-1',
+      'user-1'
+    );
+  });
+
+  it('creates a category with MCP defaults', async () => {
+    vi.mocked(measurementService.createCustomCategory).mockResolvedValue({
+      id: 'c9',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'create_category', category_name: 'Hydration', unit: 'ml' },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Category "Hydration" created with measurement type "ml".'
+    );
+    expect(measurementService.createCustomCategory).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      {
+        name: 'Hydration',
+        measurement_type: 'ml',
+        data_type: 'numeric',
+        frequency: 'Daily',
+      }
+    );
+  });
+
+  it('creates a unit-less category', async () => {
+    vi.mocked(measurementService.createCustomCategory).mockResolvedValue({
+      id: 'c9',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'create_category', category_name: 'Meditation' },
+      opts
+    );
+
+    expect(result).toBe('✅ Category "Meditation" created.');
+    expect(measurementService.createCustomCategory).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      {
+        name: 'Meditation',
+        measurement_type: 'unit',
+        data_type: 'numeric',
+        frequency: 'Daily',
+      }
+    );
+  });
+});
+
+describe('log_mood', () => {
+  it('upserts the mood entry and echoes notes', async () => {
+    vi.mocked(moodRepository.createOrUpdateMoodEntry).mockResolvedValue({
+      id: 'mood-1',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_mood',
+        mood_value: 8,
+        notes: 'Feeling good',
+        entry_date: '2026-06-01',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Mood logged for 2026-06-01: 8/10 — Feeling good.');
+    expect(moodRepository.createOrUpdateMoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      8,
+      'Feeling good',
+      '2026-06-01'
+    );
+  });
+
+  it('logs mood without notes', async () => {
+    vi.mocked(moodRepository.createOrUpdateMoodEntry).mockResolvedValue({
+      id: 'mood-1',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'log_mood', mood_value: 5, entry_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe('✅ Mood logged for 2026-06-01: 5/10.');
+    expect(moodRepository.createOrUpdateMoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      5,
+      null,
+      '2026-06-01'
+    );
+  });
+
+  it('rejects a missing entry_date', async () => {
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'log_mood', mood_value: 8 } as any,
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: entry_date: Invalid input: expected string, received undefined'
+    );
+  });
+});
+
+describe('log_fasting', () => {
+  it('creates an active fast without a follow-up update', async () => {
+    vi.mocked(fastingRepository.createFastingLog).mockResolvedValue({
+      id: 'f1',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'log_fasting', start_time: '2026-06-01T20:00:00Z' },
+      opts
+    );
+
+    expect(result).toBe('✅ Fasting window logged (ACTIVE).');
+    expect(fastingRepository.createFastingLog).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-01T20:00:00Z',
+      null,
+      null
+    );
+    expect(fastingRepository.updateFast).not.toHaveBeenCalled();
+  });
+
+  it('records a completed window via a follow-up update', async () => {
+    vi.mocked(fastingRepository.createFastingLog).mockResolvedValue({
+      id: 'f1',
+    });
+    vi.mocked(fastingRepository.updateFast).mockResolvedValue({ id: 'f1' });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_fasting',
+        start_time: '2026-06-01T20:00:00Z',
+        end_time: '2026-06-02T12:00:00Z',
+        fasting_status: 'COMPLETED',
+        fasting_type: '16:8',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Fasting window logged (COMPLETED) — 16:8.');
+    expect(fastingRepository.createFastingLog).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-01T20:00:00Z',
+      null,
+      '16:8'
+    );
+    expect(fastingRepository.updateFast).toHaveBeenCalledWith('f1', 'user-1', {
+      end_time: '2026-06-02T12:00:00Z',
+      status: 'COMPLETED',
+    });
+  });
+});
+
+describe('log_sleep', () => {
+  it('defaults wake time to 7 AM UTC and derives bedtime from the duration', async () => {
+    vi.mocked(measurementService.processSleepEntry).mockResolvedValue({
+      id: 's1',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_sleep',
+        entry_date: '2026-06-01',
+        duration_seconds: 27000,
+        sleep_score: 85,
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Sleep logged for 2026-06-01 (7h 30m, score: 85/100).'
+    );
+    expect(measurementService.processSleepEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      {
+        entry_date: '2026-06-01',
+        bedtime: '2026-05-31T23:30:00.000Z',
+        wake_time: '2026-06-01T07:00:00.000Z',
+        duration_in_seconds: 27000,
+        source: 'manual',
+      }
+    );
+  });
+
+  it('derives wake time from bedtime using the default 8h duration', async () => {
+    vi.mocked(measurementService.processSleepEntry).mockResolvedValue({
+      id: 's1',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_sleep',
+        entry_date: '2026-06-01',
+        bedtime: '2026-05-31T22:00:00.000Z',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Sleep logged for 2026-06-01 (recorded).');
+    expect(measurementService.processSleepEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      {
+        entry_date: '2026-06-01',
+        bedtime: '2026-05-31T22:00:00.000Z',
+        wake_time: '2026-06-01T06:00:00.000Z',
+        duration_in_seconds: 28800,
+        source: 'manual',
+      }
+    );
+  });
+});
+
+describe('list_checkin_diary', () => {
+  it('renders all sections with unit conversion', async () => {
+    mockEmptyDiary();
+    vi.mocked(measurementService.getCheckInMeasurements).mockResolvedValue({
+      id: 'ci-1',
+      entry_date: '2026-06-01',
+      weight: 80,
+      height: null,
+      body_fat_percentage: null,
+      neck: null,
+      waist: 90,
+      hips: null,
+      steps: 9000,
+    });
+    vi.mocked(moodRepository.getMoodEntryByDate).mockResolvedValue({
+      id: 'mood-1',
+      mood_value: 8,
+      notes: 'Good',
+      entry_date: '2026-06-01',
+    });
+    vi.mocked(
+      sleepRepository.getSleepEntriesByUserIdAndDateRange
+    ).mockResolvedValue([
+      {
+        id: 's1',
+        entry_date: '2026-06-01',
+        duration_in_seconds: 27000,
+        sleep_score: 85,
+        bedtime: '2026-05-31T23:30:00.000Z',
+        wake_time: '2026-06-01T07:00:00.000Z',
+        source: 'manual',
+        created_at: '2026-06-01T08:00:00Z',
+      },
+    ]);
+    vi.mocked(fastingRepository.getFastingLogsOverlappingDay).mockResolvedValue(
+      [
+        {
+          id: 'f1',
+          start_time: '2026-06-01T20:00:00.000Z',
+          end_time: null,
+          status: 'ACTIVE',
+          fasting_type: '16:8',
+        },
+      ]
+    );
+    vi.mocked(
+      measurementService.getCustomMeasurementEntriesByDate
+    ).mockResolvedValue([
+      {
+        id: 'm1',
+        value: '120',
+        notes: null,
+        entry_date: '2026-06-01',
+        created_at: '2026-06-01T09:00:00Z',
+        custom_categories: { name: 'Blood Pressure', measurement_type: 'mmHg' },
+      },
+    ]);
+    vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+      default_weight_unit: 'lbs',
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'list_checkin_diary', entry_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### Check-in Diary: 2026-06-01\n\n' +
+        '#### Biometrics\n' +
+        `- **Weight:** ${80 * 2.20462262} lbs\n` +
+        '- **Steps:** 9000\n' +
+        '- **Waist:** 90 cm\n' +
+        '\n' +
+        '## Mood\n' +
+        '- 8/10 — Good\n' +
+        '\n' +
+        '## Sleep\n' +
+        '- 7h 30m | score: 85/100 | bed: 2026-05-31T23:30:00.000Z | wake: 2026-06-01T07:00:00.000Z | (manual)\n' +
+        '\n' +
+        '## Fasting\n' +
+        '- ACTIVE (16:8): 2026-06-01T20:00:00.000Z\n' +
+        '\n' +
+        '## Custom Metrics\n' +
+        '- **Blood Pressure**: 120\n' +
+        '\n'
+    );
+  });
+
+  it('defaults to today and reports an empty diary', async () => {
+    mockEmptyDiary();
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'list_checkin_diary' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### Check-in Diary: today\n\nNo check-in data found for this date.\n'
+    );
+    expect(measurementService.getCheckInMeasurements).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      todayInZone('UTC')
+    );
+  });
+});
+
+describe('get_fasting_status', () => {
+  it('returns the active fasting session', async () => {
+    vi.mocked(fastingRepository.getCurrentFast).mockResolvedValue({
+      id: 'f1',
+      user_id: 'user-1',
+      start_time: '2026-06-01T20:00:00.000Z',
+      end_time: null,
+      status: 'ACTIVE',
+      fasting_type: '16:8',
+      created_at: '2026-06-01T20:00:01.000Z',
+      target_end_time: null,
+    });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'get_fasting_status' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Fasting Status\n\n' +
+        JSON.stringify(
+          {
+            id: 'f1',
+            user_id: 'user-1',
+            start_time: '2026-06-01T20:00:00.000Z',
+            end_time: null,
+            fasting_status: 'ACTIVE',
+            fasting_type: '16:8',
+            created_at: '2026-06-01T20:00:01.000Z',
+          },
+          null,
+          2
+        )
+    );
+  });
+
+  it('reports when no fast is active', async () => {
+    vi.mocked(fastingRepository.getCurrentFast).mockResolvedValue(undefined);
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'get_fasting_status' },
+      opts
+    );
+
+    expect(result).toBe('No active fasting session.');
+  });
+});
+
+describe('get_biometrics_history', () => {
+  it('renders oldest-first with converted units', async () => {
+    vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+      default_weight_unit: 'lbs',
+    });
+    vi.mocked(
+      measurementService.getCheckInMeasurementsByDateRange
+    ).mockResolvedValue([
+      {
+        entry_date: '2026-06-02',
+        weight: 80,
+        body_fat_percentage: 22,
+        steps: 9000,
+      },
+      { entry_date: '2026-06-01', weight: 81, steps: null },
+    ]);
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'get_biometrics_history',
+        start_date: '2026-06-01',
+        end_date: '2026-06-02',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Biometrics History\n\n' +
+        `**2026-06-01**: Weight: ${81 * 2.20462262}lbs \n\n` +
+        `**2026-06-02**: Weight: ${80 * 2.20462262}lbs | BF: 22% | Steps: 9000`
+    );
+    expect(
+      measurementService.getCheckInMeasurementsByDateRange
+    ).toHaveBeenCalledWith('user-1', 'user-1', '2026-06-01', '2026-06-02');
+  });
+
+  it('defaults to the full history range', async () => {
+    vi.mocked(
+      measurementService.getCheckInMeasurementsByDateRange
+    ).mockResolvedValue([]);
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'get_biometrics_history' },
+      opts
+    );
+
+    expect(result).toBe('# Biometrics History\n\nNo results found.');
+    expect(
+      measurementService.getCheckInMeasurementsByDateRange
+    ).toHaveBeenCalledWith('user-1', 'user-1', '1970-01-01', '9999-12-31');
+  });
+});
+
+describe('error handling', () => {
+  it("maps service 'not found' errors to VALIDATION", async () => {
+    vi.mocked(measurementService.getCustomCategories).mockResolvedValue([
+      { id: 'c1', name: 'Hydration' },
+    ]);
+    vi.mocked(
+      measurementService.upsertCustomMeasurementEntry
+    ).mockRejectedValue(new Error('Custom category with ID c1 not found.'));
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_custom_metric',
+        category_name: 'Hydration',
+        value: 5,
+        entry_date: '2026-06-01',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: Custom category with ID c1 not found.'
+    );
+  });
+
+  it('returns DB_ERROR for other failures', async () => {
+    vi.mocked(moodRepository.createOrUpdateMoodEntry).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      { action: 'log_mood', mood_value: 8, entry_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsCoach.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsCoach.test.ts
@@ -1,0 +1,672 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { todayInZone } from '@workspace/shared';
+import { buildCoachTools } from '../ai/tools/coachTools.js';
+import coachRepository from '../models/coachRepository.js';
+
+vi.mock('../models/coachRepository', () => ({
+  default: {
+    getNutritionAggregates: vi.fn(),
+    getExerciseAggregates: vi.fn(),
+    getLatestWeightInRange: vi.fn(),
+    getWaterIntakeTotal: vi.fn(),
+    getWeightSeries: vi.fn(),
+    getDailyCalorieSeries: vi.fn(),
+    get30DayFoodAggregates: vi.fn(),
+    get30DayExerciseAggregates: vi.fn(),
+    get30DayMoodAggregates: vi.fn(),
+    get30DaySleepAggregates: vi.fn(),
+    get30DayWeightSeries: vi.fn(),
+    getDailyCorrelationRows: vi.fn(),
+    getFrequentHighProteinFoods: vi.fn(),
+  },
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+const DB_ERROR_TEXT =
+  'Error [DB_ERROR]: A database error occurred. Please try again.\n\nSuggestion: If the issue persists, contact support.';
+
+let tools: ReturnType<typeof buildCoachTools>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tools = buildCoachTools('user-1');
+});
+
+describe('sparky_get_health_summary', () => {
+  it('renders nutrition, fitness, vitals, and hydration as JSON', async () => {
+    vi.mocked(coachRepository.getNutritionAggregates).mockResolvedValue({
+      total_calories: '12450.5',
+      avg_protein: '98.7654',
+      avg_carbs: '210.1234',
+      avg_fat: '65.4321',
+      entry_count: 21,
+    });
+    vi.mocked(coachRepository.getExerciseAggregates).mockResolvedValue({
+      total_calories_burned: '3200',
+      workout_count: 5,
+    });
+    vi.mocked(coachRepository.getLatestWeightInRange).mockResolvedValue({
+      weight: '81.5',
+      entry_date: '2026-06-07',
+    });
+    vi.mocked(coachRepository.getWaterIntakeTotal).mockResolvedValue({
+      total_water: '14000',
+    });
+
+    const result = await tools.sparky_get_health_summary.execute!(
+      { start_date: '2026-06-01', end_date: '2026-06-07' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Health Summary\n\n' +
+        JSON.stringify(
+          {
+            period: { start_date: '2026-06-01', end_date: '2026-06-07' },
+            nutrition: {
+              total_calories: 12450.5,
+              avg_protein: 98.8,
+              avg_carbs: 210.1,
+              avg_fat: 65.4,
+              entry_count: 21,
+            },
+            fitness: {
+              total_calories_burned: 3200,
+              workout_count: 5,
+            },
+            vitals: {
+              latest_weight: { weight: 81.5, date: '2026-06-07' },
+            },
+            hydration: {
+              total_water_ml: 14000,
+            },
+          },
+          null,
+          2
+        )
+    );
+    expect(coachRepository.getNutritionAggregates).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-01',
+      '2026-06-07'
+    );
+    expect(coachRepository.getWaterIntakeTotal).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-01',
+      '2026-06-07'
+    );
+  });
+
+  it('defaults end_date to start_date and renders a null latest weight', async () => {
+    vi.mocked(coachRepository.getNutritionAggregates).mockResolvedValue({
+      total_calories: '0',
+      avg_protein: '0',
+      avg_carbs: '0',
+      avg_fat: '0',
+      entry_count: 0,
+    });
+    vi.mocked(coachRepository.getExerciseAggregates).mockResolvedValue({
+      total_calories_burned: '0',
+      workout_count: 0,
+    });
+    vi.mocked(coachRepository.getLatestWeightInRange).mockResolvedValue(null);
+    vi.mocked(coachRepository.getWaterIntakeTotal).mockResolvedValue({
+      total_water: '0',
+    });
+
+    const result = await tools.sparky_get_health_summary.execute!(
+      { start_date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Health Summary\n\n' +
+        JSON.stringify(
+          {
+            period: { start_date: '2026-06-10', end_date: '2026-06-10' },
+            nutrition: {
+              total_calories: 0,
+              avg_protein: 0,
+              avg_carbs: 0,
+              avg_fat: 0,
+              entry_count: 0,
+            },
+            fitness: {
+              total_calories_burned: 0,
+              workout_count: 0,
+            },
+            vitals: {
+              latest_weight: null,
+            },
+            hydration: {
+              total_water_ml: 0,
+            },
+          },
+          null,
+          2
+        )
+    );
+    expect(coachRepository.getLatestWeightInRange).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-10',
+      '2026-06-10'
+    );
+  });
+
+  it('returns a validation error when start_date is missing', async () => {
+    const result = await tools.sparky_get_health_summary.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: start_date: Invalid input: expected string, received undefined'
+    );
+  });
+
+  it('maps repository failures to DB_ERROR', async () => {
+    vi.mocked(coachRepository.getNutritionAggregates).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_get_health_summary.execute!(
+      { start_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+describe('sparky_analyze_trends', () => {
+  it('classifies a small weight change as stable and averages calories', async () => {
+    vi.mocked(coachRepository.getWeightSeries).mockResolvedValue([
+      { entry_date: '2026-06-01', weight: '80.0' },
+      { entry_date: '2026-06-07', weight: '80.3' },
+    ]);
+    vi.mocked(coachRepository.getDailyCalorieSeries).mockResolvedValue([
+      { entry_date: '2026-06-01', daily_calories: '2000' },
+      { entry_date: '2026-06-02', daily_calories: '2100' },
+    ]);
+
+    const result = await tools.sparky_analyze_trends.execute!(
+      { days: 14 },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Trend Analysis\n\n' +
+        JSON.stringify(
+          {
+            period_days: 14,
+            weight: {
+              trend: 'stable',
+              data_points: 2,
+              entries: [
+                { date: '2026-06-01', weight: 80 },
+                { date: '2026-06-07', weight: 80.3 },
+              ],
+            },
+            calories: {
+              average_daily: 2050,
+              data_points: 2,
+              entries: [
+                { date: '2026-06-01', calories: 2000 },
+                { date: '2026-06-02', calories: 2100 },
+              ],
+            },
+          },
+          null,
+          2
+        )
+    );
+    expect(coachRepository.getWeightSeries).toHaveBeenCalledWith('user-1', 14);
+    expect(coachRepository.getDailyCalorieSeries).toHaveBeenCalledWith(
+      'user-1',
+      14
+    );
+  });
+
+  it('classifies a falling series as decreasing', async () => {
+    vi.mocked(coachRepository.getWeightSeries).mockResolvedValue([
+      { entry_date: '2026-06-01', weight: '82' },
+      { entry_date: '2026-06-07', weight: '80.5' },
+    ]);
+    vi.mocked(coachRepository.getDailyCalorieSeries).mockResolvedValue([]);
+
+    const result = await tools.sparky_analyze_trends.execute!(
+      { days: 7 },
+      opts
+    );
+
+    expect(result).toContain('"trend": "decreasing"');
+  });
+
+  it('defaults days to 7 and reports insufficient data with no entries', async () => {
+    vi.mocked(coachRepository.getWeightSeries).mockResolvedValue([]);
+    vi.mocked(coachRepository.getDailyCalorieSeries).mockResolvedValue([]);
+
+    const result = await tools.sparky_analyze_trends.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      opts
+    );
+
+    expect(result).toBe(
+      '# Trend Analysis\n\n' +
+        JSON.stringify(
+          {
+            period_days: 7,
+            weight: {
+              trend: 'insufficient_data',
+              data_points: 0,
+              entries: [],
+            },
+            calories: {
+              average_daily: 0,
+              data_points: 0,
+              entries: [],
+            },
+          },
+          null,
+          2
+        )
+    );
+    expect(coachRepository.getWeightSeries).toHaveBeenCalledWith('user-1', 7);
+  });
+
+  it('maps repository failures to DB_ERROR', async () => {
+    vi.mocked(coachRepository.getWeightSeries).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_analyze_trends.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+describe('sparky_get_30_day_trends', () => {
+  it('renders all five trend sections with unit conversions', async () => {
+    vi.mocked(coachRepository.get30DayFoodAggregates).mockResolvedValue({
+      days_logged: 12,
+      avg_daily_calories: '2150.6',
+      avg_daily_protein: '95.25',
+    });
+    vi.mocked(coachRepository.get30DayExerciseAggregates).mockResolvedValue({
+      total_workouts: 8,
+      active_days: 6,
+      total_calories_burned: '2400',
+    });
+    vi.mocked(coachRepository.get30DayMoodAggregates).mockResolvedValue({
+      entries: 10,
+      avg_mood: '7.44',
+    });
+    vi.mocked(coachRepository.get30DaySleepAggregates).mockResolvedValue({
+      entries: 9,
+      avg_duration_seconds: '27000',
+      avg_sleep_score: '82.6',
+    });
+    vi.mocked(coachRepository.get30DayWeightSeries).mockResolvedValue([
+      { entry_date: '2026-05-20', weight: '82' },
+      { entry_date: '2026-06-05', weight: '81.2' },
+    ]);
+
+    const result = await tools.sparky_get_30_day_trends.execute!(
+      { end_date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# 30-Day Trends\n\n' +
+        JSON.stringify(
+          {
+            period: { end_date: '2026-06-10', days: 30 },
+            food: {
+              days_logged: 12,
+              avg_daily_calories: 2151,
+              avg_daily_protein: 95.3,
+            },
+            exercise: {
+              total_workouts: 8,
+              active_days: 6,
+              total_calories_burned: 2400,
+            },
+            mood: {
+              entries: 10,
+              avg_mood: 7.4,
+            },
+            sleep: {
+              entries: 9,
+              avg_duration_hours: 7.5,
+              avg_sleep_score: 83,
+            },
+            biometrics: {
+              weight_entries: 2,
+              weights: [
+                { date: '2026-05-20', weight: 82 },
+                { date: '2026-06-05', weight: 81.2 },
+              ],
+            },
+          },
+          null,
+          2
+        )
+    );
+    expect(coachRepository.get30DayFoodAggregates).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-10'
+    );
+  });
+
+  it('defaults end_date to today (UTC)', async () => {
+    vi.mocked(coachRepository.get30DayFoodAggregates).mockResolvedValue({
+      days_logged: 0,
+      avg_daily_calories: '0',
+      avg_daily_protein: '0',
+    });
+    vi.mocked(coachRepository.get30DayExerciseAggregates).mockResolvedValue({
+      total_workouts: 0,
+      active_days: 0,
+      total_calories_burned: '0',
+    });
+    vi.mocked(coachRepository.get30DayMoodAggregates).mockResolvedValue({
+      entries: 0,
+      avg_mood: '0',
+    });
+    vi.mocked(coachRepository.get30DaySleepAggregates).mockResolvedValue({
+      entries: 0,
+      avg_duration_seconds: '0',
+      avg_sleep_score: '0',
+    });
+    vi.mocked(coachRepository.get30DayWeightSeries).mockResolvedValue([]);
+
+    await tools.sparky_get_30_day_trends.execute!({}, opts);
+
+    expect(coachRepository.get30DayFoodAggregates).toHaveBeenCalledWith(
+      'user-1',
+      todayInZone('UTC')
+    );
+  });
+
+  it('maps repository failures to DB_ERROR', async () => {
+    vi.mocked(coachRepository.get30DayFoodAggregates).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_get_30_day_trends.execute!({}, opts);
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+// Full correlation row as returned by coachRepository.getDailyCorrelationRows.
+function makeCorrelationRow(
+  date: string,
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    entry_date: date,
+    calories: '2000',
+    protein: '90',
+    carbs: '250',
+    fat: '70',
+    sugars: '40',
+    sodium: '1000',
+    fiber: '30',
+    sat_fat: '20',
+    cholesterol: '300',
+    potassium: '3500',
+    vit_a: '700',
+    vit_c: '60',
+    calcium: '1000',
+    iron: '8',
+    duration_in_seconds: 28800,
+    sleep_score: 80,
+    mood_value: 6,
+    ...overrides,
+  };
+}
+
+// The nutrition projection detectPatterns emits for a default makeCorrelationRow.
+function expectedCorrelation(
+  date: string,
+  overrides: Record<string, unknown> = {}
+) {
+  return {
+    date,
+    nutrition: {
+      calories: 2000,
+      protein: 90,
+      carbs: 250,
+      fat: 70,
+      sugars: 40,
+      sodium: 1000,
+      fiber: 30,
+      saturated_fat: 20,
+      cholesterol: 300,
+      potassium: 3500,
+      vitamin_a: 700,
+      vitamin_c: 60,
+      calcium: 1000,
+      iron: 8,
+      ...(overrides.nutrition as Record<string, unknown>),
+    },
+    sleep_score: 'sleep_score' in overrides ? overrides.sleep_score : 80,
+    mood_value: 'mood_value' in overrides ? overrides.mood_value : 6,
+  };
+}
+
+describe('sparky_detect_patterns', () => {
+  it('defaults days to 30 and reports no patterns for sparse data', async () => {
+    vi.mocked(coachRepository.getDailyCorrelationRows).mockResolvedValue([
+      makeCorrelationRow('2026-06-10'),
+      makeCorrelationRow('2026-06-09', { sleep_score: null, mood_value: null }),
+    ]);
+
+    const result = await tools.sparky_detect_patterns.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      opts
+    );
+
+    expect(result).toBe(
+      '# Pattern Detection\n\n' +
+        JSON.stringify(
+          {
+            period_days: 30,
+            data_points: 2,
+            detected_patterns: [
+              'No strong patterns detected in the current data range.',
+            ],
+            raw_correlations: [
+              expectedCorrelation('2026-06-10'),
+              expectedCorrelation('2026-06-09', {
+                sleep_score: null,
+                mood_value: null,
+              }),
+            ],
+          },
+          null,
+          2
+        )
+    );
+    expect(coachRepository.getDailyCorrelationRows).toHaveBeenCalledWith(
+      'user-1',
+      30
+    );
+  });
+
+  it('detects sugar/sleep, calorie/mood, and sodium patterns and caps raw rows at 7', async () => {
+    const highDays = ['2026-06-10', '2026-06-09', '2026-06-08'].map((d) =>
+      makeCorrelationRow(d, {
+        sugars: '60',
+        sodium: '2400',
+        calories: '2600',
+        sleep_score: 60,
+        mood_value: 8,
+      })
+    );
+    const normalDays = [
+      '2026-06-07',
+      '2026-06-06',
+      '2026-06-05',
+      '2026-06-04',
+      '2026-06-03',
+    ].map((d) => makeCorrelationRow(d));
+    vi.mocked(coachRepository.getDailyCorrelationRows).mockResolvedValue([
+      ...highDays,
+      ...normalDays,
+    ]);
+
+    const result = (await tools.sparky_detect_patterns.execute!(
+      { days: 14 },
+      opts
+    )) as string;
+
+    const parsed = JSON.parse(result.replace('# Pattern Detection\n\n', ''));
+    expect(parsed.period_days).toBe(14);
+    expect(parsed.data_points).toBe(8);
+    expect(parsed.detected_patterns).toEqual([
+      'High sugar intake (>50g) correlates with a lower sleep score.',
+      'High calorie days (>2500) are associated with higher reported mood.',
+      'Frequent high sodium intake (>2300mg) detected; this may impact morning weight fluctuations.',
+    ]);
+    expect(parsed.raw_correlations).toHaveLength(7);
+    expect(parsed.raw_correlations[0]).toEqual(
+      expectedCorrelation('2026-06-10', {
+        nutrition: { sugars: 60, sodium: 2400, calories: 2600 },
+        sleep_score: 60,
+        mood_value: 8,
+      })
+    );
+  });
+
+  it('maps repository failures to DB_ERROR', async () => {
+    vi.mocked(coachRepository.getDailyCorrelationRows).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_detect_patterns.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+describe('sparky_generate_coaching_plan', () => {
+  it('estimates TDEE from 14-day trends and applies the weight_loss deficit', async () => {
+    vi.mocked(coachRepository.getWeightSeries).mockResolvedValue([
+      { entry_date: '2026-05-28', weight: '80' },
+      { entry_date: '2026-06-10', weight: '81' },
+    ]);
+    vi.mocked(coachRepository.getDailyCalorieSeries).mockResolvedValue(
+      [
+        '2026-06-04',
+        '2026-06-05',
+        '2026-06-06',
+        '2026-06-07',
+        '2026-06-08',
+        '2026-06-09',
+        '2026-06-10',
+      ].map((d) => ({ entry_date: d, daily_calories: '2400' }))
+    );
+    vi.mocked(coachRepository.getFrequentHighProteinFoods).mockResolvedValue([
+      { food_name: 'Chicken Breast', frequency: '12' },
+      { food_name: 'Greek Yogurt', frequency: '8' },
+    ]);
+
+    const result = await tools.sparky_generate_coaching_plan.execute!(
+      { goal: 'weight_loss', target_weight: 75 },
+      opts
+    );
+
+    // avg 2400 kcal; +1kg over 14 days -> daily balance 550 -> TDEE 1850;
+    // weight_loss deficit -> 1350 target.
+    expect(result).toBe(
+      '# Coaching Plan\n\n' +
+        JSON.stringify(
+          {
+            goal: 'weight_loss',
+            current_estimated_tdee: 1850,
+            recommended_targets: {
+              daily_calories: 1350,
+              protein_grams: 101,
+              carbs_grams: 135,
+              fat_grams: 45,
+            },
+            shopping_list_suggestions: ['Chicken Breast', 'Greek Yogurt'],
+            coaching_insight:
+              'Your weight is currently trending up. To hit your weight loss goal, we need to bring daily calories down to 1350.',
+          },
+          null,
+          2
+        )
+    );
+    expect(coachRepository.getWeightSeries).toHaveBeenCalledWith('user-1', 14);
+    expect(coachRepository.getDailyCalorieSeries).toHaveBeenCalledWith(
+      'user-1',
+      14
+    );
+  });
+
+  it('falls back to a 2200 TDEE and the default maintenance goal', async () => {
+    vi.mocked(coachRepository.getWeightSeries).mockResolvedValue([]);
+    vi.mocked(coachRepository.getDailyCalorieSeries).mockResolvedValue([]);
+    vi.mocked(coachRepository.getFrequentHighProteinFoods).mockResolvedValue(
+      []
+    );
+
+    const result = await tools.sparky_generate_coaching_plan.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      opts
+    );
+
+    expect(result).toBe(
+      '# Coaching Plan\n\n' +
+        JSON.stringify(
+          {
+            goal: 'maintenance',
+            current_estimated_tdee: 2200,
+            recommended_targets: {
+              daily_calories: 2200,
+              protein_grams: 165,
+              carbs_grams: 220,
+              fat_grams: 73,
+            },
+            shopping_list_suggestions: [],
+            coaching_insight:
+              'You are on the right track for your maintenance goal.',
+          },
+          null,
+          2
+        )
+    );
+  });
+
+  it('maps repository failures to DB_ERROR', async () => {
+    vi.mocked(coachRepository.getWeightSeries).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_generate_coaching_plan.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsCoach.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsCoach.test.ts
@@ -32,7 +32,7 @@ let tools: ReturnType<typeof buildCoachTools>;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  tools = buildCoachTools('user-1');
+  tools = buildCoachTools('user-1', 'UTC');
 });
 
 describe('sparky_get_health_summary', () => {
@@ -97,6 +97,60 @@ describe('sparky_get_health_summary', () => {
       'user-1',
       '2026-06-01',
       '2026-06-07'
+    );
+  });
+
+  it('renders a pg local-midnight Date weight date as a calendar-day string', async () => {
+    vi.mocked(coachRepository.getNutritionAggregates).mockResolvedValue({
+      total_calories: '0',
+      avg_protein: '0',
+      avg_carbs: '0',
+      avg_fat: '0',
+      entry_count: 0,
+    });
+    vi.mocked(coachRepository.getExerciseAggregates).mockResolvedValue({
+      total_calories_burned: '0',
+      workout_count: 0,
+    });
+    vi.mocked(coachRepository.getLatestWeightInRange).mockResolvedValue({
+      weight: '81.5',
+      entry_date: new Date(2026, 5, 10),
+    });
+    vi.mocked(coachRepository.getWaterIntakeTotal).mockResolvedValue({
+      total_water: '0',
+    });
+
+    const result = await tools.sparky_get_health_summary.execute!(
+      { start_date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Health Summary\n\n' +
+        JSON.stringify(
+          {
+            period: { start_date: '2026-06-10', end_date: '2026-06-10' },
+            nutrition: {
+              total_calories: 0,
+              avg_protein: 0,
+              avg_carbs: 0,
+              avg_fat: 0,
+              entry_count: 0,
+            },
+            fitness: {
+              total_calories_burned: 0,
+              workout_count: 0,
+            },
+            vitals: {
+              latest_weight: { weight: 81.5, date: '2026-06-10' },
+            },
+            hydration: {
+              total_water_ml: 0,
+            },
+          },
+          null,
+          2
+        )
     );
   });
 
@@ -224,10 +278,15 @@ describe('sparky_analyze_trends', () => {
           2
         )
     );
-    expect(coachRepository.getWeightSeries).toHaveBeenCalledWith('user-1', 14);
+    expect(coachRepository.getWeightSeries).toHaveBeenCalledWith(
+      'user-1',
+      14,
+      todayInZone('UTC')
+    );
     expect(coachRepository.getDailyCalorieSeries).toHaveBeenCalledWith(
       'user-1',
-      14
+      14,
+      todayInZone('UTC')
     );
   });
 
@@ -276,7 +335,11 @@ describe('sparky_analyze_trends', () => {
           2
         )
     );
-    expect(coachRepository.getWeightSeries).toHaveBeenCalledWith('user-1', 7);
+    expect(coachRepository.getWeightSeries).toHaveBeenCalledWith(
+      'user-1',
+      7,
+      todayInZone('UTC')
+    );
   });
 
   it('maps repository failures to DB_ERROR', async () => {
@@ -501,7 +564,8 @@ describe('sparky_detect_patterns', () => {
     );
     expect(coachRepository.getDailyCorrelationRows).toHaveBeenCalledWith(
       'user-1',
-      30
+      30,
+      todayInZone('UTC')
     );
   });
 
@@ -614,10 +678,15 @@ describe('sparky_generate_coaching_plan', () => {
           2
         )
     );
-    expect(coachRepository.getWeightSeries).toHaveBeenCalledWith('user-1', 14);
+    expect(coachRepository.getWeightSeries).toHaveBeenCalledWith(
+      'user-1',
+      14,
+      todayInZone('UTC')
+    );
     expect(coachRepository.getDailyCalorieSeries).toHaveBeenCalledWith(
       'user-1',
-      14
+      14,
+      todayInZone('UTC')
     );
   });
 

--- a/SparkyFitnessServer/tests/chatbotToolsEngagement.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsEngagement.test.ts
@@ -1,0 +1,290 @@
+import { vi, beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { buildEngagementTools } from '../ai/tools/engagementTools.js';
+import engagementRepository from '../models/engagementRepository.js';
+
+vi.mock('../models/engagementRepository', () => ({
+  default: {
+    getLastExerciseDate: vi.fn(),
+    getRecentWeights: vi.fn(),
+    getWeeklyLoggedDayCount: vi.fn(),
+    getLoggedDates: vi.fn(),
+    getTodayActivityCounts: vi.fn(),
+  },
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+const DB_ERROR_TEXT =
+  'Error [DB_ERROR]: A database error occurred. Please try again.\n\nSuggestion: If the issue persists, contact support.';
+
+// pg returns DATE columns as local-midnight Date objects; fixtures mirror that.
+const day = (dayOfMonth: number) => new Date(2026, 5, dayOfMonth);
+
+function success(title: string, data: unknown): string {
+  return `# ${title}\n\n${JSON.stringify(data, null, 2)}`;
+}
+
+let tools: ReturnType<typeof buildEngagementTools>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  // Local noon, June 11 2026
+  vi.setSystemTime(new Date(2026, 5, 11, 12, 0, 0));
+  tools = buildEngagementTools('user-1');
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('sparky_check_engagement', () => {
+  it('composes missed-workout, plateau and streak-building triggers', async () => {
+    vi.mocked(engagementRepository.getLastExerciseDate).mockResolvedValue(
+      day(1)
+    );
+    vi.mocked(engagementRepository.getRecentWeights).mockResolvedValue([
+      { weight: '80.2', entry_date: day(10) },
+      { weight: '80.1', entry_date: day(9) },
+    ]);
+    vi.mocked(engagementRepository.getWeeklyLoggedDayCount).mockResolvedValue(
+      5
+    );
+
+    const result = await tools.sparky_check_engagement.execute!({}, opts);
+
+    expect(result).toBe(
+      success('Engagement Triggers', {
+        triggers: [
+          {
+            type: 'missed_workout',
+            message: 'No workout logged in 10 days. Time to get moving!',
+          },
+          {
+            type: 'weight_plateau',
+            message:
+              "Your weight has been stable for the past week. Consider adjusting your routine if you're trying to change.",
+          },
+          {
+            type: 'streak_building',
+            message: "You're on a 5-day logging streak. Keep going!",
+          },
+        ],
+        trigger_count: 3,
+        checked_at: new Date().toISOString(),
+      })
+    );
+    expect(engagementRepository.getLastExerciseDate).toHaveBeenCalledWith(
+      'user-1'
+    );
+  });
+
+  it('reports no_workouts and achievement for a workout-free week of logging', async () => {
+    vi.mocked(engagementRepository.getLastExerciseDate).mockResolvedValue(null);
+    vi.mocked(engagementRepository.getRecentWeights).mockResolvedValue([]);
+    vi.mocked(engagementRepository.getWeeklyLoggedDayCount).mockResolvedValue(
+      7
+    );
+
+    const result = await tools.sparky_check_engagement.execute!({}, opts);
+
+    expect(result).toBe(
+      success('Engagement Triggers', {
+        triggers: [
+          {
+            type: 'no_workouts',
+            message:
+              'No workouts logged yet. Start your fitness journey today!',
+          },
+          {
+            type: 'achievement',
+            message:
+              "Amazing! You've logged data every day for the past week. Keep it up!",
+          },
+        ],
+        trigger_count: 2,
+        checked_at: new Date().toISOString(),
+      })
+    );
+  });
+
+  it('finds no triggers for a recently active user with moving weight', async () => {
+    vi.mocked(engagementRepository.getLastExerciseDate).mockResolvedValue(
+      day(10)
+    );
+    vi.mocked(engagementRepository.getRecentWeights).mockResolvedValue([
+      { weight: '81', entry_date: day(10) },
+      { weight: '80', entry_date: day(9) },
+    ]);
+    vi.mocked(engagementRepository.getWeeklyLoggedDayCount).mockResolvedValue(
+      2
+    );
+
+    const result = await tools.sparky_check_engagement.execute!({}, opts);
+
+    expect(result).toBe(
+      success('Engagement Triggers', {
+        triggers: [],
+        trigger_count: 0,
+        checked_at: new Date().toISOString(),
+      })
+    );
+  });
+
+  it('returns DB_ERROR when the repository throws', async () => {
+    vi.mocked(engagementRepository.getLastExerciseDate).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_check_engagement.execute!({}, opts);
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+describe('sparky_get_logging_streak', () => {
+  it('counts consecutive days including today', async () => {
+    const rows = [
+      { entry_date: day(11) },
+      { entry_date: day(10) },
+      { entry_date: day(9) },
+    ];
+    vi.mocked(engagementRepository.getLoggedDates).mockResolvedValue(rows);
+
+    const result = await tools.sparky_get_logging_streak.execute!({}, opts);
+
+    expect(result).toBe(
+      success('Logging Streak', {
+        current_streak: 3,
+        last_logged: rows[0].entry_date,
+      })
+    );
+    expect(engagementRepository.getLoggedDates).toHaveBeenCalledWith('user-1');
+  });
+
+  it('lets the streak start from yesterday when nothing is logged today', async () => {
+    const rows = [{ entry_date: day(10) }, { entry_date: day(9) }];
+    vi.mocked(engagementRepository.getLoggedDates).mockResolvedValue(rows);
+
+    const result = await tools.sparky_get_logging_streak.execute!({}, opts);
+
+    expect(result).toBe(
+      success('Logging Streak', {
+        current_streak: 2,
+        last_logged: rows[0].entry_date,
+      })
+    );
+  });
+
+  it('reports a zero streak when the last log is older than yesterday', async () => {
+    const rows = [{ entry_date: day(8) }];
+    vi.mocked(engagementRepository.getLoggedDates).mockResolvedValue(rows);
+
+    const result = await tools.sparky_get_logging_streak.execute!({}, opts);
+
+    expect(result).toBe(
+      success('Logging Streak', {
+        current_streak: 0,
+        last_logged: rows[0].entry_date,
+      })
+    );
+  });
+
+  it('stops counting at a gap', async () => {
+    const rows = [{ entry_date: day(11) }, { entry_date: day(9) }];
+    vi.mocked(engagementRepository.getLoggedDates).mockResolvedValue(rows);
+
+    const result = await tools.sparky_get_logging_streak.execute!({}, opts);
+
+    expect(result).toBe(
+      success('Logging Streak', {
+        current_streak: 1,
+        last_logged: rows[0].entry_date,
+      })
+    );
+  });
+
+  it('handles a user with no logs at all', async () => {
+    vi.mocked(engagementRepository.getLoggedDates).mockResolvedValue([]);
+
+    const result = await tools.sparky_get_logging_streak.execute!({}, opts);
+
+    expect(result).toBe(
+      success('Logging Streak', { current_streak: 0, last_logged: null })
+    );
+  });
+
+  it('returns DB_ERROR when the repository throws', async () => {
+    vi.mocked(engagementRepository.getLoggedDates).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_get_logging_streak.execute!({}, opts);
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+describe('sparky_get_contextual_nudge', () => {
+  it.each([
+    [
+      { food_count: 0, exercise_count: 0, checkin_count: 0 },
+      "You haven't logged anything today yet. Start with a quick check-in or log your breakfast!",
+      'start_day',
+    ],
+    [
+      { food_count: 2, exercise_count: 0, checkin_count: 0 },
+      "You've logged your meals but no exercise today. Even a short walk counts!",
+      'suggest_exercise',
+    ],
+    [
+      { food_count: 0, exercise_count: 1, checkin_count: 1 },
+      "Great workout! Don't forget to log your meals to track your nutrition.",
+      'suggest_food',
+    ],
+    [
+      { food_count: 2, exercise_count: 1, checkin_count: 0 },
+      "You're doing great with logging today! Consider a quick check-in to track your weight or mood.",
+      'suggest_checkin',
+    ],
+    [
+      { food_count: 2, exercise_count: 1, checkin_count: 1 },
+      "Excellent! You've been thorough with your logging today. Keep up the great work!",
+      'encouragement',
+    ],
+  ])('nudges based on today activity %o', async (counts, nudge, nudgeType) => {
+    vi.mocked(engagementRepository.getTodayActivityCounts).mockResolvedValue(
+      counts
+    );
+
+    const result = await tools.sparky_get_contextual_nudge.execute!({}, opts);
+
+    expect(result).toBe(
+      success('Contextual Nudge', {
+        nudge,
+        nudge_type: nudgeType,
+        today_summary: {
+          food_entries: counts.food_count,
+          exercise_entries: counts.exercise_count,
+          checkin_entries: counts.checkin_count,
+        },
+        generated_at: new Date().toISOString(),
+      })
+    );
+    expect(engagementRepository.getTodayActivityCounts).toHaveBeenCalledWith(
+      'user-1'
+    );
+  });
+
+  it('returns DB_ERROR when the repository throws', async () => {
+    vi.mocked(engagementRepository.getTodayActivityCounts).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_get_contextual_nudge.execute!({}, opts);
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsEngagement.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsEngagement.test.ts
@@ -31,9 +31,10 @@ let tools: ReturnType<typeof buildEngagementTools>;
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
-  // Local noon, June 11 2026
-  vi.setSystemTime(new Date(2026, 5, 11, 12, 0, 0));
-  tools = buildEngagementTools('user-1');
+  // A UTC instant ("today" is computed via todayInZone, so a local-time
+  // anchor would make the suite host-timezone-dependent).
+  vi.setSystemTime(new Date('2026-06-11T12:00:00Z'));
+  tools = buildEngagementTools('user-1', 'UTC');
 });
 
 afterEach(() => {
@@ -78,6 +79,10 @@ describe('sparky_check_engagement', () => {
     );
     expect(engagementRepository.getLastExerciseDate).toHaveBeenCalledWith(
       'user-1'
+    );
+    expect(engagementRepository.getWeeklyLoggedDayCount).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-11'
     );
   });
 
@@ -158,7 +163,7 @@ describe('sparky_get_logging_streak', () => {
     expect(result).toBe(
       success('Logging Streak', {
         current_streak: 3,
-        last_logged: rows[0].entry_date,
+        last_logged: '2026-06-11',
       })
     );
     expect(engagementRepository.getLoggedDates).toHaveBeenCalledWith('user-1');
@@ -173,7 +178,7 @@ describe('sparky_get_logging_streak', () => {
     expect(result).toBe(
       success('Logging Streak', {
         current_streak: 2,
-        last_logged: rows[0].entry_date,
+        last_logged: '2026-06-10',
       })
     );
   });
@@ -187,7 +192,7 @@ describe('sparky_get_logging_streak', () => {
     expect(result).toBe(
       success('Logging Streak', {
         current_streak: 0,
-        last_logged: rows[0].entry_date,
+        last_logged: '2026-06-08',
       })
     );
   });
@@ -201,7 +206,27 @@ describe('sparky_get_logging_streak', () => {
     expect(result).toBe(
       success('Logging Streak', {
         current_streak: 1,
-        last_logged: rows[0].entry_date,
+        last_logged: '2026-06-11',
+      })
+    );
+  });
+
+  it("anchors the streak on the user's timezone today", async () => {
+    // 20:00 UTC June 11 is already June 12 in Tokyo.
+    vi.setSystemTime(new Date('2026-06-11T20:00:00Z'));
+    const rows = [{ entry_date: day(12) }, { entry_date: day(11) }];
+    vi.mocked(engagementRepository.getLoggedDates).mockResolvedValue(rows);
+
+    const tokyoTools = buildEngagementTools('user-1', 'Asia/Tokyo');
+    const result = await tokyoTools.sparky_get_logging_streak.execute!(
+      {},
+      opts
+    );
+
+    expect(result).toBe(
+      success('Logging Streak', {
+        current_streak: 2,
+        last_logged: '2026-06-12',
       })
     );
   });
@@ -274,7 +299,9 @@ describe('sparky_get_contextual_nudge', () => {
       })
     );
     expect(engagementRepository.getTodayActivityCounts).toHaveBeenCalledWith(
-      'user-1'
+      'user-1',
+      '2026-06-11',
+      'UTC'
     );
   });
 

--- a/SparkyFitnessServer/tests/chatbotToolsExercise.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsExercise.test.ts
@@ -1,0 +1,1278 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { todayInZone } from '@workspace/shared';
+import { buildExerciseTools } from '../ai/tools/exerciseTools.js';
+import exerciseService from '../services/exerciseService.js';
+import workoutPresetService from '../services/workoutPresetService.js';
+import exerciseDb from '../models/exercise.js';
+import exerciseEntryDb from '../models/exerciseEntry.js';
+import workoutPresetRepository from '../models/workoutPresetRepository.js';
+
+vi.mock('../services/exerciseService', () => ({
+  default: {
+    searchExercises: vi.fn(),
+    searchExercisesPaginated: vi.fn(),
+    createExercise: vi.fn(),
+    createExerciseEntry: vi.fn(),
+    getExerciseEntriesByDate: vi.fn(),
+    updateExerciseEntry: vi.fn(),
+    deleteExerciseEntry: vi.fn(),
+    getExerciseById: vi.fn(),
+    getExerciseProgressData: vi.fn(),
+    logWorkoutPresetGrouped: vi.fn(),
+  },
+}));
+vi.mock('../services/workoutPresetService', () => ({
+  default: {
+    getWorkoutPresets: vi.fn(),
+    createWorkoutPreset: vi.fn(),
+  },
+}));
+vi.mock('../models/exercise', () => ({
+  default: {
+    getExercisesWithPagination: vi.fn(),
+    countExercises: vi.fn(),
+  },
+}));
+vi.mock('../models/exerciseEntry', () => ({
+  default: {
+    getExerciseDiaryRange: vi.fn(),
+    getDailyExerciseTotalsRange: vi.fn(),
+    getRecentExerciseEntries: vi.fn(),
+    getExerciseUsage: vi.fn(),
+  },
+}));
+vi.mock('../models/workoutPresetRepository', () => ({
+  default: {
+    getWorkoutPresetByName: vi.fn(),
+  },
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+const DB_ERROR_TEXT =
+  'Error [DB_ERROR]: A database error occurred. Please try again.\n\nSuggestion: If the issue persists, contact support.';
+const NOT_FOUND_RESOURCE_TEXT =
+  "Error [NOT_FOUND]: Resource with ID 'unknown' not found.\n\nSuggestion: Check the ID and try again.";
+
+const ENTRY_ID = '11111111-1111-4111-8111-111111111111';
+const EXERCISE_ID = '22222222-2222-4222-8222-222222222222';
+const EXERCISE_ID_2 = '33333333-3333-4333-8333-333333333333';
+const PRESET_ID = '44444444-4444-4444-8444-444444444444';
+
+let tools: ReturnType<typeof buildExerciseTools>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tools = buildExerciseTools('user-1');
+});
+
+describe('sparky_manage_exercise validation', () => {
+  it('renders zod issues for a missing per-action field', async () => {
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'search_exercises' },
+      opts
+    );
+    expect(result).toBe(
+      'Error [VALIDATION]: searchTerm: Invalid input: expected string, received undefined'
+    );
+  });
+});
+
+describe('search_exercises', () => {
+  it('renders the paginated catalog matches', async () => {
+    vi.mocked(exerciseService.searchExercisesPaginated).mockResolvedValue({
+      exercises: [
+        {
+          id: EXERCISE_ID,
+          name: 'Bench Press',
+          category: 'Strength',
+          primary_muscles: ['Chest', 'Triceps'],
+          equipment: ['Barbell'],
+          level: 'intermediate',
+          calories_per_hour: 400,
+          description: null,
+          is_custom: false,
+          user_id: 'user-1',
+          tags: ['private'],
+        },
+      ],
+      totalCount: 1,
+    });
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'search_exercises', searchTerm: 'bench' },
+      opts
+    );
+
+    expect(result).toBe(
+      `# Exercise Search: "bench"\n\n**Bench Press** (Strength)\n  Muscles: Chest, Triceps | Equipment: Barbell\n  ID: ${EXERCISE_ID}\n\n---\nShowing 1 of 1 results.`
+    );
+    expect(exerciseService.searchExercisesPaginated).toHaveBeenCalledWith(
+      'user-1',
+      'bench',
+      'user-1',
+      undefined,
+      undefined,
+      20,
+      0
+    );
+  });
+
+  it('passes filters as single-element arrays and reports remaining pages', async () => {
+    vi.mocked(exerciseService.searchExercisesPaginated).mockResolvedValue({
+      exercises: [
+        {
+          id: EXERCISE_ID,
+          name: 'Cable Fly',
+          category: null,
+          primary_muscles: [],
+          equipment: [],
+        },
+      ],
+      totalCount: 41,
+    });
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'search_exercises',
+        searchTerm: 'fly',
+        muscleGroup: 'Chest',
+        equipment: 'Cable',
+        limit: 1,
+        offset: 0,
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      `# Exercise Search: "fly"\n\n**Cable Fly** (Uncategorized)\n  Muscles: N/A | Equipment: None\n  ID: ${EXERCISE_ID}\n\n---\nShowing 1 of 41 results. Use offset=1 to see more.`
+    );
+    expect(exerciseService.searchExercisesPaginated).toHaveBeenCalledWith(
+      'user-1',
+      'fly',
+      'user-1',
+      ['Cable'],
+      ['Chest'],
+      1,
+      0
+    );
+  });
+
+  it('renders an empty result set', async () => {
+    vi.mocked(exerciseService.searchExercisesPaginated).mockResolvedValue({
+      exercises: [],
+      totalCount: 0,
+    });
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'search_exercises', searchTerm: 'zzz' },
+      opts
+    );
+    expect(result).toBe(
+      '# Exercise Search: "zzz"\n\nNo results found.\n\n---\nShowing 0 of 0 results.'
+    );
+  });
+
+  it('maps service failures to DB_ERROR', async () => {
+    vi.mocked(exerciseService.searchExercisesPaginated).mockRejectedValue(
+      new Error('boom')
+    );
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'search_exercises', searchTerm: 'bench' },
+      opts
+    );
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+describe('create_exercise', () => {
+  it('reuses an existing exercise matched case-insensitively', async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([
+      { id: EXERCISE_ID, name: 'Running' },
+    ]);
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'create_exercise', name: 'running' },
+      opts
+    );
+
+    expect(result).toBe('✅ Exercise "Running" created.');
+    expect(exerciseService.createExercise).not.toHaveBeenCalled();
+  });
+
+  it("creates with MCP's defaults when no exercise matches", async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([]);
+    vi.mocked(exerciseService.createExercise).mockResolvedValue({
+      id: EXERCISE_ID,
+      name: 'Jump Rope',
+    });
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'create_exercise', name: 'Jump Rope' },
+      opts
+    );
+
+    expect(result).toBe('✅ Exercise "Jump Rope" created.');
+    expect(exerciseService.createExercise).toHaveBeenCalledWith('user-1', {
+      name: 'Jump Rope',
+      category: 'custom',
+      calories_per_hour: 300,
+      description: null,
+      is_custom: true,
+      shared_with_public: false,
+      source: 'manual',
+    });
+  });
+
+  it('passes provided category, calories and description through', async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([]);
+    vi.mocked(exerciseService.createExercise).mockResolvedValue({
+      id: EXERCISE_ID,
+      name: 'Rowing',
+    });
+
+    await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'create_exercise',
+        name: 'Rowing',
+        category: 'Cardio',
+        calories_per_hour: 550,
+        description: 'Indoor rower',
+      },
+      opts
+    );
+
+    expect(exerciseService.createExercise).toHaveBeenCalledWith('user-1', {
+      name: 'Rowing',
+      category: 'Cardio',
+      calories_per_hour: 550,
+      description: 'Indoor rower',
+      is_custom: true,
+      shared_with_public: false,
+      source: 'manual',
+    });
+  });
+});
+
+describe('log_exercise', () => {
+  it('requires exercise_id or exercise_name', async () => {
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'log_exercise', entry_date: '2026-06-10' },
+      opts
+    );
+    expect(result).toBe(
+      'Error [VALIDATION]: Either exercise_id or exercise_name must be provided'
+    );
+  });
+
+  it('logs by exercise_id with repository-shaped sets', async () => {
+    vi.mocked(exerciseService.createExerciseEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'log_exercise',
+        exercise_id: EXERCISE_ID,
+        entry_date: '2026-06-10',
+        duration_minutes: 40,
+        sets: [
+          { reps: 10, weight: 60 },
+          { reps: 8, weight: 65, set_type: 'Drop Set' },
+        ],
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Exercise logged for 2026-06-10.');
+    expect(exerciseService.searchExercises).not.toHaveBeenCalled();
+    expect(exerciseService.createExerciseEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      {
+        exercise_id: EXERCISE_ID,
+        entry_date: '2026-06-10',
+        duration_minutes: 40,
+        sets: [
+          {
+            set_number: 1,
+            set_type: 'Working Set',
+            reps: 10,
+            weight: 60,
+            duration: null,
+            rest_time: null,
+            rpe: null,
+            notes: null,
+          },
+          {
+            set_number: 2,
+            set_type: 'Drop Set',
+            reps: 8,
+            weight: 65,
+            duration: null,
+            rest_time: null,
+            rpe: null,
+            notes: null,
+          },
+        ],
+      },
+      { skipDuplicateCheck: true }
+    );
+  });
+
+  it('prefers the case-insensitive exact name match over substring matches', async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([
+      { id: EXERCISE_ID_2, name: 'Running Intervals' },
+      { id: EXERCISE_ID, name: 'Running' },
+    ]);
+    vi.mocked(exerciseService.createExerciseEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'log_exercise',
+        exercise_name: 'running',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(exerciseService.createExerciseEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.objectContaining({ exercise_id: EXERCISE_ID }),
+      { skipDuplicateCheck: true }
+    );
+  });
+
+  it('falls back to the first fuzzy match', async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([
+      { id: EXERCISE_ID_2, name: 'Running Intervals' },
+    ]);
+    vi.mocked(exerciseService.createExerciseEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'log_exercise',
+        exercise_name: 'running',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(exerciseService.createExerciseEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.objectContaining({ exercise_id: EXERCISE_ID_2 }),
+      { skipDuplicateCheck: true }
+    );
+  });
+
+  it('auto-creates a custom 300 kcal/h exercise when nothing matches', async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([]);
+    vi.mocked(exerciseService.createExercise).mockResolvedValue({
+      id: EXERCISE_ID,
+      name: 'Underwater Hockey',
+    });
+    vi.mocked(exerciseService.createExerciseEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'log_exercise',
+        exercise_name: 'Underwater Hockey',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Exercise logged for 2026-06-10.');
+    expect(exerciseService.createExercise).toHaveBeenCalledWith('user-1', {
+      name: 'Underwater Hockey',
+      category: 'custom',
+      calories_per_hour: 300,
+      is_custom: true,
+      shared_with_public: false,
+      source: 'manual',
+    });
+    expect(exerciseService.createExerciseEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.objectContaining({ exercise_id: EXERCISE_ID }),
+      { skipDuplicateCheck: true }
+    );
+  });
+
+  it('parses sets passed as a JSON string', async () => {
+    vi.mocked(exerciseService.createExerciseEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'log_exercise',
+        exercise_id: EXERCISE_ID,
+        entry_date: '2026-06-10',
+        sets: '[{"reps":5,"weight":100}]',
+      },
+      opts
+    );
+
+    expect(exerciseService.createExerciseEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.objectContaining({
+        sets: [
+          {
+            set_number: 1,
+            set_type: 'Working Set',
+            reps: 5,
+            weight: 100,
+            duration: null,
+            rest_time: null,
+            rpe: null,
+            notes: null,
+          },
+        ],
+      }),
+      { skipDuplicateCheck: true }
+    );
+  });
+
+  it('ignores an unparseable sets string and still logs', async () => {
+    vi.mocked(exerciseService.createExerciseEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'log_exercise',
+        exercise_id: EXERCISE_ID,
+        entry_date: '2026-06-10',
+        sets: '{not json',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Exercise logged for 2026-06-10.');
+    expect(exerciseService.createExerciseEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.objectContaining({ sets: undefined }),
+      { skipDuplicateCheck: true }
+    );
+  });
+});
+
+describe('list_exercise_diary', () => {
+  it('flattens preset sessions and renders the per-entry list in created_at order', async () => {
+    vi.mocked(exerciseService.getExerciseEntriesByDate).mockResolvedValue([
+      {
+        type: 'preset',
+        id: 'pe-1',
+        name: 'Push Day',
+        created_at: '2026-06-10T08:00:00Z',
+        exercises: [
+          {
+            id: 'ee-2',
+            name: 'Bench Press',
+            sets: [
+              {
+                id: 's1',
+                set_number: 1,
+                set_type: 'Working Set',
+                reps: 10,
+                weight: 60,
+                duration: null,
+                rest_time: 90,
+                rpe: 8,
+                notes: null,
+              },
+              {
+                id: 's2',
+                set_number: 2,
+                set_type: 'Working Set',
+                reps: 8,
+                weight: 65,
+                duration: null,
+                rest_time: null,
+                rpe: null,
+                notes: 'tough',
+              },
+            ],
+            duration_minutes: 0,
+            calories_burned: 0,
+            notes: 'felt good',
+            distance: null,
+            avg_heart_rate: null,
+            steps: null,
+            created_at: '2026-06-10T08:05:00Z',
+          },
+        ],
+      },
+      {
+        type: 'individual',
+        id: 'ee-1',
+        name: 'Morning Run',
+        sets: [],
+        duration_minutes: 30,
+        calories_burned: 300,
+        notes: null,
+        distance: 5,
+        avg_heart_rate: 150,
+        steps: 6000,
+        created_at: '2026-06-10T07:00:00Z',
+      },
+    ]);
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'list_exercise_diary', entry_date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Exercise Diary: 2026-06-10\n\n' +
+        '**Morning Run** | 30 min | 300 kcal | 5 dist | 150 bpm | 6000 steps\n  ID: ee-1\n\n' +
+        '**Bench Press** — 2 sets\n  Sets: 10r×60kg×RPE 8 (rest 90s); 8r×65kg (tough)\n  Notes: felt good\n  ID: ee-2'
+    );
+    expect(exerciseService.getExerciseEntriesByDate).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      '2026-06-10'
+    );
+  });
+
+  it('renders an empty diary', async () => {
+    vi.mocked(exerciseService.getExerciseEntriesByDate).mockResolvedValue([]);
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'list_exercise_diary', entry_date: '2026-06-11' },
+      opts
+    );
+    expect(result).toBe('# Exercise Diary: 2026-06-11\n\nNo results found.');
+  });
+});
+
+describe('workout presets', () => {
+  it('get_workout_presets lists presets with exercise counts', async () => {
+    vi.mocked(workoutPresetService.getWorkoutPresets).mockResolvedValue({
+      presets: [{ id: 7, name: 'Push Day', exercises: [{}, {}, {}] }],
+      total: 1,
+      page: 1,
+      limit: 1000,
+    });
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'get_workout_presets' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Workout Presets\n\n**Push Day** — 3 exercises\n  ID: 7'
+    );
+    expect(workoutPresetService.getWorkoutPresets).toHaveBeenCalledWith(
+      'user-1',
+      1,
+      1000
+    );
+  });
+
+  it('log_workout_preset requires preset_id or preset_name', async () => {
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'log_workout_preset', entry_date: '2026-06-10' },
+      opts
+    );
+    expect(result).toBe(
+      'Error [VALIDATION]: Either preset_id or preset_name must be provided'
+    );
+  });
+
+  it('log_workout_preset resolves the preset by name and logs a grouped session', async () => {
+    vi.mocked(workoutPresetRepository.getWorkoutPresetByName).mockResolvedValue(
+      { id: 7, name: 'Push Day' }
+    );
+    vi.mocked(exerciseService.logWorkoutPresetGrouped).mockResolvedValue({
+      id: 'pe-1',
+      exercises: [{}, {}],
+      // The full PresetSessionResponse shape isn't needed by the handler.
+    } as never);
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'log_workout_preset',
+        preset_name: 'Push Day',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Workout preset logged for 2026-06-10. 2 exercises added.'
+    );
+    expect(workoutPresetRepository.getWorkoutPresetByName).toHaveBeenCalledWith(
+      'user-1',
+      'Push Day'
+    );
+    expect(exerciseService.logWorkoutPresetGrouped).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      7,
+      '2026-06-10'
+    );
+  });
+
+  it('log_workout_preset reports an unknown preset name as not found', async () => {
+    vi.mocked(workoutPresetRepository.getWorkoutPresetByName).mockResolvedValue(
+      null
+    );
+    const result = await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'log_workout_preset',
+        preset_name: 'Nope',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+    expect(result).toBe(NOT_FOUND_RESOURCE_TEXT);
+    expect(exerciseService.logWorkoutPresetGrouped).not.toHaveBeenCalled();
+  });
+
+  it('log_workout_preset maps a missing preset_id to not found', async () => {
+    vi.mocked(exerciseService.logWorkoutPresetGrouped).mockRejectedValue(
+      new Error('Workout preset not found.')
+    );
+    const result = await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'log_workout_preset',
+        preset_id: PRESET_ID,
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+    expect(result).toBe(NOT_FOUND_RESOURCE_TEXT);
+  });
+
+  it('create_workout_preset builds ordered exercises and confirms', async () => {
+    vi.mocked(workoutPresetService.createWorkoutPreset).mockResolvedValue({
+      id: 9,
+      name: 'Leg Day',
+      exercises: [{}, {}],
+    });
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'create_workout_preset',
+        name: 'Leg Day',
+        exercise_ids: [EXERCISE_ID, EXERCISE_ID_2],
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Workout preset "Leg Day" created with 2 exercises.'
+    );
+    expect(workoutPresetService.createWorkoutPreset).toHaveBeenCalledWith(
+      'user-1',
+      {
+        user_id: 'user-1',
+        name: 'Leg Day',
+        description: null,
+        is_public: false,
+        exercises: [
+          { exercise_id: EXERCISE_ID, sort_order: 0 },
+          { exercise_id: EXERCISE_ID_2, sort_order: 1 },
+        ],
+      }
+    );
+  });
+});
+
+describe('update_exercise_entry / delete_exercise_entry', () => {
+  it('updates only the provided fields and replaces sets', async () => {
+    vi.mocked(exerciseService.updateExerciseEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      {
+        action: 'update_exercise_entry',
+        entry_id: ENTRY_ID,
+        duration_minutes: 45,
+        steps: 1234,
+        sets: '[{"reps":12}]',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Exercise entry updated.');
+    expect(exerciseService.updateExerciseEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      ENTRY_ID,
+      {
+        duration_minutes: 45,
+        steps: 1234,
+        sets: [
+          {
+            set_number: 1,
+            set_type: 'Working Set',
+            reps: 12,
+            weight: null,
+            duration: null,
+            rest_time: null,
+            rpe: null,
+            notes: null,
+          },
+        ],
+      }
+    );
+  });
+
+  it('rejects an unparseable sets string', async () => {
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'update_exercise_entry', entry_id: ENTRY_ID, sets: '{bad' },
+      opts
+    );
+    expect(result).toBe('Error [VALIDATION]: Invalid JSON format for sets');
+    expect(exerciseService.updateExerciseEntry).not.toHaveBeenCalled();
+  });
+
+  it('maps a missing entry to NOT_FOUND with the entry id', async () => {
+    vi.mocked(exerciseService.updateExerciseEntry).mockRejectedValue(
+      new Error('Exercise entry not found.')
+    );
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'update_exercise_entry', entry_id: ENTRY_ID, notes: 'x' },
+      opts
+    );
+    expect(result).toBe(
+      `Error [NOT_FOUND]: Exercise Entry with ID '${ENTRY_ID}' not found.\n\nSuggestion: Check the ID and try again.`
+    );
+  });
+
+  it('deletes an entry', async () => {
+    vi.mocked(exerciseService.deleteExerciseEntry).mockResolvedValue({
+      message: 'Exercise entry deleted successfully.',
+    });
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'delete_exercise_entry', entry_id: ENTRY_ID },
+      opts
+    );
+    expect(result).toBe('✅ Exercise entry deleted.');
+    expect(exerciseService.deleteExerciseEntry).toHaveBeenCalledWith(
+      'user-1',
+      ENTRY_ID
+    );
+  });
+
+  it('maps a missing entry on delete to NOT_FOUND with the entry id', async () => {
+    vi.mocked(exerciseService.deleteExerciseEntry).mockRejectedValue(
+      new Error('Exercise entry not found.')
+    );
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'delete_exercise_entry', entry_id: ENTRY_ID },
+      opts
+    );
+    expect(result).toBe(
+      `Error [NOT_FOUND]: Exercise Entry with ID '${ENTRY_ID}' not found.\n\nSuggestion: Check the ID and try again.`
+    );
+  });
+});
+
+describe('get_exercise_details (manage action)', () => {
+  it('renders the markdown detail card with parsed text columns', async () => {
+    vi.mocked(exerciseService.getExerciseById).mockResolvedValue({
+      id: EXERCISE_ID,
+      name: 'Bench Press',
+      description: 'A classic chest press.',
+      category: 'Strength',
+      equipment: '["Barbell"]',
+      primary_muscles: '["Chest","Triceps"]',
+      instructions: '["Lie on the bench.","Press the bar."]',
+      images: ['bench.png'],
+      level: 'intermediate',
+      calories_per_hour: 400,
+      is_custom: false,
+    });
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'get_exercise_details', exercise_id: EXERCISE_ID },
+      opts
+    );
+
+    expect(result).toBe(
+      '### Bench Press\n\n' +
+        '*A classic chest press.*\n\n' +
+        '**Category:** Strength\n' +
+        '**Equipment:** Barbell\n' +
+        '**Muscles:** Chest, Triceps\n\n' +
+        '#### Instructions\n' +
+        '1. Lie on the bench.\n' +
+        '2. Press the bar.\n'
+    );
+    expect(exerciseService.getExerciseById).toHaveBeenCalledWith(
+      'user-1',
+      EXERCISE_ID
+    );
+  });
+
+  it('returns DB_ERROR when neither id nor name is given (MCP quirk)', async () => {
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'get_exercise_details' },
+      opts
+    );
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+
+  it('maps an unmatched name to the generic not-found text', async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([]);
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'get_exercise_details', exercise_name: 'Benchh' },
+      opts
+    );
+    expect(result).toBe(NOT_FOUND_RESOURCE_TEXT);
+  });
+});
+
+describe('get_exercise_progress (manage action)', () => {
+  it('aggregates per-day set stats, skipping days without sets', async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([
+      { id: EXERCISE_ID, name: 'Bench Press' },
+    ]);
+    vi.mocked(exerciseService.getExerciseProgressData).mockResolvedValue([
+      {
+        entry_date: '2026-06-01',
+        sets: [
+          { reps: 10, weight: 60 },
+          { reps: 8, weight: 70 },
+        ],
+      },
+      { entry_date: '2026-06-01', sets: [{ reps: 5, weight: 80 }] },
+      { entry_date: '2026-06-03', sets: [] },
+      {
+        entry_date: '2026-06-05',
+        sets: [
+          { reps: null, weight: 50 },
+          { reps: 12, weight: null },
+        ],
+      },
+    ]);
+
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'get_exercise_progress', exercise_name: 'bench press' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Exercise Progress: bench press\n\n' +
+        '**2026-06-01**: Max Weight: 80kg | Max Reps: 10 | Volume: 1560kg\n\n' +
+        '**2026-06-05**: Max Weight: 50kg | Max Reps: 12 | Volume: 0kg\n\n' +
+        '---\nShowing 2 of 2 results.'
+    );
+    expect(exerciseService.getExerciseProgressData).toHaveBeenCalledWith(
+      'user-1',
+      EXERCISE_ID,
+      '1970-01-01',
+      '9999-12-31'
+    );
+  });
+
+  it('maps an unknown exercise to the generic not-found text', async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([]);
+    const result = await tools.sparky_manage_exercise.execute!(
+      { action: 'get_exercise_progress', exercise_name: 'nope' },
+      opts
+    );
+    expect(result).toBe(NOT_FOUND_RESOURCE_TEXT);
+  });
+});
+
+describe('sparky_list_exercises', () => {
+  it('returns the paginated catalog as JSON', async () => {
+    vi.mocked(exerciseDb.getExercisesWithPagination).mockResolvedValue([
+      { id: EXERCISE_ID, name: 'Bench Press' },
+    ]);
+    vi.mocked(exerciseDb.countExercises).mockResolvedValue(1);
+
+    const result = await tools.sparky_list_exercises.execute!({}, opts);
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          data: [{ id: EXERCISE_ID, name: 'Bench Press' }],
+          has_more: false,
+          next_offset: null,
+          total_count: 1,
+        },
+        null,
+        2
+      )
+    );
+    expect(exerciseDb.getExercisesWithPagination).toHaveBeenCalledWith(
+      'user-1',
+      undefined,
+      null,
+      null,
+      null,
+      null,
+      20,
+      0
+    );
+    expect(exerciseDb.countExercises).toHaveBeenCalledWith(
+      'user-1',
+      undefined,
+      null,
+      null,
+      null,
+      null
+    );
+  });
+
+  it('clamps the limit to 50 and treats a blank search as absent', async () => {
+    vi.mocked(exerciseDb.getExercisesWithPagination).mockResolvedValue([]);
+    vi.mocked(exerciseDb.countExercises).mockResolvedValue(0);
+
+    await tools.sparky_list_exercises.execute!(
+      { limit: 500, offset: 10, search: '   ' },
+      opts
+    );
+
+    expect(exerciseDb.getExercisesWithPagination).toHaveBeenCalledWith(
+      'user-1',
+      undefined,
+      null,
+      null,
+      null,
+      null,
+      50,
+      10
+    );
+  });
+});
+
+describe('sparky_get_exercise_details', () => {
+  it('returns the projected exercise as JSON', async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([
+      {
+        id: EXERCISE_ID,
+        name: 'Bench Press',
+        category: 'Strength',
+        primary_muscles: ['Chest', 'Triceps'],
+        equipment: ['Barbell'],
+        level: 'intermediate',
+        calories_per_hour: 400,
+        description: null,
+        is_custom: false,
+        instructions: ['Lie on the bench.'],
+        images: [],
+        user_id: 'user-1',
+      },
+    ]);
+
+    const result = await tools.sparky_get_exercise_details.execute!(
+      { exercise_name: 'Bench Press' },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          id: EXERCISE_ID,
+          name: 'Bench Press',
+          category: 'Strength',
+          muscle_groups: ['Chest', 'Triceps'],
+          equipment: ['Barbell'],
+          level: 'intermediate',
+          calories_per_hour: 400,
+          description: null,
+          is_custom: false,
+          instructions: ['Lie on the bench.'],
+          images: [],
+        },
+        null,
+        2
+      )
+    );
+  });
+
+  it('names the missing exercise in the NOT_FOUND error', async () => {
+    vi.mocked(exerciseService.searchExercises).mockResolvedValue([]);
+    const result = await tools.sparky_get_exercise_details.execute!(
+      { exercise_name: 'Benchh' },
+      opts
+    );
+    expect(result).toBe(
+      "Error [NOT_FOUND]: Exercise with ID 'Benchh' not found.\n\nSuggestion: Check the ID and try again."
+    );
+  });
+});
+
+describe('sparky_search_exercises', () => {
+  it('requires a query', async () => {
+    const result = await tools.sparky_search_exercises.execute!(
+      {} as never,
+      opts
+    );
+    expect(result).toBe(
+      'Error [VALIDATION]: query: Invalid input: expected string, received undefined'
+    );
+  });
+
+  it('returns projected matches as JSON', async () => {
+    vi.mocked(exerciseService.searchExercisesPaginated).mockResolvedValue({
+      exercises: [
+        {
+          id: EXERCISE_ID,
+          name: 'Bench Press',
+          category: 'Strength',
+          primary_muscles: ['Chest'],
+          equipment: ['Barbell'],
+          level: 'intermediate',
+          calories_per_hour: 400,
+          description: null,
+          is_custom: false,
+          user_id: 'user-1',
+          tags: ['private'],
+        },
+      ],
+      totalCount: 1,
+    });
+
+    const result = await tools.sparky_search_exercises.execute!(
+      { query: 'bench', muscle_group: 'Chest' },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          data: [
+            {
+              id: EXERCISE_ID,
+              name: 'Bench Press',
+              category: 'Strength',
+              muscle_groups: ['Chest'],
+              equipment: ['Barbell'],
+              level: 'intermediate',
+              calories_per_hour: 400,
+              description: null,
+              is_custom: false,
+            },
+          ],
+          has_more: false,
+          next_offset: null,
+          total_count: 1,
+        },
+        null,
+        2
+      )
+    );
+    expect(exerciseService.searchExercisesPaginated).toHaveBeenCalledWith(
+      'user-1',
+      'bench',
+      'user-1',
+      undefined,
+      ['Chest'],
+      20,
+      0
+    );
+  });
+});
+
+describe('sparky_get_exercise_diary', () => {
+  it('lets a single date override the range and wraps entries plus sets', async () => {
+    vi.mocked(exerciseEntryDb.getExerciseDiaryRange).mockResolvedValue({
+      entries: [{ id: 'ee-1' }],
+      sets: [{ id: 's-1' }],
+    });
+
+    const result = await tools.sparky_get_exercise_diary.execute!(
+      { date: '2026-06-10', start_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          start_date: '2026-06-10',
+          end_date: '2026-06-10',
+          entries: [{ id: 'ee-1' }],
+          sets: [{ id: 's-1' }],
+        },
+        null,
+        2
+      )
+    );
+    expect(exerciseEntryDb.getExerciseDiaryRange).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-10',
+      '2026-06-10'
+    );
+  });
+
+  it('defaults to today (UTC) when no dates are given', async () => {
+    vi.mocked(exerciseEntryDb.getExerciseDiaryRange).mockResolvedValue({
+      entries: [],
+      sets: [],
+    });
+    await tools.sparky_get_exercise_diary.execute!({}, opts);
+    const today = todayInZone('UTC');
+    expect(exerciseEntryDb.getExerciseDiaryRange).toHaveBeenCalledWith(
+      'user-1',
+      today,
+      today
+    );
+  });
+});
+
+describe('sparky_get_daily_exercise_totals', () => {
+  it('uses start_date as the end of an open range and wraps the rows', async () => {
+    vi.mocked(exerciseEntryDb.getDailyExerciseTotalsRange).mockResolvedValue([
+      { entry_date: '2026-06-01', entry_count: 2 },
+    ]);
+
+    const result = await tools.sparky_get_daily_exercise_totals.execute!(
+      { start_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          start_date: '2026-06-01',
+          end_date: '2026-06-01',
+          rows: [{ entry_date: '2026-06-01', entry_count: 2 }],
+        },
+        null,
+        2
+      )
+    );
+    expect(exerciseEntryDb.getDailyExerciseTotalsRange).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-01',
+      '2026-06-01'
+    );
+  });
+});
+
+describe('sparky_get_recent_exercise_entries', () => {
+  it('defaults the limit to 50 and returns raw rows as JSON', async () => {
+    vi.mocked(exerciseEntryDb.getRecentExerciseEntries).mockResolvedValue([
+      { id: 'ee-1', exercise_name_from_catalog: 'Running' },
+    ]);
+
+    const result = await tools.sparky_get_recent_exercise_entries.execute!(
+      {},
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        [{ id: 'ee-1', exercise_name_from_catalog: 'Running' }],
+        null,
+        2
+      )
+    );
+    expect(exerciseEntryDb.getRecentExerciseEntries).toHaveBeenCalledWith(
+      'user-1',
+      50
+    );
+  });
+
+  it('rejects an out-of-range limit', async () => {
+    const result = await tools.sparky_get_recent_exercise_entries.execute!(
+      { limit: 999 },
+      opts
+    );
+    expect(result).toBe(
+      'Error [VALIDATION]: limit: Too big: expected number to be <=200'
+    );
+  });
+});
+
+describe('sparky_get_exercise_usage', () => {
+  it('returns paginated usage rows as JSON', async () => {
+    vi.mocked(exerciseEntryDb.getExerciseUsage).mockResolvedValue({
+      rows: [{ id: 'ee-1' }, { id: 'ee-2' }],
+      totalCount: 12,
+    });
+
+    const result = await tools.sparky_get_exercise_usage.execute!(
+      {
+        exercise_id: EXERCISE_ID,
+        start_date: '2026-06-01',
+        end_date: '2026-06-07',
+        limit: 2,
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          data: [{ id: 'ee-1' }, { id: 'ee-2' }],
+          has_more: true,
+          next_offset: 2,
+          total_count: 12,
+        },
+        null,
+        2
+      )
+    );
+    expect(exerciseEntryDb.getExerciseUsage).toHaveBeenCalledWith(
+      'user-1',
+      EXERCISE_ID,
+      '2026-06-01',
+      '2026-06-07',
+      2,
+      0
+    );
+  });
+});
+
+describe('sparky_get_exercise_progress', () => {
+  it('returns the aggregated days as JSON and forwards the date range', async () => {
+    vi.mocked(exerciseService.getExerciseProgressData).mockResolvedValue([
+      { entry_date: '2026-06-01', sets: [{ reps: 10, weight: 60 }] },
+    ]);
+
+    const result = await tools.sparky_get_exercise_progress.execute!(
+      {
+        exercise_id: EXERCISE_ID,
+        start_date: '2026-06-01',
+        end_date: '2026-06-07',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          data: [
+            {
+              entry_date: '2026-06-01',
+              max_weight: 60,
+              max_reps: 10,
+              total_volume: 600,
+            },
+          ],
+          has_more: false,
+          next_offset: null,
+          total_count: 1,
+        },
+        null,
+        2
+      )
+    );
+    expect(exerciseService.getExerciseProgressData).toHaveBeenCalledWith(
+      'user-1',
+      EXERCISE_ID,
+      '2026-06-01',
+      '2026-06-07'
+    );
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsExercise.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsExercise.test.ts
@@ -65,7 +65,7 @@ let tools: ReturnType<typeof buildExerciseTools>;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  tools = buildExerciseTools('user-1');
+  tools = buildExerciseTools('user-1', 'UTC');
 });
 
 describe('sparky_manage_exercise validation', () => {
@@ -1273,6 +1273,38 @@ describe('sparky_get_exercise_progress', () => {
       EXERCISE_ID,
       '2026-06-01',
       '2026-06-07'
+    );
+  });
+
+  it('collapses two same-day pg Date entries into one calendar-day group', async () => {
+    vi.mocked(exerciseService.getExerciseProgressData).mockResolvedValue([
+      { entry_date: new Date(2026, 5, 10), sets: [{ reps: 10, weight: 60 }] },
+      { entry_date: new Date(2026, 5, 10), sets: [{ reps: 8, weight: 70 }] },
+    ]);
+
+    const result = await tools.sparky_get_exercise_progress.execute!(
+      { exercise_id: EXERCISE_ID },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          data: [
+            {
+              entry_date: '2026-06-10',
+              max_weight: 70,
+              max_reps: 10,
+              total_volume: 10 * 60 + 8 * 70,
+            },
+          ],
+          has_more: false,
+          next_offset: null,
+          total_count: 1,
+        },
+        null,
+        2
+      )
     );
   });
 });

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -145,7 +145,7 @@ beforeEach(() => {
     energy_unit: 'kcal',
     water_display_unit: 'ml',
   });
-  tools = buildFoodTools('user-1');
+  tools = buildFoodTools('user-1', 'UTC');
 });
 
 describe('sparky_manage_food validation', () => {
@@ -831,6 +831,41 @@ describe('list_diary', () => {
       'user-1',
       todayInZone('UTC')
     );
+  });
+
+  it("computes the default 'today' in the user's timezone", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T20:00:00Z'));
+    try {
+      vi.mocked(foodEntryService.getFoodEntriesByDate).mockResolvedValue([]);
+      vi.mocked(
+        foodEntryMealRepository.getFoodEntryMealsByDate
+      ).mockResolvedValue([]);
+
+      const tokyoTools = buildFoodTools('user-1', 'Asia/Tokyo');
+      await tokyoTools.sparky_manage_food.execute!(
+        { action: 'list_diary' },
+        opts
+      );
+      expect(foodEntryService.getFoodEntriesByDate).toHaveBeenLastCalledWith(
+        'user-1',
+        'user-1',
+        '2026-06-11'
+      );
+
+      const utcTools = buildFoodTools('user-1', 'UTC');
+      await utcTools.sparky_manage_food.execute!(
+        { action: 'list_diary' },
+        opts
+      );
+      expect(foodEntryService.getFoodEntriesByDate).toHaveBeenLastCalledWith(
+        'user-1',
+        'user-1',
+        '2026-06-10'
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('converts displayed calories when the user prefers kJ', async () => {

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -1,0 +1,1719 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { addDays, todayInZone } from '@workspace/shared';
+import { buildFoodTools } from '../ai/tools/foodTools.js';
+import foodCoreService from '../services/foodCoreService.js';
+import foodEntryService from '../services/foodEntryService.js';
+import mealService from '../services/mealService.js';
+import preferenceService from '../services/preferenceService.js';
+import { searchProviderFoods } from '../services/externalFoodSearchService.js';
+import foodRepository from '../models/foodRepository.js';
+import foodEntryMealRepository from '../models/foodEntryMealRepository.js';
+import measurementRepository from '../models/measurementRepository.js';
+import reportRepository from '../models/reportRepository.js';
+import externalProviderRepository from '../models/externalProviderRepository.js';
+
+vi.mock('../services/foodCoreService', () => ({
+  default: {
+    createFood: vi.fn(),
+    getFoodById: vi.fn(),
+    deleteFood: vi.fn(),
+    updateFoodEntriesSnapshot: vi.fn(),
+  },
+}));
+vi.mock('../services/foodEntryService', () => ({
+  default: {
+    createFoodEntry: vi.fn(),
+    getFoodEntriesByDate: vi.fn(),
+    getFoodEntriesByDateRange: vi.fn(),
+    createFoodEntryMeal: vi.fn(),
+    deleteFoodEntry: vi.fn(),
+    deleteFoodEntryMeal: vi.fn(),
+    updateFoodEntry: vi.fn(),
+    updateFoodEntryMeal: vi.fn(),
+    getFoodEntryMealWithComponents: vi.fn(),
+    copyFoodEntries: vi.fn(),
+    copyAllFoodEntries: vi.fn(),
+  },
+}));
+vi.mock('../services/mealService', () => ({
+  default: {
+    searchMeals: vi.fn(),
+    getMealById: vi.fn(),
+    createMealFromDiaryEntries: vi.fn(),
+  },
+}));
+vi.mock('../services/preferenceService', () => ({
+  default: {
+    getUserPreferences: vi.fn(),
+  },
+}));
+vi.mock('../services/externalFoodSearchService', () => ({
+  searchProviderFoods: vi.fn(),
+}));
+vi.mock('../models/foodRepository', () => ({
+  default: {
+    getFoodsWithPagination: vi.fn(),
+    countFoods: vi.fn(),
+    getFoodById: vi.fn(),
+    getFoodVariantById: vi.fn(),
+    updateFoodVariant: vi.fn(),
+    getFoodVariantsByFoodId: vi.fn(),
+    getRecentFoodEntries: vi.fn(),
+    getFoodUsage: vi.fn(),
+  },
+}));
+vi.mock('../models/foodEntryMealRepository', () => ({
+  default: {
+    getFoodEntryMealsByDate: vi.fn(),
+    getFoodEntryMealsByDateRange: vi.fn(),
+  },
+}));
+vi.mock('../models/measurementRepository', () => ({
+  default: {
+    insertWaterIntakeLog: vi.fn(),
+    getWaterTotalsByDateRange: vi.fn(),
+  },
+}));
+vi.mock('../models/reportRepository', () => ({
+  default: {
+    getDailyNutritionTotalsRange: vi.fn(),
+  },
+}));
+vi.mock('../models/externalProviderRepository', () => ({
+  default: {
+    getActiveProvidersByTypes: vi.fn(),
+  },
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+const DB_ERROR_TEXT =
+  'Error [DB_ERROR]: A database error occurred. Please try again.\n\nSuggestion: If the issue persists, contact support.';
+
+const FOOD_ID = '11111111-1111-4111-8111-111111111111';
+const VARIANT_ID = '22222222-2222-4222-8222-222222222222';
+const ENTRY_ID = '33333333-3333-4333-8333-333333333333';
+const MEAL_ID = '44444444-4444-4444-8444-444444444444';
+const FOOD_ID_2 = '55555555-5555-4555-8555-555555555555';
+
+const FOOD_PROVIDER_TYPES = [
+  'fatsecret',
+  'mealie',
+  'tandoor',
+  'norish',
+  'usda',
+  'openfoodfacts',
+];
+
+const eggsRow = {
+  id: FOOD_ID,
+  name: 'Eggs',
+  brand: 'Farm Fresh',
+  user_id: 'user-1',
+  default_variant: {
+    id: VARIANT_ID,
+    serving_size: 100,
+    serving_unit: 'g',
+    calories: 155,
+    protein: 13,
+    carbs: 1.1,
+    fat: 11,
+    saturated_fat: 3.3,
+    polyunsaturated_fat: null,
+    monounsaturated_fat: null,
+    trans_fat: null,
+    cholesterol: 373,
+    sodium: 124,
+    potassium: null,
+    dietary_fiber: 0,
+    sugars: 1.1,
+    vitamin_a: null,
+    vitamin_c: null,
+    calcium: null,
+    iron: null,
+    glycemic_index: null,
+  },
+};
+
+let tools: ReturnType<typeof buildFoodTools>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+    energy_unit: 'kcal',
+    water_display_unit: 'ml',
+  });
+  tools = buildFoodTools('user-1');
+});
+
+describe('sparky_manage_food validation', () => {
+  it('renders zod issues for a missing per-action field', async () => {
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'search_food', search_type: 'broad' },
+      opts
+    );
+    expect(result).toBe(
+      'Error [VALIDATION]: food_name: Invalid input: expected string, received undefined'
+    );
+  });
+});
+
+describe('search_food', () => {
+  it('renders broad matches with the default-variant macro line', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([
+      eggsRow,
+    ]);
+    vi.mocked(foodRepository.countFoods).mockResolvedValue(1);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'search_food', food_name: 'egg', search_type: 'broad' },
+      opts
+    );
+
+    expect(result).toBe(
+      `# Food Search: "egg" (broad)\n\n**Eggs** (Farm Fresh)\n  100g: 155 kcal | P: 13g | C: 1.1g | F: 11g\n  ID: ${FOOD_ID} | Variant: ${VARIANT_ID}\n\n---\nShowing 1 of 1 results.`
+    );
+    expect(foodRepository.getFoodsWithPagination).toHaveBeenCalledWith(
+      'egg',
+      null,
+      'user-1',
+      20,
+      0,
+      null
+    );
+  });
+
+  it('filters exact matches by case-insensitive name equality in the tool layer', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([
+      { ...eggsRow, id: FOOD_ID_2, name: 'Eggs Benedict Mix' },
+      { ...eggsRow, name: 'eggs' },
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'search_food', food_name: 'Eggs', search_type: 'exact' },
+      opts
+    );
+
+    expect(result).toBe(
+      `# Food Search: "Eggs" (exact)\n\n**eggs** (Farm Fresh)\n  100g: 155 kcal | P: 13g | C: 1.1g | F: 11g\n  ID: ${FOOD_ID} | Variant: ${VARIANT_ID}\n\n---\nShowing 1 of 1 results.`
+    );
+    expect(foodRepository.getFoodsWithPagination).toHaveBeenCalledWith(
+      'Eggs',
+      null,
+      'user-1',
+      500,
+      0,
+      null
+    );
+    expect(foodRepository.countFoods).not.toHaveBeenCalled();
+  });
+
+  it('renders no results for an empty search', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([]);
+    vi.mocked(foodRepository.countFoods).mockResolvedValue(0);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'search_food', food_name: 'nope', search_type: 'broad' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Food Search: "nope" (broad)\n\nNo results found.\n\n---\nShowing 0 of 0 results.'
+    );
+  });
+});
+
+describe('lookup_food_nutrition', () => {
+  it('returns the internal match without touching external providers', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([
+      eggsRow,
+      { ...eggsRow, id: FOOD_ID_2, name: 'eggs', brand: 'Other Farm' },
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'lookup_food_nutrition', food_name: 'Eggs' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### Found match in **internal**:\n**Eggs** (Farm Fresh)\n  Serving Size: 100 g\n  Energy: 155 kcal\n  Macros: Protein: 13g | Carbs: 1.1g | Fat: 11g\n  Details: Fiber: 0g | Sugar: 1.1g | Sodium: 124mg | SatFat: 3.3g\n\n**Other Alternatives found:**\n- **eggs** (Other Farm) (100g: 155 kcal)'
+    );
+    expect(searchProviderFoods).not.toHaveBeenCalled();
+  });
+
+  it('cascades through active providers in order and appends OpenFoodFacts', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([]);
+    vi.mocked(foodRepository.countFoods).mockResolvedValue(0);
+    vi.mocked(
+      externalProviderRepository.getActiveProvidersByTypes
+    ).mockResolvedValue([
+      { id: 'prov-1', provider_type: 'usda', provider_name: 'USDA' },
+    ]);
+    vi.mocked(searchProviderFoods).mockResolvedValue({
+      foods: [],
+      pagination: { page: 1, pageSize: 20, totalCount: 0, hasMore: false },
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'lookup_food_nutrition', food_name: 'dragonfruit smoothie' },
+      opts
+    );
+
+    expect(result).toBe(
+      'No matches found in internal DB or configured external databases/OpenFoodFacts for "dragonfruit smoothie". You may estimate the nutrition using AI and save it using create_food.'
+    );
+    expect(
+      externalProviderRepository.getActiveProvidersByTypes
+    ).toHaveBeenCalledWith('user-1', FOOD_PROVIDER_TYPES);
+    expect(searchProviderFoods).toHaveBeenNthCalledWith(
+      1,
+      'user-1',
+      'usda',
+      'dragonfruit smoothie',
+      { providerId: 'prov-1' }
+    );
+    expect(searchProviderFoods).toHaveBeenNthCalledWith(
+      2,
+      'user-1',
+      'openfoodfacts',
+      'dragonfruit smoothie',
+      { providerId: undefined }
+    );
+  });
+
+  it('renders a provider match with external id and alternatives', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([]);
+    vi.mocked(foodRepository.countFoods).mockResolvedValue(0);
+    vi.mocked(
+      externalProviderRepository.getActiveProvidersByTypes
+    ).mockResolvedValue([
+      { id: 'prov-1', provider_type: 'usda', provider_name: 'USDA' },
+    ]);
+    vi.mocked(searchProviderFoods).mockResolvedValue({
+      foods: [
+        {
+          name: 'Apple',
+          brand: 'USDA',
+          provider_external_id: '171688',
+          default_variant: {
+            serving_size: 100,
+            serving_unit: 'g',
+            calories: 52,
+            protein: 0.3,
+            carbs: 14,
+            fat: 0.2,
+            saturated_fat: null,
+            dietary_fiber: 2.4,
+            sugars: 10,
+            sodium: 1,
+          },
+        },
+        {
+          name: 'Apple juice',
+          default_variant: {
+            serving_size: 240,
+            serving_unit: 'ml',
+            calories: 110,
+          },
+        },
+      ],
+      pagination: { page: 1, pageSize: 20, totalCount: 2, hasMore: false },
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'lookup_food_nutrition', food_name: 'apple' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### Found match in **usda**:\n**Apple** (USDA)\n  Serving Size: 100 g\n  Energy: 52 kcal\n  Macros: Protein: 0.3g | Carbs: 14g | Fat: 0.2g\n  Details: Fiber: 2.4g | Sugar: 10g | Sodium: 1mg | SatFat: 0g\n  External ID: 171688\n\n**Other Alternatives found:**\n- **Apple juice** (240ml: 110 kcal)'
+    );
+  });
+
+  it('continues past a failing provider to the next one', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([]);
+    vi.mocked(foodRepository.countFoods).mockResolvedValue(0);
+    vi.mocked(
+      externalProviderRepository.getActiveProvidersByTypes
+    ).mockResolvedValue([
+      { id: 'prov-1', provider_type: 'fatsecret', provider_name: 'FatSecret' },
+    ]);
+    vi.mocked(searchProviderFoods)
+      .mockRejectedValueOnce(new Error('provider exploded'))
+      .mockResolvedValueOnce({
+        foods: [
+          {
+            name: 'Apple',
+            default_variant: {
+              serving_size: 100,
+              serving_unit: 'g',
+              calories: 52,
+              protein: 0.3,
+              carbs: 14,
+              fat: 0.2,
+            },
+          },
+        ],
+        pagination: { page: 1, pageSize: 20, totalCount: 1, hasMore: false },
+      });
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'lookup_food_nutrition', food_name: 'apple' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### Found match in **openfoodfacts**:\n**Apple**\n  Serving Size: 100 g\n  Energy: 52 kcal\n  Macros: Protein: 0.3g | Carbs: 14g | Fat: 0.2g'
+    );
+  });
+
+  it('falls through to ai_estimate when an explicitly requested provider is unconfigured', async () => {
+    vi.mocked(
+      externalProviderRepository.getActiveProvidersByTypes
+    ).mockResolvedValue([]);
+    vi.mocked(searchProviderFoods).mockRejectedValue(
+      new Error('Missing providerId query parameter')
+    );
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'lookup_food_nutrition',
+        food_name: 'apple',
+        provider_type: 'usda',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      'No matches found in internal DB or configured external databases/OpenFoodFacts for "apple". You may estimate the nutrition using AI and save it using create_food.'
+    );
+    // Explicit provider bypasses the internal search entirely.
+    expect(foodRepository.getFoodsWithPagination).not.toHaveBeenCalled();
+    expect(searchProviderFoods).toHaveBeenCalledTimes(1);
+    expect(searchProviderFoods).toHaveBeenCalledWith(
+      'user-1',
+      'usda',
+      'apple',
+      { providerId: undefined }
+    );
+  });
+
+  it('returns a DB error for an explicit internal miss (MCP quirk)', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([]);
+    vi.mocked(foodRepository.countFoods).mockResolvedValue(0);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'lookup_food_nutrition',
+        food_name: 'nope',
+        provider_type: 'internal',
+      },
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+    expect(searchProviderFoods).not.toHaveBeenCalled();
+  });
+});
+
+describe('log_food', () => {
+  it('resolves the food by exact name and logs with the default variant', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([
+      { ...eggsRow, name: 'eggs' },
+    ]);
+    vi.mocked(foodEntryService.createFoodEntry).mockResolvedValue({
+      id: ENTRY_ID,
+      food_name: 'eggs',
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'log_food',
+        food_name: 'Eggs',
+        quantity: 2,
+        unit: 'serving',
+        meal_type: 'breakfast',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Logged "eggs" (2 serving) for breakfast on 2026-06-10.'
+    );
+    expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      {
+        user_id: 'user-1',
+        food_id: FOOD_ID,
+        variant_id: VARIANT_ID,
+        entry_date: '2026-06-10',
+        quantity: 2,
+        unit: 'serving',
+        meal_type: 'breakfast',
+      }
+    );
+  });
+
+  it('asks for create_food when no food matches the name', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'log_food',
+        food_name: 'Unicorn Steak',
+        quantity: 1,
+        unit: 'serving',
+        meal_type: 'dinner',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: Food "Unicorn Steak" not found. Create it first using create_food action.'
+    );
+    expect(foodEntryService.createFoodEntry).not.toHaveBeenCalled();
+  });
+
+  it('uses an explicit food_id and resolves its default variant', async () => {
+    vi.mocked(foodRepository.getFoodById).mockResolvedValue(eggsRow);
+    vi.mocked(foodEntryService.createFoodEntry).mockResolvedValue({
+      id: ENTRY_ID,
+      food_name: 'Eggs',
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'log_food',
+        food_name: 'Eggs',
+        food_id: FOOD_ID,
+        quantity: 100,
+        unit: 'g',
+        meal_type: 'lunch',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Logged "Eggs" (100 g) for lunch on 2026-06-10.');
+    expect(foodRepository.getFoodsWithPagination).not.toHaveBeenCalled();
+    expect(foodRepository.getFoodById).toHaveBeenCalledWith(FOOD_ID, 'user-1');
+  });
+
+  it('maps a snapshotting failure to a validation error with the service message', async () => {
+    vi.mocked(foodRepository.getFoodById).mockResolvedValue(eggsRow);
+    vi.mocked(foodEntryService.createFoodEntry).mockRejectedValue(
+      new Error('Food or variant not found for snapshotting.')
+    );
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'log_food',
+        food_name: 'Eggs',
+        food_id: FOOD_ID,
+        quantity: 1,
+        unit: 'serving',
+        meal_type: 'lunch',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: Food or variant not found for snapshotting.'
+    );
+  });
+});
+
+describe('create_food', () => {
+  it('applies count-unit defaults and the 0-becomes-null storage quirk', async () => {
+    vi.mocked(foodCoreService.createFood).mockResolvedValue({
+      id: FOOD_ID,
+      name: 'Protein Bar',
+      brand: 'BrandX',
+      default_variant: {
+        id: VARIANT_ID,
+        serving_size: 1,
+        serving_unit: 'serving',
+        calories: 220,
+      },
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'create_food',
+        food_name: 'Protein Bar',
+        brand: 'BrandX',
+        calories: 220,
+        protein: 20,
+        carbs: 25,
+        fat: 8,
+        saturated_fat: 3,
+        sodium: 180,
+        fiber: 2,
+        sugar: 0,
+        gi: 'Low',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Food "Protein Bar" created with 220 kcal per 1serving.'
+    );
+    expect(foodCoreService.createFood).toHaveBeenCalledWith('user-1', {
+      user_id: 'user-1',
+      name: 'Protein Bar',
+      brand: 'BrandX',
+      serving_size: 1,
+      serving_unit: 'serving',
+      calories: 220,
+      protein: 20,
+      carbs: 25,
+      fat: 8,
+      saturated_fat: 3,
+      polyunsaturated_fat: null,
+      monounsaturated_fat: null,
+      trans_fat: null,
+      cholesterol: null,
+      sodium: 180,
+      potassium: null,
+      dietary_fiber: 2,
+      sugars: null,
+      vitamin_a: null,
+      vitamin_c: null,
+      calcium: null,
+      iron: null,
+      glycemic_index: 'Low',
+    });
+    expect(foodEntryService.createFoodEntry).not.toHaveBeenCalled();
+  });
+
+  it('defaults non-count units to 100 and auto-logs when meal_type is given', async () => {
+    vi.mocked(foodCoreService.createFood).mockResolvedValue({
+      id: FOOD_ID,
+      name: 'Rice',
+      brand: null,
+      default_variant: {
+        id: VARIANT_ID,
+        serving_size: 100,
+        serving_unit: 'g',
+        calories: 130,
+      },
+    });
+    vi.mocked(foodEntryService.createFoodEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'create_food',
+        food_name: 'Rice',
+        calories: 130,
+        protein: 2.7,
+        carbs: 28,
+        fat: 0.3,
+        unit: 'g',
+        meal_type: 'lunch',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Food "Rice" created with 130 kcal per 100g. Also logged to lunch for 2026-06-10.'
+    );
+    expect(foodCoreService.createFood).toHaveBeenCalledWith(
+      'user-1',
+      expect.objectContaining({ serving_size: 100, serving_unit: 'g' })
+    );
+    expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      {
+        user_id: 'user-1',
+        food_id: FOOD_ID,
+        variant_id: VARIANT_ID,
+        entry_date: '2026-06-10',
+        quantity: 100,
+        unit: 'g',
+        meal_type: 'lunch',
+      }
+    );
+  });
+});
+
+describe('search_meal', () => {
+  it('renders meal templates with their food lists', async () => {
+    vi.mocked(mealService.searchMeals).mockResolvedValue([
+      {
+        id: MEAL_ID,
+        name: 'Overnight Oats',
+        description: 'Easy breakfast',
+        foods: [{ food_name: 'Oats' }, { food_name: 'Milk' }],
+      },
+      {
+        id: FOOD_ID_2,
+        name: 'Oatmeal Cookies',
+        description: null,
+        foods: [],
+      },
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'search_meal', meal_name: 'oat' },
+      opts
+    );
+
+    expect(result).toBe(
+      `# Meal Search: "oat"\n\n**Overnight Oats** — Easy breakfast\n  Foods: 2 items (Oats, Milk)\n  ID: ${MEAL_ID}\n\n**Oatmeal Cookies**\n  Foods: 0 items\n  ID: ${FOOD_ID_2}`
+    );
+    expect(mealService.searchMeals).toHaveBeenCalledWith('user-1', 'oat');
+  });
+});
+
+describe('log_meal', () => {
+  it('requires meal_id or meal_name', async () => {
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'log_meal', meal_type: 'breakfast', entry_date: '2026-06-10' },
+      opts
+    );
+    expect(result).toBe(
+      'Error [VALIDATION]: Either meal_id or meal_name must be provided'
+    );
+  });
+
+  it('resolves the meal by exact-insensitive name and logs with v2 serving semantics', async () => {
+    vi.mocked(mealService.searchMeals).mockResolvedValue([
+      { id: FOOD_ID_2, name: 'Overnight Oats Deluxe', foods: [] },
+      { id: MEAL_ID, name: 'Overnight Oats', foods: [] },
+    ]);
+    vi.mocked(foodEntryService.createFoodEntryMeal).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'log_meal',
+        meal_name: 'overnight oats',
+        meal_type: 'breakfast',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Meal "Overnight Oats" logged for breakfast on 2026-06-10.'
+    );
+    expect(foodEntryService.createFoodEntryMeal).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      {
+        user_id: 'user-1',
+        meal_template_id: MEAL_ID,
+        meal_type: 'breakfast',
+        entry_date: '2026-06-10',
+        name: 'Overnight Oats',
+        quantity: 1,
+        unit: 'serving',
+        _clientMealModelVersion: 2,
+      }
+    );
+  });
+
+  it('reports an unknown meal name', async () => {
+    vi.mocked(mealService.searchMeals).mockResolvedValue([]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'log_meal',
+        meal_name: 'Mystery Meal',
+        meal_type: 'dinner',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe('Error [VALIDATION]: Meal "Mystery Meal" not found.');
+  });
+
+  it('reports an unknown meal id', async () => {
+    vi.mocked(mealService.getMealById).mockRejectedValue(
+      new Error('Meal not found.')
+    );
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'log_meal',
+        meal_id: MEAL_ID,
+        meal_type: 'dinner',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      `Error [VALIDATION]: Meal with ID "${MEAL_ID}" not found.`
+    );
+  });
+});
+
+describe('list_diary', () => {
+  it('renders grouped entries with scaled nutrition and the energy total', async () => {
+    vi.mocked(foodEntryService.getFoodEntriesByDate).mockResolvedValue([
+      {
+        id: ENTRY_ID,
+        food_name: 'Oatmeal',
+        quantity: 50,
+        unit: 'g',
+        serving_size: 100,
+        serving_unit: 'g',
+        meal_type: 'breakfast',
+        calories: 380,
+        protein: 13,
+        carbs: 67,
+        fat: 7,
+      },
+      {
+        id: FOOD_ID_2,
+        food_name: 'Banana',
+        quantity: 2,
+        unit: 'serving',
+        serving_size: 1,
+        serving_unit: 'serving',
+        meal_type: 'snacks',
+        calories: 89,
+        protein: 1.1,
+        carbs: 23,
+        fat: 0.3,
+      },
+    ]);
+    vi.mocked(
+      foodEntryMealRepository.getFoodEntryMealsByDate
+    ).mockResolvedValue([
+      {
+        id: MEAL_ID,
+        name: 'Protein Shake',
+        quantity: 1,
+        meal_type: 'breakfast',
+      },
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'list_diary', entry_date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      `# Food Diary: 2026-06-10\n\n## Breakfast\n- **Oatmeal** — 50 g (190 kcal)\n  ID: ${ENTRY_ID} | Type: food_entry\n- **Protein Shake** (meal template) — 1x\n  ID: ${MEAL_ID} | Type: food_entry_meal\n\n## Snacks\n- **Banana** — 2 serving (178 kcal)\n  ID: ${FOOD_ID_2} | Type: food_entry\n\n---\n**Total Energy:** 368 kcal`
+    );
+  });
+
+  it('defaults to today and renders the empty state', async () => {
+    vi.mocked(foodEntryService.getFoodEntriesByDate).mockResolvedValue([]);
+    vi.mocked(
+      foodEntryMealRepository.getFoodEntryMealsByDate
+    ).mockResolvedValue([]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'list_diary' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Food Diary: Today\n\nNo entries found for this date.'
+    );
+    expect(foodEntryService.getFoodEntriesByDate).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      todayInZone('UTC')
+    );
+  });
+
+  it('converts displayed calories when the user prefers kJ', async () => {
+    vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+      energy_unit: 'kJ',
+    });
+    vi.mocked(foodEntryService.getFoodEntriesByDate).mockResolvedValue([
+      {
+        id: ENTRY_ID,
+        food_name: 'Oatmeal',
+        quantity: 50,
+        unit: 'g',
+        serving_size: 100,
+        serving_unit: 'g',
+        meal_type: 'breakfast',
+        calories: 380,
+        protein: 13,
+        carbs: 67,
+        fat: 7,
+      },
+    ]);
+    vi.mocked(
+      foodEntryMealRepository.getFoodEntryMealsByDate
+    ).mockResolvedValue([]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'list_diary', entry_date: '2026-06-10' },
+      opts
+    );
+
+    // 380 kcal × 0.5 = 190 kcal → ×4.184 = 794.96 → rounded 795 kJ
+    expect(result).toBe(
+      `# Food Diary: 2026-06-10\n\n## Breakfast\n- **Oatmeal** — 50 g (795 kJ)\n  ID: ${ENTRY_ID} | Type: food_entry\n\n---\n**Total Energy:** 795 kJ`
+    );
+  });
+});
+
+describe('delete_entry', () => {
+  it('deletes a food entry', async () => {
+    vi.mocked(foodEntryService.deleteFoodEntry).mockResolvedValue(true);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'delete_entry', entry_id: ENTRY_ID, entry_type: 'food_entry' },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry deleted.');
+    expect(foodEntryService.deleteFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      ENTRY_ID
+    );
+  });
+
+  it('maps a missing meal entry to NOT_FOUND', async () => {
+    vi.mocked(foodEntryService.deleteFoodEntryMeal).mockRejectedValue(
+      new Error('Food entry meal not found or not authorized to delete.')
+    );
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'delete_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      `Error [NOT_FOUND]: Entry with ID '${ENTRY_ID}' not found.\n\nSuggestion: Check the ID and try again.`
+    );
+  });
+});
+
+describe('delete_food', () => {
+  it('requires food_id or food_name', async () => {
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'delete_food' },
+      opts
+    );
+    expect(result).toBe(
+      'Error [VALIDATION]: Either food_id or food_name must be provided'
+    );
+  });
+
+  it('resolves by name and force-deletes', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([
+      eggsRow,
+    ]);
+    vi.mocked(foodCoreService.deleteFood).mockResolvedValue({
+      message: 'Food and all its references deleted permanently.',
+      status: 'force_deleted',
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'delete_food', food_name: 'eggs' },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Food "Eggs" deleted (including variants and diary entries).'
+    );
+    expect(foodCoreService.deleteFood).toHaveBeenCalledWith(
+      'user-1',
+      FOOD_ID,
+      true
+    );
+  });
+
+  it('reports the hidden outcome when other users still reference the food', async () => {
+    vi.mocked(foodRepository.getFoodById).mockResolvedValue(eggsRow);
+    vi.mocked(foodCoreService.deleteFood).mockResolvedValue({
+      message:
+        'Food hidden (marked as quick food). Existing references remain.',
+      status: 'hidden',
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'delete_food', food_id: FOOD_ID },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Food "Eggs" hidden (marked as quick food). Existing references remain.'
+    );
+  });
+
+  it('maps an unknown food_id to NOT_FOUND', async () => {
+    vi.mocked(foodRepository.getFoodById).mockResolvedValue(undefined);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'delete_food', food_id: FOOD_ID },
+      opts
+    );
+
+    expect(result).toBe(
+      `Error [NOT_FOUND]: Food with ID '${FOOD_ID}' not found.\n\nSuggestion: Check the ID and try again.`
+    );
+    expect(foodCoreService.deleteFood).not.toHaveBeenCalled();
+  });
+});
+
+describe('update_entry', () => {
+  it('updates a food entry quantity and unit', async () => {
+    vi.mocked(foodEntryService.updateFoodEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry',
+        quantity: 3,
+        unit: 'serving',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry updated to 3 serving.');
+    expect(foodEntryService.updateFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      ENTRY_ID,
+      { quantity: 3, unit: 'serving' }
+    );
+  });
+
+  it('round-trips the template link and foods when updating a meal entry', async () => {
+    const componentFoods = [
+      { food_id: FOOD_ID, variant_id: VARIANT_ID, quantity: 100, unit: 'g' },
+    ];
+    vi.mocked(
+      foodEntryService.getFoodEntryMealWithComponents
+    ).mockResolvedValue({
+      id: ENTRY_ID,
+      meal_template_id: MEAL_ID,
+      entry_date: new Date(2026, 5, 10),
+      foods: componentFoods,
+    });
+    vi.mocked(foodEntryService.updateFoodEntryMeal).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+        quantity: 2,
+        unit: 'serving',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry updated to 2 serving.');
+    expect(foodEntryService.updateFoodEntryMeal).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      ENTRY_ID,
+      {
+        meal_template_id: MEAL_ID,
+        entry_date: '2026-06-10',
+        quantity: 2,
+        unit: 'serving',
+        foods: componentFoods,
+      }
+    );
+  });
+
+  it('maps a missing meal entry to NOT_FOUND', async () => {
+    vi.mocked(
+      foodEntryService.getFoodEntryMealWithComponents
+    ).mockResolvedValue(null);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+        quantity: 2,
+        unit: 'serving',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      `Error [NOT_FOUND]: Entry with ID '${ENTRY_ID}' not found.\n\nSuggestion: Check the ID and try again.`
+    );
+  });
+});
+
+describe('update_food_variant', () => {
+  it('updates only the provided fields and renders the updated variant', async () => {
+    vi.mocked(foodRepository.getFoodVariantById).mockResolvedValue({
+      id: VARIANT_ID,
+      food_id: FOOD_ID,
+    });
+    vi.mocked(foodRepository.getFoodById).mockResolvedValue({
+      id: FOOD_ID,
+      name: 'Oatmeal',
+      user_id: 'user-1',
+    });
+    vi.mocked(foodRepository.updateFoodVariant).mockResolvedValue({
+      id: VARIANT_ID,
+      food_id: FOOD_ID,
+      calories: 390,
+      serving_size: 100,
+      serving_unit: 'g',
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_food_variant',
+        variant_id: VARIANT_ID,
+        calories: 390,
+        fiber: 10,
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Food variant updated for "Oatmeal" (390 kcal per 100g).'
+    );
+    expect(foodRepository.updateFoodVariant).toHaveBeenCalledWith(
+      VARIANT_ID,
+      { calories: 390, dietary_fiber: 10 },
+      'user-1'
+    );
+    expect(foodCoreService.updateFoodEntriesSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('refreshes diary snapshots when update_existing_entries is true', async () => {
+    vi.mocked(foodRepository.getFoodVariantById).mockResolvedValue({
+      id: VARIANT_ID,
+      food_id: FOOD_ID,
+    });
+    vi.mocked(foodRepository.getFoodById).mockResolvedValue({
+      id: FOOD_ID,
+      name: 'Oatmeal',
+      user_id: 'user-1',
+    });
+    vi.mocked(foodRepository.updateFoodVariant).mockResolvedValue({
+      id: VARIANT_ID,
+      food_id: FOOD_ID,
+      calories: 390,
+      serving_size: 100,
+      serving_unit: 'g',
+    });
+    vi.mocked(foodCoreService.updateFoodEntriesSnapshot).mockResolvedValue({
+      message: 'Food entries updated successfully.',
+    });
+
+    await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_food_variant',
+        variant_id: VARIANT_ID,
+        calories: 390,
+        update_existing_entries: true,
+      },
+      opts
+    );
+
+    expect(foodCoreService.updateFoodEntriesSnapshot).toHaveBeenCalledWith(
+      'user-1',
+      FOOD_ID,
+      VARIANT_ID
+    );
+  });
+
+  it('rejects a default-variant lookup on a food the user does not own', async () => {
+    vi.mocked(foodRepository.getFoodById).mockResolvedValue({
+      id: FOOD_ID,
+      name: 'Eggs',
+      user_id: 'someone-else',
+      default_variant: { id: VARIANT_ID },
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'update_food_variant', food_id: FOOD_ID, calories: 100 },
+      opts
+    );
+
+    expect(result).toBe(
+      `Error [VALIDATION]: Default variant for food_id "${FOOD_ID}" not found or not editable.`
+    );
+  });
+
+  it('returns a DB error when neither id is provided (MCP quirk)', async () => {
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'update_food_variant', calories: 100 },
+      opts
+    );
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+
+  it('returns a DB error when no updatable field is provided (MCP quirk)', async () => {
+    vi.mocked(foodRepository.getFoodVariantById).mockResolvedValue({
+      id: VARIANT_ID,
+      food_id: FOOD_ID,
+    });
+    vi.mocked(foodRepository.getFoodById).mockResolvedValue({
+      id: FOOD_ID,
+      name: 'Oatmeal',
+      user_id: 'user-1',
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'update_food_variant', variant_id: VARIANT_ID },
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+    expect(foodRepository.updateFoodVariant).not.toHaveBeenCalled();
+  });
+});
+
+describe('copy_from_yesterday', () => {
+  it('defaults to copying all of yesterday into today', async () => {
+    const today = todayInZone('UTC');
+    const yesterday = addDays(today, -1);
+    vi.mocked(foodEntryService.copyAllFoodEntries).mockResolvedValue([
+      {},
+      {},
+      {},
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'copy_from_yesterday' },
+      opts
+    );
+
+    expect(result).toBe(`✅ Copied 3 entries to ${today}.`);
+    expect(foodEntryService.copyAllFoodEntries).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      yesterday,
+      today
+    );
+  });
+
+  it('copies a single meal slot and reports an empty source', async () => {
+    vi.mocked(foodEntryService.copyFoodEntries).mockResolvedValue([]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'copy_from_yesterday',
+        source_date: '2026-06-09',
+        target_date: '2026-06-10',
+        meal_type: 'breakfast',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ No entries found to copy from the source date.');
+    expect(foodEntryService.copyFoodEntries).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      '2026-06-09',
+      'breakfast',
+      '2026-06-10',
+      'breakfast'
+    );
+  });
+});
+
+describe('save_as_meal_template', () => {
+  it('saves the slot as a template and counts its foods', async () => {
+    vi.mocked(mealService.createMealFromDiaryEntries).mockResolvedValue({
+      id: MEAL_ID,
+      name: 'My Lunch',
+    });
+    vi.mocked(mealService.getMealById).mockResolvedValue({
+      id: MEAL_ID,
+      name: 'My Lunch',
+      foods: [{}, {}],
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'save_as_meal_template',
+        entry_date: '2026-06-10',
+        meal_type: 'lunch',
+        meal_name: 'My Lunch',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Meal template "My Lunch" saved with 2 food items.');
+    expect(mealService.createMealFromDiaryEntries).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-10',
+      'lunch',
+      'My Lunch',
+      null
+    );
+  });
+
+  it('surfaces an empty slot as a DB error (message lacks "not found")', async () => {
+    vi.mocked(mealService.createMealFromDiaryEntries).mockRejectedValue(
+      new Error('No food entries found for lunch on 2026-06-10.')
+    );
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'save_as_meal_template',
+        entry_date: '2026-06-10',
+        meal_type: 'lunch',
+        meal_name: 'My Lunch',
+      },
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+describe('log_water', () => {
+  it('inserts a manual water entry', async () => {
+    vi.mocked(measurementRepository.insertWaterIntakeLog).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'log_water', amount_ml: 500, entry_date: '2026-06-11' },
+      opts
+    );
+
+    expect(result).toBe('✅ Logged 500ml water for 2026-06-11.');
+    expect(measurementRepository.insertWaterIntakeLog).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      '2026-06-11',
+      500,
+      null,
+      null
+    );
+  });
+});
+
+describe('get_nutritional_summary', () => {
+  it('renders per-day macro breakdowns with the conditional Other line', async () => {
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockResolvedValue([
+      {
+        entry_date: new Date(2026, 5, 1),
+        calories: 1850.5,
+        protein: 95.2,
+        carbs: 210,
+        fat: 65.5,
+        saturated_fat: 12,
+        polyunsaturated_fat: 8,
+        monounsaturated_fat: 20,
+        trans_fat: 0,
+        cholesterol: 180,
+        sodium: 2300,
+        potassium: 3400,
+        fiber: 25,
+        sugar: 48,
+        vitamin_a: 80,
+        vitamin_c: 60,
+        calcium: 90,
+        iron: 70,
+      },
+      {
+        entry_date: new Date(2026, 5, 2),
+        calories: 1500,
+        protein: 80,
+        carbs: 180,
+        fat: 50,
+        saturated_fat: 0,
+        cholesterol: 0,
+        sodium: 1800,
+        potassium: 0,
+        fiber: 20,
+        sugar: 30,
+      },
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'get_nutritional_summary',
+        start_date: '2026-06-01',
+        end_date: '2026-06-07',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Nutritional Summary (2026-06-01 to 2026-06-07)\n\n**2026-06-01**:\n  Macros: 1850.5 kcal | P: 95.2g | C: 210g | F: 65.5g\n  Fiber: 25g | Sugar: 48g | Sodium: 2300mg\n  Other: SatFat: 12g | Chol: 180mg | Potas: 3400mg\n\n**2026-06-02**:\n  Macros: 1500 kcal | P: 80g | C: 180g | F: 50g\n  Fiber: 20g | Sugar: 30g | Sodium: 1800mg\n'
+    );
+    expect(reportRepository.getDailyNutritionTotalsRange).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-01',
+      '2026-06-07'
+    );
+  });
+
+  it('converts calories to kJ when the user prefers it', async () => {
+    vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+      energy_unit: 'kJ',
+    });
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockResolvedValue([
+      {
+        entry_date: new Date(2026, 5, 1),
+        calories: 1000,
+        protein: 80,
+        carbs: 100,
+        fat: 30,
+        sodium: 1500,
+        fiber: 20,
+        sugar: 25,
+      },
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'get_nutritional_summary',
+        start_date: '2026-06-01',
+        end_date: '2026-06-01',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Nutritional Summary (2026-06-01 to 2026-06-01)\n\n**2026-06-01**:\n  Macros: 4184 kJ | P: 80g | C: 100g | F: 30g\n  Fiber: 20g | Sugar: 25g | Sodium: 1500mg\n'
+    );
+  });
+});
+
+describe('get_water_history', () => {
+  it('renders daily totals in ml', async () => {
+    vi.mocked(
+      measurementRepository.getWaterTotalsByDateRange
+    ).mockResolvedValue([
+      { entry_date: new Date(2026, 5, 10), total_ml: '2500' },
+      { entry_date: new Date(2026, 5, 11), total_ml: '1800' },
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'get_water_history', start_date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Water Intake History\n\n**2026-06-10**: 2500 ml\n\n**2026-06-11**: 1800 ml'
+    );
+    expect(
+      measurementRepository.getWaterTotalsByDateRange
+    ).toHaveBeenCalledWith('user-1', '2026-06-10', undefined);
+  });
+
+  it('converts totals to oz when the user prefers it', async () => {
+    vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+      water_display_unit: 'oz',
+    });
+    vi.mocked(
+      measurementRepository.getWaterTotalsByDateRange
+    ).mockResolvedValue([
+      { entry_date: new Date(2026, 5, 10), total_ml: '591' },
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'get_water_history' },
+      opts
+    );
+
+    expect(result).toBe('# Water Intake History\n\n**2026-06-10**: 20 oz');
+  });
+});
+
+describe('service errors surface as tool error strings', () => {
+  it('maps an unexpected service failure to DB_ERROR', async () => {
+    vi.mocked(foodEntryService.getFoodEntriesByDate).mockRejectedValue(
+      new Error('connection refused')
+    );
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'list_diary', entry_date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+describe('sparky_list_foods', () => {
+  it('returns the paginated catalog with the default variant folded into variants', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([
+      {
+        id: FOOD_ID,
+        name: 'Eggs',
+        brand: null,
+        is_custom: true,
+        user_id: 'user-1',
+        default_variant: { id: VARIANT_ID, calories: 155 },
+      },
+      {
+        id: FOOD_ID_2,
+        name: 'Quick Add',
+        brand: null,
+        is_custom: true,
+        user_id: 'user-1',
+        default_variant: { id: null },
+      },
+    ]);
+    vi.mocked(foodRepository.countFoods).mockResolvedValue(2);
+
+    const result = await tools.sparky_list_foods.execute!(
+      { search: 'egg' },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          data: [
+            {
+              id: FOOD_ID,
+              name: 'Eggs',
+              brand: null,
+              is_custom: true,
+              user_id: 'user-1',
+              variants: [{ id: VARIANT_ID, calories: 155 }],
+            },
+            {
+              id: FOOD_ID_2,
+              name: 'Quick Add',
+              brand: null,
+              is_custom: true,
+              user_id: 'user-1',
+              variants: [],
+            },
+          ],
+          has_more: false,
+          next_offset: null,
+          total_count: 2,
+        },
+        null,
+        2
+      )
+    );
+    expect(foodRepository.getFoodsWithPagination).toHaveBeenCalledWith(
+      'egg',
+      null,
+      'user-1',
+      20,
+      0,
+      null
+    );
+  });
+});
+
+describe('sparky_get_food_details', () => {
+  it('returns the food with all variants', async () => {
+    vi.mocked(foodCoreService.getFoodById).mockResolvedValue({
+      id: FOOD_ID,
+      name: 'Eggs',
+      brand: 'Farm Fresh',
+      default_variant: { id: VARIANT_ID },
+    });
+    vi.mocked(foodRepository.getFoodVariantsByFoodId).mockResolvedValue([
+      { id: VARIANT_ID, serving_unit: 'g' },
+      { id: FOOD_ID_2, serving_unit: 'serving' },
+    ]);
+
+    const result = await tools.sparky_get_food_details.execute!(
+      { food_id: FOOD_ID },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          id: FOOD_ID,
+          name: 'Eggs',
+          brand: 'Farm Fresh',
+          variants: [
+            { id: VARIANT_ID, serving_unit: 'g' },
+            { id: FOOD_ID_2, serving_unit: 'serving' },
+          ],
+        },
+        null,
+        2
+      )
+    );
+  });
+
+  it('maps a missing food to NOT_FOUND', async () => {
+    vi.mocked(foodCoreService.getFoodById).mockRejectedValue(
+      new Error('Food not found.')
+    );
+
+    const result = await tools.sparky_get_food_details.execute!(
+      { food_id: FOOD_ID },
+      opts
+    );
+
+    expect(result).toBe(
+      `Error [NOT_FOUND]: Food with ID '${FOOD_ID}' not found.\n\nSuggestion: Check the ID and try again.`
+    );
+  });
+});
+
+describe('sparky_search_foods', () => {
+  it('requires a query', async () => {
+    const result = await tools.sparky_search_foods.execute!(
+      {} as { query: string },
+      opts
+    );
+    expect(result).toBe(
+      'Error [VALIDATION]: query: Invalid input: expected string, received undefined'
+    );
+  });
+
+  it('searches the catalog by name', async () => {
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([]);
+    vi.mocked(foodRepository.countFoods).mockResolvedValue(0);
+
+    const result = await tools.sparky_search_foods.execute!(
+      { query: 'egg', limit: 5 },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        { data: [], has_more: false, next_offset: null, total_count: 0 },
+        null,
+        2
+      )
+    );
+    expect(foodRepository.getFoodsWithPagination).toHaveBeenCalledWith(
+      'egg',
+      null,
+      'user-1',
+      5,
+      0,
+      null
+    );
+  });
+});
+
+describe('sparky_get_food_diary', () => {
+  it('uses a single date for both range bounds and returns entries plus meals', async () => {
+    const foodEntries = [{ id: ENTRY_ID, food_name: 'Eggs' }];
+    const mealEntries = [{ id: MEAL_ID, name: 'Protein Shake' }];
+    vi.mocked(foodEntryService.getFoodEntriesByDateRange).mockResolvedValue(
+      foodEntries
+    );
+    vi.mocked(
+      foodEntryMealRepository.getFoodEntryMealsByDateRange
+    ).mockResolvedValue(mealEntries);
+
+    const result = await tools.sparky_get_food_diary.execute!(
+      { date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          start_date: '2026-06-10',
+          end_date: '2026-06-10',
+          food_entries: foodEntries,
+          meal_entries: mealEntries,
+        },
+        null,
+        2
+      )
+    );
+    expect(foodEntryService.getFoodEntriesByDateRange).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      '2026-06-10',
+      '2026-06-10'
+    );
+    expect(
+      foodEntryMealRepository.getFoodEntryMealsByDateRange
+    ).toHaveBeenCalledWith('user-1', '2026-06-10', '2026-06-10');
+  });
+});
+
+describe('sparky_get_nutrition_summary', () => {
+  it('defaults the range to today', async () => {
+    const today = todayInZone('UTC');
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockResolvedValue(
+      []
+    );
+
+    const result = await tools.sparky_get_nutrition_summary.execute!({}, opts);
+
+    expect(result).toBe('[]');
+    expect(reportRepository.getDailyNutritionTotalsRange).toHaveBeenCalledWith(
+      'user-1',
+      today,
+      today
+    );
+  });
+});
+
+describe('sparky_get_recent_food_entries', () => {
+  it('clamps the limit to 200', async () => {
+    vi.mocked(foodRepository.getRecentFoodEntries).mockResolvedValue([]);
+
+    const result = await tools.sparky_get_recent_food_entries.execute!(
+      { limit: 200 },
+      opts
+    );
+
+    expect(result).toBe('[]');
+    expect(foodRepository.getRecentFoodEntries).toHaveBeenCalledWith(
+      'user-1',
+      200
+    );
+  });
+});
+
+describe('sparky_get_food_usage', () => {
+  it('returns paginated usage rows with today as the default range', async () => {
+    const today = todayInZone('UTC');
+    const rows = [{ id: ENTRY_ID, food_id: FOOD_ID }];
+    vi.mocked(foodRepository.getFoodUsage).mockResolvedValue({
+      rows,
+      totalCount: 1,
+    });
+
+    const result = await tools.sparky_get_food_usage.execute!(
+      { food_id: FOOD_ID },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        { data: rows, has_more: false, next_offset: null, total_count: 1 },
+        null,
+        2
+      )
+    );
+    expect(foodRepository.getFoodUsage).toHaveBeenCalledWith(
+      'user-1',
+      FOOD_ID,
+      today,
+      today,
+      20,
+      0
+    );
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsGoals.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsGoals.test.ts
@@ -1,0 +1,290 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { todayInZone } from '@workspace/shared';
+import { buildGoalTools } from '../ai/tools/goalTools.js';
+import goalService from '../services/goalService.js';
+import goalRepository from '../models/goalRepository.js';
+
+vi.mock('../services/goalService', () => ({
+  default: {
+    getUserGoals: vi.fn(),
+    manageGoalTimeline: vi.fn(),
+  },
+}));
+vi.mock('../models/goalRepository', () => ({
+  default: {
+    getGoalTimeline: vi.fn(),
+  },
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+const DB_ERROR_TEXT =
+  'Error [DB_ERROR]: A database error occurred. Please try again.\n\nSuggestion: If the issue persists, contact support.';
+
+let tools: ReturnType<typeof buildGoalTools>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tools = buildGoalTools('user-1');
+});
+
+describe('sparky_manage_goals', () => {
+  it('get_goals renders the goals for an explicit date', async () => {
+    vi.mocked(goalService.getUserGoals).mockResolvedValue({
+      calories: 2100,
+      protein: 160,
+      carbs: 240,
+      fat: 70,
+      water_goal_ml: 2200,
+      saturated_fat: 20,
+    });
+
+    const result = await tools.sparky_manage_goals.execute!(
+      { action: 'get_goals', target_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### Goals for 2026-06-01\n\n' +
+        '- **Calories:** 2100 kcal\n' +
+        '- **Protein:** 160g\n' +
+        '- **Carbs:** 240g\n' +
+        '- **Fat:** 70g\n' +
+        '- **Water:** 2200ml\n'
+    );
+    expect(goalService.getUserGoals).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-01'
+    );
+  });
+
+  it('get_goals defaults to today (UTC) and labels it "today"', async () => {
+    vi.mocked(goalService.getUserGoals).mockResolvedValue({
+      calories: 2000,
+      protein: 150,
+      carbs: 250,
+      fat: 67,
+      water_goal_ml: 1920,
+    });
+
+    const result = await tools.sparky_manage_goals.execute!(
+      { action: 'get_goals' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### Goals for today\n\n' +
+        '- **Calories:** 2000 kcal\n' +
+        '- **Protein:** 150g\n' +
+        '- **Carbs:** 250g\n' +
+        '- **Fat:** 67g\n' +
+        '- **Water:** 1920ml\n'
+    );
+    expect(goalService.getUserGoals).toHaveBeenCalledWith(
+      'user-1',
+      todayInZone('UTC')
+    );
+  });
+
+  it('set_goals applies MCP defaults for omitted fields and cascades', async () => {
+    vi.mocked(goalService.manageGoalTimeline).mockResolvedValue({
+      message: 'ok',
+    });
+
+    const result = await tools.sparky_manage_goals.execute!(
+      { action: 'set_goals', start_date: '2026-06-15', calories: 2200 },
+      opts
+    );
+
+    expect(result).toBe('✅ Goals set successfully starting from 2026-06-15.');
+    expect(goalService.manageGoalTimeline).toHaveBeenCalledWith('user-1', {
+      p_start_date: '2026-06-15',
+      p_cascade: true,
+      p_calories: 2200,
+      p_protein: 150,
+      p_carbs: 250,
+      p_fat: 67,
+      p_water_goal_ml: 2000,
+    });
+  });
+
+  it('set_goals without start_date returns a validation error', async () => {
+    const result = await tools.sparky_manage_goals.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { action: 'set_goals' } as any,
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: start_date: Invalid input: expected string, received undefined'
+    );
+    expect(goalService.manageGoalTimeline).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown actions', async () => {
+    const result = await tools.sparky_manage_goals.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { action: 'bogus_action' } as any,
+      opts
+    );
+
+    expect(result).toBe('Error [VALIDATION]: action: Invalid input');
+  });
+
+  it('rejects stray keys (strict per-action schema)', async () => {
+    const result = await tools.sparky_manage_goals.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { action: 'get_goals', foo: 1 } as any,
+      opts
+    );
+
+    expect(result).toBe('Error [VALIDATION]: Unrecognized key: "foo"');
+  });
+
+  it('list_goal_timeline renders one line per goal change', async () => {
+    vi.mocked(goalRepository.getGoalTimeline).mockResolvedValue([
+      {
+        id: 1,
+        goal_date: '2026-06-01',
+        calories: 2000,
+        protein: 150,
+        carbs: 250,
+        fat: 67,
+        water_goal_ml: 2000,
+      },
+      {
+        id: 2,
+        goal_date: '2026-05-01',
+        calories: 1800,
+        protein: 140,
+        carbs: 200,
+        fat: 60,
+        water_goal_ml: 1500,
+      },
+    ]);
+
+    const result = await tools.sparky_manage_goals.execute!(
+      { action: 'list_goal_timeline' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Goal Timeline\n\n' +
+        '**2026-06-01**: 2000 kcal | P: 150g | C: 250g | F: 67g | W: 2000ml\n\n' +
+        '**2026-05-01**: 1800 kcal | P: 140g | C: 200g | F: 60g | W: 1500ml'
+    );
+    expect(goalRepository.getGoalTimeline).toHaveBeenCalledWith('user-1');
+  });
+
+  it('list_goal_timeline reports when there are no goals', async () => {
+    vi.mocked(goalRepository.getGoalTimeline).mockResolvedValue([]);
+
+    const result = await tools.sparky_manage_goals.execute!(
+      { action: 'list_goal_timeline' },
+      opts
+    );
+
+    expect(result).toBe('# Goal Timeline\n\nNo results found.');
+  });
+
+  it('returns DB_ERROR when the service throws', async () => {
+    vi.mocked(goalService.getUserGoals).mockRejectedValue(new Error('boom'));
+
+    const result = await tools.sparky_manage_goals.execute!(
+      { action: 'get_goals' },
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+describe('sparky_get_goal_snapshot', () => {
+  it("projects the server's goal object down to MCP's column set", async () => {
+    const snapshotFields = {
+      calories: 2000,
+      protein: 150,
+      carbs: 250,
+      fat: 67,
+      water_goal_ml: 1920,
+      saturated_fat: 20,
+      polyunsaturated_fat: 10,
+      monounsaturated_fat: 25,
+      trans_fat: 0,
+      cholesterol: 300,
+      sodium: 2300,
+      potassium: 3500,
+      dietary_fiber: 25,
+      sugars: 50,
+      vitamin_a: 900,
+      vitamin_c: 90,
+      calcium: 1000,
+      iron: 18,
+    };
+    vi.mocked(goalService.getUserGoals).mockResolvedValue({
+      ...snapshotFields,
+      protein_percentage: null,
+      breakfast_percentage: 25,
+      custom_nutrients: {},
+    });
+
+    const result = await tools.sparky_get_goal_snapshot.execute!(
+      { target_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe(JSON.stringify(snapshotFields, null, 2));
+    expect(goalService.getUserGoals).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-01'
+    );
+  });
+
+  it('defaults to today (UTC) when no target_date is given', async () => {
+    vi.mocked(goalService.getUserGoals).mockResolvedValue({ calories: 2000 });
+
+    const result = await tools.sparky_get_goal_snapshot.execute!({}, opts);
+
+    expect(result).toBe(JSON.stringify({ calories: 2000 }, null, 2));
+    expect(goalService.getUserGoals).toHaveBeenCalledWith(
+      'user-1',
+      todayInZone('UTC')
+    );
+  });
+
+  it("maps 'not found' service errors to NOT_FOUND", async () => {
+    vi.mocked(goalService.getUserGoals).mockRejectedValue(
+      new Error('Goal not found')
+    );
+
+    const result = await tools.sparky_get_goal_snapshot.execute!(
+      { target_date: '2026-06-01' },
+      opts
+    );
+
+    expect(result).toBe(
+      "Error [NOT_FOUND]: Goal with ID '2026-06-01' not found.\n\nSuggestion: Check the ID and try again."
+    );
+  });
+
+  it('rejects malformed dates', async () => {
+    const result = await tools.sparky_get_goal_snapshot.execute!(
+      { target_date: '06/01/2026' },
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: target_date: Invalid string: must match pattern /^\\d{4}-\\d{2}-\\d{2}$/'
+    );
+  });
+
+  it('returns DB_ERROR for other service failures', async () => {
+    vi.mocked(goalService.getUserGoals).mockRejectedValue(new Error('boom'));
+
+    const result = await tools.sparky_get_goal_snapshot.execute!({}, opts);
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsGoals.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsGoals.test.ts
@@ -27,7 +27,7 @@ let tools: ReturnType<typeof buildGoalTools>;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  tools = buildGoalTools('user-1');
+  tools = buildGoalTools('user-1', 'UTC');
 });
 
 describe('sparky_manage_goals', () => {
@@ -176,6 +176,30 @@ describe('sparky_manage_goals', () => {
         '**2026-05-01**: 1800 kcal | P: 140g | C: 200g | F: 60g | W: 1500ml'
     );
     expect(goalRepository.getGoalTimeline).toHaveBeenCalledWith('user-1');
+  });
+
+  it('list_goal_timeline renders a pg local-midnight Date goal_date as a calendar-day string', async () => {
+    vi.mocked(goalRepository.getGoalTimeline).mockResolvedValue([
+      {
+        id: 1,
+        goal_date: new Date(2026, 5, 1),
+        calories: 2000,
+        protein: 150,
+        carbs: 250,
+        fat: 67,
+        water_goal_ml: 2000,
+      },
+    ]);
+
+    const result = await tools.sparky_manage_goals.execute!(
+      { action: 'list_goal_timeline' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Goal Timeline\n\n' +
+        '**2026-06-01**: 2000 kcal | P: 150g | C: 250g | F: 67g | W: 2000ml'
+    );
   });
 
   it('list_goal_timeline reports when there are no goals', async () => {

--- a/SparkyFitnessServer/tests/chatbotToolsHabits.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsHabits.test.ts
@@ -1,0 +1,167 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { buildHabitTools } from '../ai/tools/habitTools.js';
+import habitRepository from '../models/habitRepository.js';
+
+vi.mock('../models/habitRepository', () => ({
+  default: {
+    listHabits: vi.fn(),
+    upsertHabitLog: vi.fn(),
+    getHabitHistory: vi.fn(),
+  },
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+const HABIT_ID = '123e4567-e89b-12d3-a456-426614174000';
+const DB_ERROR_TEXT =
+  'Error [DB_ERROR]: A database error occurred. Please try again.\n\nSuggestion: If the issue persists, contact support.';
+
+let tools: ReturnType<typeof buildHabitTools>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tools = buildHabitTools('user-1');
+});
+
+describe('sparky_manage_habits', () => {
+  it('list_habits renders display name (falling back to name) and id', async () => {
+    vi.mocked(habitRepository.listHabits).mockResolvedValue([
+      { id: 'h1', name: 'meditate', display_name: 'Meditate' },
+      { id: 'h2', name: 'stretch', display_name: null },
+    ]);
+
+    const result = await tools.sparky_manage_habits.execute!(
+      { action: 'list_habits' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Available Habits\n\n' +
+        '**Meditate**\n  ID: h1\n\n' +
+        '**stretch**\n  ID: h2'
+    );
+    expect(habitRepository.listHabits).toHaveBeenCalledWith('user-1');
+  });
+
+  it('list_habits reports when there are none', async () => {
+    vi.mocked(habitRepository.listHabits).mockResolvedValue([]);
+
+    const result = await tools.sparky_manage_habits.execute!(
+      { action: 'list_habits' },
+      opts
+    );
+
+    expect(result).toBe('# Available Habits\n\nNo results found.');
+  });
+
+  it("log_habit stores 'true' for a completed habit", async () => {
+    vi.mocked(habitRepository.upsertHabitLog).mockResolvedValue(undefined);
+
+    const result = await tools.sparky_manage_habits.execute!(
+      {
+        action: 'log_habit',
+        habit_id: HABIT_ID,
+        entry_date: '2026-06-01',
+        completed: true,
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Habit completed for 2026-06-01.');
+    expect(habitRepository.upsertHabitLog).toHaveBeenCalledWith(
+      'user-1',
+      HABIT_ID,
+      '2026-06-01',
+      'true'
+    );
+  });
+
+  it("log_habit stores 'false' for a missed habit", async () => {
+    vi.mocked(habitRepository.upsertHabitLog).mockResolvedValue(undefined);
+
+    const result = await tools.sparky_manage_habits.execute!(
+      {
+        action: 'log_habit',
+        habit_id: HABIT_ID,
+        entry_date: '2026-06-01',
+        completed: false,
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Habit not completed for 2026-06-01.');
+    expect(habitRepository.upsertHabitLog).toHaveBeenCalledWith(
+      'user-1',
+      HABIT_ID,
+      '2026-06-01',
+      'false'
+    );
+  });
+
+  it('log_habit rejects a non-UUID habit_id', async () => {
+    const result = await tools.sparky_manage_habits.execute!(
+      {
+        action: 'log_habit',
+        habit_id: 'nope',
+        entry_date: '2026-06-01',
+        completed: true,
+      },
+      opts
+    );
+
+    expect(result).toBe('Error [VALIDATION]: habit_id: Must be a valid UUID');
+    expect(habitRepository.upsertHabitLog).not.toHaveBeenCalled();
+  });
+
+  it("get_habit_history maps stored values to '✅ Completed' / '❌ Missed'", async () => {
+    vi.mocked(habitRepository.getHabitHistory).mockResolvedValue([
+      {
+        id: 'm1',
+        value: 'true',
+        entry_date: '2026-06-01',
+        created_at: '2026-06-01T08:00:00Z',
+      },
+      {
+        id: 'm2',
+        value: 'false',
+        entry_date: '2026-06-02',
+        created_at: '2026-06-02T08:00:00Z',
+      },
+    ]);
+
+    const result = await tools.sparky_manage_habits.execute!(
+      {
+        action: 'get_habit_history',
+        habit_id: HABIT_ID,
+        start_date: '2026-06-01',
+        end_date: '2026-06-02',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Habit History\n\n' +
+        '2026-06-01: ✅ Completed\n\n' +
+        '2026-06-02: ❌ Missed'
+    );
+    expect(habitRepository.getHabitHistory).toHaveBeenCalledWith(
+      'user-1',
+      HABIT_ID,
+      '2026-06-01',
+      '2026-06-02'
+    );
+  });
+
+  it('returns DB_ERROR when the repository throws', async () => {
+    vi.mocked(habitRepository.listHabits).mockRejectedValue(new Error('boom'));
+
+    const result = await tools.sparky_manage_habits.execute!(
+      { action: 'list_habits' },
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsHabits.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsHabits.test.ts
@@ -154,6 +154,27 @@ describe('sparky_manage_habits', () => {
     );
   });
 
+  it('get_habit_history renders a pg local-midnight Date entry_date as a calendar-day string', async () => {
+    vi.mocked(habitRepository.getHabitHistory).mockResolvedValue([
+      {
+        id: 'm1',
+        value: 'true',
+        entry_date: new Date(2026, 5, 10),
+        created_at: '2026-06-10T08:00:00Z',
+      },
+    ]);
+
+    const result = await tools.sparky_manage_habits.execute!(
+      {
+        action: 'get_habit_history',
+        habit_id: HABIT_ID,
+      },
+      opts
+    );
+
+    expect(result).toBe('# Habit History\n\n2026-06-10: ✅ Completed');
+  });
+
   it('returns DB_ERROR when the repository throws', async () => {
     vi.mocked(habitRepository.listHabits).mockRejectedValue(new Error('boom'));
 

--- a/SparkyFitnessServer/tests/chatbotToolsIndex.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsIndex.test.ts
@@ -63,4 +63,14 @@ describe('buildChatbotTools', () => {
       expect(typeof t.execute, `${name} execute`).toBe('function');
     }
   });
+
+  // OpenAI's Responses API treats an omitted strict flag as "attempt strict
+  // mode", which forces models to fill every published property with
+  // placeholder values that the per-action union validation then rejects.
+  it('publishes every tool with provider strict mode disabled', () => {
+    const tools = buildChatbotTools('user-1', 'UTC');
+    for (const [name, t] of Object.entries(tools)) {
+      expect(t.strict, `${name} strict`).toBe(false);
+    }
+  });
 });

--- a/SparkyFitnessServer/tests/chatbotToolsIndex.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsIndex.test.ts
@@ -1,0 +1,66 @@
+import { vi, describe, expect, it } from 'vitest';
+import { buildChatbotTools } from '../ai/tools/index.js';
+
+// Loading the real foodEntryService trips on a deep '@workspace/shared'
+// subpath import; the registry surface test never executes handlers.
+vi.mock('../services/foodEntryService', () => ({ default: {} }));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+// The chat-visible tool surface: every MCP tool except the four dev tools
+// (sparky_inspect_schema, sparky_get_user_info, sparky_get_db_stats,
+// sparky_run_project_tests), which are intentionally not ported.
+const EXPECTED_TOOLS = [
+  'sparky_analyze_food_image',
+  'sparky_analyze_trends',
+  'sparky_check_engagement',
+  'sparky_daily_checkin_wizard',
+  'sparky_detect_patterns',
+  'sparky_generate_coaching_plan',
+  'sparky_get_30_day_trends',
+  'sparky_get_contextual_nudge',
+  'sparky_get_daily_exercise_totals',
+  'sparky_get_daily_report',
+  'sparky_get_exercise_details',
+  'sparky_get_exercise_diary',
+  'sparky_get_exercise_progress',
+  'sparky_get_exercise_usage',
+  'sparky_get_food_details',
+  'sparky_get_food_diary',
+  'sparky_get_food_usage',
+  'sparky_get_goal_snapshot',
+  'sparky_get_health_summary',
+  'sparky_get_logging_streak',
+  'sparky_get_nutrition_summary',
+  'sparky_get_recent_exercise_entries',
+  'sparky_get_recent_food_entries',
+  'sparky_get_report',
+  'sparky_list_exercises',
+  'sparky_list_foods',
+  'sparky_manage_checkin',
+  'sparky_manage_exercise',
+  'sparky_manage_food',
+  'sparky_manage_goals',
+  'sparky_manage_habits',
+  'sparky_manage_profile',
+  'sparky_scan_label',
+  'sparky_search_exercises',
+  'sparky_search_foods',
+];
+
+describe('buildChatbotTools', () => {
+  it('exposes exactly the MCP chat-visible tool surface', () => {
+    const tools = buildChatbotTools('user-1');
+    expect(Object.keys(tools).sort()).toEqual(EXPECTED_TOOLS);
+  });
+
+  it('gives every tool a description, an input schema, and an executor', () => {
+    const tools = buildChatbotTools('user-1');
+    for (const [name, t] of Object.entries(tools)) {
+      expect(t.description, `${name} description`).toBeTruthy();
+      expect(t.inputSchema, `${name} inputSchema`).toBeDefined();
+      expect(typeof t.execute, `${name} execute`).toBe('function');
+    }
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsIndex.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsIndex.test.ts
@@ -51,12 +51,12 @@ const EXPECTED_TOOLS = [
 
 describe('buildChatbotTools', () => {
   it('exposes exactly the MCP chat-visible tool surface', () => {
-    const tools = buildChatbotTools('user-1');
+    const tools = buildChatbotTools('user-1', 'UTC');
     expect(Object.keys(tools).sort()).toEqual(EXPECTED_TOOLS);
   });
 
   it('gives every tool a description, an input schema, and an executor', () => {
-    const tools = buildChatbotTools('user-1');
+    const tools = buildChatbotTools('user-1', 'UTC');
     for (const [name, t] of Object.entries(tools)) {
       expect(t.description, `${name} description`).toBeTruthy();
       expect(t.inputSchema, `${name} inputSchema`).toBeDefined();

--- a/SparkyFitnessServer/tests/chatbotToolsProfile.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsProfile.test.ts
@@ -1,0 +1,233 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { buildProfileTools } from '../ai/tools/profileTools.js';
+import userRepository from '../models/userRepository.js';
+import preferenceService from '../services/preferenceService.js';
+
+vi.mock('../models/userRepository', () => ({
+  default: {
+    getAuthUserProfile: vi.fn(),
+    updateAuthUserProfile: vi.fn(),
+  },
+}));
+vi.mock('../services/preferenceService', () => ({
+  default: {
+    getUserPreferences: vi.fn(),
+    updateUserPreferences: vi.fn(),
+    upsertUserPreferences: vi.fn(),
+  },
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+const DB_ERROR_TEXT =
+  'Error [DB_ERROR]: A database error occurred. Please try again.\n\nSuggestion: If the issue persists, contact support.';
+
+let tools: ReturnType<typeof buildProfileTools>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tools = buildProfileTools('user-1');
+});
+
+describe('sparky_manage_profile', () => {
+  it('get_profile renders name, email and id', async () => {
+    vi.mocked(userRepository.getAuthUserProfile).mockResolvedValue({
+      id: 'user-1',
+      email: 'andrew@example.com',
+      name: 'Andrew',
+      image: null,
+    });
+
+    const result = await tools.sparky_manage_profile.execute!(
+      { action: 'get_profile' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### User Profile\n\n' +
+        '- **Name:** Andrew\n' +
+        '- **Email:** andrew@example.com\n' +
+        '- **ID:** user-1\n'
+    );
+    expect(userRepository.getAuthUserProfile).toHaveBeenCalledWith('user-1');
+  });
+
+  it('get_profile falls back to N/A when name is unset', async () => {
+    vi.mocked(userRepository.getAuthUserProfile).mockResolvedValue({
+      id: 'user-1',
+      email: 'andrew@example.com',
+      name: null,
+      image: null,
+    });
+
+    const result = await tools.sparky_manage_profile.execute!(
+      { action: 'get_profile' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### User Profile\n\n' +
+        '- **Name:** N/A\n' +
+        '- **Email:** andrew@example.com\n' +
+        '- **ID:** user-1\n'
+    );
+  });
+
+  it('update_profile passes provided fields and nulls for the rest', async () => {
+    vi.mocked(userRepository.updateAuthUserProfile).mockResolvedValue({
+      id: 'user-1',
+      email: 'andrew@example.com',
+      name: 'New Name',
+      image: null,
+    });
+
+    const result = await tools.sparky_manage_profile.execute!(
+      { action: 'update_profile', display_name: 'New Name' },
+      opts
+    );
+
+    expect(result).toBe('✅ Profile updated.');
+    expect(userRepository.updateAuthUserProfile).toHaveBeenCalledWith(
+      'user-1',
+      'New Name',
+      null,
+      null
+    );
+  });
+
+  it('update_profile rejects an invalid email', async () => {
+    const result = await tools.sparky_manage_profile.execute!(
+      { action: 'update_profile', email: 'not-an-email' },
+      opts
+    );
+
+    expect(result).toBe('Error [VALIDATION]: email: Invalid email address');
+    expect(userRepository.updateAuthUserProfile).not.toHaveBeenCalled();
+  });
+
+  it('get_preferences renders stored preferences', async () => {
+    vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+      timezone: 'America/New_York',
+      energy_unit: 'kJ',
+      default_weight_unit: 'lbs',
+      default_distance_unit: 'miles',
+      item_display_limit: 10,
+    });
+
+    const result = await tools.sparky_manage_profile.execute!(
+      { action: 'get_preferences' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### User Preferences\n\n' +
+        '- **Timezone:** America/New_York\n' +
+        '- **Energy Unit:** kJ\n' +
+        '- **Weight Unit:** lbs\n' +
+        '- **Distance Unit:** miles\n'
+    );
+    expect(preferenceService.getUserPreferences).toHaveBeenCalledWith(
+      'user-1',
+      'user-1'
+    );
+  });
+
+  it('get_preferences falls back to defaults when fields are unset', async () => {
+    vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+      calorie_goal_adjustment_mode: 'dynamic',
+      show_net_carbs: false,
+      timezone: null,
+    });
+
+    const result = await tools.sparky_manage_profile.execute!(
+      { action: 'get_preferences' },
+      opts
+    );
+
+    expect(result).toBe(
+      '### User Preferences\n\n' +
+        '- **Timezone:** UTC\n' +
+        '- **Energy Unit:** kcal\n' +
+        '- **Weight Unit:** kg\n' +
+        '- **Distance Unit:** km\n'
+    );
+  });
+
+  it('update_preferences sends a partial COALESCE update', async () => {
+    vi.mocked(preferenceService.updateUserPreferences).mockResolvedValue({});
+
+    const result = await tools.sparky_manage_profile.execute!(
+      { action: 'update_preferences', energy_unit: 'kJ' },
+      opts
+    );
+
+    expect(result).toBe('✅ Preferences updated.');
+    expect(preferenceService.updateUserPreferences).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      {
+        timezone: null,
+        energy_unit: 'kJ',
+        default_weight_unit: null,
+        default_measurement_unit: null,
+        default_distance_unit: null,
+        water_display_unit: null,
+      }
+    );
+    expect(preferenceService.upsertUserPreferences).not.toHaveBeenCalled();
+  });
+
+  it('update_preferences creates the row when none exists yet', async () => {
+    vi.mocked(preferenceService.updateUserPreferences).mockRejectedValue(
+      new Error('User preferences not found or not authorized to update.')
+    );
+    vi.mocked(preferenceService.upsertUserPreferences).mockResolvedValue({});
+
+    const result = await tools.sparky_manage_profile.execute!(
+      { action: 'update_preferences', timezone: 'UTC' },
+      opts
+    );
+
+    expect(result).toBe('✅ Preferences updated.');
+    expect(preferenceService.upsertUserPreferences).toHaveBeenCalledWith(
+      'user-1',
+      {
+        timezone: 'UTC',
+        energy_unit: null,
+        default_weight_unit: null,
+        default_measurement_unit: null,
+        default_distance_unit: null,
+        water_display_unit: null,
+      }
+    );
+  });
+
+  it('update_preferences surfaces invalid timezones as validation errors', async () => {
+    vi.mocked(preferenceService.updateUserPreferences).mockRejectedValue(
+      new Error("Invalid timezone: 'Mars/Olympus'")
+    );
+
+    const result = await tools.sparky_manage_profile.execute!(
+      { action: 'update_preferences', timezone: 'Mars/Olympus' },
+      opts
+    );
+
+    expect(result).toBe("Error [VALIDATION]: Invalid timezone: 'Mars/Olympus'");
+    expect(preferenceService.upsertUserPreferences).not.toHaveBeenCalled();
+  });
+
+  it('returns DB_ERROR when the repository throws', async () => {
+    vi.mocked(userRepository.getAuthUserProfile).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_manage_profile.execute!(
+      { action: 'get_profile' },
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsReport.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsReport.test.ts
@@ -1,0 +1,325 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { addDays, todayInZone } from '@workspace/shared';
+import { buildReportTools } from '../ai/tools/reportTools.js';
+import preferenceService from '../services/preferenceService.js';
+import measurementService from '../services/measurementService.js';
+import exerciseEntryDb from '../models/exerciseEntry.js';
+import measurementRepository from '../models/measurementRepository.js';
+import reportRepository from '../models/reportRepository.js';
+
+// Stubs for foodTools/checkinTools imports the report tools never call;
+// loading the real services trips on deep '@workspace/shared' subpath imports.
+vi.mock('../services/foodCoreService', () => ({ default: {} }));
+vi.mock('../services/foodEntryService', () => ({ default: {} }));
+vi.mock('../services/mealService', () => ({ default: {} }));
+vi.mock('../services/externalFoodSearchService', () => ({
+  searchProviderFoods: vi.fn(),
+}));
+vi.mock('../services/preferenceService', () => ({
+  default: {
+    getUserPreferences: vi.fn(),
+  },
+}));
+vi.mock('../services/measurementService', () => ({
+  default: {
+    getCheckInMeasurementsByDateRange: vi.fn(),
+  },
+}));
+vi.mock('../models/exerciseEntry', () => ({
+  default: {
+    getDailyExerciseTotalsRange: vi.fn(),
+  },
+}));
+vi.mock('../models/measurementRepository', () => ({
+  default: {
+    getWaterTotalsByDateRange: vi.fn(),
+  },
+}));
+vi.mock('../models/reportRepository', () => ({
+  default: {
+    getDailyNutritionTotalsRange: vi.fn(),
+  },
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+const DB_ERROR_TEXT =
+  'Error [DB_ERROR]: A database error occurred. Please try again.\n\nSuggestion: If the issue persists, contact support.';
+
+const PREFS = {
+  energy_unit: 'kcal',
+  water_display_unit: 'ml',
+  default_weight_unit: 'kg',
+  default_measurement_unit: 'cm',
+};
+
+let tools: ReturnType<typeof buildReportTools>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(preferenceService.getUserPreferences).mockResolvedValue(PREFS);
+  tools = buildReportTools('user-1');
+});
+
+describe('sparky_get_report (get_weekly_report)', () => {
+  it('renders the three weekly sections from the trailing 7-day window', async () => {
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockResolvedValue([
+      {
+        entry_date: '2026-06-08',
+        calories: '2100.5',
+        protein: '95',
+        carbs: '240',
+        fat: '70',
+      },
+    ]);
+    vi.mocked(
+      measurementRepository.getWaterTotalsByDateRange
+    ).mockResolvedValue([
+      { entry_date: '2026-06-08', total_ml: '1500' },
+      { entry_date: '2026-06-09', total_ml: '2000' },
+    ]);
+    vi.mocked(
+      measurementService.getCheckInMeasurementsByDateRange
+    ).mockResolvedValue([
+      {
+        entry_date: '2026-06-09',
+        weight: '81.5',
+        body_fat_percentage: '22.5',
+        steps: 9000,
+      },
+      {
+        entry_date: '2026-06-08',
+        weight: '82',
+        body_fat_percentage: null,
+        steps: null,
+      },
+    ]);
+
+    const result = await tools.sparky_get_report.execute!(
+      { action: 'get_weekly_report', end_date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      '# Weekly Performance Report (2026-06-04 to 2026-06-10)\n\n' +
+        '## Nutrition & Energy\n' +
+        '| Date | Calories (kcal) | P (g) | C (g) | F (g) |\n' +
+        '| :--- | :--- | :--- | :--- | :--- |\n' +
+        '| 2026-06-08 | 2100.5 | 95 | 240 | 70 |\n' +
+        '\n' +
+        '## Water Intake\n' +
+        '| Date | Amount (ml) |\n' +
+        '| :--- | :--- |\n' +
+        '| 2026-06-08 | 1500 |\n' +
+        '| 2026-06-09 | 2000 |\n' +
+        '\n' +
+        '## Biometrics Trend\n' +
+        '| Date | Weight (kg) | BF % | Steps |\n' +
+        '| :--- | :--- | :--- | :--- |\n' +
+        '| 2026-06-08 | 82 | - | - |\n' +
+        '| 2026-06-09 | 81.5 | 22.5 | 9000 |\n'
+    );
+    expect(reportRepository.getDailyNutritionTotalsRange).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-04',
+      '2026-06-10'
+    );
+    expect(
+      measurementRepository.getWaterTotalsByDateRange
+    ).toHaveBeenCalledWith('user-1', '2026-06-04', '2026-06-10');
+    expect(
+      measurementService.getCheckInMeasurementsByDateRange
+    ).toHaveBeenCalledWith('user-1', 'user-1', '2026-06-04', '2026-06-10');
+  });
+
+  it('defaults the window to today (UTC) and renders empty-section placeholders', async () => {
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockResolvedValue(
+      []
+    );
+    vi.mocked(
+      measurementRepository.getWaterTotalsByDateRange
+    ).mockResolvedValue([]);
+    vi.mocked(
+      measurementService.getCheckInMeasurementsByDateRange
+    ).mockResolvedValue([]);
+
+    const result = await tools.sparky_get_report.execute!(
+      { action: 'get_weekly_report' },
+      opts
+    );
+
+    const end = todayInZone('UTC');
+    const start = addDays(end, -6);
+    expect(result).toBe(
+      `# Weekly Performance Report (${start} to ${end})\n\n` +
+        '## Nutrition & Energy\n' +
+        '_No nutrition data logged this week._\n' +
+        '\n' +
+        '## Water Intake\n' +
+        '_No water intake logged this week._\n' +
+        '\n' +
+        '## Biometrics Trend\n' +
+        '_No biometric data logged this week._\n'
+    );
+    expect(reportRepository.getDailyNutritionTotalsRange).toHaveBeenCalledWith(
+      'user-1',
+      start,
+      end
+    );
+  });
+
+  it('returns a validation error for a malformed end_date', async () => {
+    const result = await tools.sparky_get_report.execute!(
+      { action: 'get_weekly_report', end_date: 'June 10' },
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: end_date: Date must be in YYYY-MM-DD format'
+    );
+  });
+
+  it('maps repository failures to DB_ERROR', async () => {
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_get_report.execute!(
+      { action: 'get_weekly_report' },
+      opts
+    );
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});
+
+describe('sparky_get_daily_report', () => {
+  it('returns nutrition, exercise, and water rows projected to MCP columns', async () => {
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockResolvedValue([
+      {
+        entry_date: '2026-06-10',
+        calories: 2100.5,
+        protein: 95,
+        carbs: 240,
+        fat: 70,
+        fiber: 28,
+        sugar: 40,
+        sodium: 1500,
+      },
+    ]);
+    vi.mocked(exerciseEntryDb.getDailyExerciseTotalsRange).mockResolvedValue([
+      {
+        entry_date: '2026-06-10',
+        entry_count: 2,
+        duration_minutes: 45,
+        calories_burned: 400,
+        distance: 5,
+        steps: 8000,
+      },
+    ]);
+    vi.mocked(
+      measurementRepository.getWaterTotalsByDateRange
+    ).mockResolvedValue([{ entry_date: '2026-06-10', total_ml: 1500 }]);
+
+    const result = await tools.sparky_get_daily_report.execute!(
+      { date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          start_date: '2026-06-10',
+          end_date: '2026-06-10',
+          nutrition: [
+            {
+              entry_date: '2026-06-10',
+              calories: 2100.5,
+              protein: 95,
+              carbs: 240,
+              fat: 70,
+              fiber: 28,
+            },
+          ],
+          exercise: [
+            {
+              entry_date: '2026-06-10',
+              exercise_calories: 400,
+              exercise_minutes: 45,
+              steps: 8000,
+            },
+          ],
+          water: [{ entry_date: '2026-06-10', water_ml: 1500 }],
+        },
+        null,
+        2
+      )
+    );
+    expect(exerciseEntryDb.getDailyExerciseTotalsRange).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-10',
+      '2026-06-10'
+    );
+  });
+
+  it('lets date override start/end and defaults the range to today (UTC)', async () => {
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockResolvedValue(
+      []
+    );
+    vi.mocked(exerciseEntryDb.getDailyExerciseTotalsRange).mockResolvedValue(
+      []
+    );
+    vi.mocked(
+      measurementRepository.getWaterTotalsByDateRange
+    ).mockResolvedValue([]);
+
+    await tools.sparky_get_daily_report.execute!(
+      {
+        date: '2026-06-01',
+        start_date: '2026-05-01',
+        end_date: '2026-05-31',
+      },
+      opts
+    );
+    expect(reportRepository.getDailyNutritionTotalsRange).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-01',
+      '2026-06-01'
+    );
+
+    await tools.sparky_get_daily_report.execute!({}, opts);
+    const today = todayInZone('UTC');
+    expect(reportRepository.getDailyNutritionTotalsRange).toHaveBeenCalledWith(
+      'user-1',
+      today,
+      today
+    );
+  });
+
+  it("maps a 'not found' failure to NOT_FOUND keyed by the requested date", async () => {
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockRejectedValue(
+      new Error('Daily report not found')
+    );
+
+    const result = await tools.sparky_get_daily_report.execute!(
+      { date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      "Error [NOT_FOUND]: Daily report with ID '2026-06-10' not found.\n\nSuggestion: Check the ID and try again."
+    );
+  });
+
+  it('maps other failures to DB_ERROR', async () => {
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_get_daily_report.execute!({}, opts);
+
+    expect(result).toBe(DB_ERROR_TEXT);
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsReport.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsReport.test.ts
@@ -60,7 +60,7 @@ let tools: ReturnType<typeof buildReportTools>;
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(preferenceService.getUserPreferences).mockResolvedValue(PREFS);
-  tools = buildReportTools('user-1');
+  tools = buildReportTools('user-1', 'UTC');
 });
 
 describe('sparky_get_report (get_weekly_report)', () => {
@@ -264,6 +264,69 @@ describe('sparky_get_daily_report', () => {
     );
   });
 
+  it('renders pg local-midnight Date rows as calendar-day strings in all three sets', async () => {
+    vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockResolvedValue([
+      {
+        entry_date: new Date(2026, 5, 10),
+        calories: 2100.5,
+        protein: 95,
+        carbs: 240,
+        fat: 70,
+        fiber: 28,
+      },
+    ]);
+    vi.mocked(exerciseEntryDb.getDailyExerciseTotalsRange).mockResolvedValue([
+      {
+        entry_date: new Date(2026, 5, 10),
+        entry_count: 2,
+        duration_minutes: 45,
+        calories_burned: 400,
+        distance: 5,
+        steps: 8000,
+      },
+    ]);
+    vi.mocked(
+      measurementRepository.getWaterTotalsByDateRange
+    ).mockResolvedValue([
+      { entry_date: new Date(2026, 5, 10), total_ml: 1500 },
+    ]);
+
+    const result = await tools.sparky_get_daily_report.execute!(
+      { date: '2026-06-10' },
+      opts
+    );
+
+    expect(result).toBe(
+      JSON.stringify(
+        {
+          start_date: '2026-06-10',
+          end_date: '2026-06-10',
+          nutrition: [
+            {
+              entry_date: '2026-06-10',
+              calories: 2100.5,
+              protein: 95,
+              carbs: 240,
+              fat: 70,
+              fiber: 28,
+            },
+          ],
+          exercise: [
+            {
+              entry_date: '2026-06-10',
+              exercise_calories: 400,
+              exercise_minutes: 45,
+              steps: 8000,
+            },
+          ],
+          water: [{ entry_date: '2026-06-10', water_ml: 1500 }],
+        },
+        null,
+        2
+      )
+    );
+  });
+
   it('lets date override start/end and defaults the range to today (UTC)', async () => {
     vi.mocked(reportRepository.getDailyNutritionTotalsRange).mockResolvedValue(
       []
@@ -296,6 +359,36 @@ describe('sparky_get_daily_report', () => {
       today,
       today
     );
+  });
+
+  it("computes the default range in the user's timezone", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-10T20:00:00Z'));
+    try {
+      vi.mocked(
+        reportRepository.getDailyNutritionTotalsRange
+      ).mockResolvedValue([]);
+      vi.mocked(exerciseEntryDb.getDailyExerciseTotalsRange).mockResolvedValue(
+        []
+      );
+      vi.mocked(
+        measurementRepository.getWaterTotalsByDateRange
+      ).mockResolvedValue([]);
+
+      const tokyoTools = buildReportTools('user-1', 'Asia/Tokyo');
+      await tokyoTools.sparky_get_daily_report.execute!({}, opts);
+      expect(
+        reportRepository.getDailyNutritionTotalsRange
+      ).toHaveBeenLastCalledWith('user-1', '2026-06-11', '2026-06-11');
+
+      const utcTools = buildReportTools('user-1', 'UTC');
+      await utcTools.sparky_get_daily_report.execute!({}, opts);
+      expect(
+        reportRepository.getDailyNutritionTotalsRange
+      ).toHaveBeenLastCalledWith('user-1', '2026-06-10', '2026-06-10');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("maps a 'not found' failure to NOT_FOUND keyed by the requested date", async () => {

--- a/SparkyFitnessServer/tests/chatbotToolsVision.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsVision.test.ts
@@ -1,0 +1,328 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { buildVisionTools } from '../ai/tools/visionTools.js';
+import foodPhotoEstimationService from '../services/foodPhotoEstimationService.js';
+import labelScanService from '../services/labelScanService.js';
+
+vi.mock('../services/foodPhotoEstimationService', () => ({
+  default: {
+    estimateFoodPhotoNutrition: vi.fn(),
+  },
+}));
+vi.mock('../services/labelScanService', () => ({
+  default: {
+    extractNutritionFromLabel: vi.fn(),
+  },
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+
+// A syntactically valid base64 JPEG prefix.
+const JPEG_BASE64 = '/9j/4AAQSkZJRgABAQAAAQ==';
+const PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUg==';
+
+const ESTIMATE = {
+  meal_summary: 'Grilled chicken with rice and broccoli',
+  overall_confidence: 'medium' as const,
+  confidence_reason: 'portion depth not visible',
+  items: [
+    {
+      name: 'grilled chicken thigh',
+      estimated_grams: 150,
+      portion_description: '1 medium thigh',
+      preparation: 'grilled',
+      calories_kcal: 250,
+      protein_g: 25,
+      carbs_g: 0,
+      fat_g: 15,
+      fiber_g: 0,
+      sugar_g: 0,
+      item_confidence: 'high' as const,
+      assumptions: ['assumed skinless'],
+    },
+    {
+      name: 'white jasmine rice',
+      estimated_grams: 200,
+      portion_description: '1 cup cooked',
+      preparation: '',
+      calories_kcal: 260,
+      protein_g: 5,
+      carbs_g: 57,
+      fat_g: 1,
+      fiber_g: 1,
+      sugar_g: 0,
+      item_confidence: 'medium' as const,
+      assumptions: [],
+    },
+  ],
+  totals: {
+    calories_kcal: 510,
+    protein_g: 30,
+    carbs_g: 57,
+    fat_g: 16,
+    fiber_g: 1,
+    sugar_g: 0,
+    total_grams: 350,
+  },
+  user_weight_reconciliation: '',
+  clarifying_questions: ['Was the chicken cooked with oil or butter?'],
+};
+
+let tools: ReturnType<typeof buildVisionTools>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tools = buildVisionTools('user-1');
+});
+
+describe('sparky_analyze_food_image', () => {
+  it('parses a data: URL and renders the structured estimate', async () => {
+    vi.mocked(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).mockResolvedValue({ success: true, estimate: ESTIMATE });
+
+    const result = await tools.sparky_analyze_food_image.execute!(
+      { image_url: `data:image/png;base64,${PNG_BASE64}` },
+      opts
+    );
+
+    expect(result).toBe(
+      '🔬 Food Image Analysis Result:\n\n' +
+        '**Grilled chicken with rice and broccoli** (confidence: medium)\n' +
+        'Confidence notes: portion depth not visible\n' +
+        '\n' +
+        'Items:\n' +
+        '- grilled chicken thigh (1 medium thigh, ~150g, grilled): 250 kcal | P: 25g | C: 0g | F: 15g | Fiber: 0g | Sugar: 0g\n' +
+        '  Assumptions: assumed skinless\n' +
+        '- white jasmine rice (1 cup cooked, ~200g): 260 kcal | P: 5g | C: 57g | F: 1g | Fiber: 1g | Sugar: 0g\n' +
+        '\n' +
+        'Total (~350g): 510 kcal | P: 30g | C: 57g | F: 16g | Fiber: 1g | Sugar: 0g\n' +
+        '\n' +
+        'To improve this estimate, the user could clarify:\n' +
+        '- Was the chicken cooked with oil or butter?'
+    );
+    expect(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).toHaveBeenCalledWith({
+      images: [{ base64: PNG_BASE64, mimeType: 'image/png' }],
+      userId: 'user-1',
+    });
+  });
+
+  it('sniffs the MIME type of bare base64 input', async () => {
+    vi.mocked(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).mockResolvedValue({
+      success: true,
+      estimate: {
+        ...ESTIMATE,
+        confidence_reason: '',
+        items: [],
+        user_weight_reconciliation: 'Distributed 350g across items.',
+        clarifying_questions: [],
+      },
+    });
+
+    const result = await tools.sparky_analyze_food_image.execute!(
+      { image_url: JPEG_BASE64 },
+      opts
+    );
+
+    expect(result).toBe(
+      '🔬 Food Image Analysis Result:\n\n' +
+        '**Grilled chicken with rice and broccoli** (confidence: medium)\n' +
+        '\n' +
+        'Items:\n' +
+        '\n' +
+        'Total (~350g): 510 kcal | P: 30g | C: 57g | F: 16g | Fiber: 1g | Sugar: 0g\n' +
+        '\n' +
+        'Weight reconciliation: Distributed 350g across items.'
+    );
+    expect(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).toHaveBeenCalledWith({
+      images: [{ base64: JPEG_BASE64, mimeType: 'image/jpeg' }],
+      userId: 'user-1',
+    });
+  });
+
+  it('rejects remote URLs without calling the estimation service', async () => {
+    const result = await tools.sparky_analyze_food_image.execute!(
+      { image_url: 'https://example.com/meal.jpg' },
+      opts
+    );
+
+    expect(result).toBe(
+      '❌ Error analyzing image: Remote image URLs are not supported. Please attach the image directly to the chat.'
+    );
+    expect(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed data: URL', async () => {
+    const result = await tools.sparky_analyze_food_image.execute!(
+      { image_url: 'data:text/plain;base64,aGVsbG8=' },
+      opts
+    );
+
+    expect(result).toBe(
+      '❌ Error analyzing image: The provided data: URL is not a valid base64-encoded image.'
+    );
+  });
+
+  it('explains how to enable vision when no AI service is configured', async () => {
+    vi.mocked(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).mockResolvedValue({
+      success: false,
+      code: 'NO_AI_CONFIGURED',
+      error: 'No AI service configured.',
+    });
+
+    const result = await tools.sparky_analyze_food_image.execute!(
+      { image_url: JPEG_BASE64 },
+      opts
+    );
+
+    expect(result).toBe(
+      '⚠️ Vision is not configured.\n\nNo AI service is configured. To enable food image analysis, configure an AI service in the chat settings.'
+    );
+  });
+
+  it('surfaces other estimation failures as analysis errors', async () => {
+    vi.mocked(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).mockResolvedValue({
+      success: false,
+      code: 'UPSTREAM_ERROR',
+      error: 'Provider returned HTTP 500',
+    });
+
+    const result = await tools.sparky_analyze_food_image.execute!(
+      { image_url: JPEG_BASE64 },
+      opts
+    );
+
+    expect(result).toBe('❌ Error analyzing image: Provider returned HTTP 500');
+  });
+
+  it('never throws when the service rejects', async () => {
+    vi.mocked(
+      foodPhotoEstimationService.estimateFoodPhotoNutrition
+    ).mockRejectedValue(new Error('boom'));
+
+    const result = await tools.sparky_analyze_food_image.execute!(
+      { image_url: JPEG_BASE64 },
+      opts
+    );
+
+    expect(result).toBe('❌ Error analyzing image: boom');
+  });
+
+  it('returns a validation error when image_url is missing', async () => {
+    const result = await tools.sparky_analyze_food_image.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      {} as any,
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: image_url: Invalid input: expected string, received undefined'
+    );
+  });
+});
+
+describe('sparky_scan_label', () => {
+  it('renders extracted nutrition as JSON inside the scan wrapper', async () => {
+    const nutrition = {
+      name: 'Oat Crunch Cereal',
+      brand: 'Acme',
+      serving_size: 40,
+      serving_unit: 'g',
+      calories: 150,
+      protein: 5,
+      carbs: 30,
+      fat: 2.5,
+    };
+    vi.mocked(labelScanService.extractNutritionFromLabel).mockResolvedValue({
+      success: true,
+      nutrition,
+    });
+
+    const result = await tools.sparky_scan_label.execute!(
+      { image_url: `data:image/jpeg;base64,${JPEG_BASE64}` },
+      opts
+    );
+
+    expect(result).toBe(
+      `🏷️ Nutrition Label Scan Result:\n\n${JSON.stringify(nutrition, null, 2)}`
+    );
+    expect(labelScanService.extractNutritionFromLabel).toHaveBeenCalledWith(
+      JPEG_BASE64,
+      'image/jpeg',
+      'user-1'
+    );
+  });
+
+  it('rejects remote URLs without calling the scan service', async () => {
+    const result = await tools.sparky_scan_label.execute!(
+      { image_url: 'http://example.com/label.png' },
+      opts
+    );
+
+    expect(result).toBe(
+      '❌ Error scanning label: Remote image URLs are not supported. Please attach the image directly to the chat.'
+    );
+    expect(labelScanService.extractNutritionFromLabel).not.toHaveBeenCalled();
+  });
+
+  it('explains how to enable vision when no AI service is configured', async () => {
+    vi.mocked(labelScanService.extractNutritionFromLabel).mockResolvedValue({
+      success: false,
+      category: 'no_ai_configured',
+      error: 'No AI service configured',
+    });
+
+    const result = await tools.sparky_scan_label.execute!(
+      { image_url: JPEG_BASE64 },
+      opts
+    );
+
+    expect(result).toBe(
+      '⚠️ Vision is not configured.\n\nNo AI service is configured. To enable nutrition label scanning, configure an AI service in the chat settings.'
+    );
+  });
+
+  it('surfaces scan failures with the service detail', async () => {
+    vi.mocked(labelScanService.extractNutritionFromLabel).mockResolvedValue({
+      success: false,
+      category: 'parse_error',
+      error: 'Model returned malformed JSON',
+    });
+
+    const result = await tools.sparky_scan_label.execute!(
+      { image_url: JPEG_BASE64 },
+      opts
+    );
+
+    expect(result).toBe(
+      '❌ Error scanning label: Model returned malformed JSON'
+    );
+  });
+
+  it('never throws when the service rejects', async () => {
+    vi.mocked(labelScanService.extractNutritionFromLabel).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const result = await tools.sparky_scan_label.execute!(
+      { image_url: JPEG_BASE64 },
+      opts
+    );
+
+    expect(result).toBe('❌ Error scanning label: boom');
+  });
+});

--- a/SparkyFitnessServer/tests/chatbotToolsWizard.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsWizard.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { buildWizardTools } from '../ai/tools/wizardTools.js';
+
+const opts = { toolCallId: 'tc-1', messages: [] };
+
+const tools = buildWizardTools('user-1');
+
+describe('sparky_daily_checkin_wizard', () => {
+  it("defaults to the 'start' step", async () => {
+    const result = await tools.sparky_daily_checkin_wizard.execute!(
+      { action: 'daily_checkin' },
+      opts
+    );
+
+    expect(result).toBe(
+      "Welcome to your daily check-in! Let's start with your **weight**. What is it today?"
+    );
+  });
+
+  it.each([
+    [
+      'start',
+      "Welcome to your daily check-in! Let's start with your **weight**. What is it today?",
+    ],
+    ['weight', 'Got it. How many **steps** did you get in yesterday or today?'],
+    [
+      'steps',
+      'Nice! How was your **sleep**? (Duration and quality score 0-100)',
+    ],
+    ['sleep', 'And your **mood** today? (Scale of 1-10)'],
+    [
+      'mood',
+      "Finally, let's check your **habits**. Did you complete your daily goals?",
+    ],
+    [
+      'habits',
+      "All set! I've prepared a summary of your entries. Should I save everything?",
+    ],
+    [
+      'complete',
+      'Excellent. Your daily check-in is complete and saved. Have a great day!',
+    ],
+  ] as const)('asks the %s question', async (step, question) => {
+    const result = await tools.sparky_daily_checkin_wizard.execute!(
+      { action: 'daily_checkin', step },
+      opts
+    );
+
+    expect(result).toBe(question);
+  });
+
+  it('rejects an unknown step', async () => {
+    const result = await tools.sparky_daily_checkin_wizard.execute!(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { action: 'daily_checkin', step: 'nope' } as any,
+      opts
+    );
+
+    expect(result).toBe(
+      'Error [VALIDATION]: step: Invalid option: expected one of "start"|"weight"|"steps"|"sleep"|"mood"|"habits"|"complete"'
+    );
+  });
+});

--- a/SparkyFitnessServer/tests/foodOptionsService.test.ts
+++ b/SparkyFitnessServer/tests/foodOptionsService.test.ts
@@ -6,6 +6,9 @@ import { processFoodOptionsRequest } from '../services/chatService.js';
 vi.mock('../models/chatRepository');
 vi.mock('../models/measurementRepository');
 vi.mock('../config/logging', () => ({ log: vi.fn() }));
+// chatService pulls in the tool registry, whose real foodEntryService trips
+// on a deep '@workspace/shared' subpath import under vitest.
+vi.mock('../services/foodEntryService', () => ({ default: {} }));
 
 // Mock the undici Agent so the Ollama path never constructs a real agent.
 // (global.fetch is mocked per-test; the dispatcher option is ignored by it.)

--- a/SparkyFitnessServer/tests/foodRoutesV2.test.ts
+++ b/SparkyFitnessServer/tests/foodRoutesV2.test.ts
@@ -3,12 +3,24 @@ import express from 'express';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'supe... Remove this comment to see the full error message
 import request from 'supertest';
 import foodCoreService from '../services/foodCoreService.js';
+import { searchProviderFoods } from '../services/externalFoodSearchService.js';
 // @ts-expect-error TS(2691): An import path cannot end with a '.ts' extension. ... Remove this comment to see the full error message
 import foodRoutesV2 from '../routes/v2/foodRoutes.js';
 vi.mock('../middleware/checkPermissionMiddleware.js', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   default: vi.fn(() => (req: any, res: any, next: any) => next()),
 }));
+
+vi.mock('../services/externalFoodSearchService.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../services/externalFoodSearchService.js')
+    >();
+  return {
+    ...actual,
+    searchProviderFoods: vi.fn(),
+  };
+});
 
 vi.mock('../services/foodCoreService.js', () => ({
   default: {
@@ -153,5 +165,108 @@ describe('GET /v2/foods/barcode/:barcode', () => {
     expect(res.body.food.default_variant).not.toHaveProperty(
       'custom_nutrients'
     );
+  });
+});
+
+describe('GET /v2/foods/search/:providerType', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates to searchProviderFoods and normalizes the result', async () => {
+    vi.mocked(searchProviderFoods).mockResolvedValue({
+      foods: [
+        {
+          id: 'food-off-1',
+          name: 'Oat Milk',
+          brand: null,
+          barcode: null,
+          provider_external_id: 'off-123',
+          provider_type: 'openfoodfacts',
+          is_custom: false,
+          default_variant: {
+            id: null,
+            serving_size: 100,
+            serving_unit: 'ml',
+            calories: 45,
+            protein: 1,
+            carbs: 7,
+            fat: 1.5,
+            saturated_fat: null,
+            is_default: true,
+            custom_nutrients: null,
+          },
+          variants: null,
+        },
+      ],
+      pagination: { page: 2, pageSize: 10, totalCount: 25, hasMore: true },
+    });
+
+    const res = await request(app).get(
+      '/v2/foods/search/openfoodfacts?query=oat%20milk&page=2&pageSize=10&autoScale=false'
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(searchProviderFoods).toHaveBeenCalledWith(
+      'user-123',
+      'openfoodfacts',
+      'oat milk',
+      { page: 2, pageSize: 10, providerId: undefined, autoScale: false }
+    );
+    expect(res.body).toEqual({
+      foods: [
+        {
+          id: 'food-off-1',
+          name: 'Oat Milk',
+          brand: null,
+          provider_external_id: 'off-123',
+          provider_type: 'openfoodfacts',
+          is_custom: false,
+          default_variant: {
+            serving_size: 100,
+            serving_unit: 'ml',
+            calories: 45,
+            protein: 1,
+            carbs: 7,
+            fat: 1.5,
+            is_default: true,
+          },
+        },
+      ],
+      pagination: { page: 2, pageSize: 10, totalCount: 25, hasMore: true },
+    });
+    expect(res.body.foods[0]).not.toHaveProperty('barcode');
+    expect(res.body.foods[0].default_variant).not.toHaveProperty(
+      'saturated_fat'
+    );
+  });
+
+  it('rejects an invalid provider type without calling the service', async () => {
+    const res = await request(app).get('/v2/foods/search/bogus?query=apple');
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid provider type: bogus' });
+    expect(searchProviderFoods).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing query without calling the service', async () => {
+    const res = await request(app).get('/v2/foods/search/usda');
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Missing query parameter' });
+    expect(searchProviderFoods).not.toHaveBeenCalled();
+  });
+
+  it('maps status-tagged service errors to HTTP status codes', async () => {
+    vi.mocked(searchProviderFoods).mockRejectedValue(
+      Object.assign(new Error('Missing providerId query parameter'), {
+        status: 400,
+      })
+    );
+
+    const res = await request(app).get('/v2/foods/search/usda?query=apple');
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({ error: 'Missing providerId query parameter' });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,9 +635,6 @@ importers:
       '@ai-sdk/google':
         specifier: ^3.0.79
         version: 3.0.79(zod@4.3.6)
-      '@ai-sdk/mcp':
-        specifier: ^1.0.43
-        version: 1.0.43(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^3.0.65
         version: 3.0.65(zod@4.3.6)
@@ -650,9 +647,6 @@ importers:
       '@better-auth/sso':
         specifier: ^1.5.6
         version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@2.0.2(zod@4.3.6))
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.3.6)
       '@workspace/shared':
         specifier: workspace:*
         version: link:../shared
@@ -855,12 +849,6 @@ packages:
 
   '@ai-sdk/google@3.0.79':
     resolution: {integrity: sha512-QWVAvYeA7JzEX2wkSyXOWv/I9PD9kvTzdykkSTLi+Eu8RyJ6gA0tdPIGa8esEtOcHE//G5vy6FTB70qQw8l/uw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/mcp@1.0.43':
-    resolution: {integrity: sha512-HdDMeyCcfIn5tW/P1kJ+BmYP8vfY8vppRn7swbVNRcLeFz/cpwik+B+C49Up4u5scRAcATtRJywOa7/rA4BmIA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -15001,13 +14989,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/mcp@1.0.43(zod@4.3.6)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.3.6)
-      pkce-challenge: 5.0.1
-      zod: 4.3.6
-
   '@ai-sdk/openai@3.0.65(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -17875,28 +17856,6 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
-    dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.8
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.18
-      jose: 6.2.1
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -32249,10 +32208,6 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
-
-  zod-to-json-schema@3.25.2(zod@4.3.6):
-    dependencies:
-      zod: 4.3.6
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

The chatbot executed tool calls by using the external mcp server over http or a spawned process. That server reimplemented SQL/business logic against the same db and required extra setup. This PR gives the server an in process tool registry which calls the service layer and switches the chatbot to use it. The MCP client, auth forrwarding, and client dependencies are removed. The MCP server itself remains untouched and all of the tools in the registry are **fully tested** with new tests. This is half of the full refactor. Turning it into a thin wrapper is probably coming soon.

Many bugs were fixed both in the mcp tools and in the server with related functions. They are mostly minor but there were some real changes to how the mcp does things but really they are all improvements. I'm going to put a list of 'drift' from Claude under extra notes. I prefer to not use AI in these descriptions but this info is likely useful later.

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [x] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

I'm going to paste in some of Claude's notes on what we changed here for future reference along with possible follow ups:

## Accepted drift

Output parity is enforced by golden tests; everything that deliberately differs from the MCP path is listed here. Nothing drifts silently.

### Server-correct fixes (MCP had a bug or wrote worse data)

- **`get_fasting_status` actually works** — MCP's action switch was missing the case and returned `INVALID_ACTION` despite advertising it.
- **Timezone-safe dates** — renderers and reports use calendar-day strings instead of MCP's `toISOString().split('T')[0]`, which shifts dates on positive-UTC-offset servers (biometrics history, weekly report, nutrition/water summaries). Food/meal confirmations render the `entry_date` argument instead of a verbose pg `Date.toString()`. Byte-identical on UTC servers.
- **`get_biometrics_history`** returns ascending order with correct day strings.
- **`list_exercise_diary`** renders the entry's snapshot name; MCP joined the catalog and silently dropped entries whose catalog row was gone.
- **`update_entry` on a logged meal** round-trips the template id + components so component entries rescale; MCP updated only the container row, leaving components stale.
- **`log_meal`** creates the scaled component food entries, so diary totals actually include logged meals; MCP wrote only the container row.
- **`delete_food` when other users reference the food** hides it instead of erroring: new text `Food "X" hidden (marked as quick food). Existing references remain.` (MCP hit an FK violation → DB_ERROR).
- **`update_food_variant` with `update_existing_entries`** uses the server snapshot-refresh, which also refreshes food name/brand in entries and clears ignored-update flags (superset of MCP).
- **`copy_from_yesterday`** dedups entries that already exist on the target day, and the reported count no longer double-counts meal-container rows.
- **Exercise calories auto-computed** from the catalog when omitted (MCP stored 0).
- **`log_food` on a variant-less food** → clean VALIDATION error; MCP inserted a null-nutrition entry.
- **`update_preferences` with an invalid timezone** → VALIDATION error (MCP stored it blindly).
- **`log_sleep`** — the server computes the sleep score (an LLM-supplied score is ignored, matching every other sleep write path incl. device sync) and upserts per day (MCP inserted a new row per call and stored the LLM's score). Because the provided score isn't stored, the confirmation no longer echoes it (`score: X/100` dropped from the text); `sleep_score` stays in the schema as accepted-but-ignored.
- **`log_biometrics` with no fields** writes nothing (MCP inserted an all-null row). **`log_custom_metric`** re-logging a "Daily" metric the same day updates instead of duplicating.
- **Unknown explicit ids** (exercise id, preset component ids) → clean `NOT_FOUND` instead of MCP's raw FK-violation DB_ERROR.
- **Vision URL handling** — http(s) image URLs are rejected with an explanatory error asking to attach the image; no server-side fetch of arbitrary URLs (SSRF surface stays closed). Data URLs / bare base64 work; the chat frontend already sends base64.

### Behavioral differences (accepted)

- **Grouped workout-preset sessions** — preset logging goes through `logWorkoutPresetGrouped`, so entries land as a grouped session.
- **Preset visibility** — `is_public OR own` vs MCP's `own OR user_id IS NULL`.
- **Exercise filters** — muscleGroup/equipment map to jsonb exact-key (case-sensitive) matching vs MCP's ILIKE substring on text columns.
- **Food broad search** matches the brand+name concatenation (brand substrings match) and excludes quick-foods.
- **`list_diary`** groups follow `meal_types.sort_order` vs MCP's first-logged order.
- **`set_goals`** — a past `start_date` upserts that single date (no retroactive 6-month cascade), and re-setting goals overwrites all goal columns, so previously-set micro-nutrient goal values reset (MCP's 7-column upsert preserved them). Partial-upsert is a candidate follow-up.
- **Goal defaults** are merged server-side (`DEFAULT_GOALS`) instead of `|| 2000`-style fallbacks in the render layer.
- **Vision body text** — analyze returns the structured-estimate markdown and label scan returns pretty-printed JSON, both via the user's configured AI service (`providerDispatch`); MCP returned provider free-text via its own `VISION_API_KEY`. Wrapper strings (`🔬 …`, `🏷️ …`) identical; the not-configured error now points at chat settings.
- **JSON projections** — NUMERIC columns serialize as numbers (pg float parsing) vs MCP's strings (trailing zeros dropped); catalog helpers return the server repo column sets (`sparky_list_exercises`: ordered by `name` vs `LOWER(name)`, no `is_quick_exercise`, `images` as arrays; food details: `default_variant` as a one-element `variants` array vs all variants). Daily report: a day where every entry's nutrient column is NULL renders `null` vs MCP's `0`.
- **`create_food` + auto-log is not atomic** (two service calls); tiny window where the food exists without the log entry.
- **Name-resolution windows** — exact-match lookup runs over a bounded server search window (50 exercises / 500 foods); with more substring matches than the window, an exact match could in principle be missed (MCP queried equality directly).

### Validation / format drift

- **zod 3 → zod 4** — validation message text differs (e.g. `Invalid input: expected string, received undefined` vs `Required`); the `Error [VALIDATION]: path: message` wrapper format is identical. `.uuid()` now enforces RFC-4122 version/variant bits. The checkin handler also no longer renders a stray leading `: ` for root-path issues.
- **JSON-schema serialization** of the flat schemas differs at the byte level (draft-07, `additionalProperties`); names/enums/descriptions identical.
- **Coach tools** validate args with `safeParse` + `formatZodError` (MCP relied on protocol-level validation, so there was no MCP error text to match).

### Timezone & unit fixes (post-review round)

- **Dates render as calendar-day strings** — all DATE columns in tool output render `YYYY-MM-DD` instead of MCP's runtime `Date.toString()`/day-shifted `toISOString()` JSON (daily report, coach summaries/trends/patterns, exercise diary/totals/recent/usage/progress, goal timeline, habit history, engagement `last_logged`).
- **`list_checkin_diary` fasting timestamps render ISO-8601**, matching sleep rows and `get_fasting_status`.
- **"Today" defaults computed in the user's timezone** (was UTC), matching the system prompt's current-local-date.
- **`log_sleep` default wake time is 7 AM in the user's timezone** (was 7 AM UTC). Supplied bedtime/wake instants are unaffected.
- **Streak / days-since math uses calendar-day strings in the user's tz**; engagement + coach SQL windows anchor to user-tz today instead of the DB server's `CURRENT_DATE`.
- **Check-in diary fasting overlap is computed in the user's timezone** — `getFastingLogsOverlappingDay` buckets `start_time`/`end_time` via `AT TIME ZONE` instead of the DB session timezone.
- **Unit aliases convert**: `lb`, `inch`, `g`, `ft` (already in the published schemas) now convert on `log_biometrics` instead of storing raw numbers under metric units.

## Preserved MCP quirks (ported bug-for-bug — don't "fix" in review)

- The flat `sparky_manage_food` `provider_type` enum omits `yazio`; yazio is explicitly requestable via the union but excluded from the no-provider cascade.
- `create_food` stores an explicit `0` in optional macros as NULL (`|| null`).
- `get_exercise_details` with neither id nor name → DB_ERROR (MCP's catch-mapping quirk).
- `save_as_meal_template` on an empty slot → DB_ERROR (the error text lacks the literal `not found`).
- `copy_from_yesterday`'s source default is yesterday-of-*today* even when `target_date` is given.
- Explicit `provider_type='internal'` lookup miss → DB_ERROR (MCP's renderer crashed on the null food).
- Coach health summary reads the legacy `water_intake` table while water logging writes `water_intake_entries` (as MCP did) — candidate cleanup.
- `log_biometrics` summary text falls back to kg/cm even when preferences differ (the conversion uses prefs; the text doesn't).
- **Prompt debt**: `getSystemPrompt` names `sparky_manage_water` and `sparky_lookup_food_nutrition` as if they were standalone tools — both are `sparky_manage_food` actions. Kept byte-identical for parity; fix in a follow-up.
- Tool descriptions are byte-identical to MCP's, including internal whitespace quirks.


## Possible Follow-ups

- Fix the system-prompt tool naming debt (above).
- `update_profile` email updates `"user".email` only (verbatim MCP port); consider routing through `userRepository.updateUserEmail`, which also updates the credential-login identifier (`account.account_id`).
- `set_goals` overwrite semantics (micro-nutrient zeroing) — consider a partial upsert.
- Delegated-chat support (tools acting as the active user).
- Phase 2/3: turn `SparkyFitnessMCP/` into a thin wrapper over the server; compose/env cleanup.

