### PR TITLE
Keep nutrition fields editable when Auto-Scale is on

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/NutrientFormGrid.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/NutrientFormGrid.tsx
@@ -50,7 +50,6 @@ function NutrientInput({
   value,
   step = '0.1',
   decimals,
-  disabled,
   onChange,
 }: {
   id: string;
@@ -58,7 +57,6 @@ function NutrientInput({
   value: number | undefined;
   step?: string;
   decimals?: number;
-  disabled: boolean;
   onChange: (val: number | undefined) => void;
 }) {
   return (
@@ -71,7 +69,6 @@ function NutrientInput({
         decimals={decimals}
         onValueChange={(value) => onChange(value)}
         placeholder="0"
-        disabled={disabled}
       />
     </div>
   );
@@ -87,7 +84,10 @@ export function NutrientGrid({
   onUpdate,
 }: NutrientGridProps) {
   const { t } = useTranslation();
-  const isLocked = variant.is_locked ?? false;
+  // Auto-Scale (is_locked) controls whether changing the serving size rescales
+  // the nutrition values; it no longer disables the inputs, so the user can
+  // auto-scale and still edit any value directly. A manual edit re-captures the
+  // scaling base in useFoodForm, so a later serving-size change scales from it.
   const update = (field: string) => (val: number | undefined) =>
     onUpdate(variantIndex, field, val);
 
@@ -107,10 +107,7 @@ export function NutrientGrid({
                   onUpdate(variantIndex, 'glycemic_index', val)
                 }
               >
-                <SelectTrigger
-                  id={gridId(variantIndex, 'glycemic_index')}
-                  disabled={isLocked}
-                >
+                <SelectTrigger id={gridId(variantIndex, 'glycemic_index')}>
                   <SelectValue placeholder="Select GI" />
                 </SelectTrigger>
                 <SelectContent>
@@ -141,7 +138,6 @@ export function NutrientGrid({
               }
               step="1"
               decimals={0}
-              disabled={isLocked}
               onChange={update('calories')}
             />
           );
@@ -158,7 +154,6 @@ export function NutrientGrid({
               value={variant[key as NumericFoodVariantKeys]}
               step={cfg.decimals === 0 ? '1' : '0.1'}
               decimals={cfg.decimals}
-              disabled={isLocked}
               onChange={update(key)}
             />
           );
@@ -176,7 +171,6 @@ export function NutrientGrid({
             label={`${cn.name} (${cn.unit})`}
             value={typeof value === 'number' ? value : undefined}
             decimals={1}
-            disabled={isLocked}
             onChange={update(cn.name)}
           />
         );

--- a/SparkyFitnessFrontend/src/pages/Settings/PreferenceSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/PreferenceSettings.tsx
@@ -411,18 +411,18 @@ export const PreferenceSettings = () => {
               onCheckedChange={setAutoScaleOpenFoodFactsImports}
             />
           </div>
-          <div className="flex items-center justify-between col-span-2 py-2">
+          <div className="flex items-center justify-between col-span-full py-2">
             <div className="space-y-0.5">
               <Label htmlFor="auto-scale-online-imports">
                 {t(
                   'settings.preferences.autoScaleOnlineImports',
-                  'Auto-scale Online Database Imports'
+                  'Auto-Scale foods by default'
                 )}
               </Label>
               <p className="text-sm text-muted-foreground">
                 {t(
                   'settings.preferences.autoScaleOnlineImportsHint',
-                  'When enabled, the Auto-Scale checkbox will be on by default when editing foods imported from any online database, so nutrition values scale automatically when you change the serving size.'
+                  'When enabled, the Auto-Scale checkbox is checked whenever you edit a food, meaning its nutrition values scale automatically as you change the serving size.'
                 )}
               </p>
             </div>

--- a/SparkyFitnessFrontend/src/tests/hooks/useFoodForm.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useFoodForm.test.tsx
@@ -186,6 +186,38 @@ describe('useCustomFoodForm', () => {
     expect(result.current.hasTrustedCompatibilityBase[0]).toBe(true);
   });
 
+  it('rescales a serving-size change from a value edited while auto-scale is on', async () => {
+    // With Auto-Scale on the user can still edit values directly (the inputs
+    // are no longer locked). A manual edit must re-capture the scaling base so a
+    // later serving-size change scales from the edited value, not the original.
+    mockAutoScaleOnlineImports = true;
+    const food = createFood(); // base variant: 10 g, 100 kcal
+
+    const { result } = renderHook(() =>
+      useCustomFoodForm({
+        food,
+        onSave: jest.fn(),
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.variants[0]?.is_locked).toBe(true);
+    });
+
+    // Tweak calories directly while auto-scale is on.
+    act(() => {
+      result.current.updateVariant(0, 'calories', 200);
+    });
+    expect(result.current.variants[0]?.calories).toBe(200);
+
+    // Doubling the serving size scales from the edited 200, giving 400.
+    act(() => {
+      result.current.updateVariant(0, 'serving_size', 20);
+    });
+    expect(result.current.variants[0]?.serving_size).toBe(20);
+    expect(result.current.variants[0]?.calories).toBe(400);
+  });
+
   it('opens brand-new custom foods with auto-scale off even when the preference is enabled', async () => {
     mockAutoScaleOnlineImports = true;
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
With the auto-scale preference on, opening any food to edit showed every nutrition field greyed out and uneditable until Auto-Scale was unticked on each variant. This made it look like the values could not be changed.

**How did you implement the solution?**
Decouple the Auto-Scale checkbox from the field lock. Auto-Scale still rescales a variant's nutrition values when you change its serving size, but the inputs are no longer disabled, so you can auto-scale to roughly the serving you want and then type over any value. The form already re-captures the scaling base on a manual edit, so a later serving-size change scales from your edited value rather than the original. The variant-scaling logic in useFoodForm is unchanged, including the guard that does not scale variants from an AI unit conversion, so this is a UI-only change in NutrientFormGrid plus a wording update.

Linked Issue: Closes #1510

## How to Test

1. Check out this branch and run `pnpm install` at the repo root, then start the stack.
2. In Settings, Preferences, enable Auto-Scale (or open a food whose variant has Auto-Scale checked).
3. Open a food to edit. Confirm the calorie and macro fields are editable while Auto-Scale is checked.
4. Change the serving size and confirm the values rescale.
5. Type a new value into a macro field, then change the serving size again, and confirm it scales from your edited value.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="1108" height="458" alt="2026-06-11 22_28_03-Greenshot" src="https://github.com/user-attachments/assets/6a119309-548e-4cc6-920c-ded50ed094a0" />

<img width="683" height="777" alt="2026-06-11 22_37_13-Greenshot" src="https://github.com/user-attachments/assets/4cc4a648-fc93-4147-846f-23ff8a0f53cc" />

### After

<img width="1111" height="437" alt="2026-06-11 22_28_12-Greenshot" src="https://github.com/user-attachments/assets/549fa7c9-cc7b-45ef-9bc3-5ca9eda3d6ef" />

<img width="686" height="777" alt="2026-06-11 22_35_49-Greenshot" src="https://github.com/user-attachments/assets/ac4aa302-5809-4d49-904b-4c35be95ee08" />

</details>

## Notes for Reviewers

This follows the discussion on #1510. Auto-Scale no longer disables the inputs, so the on/off default stops being a blocker either way. I left the preference default unchanged (on); happy to flip it to off as well if preferred, it is a one-line change.

The scaling behaviour itself is untouched: useFoodForm already sets an edited value as the new scaling base and already skips scaling for AI-unit-converted variants. Only the field disable in NutrientFormGrid and the preference wording changed. Added a hook test covering the edit-then-rescale case.
