### PR TITLE
fix: DATE column timezone shift

### DIFF
--- a/SparkyFitnessServer/db/poolManager.ts
+++ b/SparkyFitnessServer/db/poolManager.ts
@@ -3,6 +3,12 @@ import { log } from '../config/logging.js';
 const { Pool, types } = pg;
 // Parse numeric types
 types.setTypeParser(types.builtins.NUMERIC, (value) => parseFloat(value));
+// Keep DATE columns (oid 1082) as raw 'YYYY-MM-DD' calendar-day strings. The default
+// parser builds a JS Date at the server process's local midnight, which then serializes
+// to a UTC instant and shifts the calendar day backward on servers running ahead of UTC
+// (e.g. TZ=Europe/Berlin). Returning the string keeps day values stable regardless of the
+// process timezone. timestamp/timestamptz columns use different oids and are unaffected.
+types.setTypeParser(types.builtins.DATE, (value) => value);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let ownerPoolInstance: any = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -64,9 +64,12 @@ async function calculateAdaptiveTdee(userId: any, dateParam: any) {
     const multiplier = bmrService.ActivityMultiplier[activityLevel] || 1.2;
     let age = 30;
     if (userProfile?.date_of_birth) {
-      // date_of_birth comes from pg as a 'YYYY-MM-DD' string; parseISO yields local
-      // midnight so the getFullYear/Month/Date comparison below is timezone-stable.
-      const dob = parseISO(String(userProfile.date_of_birth).slice(0, 10));
+      // date_of_birth comes from pg as a 'YYYY-MM-DD' string; parse it to local midnight
+      // so the getFullYear/Month/Date comparison below is timezone-stable. Guard the Date
+      // shape too, in case a caller supplies an already-parsed value.
+      const rawDob = userProfile.date_of_birth;
+      const dob =
+        typeof rawDob === 'string' ? parseISO(rawDob.slice(0, 10)) : rawDob;
       age = calculationDate.getFullYear() - dob.getFullYear();
       const m = calculationDate.getMonth() - dob.getMonth();
       if (m < 0 || (m === 0 && calculationDate.getDate() < dob.getDate())) {

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -3,7 +3,6 @@ import {
   format,
   startOfDay,
   eachDayOfInterval,
-  isSameDay,
   parseISO,
   differenceInDays,
 } from 'date-fns';
@@ -65,7 +64,9 @@ async function calculateAdaptiveTdee(userId: any, dateParam: any) {
     const multiplier = bmrService.ActivityMultiplier[activityLevel] || 1.2;
     let age = 30;
     if (userProfile?.date_of_birth) {
-      const dob = new Date(userProfile.date_of_birth);
+      // date_of_birth comes from pg as a 'YYYY-MM-DD' string; parseISO yields local
+      // midnight so the getFullYear/Month/Date comparison below is timezone-stable.
+      const dob = parseISO(String(userProfile.date_of_birth).slice(0, 10));
       age = calculationDate.getFullYear() - dob.getFullYear();
       const m = calculationDate.getMonth() - dob.getMonth();
       if (m < 0 || (m === 0 && calculationDate.getDate() < dob.getDate())) {
@@ -129,8 +130,10 @@ async function calculateAdaptiveTdee(userId: any, dateParam: any) {
       const dateStr = format(day, 'yyyy-MM-dd');
       // Find actual weight or null
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const actualWeightEntry = weightEntries.find((we: any) =>
-        isSameDay(new Date(we.entry_date), day)
+      const actualWeightEntry = weightEntries.find(
+        // entry_date comes from pg as a 'YYYY-MM-DD' string; match on the day string
+        // (reusing dateStr) so a non-UTC server can't shift the comparison.
+        (we: any) => String(we.entry_date).slice(0, 10) === dateStr
       );
       const actualWeight = actualWeightEntry
         ? parseFloat(actualWeightEntry.weight)

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -37,7 +37,11 @@ async function getUserGoalsForRange(
   );
   const explicitByDate = Object.fromEntries(
     explicitGoals.map((g: Goals) => [
-      format(new Date(g.goal_date), 'yyyy-MM-dd'),
+      // goal_date arrives from pg as a 'YYYY-MM-DD' string; use it directly so the key
+      // is not shifted by new Date()/format() on a non-UTC server.
+      typeof g.goal_date === 'string'
+        ? g.goal_date.slice(0, 10)
+        : format(g.goal_date, 'yyyy-MM-dd'),
       g,
     ])
   );

--- a/SparkyFitnessServer/tests/dateColumnParser.test.ts
+++ b/SparkyFitnessServer/tests/dateColumnParser.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import pg from 'pg';
+// Importing poolManager registers the DATE type parser as a module side effect.
+// The connection pools are constructed lazily and never connect during this test.
+import '../db/poolManager.js';
+
+/**
+ * Regression test for issue #1516: diary entries displayed one day off.
+ *
+ * Every `date` column (food_entries.entry_date, etc.) is read through node-pg.
+ * Without a custom parser, pg builds a JS Date at the server process's LOCAL
+ * midnight; serializing that Date to JSON converts it to UTC and rolls the
+ * calendar day backward on servers running ahead of UTC (e.g. TZ=Europe/Berlin),
+ * so '2026-06-12' reached clients as '2026-06-11T22:00:00.000Z' and displayed as
+ * the previous day. The database value was always correct — only the read-back
+ * was shifted.
+ *
+ * poolManager registers a DATE (oid 1082) parser that returns the raw
+ * 'YYYY-MM-DD' string, so the day is stable regardless of the process timezone.
+ *
+ * Run under a non-UTC zone to prove the fix holds on the affected servers:
+ *   TZ=Europe/Berlin pnpm exec vitest run tests/dateColumnParser.test.ts
+ */
+describe('pg DATE column parser (issue #1516)', () => {
+  const parseDate = pg.types.getTypeParser(pg.types.builtins.DATE);
+
+  it('returns the raw YYYY-MM-DD string, not a Date', () => {
+    const value = parseDate('2026-06-12');
+    expect(typeof value).toBe('string');
+    expect(value).toBe('2026-06-12');
+  });
+
+  it('does not shift the calendar day when serialized into an API response', () => {
+    // This is the exact transformation that produced the bug: a date-column value
+    // round-tripped through a JSON response body.
+    const apiBody = JSON.stringify({ entry_date: parseDate('2026-06-12') });
+    expect(JSON.parse(apiBody).entry_date).toBe('2026-06-12');
+  });
+
+  it.each(['2024-01-01', '2026-06-12', '2026-12-31'])(
+    'preserves %s exactly',
+    (day) => {
+      expect(parseDate(day)).toBe(day);
+    }
+  );
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

This PR fixes an issue where entries would appear off by one day if the servers timezone was set to something other than UTC.

Linked Issue: Closes #1516

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).


**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
