### PR TITLE
feat: mobile date context improvements

### DIFF
--- a/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, useMemo } from 'react';
+import React, { useState, useCallback, useRef, useMemo, useEffect } from 'react';
 import { View, Text, ActivityIndicator, ScrollView, RefreshControl, Pressable } from 'react-native';
 import Button from '../components/ui/Button';
 import { useFocusEffect } from '@react-navigation/native';
@@ -41,6 +41,7 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
   const [selectedDate, setSelectedDate] = useState(getTodayDate);
   const [stepsRange, setStepsRange] = useState<StepsRange>('7d');
   const lastKnownToday = useRef(getTodayDate());
+  const scrollViewRef = useRef<ScrollView>(null);
   const calendarRef = useRef<CalendarSheetRef>(null);
 
   // Only reset to today when the calendar day has actually changed (midnight rollover)
@@ -53,6 +54,17 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
       }
     }, [])
   );
+
+  // Re-tapping the active Dashboard tab acts as a quick return to
+  // today's summary and the top of the screen.
+  useEffect(() => {
+    return navigation.addListener('tabPress', () => {
+      if (navigation.isFocused()) {
+        setSelectedDate(getTodayDate());
+        scrollViewRef.current?.scrollTo({ y: 0, animated: true });
+      }
+    });
+  }, [navigation]);
 
   const goToPreviousDay = () => setSelectedDate(prev => addDays(prev, -1));
   const goToNextDay = () => setSelectedDate(prev => addDays(prev, 1));
@@ -203,6 +215,7 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
 
     return (
       <ScrollView
+        ref={scrollViewRef}
         contentContainerStyle={{ padding: 16, paddingTop: 0, paddingBottom: 80 + activeWorkoutBarPadding }}
         showsVerticalScrollIndicator={false}
         contentInsetAdjustmentBehavior="never"

--- a/SparkyFitnessMobile/src/screens/DiaryScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DiaryScreen.tsx
@@ -36,6 +36,7 @@ const DiaryScreen: React.FC<DiaryScreenProps> = ({ navigation }) => {
   const insets = useSafeAreaInsets();
   const [selectedDate, setSelectedDate] = useState(getTodayDate);
   const lastKnownToday = useRef(getTodayDate());
+  const scrollViewRef = useRef<ScrollView>(null);
   const calendarRef = useRef<CalendarSheetRef>(null);
   const servingSheetRef = useRef<ServingAdjustSheetRef>(null);
 
@@ -48,6 +49,17 @@ const DiaryScreen: React.FC<DiaryScreenProps> = ({ navigation }) => {
       }
     }, [])
   );
+
+  // Re-tapping the active Diary tab acts as a quick return to today's
+  // entries and the top of the screen.
+  useEffect(() => {
+    return navigation.addListener('tabPress', () => {
+      if (navigation.isFocused()) {
+        setSelectedDate(getTodayDate());
+        scrollViewRef.current?.scrollTo({ y: 0, animated: true });
+      }
+    });
+  }, [navigation]);
 
   useEffect(() => {
     navigation.setParams({ selectedDate });
@@ -160,6 +172,7 @@ const DiaryScreen: React.FC<DiaryScreenProps> = ({ navigation }) => {
 
     return (
       <ScrollView
+        ref={scrollViewRef}
         contentContainerStyle={{ padding: 16, paddingTop: 0, paddingBottom: 80 + activeWorkoutBarPadding }}
         showsVerticalScrollIndicator={false}
         contentInsetAdjustmentBehavior="never"
@@ -225,7 +238,6 @@ const DiaryScreen: React.FC<DiaryScreenProps> = ({ navigation }) => {
             onNextDay={goToNextDay}
             onToday={goToToday}
             onDatePress={openCalendar}
-            showDateAlways
             skipSafeAreaTop
           />
         ) : !isConnectionLoading && (

--- a/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
@@ -1193,10 +1193,11 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
 
         {!isMealBuilderMode ? (
           <>
+          <View className="flex-row items-center mt-2">
             <TouchableOpacity
               onPress={() => calendarRef.current?.present()}
               activeOpacity={0.7}
-              className="flex-row items-center mt-2"
+              className="flex-row items-center"
             >
               <Text className="text-text-secondary text-base">Date</Text>
               <Text className="text-text-primary text-base font-medium mx-1.5">
@@ -1209,6 +1210,15 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
                 weight="medium"
               />
             </TouchableOpacity>
+
+            {selectedDate !== getTodayDate() && (
+                <TouchableOpacity activeOpacity={0.7} className="flex-row items-center mx-4" onPress={
+                  () => setSelectedDate(getTodayDate())
+                }>
+                  <Text className="text-text-link text-small font-medium mx-1.5">Use Today</Text>
+                </TouchableOpacity>
+              )}
+            </View>
 
             {selectedMealType ? (
               <View className="flex-row items-center mt-2">

--- a/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
@@ -1193,29 +1193,30 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
 
         {!isMealBuilderMode ? (
           <>
-          <View className="flex-row items-center mt-2">
-            <TouchableOpacity
-              onPress={() => calendarRef.current?.present()}
-              activeOpacity={0.7}
-              className="flex-row items-center"
-            >
-              <Text className="text-text-secondary text-base">Date</Text>
-              <Text className="text-text-primary text-base font-medium mx-1.5">
-                {formatDateLabel(selectedDate)}
-              </Text>
-              <Icon
-                name="chevron-down"
-                size={12}
-                color={textPrimary}
-                weight="medium"
-              />
-            </TouchableOpacity>
+            <View className="flex-row items-center mt-2">
+              <TouchableOpacity
+                onPress={() => calendarRef.current?.present()}
+                activeOpacity={0.7}
+                className="flex-row items-center"
+              >
+                <Text className="text-text-secondary text-base">Date</Text>
+                <Text className="text-text-primary text-base font-medium mx-1.5">
+                  {formatDateLabel(selectedDate)}
+                </Text>
+                <Icon
+                  name="chevron-down"
+                  size={12}
+                  color={textPrimary}
+                  weight="medium"
+                />
+              </TouchableOpacity>
 
-            {selectedDate !== getTodayDate() && (
-                <TouchableOpacity activeOpacity={0.7} className="flex-row items-center mx-4" onPress={
-                  () => setSelectedDate(getTodayDate())
-                }>
-                  <Text className="text-text-link text-small font-medium mx-1.5">Use Today</Text>
+              {selectedDate !== getTodayDate() && (
+                <TouchableOpacity activeOpacity={0.7}
+                  className="flex-row items-center mx-4"
+                  onPress={() => setSelectedDate(getTodayDate())}
+                >
+                  <Text className="text-text-link text-sm font-medium mx-1.5">Use Today</Text>
                 </TouchableOpacity>
               )}
             </View>


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Improves mobile date navigation consistency and makes it easier to return date-based screens to today.

**How did you implement the solution?**
For Dashboard and Diary Screens:
  - Show Today/Yesterday labels in the Diary date navigator, matching Dashboard.
  - Reset Dashboard and Diary to today when re-tapping the active bottom tab.
  - Scroll Dashboard and Diary to the top on active tab re-tap to make it more obvious we reset date to Today.

For Add Food Entry Screen:
  - Add a 'Use Today' button to reset the date on the Add Food Entry screen.

Linked Issue: Closes #

## How to Test

  1. Check out this branch and emulate Mobile app
  2. Open Diary and verify the date navigator shows Today/Yesterday labels.
  3. Open Add Food Entry on a non-today date and verify the `Use Today` button resets the entry
  date to today.
  4. On Dashboard or Diary, navigate to a non-today date and scroll down.
  5. Re-tap the active bottom tab and verify it resets to today and scrolls to the top.

## PR Type

- [ ] Issue (bug fix)
- [X] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**UI changes (components, screens, pages):**

- [X] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [X] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

"Use Today" button beside the date.

<img width="392" height="850" alt="image" src="https://github.com/user-attachments/assets/beac14c3-235d-4672-b7ce-872797da49be" />


Diary DateNavigator shows "Today" label instead of full date.

<img width="392" height="181" alt="image" src="https://github.com/user-attachments/assets/18b93ff6-e3d7-4ba7-9a88-872ebcedafe2" />

</details>

## Notes for Reviewers
