### PR TITLE
feat(health-connect): write nutrition & hydration back to Health Connect (Android)

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/healthconnect/dataTransformation.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/dataTransformation.test.ts
@@ -1,4 +1,4 @@
-import { transformHealthRecords, extractTimezoneMetadata } from '../../../src/services/healthconnect/dataTransformation';
+import { transformHealthRecords, extractTimezoneMetadata, setOwnPackageName } from '../../../src/services/healthconnect/dataTransformation';
 import { toLocalDateString } from '../../../src/services/healthconnect/dataAggregation';
 import type {
   TransformedRecord,
@@ -1646,5 +1646,40 @@ describe('extractTimezoneMetadata', () => {
     // Some zones have 30/45-minute offsets (e.g., India UTC+5:30 = 19800s)
     const rec = { startZoneOffset: { totalSeconds: 19800 } };
     expect(extractTimezoneMetadata(rec)).toEqual({ record_utc_offset_minutes: 330 });
+  });
+});
+
+describe('own-app exclusion (writeback feedback-loop guard)', () => {
+  const OWN = 'com.sparky.app';
+  afterEach(() => setOwnPackageName(null)); // don't leak into other tests
+
+  test('Nutrition: records written by our own app are dropped, others pass', () => {
+    setOwnPackageName(OWN);
+    const records = [
+      { startTime: '2024-01-15T08:00:00Z', name: 'Ours', mealType: 1, metadata: { id: 'a', dataOrigin: OWN } },
+      { startTime: '2024-01-15T09:00:00Z', name: 'Theirs', mealType: 1, metadata: { id: 'b', dataOrigin: 'com.other.app' } },
+    ];
+    const result = transformHealthRecords(records, { recordType: 'Nutrition', unit: 'kcal', type: 'nutrition' }) as TransformedNutritionEntry[];
+    expect(result).toHaveLength(1);
+    expect(result[0].food_name).toBe('Theirs');
+  });
+
+  test('Hydration: records written by our own app are dropped, others pass', () => {
+    setOwnPackageName(OWN);
+    const records = [
+      { startTime: '2024-01-15T08:00:00Z', volume: { inLiters: 0.5 }, metadata: { dataOrigin: OWN } },
+      { startTime: '2024-01-15T09:00:00Z', volume: { inLiters: 0.3 }, metadata: { dataOrigin: 'com.other.app' } },
+    ];
+    const result = transformHealthRecords(records, { recordType: 'Hydration', unit: 'L', type: 'hydration' }) as TransformedRecord[];
+    expect(result).toHaveLength(1);
+    expect(result[0].value).toBe(0.3);
+  });
+
+  test('with no own package set, nothing is excluded', () => {
+    const records = [
+      { startTime: '2024-01-15T08:00:00Z', name: 'X', mealType: 1, metadata: { id: 'a', dataOrigin: OWN } },
+    ];
+    const result = transformHealthRecords(records, { recordType: 'Nutrition', unit: 'kcal', type: 'nutrition' }) as TransformedNutritionEntry[];
+    expect(result).toHaveLength(1);
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
@@ -145,19 +145,33 @@ describe('writebackPhase', () => {
     expect(mockDelete).toHaveBeenCalledWith('Hydration', [], ['sparky-water-2026-06-01-1']);
   });
 
-  it('is idempotent — a second run deletes the first run\'s record', async () => {
+  it('makes no Health Connect writes on an unchanged second run', async () => {
     prefs({ writebackNutritionEnabled: true });
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
     await writebackPhase(['2026-06-01']);
-    const firstId = mockInsert.mock.calls[0][0][0].metadata.clientRecordId;
-    expect(firstId).toBe('sparky-nutrition-fe1-1000');
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const deletesAfterFirst = mockDelete.mock.calls.length;
 
+    // Version differs (Date.now changed) but the day's content is identical → skip.
     nowSpy.mockReturnValue(2000);
     await writebackPhase(['2026-06-01']);
-    // Second run deletes exactly what the first run wrote, then inserts fresh.
-    expect(mockDelete).toHaveBeenLastCalledWith('Nutrition', [], ['sparky-nutrition-fe1-1000']);
-    expect(mockInsert.mock.calls[1][0][0].metadata.clientRecordId).toBe('sparky-nutrition-fe1-2000');
+    expect(mockInsert).toHaveBeenCalledTimes(1); // no new insert
+    expect(mockDelete.mock.calls.length).toBe(deletesAfterFirst); // no new delete
     nowSpy.mockRestore();
+  });
+
+  it("rewrites when the day's data changed", async () => {
+    prefs({ writebackNutritionEnabled: true });
+    await writebackPhase(['2026-06-01']);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+
+    // Diary changed (different calories) → different signature → re-write.
+    mockSummary.mockResolvedValue({
+      foodEntries: [{ ...foodEntry, calories: 999 }],
+      waterIntake: 500,
+    });
+    await writebackPhase(['2026-06-01']);
+    expect(mockInsert).toHaveBeenCalledTimes(2);
   });
 
   it('returns false (does not throw) on a Health Connect quota error', async () => {

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
@@ -4,7 +4,10 @@ import {
   getGrantedPermissions,
 } from 'react-native-health-connect';
 import { fetchDailySummary } from '../../../src/services/api/dailySummaryApi';
-import { loadHealthPreference } from '../../../src/services/healthconnect/preferences';
+import {
+  loadHealthPreference,
+  saveHealthPreference,
+} from '../../../src/services/healthconnect/preferences';
 // Jest resolves './writeback' to the iOS no-op stub by default; require the .ts
 // explicitly to test the real Android implementation (see SparkyFitnessMobile CLAUDE.md).
 const { writebackPhase } = require('../../../src/services/healthconnect/writeback.ts');
@@ -23,7 +26,7 @@ jest.mock('../../../src/utils/loggedMealCollapse', () => ({
 }));
 jest.mock('../../../src/services/healthconnect/preferences', () => ({
   loadHealthPreference: jest.fn(),
-  saveHealthPreference: jest.fn().mockResolvedValue(undefined),
+  saveHealthPreference: jest.fn(),
 }));
 jest.mock('../../../src/services/healthconnect/index', () => ({
   isQuotaExceededError: jest.fn(() => false),
@@ -35,6 +38,7 @@ const mockDelete = deleteRecordsByUuids as jest.Mock;
 const mockGranted = getGrantedPermissions as jest.Mock;
 const mockSummary = fetchDailySummary as jest.Mock;
 const mockLoadPref = loadHealthPreference as jest.Mock;
+const mockSavePref = saveHealthPreference as jest.Mock;
 
 const foodEntry = {
   id: 'fe1',
@@ -48,15 +52,23 @@ const foodEntry = {
   protein: 12,
 };
 
-// loadHealthPreference is used both for the enable flags and the written-id sets.
-const prefs = (overrides: Record<string, unknown>) => {
+// Stateful preference store so saveHealthPreference writes are visible to a later
+// loadHealthPreference — this is what lets us verify the delete-previous behaviour.
+let store: Record<string, unknown> = {};
+const prefs = (initial: Record<string, unknown>) => {
+  store = { ...initial };
   mockLoadPref.mockImplementation((key: string) =>
-    Promise.resolve(key in overrides ? overrides[key] : null),
+    Promise.resolve(key in store ? store[key] : null),
   );
+  mockSavePref.mockImplementation((key: string, value: unknown) => {
+    store[key] = value;
+    return Promise.resolve();
+  });
 };
 
 beforeEach(() => {
   jest.clearAllMocks();
+  store = {};
   mockGranted.mockResolvedValue([
     { recordType: 'Nutrition', accessType: 'write' },
     { recordType: 'Hydration', accessType: 'write' },
@@ -66,7 +78,7 @@ beforeEach(() => {
 
 describe('writebackPhase', () => {
   it('does nothing when both metrics are disabled', async () => {
-    prefs({ writebackNutritionEnabled: false, writebackWaterEnabled: false });
+    prefs({ writebackNutritionEnabled: false, writebackHydrationEnabled: false });
     await writebackPhase(['2026-06-14']);
     expect(mockInsert).not.toHaveBeenCalled();
   });
@@ -78,7 +90,8 @@ describe('writebackPhase', () => {
     const records = mockInsert.mock.calls[0][0];
     expect(records).toHaveLength(1);
     expect(records[0].recordType).toBe('Nutrition');
-    expect(records[0].metadata.clientRecordId).toBe('sparky-nutrition-fe1');
+    // clientRecordId is version-suffixed (fresh per run) but stable in shape.
+    expect(records[0].metadata.clientRecordId).toMatch(/^sparky-nutrition-fe1-\d+$/);
   });
 
   it('skips a metric when its write permission is not granted', async () => {
@@ -88,34 +101,56 @@ describe('writebackPhase', () => {
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
-  it('deletes stale records that are no longer present', async () => {
-    // Previously wrote two ids; only fe1 remains this run → the other is stale.
-    prefs({
-      writebackNutritionEnabled: true,
-      'writebackNutritionIds:2026-06-14': ['sparky-nutrition-fe1', 'sparky-nutrition-gone'],
+  it('skips entries imported from a provider (source set)', async () => {
+    prefs({ writebackNutritionEnabled: true });
+    mockSummary.mockResolvedValue({
+      foodEntries: [{ ...foodEntry, source: 'health_connect' }],
+      waterIntake: 0,
     });
     await writebackPhase(['2026-06-14']);
-    expect(mockDelete).toHaveBeenCalledWith('Nutrition', [], ['sparky-nutrition-gone']);
+    expect(mockInsert).not.toHaveBeenCalled(); // nothing originated in Sparky
+  });
+
+  it("deletes the previous run's records before inserting", async () => {
+    prefs({
+      writebackNutritionEnabled: true,
+      'writebackNutritionIds:2026-06-14': [
+        'sparky-nutrition-fe1-1',
+        'sparky-nutrition-gone-1',
+      ],
+    });
+    await writebackPhase(['2026-06-14']);
+    expect(mockDelete).toHaveBeenCalledWith('Nutrition', [], [
+      'sparky-nutrition-fe1-1',
+      'sparky-nutrition-gone-1',
+    ]);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
   });
 
   it('writes water and deletes the day record when water drops to 0', async () => {
     prefs({
       writebackHydrationEnabled: true,
-      'writebackHydrationIds:2026-06-14': ['sparky-water-2026-06-14'],
+      'writebackHydrationIds:2026-06-14': ['sparky-water-2026-06-14-1'],
     });
     mockSummary.mockResolvedValue({ foodEntries: [], waterIntake: 0 });
     await writebackPhase(['2026-06-14']);
     expect(mockInsert).not.toHaveBeenCalled(); // ml<=0 → no record
-    expect(mockDelete).toHaveBeenCalledWith('Hydration', [], ['sparky-water-2026-06-14']);
+    expect(mockDelete).toHaveBeenCalledWith('Hydration', [], ['sparky-water-2026-06-14-1']);
   });
 
-  it('is idempotent — same input yields the same clientRecordIds', async () => {
+  it('is idempotent — a second run deletes the first run\'s record', async () => {
     prefs({ writebackNutritionEnabled: true });
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
     await writebackPhase(['2026-06-14']);
+    const firstId = mockInsert.mock.calls[0][0][0].metadata.clientRecordId;
+    expect(firstId).toBe('sparky-nutrition-fe1-1000');
+
+    nowSpy.mockReturnValue(2000);
     await writebackPhase(['2026-06-14']);
-    const first = mockInsert.mock.calls[0][0][0].metadata.clientRecordId;
-    const second = mockInsert.mock.calls[1][0][0].metadata.clientRecordId;
-    expect(first).toBe(second);
+    // Second run deletes exactly what the first run wrote, then inserts fresh.
+    expect(mockDelete).toHaveBeenLastCalledWith('Nutrition', [], ['sparky-nutrition-fe1-1000']);
+    expect(mockInsert.mock.calls[1][0][0].metadata.clientRecordId).toBe('sparky-nutrition-fe1-2000');
+    nowSpy.mockRestore();
   });
 
   it('swallows a Health Connect quota error', async () => {

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
@@ -45,7 +45,7 @@ const foodEntry = {
   meal_type: 'breakfast',
   quantity: 1,
   unit: 'serving',
-  entry_date: '2026-06-14',
+  entry_date: '2026-06-01',
   serving_size: 1,
   food_name: 'Eggs',
   calories: 150,
@@ -79,13 +79,13 @@ beforeEach(() => {
 describe('writebackPhase', () => {
   it('does nothing when both metrics are disabled', async () => {
     prefs({ writebackNutritionEnabled: false, writebackHydrationEnabled: false });
-    await writebackPhase(['2026-06-14']);
+    await writebackPhase(['2026-06-01']);
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
   it('writes nutrition records when enabled and permission granted', async () => {
     prefs({ writebackNutritionEnabled: true });
-    await writebackPhase(['2026-06-14']);
+    await writebackPhase(['2026-06-01']);
     expect(mockInsert).toHaveBeenCalledTimes(1);
     const records = mockInsert.mock.calls[0][0];
     expect(records).toHaveLength(1);
@@ -97,7 +97,7 @@ describe('writebackPhase', () => {
   it('skips a metric when its write permission is not granted', async () => {
     prefs({ writebackNutritionEnabled: true });
     mockGranted.mockResolvedValue([]); // nothing granted
-    await writebackPhase(['2026-06-14']);
+    await writebackPhase(['2026-06-01']);
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
@@ -107,19 +107,19 @@ describe('writebackPhase', () => {
       foodEntries: [{ ...foodEntry, source: 'health_connect' }],
       waterIntake: 0,
     });
-    await writebackPhase(['2026-06-14']);
+    await writebackPhase(['2026-06-01']);
     expect(mockInsert).not.toHaveBeenCalled(); // nothing originated in Sparky
   });
 
   it("deletes the previous run's records before inserting", async () => {
     prefs({
       writebackNutritionEnabled: true,
-      'writebackNutritionIds:2026-06-14': [
+      'writebackNutritionIds:2026-06-01': [
         'sparky-nutrition-fe1-1',
         'sparky-nutrition-gone-1',
       ],
     });
-    await writebackPhase(['2026-06-14']);
+    await writebackPhase(['2026-06-01']);
     expect(mockDelete).toHaveBeenCalledWith('Nutrition', [], [
       'sparky-nutrition-fe1-1',
       'sparky-nutrition-gone-1',
@@ -130,23 +130,23 @@ describe('writebackPhase', () => {
   it('writes water and deletes the day record when water drops to 0', async () => {
     prefs({
       writebackHydrationEnabled: true,
-      'writebackHydrationIds:2026-06-14': ['sparky-water-2026-06-14-1'],
+      'writebackHydrationIds:2026-06-01': ['sparky-water-2026-06-01-1'],
     });
     mockSummary.mockResolvedValue({ foodEntries: [], waterIntake: 0 });
-    await writebackPhase(['2026-06-14']);
+    await writebackPhase(['2026-06-01']);
     expect(mockInsert).not.toHaveBeenCalled(); // ml<=0 → no record
-    expect(mockDelete).toHaveBeenCalledWith('Hydration', [], ['sparky-water-2026-06-14-1']);
+    expect(mockDelete).toHaveBeenCalledWith('Hydration', [], ['sparky-water-2026-06-01-1']);
   });
 
   it('is idempotent — a second run deletes the first run\'s record', async () => {
     prefs({ writebackNutritionEnabled: true });
     const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1000);
-    await writebackPhase(['2026-06-14']);
+    await writebackPhase(['2026-06-01']);
     const firstId = mockInsert.mock.calls[0][0][0].metadata.clientRecordId;
     expect(firstId).toBe('sparky-nutrition-fe1-1000');
 
     nowSpy.mockReturnValue(2000);
-    await writebackPhase(['2026-06-14']);
+    await writebackPhase(['2026-06-01']);
     // Second run deletes exactly what the first run wrote, then inserts fresh.
     expect(mockDelete).toHaveBeenLastCalledWith('Nutrition', [], ['sparky-nutrition-fe1-1000']);
     expect(mockInsert.mock.calls[1][0][0].metadata.clientRecordId).toBe('sparky-nutrition-fe1-2000');
@@ -158,6 +158,6 @@ describe('writebackPhase', () => {
     mockInsert.mockRejectedValueOnce(new Error('quota'));
     const { isQuotaExceededError } = jest.requireMock('../../../src/services/healthconnect/index');
     (isQuotaExceededError as jest.Mock).mockReturnValue(true);
-    await expect(writebackPhase(['2026-06-14'])).resolves.toBeUndefined();
+    await expect(writebackPhase(['2026-06-01'])).resolves.toBeUndefined();
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
@@ -1,0 +1,128 @@
+import {
+  insertRecords,
+  deleteRecordsByUuids,
+  getGrantedPermissions,
+} from 'react-native-health-connect';
+import { fetchDailySummary } from '../../../src/services/api/dailySummaryApi';
+import { loadHealthPreference } from '../../../src/services/healthconnect/preferences';
+// Jest resolves './writeback' to the iOS no-op stub by default; require the .ts
+// explicitly to test the real Android implementation (see SparkyFitnessMobile CLAUDE.md).
+const { writebackPhase } = require('../../../src/services/healthconnect/writeback.ts');
+
+jest.mock('react-native-health-connect', () => ({
+  insertRecords: jest.fn().mockResolvedValue([]),
+  deleteRecordsByUuids: jest.fn().mockResolvedValue(undefined),
+  getGrantedPermissions: jest.fn(),
+  RecordingMethod: { RECORDING_METHOD_MANUAL_ENTRY: 3 },
+}));
+jest.mock('../../../src/services/api/dailySummaryApi', () => ({
+  fetchDailySummary: jest.fn(),
+}));
+jest.mock('../../../src/utils/loggedMealCollapse', () => ({
+  resolveCollapsedFoodEntries: jest.fn((_date: string, entries: unknown) => Promise.resolve(entries)),
+}));
+jest.mock('../../../src/services/healthconnect/preferences', () => ({
+  loadHealthPreference: jest.fn(),
+  saveHealthPreference: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../../src/services/healthconnect/index', () => ({
+  isQuotaExceededError: jest.fn(() => false),
+}));
+jest.mock('../../../src/services/LogService', () => ({ addLog: jest.fn() }));
+
+const mockInsert = insertRecords as jest.Mock;
+const mockDelete = deleteRecordsByUuids as jest.Mock;
+const mockGranted = getGrantedPermissions as jest.Mock;
+const mockSummary = fetchDailySummary as jest.Mock;
+const mockLoadPref = loadHealthPreference as jest.Mock;
+
+const foodEntry = {
+  id: 'fe1',
+  meal_type: 'breakfast',
+  quantity: 1,
+  unit: 'serving',
+  entry_date: '2026-06-14',
+  serving_size: 1,
+  food_name: 'Eggs',
+  calories: 150,
+  protein: 12,
+};
+
+// loadHealthPreference is used both for the enable flags and the written-id sets.
+const prefs = (overrides: Record<string, unknown>) => {
+  mockLoadPref.mockImplementation((key: string) =>
+    Promise.resolve(key in overrides ? overrides[key] : null),
+  );
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGranted.mockResolvedValue([
+    { recordType: 'Nutrition', accessType: 'write' },
+    { recordType: 'Hydration', accessType: 'write' },
+  ]);
+  mockSummary.mockResolvedValue({ foodEntries: [foodEntry], waterIntake: 500 });
+});
+
+describe('writebackPhase', () => {
+  it('does nothing when both metrics are disabled', async () => {
+    prefs({ writebackNutritionEnabled: false, writebackWaterEnabled: false });
+    await writebackPhase(['2026-06-14']);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('writes nutrition records when enabled and permission granted', async () => {
+    prefs({ writebackNutritionEnabled: true });
+    await writebackPhase(['2026-06-14']);
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    const records = mockInsert.mock.calls[0][0];
+    expect(records).toHaveLength(1);
+    expect(records[0].recordType).toBe('Nutrition');
+    expect(records[0].metadata.clientRecordId).toBe('sparky-nutrition-fe1');
+  });
+
+  it('skips a metric when its write permission is not granted', async () => {
+    prefs({ writebackNutritionEnabled: true });
+    mockGranted.mockResolvedValue([]); // nothing granted
+    await writebackPhase(['2026-06-14']);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it('deletes stale records that are no longer present', async () => {
+    // Previously wrote two ids; only fe1 remains this run → the other is stale.
+    prefs({
+      writebackNutritionEnabled: true,
+      'writebackNutritionIds:2026-06-14': ['sparky-nutrition-fe1', 'sparky-nutrition-gone'],
+    });
+    await writebackPhase(['2026-06-14']);
+    expect(mockDelete).toHaveBeenCalledWith('Nutrition', [], ['sparky-nutrition-gone']);
+  });
+
+  it('writes water and deletes the day record when water drops to 0', async () => {
+    prefs({
+      writebackHydrationEnabled: true,
+      'writebackHydrationIds:2026-06-14': ['sparky-water-2026-06-14'],
+    });
+    mockSummary.mockResolvedValue({ foodEntries: [], waterIntake: 0 });
+    await writebackPhase(['2026-06-14']);
+    expect(mockInsert).not.toHaveBeenCalled(); // ml<=0 → no record
+    expect(mockDelete).toHaveBeenCalledWith('Hydration', [], ['sparky-water-2026-06-14']);
+  });
+
+  it('is idempotent — same input yields the same clientRecordIds', async () => {
+    prefs({ writebackNutritionEnabled: true });
+    await writebackPhase(['2026-06-14']);
+    await writebackPhase(['2026-06-14']);
+    const first = mockInsert.mock.calls[0][0][0].metadata.clientRecordId;
+    const second = mockInsert.mock.calls[1][0][0].metadata.clientRecordId;
+    expect(first).toBe(second);
+  });
+
+  it('swallows a Health Connect quota error', async () => {
+    prefs({ writebackNutritionEnabled: true });
+    mockInsert.mockRejectedValueOnce(new Error('quota'));
+    const { isQuotaExceededError } = jest.requireMock('../../../src/services/healthconnect/index');
+    (isQuotaExceededError as jest.Mock).mockReturnValue(true);
+    await expect(writebackPhase(['2026-06-14'])).resolves.toBeUndefined();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
@@ -10,7 +10,10 @@ import {
 } from '../../../src/services/healthconnect/preferences';
 // Jest resolves './writeback' to the iOS no-op stub by default; require the .ts
 // explicitly to test the real Android implementation (see SparkyFitnessMobile CLAUDE.md).
-const { writebackPhase } = require('../../../src/services/healthconnect/writeback.ts');
+const {
+  writebackPhase,
+  runWriteback,
+} = require('../../../src/services/healthconnect/writeback.ts');
 
 jest.mock('react-native-health-connect', () => ({
   insertRecords: jest.fn().mockResolvedValue([]),
@@ -30,6 +33,10 @@ jest.mock('../../../src/services/healthconnect/preferences', () => ({
 }));
 jest.mock('../../../src/services/healthconnect/index', () => ({
   isQuotaExceededError: jest.fn(() => false),
+}));
+jest.mock('../../../src/services/storage', () => ({
+  loadLastWritebackTime: jest.fn().mockResolvedValue(null),
+  saveLastWritebackTime: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('../../../src/services/LogService', () => ({ addLog: jest.fn() }));
 
@@ -153,11 +160,31 @@ describe('writebackPhase', () => {
     nowSpy.mockRestore();
   });
 
-  it('swallows a Health Connect quota error', async () => {
+  it('returns false (does not throw) on a Health Connect quota error', async () => {
     prefs({ writebackNutritionEnabled: true });
     mockInsert.mockRejectedValueOnce(new Error('quota'));
     const { isQuotaExceededError } = jest.requireMock('../../../src/services/healthconnect/index');
     (isQuotaExceededError as jest.Mock).mockReturnValue(true);
-    await expect(writebackPhase(['2026-06-01'])).resolves.toBeUndefined();
+    await expect(writebackPhase(['2026-06-01'])).resolves.toBe(false);
+  });
+});
+
+describe('runWriteback (cursor)', () => {
+  const { saveLastWritebackTime } = jest.requireMock('../../../src/services/storage');
+  const mockSaveCursor = saveLastWritebackTime as jest.Mock;
+
+  it('advances the cursor after a completed run', async () => {
+    prefs({ writebackNutritionEnabled: true });
+    await runWriteback();
+    expect(mockSaveCursor).toHaveBeenCalled();
+  });
+
+  it('holds the cursor when a quota error stops the run early', async () => {
+    prefs({ writebackNutritionEnabled: true });
+    mockInsert.mockRejectedValue(new Error('quota'));
+    const { isQuotaExceededError } = jest.requireMock('../../../src/services/healthconnect/index');
+    (isQuotaExceededError as jest.Mock).mockReturnValue(true);
+    await runWriteback();
+    expect(mockSaveCursor).not.toHaveBeenCalled();
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/writebackMappers.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/writebackMappers.test.ts
@@ -61,10 +61,10 @@ describe('foodEntryToNutritionRecord', () => {
     expect(foodEntryToNutritionRecord({ ...baseEntry, serving_size: 0 }, 1)).toBeNull();
   });
 
-  it('stamps a deterministic, prefixed clientRecordId + version', () => {
+  it('stamps a version-suffixed, prefixed clientRecordId + version', () => {
     const record = foodEntryToNutritionRecord(baseEntry, 4242)!;
     const metadata = field(record, 'metadata');
-    expect(metadata.clientRecordId).toBe('sparky-nutrition-fe1');
+    expect(metadata.clientRecordId).toBe('sparky-nutrition-fe1-4242');
     expect(metadata.clientRecordVersion).toBe(4242);
     expect(metadata.recordingMethod).toBe(3); // MANUAL_ENTRY
   });
@@ -86,7 +86,7 @@ describe('waterMlToHydrationRecord', () => {
   it('builds an interval Hydration record in milliliters', () => {
     const record = waterMlToHydrationRecord('2026-06-14', 750, 99)!;
     expect(field(record, 'volume')).toEqual({ value: 750, unit: 'milliliters' });
-    expect(field(record, 'metadata').clientRecordId).toBe('sparky-water-2026-06-14');
+    expect(field(record, 'metadata').clientRecordId).toBe('sparky-water-2026-06-14-99');
     expect(field(record, 'metadata').clientRecordVersion).toBe(99);
     expect(new Date(field(record, 'endTime')).getTime()).toBeGreaterThan(
       new Date(field(record, 'startTime')).getTime(),
@@ -95,9 +95,9 @@ describe('waterMlToHydrationRecord', () => {
 });
 
 describe('clientRecordId helpers', () => {
-  it('are prefixed and deterministic', () => {
-    expect(nutritionClientRecordId('abc')).toBe('sparky-nutrition-abc');
-    expect(waterClientRecordId('2026-06-14')).toBe('sparky-water-2026-06-14');
+  it('are prefixed and version-suffixed (fresh per write run)', () => {
+    expect(nutritionClientRecordId('abc', 7)).toBe('sparky-nutrition-abc-7');
+    expect(waterClientRecordId('2026-06-14', 7)).toBe('sparky-water-2026-06-14-7');
   });
 });
 

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/writebackMappers.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/writebackMappers.test.ts
@@ -16,12 +16,14 @@ import type { FoodEntry } from '../../../src/types/foodEntries';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const field = (record: any, key: string) => record[key];
 
+// A clearly-past date so every meal-time anchor (incl. dinner 19:00) is in the
+// past at test time — otherwise recordInterval would defer same-day future anchors.
 const baseEntry: FoodEntry = {
   id: 'fe1',
   meal_type: 'breakfast',
   quantity: 150,
   unit: 'g',
-  entry_date: '2026-06-14',
+  entry_date: '2026-06-01',
   serving_size: 100, // consumed = value * 150 / 100 = value * 1.5
   food_name: 'Oatmeal',
   calories: 200, // -> 300 kcal
@@ -61,6 +63,11 @@ describe('foodEntryToNutritionRecord', () => {
     expect(foodEntryToNutritionRecord({ ...baseEntry, serving_size: 0 }, 1)).toBeNull();
   });
 
+  it('defers (returns null) when the meal-time anchor is still in the future', () => {
+    // Far-future date → anchor is after "now", so HC would reject it; skip this run.
+    expect(foodEntryToNutritionRecord({ ...baseEntry, entry_date: '2099-01-01' }, 1)).toBeNull();
+  });
+
   it('stamps a version-suffixed, prefixed clientRecordId + version', () => {
     const record = foodEntryToNutritionRecord(baseEntry, 4242)!;
     const metadata = field(record, 'metadata');
@@ -79,14 +86,18 @@ describe('foodEntryToNutritionRecord', () => {
 
 describe('waterMlToHydrationRecord', () => {
   it('returns null for non-positive ml', () => {
-    expect(waterMlToHydrationRecord('2026-06-14', 0, 1)).toBeNull();
-    expect(waterMlToHydrationRecord('2026-06-14', -5, 1)).toBeNull();
+    expect(waterMlToHydrationRecord('2026-06-01', 0, 1)).toBeNull();
+    expect(waterMlToHydrationRecord('2026-06-01', -5, 1)).toBeNull();
+  });
+
+  it('defers (returns null) when the noon anchor is still in the future', () => {
+    expect(waterMlToHydrationRecord('2099-01-01', 500, 1)).toBeNull();
   });
 
   it('builds an interval Hydration record in milliliters', () => {
-    const record = waterMlToHydrationRecord('2026-06-14', 750, 99)!;
+    const record = waterMlToHydrationRecord('2026-06-01', 750, 99)!;
     expect(field(record, 'volume')).toEqual({ value: 750, unit: 'milliliters' });
-    expect(field(record, 'metadata').clientRecordId).toBe('sparky-water-2026-06-14-99');
+    expect(field(record, 'metadata').clientRecordId).toBe('sparky-water-2026-06-01-99');
     expect(field(record, 'metadata').clientRecordVersion).toBe(99);
     expect(new Date(field(record, 'endTime')).getTime()).toBeGreaterThan(
       new Date(field(record, 'startTime')).getTime(),

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/writebackMappers.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/writebackMappers.test.ts
@@ -1,0 +1,121 @@
+// writebackMappers imports RecordingMethod (a runtime enum) from the library, so
+// provide it here (the global jest mock only stubs the read APIs).
+jest.mock('react-native-health-connect', () => ({
+  RecordingMethod: { RECORDING_METHOD_MANUAL_ENTRY: 3 },
+}));
+
+import {
+  foodEntryToNutritionRecord,
+  waterMlToHydrationRecord,
+  nutritionClientRecordId,
+  waterClientRecordId,
+  computeWritebackDates,
+} from '../../../src/services/healthconnect/writebackMappers';
+import type { FoodEntry } from '../../../src/types/foodEntries';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const field = (record: any, key: string) => record[key];
+
+const baseEntry: FoodEntry = {
+  id: 'fe1',
+  meal_type: 'breakfast',
+  quantity: 150,
+  unit: 'g',
+  entry_date: '2026-06-14',
+  serving_size: 100, // consumed = value * 150 / 100 = value * 1.5
+  food_name: 'Oatmeal',
+  calories: 200, // -> 300 kcal
+  protein: 10, // -> 15 g
+  sodium: 400, // mg -> 600 mg (no conversion, just unit string)
+  vitamin_a: 80, // mcg -> 120 mcg
+  monounsaturated_fat: 0, // omitted
+};
+
+describe('foodEntryToNutritionRecord', () => {
+  it('scales nutrients by quantity/serving_size and keeps native units', () => {
+    const record = foodEntryToNutritionRecord(baseEntry, 1000)!;
+    expect(record).not.toBeNull();
+    expect(record.mealType).toBe(1); // breakfast
+    expect(field(record, 'name')).toBe('Oatmeal');
+    expect(field(record, 'energy')).toEqual({ value: 300, unit: 'kilocalories' });
+    expect(field(record, 'protein')).toEqual({ value: 15, unit: 'grams' });
+    // mg/mcg columns are written in their native unit with the value unchanged.
+    expect(field(record, 'sodium')).toEqual({ value: 600, unit: 'milligrams' });
+    expect(field(record, 'vitaminA')).toEqual({ value: 120, unit: 'micrograms' });
+  });
+
+  it('omits zero / undefined nutrients', () => {
+    const record = foodEntryToNutritionRecord(baseEntry, 1000)!;
+    expect(field(record, 'monounsaturatedFat')).toBeUndefined();
+    expect(field(record, 'cholesterol')).toBeUndefined(); // absent in fixture
+  });
+
+  it('maps meal types (unknown -> snack=4)', () => {
+    expect(foodEntryToNutritionRecord({ ...baseEntry, meal_type: 'lunch' }, 1)!.mealType).toBe(2);
+    expect(foodEntryToNutritionRecord({ ...baseEntry, meal_type: 'dinner' }, 1)!.mealType).toBe(3);
+    expect(foodEntryToNutritionRecord({ ...baseEntry, meal_type: 'snacks' }, 1)!.mealType).toBe(4);
+    expect(foodEntryToNutritionRecord({ ...baseEntry, meal_type: 'pre-workout' }, 1)!.mealType).toBe(4);
+  });
+
+  it('returns null when serving_size is 0 (cannot scale)', () => {
+    expect(foodEntryToNutritionRecord({ ...baseEntry, serving_size: 0 }, 1)).toBeNull();
+  });
+
+  it('stamps a deterministic, prefixed clientRecordId + version', () => {
+    const record = foodEntryToNutritionRecord(baseEntry, 4242)!;
+    const metadata = field(record, 'metadata');
+    expect(metadata.clientRecordId).toBe('sparky-nutrition-fe1');
+    expect(metadata.clientRecordVersion).toBe(4242);
+    expect(metadata.recordingMethod).toBe(3); // MANUAL_ENTRY
+  });
+
+  it('sets an end time after the start time (interval record)', () => {
+    const record = foodEntryToNutritionRecord(baseEntry, 1)!;
+    expect(new Date(field(record, 'endTime')).getTime()).toBeGreaterThan(
+      new Date(field(record, 'startTime')).getTime(),
+    );
+  });
+});
+
+describe('waterMlToHydrationRecord', () => {
+  it('returns null for non-positive ml', () => {
+    expect(waterMlToHydrationRecord('2026-06-14', 0, 1)).toBeNull();
+    expect(waterMlToHydrationRecord('2026-06-14', -5, 1)).toBeNull();
+  });
+
+  it('builds an interval Hydration record in milliliters', () => {
+    const record = waterMlToHydrationRecord('2026-06-14', 750, 99)!;
+    expect(field(record, 'volume')).toEqual({ value: 750, unit: 'milliliters' });
+    expect(field(record, 'metadata').clientRecordId).toBe('sparky-water-2026-06-14');
+    expect(field(record, 'metadata').clientRecordVersion).toBe(99);
+    expect(new Date(field(record, 'endTime')).getTime()).toBeGreaterThan(
+      new Date(field(record, 'startTime')).getTime(),
+    );
+  });
+});
+
+describe('clientRecordId helpers', () => {
+  it('are prefixed and deterministic', () => {
+    expect(nutritionClientRecordId('abc')).toBe('sparky-nutrition-abc');
+    expect(waterClientRecordId('2026-06-14')).toBe('sparky-water-2026-06-14');
+  });
+});
+
+describe('computeWritebackDates', () => {
+  const now = new Date('2026-06-14T10:00:00');
+
+  it('defaults to yesterday + today when no cursor', () => {
+    expect(computeWritebackDates(null, now)).toEqual(['2026-06-13', '2026-06-14']);
+  });
+
+  it('extends the window to cover a gap since the last writeback', () => {
+    const dates = computeWritebackDates('2026-06-11T10:00:00', now);
+    expect(dates[dates.length - 1]).toBe('2026-06-14');
+    expect(dates).toContain('2026-06-10'); // 1-day overlap before 06-11
+  });
+
+  it('caps the window at 7 days', () => {
+    const dates = computeWritebackDates('2026-01-01T00:00:00', now);
+    expect(dates.length).toBeLessThanOrEqual(8); // 7 back + today
+  });
+});

--- a/SparkyFitnessMobile/app.config.ts
+++ b/SparkyFitnessMobile/app.config.ts
@@ -52,6 +52,10 @@ const androidPermissions = [
   'android.permission.health.READ_WHEELCHAIR_PUSHES',
   'android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND',
   'android.permission.health.READ_HEALTH_DATA_HISTORY',
+  // Writeback (Sparky → Health Connect): nutrition + water. Production feature,
+  // so these live in the base list (not the dev-only writes below).
+  'android.permission.health.WRITE_NUTRITION',
+  'android.permission.health.WRITE_HYDRATION',
 ];
 
 const devAndroidPermissions = [
@@ -71,7 +75,7 @@ const devAndroidPermissions = [
   'android.permission.health.WRITE_FLOORS_CLIMBED',
   'android.permission.health.WRITE_HEART_RATE',
   'android.permission.health.WRITE_HEIGHT',
-  'android.permission.health.WRITE_HYDRATION',
+  // WRITE_HYDRATION moved to the base androidPermissions list (writeback feature).
   'android.permission.health.WRITE_LEAN_BODY_MASS',
   'android.permission.health.WRITE_INTERMENSTRUAL_BLEEDING',
   'android.permission.health.WRITE_MENSTRUATION',

--- a/SparkyFitnessMobile/src/WritebackMetrics.ts
+++ b/SparkyFitnessMobile/src/WritebackMetrics.ts
@@ -1,0 +1,47 @@
+import type { ImageSourcePropType } from 'react-native';
+
+// Health Connect writeback metrics (Sparky → HC). Kept separate from the read
+// HealthMetrics list: those drive background-delivery subscriptions and inbound
+// sync, whereas these are outbound, opt-in, and Android-only. Off by default.
+//
+// Mirrors the read metrics' shape (icon + category) so the UI can group them in
+// the same accordion style. We start with Nutrition + Hydration; a follow-up PR
+// will extend writeback to the other readable metrics (which is why this is a
+// category-grouped list rather than a flat pair).
+
+export type WritebackMetricId = 'nutrition' | 'hydration';
+
+export interface WritebackMetric {
+  id: WritebackMetricId;
+  label: string;
+  /** loadHealthPreference/saveHealthPreference key (under the @HealthConnect prefix). */
+  preferenceKey: string;
+  recordType: 'Nutrition' | 'Hydration';
+  permission: { accessType: 'write'; recordType: 'Nutrition' | 'Hydration' };
+  icon: ImageSourcePropType;
+  category: string;
+}
+
+export const WRITEBACK_METRICS: WritebackMetric[] = [
+  {
+    id: 'nutrition',
+    label: 'Nutrition',
+    preferenceKey: 'writebackNutritionEnabled',
+    recordType: 'Nutrition',
+    permission: { accessType: 'write', recordType: 'Nutrition' },
+    icon: require('../assets/icons/health-metrics/nutrition.png'),
+    category: 'Nutrition',
+  },
+  {
+    id: 'hydration',
+    label: 'Hydration',
+    preferenceKey: 'writebackHydrationEnabled',
+    recordType: 'Hydration',
+    permission: { accessType: 'write', recordType: 'Hydration' },
+    icon: require('../assets/icons/health-metrics/hydration.png'),
+    category: 'Nutrition',
+  },
+];
+
+/** Order categories render in (mirrors the read section's grouping). */
+export const WRITEBACK_CATEGORY_ORDER: string[] = ['Nutrition'];

--- a/SparkyFitnessMobile/src/components/HealthDataWriteback.tsx
+++ b/SparkyFitnessMobile/src/components/HealthDataWriteback.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import { View, Text, Switch, Image, Platform } from 'react-native';
+import { useCSSVariable } from 'uniwind';
+import CollapsibleSection from './CollapsibleSection';
+import {
+  WRITEBACK_METRICS,
+  WRITEBACK_CATEGORY_ORDER,
+  type WritebackMetric,
+} from '../WritebackMetrics';
+
+interface HealthDataWritebackProps {
+  writebackStates: Record<string, boolean>;
+  handleToggleWriteback: (metric: WritebackMetric, newValue: boolean) => void;
+}
+
+const groupByCategory = (metrics: WritebackMetric[]): Record<string, WritebackMetric[]> =>
+  metrics.reduce(
+    (acc, metric) => {
+      (acc[metric.category] ??= []).push(metric);
+      return acc;
+    },
+    {} as Record<string, WritebackMetric[]>,
+  );
+
+/**
+ * Opt-in toggles for writing SparkyFitness diary data out to Health Connect.
+ * Grouped into accordion categories to match the read "Health Data to Sync" card.
+ * Android-only (Health Connect); renders nothing on iOS.
+ */
+const HealthDataWriteback: React.FC<HealthDataWritebackProps> = ({
+  writebackStates,
+  handleToggleWriteback,
+}) => {
+  const [formEnabled, formDisabled] = useCSSVariable([
+    '--color-form-enabled',
+    '--color-form-disabled',
+  ]) as [string, string];
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set());
+
+  if (Platform.OS !== 'android') {
+    return null;
+  }
+
+  const grouped = groupByCategory(WRITEBACK_METRICS);
+
+  const toggleCategory = (category: string) => {
+    setCollapsedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      return next;
+    });
+  };
+
+  const renderMetricItem = (metric: WritebackMetric) => (
+    <View key={metric.id} className="flex-row justify-between items-center mb-2">
+      <View className="flex-row items-center flex-1 mr-2">
+        <Image source={metric.icon} className="w-6 h-6" />
+        <Text className="ml-2 text-base text-text-primary flex-shrink" numberOfLines={1}>
+          {metric.label}
+        </Text>
+      </View>
+      <Switch
+        onValueChange={(newValue) => handleToggleWriteback(metric, newValue)}
+        value={!!writebackStates[metric.id]}
+        trackColor={{ false: formDisabled, true: formEnabled }}
+        thumbColor="#FFFFFF"
+      />
+    </View>
+  );
+
+  return (
+    <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
+      <Text className="text-lg font-bold mb-1 text-text-primary">Write to Health Connect</Text>
+      <Text className="text-sm text-text-muted mb-3">
+        Syncs the data you log in SparkyFitness out to Health Connect, keeping the two in sync.
+      </Text>
+      {WRITEBACK_CATEGORY_ORDER.map((category) => {
+        const metricsInCategory = grouped[category];
+        if (!metricsInCategory || metricsInCategory.length === 0) {
+          return null;
+        }
+        return (
+          <CollapsibleSection
+            key={category}
+            title={category}
+            expanded={!collapsedCategories.has(category)}
+            onToggle={() => toggleCategory(category)}
+            itemCount={metricsInCategory.length}
+          >
+            {metricsInCategory.map(renderMetricItem)}
+          </CollapsibleSection>
+        );
+      })}
+    </View>
+  );
+};
+
+export default HealthDataWriteback;

--- a/SparkyFitnessMobile/src/hooks/useDailySummary.ts
+++ b/SparkyFitnessMobile/src/hooks/useDailySummary.ts
@@ -8,11 +8,10 @@ import {
 } from '../services/api/foodEntriesApi';
 import { calculateExerciseStats } from '../utils/workoutSession';
 import { fetchDailySummary } from '../services/api/dailySummaryApi';
-import { fetchFoodEntryMealsByDate } from '../services/api/foodEntryMealsApi';
+import { resolveCollapsedFoodEntries } from '../utils/loggedMealCollapse';
 import type { DailySummary } from '../types/dailySummary';
 import type { DailyGoals } from '../types/goals';
 import type { FoodEntry } from '../types/foodEntries';
-import type { FoodEntryMeal } from '../types/foodEntryMeals';
 import type { ExerciseSessionResponse, CalorieBalance } from '@workspace/shared';
 import type { WaterIntake } from '../types/measurements';
 
@@ -33,103 +32,12 @@ interface UseDailySummaryOptions {
   enabled?: boolean;
 }
 
-function hasLoggedMealComponents(foodEntries: FoodEntry[]): boolean {
-  return foodEntries.some((entry) => !!entry.food_entry_meal_id);
-}
-
-function loggedMealToFoodEntry(meal: FoodEntryMeal): FoodEntry {
-  const quantity = Number(meal.quantity) > 0 ? Number(meal.quantity) : 1;
-
-  return {
-    id: meal.id,
-    user_id: meal.user_id,
-    meal_id: meal.meal_template_id ?? undefined,
-    food_entry_meal_id: meal.id,
-    meal_type: meal.meal_type,
-    meal_type_id: meal.meal_type_id ?? undefined,
-    quantity,
-    unit: meal.unit,
-    entry_date: meal.entry_date,
-    food_name: meal.name,
-    serving_size: quantity,
-    serving_unit: meal.unit,
-    calories: meal.calories ?? 0,
-    protein: meal.protein,
-    carbs: meal.carbs,
-    fat: meal.fat,
-    saturated_fat: meal.saturated_fat,
-    polyunsaturated_fat: meal.polyunsaturated_fat,
-    monounsaturated_fat: meal.monounsaturated_fat,
-    trans_fat: meal.trans_fat,
-    cholesterol: meal.cholesterol,
-    sodium: meal.sodium,
-    potassium: meal.potassium,
-    dietary_fiber: meal.dietary_fiber,
-    sugars: meal.sugars,
-    vitamin_a: meal.vitamin_a,
-    vitamin_c: meal.vitamin_c,
-    calcium: meal.calcium,
-    iron: meal.iron,
-    glycemic_index: meal.glycemic_index,
-    custom_nutrients: meal.custom_nutrients,
-  };
-}
-
-function collapseLoggedMealComponents(
-  foodEntries: FoodEntry[],
-  loggedMeals: FoodEntryMeal[],
-): FoodEntry[] {
-  if (loggedMeals.length === 0) {
-    return foodEntries;
-  }
-
-  const mealById = new Map(loggedMeals.map((meal) => [meal.id, meal]));
-  const addedMealIds = new Set<string>();
-  const collapsedEntries: FoodEntry[] = [];
-
-  for (const entry of foodEntries) {
-    const loggedMealId = entry.food_entry_meal_id;
-    if (!loggedMealId) {
-      collapsedEntries.push(entry);
-      continue;
-    }
-
-    const loggedMeal = mealById.get(loggedMealId);
-    if (!loggedMeal) {
-      collapsedEntries.push(entry);
-      continue;
-    }
-
-    if (!addedMealIds.has(loggedMealId)) {
-      collapsedEntries.push(loggedMealToFoodEntry(loggedMeal));
-      addedMealIds.add(loggedMealId);
-    }
-  }
-
-  for (const meal of loggedMeals) {
-    if (!addedMealIds.has(meal.id)) {
-      collapsedEntries.push(loggedMealToFoodEntry(meal));
-    }
-  }
-
-  return collapsedEntries;
-}
-
 export function useDailySummary({ date, enabled = true }: UseDailySummaryOptions) {
   const query = useQuery({
     queryKey: dailySummaryQueryKey(date),
     queryFn: async () => {
       const data = await fetchDailySummary(date);
-      let foodEntries = data.foodEntries;
-
-      if (hasLoggedMealComponents(data.foodEntries)) {
-        try {
-          const loggedMeals = await fetchFoodEntryMealsByDate(date);
-          foodEntries = collapseLoggedMealComponents(data.foodEntries, loggedMeals);
-        } catch {
-          foodEntries = data.foodEntries;
-        }
-      }
+      const foodEntries = await resolveCollapsedFoodEntries(date, data.foodEntries);
 
       return {
         goals: data.goals,

--- a/SparkyFitnessMobile/src/screens/SyncScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SyncScreen.tsx
@@ -6,6 +6,8 @@ import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import SyncFrequency from '../components/SyncFrequency';
 import SyncOnOpen from '../components/SyncOnOpen';
 import HealthDataSync from '../components/HealthDataSync';
+import HealthDataWriteback from '../components/HealthDataWriteback';
+import { WRITEBACK_METRICS, type WritebackMetric } from '../WritebackMetrics';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
 import BottomSheetPicker from '../components/BottomSheetPicker';
@@ -74,6 +76,7 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
   const accentPrimary = useCSSVariable('--color-accent-primary') as string | undefined;
   const [healthMetricStates, setHealthMetricStates] = useState<HealthMetricStates>({});
+  const [writebackStates, setWritebackStates] = useState<Record<string, boolean>>({});
   const [isBackgroundSyncEnabled, setIsBackgroundSyncEnabled] = useState<boolean>(false);
   const [isSyncOnOpenEnabled, setIsSyncOnOpenEnabled] = useState<boolean>(false);
   const [lastSyncedTime, setLastSyncedTime] = useState<string | null>(null);
@@ -117,8 +120,15 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
       newHealthMetricStates[metric.stateKey] = enabled === true;
     }
 
+    const newWritebackStates: Record<string, boolean> = {};
+    for (const metric of WRITEBACK_METRICS) {
+      const enabled = await loadHealthPreference<boolean>(metric.preferenceKey);
+      newWritebackStates[metric.id] = enabled === true;
+    }
+
     setSelectedTimeRange(initialTimeRange);
     setHealthMetricStates(newHealthMetricStates);
+    setWritebackStates(newWritebackStates);
 
     if (initialized) {
       await refreshEnabledMetricPermissions(newHealthMetricStates);
@@ -257,6 +267,42 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
     }
     refreshSubscriptions();
     setHealthDataRefreshKey(k => k + 1);
+  };
+
+  const handleToggleWriteback = async (
+    metric: WritebackMetric,
+    newValue: boolean
+  ): Promise<void> => {
+    setWritebackStates(prev => ({ ...prev, [metric.id]: newValue }));
+    await saveHealthPreference(metric.preferenceKey, newValue);
+    if (!newValue) {
+      return;
+    }
+    // Enabling: request the write permission; revert the toggle if denied.
+    try {
+      const granted = await requestHealthPermissions([metric.permission]);
+      if (!granted) {
+        Alert.alert(
+          'Permission Denied',
+          `Please grant ${metric.label.toLowerCase()} write permission in ${healthSettingsName}.`
+        );
+        setWritebackStates(prev => ({ ...prev, [metric.id]: false }));
+        await saveHealthPreference(metric.preferenceKey, false);
+        addLog(`Writeback permission denied: ${metric.label}.`, 'WARNING');
+      } else {
+        addLog(`${metric.label} writeback enabled and write permission granted.`, 'INFO');
+      }
+    } catch (permissionError) {
+      const errorMessage =
+        permissionError instanceof Error ? permissionError.message : String(permissionError);
+      Alert.alert(
+        'Permission Error',
+        `Failed to request ${metric.label.toLowerCase()} write permission: ${errorMessage}`
+      );
+      setWritebackStates(prev => ({ ...prev, [metric.id]: false }));
+      await saveHealthPreference(metric.preferenceKey, false);
+      addLog(`Writeback permission request error for ${metric.label}: ${errorMessage}`, 'ERROR');
+    }
   };
 
   const handleToggleAllMetrics = async (): Promise<void> => {
@@ -449,6 +495,11 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
           handleToggleAllMetrics={handleToggleAllMetrics}
           healthData={healthData}
           isLoadingHealthData={isLoadingHealthData}
+        />
+
+        <HealthDataWriteback
+          writebackStates={writebackStates}
+          handleToggleWriteback={handleToggleWriteback}
         />
 
         {/* Health Data Report — Android only */}

--- a/SparkyFitnessMobile/src/services/backgroundSyncService.ts
+++ b/SparkyFitnessMobile/src/services/backgroundSyncService.ts
@@ -2,6 +2,7 @@ import * as TaskManager from 'expo-task-manager';
 import * as BackgroundTask from 'expo-background-task';
 import { AppState } from 'react-native';
 import { syncHealthData, HealthDataPayload } from './api/healthDataApi';
+import { runWriteback } from './healthconnect/writeback';
 import { addLog, _flushBuffer } from './LogService';
 import { HEALTH_METRICS } from '../HealthMetrics';
 import {
@@ -278,6 +279,16 @@ const performBackgroundSyncInternal = async (taskId: string): Promise<void> => {
     await addLog(`[Background Sync] Sync completed successfully${syncErrors > 0 ? ` (${syncErrors} metric(s) had errors)` : ''}`, 'INFO');
   } else {
     await addLog(`[Background Sync] No health data collected to sync${syncErrors > 0 ? ` (${syncErrors} metric(s) had errors)` : ''}`, 'INFO');
+  }
+
+  // Outbound phase: SparkyFitness diary → Health Connect (Android-only; iOS no-op).
+  // Runs regardless of inbound results and in its own try/catch so a writeback
+  // failure never affects the inbound sync or its cursor above.
+  try {
+    await runWriteback();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await addLog(`[Background Sync] Writeback phase failed: ${message}`, 'ERROR');
   }
 };
 

--- a/SparkyFitnessMobile/src/services/healthConnectService.ts
+++ b/SparkyFitnessMobile/src/services/healthConnectService.ts
@@ -15,9 +15,16 @@ import {
 import { SyncDuration } from './healthconnect/preferences';
 import { migrateEnabledMetricPermissionsIfNeeded } from './shared/healthPermissionMigration';
 import { runTasksInBatches, TimeoutError, withTimeout } from '../utils/concurrency';
+import { runWriteback } from './healthconnect/writeback';
+import * as Application from 'expo-application';
 
 const METRIC_FETCH_CONCURRENCY = 3;
 const METRIC_TIMEOUT_MS = 60_000; // 60s per metric query
+
+// Tell the read transformers which package is "us" so they skip Health Connect
+// records this app wrote (writeback feedback-loop guard). Resolved once here so
+// the pure transformer module stays free of expo-application.
+HealthConnectTransformation.setOwnPackageName(Application.applicationId);
 
 export const initHealthConnect = HealthConnect.initHealthConnect;
 export const requestHealthPermissions = HealthConnect.requestHealthPermissions;
@@ -262,6 +269,16 @@ export const syncHealthData = async (
       addLog(`[HealthConnectService] Error processing ${type}: ${message}`, 'ERROR');
       syncErrors.push({ type, error: message });
     }
+  }
+
+  // Outbound phase: SparkyFitness diary → Health Connect. Runs before the inbound
+  // result is returned, in its own try/catch so a writeback failure never affects
+  // the inbound sync outcome.
+  try {
+    await runWriteback();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    addLog(`[HealthConnectService] Writeback phase failed: ${message}`, 'ERROR');
   }
 
   if (allTransformedData.length > 0) {

--- a/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
@@ -14,6 +14,26 @@ import {
 import { toLocalDateString } from '../../utils/dateUtils';
 
 // ============================================================================
+// Own-app exclusion (read/write feedback-loop guard)
+// ============================================================================
+
+// Health Connect returns records written by *this* app too. If writeback is on,
+// re-importing them would duplicate diary entries (and compound every sync). Per
+// Google's guidance we skip records whose dataOrigin is our own package. The
+// package name is injected from the service layer (setOwnPackageName) so this
+// pure module needs no expo-application import.
+let ownPackageName: string | null = null;
+export const setOwnPackageName = (pkg: string | null): void => {
+  ownPackageName = pkg;
+};
+
+const isOwnRecord = (rec: Record<string, unknown>): boolean => {
+  if (!ownPackageName) return false;
+  const dataOrigin = (rec.metadata as { dataOrigin?: string } | undefined)?.dataOrigin;
+  return dataOrigin === ownPackageName;
+};
+
+// ============================================================================
 // Transformer Infrastructure
 // ============================================================================
 
@@ -187,6 +207,7 @@ const VALUE_TRANSFORMERS: Record<string, ValueTransformer> = {
   },
 
   Hydration: (rec) => {
+    if (isOwnRecord(rec)) return null; // don't re-import water Sparky wrote
     const value = extractNestedValue(rec, 'volume', 'inLiters');
     const date = getDateString(rec.startTime);
     return value !== null && date ? { value, date } : null;
@@ -492,11 +513,14 @@ const mapHealthConnectMealType = (mealType: unknown): SparkyMealType => {
 // specific unit per nutrient — matching how OpenFoodFacts/Garmin populate them:
 // macros in grams, most minerals/vitamins in mg, a few trace nutrients in mcg.
 // We convert from grams accordingly; otherwise e.g. sodium lands 1000x too low.
-const G_TO_MG = 1_000;
-const G_TO_MCG = 1_000_000;
+export const G_TO_MG = 1_000;
+export const G_TO_MCG = 1_000_000;
 
 // HC NutritionRecord Mass field → { Sparky column, grams→column-unit factor }.
-const HC_NUTRIENT_COLUMNS: { hcField: string; column: string; factor: number }[] = [
+// Exported so the writeback mapper reuses the exact same field/unit mapping
+// (read multiplies grams→column-unit; writeback writes the column value back in
+// that same unit via factor→HC-unit, so the two directions never drift).
+export const HC_NUTRIENT_COLUMNS: { hcField: string; column: string; factor: number }[] = [
   { hcField: 'protein', column: 'protein', factor: 1 },
   { hcField: 'totalCarbohydrate', column: 'carbs', factor: 1 },
   { hcField: 'totalFat', column: 'fat', factor: 1 },
@@ -554,6 +578,7 @@ const extractEnergyKcal = (rec: Record<string, unknown>, field: string): number 
 const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
   Nutrition: (rec, _record, _metricConfig, output) => {
     if (!rec.startTime) return;
+    if (isOwnRecord(rec)) return; // don't re-import nutrition Sparky wrote
 
     const metadata = rec.metadata as { id?: string } | undefined;
     // Skip records without HC's stable id: the server keys idempotent re-sync on

--- a/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
@@ -546,8 +546,9 @@ export const HC_NUTRIENT_COLUMNS: { hcField: string; column: string; factor: num
 // fabricating both the value's unit and a name that nothing renders.
 
 // Strip float noise (4.949999999999999 -> 4.95). Significant figures (not fixed
-// decimals) so small post-conversion values aren't truncated.
-const tidyNumber = (value: number): number => Number(value.toPrecision(6));
+// decimals) so small post-conversion values aren't truncated. Shared with the
+// writeback mappers so read and write rounding can never drift.
+export const tidyNumber = (value: number): number => Number(value.toPrecision(6));
 
 // HC's native bridge emits `{ inGrams: 0 }` / `{ inKilocalories: 0 }` for every
 // nutrient a source did NOT set — it cannot distinguish "0" from "absent". So we

--- a/SparkyFitnessMobile/src/services/healthconnect/writeback.ios.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writeback.ios.ts
@@ -1,0 +1,13 @@
+// iOS no-op: Health Connect writeback is Android-only. Mirrors the platform-split
+// convention so cross-platform callers can import { writebackPhase } unconditionally.
+//
+// To add HealthKit writeback: implement these here using a healthkit/ mapper
+// (parallel to healthconnect/writebackMappers.ts). Note: HealthKit has no
+// clientRecordId — dedupe by tracking saved sample UUIDs instead.
+export const writebackPhase = async (_dates: string[]): Promise<void> => {
+  // intentionally does nothing on iOS
+};
+
+export const runWriteback = async (): Promise<void> => {
+  // intentionally does nothing on iOS
+};

--- a/SparkyFitnessMobile/src/services/healthconnect/writeback.ios.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writeback.ios.ts
@@ -4,10 +4,6 @@
 // To add HealthKit writeback: implement these here using a healthkit/ mapper
 // (parallel to healthconnect/writebackMappers.ts). Note: HealthKit has no
 // clientRecordId — dedupe by tracking saved sample UUIDs instead.
-export const writebackPhase = async (_dates: string[]): Promise<void> => {
-  // intentionally does nothing on iOS
-};
+export const writebackPhase = async (_dates: string[]): Promise<boolean> => true;
 
-export const runWriteback = async (): Promise<void> => {
-  // intentionally does nothing on iOS
-};
+export const runWriteback = async (): Promise<void> => {};

--- a/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
@@ -41,6 +41,18 @@ const loadWrittenIds = async (recordType: string, date: string): Promise<string[
 const saveWrittenIds = (recordType: string, date: string, ids: string[]): Promise<void> =>
   saveHealthPreference(writtenIdsKey(recordType, date), ids);
 
+// Content signature of the last successful write for a date, so an unchanged day can
+// be skipped entirely (no delete/insert) — Health Connect rate-limits writes, and
+// re-writing identical data every sync wastes that quota.
+const writtenSignatureKey = (recordType: string, date: string): string =>
+  `writeback${recordType}Sig:${date}`;
+
+const loadWrittenSignature = (recordType: string, date: string): Promise<string | null> =>
+  loadHealthPreference<string>(writtenSignatureKey(recordType, date));
+
+const saveWrittenSignature = (recordType: string, date: string, signature: string): Promise<void> =>
+  saveHealthPreference(writtenSignatureKey(recordType, date), signature);
+
 // Deterministic replace: delete the exact ids we wrote last run, then insert this
 // run's records (which carry brand-new, version-suffixed clientRecordIds — see
 // writebackMappers). We do NOT rely on Health Connect's clientRecordId+version
@@ -62,6 +74,27 @@ const replaceTrackedRecords = async (
 
 const recordIds = (records: HealthConnectRecord[]): string[] =>
   records.map((r) => r.metadata?.clientRecordId).filter((id): id is string => id != null);
+
+// Order-independent content signature for a run's records, excluding metadata: the
+// clientRecordId carries a per-run version suffix and clientRecordVersion changes
+// every run, so neither belongs in a *content* hash — we want to detect diary
+// changes, not the version stamp.
+const hashString = (value: string): string => {
+  let h = 5381;
+  for (let i = 0; i < value.length; i += 1) h = ((h << 5) + h + value.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(36);
+};
+
+const recordsSignature = (records: HealthConnectRecord[]): string => {
+  const projections = records
+    .map((r) => {
+      const content = { ...(r as unknown as Record<string, unknown>) };
+      delete content.metadata;
+      return JSON.stringify(content);
+    })
+    .sort();
+  return hashString(projections.join('|'));
+};
 
 // Active metrics that also hold a granted write permission. getGrantedPermissions is
 // queried once per run, not per metric/date.
@@ -94,8 +127,15 @@ const writeNutritionForDate = async (
     .map((entry) => foodEntryToNutritionRecord(entry, version))
     .filter((r): r is NonNullable<typeof r> => r !== null);
 
+  const signature = recordsSignature(records);
+  if (signature === (await loadWrittenSignature('Nutrition', date))) {
+    addLog(`[Writeback] Nutrition ${date}: unchanged — skipped`, 'DEBUG');
+    return;
+  }
+
   await replaceTrackedRecords(await loadWrittenIds('Nutrition', date), 'Nutrition', records);
   await saveWrittenIds('Nutrition', date, recordIds(records));
+  await saveWrittenSignature('Nutrition', date, signature);
   addLog(`[Writeback] Nutrition ${date}: wrote ${records.length} record(s)`, 'INFO');
 };
 
@@ -108,8 +148,15 @@ const writeHydrationForDate = async (
   const record = waterMlToHydrationRecord(date, ml, version);
   const records = record ? [record] : [];
 
+  const signature = recordsSignature(records);
+  if (signature === (await loadWrittenSignature('Hydration', date))) {
+    addLog(`[Writeback] Hydration ${date}: unchanged — skipped`, 'DEBUG');
+    return;
+  }
+
   await replaceTrackedRecords(await loadWrittenIds('Hydration', date), 'Hydration', records);
   await saveWrittenIds('Hydration', date, recordIds(records));
+  await saveWrittenSignature('Hydration', date, signature);
   addLog(`[Writeback] Hydration ${date}: ${ml} ml -> wrote ${records.length} record(s)`, 'INFO');
 };
 

--- a/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
@@ -1,0 +1,146 @@
+import {
+  insertRecords,
+  deleteRecordsByUuids,
+  getGrantedPermissions,
+} from 'react-native-health-connect';
+import { addLog } from '../LogService';
+import { fetchDailySummary } from '../api/dailySummaryApi';
+import { resolveCollapsedFoodEntries } from '../../utils/loggedMealCollapse';
+import { loadHealthPreference, saveHealthPreference } from './preferences';
+import { isQuotaExceededError } from './index';
+import { loadLastWritebackTime, saveLastWritebackTime } from '../storage';
+import {
+  foodEntryToNutritionRecord,
+  waterMlToHydrationRecord,
+  nutritionClientRecordId,
+  waterClientRecordId,
+  computeWritebackDates,
+} from './writebackMappers';
+import { WRITEBACK_METRICS, type WritebackMetric } from '../../WritebackMetrics';
+
+// Orchestrates the outbound phase: SparkyFitness diary → Health Connect. Reads
+// the existing daily summary (no server changes), maps to HC records, upserts via
+// insertRecords (idempotent by clientRecordId), and deletes records that no
+// longer exist in the app. Android-only; the iOS entry point is a no-op.
+
+// Per-date set of clientRecordIds we last wrote, so a later sync can delete the
+// ones that disappeared (food deleted / water zeroed). Stored under the same
+// @HealthConnect preference prefix.
+const writtenIdsKey = (metricId: string, date: string): string =>
+  `writeback${metricId}Ids:${date}`;
+
+const loadWrittenIds = async (metricId: string, date: string): Promise<string[]> =>
+  (await loadHealthPreference<string[]>(writtenIdsKey(metricId, date))) ?? [];
+
+const saveWrittenIds = (metricId: string, date: string, ids: string[]): Promise<void> =>
+  saveHealthPreference(writtenIdsKey(metricId, date), ids);
+
+// Delete clientRecordIds we wrote previously but didn't write this run.
+const deleteStale = async (
+  recordType: 'Nutrition' | 'Hydration',
+  previousIds: string[],
+  currentIds: string[],
+): Promise<void> => {
+  const current = new Set(currentIds);
+  const stale = previousIds.filter((id) => !current.has(id));
+  if (stale.length > 0) {
+    await deleteRecordsByUuids(recordType, [], stale);
+    addLog(`[Writeback] Deleted ${stale.length} stale ${recordType} record(s)`, 'DEBUG');
+  }
+};
+
+const hasWritePermission = async (metric: WritebackMetric): Promise<boolean> => {
+  try {
+    const granted = await getGrantedPermissions();
+    return granted.some(
+      (p) =>
+        (p as { recordType?: string; accessType?: string }).recordType === metric.recordType &&
+        (p as { accessType?: string }).accessType === 'write',
+    );
+  } catch {
+    return false;
+  }
+};
+
+const writeNutritionForDate = async (date: string, version: number): Promise<void> => {
+  const summary = await fetchDailySummary(date);
+  const entries = await resolveCollapsedFoodEntries(date, summary.foodEntries);
+
+  const records = entries
+    .map((entry) => foodEntryToNutritionRecord(entry, version))
+    .filter((r): r is NonNullable<typeof r> => r !== null);
+
+  if (records.length > 0) {
+    await insertRecords(records);
+  }
+  const currentIds = entries
+    .filter((e) => e.serving_size !== 0)
+    .map((e) => nutritionClientRecordId(e.id));
+
+  await deleteStale('Nutrition', await loadWrittenIds('Nutrition', date), currentIds);
+  await saveWrittenIds('Nutrition', date, currentIds);
+};
+
+const writeHydrationForDate = async (date: string, version: number): Promise<void> => {
+  const summary = await fetchDailySummary(date);
+  const ml = summary.waterIntake ?? 0;
+  const record = waterMlToHydrationRecord(date, ml, version);
+
+  if (record) {
+    await insertRecords([record]);
+  }
+  const currentIds = record ? [waterClientRecordId(date)] : [];
+
+  await deleteStale('Hydration', await loadWrittenIds('Hydration', date), currentIds);
+  await saveWrittenIds('Hydration', date, currentIds);
+};
+
+/**
+ * Run the writeback phase for the given calendar dates. Gated per-metric on the
+ * opt-in preference AND a granted write permission. Each metric/date is isolated
+ * so one failure doesn't abort the rest; a Health Connect quota error stops the
+ * phase early (it will resume next sync).
+ */
+export const writebackPhase = async (dates: string[]): Promise<void> => {
+  const enabled = await Promise.all(
+    WRITEBACK_METRICS.map((m) => loadHealthPreference<boolean>(m.preferenceKey)),
+  );
+  const active = WRITEBACK_METRICS.filter((_, i) => enabled[i] === true);
+  if (active.length === 0) return;
+
+  const version = Date.now(); // monotonic clientRecordVersion so edits overwrite
+
+  for (const metric of active) {
+    if (!(await hasWritePermission(metric))) {
+      addLog(`[Writeback] Skipping ${metric.label}: write permission not granted`, 'WARNING');
+      continue;
+    }
+    for (const date of dates) {
+      try {
+        if (metric.id === 'nutrition') {
+          await writeNutritionForDate(date, version);
+        } else {
+          await writeHydrationForDate(date, version);
+        }
+      } catch (error) {
+        if (isQuotaExceededError(error)) {
+          addLog('[Writeback] Health Connect quota exceeded — stopping; resumes next sync', 'WARNING');
+          return;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        addLog(`[Writeback] Failed ${metric.label} for ${date}: ${message}`, 'ERROR');
+      }
+    }
+  }
+};
+
+/**
+ * Cursor-aware entry point called from the sync engine. Computes the date window,
+ * runs the writeback phase, and advances the writeback cursor on completion.
+ * Callers wrap this in their own try/catch so writeback can't block inbound sync.
+ */
+export const runWriteback = async (): Promise<void> => {
+  const dates = computeWritebackDates(await loadLastWritebackTime());
+  await writebackPhase(dates);
+  await saveLastWritebackTime();
+};

--- a/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
@@ -17,22 +17,29 @@ import {
 } from './writebackMappers';
 import { WRITEBACK_METRICS, type WritebackMetric } from '../../WritebackMetrics';
 
-// Orchestrates the outbound phase: SparkyFitness diary → Health Connect. Reads
-// the existing daily summary, maps the manually-logged entries to HC records, and
+type DailySummary = Awaited<ReturnType<typeof fetchDailySummary>>;
+
+// Orchestrates the outbound phase: SparkyFitness diary → Health Connect. Reads the
+// daily summary once per date, maps the manually-logged entries to HC records, and
 // replaces the previous run's records (delete-then-insert with fresh ids). Android
 // only; the iOS entry point is a no-op.
 
+const message = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
 // Per-date set of clientRecordIds we last wrote, so the next run can delete exactly
 // those before inserting fresh ones (handles add / edit / delete uniformly).
-// Stored under the same @HealthConnect preference prefix.
-const writtenIdsKey = (metricId: string, date: string): string =>
-  `writeback${metricId}Ids:${date}`;
+const writtenIdsKey = (recordType: string, date: string): string =>
+  `writeback${recordType}Ids:${date}`;
 
-const loadWrittenIds = async (metricId: string, date: string): Promise<string[]> =>
-  (await loadHealthPreference<string[]>(writtenIdsKey(metricId, date))) ?? [];
+const loadWrittenIds = async (recordType: string, date: string): Promise<string[]> =>
+  (await loadHealthPreference<string[]>(writtenIdsKey(recordType, date))) ?? [];
 
-const saveWrittenIds = (metricId: string, date: string, ids: string[]): Promise<void> =>
-  saveHealthPreference(writtenIdsKey(metricId, date), ids);
+// Persisted AFTER the insert resolves. A crash in that gap orphans the just-written
+// records (the next run can't find them to delete) — a rare, self-correcting-on-edit
+// tradeoff we accept rather than a write-ahead log.
+const saveWrittenIds = (recordType: string, date: string, ids: string[]): Promise<void> =>
+  saveHealthPreference(writtenIdsKey(recordType, date), ids);
 
 // Deterministic replace: delete the exact ids we wrote last run, then insert this
 // run's records (which carry brand-new, version-suffixed clientRecordIds — see
@@ -40,7 +47,7 @@ const saveWrittenIds = (metricId: string, date: string, ids: string[]): Promise<
 // upsert: via the RN bridge it does not reliably overwrite on edit, and re-inserting
 // a stable id we just deleted is rejected (HC tombstones deleted clientRecordIds).
 // Fresh ids each run sidestep both. Mirrors the read/Garmin provider pattern.
-const replaceProviderRecords = async (
+const replaceTrackedRecords = async (
   previousIds: string[],
   recordType: 'Nutrition' | 'Hydration',
   records: HealthConnectRecord[],
@@ -53,25 +60,30 @@ const replaceProviderRecords = async (
   }
 };
 
-// clientRecordIds of the records actually built this run (what we just inserted).
 const recordIds = (records: HealthConnectRecord[]): string[] =>
   records.map((r) => r.metadata?.clientRecordId).filter((id): id is string => id != null);
 
-const hasWritePermission = async (metric: WritebackMetric): Promise<boolean> => {
+// Active metrics that also hold a granted write permission. getGrantedPermissions is
+// queried once per run, not per metric/date.
+const writableMetrics = async (metrics: WritebackMetric[]): Promise<WritebackMetric[]> => {
+  let granted: { recordType?: string; accessType?: string }[];
   try {
-    const granted = await getGrantedPermissions();
-    return granted.some(
-      (p) =>
-        (p as { recordType?: string; accessType?: string }).recordType === metric.recordType &&
-        (p as { accessType?: string }).accessType === 'write',
-    );
+    granted = await getGrantedPermissions();
   } catch {
-    return false;
+    return [];
   }
+  return metrics.filter((m) => {
+    const ok = granted.some((p) => p.recordType === m.recordType && p.accessType === 'write');
+    if (!ok) addLog(`[Writeback] Skipping ${m.label}: write permission not granted`, 'WARNING');
+    return ok;
+  });
 };
 
-const writeNutritionForDate = async (date: string, version: number): Promise<void> => {
-  const summary = await fetchDailySummary(date);
+const writeNutritionForDate = async (
+  date: string,
+  summary: DailySummary,
+  version: number,
+): Promise<void> => {
   const entries = await resolveCollapsedFoodEntries(date, summary.foodEntries);
 
   // Only write entries that originated in Sparky. Entries with a `source` were
@@ -82,70 +94,82 @@ const writeNutritionForDate = async (date: string, version: number): Promise<voi
     .map((entry) => foodEntryToNutritionRecord(entry, version))
     .filter((r): r is NonNullable<typeof r> => r !== null);
 
-  const previousIds = await loadWrittenIds('Nutrition', date);
-  await replaceProviderRecords(previousIds, 'Nutrition', records);
+  await replaceTrackedRecords(await loadWrittenIds('Nutrition', date), 'Nutrition', records);
   await saveWrittenIds('Nutrition', date, recordIds(records));
   addLog(`[Writeback] Nutrition ${date}: wrote ${records.length} record(s)`, 'INFO');
 };
 
-const writeHydrationForDate = async (date: string, version: number): Promise<void> => {
-  const summary = await fetchDailySummary(date);
+const writeHydrationForDate = async (
+  date: string,
+  summary: DailySummary,
+  version: number,
+): Promise<void> => {
   const ml = summary.waterIntake ?? 0;
   const record = waterMlToHydrationRecord(date, ml, version);
   const records = record ? [record] : [];
 
-  const previousIds = await loadWrittenIds('Hydration', date);
-  await replaceProviderRecords(previousIds, 'Hydration', records);
+  await replaceTrackedRecords(await loadWrittenIds('Hydration', date), 'Hydration', records);
   await saveWrittenIds('Hydration', date, recordIds(records));
   addLog(`[Writeback] Hydration ${date}: ${ml} ml -> wrote ${records.length} record(s)`, 'INFO');
 };
 
 /**
  * Run the writeback phase for the given calendar dates. Gated per-metric on the
- * opt-in preference AND a granted write permission. Each metric/date is isolated
- * so one failure doesn't abort the rest; a Health Connect quota error stops the
- * phase early (it will resume next sync).
+ * opt-in preference AND a granted write permission. Each metric/date is isolated so
+ * one failure doesn't abort the rest. Returns `false` if a Health Connect quota
+ * error stopped the run early — the caller holds the cursor so the unwritten dates
+ * retry next sync; `true` once every date has been attempted. A metric the user
+ * hasn't granted is skipped without holding the cursor (otherwise it would retry
+ * forever); a per-date failure is logged and reconciled by the cursor's overlap.
  */
-export const writebackPhase = async (dates: string[]): Promise<void> => {
+export const writebackPhase = async (dates: string[]): Promise<boolean> => {
   const enabled = await Promise.all(
     WRITEBACK_METRICS.map((m) => loadHealthPreference<boolean>(m.preferenceKey)),
   );
   const active = WRITEBACK_METRICS.filter((_, i) => enabled[i] === true);
-  if (active.length === 0) return;
+  if (active.length === 0) return true;
 
-  const version = Date.now(); // monotonic clientRecordVersion so edits overwrite
+  const writable = await writableMetrics(active);
+  if (writable.length === 0) return true;
 
-  for (const metric of active) {
-    if (!(await hasWritePermission(metric))) {
-      addLog(`[Writeback] Skipping ${metric.label}: write permission not granted`, 'WARNING');
+  // Also the clientRecordId suffix, so each run writes fresh ids (see writebackMappers).
+  const version = Date.now();
+
+  for (const date of dates) {
+    let summary: DailySummary;
+    try {
+      summary = await fetchDailySummary(date); // once per date, shared by both metrics
+    } catch (error) {
+      addLog(`[Writeback] Failed to load summary for ${date}: ${message(error)}`, 'ERROR');
       continue;
     }
-    for (const date of dates) {
+    for (const metric of writable) {
       try {
         if (metric.id === 'nutrition') {
-          await writeNutritionForDate(date, version);
+          await writeNutritionForDate(date, summary, version);
         } else {
-          await writeHydrationForDate(date, version);
+          await writeHydrationForDate(date, summary, version);
         }
       } catch (error) {
         if (isQuotaExceededError(error)) {
           addLog('[Writeback] Health Connect quota exceeded — stopping; resumes next sync', 'WARNING');
-          return;
+          return false;
         }
-        const message = error instanceof Error ? error.message : String(error);
-        addLog(`[Writeback] Failed ${metric.label} for ${date}: ${message}`, 'ERROR');
+        addLog(`[Writeback] Failed ${metric.label} for ${date}: ${message(error)}`, 'ERROR');
       }
     }
   }
+  return true;
 };
 
 /**
  * Cursor-aware entry point called from the sync engine. Computes the date window,
- * runs the writeback phase, and advances the writeback cursor on completion.
+ * runs the writeback phase, and advances the cursor only on a complete run (a
+ * quota-stopped run keeps the cursor so the unwritten dates retry next sync).
  * Callers wrap this in their own try/catch so writeback can't block inbound sync.
  */
 export const runWriteback = async (): Promise<void> => {
   const dates = computeWritebackDates(await loadLastWritebackTime());
-  await writebackPhase(dates);
-  await saveLastWritebackTime();
+  const completed = await writebackPhase(dates);
+  if (completed) await saveLastWritebackTime();
 };

--- a/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
@@ -2,6 +2,7 @@ import {
   insertRecords,
   deleteRecordsByUuids,
   getGrantedPermissions,
+  type HealthConnectRecord,
 } from 'react-native-health-connect';
 import { addLog } from '../LogService';
 import { fetchDailySummary } from '../api/dailySummaryApi';
@@ -12,20 +13,18 @@ import { loadLastWritebackTime, saveLastWritebackTime } from '../storage';
 import {
   foodEntryToNutritionRecord,
   waterMlToHydrationRecord,
-  nutritionClientRecordId,
-  waterClientRecordId,
   computeWritebackDates,
 } from './writebackMappers';
 import { WRITEBACK_METRICS, type WritebackMetric } from '../../WritebackMetrics';
 
 // Orchestrates the outbound phase: SparkyFitness diary → Health Connect. Reads
-// the existing daily summary (no server changes), maps to HC records, upserts via
-// insertRecords (idempotent by clientRecordId), and deletes records that no
-// longer exist in the app. Android-only; the iOS entry point is a no-op.
+// the existing daily summary, maps the manually-logged entries to HC records, and
+// replaces the previous run's records (delete-then-insert with fresh ids). Android
+// only; the iOS entry point is a no-op.
 
-// Per-date set of clientRecordIds we last wrote, so a later sync can delete the
-// ones that disappeared (food deleted / water zeroed). Stored under the same
-// @HealthConnect preference prefix.
+// Per-date set of clientRecordIds we last wrote, so the next run can delete exactly
+// those before inserting fresh ones (handles add / edit / delete uniformly).
+// Stored under the same @HealthConnect preference prefix.
 const writtenIdsKey = (metricId: string, date: string): string =>
   `writeback${metricId}Ids:${date}`;
 
@@ -35,19 +34,28 @@ const loadWrittenIds = async (metricId: string, date: string): Promise<string[]>
 const saveWrittenIds = (metricId: string, date: string, ids: string[]): Promise<void> =>
   saveHealthPreference(writtenIdsKey(metricId, date), ids);
 
-// Delete clientRecordIds we wrote previously but didn't write this run.
-const deleteStale = async (
-  recordType: 'Nutrition' | 'Hydration',
+// Deterministic replace: delete the exact ids we wrote last run, then insert this
+// run's records (which carry brand-new, version-suffixed clientRecordIds — see
+// writebackMappers). We do NOT rely on Health Connect's clientRecordId+version
+// upsert: via the RN bridge it does not reliably overwrite on edit, and re-inserting
+// a stable id we just deleted is rejected (HC tombstones deleted clientRecordIds).
+// Fresh ids each run sidestep both. Mirrors the read/Garmin provider pattern.
+const replaceProviderRecords = async (
   previousIds: string[],
-  currentIds: string[],
+  recordType: 'Nutrition' | 'Hydration',
+  records: HealthConnectRecord[],
 ): Promise<void> => {
-  const current = new Set(currentIds);
-  const stale = previousIds.filter((id) => !current.has(id));
-  if (stale.length > 0) {
-    await deleteRecordsByUuids(recordType, [], stale);
-    addLog(`[Writeback] Deleted ${stale.length} stale ${recordType} record(s)`, 'DEBUG');
+  if (previousIds.length > 0) {
+    await deleteRecordsByUuids(recordType, [], previousIds);
+  }
+  if (records.length > 0) {
+    await insertRecords(records);
   }
 };
+
+// clientRecordIds of the records actually built this run (what we just inserted).
+const recordIds = (records: HealthConnectRecord[]): string[] =>
+  records.map((r) => r.metadata?.clientRecordId).filter((id): id is string => id != null);
 
 const hasWritePermission = async (metric: WritebackMetric): Promise<boolean> => {
   try {
@@ -66,33 +74,30 @@ const writeNutritionForDate = async (date: string, version: number): Promise<voi
   const summary = await fetchDailySummary(date);
   const entries = await resolveCollapsedFoodEntries(date, summary.foodEntries);
 
+  // Only write entries that originated in Sparky. Entries with a `source` were
+  // imported from a provider (e.g. Health Connect itself) — re-exporting them
+  // would duplicate that provider's own data back into HC.
   const records = entries
+    .filter((e) => !e.source)
     .map((entry) => foodEntryToNutritionRecord(entry, version))
     .filter((r): r is NonNullable<typeof r> => r !== null);
 
-  if (records.length > 0) {
-    await insertRecords(records);
-  }
-  const currentIds = entries
-    .filter((e) => e.serving_size !== 0)
-    .map((e) => nutritionClientRecordId(e.id));
-
-  await deleteStale('Nutrition', await loadWrittenIds('Nutrition', date), currentIds);
-  await saveWrittenIds('Nutrition', date, currentIds);
+  const previousIds = await loadWrittenIds('Nutrition', date);
+  await replaceProviderRecords(previousIds, 'Nutrition', records);
+  await saveWrittenIds('Nutrition', date, recordIds(records));
+  addLog(`[Writeback] Nutrition ${date}: wrote ${records.length} record(s)`, 'INFO');
 };
 
 const writeHydrationForDate = async (date: string, version: number): Promise<void> => {
   const summary = await fetchDailySummary(date);
   const ml = summary.waterIntake ?? 0;
   const record = waterMlToHydrationRecord(date, ml, version);
+  const records = record ? [record] : [];
 
-  if (record) {
-    await insertRecords([record]);
-  }
-  const currentIds = record ? [waterClientRecordId(date)] : [];
-
-  await deleteStale('Hydration', await loadWrittenIds('Hydration', date), currentIds);
-  await saveWrittenIds('Hydration', date, currentIds);
+  const previousIds = await loadWrittenIds('Hydration', date);
+  await replaceProviderRecords(previousIds, 'Hydration', records);
+  await saveWrittenIds('Hydration', date, recordIds(records));
+  addLog(`[Writeback] Hydration ${date}: ${ml} ml -> wrote ${records.length} record(s)`, 'INFO');
 };
 
 /**

--- a/SparkyFitnessMobile/src/services/healthconnect/writebackMappers.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writebackMappers.ts
@@ -4,8 +4,8 @@ import {
   type HydrationRecord,
 } from 'react-native-health-connect';
 import type { FoodEntry } from '../../types/foodEntries';
-import { HC_NUTRIENT_COLUMNS, G_TO_MG, G_TO_MCG } from './dataTransformation';
-import { toLocalDateString } from '../../utils/dateUtils';
+import { HC_NUTRIENT_COLUMNS, G_TO_MG, G_TO_MCG, tidyNumber } from './dataTransformation';
+import { toLocalDateString, addDays } from '../../utils/dateUtils';
 
 // HC Mass units we emit (subset of the library's Mass['unit']).
 type MassUnit = 'grams' | 'milligrams' | 'micrograms';
@@ -63,9 +63,6 @@ const MEAL_START_HM: Record<string, [number, number]> = {
   dinner: [19, 0],
   snacks: [15, 0],
 };
-
-// Strip float noise from scaling (0.1*3 -> 0.30000000000000004 -> 0.3).
-const tidy = (value: number): number => Number(value.toPrecision(6));
 
 // Consumed amount of a per-serving snapshot value — same formula the diary uses
 // (calculateMacro / calculateCaloriesConsumed in foodEntriesApi). For collapsed
@@ -135,7 +132,7 @@ export const foodEntryToNutritionRecord = (
 
   const calories = scaleConsumed(entry.calories, entry.quantity, entry.serving_size);
   if (calories != null && calories > 0) {
-    record.energy = { value: tidy(calories), unit: 'kilocalories' };
+    record.energy = { value: tidyNumber(calories), unit: 'kilocalories' };
   }
 
   // Each nutrient is written in the unit Sparky stores it in (factor → HC unit),
@@ -148,7 +145,7 @@ export const foodEntryToNutritionRecord = (
     );
     if (value != null && value > 0) {
       record[hcField] = {
-        value: tidy(value),
+        value: tidyNumber(value),
         unit: MASS_UNIT_BY_FACTOR[factor] ?? 'grams',
       };
     }
@@ -201,13 +198,15 @@ export const computeWritebackDates = (
 ): string[] => {
   let backDays = 1; // default: yesterday + today
   if (lastWritebackIso) {
-    const last = new Date(lastWritebackIso);
-    const elapsed = Math.floor((now.getTime() - last.getTime()) / DAY_MS);
+    const elapsed = Math.floor((now.getTime() - new Date(lastWritebackIso).getTime()) / DAY_MS);
     backDays = Math.min(Math.max(elapsed + 1, 1), MAX_WRITEBACK_DAYS);
   }
+  // Generate calendar days with addDays (local, DST-safe) rather than subtracting
+  // fixed-millisecond offsets, which can skip/duplicate a day across a DST boundary.
+  const today = toLocalDateString(now);
   const dates: string[] = [];
   for (let i = backDays; i >= 0; i--) {
-    dates.push(toLocalDateString(new Date(now.getTime() - i * DAY_MS)));
+    dates.push(addDays(today, -i));
   }
-  return Array.from(new Set(dates));
+  return dates;
 };

--- a/SparkyFitnessMobile/src/services/healthconnect/writebackMappers.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writebackMappers.ts
@@ -79,15 +79,35 @@ const scaleConsumed = (
   return (value * quantity) / servingSize;
 };
 
+const MINUTE_MS = 60_000;
+
 const localDayInstant = (date: string, hour: number, minute: number): Date => {
   const d = new Date(`${date}T00:00:00`); // parsed in device-local time
   d.setHours(hour, minute, 0, 0);
   return d;
 };
 
+// A short interval anchored to a representative local meal time. Returns null when
+// the anchor is still in the future — Health Connect rejects records whose time is
+// after "now" (and one bad record fails the whole insert batch). A snack logged at
+// 13:00 anchors to 15:00, so we defer it; a later sync writes it once 15:00 has
+// passed (the entry's day stays in the writeback window). Past dates never defer.
+const recordInterval = (
+  date: string,
+  hour: number,
+  minute: number,
+  now: Date = new Date(),
+): { start: string; end: string } | null => {
+  const start = localDayInstant(date, hour, minute);
+  const end = new Date(start.getTime() + MINUTE_MS);
+  if (end.getTime() > now.getTime()) return null;
+  return { start: start.toISOString(), end: end.toISOString() };
+};
+
 /**
  * Map one Sparky food entry to a Health Connect NutritionRecord.
- * Returns null when the entry can't be scaled (serving_size === 0).
+ * Returns null when the entry can't be scaled (serving_size === 0) or its meal-time
+ * anchor is still in the future (deferred to a later sync).
  */
 export const foodEntryToNutritionRecord = (
   entry: FoodEntry,
@@ -96,14 +116,14 @@ export const foodEntryToNutritionRecord = (
   if (entry.serving_size === 0) return null;
 
   const [hour, minute] = MEAL_START_HM[entry.meal_type] ?? MEAL_START_HM.snacks;
-  const start = localDayInstant(entry.entry_date, hour, minute);
-  const end = new Date(start.getTime() + 60_000);
+  const interval = recordInterval(entry.entry_date, hour, minute);
+  if (!interval) return null; // anchor still in the future — defer to a later sync
 
   // Built as a loose record because nutrient columns are assigned by dynamic key.
   const record: Record<string, unknown> = {
     recordType: 'Nutrition',
-    startTime: start.toISOString(),
-    endTime: end.toISOString(),
+    startTime: interval.start,
+    endTime: interval.end,
     mealType: mealSlugToInt(entry.meal_type),
     name: entry.food_name || 'SparkyFitness food',
     metadata: {
@@ -140,7 +160,8 @@ export const foodEntryToNutritionRecord = (
 /**
  * Map a day's total water (ml) to a Health Connect HydrationRecord.
  * Returns null when there's nothing to write (ml <= 0) — the caller treats that
- * as "delete the day's record" rather than writing an empty one.
+ * as "delete the day's record" rather than writing an empty one — or when the noon
+ * anchor is still in the future (deferred to a later sync).
  */
 export const waterMlToHydrationRecord = (
   entryDate: string,
@@ -149,13 +170,13 @@ export const waterMlToHydrationRecord = (
 ): HydrationRecord | null => {
   if (ml <= 0) return null;
 
-  const start = localDayInstant(entryDate, 12, 0);
-  const end = new Date(start.getTime() + 60_000); // Hydration is an interval record
+  const interval = recordInterval(entryDate, 12, 0); // Hydration is an interval record
+  if (!interval) return null; // noon anchor still in the future — defer to a later sync
 
   return {
     recordType: 'Hydration',
-    startTime: start.toISOString(),
-    endTime: end.toISOString(),
+    startTime: interval.start,
+    endTime: interval.end,
     volume: { value: ml, unit: 'milliliters' },
     metadata: {
       clientRecordId: waterClientRecordId(entryDate, clientRecordVersion),

--- a/SparkyFitnessMobile/src/services/healthconnect/writebackMappers.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writebackMappers.ts
@@ -1,0 +1,184 @@
+import {
+  RecordingMethod,
+  type NutritionRecord,
+  type HydrationRecord,
+} from 'react-native-health-connect';
+import type { FoodEntry } from '../../types/foodEntries';
+import { HC_NUTRIENT_COLUMNS, G_TO_MG, G_TO_MCG } from './dataTransformation';
+import { toLocalDateString } from '../../utils/dateUtils';
+
+// HC Mass units we emit (subset of the library's Mass['unit']).
+type MassUnit = 'grams' | 'milligrams' | 'micrograms';
+
+// Pure mappers: SparkyFitness diary data → Health Connect write records. No HC
+// I/O here so this stays unit-testable. The orchestrator (writeback.ts) supplies
+// `clientRecordVersion` (a timestamp) and performs the actual insert/delete.
+
+/** Prefix on every clientRecordId Sparky writes, so the read path can recognise
+ *  and skip its own records (see the read transformers' dataOrigin guard, which
+ *  is the canonical exclusion; this prefix is purely a write-side namespace). */
+export const SPARKY_CLIENT_RECORD_PREFIX = 'sparky-';
+
+/** Stable per-food-entry id — Health Connect upserts on it, so edits replace. */
+export const nutritionClientRecordId = (entryId: string): string =>
+  `${SPARKY_CLIENT_RECORD_PREFIX}nutrition-${entryId}`;
+
+/** One water record per day, keyed by date. */
+export const waterClientRecordId = (entryDate: string): string =>
+  `${SPARKY_CLIENT_RECORD_PREFIX}water-${entryDate}`;
+
+// factor (from HC_NUTRIENT_COLUMNS) → the HC Mass unit Sparky already stores that
+// column in, so we write the value verbatim with no conversion (and never drift
+// from the read side, which multiplies grams by the same factor).
+const MASS_UNIT_BY_FACTOR: Record<number, MassUnit> = {
+  [1]: 'grams',
+  [G_TO_MG]: 'milligrams',
+  [G_TO_MCG]: 'micrograms',
+};
+
+// Sparky meal slug → Health Connect MealType int (inverse of the read side's
+// mapHealthConnectMealType; HC: BREAKFAST=1, LUNCH=2, DINNER=3, SNACK=4).
+// Unknown/custom meal types fall back to snack (HC has no neutral bucket).
+const MEAL_TYPE_INT: Record<string, number> = {
+  breakfast: 1,
+  lunch: 2,
+  dinner: 3,
+  snacks: 4,
+};
+const mealSlugToInt = (slug: string): number => MEAL_TYPE_INT[slug] ?? 4;
+
+// Food entries carry only a calendar date; HC needs an instant. Anchor each meal
+// to a representative local time so records order sensibly within the day.
+const MEAL_START_HM: Record<string, [number, number]> = {
+  breakfast: [8, 0],
+  lunch: [12, 30],
+  dinner: [19, 0],
+  snacks: [15, 0],
+};
+
+// Strip float noise from scaling (0.1*3 -> 0.30000000000000004 -> 0.3).
+const tidy = (value: number): number => Number(value.toPrecision(6));
+
+// Consumed amount of a per-serving snapshot value — same formula the diary uses
+// (calculateMacro / calculateCaloriesConsumed in foodEntriesApi). For collapsed
+// logged meals serving_size === quantity, so this returns the meal's own total.
+const scaleConsumed = (
+  value: number | undefined,
+  quantity: number,
+  servingSize: number,
+): number | undefined => {
+  if (servingSize === 0 || value == null || isNaN(value)) return undefined;
+  return (value * quantity) / servingSize;
+};
+
+const localDayInstant = (date: string, hour: number, minute: number): Date => {
+  const d = new Date(`${date}T00:00:00`); // parsed in device-local time
+  d.setHours(hour, minute, 0, 0);
+  return d;
+};
+
+/**
+ * Map one Sparky food entry to a Health Connect NutritionRecord.
+ * Returns null when the entry can't be scaled (serving_size === 0).
+ */
+export const foodEntryToNutritionRecord = (
+  entry: FoodEntry,
+  clientRecordVersion: number,
+): NutritionRecord | null => {
+  if (entry.serving_size === 0) return null;
+
+  const [hour, minute] = MEAL_START_HM[entry.meal_type] ?? MEAL_START_HM.snacks;
+  const start = localDayInstant(entry.entry_date, hour, minute);
+  const end = new Date(start.getTime() + 60_000);
+
+  // Built as a loose record because nutrient columns are assigned by dynamic key.
+  const record: Record<string, unknown> = {
+    recordType: 'Nutrition',
+    startTime: start.toISOString(),
+    endTime: end.toISOString(),
+    mealType: mealSlugToInt(entry.meal_type),
+    name: entry.food_name || 'SparkyFitness food',
+    metadata: {
+      clientRecordId: nutritionClientRecordId(entry.id),
+      clientRecordVersion,
+      recordingMethod: RecordingMethod.RECORDING_METHOD_MANUAL_ENTRY,
+    },
+  };
+
+  const calories = scaleConsumed(entry.calories, entry.quantity, entry.serving_size);
+  if (calories != null && calories > 0) {
+    record.energy = { value: tidy(calories), unit: 'kilocalories' };
+  }
+
+  // Each nutrient is written in the unit Sparky stores it in (factor → HC unit),
+  // so no conversion is needed. Zero/absent values are omitted, not written as 0.
+  for (const { hcField, column, factor } of HC_NUTRIENT_COLUMNS) {
+    const value = scaleConsumed(
+      entry[column as keyof FoodEntry] as number | undefined,
+      entry.quantity,
+      entry.serving_size,
+    );
+    if (value != null && value > 0) {
+      record[hcField] = {
+        value: tidy(value),
+        unit: MASS_UNIT_BY_FACTOR[factor] ?? 'grams',
+      };
+    }
+  }
+
+  return record as unknown as NutritionRecord;
+};
+
+/**
+ * Map a day's total water (ml) to a Health Connect HydrationRecord.
+ * Returns null when there's nothing to write (ml <= 0) — the caller treats that
+ * as "delete the day's record" rather than writing an empty one.
+ */
+export const waterMlToHydrationRecord = (
+  entryDate: string,
+  ml: number,
+  clientRecordVersion: number,
+): HydrationRecord | null => {
+  if (ml <= 0) return null;
+
+  const start = localDayInstant(entryDate, 12, 0);
+  const end = new Date(start.getTime() + 60_000); // Hydration is an interval record
+
+  return {
+    recordType: 'Hydration',
+    startTime: start.toISOString(),
+    endTime: end.toISOString(),
+    volume: { value: ml, unit: 'milliliters' },
+    metadata: {
+      clientRecordId: waterClientRecordId(entryDate),
+      clientRecordVersion,
+      recordingMethod: RecordingMethod.RECORDING_METHOD_MANUAL_ENTRY,
+    },
+  } as HydrationRecord;
+};
+
+const DAY_MS = 86_400_000;
+const MAX_WRITEBACK_DAYS = 7;
+
+/**
+ * Local calendar days to write on a run: from one day before the last successful
+ * writeback (1-day overlap so edits/deletes near midnight reconcile) up to today,
+ * capped at MAX_WRITEBACK_DAYS. Defaults to yesterday+today on first run. `now` is
+ * injectable for tests. Pure (no storage) so it lives with the mappers.
+ */
+export const computeWritebackDates = (
+  lastWritebackIso: string | null,
+  now: Date = new Date(),
+): string[] => {
+  let backDays = 1; // default: yesterday + today
+  if (lastWritebackIso) {
+    const last = new Date(lastWritebackIso);
+    const elapsed = Math.floor((now.getTime() - last.getTime()) / DAY_MS);
+    backDays = Math.min(Math.max(elapsed + 1, 1), MAX_WRITEBACK_DAYS);
+  }
+  const dates: string[] = [];
+  for (let i = backDays; i >= 0; i--) {
+    dates.push(toLocalDateString(new Date(now.getTime() - i * DAY_MS)));
+  }
+  return Array.from(new Set(dates));
+};

--- a/SparkyFitnessMobile/src/services/healthconnect/writebackMappers.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writebackMappers.ts
@@ -19,13 +19,21 @@ type MassUnit = 'grams' | 'milligrams' | 'micrograms';
  *  is the canonical exclusion; this prefix is purely a write-side namespace). */
 export const SPARKY_CLIENT_RECORD_PREFIX = 'sparky-';
 
-/** Stable per-food-entry id — Health Connect upserts on it, so edits replace. */
-export const nutritionClientRecordId = (entryId: string): string =>
-  `${SPARKY_CLIENT_RECORD_PREFIX}nutrition-${entryId}`;
+// clientRecordIds embed the write version (a timestamp) so every run produces
+// *fresh* ids. The orchestrator deletes the previous run's ids and inserts these,
+// rather than reusing a stable id: Health Connect tombstones a deleted
+// clientRecordId and silently rejects re-inserting it, so an edit done as
+// delete-then-insert on the same id would vanish. Fresh ids sidestep that (and the
+// unreliable clientRecordId+version upsert) — dedup is via the tracked id set, the
+// same delete-then-insert pattern the read/Garmin provider path uses.
 
-/** One water record per day, keyed by date. */
-export const waterClientRecordId = (entryDate: string): string =>
-  `${SPARKY_CLIENT_RECORD_PREFIX}water-${entryDate}`;
+/** Per-food-entry id for one write run (entry id + version → unique per run). */
+export const nutritionClientRecordId = (entryId: string, version: number): string =>
+  `${SPARKY_CLIENT_RECORD_PREFIX}nutrition-${entryId}-${version}`;
+
+/** One water record per day, scoped to the write run by version. */
+export const waterClientRecordId = (entryDate: string, version: number): string =>
+  `${SPARKY_CLIENT_RECORD_PREFIX}water-${entryDate}-${version}`;
 
 // factor (from HC_NUTRIENT_COLUMNS) → the HC Mass unit Sparky already stores that
 // column in, so we write the value verbatim with no conversion (and never drift
@@ -99,7 +107,7 @@ export const foodEntryToNutritionRecord = (
     mealType: mealSlugToInt(entry.meal_type),
     name: entry.food_name || 'SparkyFitness food',
     metadata: {
-      clientRecordId: nutritionClientRecordId(entry.id),
+      clientRecordId: nutritionClientRecordId(entry.id, clientRecordVersion),
       clientRecordVersion,
       recordingMethod: RecordingMethod.RECORDING_METHOD_MANUAL_ENTRY,
     },
@@ -150,7 +158,7 @@ export const waterMlToHydrationRecord = (
     endTime: end.toISOString(),
     volume: { value: ml, unit: 'milliliters' },
     metadata: {
-      clientRecordId: waterClientRecordId(entryDate),
+      clientRecordId: waterClientRecordId(entryDate, clientRecordVersion),
       clientRecordVersion,
       recordingMethod: RecordingMethod.RECORDING_METHOD_MANUAL_ENTRY,
     },

--- a/SparkyFitnessMobile/src/services/healthconnect/writebackMappers.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writebackMappers.ts
@@ -72,16 +72,19 @@ const scaleConsumed = (
   quantity: number,
   servingSize: number,
 ): number | undefined => {
-  if (servingSize === 0 || value == null || isNaN(value)) return undefined;
+  // Guard falsy serving sizes (0/null/undefined/NaN): the type says number, but the
+  // daily-summary can return null, and `x / null` coerces to `x / 0` → Infinity.
+  if (!servingSize || value == null || isNaN(value)) return undefined;
   return (value * quantity) / servingSize;
 };
 
 const MINUTE_MS = 60_000;
 
 const localDayInstant = (date: string, hour: number, minute: number): Date => {
-  const d = new Date(`${date}T00:00:00`); // parsed in device-local time
-  d.setHours(hour, minute, 0, 0);
-  return d;
+  // Construct from parts in local time. `new Date('YYYY-MM-DDT00:00:00')` is parsed
+  // as UTC in some JS engines, which shifts the calendar day for non-UTC offsets.
+  const [year, month, day] = date.split('-').map(Number);
+  return new Date(year, month - 1, day, hour, minute, 0, 0);
 };
 
 // A short interval anchored to a representative local meal time. Returns null when
@@ -110,7 +113,7 @@ export const foodEntryToNutritionRecord = (
   entry: FoodEntry,
   clientRecordVersion: number,
 ): NutritionRecord | null => {
-  if (entry.serving_size === 0) return null;
+  if (!entry.serving_size) return null; // 0 / null / undefined — can't scale
 
   const [hour, minute] = MEAL_START_HM[entry.meal_type] ?? MEAL_START_HM.snacks;
   const interval = recordInterval(entry.entry_date, hour, minute);

--- a/SparkyFitnessMobile/src/services/storage.ts
+++ b/SparkyFitnessMobile/src/services/storage.ts
@@ -31,6 +31,7 @@ const SERVER_CONFIGS_KEY = 'serverConfigs';
 const ACTIVE_SERVER_CONFIG_ID_KEY = 'activeServerConfigId';
 const TIME_RANGE_KEY = 'timeRange';
 const LAST_SYNCED_TIME_KEY = 'lastSyncedTime';
+const LAST_WRITEBACK_TIME_KEY = 'lastWritebackTime';
 const BACKGROUND_SYNC_ENABLED_KEY = 'backgroundSyncEnabled';
 const SYNC_ON_OPEN_ENABLED_KEY = 'syncOnOpenEnabled';
 const PENDING_HEALTH_SYNC_CACHE_REFRESH_KEY = 'pendingHealthSyncCacheRefresh';
@@ -290,6 +291,30 @@ export const saveLastSyncedTime = async (): Promise<string | null> => {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     addLog(`[Storage] Failed to save sync time: ${message}`, 'ERROR');
+    return null;
+  }
+};
+
+// Separate cursor for the outbound Health Connect writeback phase, so writeback
+// failures never advance (or get blocked by) the inbound read cursor above.
+export const loadLastWritebackTime = async (): Promise<string | null> => {
+  try {
+    return await AsyncStorage.getItem(LAST_WRITEBACK_TIME_KEY);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    addLog(`[Storage] Failed to retrieve writeback time: ${message}`, 'ERROR');
+    return null;
+  }
+};
+
+export const saveLastWritebackTime = async (): Promise<string | null> => {
+  try {
+    const timestamp = new Date().toISOString();
+    await AsyncStorage.setItem(LAST_WRITEBACK_TIME_KEY, timestamp);
+    return timestamp;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    addLog(`[Storage] Failed to save writeback time: ${message}`, 'ERROR');
     return null;
   }
 };

--- a/SparkyFitnessMobile/src/types/foodEntries.ts
+++ b/SparkyFitnessMobile/src/types/foodEntries.ts
@@ -43,4 +43,9 @@ export interface FoodEntry {
   iron?: number;
   glycemic_index?: string;
   custom_nutrients?: Record<string, string | number>;
+
+  // Provider that produced this entry (e.g. 'health_connect'); null/undefined for
+  // manually-logged entries. Used by Health Connect writeback to avoid re-exporting
+  // entries that were themselves imported from a provider.
+  source?: string | null;
 }

--- a/SparkyFitnessMobile/src/utils/loggedMealCollapse.ts
+++ b/SparkyFitnessMobile/src/utils/loggedMealCollapse.ts
@@ -1,0 +1,113 @@
+import { fetchFoodEntryMealsByDate } from '../services/api/foodEntryMealsApi';
+import type { FoodEntry } from '../types/foodEntries';
+import type { FoodEntryMeal } from '../types/foodEntryMeals';
+
+// Logged meals arrive from the daily summary as their individual component food
+// entries (each tagged with food_entry_meal_id). Left as-is they double-count
+// against the meal total, so consumers collapse the components into one entry per
+// logged meal. Shared by useDailySummary (display) and Health Connect writeback
+// (one HC record per logged meal, not per component).
+
+export function hasLoggedMealComponents(foodEntries: FoodEntry[]): boolean {
+  return foodEntries.some((entry) => !!entry.food_entry_meal_id);
+}
+
+export function loggedMealToFoodEntry(meal: FoodEntryMeal): FoodEntry {
+  const quantity = Number(meal.quantity) > 0 ? Number(meal.quantity) : 1;
+
+  return {
+    id: meal.id,
+    user_id: meal.user_id,
+    meal_id: meal.meal_template_id ?? undefined,
+    food_entry_meal_id: meal.id,
+    meal_type: meal.meal_type,
+    meal_type_id: meal.meal_type_id ?? undefined,
+    quantity,
+    unit: meal.unit,
+    entry_date: meal.entry_date,
+    food_name: meal.name,
+    // serving_size === quantity so the consumed-amount scaling
+    // (value * quantity / serving_size) returns the meal's own totals.
+    serving_size: quantity,
+    serving_unit: meal.unit,
+    calories: meal.calories ?? 0,
+    protein: meal.protein,
+    carbs: meal.carbs,
+    fat: meal.fat,
+    saturated_fat: meal.saturated_fat,
+    polyunsaturated_fat: meal.polyunsaturated_fat,
+    monounsaturated_fat: meal.monounsaturated_fat,
+    trans_fat: meal.trans_fat,
+    cholesterol: meal.cholesterol,
+    sodium: meal.sodium,
+    potassium: meal.potassium,
+    dietary_fiber: meal.dietary_fiber,
+    sugars: meal.sugars,
+    vitamin_a: meal.vitamin_a,
+    vitamin_c: meal.vitamin_c,
+    calcium: meal.calcium,
+    iron: meal.iron,
+    glycemic_index: meal.glycemic_index,
+    custom_nutrients: meal.custom_nutrients,
+  };
+}
+
+export function collapseLoggedMealComponents(
+  foodEntries: FoodEntry[],
+  loggedMeals: FoodEntryMeal[],
+): FoodEntry[] {
+  if (loggedMeals.length === 0) {
+    return foodEntries;
+  }
+
+  const mealById = new Map(loggedMeals.map((meal) => [meal.id, meal]));
+  const addedMealIds = new Set<string>();
+  const collapsedEntries: FoodEntry[] = [];
+
+  for (const entry of foodEntries) {
+    const loggedMealId = entry.food_entry_meal_id;
+    if (!loggedMealId) {
+      collapsedEntries.push(entry);
+      continue;
+    }
+
+    const loggedMeal = mealById.get(loggedMealId);
+    if (!loggedMeal) {
+      collapsedEntries.push(entry);
+      continue;
+    }
+
+    if (!addedMealIds.has(loggedMealId)) {
+      collapsedEntries.push(loggedMealToFoodEntry(loggedMeal));
+      addedMealIds.add(loggedMealId);
+    }
+  }
+
+  for (const meal of loggedMeals) {
+    if (!addedMealIds.has(meal.id)) {
+      collapsedEntries.push(loggedMealToFoodEntry(meal));
+    }
+  }
+
+  return collapsedEntries;
+}
+
+/**
+ * Given a date and its raw daily-summary food entries, fetch the logged meals and
+ * return the collapsed list (one entry per logged meal). On any fetch failure it
+ * falls back to the raw entries. Used after `fetchDailySummary`.
+ */
+export async function resolveCollapsedFoodEntries(
+  date: string,
+  rawFoodEntries: FoodEntry[],
+): Promise<FoodEntry[]> {
+  if (!hasLoggedMealComponents(rawFoodEntries)) {
+    return rawFoodEntries;
+  }
+  try {
+    const loggedMeals = await fetchFoodEntryMealsByDate(date);
+    return collapseLoggedMealComponents(rawFoodEntries, loggedMeals);
+  } catch {
+    return rawFoodEntries;
+  }
+}

--- a/SparkyFitnessMobile/src/utils/loggedMealCollapse.ts
+++ b/SparkyFitnessMobile/src/utils/loggedMealCollapse.ts
@@ -7,6 +7,9 @@ import type { FoodEntryMeal } from '../types/foodEntryMeals';
 // against the meal total, so consumers collapse the components into one entry per
 // logged meal. Shared by useDailySummary (display) and Health Connect writeback
 // (one HC record per logged meal, not per component).
+//
+// The collapsed entry has no `source` (logged meals are assembled manually in
+// Sparky), so writeback always exports it — see the source filter in writeback.ts.
 
 export function hasLoggedMealComponents(foodEntries: FoodEntry[]): boolean {
   return foodEntries.some((entry) => !!entry.food_entry_meal_id);

--- a/SparkyFitnessMobile/src/utils/loggedMealCollapse.ts
+++ b/SparkyFitnessMobile/src/utils/loggedMealCollapse.ts
@@ -12,7 +12,7 @@ import type { FoodEntryMeal } from '../types/foodEntryMeals';
 // Sparky), so writeback always exports it — see the source filter in writeback.ts.
 
 export function hasLoggedMealComponents(foodEntries: FoodEntry[]): boolean {
-  return foodEntries.some((entry) => !!entry.food_entry_meal_id);
+  return foodEntries?.some((entry) => !!entry?.food_entry_meal_id) ?? false;
 }
 
 export function loggedMealToFoodEntry(meal: FoodEntryMeal): FoodEntry {
@@ -59,7 +59,10 @@ export function collapseLoggedMealComponents(
   foodEntries: FoodEntry[],
   loggedMeals: FoodEntryMeal[],
 ): FoodEntry[] {
-  if (loggedMeals.length === 0) {
+  if (!foodEntries) {
+    return [];
+  }
+  if (!loggedMeals || loggedMeals.length === 0) {
     return foodEntries;
   }
 
@@ -104,8 +107,8 @@ export async function resolveCollapsedFoodEntries(
   date: string,
   rawFoodEntries: FoodEntry[],
 ): Promise<FoodEntry[]> {
-  if (!hasLoggedMealComponents(rawFoodEntries)) {
-    return rawFoodEntries;
+  if (!rawFoodEntries || !hasLoggedMealComponents(rawFoodEntries)) {
+    return rawFoodEntries ?? [];
   }
   try {
     const loggedMeals = await fetchFoodEntryMealsByDate(date);

--- a/SparkyFitnessServer/models/foodEntry.ts
+++ b/SparkyFitnessServer/models/foodEntry.ts
@@ -545,6 +545,7 @@ async function getFoodEntriesByDate(userId: any, selectedDate: any) {
         fe.iron,
         fe.glycemic_index,
         fe.custom_nutrients,
+        fe.source,
         COALESCE(fe.allergens, fv.allergens) AS allergens,
         COALESCE(fe.traces, fv.traces) AS traces
        FROM food_entries fe

--- a/shared/src/schemas/api/FoodEntries.api.zod.ts
+++ b/shared/src/schemas/api/FoodEntries.api.zod.ts
@@ -36,6 +36,9 @@ export const foodEntryResponseSchema = z.object({
   iron: z.number().nullable(),
   glycemic_index: z.string().nullable(),
   custom_nutrients: z.record(z.string(), z.union([z.string(), z.number()])).nullable(),
+  // Provider that produced this entry (e.g. 'health_connect'); NULL/absent for
+  // manual entries. Not every food-entry query selects it, so keep it optional.
+  source: z.string().nullish(),
 });
 
 export type FoodEntryResponse = z.infer<typeof foodEntryResponseSchema>;


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Adds Android nutrition + hydration writeback to Health Connect: SparkyFitness data is written *out* to HC (the read sync landed in #1503), so the two stay in sync. This fully covers the Android-scoped request in #1329 and is a step toward the broader cross-platform #887.

**How did you implement the solution?**
Opt-in per-metric toggles on the Sync screen drive a writeback phase in the existing sync engine. It reads `/api/daily-summary`, maps manual entries to HC records, and does a fresh-id delete-then-insert (version-suffixed `clientRecordId`s, delete the previous run's tracked ids, then insert) — HC's `clientRecordId`+version upsert didn't reliably overwrite on edit via the RN bridge, and re-inserting a tombstoned id is rejected. The read transformers skip records whose `dataOrigin` is our own package, so enabling both directions can't loop; provider-imported entries (`source` set) are skipped so we don't duplicate another app's data; future-anchored entries are deferred to a later sync. Hydration is one record/day (water is a per-day total, not discrete events). iOS/HealthKit is a no-op stub for a follow-up.

Linked Issue: Closes #1329 (contributes to #887)

## How to Test

1. Check out this branch, build the Android dev app, grant Health Connect Nutrition/Hydration **write** permission when prompted.
2. On the **Sync** screen, enable the writeback toggles under the "Nutrition" section.
3. Log a food entry and some water, then run **Sync Now** → confirm a matching Nutrition record and a daily Hydration record appear in Health Connect.
4. Edit the entry's quantity and sync → the HC record updates (no duplicate). Delete it and sync → the HC record is removed.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Notes for Reviewers

- The only backend change is exposing `source` on `/api/daily-summary` food entries (and the shared `FoodEntry` schema) so the client can distinguish provider-imported entries from manual ones — no new tables, no new endpoints, no RLS changes.
- Validated end-to-end on a Pixel 8 Pro (add / edit / delete / future-deferral / imported-entry skip / no read-write loop); unit tests cover the mappers, the orchestrator (incl. quota/cursor handling), and the own-app read exclusion.
- Addressed the automated review: timezone-safe local date construction, falsy `serving_size` guards, and null tolerance in the shared logged-meal collapse util.

cc @apedley — follows the same conventions as the read PR.
