### PR TITLE
fix(measurements): repair DELETE /measurements/check-in/{id} (500 on every delete)

### DIFF
--- a/SparkyFitnessServer/routes/measurementRoutes.ts
+++ b/SparkyFitnessServer/routes/measurementRoutes.ts
@@ -453,8 +453,10 @@ router.delete(
       }
       if (
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
+        error.message === 'Water intake entry not found.' ||
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
         error.message ===
-        'Water intake entry not found or not authorized to delete.'
+          'Water intake entry not found or not authorized to delete.'
       ) {
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
         return res.status(404).json({ error: error.message });
@@ -820,8 +822,10 @@ router.delete(
       }
       if (
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
+        error.message === 'Check-in measurement not found.' ||
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
         error.message ===
-        'Check-in measurement not found or not authorized to delete.'
+          'Check-in measurement not found or not authorized to delete.'
       ) {
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
         return res.status(404).json({ error: error.message });
@@ -1057,8 +1061,10 @@ router.delete(
       }
       if (
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
+        error.message === 'Custom measurement entry not found.' ||
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
         error.message ===
-        'Custom measurement entry not found or not authorized to delete.'
+          'Custom measurement entry not found or not authorized to delete.'
       ) {
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
         return res.status(404).json({ error: error.message });
@@ -1197,8 +1203,10 @@ router.delete(
       }
       if (
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
+        error.message === 'Custom category not found.' ||
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
         error.message ===
-        'Custom category not found or not authorized to delete.'
+          'Custom category not found or not authorized to delete.'
       ) {
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
         return res.status(404).json({ error: error.message });

--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -1787,17 +1787,8 @@ async function updateCheckInMeasurements(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function deleteCheckInMeasurements(authenticatedUserId: any, id: any) {
   try {
-    const entryOwnerId =
-      // @ts-expect-error TS(2551): Property 'getCheckInMeasurementOwnerId' does not e... Remove this comment to see the full error message
-      await measurementRepository.getCheckInMeasurementOwnerId(id);
-    if (!entryOwnerId) {
-      throw new Error('Check-in measurement not found.');
-    }
-    if (entryOwnerId !== authenticatedUserId) {
-      throw new Error(
-        'Forbidden: You do not have permission to delete this check-in measurement.'
-      );
-    }
+    // deleteCheckInMeasurements is scoped by user_id, so it already enforces
+    // both existence and ownership; no separate owner pre-check is needed.
     const success = await measurementRepository.deleteCheckInMeasurements(
       id,
       authenticatedUserId

--- a/SparkyFitnessServer/tests/measurementService.checkInDelete.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.checkInDelete.test.ts
@@ -1,0 +1,45 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import measurementService from '../services/measurementService.js';
+import measurementRepository from '../models/measurementRepository.js';
+// Mock the repository functions
+vi.mock('../models/measurementRepository');
+describe('Measurement Service - Check-In Delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  describe('deleteCheckInMeasurements', () => {
+    // Regression: deletion used to call a non-existent repository helper
+    // (getCheckInMeasurementOwnerId), so every request threw a 500
+    // ("getCheckInMeasurementOwnerId is not a function"). This asserts the
+    // happy path resolves and delegates ownership to the scoped repository
+    // delete, which would fail if the broken pre-check were reintroduced.
+    it('deletes via the user-scoped repository call and returns success', async () => {
+      const mockUserId = 'test-user-id';
+      const mockEntryId = 'entry-123';
+      vi.mocked(
+        measurementRepository.deleteCheckInMeasurements
+      ).mockResolvedValue(true);
+      const result = await measurementService.deleteCheckInMeasurements(
+        mockUserId,
+        mockEntryId
+      );
+      expect(
+        measurementRepository.deleteCheckInMeasurements
+      ).toHaveBeenCalledWith(mockEntryId, mockUserId);
+      expect(result).toEqual({
+        message: 'Check-in measurement deleted successfully.',
+      });
+    });
+    it('throws not-found when the row does not exist or is not owned', async () => {
+      const mockUserId = 'test-user-id';
+      const mockEntryId = 'non-existent-entry';
+      // The scoped delete returns false for a missing or non-owned row.
+      vi.mocked(
+        measurementRepository.deleteCheckInMeasurements
+      ).mockResolvedValue(false);
+      await expect(
+        measurementService.deleteCheckInMeasurements(mockUserId, mockEntryId)
+      ).rejects.toThrow('Check-in measurement not found.');
+    });
+  });
+});


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
`DELETE /measurements/check-in/{id}` always returns 500 (`measurementRepository.getCheckInMeasurementOwnerId is not a function`), so a check-in/weigh-in can never be deleted via the API.

**How did you implement the solution?**
The service's ownership pre-check called `measurementRepository.getCheckInMeasurementOwnerId`, which — unlike its water-intake / custom-measurement / custom-category siblings — was never implemented in the repository. A `// @ts-expect-error` suppressed the resulting compile error, so it shipped and threw at runtime. `measurementRepository.deleteCheckInMeasurements(id, userId)` is already scoped by `user_id` (`DELETE ... WHERE id = $1 AND user_id = $2`, returns `rowCount > 0`), so it enforces both existence and ownership on its own. Removed the redundant, broken pre-check and added a vitest regression test.

Linked Issue: Closes #1532

## How to Test

1. Authenticate and ensure a check-in measurement exists (`POST /api/measurements/check-in`).
2. `DELETE /api/measurements/check-in/{id}` — **before:** `500 {"error":"measurementRepository.getCheckInMeasurementOwnerId is not a function"}`; **after:** `200 {"message":"Check-in measurement deleted successfully."}`, and the row is gone.
3. Deleting a non-existent / non-owned id returns the not-found error (the scoped delete reports `rowCount === 0`).
4. `pnpm run test` in `SparkyFitnessServer/` runs the new `tests/measurementService.checkInDelete.test.ts`.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

No UI changes (backend-only fix).

## Notes for Reviewers

**Verification** (`SparkyFitnessServer/`, pnpm 10.33.4 frozen install, matching CI):
- `pnpm run validate` (typecheck + lint + format:check) — passes
- `pnpm run test:ci` — **1321 passed (1321)**, including the new regression test
- Also validated live against a running instance: the endpoint now returns `200` and the row is actually removed.

No new endpoints, schemas, or tables — this only removes dead/broken code from an existing handler, so there are no Zod-schema or RLS changes to make.

**AI transparency:** This bug was found and fixed with the help of Claude Code (Anthropic's CLI agent). I (@bamonroe) reviewed the diff, verified it on my own instance, and asked it to prepare and open this PR on my behalf.

