### PR TITLE
Subtract dietary fiber caloric contribution from calorie target before calculating macro targets

### DIFF
--- a/SparkyFitnessFrontend/src/components/Onboarding/NutrientGoals.tsx
+++ b/SparkyFitnessFrontend/src/components/Onboarding/NutrientGoals.tsx
@@ -61,10 +61,14 @@ export const NutrientGoals = ({
                 {editedPlan?.calories
                   ? Math.round(
                       ((editedPlan.carbs * 4) /
-                        convertEnergy(
-                          editedPlan.calories,
-                          localEnergyUnit,
-                          'kcal'
+                        Math.max(
+                          1,
+                          convertEnergy(
+                            editedPlan.calories,
+                            localEnergyUnit,
+                            'kcal'
+                          ) -
+                            (editedPlan.dietary_fiber || 0) * 2
                         )) *
                         100
                     )
@@ -94,10 +98,14 @@ export const NutrientGoals = ({
                 {editedPlan?.calories
                   ? Math.round(
                       ((editedPlan.protein * 4) /
-                        convertEnergy(
-                          editedPlan.calories,
-                          localEnergyUnit,
-                          'kcal'
+                        Math.max(
+                          1,
+                          convertEnergy(
+                            editedPlan.calories,
+                            localEnergyUnit,
+                            'kcal'
+                          ) -
+                            (editedPlan.dietary_fiber || 0) * 2
                         )) *
                         100
                     )
@@ -129,10 +137,14 @@ export const NutrientGoals = ({
                 {editedPlan?.calories
                   ? Math.round(
                       ((editedPlan.fat * 9) /
-                        convertEnergy(
-                          editedPlan.calories,
-                          localEnergyUnit,
-                          'kcal'
+                        Math.max(
+                          1,
+                          convertEnergy(
+                            editedPlan.calories,
+                            localEnergyUnit,
+                            'kcal'
+                          ) -
+                            (editedPlan.dietary_fiber || 0) * 2
                         )) *
                         100
                     )

--- a/SparkyFitnessFrontend/src/components/Onboarding/NutrientGoals.tsx
+++ b/SparkyFitnessFrontend/src/components/Onboarding/NutrientGoals.tsx
@@ -59,19 +59,18 @@ export const NutrientGoals = ({
               <TableCell className="font-medium text-muted-foreground text-sm">
                 Carbohydrates (
                 {editedPlan?.calories
-                  ? Math.round(
-                      ((editedPlan.carbs * 4) /
-                        Math.max(
-                          1,
-                          convertEnergy(
-                            editedPlan.calories,
-                            localEnergyUnit,
-                            'kcal'
-                          ) -
-                            (editedPlan.dietary_fiber || 0) * 2
-                        )) *
-                        100
-                    )
+                  ? (() => {
+                      const adjusted =
+                        convertEnergy(
+                          editedPlan.calories,
+                          localEnergyUnit,
+                          'kcal'
+                        ) -
+                        (editedPlan.dietary_fiber || 0) * 2;
+                      return adjusted > 0
+                        ? Math.round(((editedPlan.carbs * 4) / adjusted) * 100)
+                        : 0;
+                    })()
                   : 0}
                 %)
               </TableCell>
@@ -96,19 +95,20 @@ export const NutrientGoals = ({
               <TableCell className="font-medium text-muted-foreground text-sm">
                 Protein (
                 {editedPlan?.calories
-                  ? Math.round(
-                      ((editedPlan.protein * 4) /
-                        Math.max(
-                          1,
-                          convertEnergy(
-                            editedPlan.calories,
-                            localEnergyUnit,
-                            'kcal'
-                          ) -
-                            (editedPlan.dietary_fiber || 0) * 2
-                        )) *
-                        100
-                    )
+                  ? (() => {
+                      const adjusted =
+                        convertEnergy(
+                          editedPlan.calories,
+                          localEnergyUnit,
+                          'kcal'
+                        ) -
+                        (editedPlan.dietary_fiber || 0) * 2;
+                      return adjusted > 0
+                        ? Math.round(
+                            ((editedPlan.protein * 4) / adjusted) * 100
+                          )
+                        : 0;
+                    })()
                   : 0}
                 %)
               </TableCell>
@@ -135,19 +135,18 @@ export const NutrientGoals = ({
               <TableCell className="font-medium text-muted-foreground text-sm">
                 Fats (
                 {editedPlan?.calories
-                  ? Math.round(
-                      ((editedPlan.fat * 9) /
-                        Math.max(
-                          1,
-                          convertEnergy(
-                            editedPlan.calories,
-                            localEnergyUnit,
-                            'kcal'
-                          ) -
-                            (editedPlan.dietary_fiber || 0) * 2
-                        )) *
-                        100
-                    )
+                  ? (() => {
+                      const adjusted =
+                        convertEnergy(
+                          editedPlan.calories,
+                          localEnergyUnit,
+                          'kcal'
+                        ) -
+                        (editedPlan.dietary_fiber || 0) * 2;
+                      return adjusted > 0
+                        ? Math.round(((editedPlan.fat * 9) / adjusted) * 100)
+                        : 0;
+                    })()
                   : 0}
                 %)
               </TableCell>

--- a/SparkyFitnessFrontend/src/components/Onboarding/PersonalPlan.tsx
+++ b/SparkyFitnessFrontend/src/components/Onboarding/PersonalPlan.tsx
@@ -279,18 +279,23 @@ const PersonalPlan = ({
           'kcal'
         );
 
+        const fiber = editedPlan.dietary_fiber || 0;
+        const macroCalories = Math.max(0, storedCalories - fiber * 2);
         const newGoals: ExpandedGoals = {
           ...editedPlan,
           calories: storedCalories,
-          protein_percentage: Math.round(
-            ((editedPlan.protein * 4) / storedCalories) * 100
-          ),
-          carbs_percentage: Math.round(
-            ((editedPlan.carbs * 4) / storedCalories) * 100
-          ),
-          fat_percentage: Math.round(
-            ((editedPlan.fat * 9) / storedCalories) * 100
-          ),
+          protein_percentage:
+            macroCalories > 0
+              ? Math.round(((editedPlan.protein * 4) / macroCalories) * 100)
+              : 0,
+          carbs_percentage:
+            macroCalories > 0
+              ? Math.round(((editedPlan.carbs * 4) / macroCalories) * 100)
+              : 0,
+          fat_percentage:
+            macroCalories > 0
+              ? Math.round(((editedPlan.fat * 9) / macroCalories) * 100)
+              : 0,
           dietary_fiber: editedPlan.dietary_fiber,
           water_goal_ml: editedPlan.water_goal_ml,
           target_exercise_duration_minutes:

--- a/SparkyFitnessFrontend/src/pages/Goals/DailyGoals.tsx
+++ b/SparkyFitnessFrontend/src/pages/Goals/DailyGoals.tsx
@@ -22,10 +22,12 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 const calculateGrams = (
   calories: number,
   percentage: number,
-  nutrient: 'protein' | 'carbs' | 'fat'
+  nutrient: 'protein' | 'carbs' | 'fat',
+  dietaryFiber: number = 0
 ) => {
   const factor = nutrient === 'fat' ? 9 : 4;
-  return Math.round((calories * (percentage / 100)) / factor);
+  const adjustedCalories = Math.max(0, calories - dietaryFiber * 2);
+  return Math.round((adjustedCalories * (percentage / 100)) / factor);
 };
 
 interface DailyGoalsProps {
@@ -86,14 +88,16 @@ export const DailyGoals = ({
     const finalGoals = { ...goals };
     if (macroInputType === 'percentages') {
       const cal = finalGoals.calories;
+      const fiber = finalGoals.dietary_fiber || 0;
+      const adjustedCal = Math.max(0, cal - fiber * 2);
       finalGoals.protein = Math.round(
-        (cal * (finalGoals.protein_percentage || 0)) / 100 / 4
+        (adjustedCal * (finalGoals.protein_percentage || 0)) / 100 / 4
       );
       finalGoals.carbs = Math.round(
-        (cal * (finalGoals.carbs_percentage || 0)) / 100 / 4
+        (adjustedCal * (finalGoals.carbs_percentage || 0)) / 100 / 4
       );
       finalGoals.fat = Math.round(
-        (cal * (finalGoals.fat_percentage || 0)) / 100 / 9
+        (adjustedCal * (finalGoals.fat_percentage || 0)) / 100 / 9
       );
     } else {
       finalGoals.protein_percentage = null;
@@ -231,7 +235,8 @@ export const DailyGoals = ({
                   {calculateGrams(
                     goals.calories,
                     goals.protein_percentage || 0,
-                    'protein'
+                    'protein',
+                    goals.dietary_fiber
                   )}
                   g
                 </span>
@@ -240,7 +245,8 @@ export const DailyGoals = ({
                   {calculateGrams(
                     goals.calories,
                     goals.carbs_percentage || 0,
-                    'carbs'
+                    'carbs',
+                    goals.dietary_fiber
                   )}
                   g
                 </span>
@@ -249,7 +255,8 @@ export const DailyGoals = ({
                   {calculateGrams(
                     goals.calories,
                     goals.fat_percentage || 0,
-                    'fat'
+                    'fat',
+                    goals.dietary_fiber
                   )}
                   g
                 </span>

--- a/SparkyFitnessFrontend/src/pages/Goals/EditGoalsForToday.tsx
+++ b/SparkyFitnessFrontend/src/pages/Goals/EditGoalsForToday.tsx
@@ -45,10 +45,12 @@ interface EditGoalsProps {
 const calculateGrams = (
   calories: number,
   percentage: number,
-  nutrient: 'protein' | 'carbs' | 'fat'
+  nutrient: 'protein' | 'carbs' | 'fat',
+  dietaryFiber: number = 0
 ) => {
   const factor = nutrient === 'fat' ? 9 : 4;
-  return Math.round((calories * (percentage / 100)) / factor);
+  const adjustedCalories = Math.max(0, calories - dietaryFiber * 2);
+  return Math.round((adjustedCalories * (percentage / 100)) / factor);
 };
 
 /**
@@ -270,7 +272,8 @@ const EditGoalsForm = ({
               {calculateGrams(
                 goals.calories,
                 goals.protein_percentage || 0,
-                'protein'
+                'protein',
+                goals.dietary_fiber
               )}
               g
             </span>
@@ -279,13 +282,19 @@ const EditGoalsForm = ({
               {calculateGrams(
                 goals.calories,
                 goals.carbs_percentage || 0,
-                'carbs'
+                'carbs',
+                goals.dietary_fiber
               )}
               g
             </span>
             <span>
               Fat:{' '}
-              {calculateGrams(goals.calories, goals.fat_percentage || 0, 'fat')}
+              {calculateGrams(
+                goals.calories,
+                goals.fat_percentage || 0,
+                'fat',
+                goals.dietary_fiber
+              )}
               g
             </span>
           </div>
@@ -380,14 +389,16 @@ const EditGoalsForToday = ({ selectedDate }: EditGoalsProps) => {
       finalGoals.protein_percentage !== undefined
     ) {
       const cal = finalGoals.calories;
+      const fiber = finalGoals.dietary_fiber || 0;
+      const adjustedCal = Math.max(0, cal - fiber * 2);
       finalGoals.protein = Math.round(
-        (cal * (finalGoals.protein_percentage || 0)) / 100 / 4
+        (adjustedCal * (finalGoals.protein_percentage || 0)) / 100 / 4
       );
       finalGoals.carbs = Math.round(
-        (cal * (finalGoals.carbs_percentage || 0)) / 100 / 4
+        (adjustedCal * (finalGoals.carbs_percentage || 0)) / 100 / 4
       );
       finalGoals.fat = Math.round(
-        (cal * (finalGoals.fat_percentage || 0)) / 100 / 9
+        (adjustedCal * (finalGoals.fat_percentage || 0)) / 100 / 9
       );
     }
 

--- a/SparkyFitnessFrontend/src/pages/Goals/GoalPresetDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Goals/GoalPresetDialog.tsx
@@ -40,10 +40,12 @@ interface GoalPresetDialogProps {
 const calculateGrams = (
   calories: number,
   percentage: number,
-  nutrient: 'protein' | 'carbs' | 'fat'
+  nutrient: 'protein' | 'carbs' | 'fat',
+  dietaryFiber: number = 0
 ) => {
   const factor = nutrient === 'fat' ? 9 : 4;
-  return Math.round((calories * (percentage / 100)) / factor);
+  const adjustedCalories = Math.max(0, calories - dietaryFiber * 2);
+  return Math.round((adjustedCalories * (percentage / 100)) / factor);
 };
 
 export const GoalPresetDialog = ({
@@ -103,13 +105,17 @@ export const GoalPresetDialog = ({
 
     if (macroInputType === 'percentages') {
       const cal = toSave.calories;
+      const fiber = toSave.dietary_fiber || 0;
+      const adjustedCal = Math.max(0, cal - fiber * 2);
       toSave.protein = Math.round(
-        (cal * (toSave.protein_percentage || 0)) / 100 / 4
+        (adjustedCal * (toSave.protein_percentage || 0)) / 100 / 4
       );
       toSave.carbs = Math.round(
-        (cal * (toSave.carbs_percentage || 0)) / 100 / 4
+        (adjustedCal * (toSave.carbs_percentage || 0)) / 100 / 4
       );
-      toSave.fat = Math.round((cal * (toSave.fat_percentage || 0)) / 100 / 9);
+      toSave.fat = Math.round(
+        (adjustedCal * (toSave.fat_percentage || 0)) / 100 / 9
+      );
     } else {
       toSave.protein_percentage = null;
       toSave.carbs_percentage = null;
@@ -260,7 +266,8 @@ export const GoalPresetDialog = ({
                     {calculateGrams(
                       formData.calories,
                       formData.protein_percentage || 0,
-                      'protein'
+                      'protein',
+                      formData.dietary_fiber
                     )}
                     g
                   </div>
@@ -269,7 +276,8 @@ export const GoalPresetDialog = ({
                     {calculateGrams(
                       formData.calories,
                       formData.carbs_percentage || 0,
-                      'carbs'
+                      'carbs',
+                      formData.dietary_fiber
                     )}
                     g
                   </div>
@@ -278,7 +286,8 @@ export const GoalPresetDialog = ({
                     {calculateGrams(
                       formData.calories,
                       formData.fat_percentage || 0,
-                      'fat'
+                      'fat',
+                      formData.dietary_fiber
                     )}
                     g
                   </div>

--- a/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
+++ b/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
@@ -629,17 +629,20 @@ export const calculateBasePlan = (
         }
       : getDietTemplate(localSelectedDiet);
 
+  const fiberGrams = Math.round((finalDailyCalories / 1000) * 14);
+  const adjustedCalories = Math.max(0, finalDailyCalories - fiberGrams * 2);
+
   const macros = {
     carbs: Math.round(
-      (finalDailyCalories * ((dietTemplate?.carbsPercentage ?? 0) / 100)) / 4
+      (adjustedCalories * ((dietTemplate?.carbsPercentage ?? 0) / 100)) / 4
     ),
     protein: Math.round(
-      (finalDailyCalories * ((dietTemplate?.proteinPercentage ?? 0) / 100)) / 4
+      (adjustedCalories * ((dietTemplate?.proteinPercentage ?? 0) / 100)) / 4
     ),
     fat: Math.round(
-      (finalDailyCalories * ((dietTemplate?.fatPercentage ?? 0) / 100)) / 9
+      (adjustedCalories * ((dietTemplate?.fatPercentage ?? 0) / 100)) / 9
     ),
-    fiber: Math.round((finalDailyCalories / 1000) * 14),
+    fiber: fiberGrams,
   };
 
   return { bmr, tdee, finalDailyCalories, macros };

--- a/SparkyFitnessServer/services/goalPresetService.ts
+++ b/SparkyFitnessServer/services/goalPresetService.ts
@@ -33,7 +33,7 @@ function calculateGramsFromPercentages(
   dietary_fiber?: any
 ) {
   const fiber = Number(dietary_fiber) || 0;
-  const adjustedCalories = Math.max(0, calories - fiber * 2);
+  const adjustedCalories = Math.max(0, (Number(calories) || 0) - fiber * 2);
   const protein_grams = (adjustedCalories * (protein_percentage / 100)) / 4;
   const carbs_grams = (adjustedCalories * (carbs_percentage / 100)) / 4;
   const fat_grams = (adjustedCalories * (fat_percentage / 100)) / 9;

--- a/SparkyFitnessServer/services/goalPresetService.ts
+++ b/SparkyFitnessServer/services/goalPresetService.ts
@@ -28,11 +28,15 @@ function calculateGramsFromPercentages(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   carbs_percentage: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fat_percentage: any
+  fat_percentage: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dietary_fiber?: any
 ) {
-  const protein_grams = (calories * (protein_percentage / 100)) / 4;
-  const carbs_grams = (calories * (carbs_percentage / 100)) / 4;
-  const fat_grams = (calories * (fat_percentage / 100)) / 9;
+  const fiber = Number(dietary_fiber) || 0;
+  const adjustedCalories = Math.max(0, calories - fiber * 2);
+  const protein_grams = (adjustedCalories * (protein_percentage / 100)) / 4;
+  const carbs_grams = (adjustedCalories * (carbs_percentage / 100)) / 4;
+  const fat_grams = (adjustedCalories * (fat_percentage / 100)) / 9;
   return { protein_grams, carbs_grams, fat_grams };
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -55,7 +59,8 @@ async function createGoalPreset(userId: any, presetData: any) {
           presetData.calories,
           presetData.protein_percentage,
           presetData.carbs_percentage,
-          presetData.fat_percentage
+          presetData.fat_percentage,
+          presetData.dietary_fiber
         );
       presetData.protein = protein_grams;
       presetData.carbs = carbs_grams;
@@ -122,7 +127,8 @@ async function updateGoalPreset(presetId: any, userId: any, presetData: any) {
           presetData.calories,
           presetData.protein_percentage,
           presetData.carbs_percentage,
-          presetData.fat_percentage
+          presetData.fat_percentage,
+          presetData.dietary_fiber
         );
       presetData.protein = protein_grams;
       presetData.carbs = carbs_grams;

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -34,7 +34,7 @@ function calculateGramsFromPercentages(
   dietary_fiber?: any
 ) {
   const fiber = Number(dietary_fiber) || 0;
-  const adjustedCalories = Math.max(0, calories - fiber * 2);
+  const adjustedCalories = Math.max(0, (Number(calories) || 0) - fiber * 2);
   const protein_grams = (adjustedCalories * (protein_percentage / 100)) / 4;
   const carbs_grams = (adjustedCalories * (carbs_percentage / 100)) / 4;
   const fat_grams = (adjustedCalories * (fat_percentage / 100)) / 9;

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -29,11 +29,15 @@ function calculateGramsFromPercentages(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   carbs_percentage: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fat_percentage: any
+  fat_percentage: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  dietary_fiber?: any
 ) {
-  const protein_grams = (calories * (protein_percentage / 100)) / 4;
-  const carbs_grams = (calories * (carbs_percentage / 100)) / 4;
-  const fat_grams = (calories * (fat_percentage / 100)) / 9;
+  const fiber = Number(dietary_fiber) || 0;
+  const adjustedCalories = Math.max(0, calories - fiber * 2);
+  const protein_grams = (adjustedCalories * (protein_percentage / 100)) / 4;
+  const carbs_grams = (adjustedCalories * (carbs_percentage / 100)) / 4;
+  const fat_grams = (adjustedCalories * (fat_percentage / 100)) / 9;
   return { protein_grams, carbs_grams, fat_grams };
 }
 
@@ -317,7 +321,8 @@ async function getUserGoalsForRange(
           processedGoals.calories,
           processedGoals.protein_percentage,
           processedGoals.carbs_percentage,
-          processedGoals.fat_percentage
+          processedGoals.fat_percentage,
+          processedGoals.dietary_fiber
         );
       processedGoals = {
         ...processedGoals,
@@ -426,7 +431,8 @@ async function manageGoalTimeline(authenticatedUserId: string, goalData: any) {
           p_calories,
           p_protein_percentage,
           p_carbs_percentage,
-          p_fat_percentage
+          p_fat_percentage,
+          p_dietary_fiber
         );
       protein_to_store = protein_grams;
       carbs_to_store = carbs_grams;


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

Deducts dietary fiber calories (2 kcal/g) from the daily calorie goal before applying percentage-based macro splits across onboarding, food goals, presets, and backend services.

**How did you implement the solution?**
(Brief technical approach.)

Updated the percentage-to-gram calculators across both the frontend (onboarding, daily goals, presets, previews) and backend (goal services) to deduct dietary_fiber * 2 from the total calorie pool before dividing the remaining budget into protein, carb, and fat targets.


Linked Issue: Closes # https://github.com/CodeWithCJ/SparkyFitness/issues/1509

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
