### PR TITLE
feat: add check-in progress photos (front, back, side)

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1135,7 +1135,21 @@
     "measurementDeletedSuccessfully": "Measurement deleted successfully",
     "failedToDeleteMeasurement": "Failed to delete measurement",
     "failedToLoadRecentMeasurements": "Failed to load recent measurements",
-    "enterCustomCategory": "Enter {{categoryName}}"
+    "enterCustomCategory": "Enter {{categoryName}}",
+    "photos": {
+      "title": "Progress Photos",
+      "subtitle": "Upload front, back, and side photos to track your physique over time.",
+      "front": "Front",
+      "back": "Back",
+      "side": "Side",
+      "tapToUpload": "Tap to upload",
+      "upload": "Upload",
+      "replace": "Replace",
+      "uploadSuccess": "Photo saved",
+      "uploadError": "Upload failed",
+      "deleteSuccess": "Photo removed",
+      "deleteError": "Failed to remove photo"
+    }
   },
   "sleepTimelineEditor": {
     "sleepTimeline": "Sleep Timeline",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1139,6 +1139,7 @@
     "photos": {
       "title": "Progress Photos",
       "subtitle": "Upload front, back, and side photos to track your physique over time.",
+      "addPhotos": "Add progress photos",
       "front": "Front",
       "back": "Back",
       "side": "Side",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1147,6 +1147,7 @@
       "replace": "Replace",
       "uploadSuccess": "Photo saved",
       "uploadError": "Upload failed",
+      "tooLarge": "Image is too large (max 10 MB).",
       "deleteSuccess": "Photo removed",
       "deleteError": "Failed to remove photo"
     }

--- a/SparkyFitnessFrontend/src/api/CheckIn/checkInPhotoService.ts
+++ b/SparkyFitnessFrontend/src/api/CheckIn/checkInPhotoService.ts
@@ -30,19 +30,18 @@ export const uploadCheckInPhoto = async (
 ): Promise<CheckInPhoto> => {
   const formData = new FormData();
   formData.append('photo', file);
-  const response = await fetch(
-    `/api/measurements/check-in-photos/${date}/${type}`,
+  // Routed through apiCall (not a raw fetch) so it shares the app's API base
+  // URL, cookie auth, and error handling. isFormData keeps apiCall from forcing
+  // a JSON Content-Type, letting the browser set the multipart boundary.
+  const response = await apiCall(
+    `/measurements/check-in-photos/${date}/${type}`,
     {
       method: 'POST',
       body: formData,
-      credentials: 'include',
+      isFormData: true,
     }
   );
-  if (!response.ok) {
-    const err = await response.json().catch(() => ({}));
-    throw new Error((err as { error?: string }).error ?? 'Upload failed');
-  }
-  return response.json() as Promise<CheckInPhoto>;
+  return response as CheckInPhoto;
 };
 
 export const deleteCheckInPhoto = async (id: string): Promise<void> => {

--- a/SparkyFitnessFrontend/src/api/CheckIn/checkInPhotoService.ts
+++ b/SparkyFitnessFrontend/src/api/CheckIn/checkInPhotoService.ts
@@ -1,0 +1,52 @@
+import { apiCall } from '@/api/api';
+
+export type PhotoType = 'front' | 'back' | 'side';
+
+export interface CheckInPhoto {
+  id: string;
+  user_id: string;
+  check_in_measurement_id: string | null;
+  entry_date: string;
+  photo_type: PhotoType;
+  file_path: string;
+  created_at: string;
+}
+
+export const fetchCheckInPhotos = async (
+  date: string
+): Promise<CheckInPhoto[]> => {
+  const response = await apiCall(`/measurements/check-in-photos/${date}`, {
+    method: 'GET',
+    suppress404Toast: true,
+  });
+  if (!response || !Array.isArray(response)) return [];
+  return response as CheckInPhoto[];
+};
+
+export const uploadCheckInPhoto = async (
+  date: string,
+  type: PhotoType,
+  file: File
+): Promise<CheckInPhoto> => {
+  const formData = new FormData();
+  formData.append('photo', file);
+  const response = await fetch(
+    `/api/measurements/check-in-photos/${date}/${type}`,
+    {
+      method: 'POST',
+      body: formData,
+      credentials: 'include',
+    }
+  );
+  if (!response.ok) {
+    const err = await response.json().catch(() => ({}));
+    throw new Error((err as { error?: string }).error ?? 'Upload failed');
+  }
+  return response.json() as Promise<CheckInPhoto>;
+};
+
+export const deleteCheckInPhoto = async (id: string): Promise<void> => {
+  await apiCall(`/measurements/check-in-photos/photo/${id}`, {
+    method: 'DELETE',
+  });
+};

--- a/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts
+++ b/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts
@@ -74,5 +74,6 @@ export const useCheckInPhotos = (selectedDate: string) => {
     deletePhoto: (id: string) => deleteMutation.mutate(id),
     isUploading: uploadMutation.isPending,
     uploadingType: uploadMutation.variables?.type,
+    isDeleting: deleteMutation.isPending,
   };
 };

--- a/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts
+++ b/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts
@@ -11,6 +11,10 @@ import {
 
 export type { PhotoType, CheckInPhoto };
 
+// Mirror the server's multer limit so oversized files are rejected up front
+// with immediate feedback instead of after a round-trip.
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
+
 export const useCheckInPhotos = (selectedDate: string) => {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -53,8 +57,20 @@ export const useCheckInPhotos = (selectedDate: string) => {
 
   return {
     photos,
-    uploadPhoto: (type: PhotoType, file: File) =>
-      uploadMutation.mutate({ type, file }),
+    uploadPhoto: (type: PhotoType, file: File) => {
+      if (file.size > MAX_UPLOAD_BYTES) {
+        toast({
+          title: t('checkIn.photos.uploadError', 'Upload failed'),
+          description: t(
+            'checkIn.photos.tooLarge',
+            'Image is too large (max 10 MB).'
+          ),
+          variant: 'destructive',
+        });
+        return;
+      }
+      uploadMutation.mutate({ type, file });
+    },
     deletePhoto: (id: string) => deleteMutation.mutate(id),
     isUploading: uploadMutation.isPending,
     uploadingType: uploadMutation.variables?.type,

--- a/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts
+++ b/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts
@@ -1,0 +1,62 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { toast } from '@/hooks/use-toast';
+import {
+  fetchCheckInPhotos,
+  uploadCheckInPhoto,
+  deleteCheckInPhoto,
+  type PhotoType,
+  type CheckInPhoto,
+} from '@/api/CheckIn/checkInPhotoService';
+
+export type { PhotoType, CheckInPhoto };
+
+export const useCheckInPhotos = (selectedDate: string) => {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+  const queryKey = ['check-in-photos', selectedDate];
+
+  const { data: photos = [] } = useQuery({
+    queryKey,
+    queryFn: () => fetchCheckInPhotos(selectedDate),
+  });
+
+  const uploadMutation = useMutation({
+    mutationFn: ({ type, file }: { type: PhotoType; file: File }) =>
+      uploadCheckInPhoto(selectedDate, type, file),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey });
+      toast({ title: t('checkIn.photos.uploadSuccess', 'Photo saved') });
+    },
+    onError: (err: Error) => {
+      toast({
+        title: t('checkIn.photos.uploadError', 'Upload failed'),
+        description: err.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteCheckInPhoto(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey });
+      toast({ title: t('checkIn.photos.deleteSuccess', 'Photo removed') });
+    },
+    onError: () => {
+      toast({
+        title: t('checkIn.photos.deleteError', 'Failed to remove photo'),
+        variant: 'destructive',
+      });
+    },
+  });
+
+  return {
+    photos,
+    uploadPhoto: (type: PhotoType, file: File) =>
+      uploadMutation.mutate({ type, file }),
+    deletePhoto: (id: string) => deleteMutation.mutate(id),
+    isUploading: uploadMutation.isPending,
+    uploadingType: uploadMutation.variables?.type,
+  };
+};

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx
@@ -8,6 +8,7 @@ import { RecentActivity } from './RecentActivity';
 import { CheckInTopRow } from './CheckInTopRow';
 import { useCheckInLogic } from '@/hooks/CheckIn/useCheckInLogic';
 import { useSearchParams } from 'react-router-dom';
+import { CheckInPhotos } from './CheckInPhotos';
 
 const CheckIn = () => {
   const { user } = useAuth();
@@ -100,6 +101,8 @@ const CheckIn = () => {
         waist={waist}
         weight={weight}
       />
+
+      <CheckInPhotos selectedDate={selectedDate} />
 
       <RecentActivity
         convertMeasurement={convertMeasurement}

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
@@ -87,12 +87,12 @@ const PhotoSlot = ({
         )}
       </div>
 
-      {/* Hidden file input — capture="environment" lets mobile show camera/gallery choice */}
+      {/* Hidden file input — no capture attribute so mobile users can pick
+          either the camera or an existing photo from the gallery. */}
       <input
         ref={fileInputRef}
         type="file"
         accept="image/*"
-        capture="environment"
         className="hidden"
         onChange={handleFileChange}
         disabled={isUploading}

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
@@ -1,0 +1,183 @@
+import { useRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Camera, Upload, Trash2, ImageIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  useCheckInPhotos,
+  type PhotoType,
+  type CheckInPhoto,
+} from '@/hooks/CheckIn/useCheckInPhotos';
+
+interface PhotoSlotProps {
+  type: PhotoType;
+  label: string;
+  photo: CheckInPhoto | undefined;
+  date: string;
+  onUpload: (type: PhotoType, file: File) => void;
+  onDelete: (id: string) => void;
+  isUploading: boolean;
+}
+
+const PhotoSlot = ({
+  type,
+  label,
+  photo,
+  date: _date,
+  onUpload,
+  onDelete,
+  isUploading,
+}: PhotoSlotProps) => {
+  const { t } = useTranslation();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) {
+        onUpload(type, file);
+        // Reset input so the same file can be re-selected after deletion
+        e.target.value = '';
+      }
+    },
+    [type, onUpload]
+  );
+
+  // Served through the authenticated, ownership-checked route (the session
+  // cookie travels with the same-origin <img> request), not the public static
+  // mount — progress photos are private.
+  const photoUrl = photo
+    ? `/api/measurements/check-in-photos/file/${photo.id}`
+    : null;
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <span className="text-sm font-medium text-foreground">{label}</span>
+
+      {/* Photo preview or placeholder */}
+      <div
+        className="relative w-full aspect-[3/4] rounded-lg border border-border bg-muted overflow-hidden
+                   flex items-center justify-center cursor-pointer group"
+        onClick={() => !isUploading && fileInputRef.current?.click()}
+      >
+        {photoUrl ? (
+          <>
+            <img
+              src={photoUrl}
+              alt={label}
+              className="w-full h-full object-cover"
+            />
+            <div className="absolute inset-0 bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
+              <Camera className="h-8 w-8 text-white" />
+            </div>
+          </>
+        ) : (
+          <div className="flex flex-col items-center gap-2 text-muted-foreground pointer-events-none">
+            <ImageIcon className="h-10 w-10" />
+            <span className="text-xs text-center px-2">
+              {t('checkIn.photos.tapToUpload', 'Tap to upload')}
+            </span>
+          </div>
+        )}
+
+        {isUploading && (
+          <div className="absolute inset-0 bg-background/60 flex items-center justify-center">
+            <div className="h-6 w-6 border-2 border-primary border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
+      </div>
+
+      {/* Hidden file input — capture="environment" lets mobile show camera/gallery choice */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={handleFileChange}
+        disabled={isUploading}
+      />
+
+      <div className="flex gap-2 w-full">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="flex-1"
+          disabled={isUploading}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          <Upload className="h-3 w-3 mr-1" />
+          {photo
+            ? t('checkIn.photos.replace', 'Replace')
+            : t('checkIn.photos.upload', 'Upload')}
+        </Button>
+
+        {photo && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="text-destructive hover:text-destructive"
+            disabled={isUploading}
+            onClick={() => onDelete(photo.id)}
+          >
+            <Trash2 className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface CheckInPhotosProps {
+  selectedDate: string;
+}
+
+const PHOTO_TYPES: {
+  type: PhotoType;
+  labelKey: string;
+  defaultLabel: string;
+}[] = [
+  { type: 'front', labelKey: 'checkIn.photos.front', defaultLabel: 'Front' },
+  { type: 'back', labelKey: 'checkIn.photos.back', defaultLabel: 'Back' },
+  { type: 'side', labelKey: 'checkIn.photos.side', defaultLabel: 'Side' },
+];
+
+export const CheckInPhotos = ({ selectedDate }: CheckInPhotosProps) => {
+  const { t } = useTranslation();
+  const { photos, uploadPhoto, deletePhoto, isUploading, uploadingType } =
+    useCheckInPhotos(selectedDate);
+
+  const photoMap = new Map(photos.map((p) => [p.photo_type, p]));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{t('checkIn.photos.title', 'Progress Photos')}</CardTitle>
+        <p className="text-sm text-muted-foreground">
+          {t(
+            'checkIn.photos.subtitle',
+            'Upload front, back, and side photos to track your physique over time.'
+          )}
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-3 gap-2 sm:gap-4">
+          {PHOTO_TYPES.map(({ type, labelKey, defaultLabel }) => (
+            <PhotoSlot
+              key={type}
+              type={type}
+              label={t(labelKey, defaultLabel)}
+              photo={photoMap.get(type)}
+              date={selectedDate}
+              onUpload={uploadPhoto}
+              onDelete={deletePhoto}
+              isUploading={isUploading && uploadingType === type}
+            />
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
@@ -1,8 +1,13 @@
-import { useRef, useCallback, useMemo } from 'react';
+import { useRef, useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Camera, Upload, Trash2, ImageIcon } from 'lucide-react';
+import { Camera, Upload, Trash2, ImageIcon, ChevronDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import {
   useCheckInPhotos,
   type PhotoType,
@@ -165,34 +170,67 @@ export const CheckInPhotos = ({ selectedDate }: CheckInPhotosProps) => {
     [photos]
   );
 
+  const hasPhotos = photos.length > 0;
+  // Expanded toggle only matters when there are no photos. Once a photo exists
+  // the section is always shown so existing photos are never hidden behind a
+  // collapse. Tracking expansion separately keeps the section compact for the
+  // (common) users who don't use the feature.
+  const [open, setOpen] = useState(false);
+  const expanded = hasPhotos || open;
+
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>{t('checkIn.photos.title', 'Progress Photos')}</CardTitle>
-        <p className="text-sm text-muted-foreground">
-          {t(
-            'checkIn.photos.subtitle',
-            'Upload front, back, and side photos to track your physique over time.'
+      <Collapsible open={expanded} onOpenChange={setOpen}>
+        <CardHeader className={expanded ? undefined : 'py-3'}>
+          {/* When collapsed, the whole header is the trigger so a single compact
+              row is all that's rendered. When expanded (or photos exist) the
+              chevron is hidden and the full header/subtitle show as before. */}
+          <CollapsibleTrigger
+            asChild
+            disabled={hasPhotos}
+            className="group disabled:cursor-default"
+          >
+            <div className="flex items-center justify-between gap-2 cursor-pointer">
+              <CardTitle>
+                {t('checkIn.photos.title', 'Progress Photos')}
+              </CardTitle>
+              {!hasPhotos && (
+                <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                  {t('checkIn.photos.addPhotos', 'Add progress photos')}
+                  <ChevronDown className="h-4 w-4 transition-transform group-data-[state=open]:rotate-180" />
+                </span>
+              )}
+            </div>
+          </CollapsibleTrigger>
+          {expanded && (
+            <p className="text-sm text-muted-foreground">
+              {t(
+                'checkIn.photos.subtitle',
+                'Upload front, back, and side photos to track your physique over time.'
+              )}
+            </p>
           )}
-        </p>
-      </CardHeader>
-      <CardContent>
-        <div className="grid grid-cols-3 gap-2 sm:gap-4">
-          {PHOTO_TYPES.map(({ type, labelKey, defaultLabel }) => (
-            <PhotoSlot
-              key={type}
-              type={type}
-              label={t(labelKey, defaultLabel)}
-              photo={photoMap.get(type)}
-              date={selectedDate}
-              onUpload={uploadPhoto}
-              onDelete={deletePhoto}
-              isUploading={isUploading && uploadingType === type}
-              disabled={isUploading || isDeleting}
-            />
-          ))}
-        </div>
-      </CardContent>
+        </CardHeader>
+        <CollapsibleContent>
+          <CardContent>
+            <div className="grid grid-cols-3 gap-2 sm:gap-4">
+              {PHOTO_TYPES.map(({ type, labelKey, defaultLabel }) => (
+                <PhotoSlot
+                  key={type}
+                  type={type}
+                  label={t(labelKey, defaultLabel)}
+                  photo={photoMap.get(type)}
+                  date={selectedDate}
+                  onUpload={uploadPhoto}
+                  onDelete={deletePhoto}
+                  isUploading={isUploading && uploadingType === type}
+                  disabled={isUploading || isDeleting}
+                />
+              ))}
+            </div>
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
     </Card>
   );
 };

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
@@ -16,7 +16,11 @@ interface PhotoSlotProps {
   date: string;
   onUpload: (type: PhotoType, file: File) => void;
   onDelete: (id: string) => void;
+  // True only while THIS slot's upload is in flight (drives the spinner).
   isUploading: boolean;
+  // True while ANY slot is uploading — blocks interaction on every slot so a
+  // second upload can't race the in-flight one.
+  disabled: boolean;
 }
 
 const PhotoSlot = ({
@@ -27,6 +31,7 @@ const PhotoSlot = ({
   onUpload,
   onDelete,
   isUploading,
+  disabled,
 }: PhotoSlotProps) => {
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -58,7 +63,7 @@ const PhotoSlot = ({
       <div
         className="relative w-full aspect-[3/4] rounded-lg border border-border bg-muted overflow-hidden
                    flex items-center justify-center cursor-pointer group"
-        onClick={() => !isUploading && fileInputRef.current?.click()}
+        onClick={() => !disabled && fileInputRef.current?.click()}
       >
         {photoUrl ? (
           <>
@@ -95,7 +100,7 @@ const PhotoSlot = ({
         accept="image/*"
         className="hidden"
         onChange={handleFileChange}
-        disabled={isUploading}
+        disabled={disabled}
       />
 
       <div className="flex gap-2 w-full">
@@ -104,7 +109,7 @@ const PhotoSlot = ({
           variant="outline"
           size="sm"
           className="flex-1"
-          disabled={isUploading}
+          disabled={disabled}
           onClick={() => fileInputRef.current?.click()}
         >
           <Upload className="h-3 w-3 mr-1" />
@@ -119,7 +124,7 @@ const PhotoSlot = ({
             variant="ghost"
             size="sm"
             className="text-destructive hover:text-destructive"
-            disabled={isUploading}
+            disabled={disabled}
             onClick={() => onDelete(photo.id)}
           >
             <Trash2 className="h-3 w-3" />
@@ -177,6 +182,7 @@ export const CheckInPhotos = ({ selectedDate }: CheckInPhotosProps) => {
               onUpload={uploadPhoto}
               onDelete={deletePhoto}
               isUploading={isUploading && uploadingType === type}
+              disabled={isUploading}
             />
           ))}
         </div>

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
@@ -151,8 +151,14 @@ const PHOTO_TYPES: {
 
 export const CheckInPhotos = ({ selectedDate }: CheckInPhotosProps) => {
   const { t } = useTranslation();
-  const { photos, uploadPhoto, deletePhoto, isUploading, uploadingType } =
-    useCheckInPhotos(selectedDate);
+  const {
+    photos,
+    uploadPhoto,
+    deletePhoto,
+    isUploading,
+    uploadingType,
+    isDeleting,
+  } = useCheckInPhotos(selectedDate);
 
   const photoMap = useMemo(
     () => new Map(photos.map((p) => [p.photo_type, p])),
@@ -182,7 +188,7 @@ export const CheckInPhotos = ({ selectedDate }: CheckInPhotosProps) => {
               onUpload={uploadPhoto}
               onDelete={deletePhoto}
               isUploading={isUploading && uploadingType === type}
-              disabled={isUploading}
+              disabled={isUploading || isDeleting}
             />
           ))}
         </div>

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInPhotos.tsx
@@ -1,4 +1,4 @@
-import { useRef, useCallback } from 'react';
+import { useRef, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Camera, Upload, Trash2, ImageIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -149,7 +149,10 @@ export const CheckInPhotos = ({ selectedDate }: CheckInPhotosProps) => {
   const { photos, uploadPhoto, deletePhoto, isUploading, uploadingType } =
     useCheckInPhotos(selectedDate);
 
-  const photoMap = new Map(photos.map((p) => [p.photo_type, p]));
+  const photoMap = useMemo(
+    () => new Map(photos.map((p) => [p.photo_type, p])),
+    [photos]
+  );
 
   return (
     <Card>

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import fs from 'fs';
+import type { ServerResponse } from 'http';
 import express from 'express';
 // @ts-expect-error TS7016
 import cors from 'cors';
@@ -25,6 +26,7 @@ import preferenceRoutes from './routes/preferenceRoutes.js';
 import nutrientDisplayPreferenceRoutes from './routes/nutrientDisplayPreferenceRoutes.js';
 import chatRoutes from './routes/chatRoutes.js';
 import measurementRoutes from './routes/measurementRoutes.js';
+import checkInPhotoRoutes from './routes/checkInPhotoRoutes.js';
 import goalRoutes from './routes/goalRoutes.js';
 import goalPresetRoutes from './routes/goalPresetRoutes.js';
 // @ts-expect-error TS1192
@@ -217,7 +219,24 @@ console.log('SparkyFitnessServer UPLOADS_BASE_DIR:', UPLOADS_BASE_DIR);
 // Disable etag/lastModified — iOS CFNetwork mis-handles the resulting 304s
 // on freshly uploaded images (#1353). Filenames embed Date.now() so URLs
 // are already effectively immutable; clients still cache by URL.
-const uploadsStaticOptions = { etag: false, lastModified: false };
+// Stored uploads are user-supplied; send `X-Content-Type-Options: nosniff` so a
+// disguised file (e.g. HTML/JS carrying an image extension) can't be MIME-sniffed
+// by the browser into an executable type and run in our origin. express.static
+// reads `setHeaders`; res.sendFile (the on-demand route below) reads `headers`.
+const uploadsStaticOptions = {
+  etag: false,
+  lastModified: false,
+  setHeaders: (res: ServerResponse) =>
+    res.setHeader('X-Content-Type-Options', 'nosniff'),
+  headers: { 'X-Content-Type-Options': 'nosniff' },
+};
+// Check-in progress photos are sensitive. Block direct access via the public
+// static mounts so they can only be reached through the authenticated,
+// ownership-checked route (GET /api/measurements/check-in-photos/file/:id).
+// 404 (not 403) so we don't confirm whether a given path exists.
+app.use(['/uploads/check-in', '/api/uploads/check-in'], (_req, res) => {
+  res.status(404).end();
+});
 app.use('/api/uploads', express.static(UPLOADS_BASE_DIR, uploadsStaticOptions));
 app.use('/uploads', express.static(UPLOADS_BASE_DIR, uploadsStaticOptions));
 // Mounted after uploads so static image Cache-Control isn't clobbered.
@@ -401,6 +420,7 @@ app.use('/api/reports', reportRoutes);
 app.use('/api/user-preferences', preferenceRoutes);
 app.use('/api/preferences/nutrient-display', nutrientDisplayPreferenceRoutes);
 app.use('/api/measurements', measurementRoutes);
+app.use('/api/measurements/check-in-photos', checkInPhotoRoutes);
 app.use('/api/goals', goalRoutes);
 app.use('/api/user-goals', goalRoutes);
 app.use('/api/goal-presets', goalPresetRoutes);

--- a/SparkyFitnessServer/db/migrations/20260614000000_add_checkin_photos.sql
+++ b/SparkyFitnessServer/db/migrations/20260614000000_add_checkin_photos.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS public.check_in_photos (
     CONSTRAINT check_in_photos_user_date_type_unique UNIQUE (user_id, entry_date, photo_type)
 );
 
-CREATE INDEX IF NOT EXISTS idx_check_in_photos_user_date
-    ON public.check_in_photos (user_id, entry_date);
+-- No separate (user_id, entry_date) index: the unique constraint above already
+-- builds a composite index whose leading columns cover lookups by user + date.
 
 COMMIT;

--- a/SparkyFitnessServer/db/migrations/20260614000000_add_checkin_photos.sql
+++ b/SparkyFitnessServer/db/migrations/20260614000000_add_checkin_photos.sql
@@ -1,0 +1,48 @@
+-- Check-in progress photos (front / back / side) -- issue #229.
+--
+-- This migration does two things, in order:
+--   1. Ensures check_in_measurements has a PRIMARY KEY on id. The table was
+--      created in InitialDB without one (unlike e.g. exercise_entries), and the
+--      check_in_photos.check_in_measurement_id foreign key below references
+--      check_in_measurements(id), which requires a unique/primary key on that
+--      column.
+--   2. Creates the check_in_photos table. user_id references public."user"
+--      (Better Auth) -- application users live there, the same target
+--      check_in_measurements uses -- not the legacy auth.users table.
+--
+-- Guarded with DO/IF NOT EXISTS throughout so the script is safe to re-run.
+
+BEGIN;
+
+-- 1. Prerequisite: primary key on check_in_measurements.id (only if missing).
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'public.check_in_measurements'::regclass
+          AND contype = 'p'
+    ) THEN
+        ALTER TABLE public.check_in_measurements ADD PRIMARY KEY (id);
+    END IF;
+END;
+$$;
+
+-- 2. Progress photos table.
+CREATE TABLE IF NOT EXISTS public.check_in_photos (
+    id uuid DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES public."user"(id) ON DELETE CASCADE,
+    check_in_measurement_id uuid REFERENCES public.check_in_measurements(id) ON DELETE SET NULL,
+    entry_date date NOT NULL,
+    photo_type varchar(5) NOT NULL,
+    file_path text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT check_in_photos_type_check CHECK (photo_type IN ('front', 'back', 'side')),
+    CONSTRAINT check_in_photos_user_date_type_unique UNIQUE (user_id, entry_date, photo_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_check_in_photos_user_date
+    ON public.check_in_photos (user_id, entry_date);
+
+COMMIT;

--- a/SparkyFitnessServer/db/rls_policies.sql
+++ b/SparkyFitnessServer/db/rls_policies.sql
@@ -24,6 +24,7 @@ BEGIN
   FOR table_name IN SELECT unnest(ARRAY[
     'ai_service_settings',
     'check_in_measurements',
+    'check_in_photos',
     'custom_categories',
     'custom_measurements',
     'exercise_entries',
@@ -349,6 +350,7 @@ WITH CHECK (admin_user_id = current_user_id() AND is_admin());
 
 -- Diary access tables
 SELECT create_diary_policy('check_in_measurements');
+SELECT create_diary_policy('check_in_photos');
 SELECT create_diary_policy('custom_categories');
 SELECT create_diary_policy('custom_measurements');
 SELECT create_diary_policy('exercise_entries');

--- a/SparkyFitnessServer/middleware/checkInPhotoUpload.ts
+++ b/SparkyFitnessServer/middleware/checkInPhotoUpload.ts
@@ -1,28 +1,75 @@
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'multer'
 import multer from 'multer';
-import { createUploadMiddleware } from './uploadMiddleware.js';
+import path from 'path';
 
-// Leading-byte signatures for the image formats accepted by uploads. The multer
-// fileFilter only inspects the client-supplied filename and mime type, both of
-// which are spoofable, so we re-check the real file content against these.
-const IMAGE_SIGNATURES: number[][] = [
-  [0xff, 0xd8, 0xff], // jpeg / jpg
-  [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], // png
-  [0x47, 0x49, 0x46, 0x38], // gif ("GIF8" -> 87a / 89a)
+// Image formats accepted by check-in photo uploads, each paired with the
+// canonical extension we persist it under. The multer fileFilter only inspects
+// the client-supplied filename and mime type, both of which are spoofable, so
+// the real file content is re-checked against these signatures downstream (see
+// getImageExtension / isAllowedImageBuffer).
+interface ImageFormat {
+  ext: string;
+  matches: (buffer: Buffer) => boolean;
+}
+
+const startsWith = (buffer: Buffer, sig: number[]): boolean =>
+  buffer.length >= sig.length && sig.every((b, i) => buffer[i] === b);
+
+const IMAGE_FORMATS: ImageFormat[] = [
+  { ext: 'jpg', matches: (b) => startsWith(b, [0xff, 0xd8, 0xff]) },
+  {
+    ext: 'png',
+    matches: (b) =>
+      startsWith(b, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  },
+  { ext: 'gif', matches: (b) => startsWith(b, [0x47, 0x49, 0x46, 0x38]) }, // "GIF8"
+  {
+    // WebP is a RIFF container: "RIFF" <4-byte size> "WEBP". The RIFF prefix
+    // alone also matches WAV/AVI, so the "WEBP" tag at offset 8 is required too.
+    ext: 'webp',
+    matches: (b) =>
+      b.length >= 12 &&
+      startsWith(b, [0x52, 0x49, 0x46, 0x46]) &&
+      b.toString('ascii', 8, 12) === 'WEBP',
+  },
 ];
 
 /**
- * Returns true only if the buffer starts with a known JPEG, PNG, or GIF
+ * Returns the canonical extension (no leading dot) for the image format the
+ * buffer's real content matches, or null if it is not an accepted image. The
+ * stored file extension is derived from this rather than the spoofable
+ * client-supplied filename, so the served Content-Type always matches the bytes.
+ */
+export const getImageExtension = (buffer: Buffer): string | null =>
+  IMAGE_FORMATS.find((f) => f.matches(buffer))?.ext ?? null;
+
+/**
+ * Returns true only if the buffer starts with a known JPEG, PNG, GIF, or WebP
  * signature. Reads a handful of leading bytes, so the cost is negligible
  * relative to the upload itself.
  */
 export const isAllowedImageBuffer = (buffer: Buffer): boolean =>
-  IMAGE_SIGNATURES.some(
-    (sig) => buffer.length >= sig.length && sig.every((b, i) => buffer[i] === b)
-  );
+  getImageExtension(buffer) !== null;
 
-// Buffer the upload in memory so its real content can be validated before the
-// service writes anything to disk. This keeps a rejected (non-image) upload
-// from ever touching the uploads directory.
-const checkInPhotoUpload = createUploadMiddleware(multer.memoryStorage());
+// Buffer the upload in memory so its real bytes can be validated before the
+// service writes anything to disk, keeping a rejected (non-image) upload from
+// ever touching the uploads directory. The fileFilter is a cheap first pass on
+// the (spoofable) filename/mime type; getImageExtension is the real gate. A
+// local multer config is used here rather than the shared jpeg/png/gif-only
+// helper so WebP uploads are accepted.
+const checkInPhotoUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 10_000_000 }, // 10 MB
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fileFilter: (_req: any, file: any, cb: any) => {
+    const allowed = /jpeg|jpg|png|gif|webp/;
+    const okExt = allowed.test(path.extname(file.originalname).toLowerCase());
+    const okMime = allowed.test(file.mimetype);
+    if (okExt && okMime) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only image files (jpeg, png, gif, webp) are allowed.'));
+    }
+  },
+});
 export default checkInPhotoUpload;

--- a/SparkyFitnessServer/middleware/checkInPhotoUpload.ts
+++ b/SparkyFitnessServer/middleware/checkInPhotoUpload.ts
@@ -1,0 +1,28 @@
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'multer'
+import multer from 'multer';
+import { createUploadMiddleware } from './uploadMiddleware.js';
+
+// Leading-byte signatures for the image formats accepted by uploads. The multer
+// fileFilter only inspects the client-supplied filename and mime type, both of
+// which are spoofable, so we re-check the real file content against these.
+const IMAGE_SIGNATURES: number[][] = [
+  [0xff, 0xd8, 0xff], // jpeg / jpg
+  [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], // png
+  [0x47, 0x49, 0x46, 0x38], // gif ("GIF8" -> 87a / 89a)
+];
+
+/**
+ * Returns true only if the buffer starts with a known JPEG, PNG, or GIF
+ * signature. Reads a handful of leading bytes, so the cost is negligible
+ * relative to the upload itself.
+ */
+export const isAllowedImageBuffer = (buffer: Buffer): boolean =>
+  IMAGE_SIGNATURES.some(
+    (sig) => buffer.length >= sig.length && sig.every((b, i) => buffer[i] === b)
+  );
+
+// Buffer the upload in memory so its real content can be validated before the
+// service writes anything to disk. This keeps a rejected (non-image) upload
+// from ever touching the uploads directory.
+const checkInPhotoUpload = createUploadMiddleware(multer.memoryStorage());
+export default checkInPhotoUpload;

--- a/SparkyFitnessServer/routes/checkInPhotoRoutes.ts
+++ b/SparkyFitnessServer/routes/checkInPhotoRoutes.ts
@@ -2,7 +2,7 @@ import express from 'express';
 import { authenticate } from '../middleware/authMiddleware.js';
 import checkPermissionMiddleware from '../middleware/checkPermissionMiddleware.js';
 import checkInPhotoUpload, {
-  isAllowedImageBuffer,
+  getImageExtension,
 } from '../middleware/checkInPhotoUpload.js';
 import checkInPhotoService from '../services/checkInPhotoService.js';
 import { log } from '../config/logging.js';
@@ -164,9 +164,10 @@ router.post(
     next();
   },
   checkInPhotoUpload.single('photo'),
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async (req: any, res: any) => {
-    if (!req.file) {
+  async (req, res) => {
+    // @ts-expect-error multer attaches req.file at runtime; it ships no types.
+    const file = req.file as { buffer: Buffer } | undefined;
+    if (!file) {
       res.status(400).json({ error: 'No photo file provided' });
       return;
     }
@@ -175,11 +176,13 @@ router.post(
       type: 'front' | 'back' | 'side';
     };
     // The multer fileFilter only trusts the client-supplied filename/mime type;
-    // verify the real bytes before anything is written to disk.
-    if (!isAllowedImageBuffer(req.file.buffer)) {
-      res
-        .status(400)
-        .json({ error: 'Uploaded file is not a valid image (jpeg, png, gif)' });
+    // verify the real bytes and derive the stored extension from them so the
+    // served Content-Type can never be spoofed by a mismatched filename.
+    const extension = getImageExtension(file.buffer);
+    if (!extension) {
+      res.status(400).json({
+        error: 'Uploaded file is not a valid image (jpeg, png, gif, webp)',
+      });
       return;
     }
     try {
@@ -187,8 +190,8 @@ router.post(
         req.userId,
         date,
         type,
-        req.file.originalname,
-        req.file.buffer
+        extension,
+        file.buffer
       );
       res.json(photo);
     } catch (err) {

--- a/SparkyFitnessServer/routes/checkInPhotoRoutes.ts
+++ b/SparkyFitnessServer/routes/checkInPhotoRoutes.ts
@@ -106,7 +106,17 @@ router.get(
       // Stored uploads are user-supplied; stop the browser from MIME-sniffing
       // the response into an executable type.
       res.setHeader('X-Content-Type-Options', 'nosniff');
-      res.sendFile(absolutePath);
+      // sendFile streams asynchronously, so a transmission error won't reach the
+      // surrounding try/catch — handle it in the callback and only respond if the
+      // headers/stream haven't started yet.
+      res.sendFile(absolutePath, (err) => {
+        if (err) {
+          log('error', 'Failed to stream check-in photo', err);
+          if (!res.headersSent) {
+            res.status(500).json({ error: 'Failed to serve check-in photo' });
+          }
+        }
+      });
     } catch (err) {
       log('error', 'Failed to serve check-in photo', err);
       res.status(500).json({ error: 'Failed to serve check-in photo' });

--- a/SparkyFitnessServer/routes/checkInPhotoRoutes.ts
+++ b/SparkyFitnessServer/routes/checkInPhotoRoutes.ts
@@ -1,0 +1,242 @@
+import express from 'express';
+import { authenticate } from '../middleware/authMiddleware.js';
+import checkPermissionMiddleware from '../middleware/checkPermissionMiddleware.js';
+import checkInPhotoUpload, {
+  isAllowedImageBuffer,
+} from '../middleware/checkInPhotoUpload.js';
+import checkInPhotoService from '../services/checkInPhotoService.js';
+import { log } from '../config/logging.js';
+import {
+  CheckInPhotoDateParamSchema,
+  CheckInPhotoUploadParamSchema,
+  CheckInPhotoIdParamSchema,
+} from '../schemas/checkInPhotoSchemas.js';
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * /measurements/check-in-photos/{date}:
+ *   get:
+ *     summary: Get progress photos for a check-in date
+ *     tags: [Wellness & Metrics]
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: date
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: date
+ *     responses:
+ *       200:
+ *         description: Array of photo records for the given date.
+ *       400:
+ *         description: Invalid date format.
+ */
+router.get(
+  '/:date',
+  authenticate,
+  checkPermissionMiddleware('checkin'),
+  async (req, res) => {
+    const parsed = CheckInPhotoDateParamSchema.safeParse(req.params);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0]?.message });
+      return;
+    }
+    try {
+      const photos = await checkInPhotoService.getPhotosByDate(
+        req.userId,
+        parsed.data.date
+      );
+      res.json(photos);
+    } catch (err) {
+      log('error', 'Failed to fetch check-in photos', err);
+      res.status(500).json({ error: 'Failed to fetch check-in photos' });
+    }
+  }
+);
+
+/**
+ * @swagger
+ * /measurements/check-in-photos/file/{id}:
+ *   get:
+ *     summary: Serve a progress photo image (authenticated, owner/family only)
+ *     tags: [Wellness & Metrics]
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: The image file.
+ *         content:
+ *           image/*:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       404:
+ *         description: Photo not found or not accessible.
+ */
+router.get(
+  '/file/:id',
+  authenticate,
+  checkPermissionMiddleware('checkin'),
+  async (req, res) => {
+    const parsed = CheckInPhotoIdParamSchema.safeParse(req.params);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0]?.message });
+      return;
+    }
+    try {
+      const absolutePath = await checkInPhotoService.getPhotoFileById(
+        req.userId,
+        parsed.data.id
+      );
+      if (!absolutePath) {
+        res.status(404).json({ error: 'Photo not found' });
+        return;
+      }
+      // Stored uploads are user-supplied; stop the browser from MIME-sniffing
+      // the response into an executable type.
+      res.setHeader('X-Content-Type-Options', 'nosniff');
+      res.sendFile(absolutePath);
+    } catch (err) {
+      log('error', 'Failed to serve check-in photo', err);
+      res.status(500).json({ error: 'Failed to serve check-in photo' });
+    }
+  }
+);
+
+/**
+ * @swagger
+ * /measurements/check-in-photos/{date}/{type}:
+ *   post:
+ *     summary: Upload a progress photo (front, back, or side)
+ *     tags: [Wellness & Metrics]
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: date
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: date
+ *       - in: path
+ *         name: type
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: [front, back, side]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               photo:
+ *                 type: string
+ *                 format: binary
+ *     responses:
+ *       200:
+ *         description: Photo uploaded successfully.
+ *       400:
+ *         description: Invalid parameters or file type.
+ */
+router.post(
+  '/:date/:type',
+  authenticate,
+  checkPermissionMiddleware('checkin'),
+  (req, res, next) => {
+    const parsed = CheckInPhotoUploadParamSchema.safeParse(req.params);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0]?.message });
+      return;
+    }
+    next();
+  },
+  checkInPhotoUpload.single('photo'),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async (req: any, res: any) => {
+    if (!req.file) {
+      res.status(400).json({ error: 'No photo file provided' });
+      return;
+    }
+    const { date, type } = req.params as {
+      date: string;
+      type: 'front' | 'back' | 'side';
+    };
+    // The multer fileFilter only trusts the client-supplied filename/mime type;
+    // verify the real bytes before anything is written to disk.
+    if (!isAllowedImageBuffer(req.file.buffer)) {
+      res
+        .status(400)
+        .json({ error: 'Uploaded file is not a valid image (jpeg, png, gif)' });
+      return;
+    }
+    try {
+      const photo = await checkInPhotoService.upsertPhoto(
+        req.userId,
+        date,
+        type,
+        req.file.originalname,
+        req.file.buffer
+      );
+      res.json(photo);
+    } catch (err) {
+      log('error', 'Failed to save check-in photo', err);
+      res.status(500).json({ error: 'Failed to save check-in photo' });
+    }
+  }
+);
+
+/**
+ * @swagger
+ * /measurements/check-in-photos/photo/{id}:
+ *   delete:
+ *     summary: Delete a progress photo by ID
+ *     tags: [Wellness & Metrics]
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       204:
+ *         description: Photo deleted.
+ *       400:
+ *         description: Invalid ID.
+ */
+router.delete(
+  '/photo/:id',
+  authenticate,
+  checkPermissionMiddleware('checkin'),
+  async (req, res) => {
+    const parsed = CheckInPhotoIdParamSchema.safeParse(req.params);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues[0]?.message });
+      return;
+    }
+    try {
+      await checkInPhotoService.deletePhoto(req.userId, parsed.data.id);
+      res.status(204).send();
+    } catch (err) {
+      log('error', 'Failed to delete check-in photo', err);
+      res.status(500).json({ error: 'Failed to delete check-in photo' });
+    }
+  }
+);
+
+export default router;

--- a/SparkyFitnessServer/schemas/checkInPhotoSchemas.ts
+++ b/SparkyFitnessServer/schemas/checkInPhotoSchemas.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod/v4';
+
+export const PhotoTypeSchema = z.enum(['front', 'back', 'side']);
+
+export const CheckInPhotoDateParamSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD'),
+});
+
+export const CheckInPhotoUploadParamSchema = z.object({
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD'),
+  type: PhotoTypeSchema,
+});
+
+export const CheckInPhotoIdParamSchema = z.object({
+  id: z.string().uuid('id must be a valid UUID'),
+});
+
+export const CheckInPhotoResponseSchema = z.object({
+  id: z.string().uuid(),
+  user_id: z.string().uuid(),
+  check_in_measurement_id: z.string().uuid().nullable(),
+  entry_date: z.string(),
+  photo_type: PhotoTypeSchema,
+  file_path: z.string(),
+  created_at: z.string(),
+});
+
+export type CheckInPhotoResponse = z.infer<typeof CheckInPhotoResponseSchema>;
+export type PhotoType = z.infer<typeof PhotoTypeSchema>;

--- a/SparkyFitnessServer/services/checkInPhotoService.ts
+++ b/SparkyFitnessServer/services/checkInPhotoService.ts
@@ -1,0 +1,217 @@
+import { getClient } from '../db/poolManager.js';
+import { log } from '../config/logging.js';
+import fs from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { fileURLToPath } from 'url';
+import { localDateToDay } from '@workspace/shared';
+import type {
+  CheckInPhotoResponse,
+  PhotoType,
+} from '../schemas/checkInPhotoSchemas.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const resolveFilePath = (relativePath: string) =>
+  path.join(__dirname, '..', relativePath);
+
+const safeUnlink = (absolutePath: string) => {
+  try {
+    if (fs.existsSync(absolutePath)) {
+      fs.unlinkSync(absolutePath);
+    }
+  } catch (err) {
+    log('warn', `Failed to remove check-in photo file ${absolutePath}`, err);
+  }
+};
+
+export const getPhotosByDate = async (
+  userId: string,
+  entryDate: string
+): Promise<CheckInPhotoResponse[]> => {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT id, user_id, check_in_measurement_id, entry_date, photo_type,
+              file_path, created_at
+       FROM check_in_photos
+       WHERE user_id = $1 AND entry_date = $2
+       ORDER BY photo_type ASC`,
+      [userId, entryDate]
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return result.rows.map((r: any) => ({
+      ...r,
+      entry_date:
+        r.entry_date instanceof Date
+          ? localDateToDay(r.entry_date)
+          : String(r.entry_date),
+      created_at:
+        r.created_at instanceof Date
+          ? r.created_at.toISOString()
+          : String(r.created_at),
+    }));
+  } finally {
+    client.release();
+  }
+};
+
+export const upsertPhoto = async (
+  userId: string,
+  entryDate: string,
+  photoType: PhotoType,
+  originalName: string,
+  buffer: Buffer
+): Promise<CheckInPhotoResponse> => {
+  const fileName = `${photoType}${path.extname(originalName).toLowerCase()}`;
+  // Store a relative path so records are portable across deployments.
+  const relativePath = path.join(
+    'uploads',
+    'check-in',
+    userId,
+    entryDate,
+    fileName
+  );
+  const finalPath = resolveFilePath(relativePath);
+  // Write to a unique temp file first; only promote it to the final name after
+  // the DB commit succeeds. This way a failed upsert never leaves an orphan and
+  // never clobbers the existing photo when replacing one with the same name.
+  const tempPath = `${finalPath}.tmp-${randomUUID()}`;
+
+  const client = await getClient(userId);
+  let committed = false;
+  try {
+    fs.mkdirSync(path.dirname(finalPath), { recursive: true });
+
+    await client.query('BEGIN');
+
+    const existing = await client.query(
+      `SELECT file_path FROM check_in_photos
+       WHERE user_id = $1 AND entry_date = $2 AND photo_type = $3`,
+      [userId, entryDate, photoType]
+    );
+    const oldRelativePath = existing.rows[0]?.file_path as string | undefined;
+
+    // Resolve the FK to check_in_measurements if a record exists for this date
+    const measurementResult = await client.query(
+      'SELECT id FROM check_in_measurements WHERE user_id = $1 AND entry_date = $2',
+      [userId, entryDate]
+    );
+    const measurementId = measurementResult.rows[0]?.id ?? null;
+
+    fs.writeFileSync(tempPath, buffer);
+
+    const result = await client.query(
+      `INSERT INTO check_in_photos
+         (user_id, check_in_measurement_id, entry_date, photo_type, file_path)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (user_id, entry_date, photo_type)
+       DO UPDATE SET
+         file_path = EXCLUDED.file_path,
+         check_in_measurement_id = EXCLUDED.check_in_measurement_id,
+         updated_at = now()
+       RETURNING id, user_id, check_in_measurement_id, entry_date, photo_type,
+                 file_path, created_at`,
+      [userId, measurementId, entryDate, photoType, relativePath]
+    );
+
+    await client.query('COMMIT');
+    committed = true;
+
+    // Atomically replace the final file with the new content.
+    fs.renameSync(tempPath, finalPath);
+
+    // Remove the previous file only when the name changed (e.g. a different
+    // extension); a same-name replace was already overwritten by the rename.
+    if (oldRelativePath && oldRelativePath !== relativePath) {
+      safeUnlink(resolveFilePath(oldRelativePath));
+    }
+
+    const r = result.rows[0];
+    return {
+      ...r,
+      entry_date:
+        r.entry_date instanceof Date
+          ? localDateToDay(r.entry_date)
+          : String(r.entry_date),
+      created_at:
+        r.created_at instanceof Date
+          ? r.created_at.toISOString()
+          : String(r.created_at),
+    };
+  } catch (err) {
+    if (!committed) {
+      await client.query('ROLLBACK').catch(() => {});
+    }
+    safeUnlink(tempPath);
+    throw err;
+  } finally {
+    client.release();
+  }
+};
+
+/**
+ * Resolves the absolute on-disk path of a photo the user is allowed to see.
+ * The SELECT is RLS-scoped (has_diary_access), so a row only comes back for the
+ * owner or a family member with check-in access. Returns null when the photo
+ * does not exist, is not accessible, or its stored path escapes the uploads
+ * root (defense in depth against a tampered file_path).
+ */
+export const getPhotoFileById = async (
+  userId: string,
+  photoId: string
+): Promise<string | null> => {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      'SELECT file_path FROM check_in_photos WHERE id = $1',
+      [photoId]
+    );
+    const filePath = result.rows[0]?.file_path;
+    if (!filePath) {
+      return null;
+    }
+    const absolute = resolveFilePath(filePath);
+    const uploadsRoot = resolveFilePath('uploads');
+    if (
+      absolute !== uploadsRoot &&
+      !absolute.startsWith(uploadsRoot + path.sep)
+    ) {
+      log(
+        'warn',
+        `Rejected check-in photo path outside uploads root: ${filePath}`
+      );
+      return null;
+    }
+    return absolute;
+  } finally {
+    client.release();
+  }
+};
+
+export const deletePhoto = async (
+  userId: string,
+  photoId: string
+): Promise<void> => {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `DELETE FROM check_in_photos WHERE id = $1 AND user_id = $2
+       RETURNING file_path`,
+      [photoId, userId]
+    );
+    if (result.rows.length === 0) {
+      return;
+    }
+    const filePath = resolveFilePath(result.rows[0].file_path);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+      log('debug', `Deleted check-in photo file: ${filePath}`);
+    }
+  } finally {
+    client.release();
+  }
+};
+
+export default { getPhotosByDate, upsertPhoto, getPhotoFileById, deletePhoto };

--- a/SparkyFitnessServer/services/checkInPhotoService.ts
+++ b/SparkyFitnessServer/services/checkInPhotoService.ts
@@ -213,9 +213,15 @@ export const deletePhoto = async (
       await fs.promises.unlink(filePath);
       log('debug', `Deleted check-in photo file: ${filePath}`);
     } catch (err) {
-      // The DB row is already gone; a missing file is not an error.
+      // The DB row is already deleted (the source of truth), so don't fail the
+      // request over the file. A missing file is expected; log anything else so
+      // the orphaned file can be cleaned up later.
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        throw err;
+        log(
+          'error',
+          `Failed to delete check-in photo file ${filePath} for photo ${photoId}`,
+          err
+        );
       }
     }
   } finally {

--- a/SparkyFitnessServer/services/checkInPhotoService.ts
+++ b/SparkyFitnessServer/services/checkInPhotoService.ts
@@ -16,13 +16,15 @@ const __dirname = path.dirname(__filename);
 const resolveFilePath = (relativePath: string) =>
   path.join(__dirname, '..', relativePath);
 
-const safeUnlink = (absolutePath: string) => {
+const safeUnlink = async (absolutePath: string) => {
   try {
-    if (fs.existsSync(absolutePath)) {
-      fs.unlinkSync(absolutePath);
-    }
+    await fs.promises.unlink(absolutePath);
   } catch (err) {
-    log('warn', `Failed to remove check-in photo file ${absolutePath}`, err);
+    // A missing file is fine here (e.g. nothing was ever written); only surface
+    // real failures.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      log('warn', `Failed to remove check-in photo file ${absolutePath}`, err);
+    }
   }
 };
 
@@ -82,7 +84,7 @@ export const upsertPhoto = async (
   const client = await getClient(userId);
   let committed = false;
   try {
-    fs.mkdirSync(path.dirname(finalPath), { recursive: true });
+    await fs.promises.mkdir(path.dirname(finalPath), { recursive: true });
 
     await client.query('BEGIN');
 
@@ -100,7 +102,7 @@ export const upsertPhoto = async (
     );
     const measurementId = measurementResult.rows[0]?.id ?? null;
 
-    fs.writeFileSync(tempPath, buffer);
+    await fs.promises.writeFile(tempPath, buffer);
 
     const result = await client.query(
       `INSERT INTO check_in_photos
@@ -120,12 +122,12 @@ export const upsertPhoto = async (
     committed = true;
 
     // Atomically replace the final file with the new content.
-    fs.renameSync(tempPath, finalPath);
+    await fs.promises.rename(tempPath, finalPath);
 
     // Remove the previous file only when the name changed (e.g. a different
     // extension); a same-name replace was already overwritten by the rename.
     if (oldRelativePath && oldRelativePath !== relativePath) {
-      safeUnlink(resolveFilePath(oldRelativePath));
+      await safeUnlink(resolveFilePath(oldRelativePath));
     }
 
     const r = result.rows[0];
@@ -144,7 +146,7 @@ export const upsertPhoto = async (
     if (!committed) {
       await client.query('ROLLBACK').catch(() => {});
     }
-    safeUnlink(tempPath);
+    await safeUnlink(tempPath);
     throw err;
   } finally {
     client.release();
@@ -205,9 +207,14 @@ export const deletePhoto = async (
       return;
     }
     const filePath = resolveFilePath(result.rows[0].file_path);
-    if (fs.existsSync(filePath)) {
-      fs.unlinkSync(filePath);
+    try {
+      await fs.promises.unlink(filePath);
       log('debug', `Deleted check-in photo file: ${filePath}`);
+    } catch (err) {
+      // The DB row is already gone; a missing file is not an error.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw err;
+      }
     }
   } finally {
     client.release();

--- a/SparkyFitnessServer/services/checkInPhotoService.ts
+++ b/SparkyFitnessServer/services/checkInPhotoService.ts
@@ -13,8 +13,25 @@ import type {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const resolveFilePath = (relativePath: string) =>
-  path.join(__dirname, '..', relativePath);
+// Mirror the uploads-root resolution used elsewhere (SparkyFitnessServer.ts,
+// routes/exerciseRoutes.ts, utils/imageDownloader.ts, services/backupService.ts)
+// so a custom uploads location is honored instead of always writing under
+// SparkyFitnessServer/uploads.
+const baseUploadsDir = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
+  ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY)
+  : path.join(__dirname, '..', 'uploads');
+
+// Stored file_path values are rooted at the logical 'uploads/' directory
+// (e.g. 'uploads/check-in/<user>/<date>/front.jpg') so records stay portable
+// across deployments. Resolve them against the configured uploads root,
+// stripping the leading 'uploads' segment. resolveFilePath('uploads') therefore
+// returns baseUploadsDir, keeping the path-traversal guard in getPhotoFileById
+// correct under a custom uploads directory.
+const resolveFilePath = (relativePath: string) => {
+  const segments = relativePath.split(/[/\\]/).filter(Boolean);
+  if (segments[0] === 'uploads') segments.shift();
+  return path.join(baseUploadsDir, ...segments);
+};
 
 const safeUnlink = async (absolutePath: string) => {
   try {

--- a/SparkyFitnessServer/services/checkInPhotoService.ts
+++ b/SparkyFitnessServer/services/checkInPhotoService.ts
@@ -159,8 +159,9 @@ export const upsertPhoto = async (
  * Resolves the absolute on-disk path of a photo the user is allowed to see.
  * The SELECT is RLS-scoped (has_diary_access), so a row only comes back for the
  * owner or a family member with check-in access. Returns null when the photo
- * does not exist, is not accessible, or its stored path escapes the uploads
- * root (defense in depth against a tampered file_path).
+ * row does not exist or is not accessible, the file is missing on disk, or its
+ * stored path escapes the uploads root (defense in depth against a tampered
+ * file_path).
  */
 export const getPhotoFileById = async (
   userId: string,
@@ -186,6 +187,13 @@ export const getPhotoFileById = async (
         'warn',
         `Rejected check-in photo path outside uploads root: ${filePath}`
       );
+      return null;
+    }
+    // Confirm the file is actually on disk so a missing file yields a clean 404
+    // at the route instead of a 500 from sendFile.
+    try {
+      await fs.promises.access(absolute);
+    } catch {
       return null;
     }
     return absolute;

--- a/SparkyFitnessServer/services/checkInPhotoService.ts
+++ b/SparkyFitnessServer/services/checkInPhotoService.ts
@@ -63,10 +63,12 @@ export const upsertPhoto = async (
   userId: string,
   entryDate: string,
   photoType: PhotoType,
-  originalName: string,
+  fileExtension: string,
   buffer: Buffer
 ): Promise<CheckInPhotoResponse> => {
-  const fileName = `${photoType}${path.extname(originalName).toLowerCase()}`;
+  // The extension is derived from the validated image bytes by the route, not
+  // from the client-supplied filename, so the stored name matches the content.
+  const fileName = `${photoType}.${fileExtension}`;
   // Store a relative path so records are portable across deployments.
   const relativePath = path.join(
     'uploads',

--- a/SparkyFitnessServer/tests/checkInPhotoRoutes.test.ts
+++ b/SparkyFitnessServer/tests/checkInPhotoRoutes.test.ts
@@ -1,0 +1,220 @@
+import {
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'
+import request from 'supertest';
+import express from 'express';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import checkInPhotoRoutes from '../routes/checkInPhotoRoutes.js';
+import checkInPhotoService from '../services/checkInPhotoService.js';
+import errorHandler from '../middleware/errorHandler.js';
+
+vi.mock('../services/checkInPhotoService.js');
+vi.mock('../middleware/authMiddleware', () => ({
+  authenticate: vi.fn((req: any, _res: any, next: any) => {
+    req.userId = 'test-user-id';
+    next();
+  }),
+}));
+vi.mock('../middleware/checkPermissionMiddleware', () => ({
+  default: vi.fn(() => (_req: any, _res: any, next: any) => next()),
+}));
+// Keep the real isAllowedImageBuffer so the magic-byte validation is exercised;
+// only stub the multer middleware and the disk-writing persist helper. The
+// fake single() lets a test drive the validated bytes via an x-test-bytes
+// header (hex), defaulting to a valid JPEG signature.
+vi.mock('../middleware/checkInPhotoUpload', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../middleware/checkInPhotoUpload.js')
+    >();
+  return {
+    ...actual,
+    default: {
+      single: vi.fn(() => (req: any, _res: any, next: any) => {
+        const hex = req.headers['x-test-bytes'] as string | undefined;
+        req.file = {
+          originalname: 'front.jpg',
+          buffer: hex
+            ? Buffer.from(hex, 'hex')
+            : Buffer.from([0xff, 0xd8, 0xff, 0x00]),
+        };
+        next();
+      }),
+    },
+  };
+});
+
+const app = express();
+app.use(express.json());
+app.use('/', checkInPhotoRoutes);
+app.use(errorHandler);
+
+const MOCK_PHOTO = {
+  id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  user_id: 'test-user-id',
+  check_in_measurement_id: null,
+  entry_date: '2026-06-14',
+  photo_type: 'front',
+  file_path: 'uploads/check-in/test-user-id/2026-06-14/front.jpg',
+  created_at: '2026-06-14T10:00:00.000Z',
+};
+
+describe('GET /:date', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns photos for a valid date', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.getPhotosByDate.mockResolvedValue([MOCK_PHOTO]);
+    const res = await request(app).get('/2026-06-14');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([MOCK_PHOTO]);
+    expect(checkInPhotoService.getPhotosByDate).toHaveBeenCalledWith(
+      'test-user-id',
+      '2026-06-14'
+    );
+  });
+
+  it('returns 400 for invalid date format', async () => {
+    const res = await request(app).get('/not-a-date');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when service throws', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.getPhotosByDate.mockRejectedValue(
+      new Error('DB error')
+    );
+    const res = await request(app).get('/2026-06-14');
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('GET /file/:id', () => {
+  const PHOTO_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+  let tempFile: string;
+
+  beforeAll(() => {
+    tempFile = path.join(os.tmpdir(), `checkin-test-${Date.now()}.jpg`);
+    fs.writeFileSync(tempFile, Buffer.from([0xff, 0xd8, 0xff, 0x00, 0x42]));
+  });
+  afterAll(() => {
+    if (fs.existsSync(tempFile)) fs.unlinkSync(tempFile);
+  });
+  beforeEach(() => vi.clearAllMocks());
+
+  it('serves the image with a nosniff header when accessible', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.getPhotoFileById.mockResolvedValue(tempFile);
+    const res = await request(app).get(`/file/${PHOTO_ID}`);
+    expect(res.status).toBe(200);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(checkInPhotoService.getPhotoFileById).toHaveBeenCalledWith(
+      'test-user-id',
+      PHOTO_ID
+    );
+  });
+
+  it('returns 404 when the photo is not found or not accessible', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.getPhotoFileById.mockResolvedValue(null);
+    const res = await request(app).get(`/file/${PHOTO_ID}`);
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for a non-UUID id', async () => {
+    const res = await request(app).get('/file/not-a-uuid');
+    expect(res.status).toBe(400);
+    expect(checkInPhotoService.getPhotoFileById).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the service throws', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.getPhotoFileById.mockRejectedValue(new Error('boom'));
+    const res = await request(app).get(`/file/${PHOTO_ID}`);
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /:date/:type', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('uploads a photo successfully', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.upsertPhoto.mockResolvedValue(MOCK_PHOTO);
+    const res = await request(app).post('/2026-06-14/front');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(MOCK_PHOTO);
+    expect(checkInPhotoService.upsertPhoto).toHaveBeenCalledWith(
+      'test-user-id',
+      '2026-06-14',
+      'front',
+      'front.jpg',
+      expect.any(Buffer)
+    );
+  });
+
+  it('returns 400 when the file content is not a valid image', async () => {
+    const res = await request(app)
+      .post('/2026-06-14/front')
+      .set('x-test-bytes', '0001020304');
+    expect(res.status).toBe(400);
+    expect(checkInPhotoService.upsertPhoto).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an invalid photo type', async () => {
+    const res = await request(app).post('/2026-06-14/diagonal');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for invalid date format', async () => {
+    const res = await request(app).post('/bad-date/front');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when service throws', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.upsertPhoto.mockRejectedValue(new Error('DB error'));
+    const res = await request(app).post('/2026-06-14/front');
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('DELETE /photo/:id', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('deletes a photo by id', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.deletePhoto.mockResolvedValue(undefined);
+    const res = await request(app).delete(
+      '/photo/a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    );
+    expect(res.status).toBe(204);
+    expect(checkInPhotoService.deletePhoto).toHaveBeenCalledWith(
+      'test-user-id',
+      'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    );
+  });
+
+  it('returns 400 for non-UUID id', async () => {
+    const res = await request(app).delete('/photo/not-a-uuid');
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when service throws', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.deletePhoto.mockRejectedValue(new Error('DB error'));
+    const res = await request(app).delete(
+      '/photo/a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    );
+    expect(res.status).toBe(500);
+  });
+});

--- a/SparkyFitnessServer/tests/checkInPhotoRoutes.test.ts
+++ b/SparkyFitnessServer/tests/checkInPhotoRoutes.test.ts
@@ -157,7 +157,24 @@ describe('POST /:date/:type', () => {
       'test-user-id',
       '2026-06-14',
       'front',
-      'front.jpg',
+      'jpg',
+      expect.any(Buffer)
+    );
+  });
+
+  it('accepts a WebP image and stores it with a webp extension', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.upsertPhoto.mockResolvedValue(MOCK_PHOTO);
+    // "RIFF" + 4-byte size + "WEBP"
+    const res = await request(app)
+      .post('/2026-06-14/front')
+      .set('x-test-bytes', '524946460000000057454250');
+    expect(res.status).toBe(200);
+    expect(checkInPhotoService.upsertPhoto).toHaveBeenCalledWith(
+      'test-user-id',
+      '2026-06-14',
+      'front',
+      'webp',
       expect.any(Buffer)
     );
   });
@@ -166,6 +183,15 @@ describe('POST /:date/:type', () => {
     const res = await request(app)
       .post('/2026-06-14/front')
       .set('x-test-bytes', '0001020304');
+    expect(res.status).toBe(400);
+    expect(checkInPhotoService.upsertPhoto).not.toHaveBeenCalled();
+  });
+
+  it('rejects a RIFF container that is not WebP (e.g. WAV/AVI)', async () => {
+    // "RIFF" + size + "WAVE" must not pass the WebP signature check.
+    const res = await request(app)
+      .post('/2026-06-14/front')
+      .set('x-test-bytes', '524946460000000057415645');
     expect(res.status).toBe(400);
     expect(checkInPhotoService.upsertPhoto).not.toHaveBeenCalled();
   });

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -1027,6 +1027,23 @@ CREATE TABLE public.check_in_measurements (
 
 
 --
+-- Name: check_in_photos; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.check_in_photos (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    user_id uuid NOT NULL,
+    check_in_measurement_id uuid,
+    entry_date date NOT NULL,
+    photo_type character varying(5) NOT NULL,
+    file_path text NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    CONSTRAINT check_in_photos_type_check CHECK (((photo_type)::text = ANY (ARRAY[('front'::character varying)::text, ('back'::character varying)::text, ('side'::character varying)::text])))
+);
+
+
+--
 -- Name: custom_categories; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -4146,6 +4163,22 @@ ALTER TABLE ONLY public.check_in_measurements
 
 
 --
+-- Name: check_in_photos check_in_photos_check_in_measurement_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.check_in_photos
+    ADD CONSTRAINT check_in_photos_check_in_measurement_id_fkey FOREIGN KEY (check_in_measurement_id) REFERENCES public.check_in_measurements(id) ON DELETE SET NULL;
+
+
+--
+-- Name: check_in_photos check_in_photos_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.check_in_photos
+    ADD CONSTRAINT check_in_photos_user_id_fkey FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+
+--
 -- Name: custom_categories custom_categories_created_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5036,6 +5069,12 @@ ALTER TABLE public.api_key ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.check_in_measurements ENABLE ROW LEVEL SECURITY;
 
 --
+-- Name: check_in_photos; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.check_in_photos ENABLE ROW LEVEL SECURITY;
+
+--
 -- Name: custom_categories; Type: ROW SECURITY; Schema: public; Owner: -
 --
 
@@ -5203,6 +5242,13 @@ ALTER TABLE public.meals ENABLE ROW LEVEL SECURITY;
 --
 
 CREATE POLICY modify_policy ON public.check_in_measurements USING (public.has_diary_access(user_id)) WITH CHECK (public.has_diary_access(user_id));
+
+
+--
+-- Name: check_in_photos modify_policy; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY modify_policy ON public.check_in_photos USING (public.has_diary_access(user_id)) WITH CHECK (public.has_diary_access(user_id));
 
 
 --
@@ -5638,6 +5684,13 @@ CREATE POLICY select_exercise_preset_entry_linked_policy ON public.exercise_entr
 --
 
 CREATE POLICY select_policy ON public.check_in_measurements FOR SELECT USING (public.has_diary_access(user_id));
+
+
+--
+-- Name: check_in_photos select_policy; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY select_policy ON public.check_in_photos FOR SELECT USING (public.has_diary_access(user_id));
 
 
 --

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -3031,6 +3031,30 @@ ALTER TABLE ONLY public.backup_settings
 
 
 --
+-- Name: check_in_measurements check_in_measurements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.check_in_measurements
+    ADD CONSTRAINT check_in_measurements_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: check_in_photos check_in_photos_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.check_in_photos
+    ADD CONSTRAINT check_in_photos_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: check_in_photos check_in_photos_user_date_type_unique; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.check_in_photos
+    ADD CONSTRAINT check_in_photos_user_date_type_unique UNIQUE (user_id, entry_date, photo_type);
+
+
+--
 -- Name: daily_sleep_need daily_sleep_need_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
Resolves #229. Add the ability to upload and track progress photos from the check-in screen, with three fixed angle slots (front, back, side) per day, plus the backend storage, retrieval, and security hardening.

Frontend:
- New CheckInPhotos UI on the check-in screen with front/back/side slots (upload / replace / remove) and en/es translations.

Backend:
- New check_in_photos table, routes, service, schemas, and upload middleware.
- Photos stored under ```uploads/check-in/<userId>/<date>/<type>.<ext>```; only the relative path is persisted, so records stay portable across deployments.
- Uploads validated by real image magic bytes (not the spoofable mime type or filename), buffered in memory, and written to a temp file that is atomically promoted only after the DB commit, so a failed insert never orphans a file and a same-name replace never clobbers a valid photo.
- Photos served through an authenticated, ownership-checked route (RLS-scoped) with X-Content-Type-Options: nosniff; direct static access to /uploads/check-in is blocked.
- RLS: enable row-level security and add the per-user diary policy for check_in_photos (previously RLS was enabled with no policy, so every insert was denied).
- DB: point check_in_photos.user_id at public."user" (Better Auth), matching check_in_measurements; uploads failed with a foreign key violation for users absent from the legacy auth.users table. Add the prerequisite PRIMARY KEY on check_in_measurements so the photos foreign key target is valid.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

## Linked Issue
Linked Issue: Closes #229

## How to Test

1. Check out this branch and start the server (`pnpm start` in `SparkyFitnessServer/`).
   The new migrations apply automatically on boot (`check_in_measurements` PK →
   `check_in_photos` table → FK repoint to `public."user"`), and RLS policies are
   re-applied, so an existing DB is upgraded in place.
2. Start the frontend (`pnpm dev` in `SparkyFitnessFrontend/`) and log in.
3. Navigate to **Check-In** and find the new **Progress Photos** section.
4. Upload a **Front**, **Back**, and **Side** photo. Verify each shows a preview,
   can be replaced, and persists after reloading the page / reopening the date.
5. Verify files land under `SparkyFitnessServer/uploads/check-in/<userId>/<date>/`.
6. Verify a non-image (e.g. a renamed `.txt` → `.jpg`) is rejected on upload.
7. (Multi-user) Log in as a second user, add photos for the same date, and confirm
   each user only sees their own — photos are served by id through an
   ownership/RLS-checked route, and `/uploads/check-in` is not publicly served.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation
## Checklist

**All PRs:**
- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the License terms.

**New features only:**
- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (SparkyFitnessFrontend/):**
- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (en) translation file.

**Backend changes (SparkyFitnessServer/):**
- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**
- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (SparkyFitnessMobile/):**
- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: N/A — no mobile changes.

## Screenshots

| Before (upstream `main`) | After (this PR) |
| --- | --- |
| <img width="1493" height="1136" alt="image" src="https://github.com/user-attachments/assets/166966a0-ae22-47f2-8491-588c76bb96df" />| <img width="2535" height="1213" alt="image" src="https://github.com/user-attachments/assets/5c5f83c7-09cb-4c7f-8619-77b37f70bedc" /> |
|--- |<img width="2524" height="1199" alt="image" src="https://github.com/user-attachments/assets/69d5cd5a-ce0b-4d3a-b726-0f7dd19430a7" />|


</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


