### PR TITLE
fix(foods): close Edit Food dialog correctly when cancelling past enrties sync

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
@@ -60,7 +60,6 @@ const CustomFoodForm = ({
     variantErrors,
     loading,
     showSyncConfirmation,
-    setShowSyncConfirmation,
     loadedVariants,
     conversionBaseVariants,
     hasTrustedCompatibilityBase,
@@ -295,8 +294,12 @@ const CustomFoodForm = ({
       {showSyncConfirmation && (
         <ConfirmationDialog
           open={showSyncConfirmation}
-          onOpenChange={setShowSyncConfirmation}
-          onConfirm={handleSyncConfirmation}
+          onOpenChange={(open) => {
+            if (!open) {
+              handleSyncConfirmation(false);
+            }
+          }}
+          onConfirm={() => handleSyncConfirmation(true)}
           title="Sync Past Entries?"
           description="Do you want to update all your past diary entries for this food with the new nutritional information?"
         />

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
@@ -351,7 +351,7 @@ export function useCustomFoodForm({
   >([]);
   const [variantMeta, setVariantMeta] = useState<VariantMeta[]>([]);
   const [showSyncConfirmation, setShowSyncConfirmation] = useState(false);
-  const [syncFoodId, setSyncFoodId] = useState<string | null>(null);
+  const [savedFoodResult, setSavedFoodResult] = useState<Food | null>(null);
   const [formData, setFormData] = useState({
     name: '',
     brand: '',
@@ -1071,7 +1071,7 @@ export function useCustomFoodForm({
       });
 
       if (food?.id && user?.id === food.user_id) {
-        setSyncFoodId(savedFood.id);
+        setSavedFoodResult(savedFood);
         setShowSyncConfirmation(true);
       } else {
         if (!food?.id) resetForm();
@@ -1094,16 +1094,21 @@ export function useCustomFoodForm({
     await persistFood();
   };
 
-  const handleSyncConfirmation = async () => {
-    if (syncFoodId) {
+  const handleSyncConfirmation = async (sync: boolean) => {
+    if (sync && savedFoodResult) {
       try {
-        await updateFoodEntriesSnapshot(syncFoodId);
+        await updateFoodEntriesSnapshot(savedFoodResult.id);
       } catch {
         /* toast handled by QueryClient */
       }
     }
     setShowSyncConfirmation(false);
-    if (food) onSave(food);
+    if (savedFoodResult) {
+      onSave(savedFoodResult);
+    } else if (food) {
+      onSave(food);
+    }
+    setSavedFoodResult(null);
   };
 
   const variantErrors = useMemo(

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
@@ -1095,7 +1095,9 @@ export function useCustomFoodForm({
   };
 
   const handleSyncConfirmation = async (sync: boolean) => {
-    if (sync && savedFoodResult) {
+    if (!savedFoodResult) return;
+
+    if (sync) {
       try {
         await updateFoodEntriesSnapshot(savedFoodResult.id);
       } catch {
@@ -1103,11 +1105,7 @@ export function useCustomFoodForm({
       }
     }
     setShowSyncConfirmation(false);
-    if (savedFoodResult) {
-      onSave(savedFoodResult);
-    } else if (food) {
-      onSave(food);
-    }
+    onSave(savedFoodResult);
     setSavedFoodResult(null);
   };
 


### PR DESCRIPTION


> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

Triggers the save callback when dismissing or cancelling the Sync Past Entries dialog so the main Edit Food form successfully closes after changes are saved.



**How did you implement the solution?**
(Brief technical approach.)

Modified the sync confirmation dialog to accept a boolean flag so that cancelling or dismissing the dialog skips the historical sync but still fires the save callback to close the form.



Linked Issue: Closes # https://github.com/CodeWithCJ/SparkyFitness/issues/1476

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
