### PR TITLE
fix: support user weight units in active workout playback and preset stats

### DIFF
--- a/SparkyFitnessFrontend/src/components/Onboarding/OnBoardingSteps.tsx
+++ b/SparkyFitnessFrontend/src/components/Onboarding/OnBoardingSteps.tsx
@@ -145,7 +145,10 @@ export const OnboardingSteps = ({
               unit={weightUnit}
               value={formData.currentWeight}
               onChange={(val) =>
-                handleInputChange('currentWeight', val.toString())
+                handleInputChange(
+                  'currentWeight',
+                  val !== null ? val.toString() : ''
+                )
               }
               className="w-64"
             />
@@ -194,7 +197,9 @@ export const OnboardingSteps = ({
               type="height"
               unit={heightUnit}
               value={formData.height}
-              onChange={(val) => handleInputChange('height', val.toString())}
+              onChange={(val) =>
+                handleInputChange('height', val !== null ? val.toString() : '')
+              }
               className="w-64"
             />
           </div>
@@ -336,7 +341,10 @@ export const OnboardingSteps = ({
               unit={weightUnit}
               value={formData.targetWeight}
               onChange={(val) =>
-                handleInputChange('targetWeight', val.toString())
+                handleInputChange(
+                  'targetWeight',
+                  val !== null ? val.toString() : ''
+                )
               }
               className="w-64"
             />

--- a/SparkyFitnessFrontend/src/components/ui/UnitInput.tsx
+++ b/SparkyFitnessFrontend/src/components/ui/UnitInput.tsx
@@ -14,13 +14,14 @@ import { getPrecision } from '@workspace/shared';
 
 interface UnitInputProps {
   id?: string;
-  value: number | string; // Metric base value (kg or cm)
+  value: number | string | null; // Metric base value (kg or cm)
   unit: string; // kg, lbs, st_lbs, cm, inches, ft_in
   type: 'weight' | 'height' | 'measurement';
-  onChange: (metricValue: number) => void;
+  onChange: (metricValue: number | null) => void;
   placeholder?: string;
   className?: string;
   inputClassName?: string;
+  'aria-label'?: string;
 }
 
 export const UnitInput: React.FC<UnitInputProps> = ({
@@ -32,9 +33,14 @@ export const UnitInput: React.FC<UnitInputProps> = ({
   placeholder,
   className,
   inputClassName = '',
+  'aria-label': ariaLabel,
 }) => {
   const metricValue =
-    typeof value === 'string' ? parseFloat(value) || 0 : value;
+    value === null || value === undefined || value === ''
+      ? null
+      : typeof value === 'string'
+        ? parseFloat(value)
+        : value;
 
   // Local state for split inputs
   const [val1, setVal1] = useState<string>(''); // stones, feet, or single value
@@ -48,7 +54,7 @@ export const UnitInput: React.FC<UnitInputProps> = ({
     setPrevMetricValue(metricValue);
     setPrevUnit(unit);
 
-    if (!metricValue) {
+    if (metricValue === null || Number.isNaN(metricValue)) {
       setVal1('');
       setVal2('');
     } else {
@@ -87,7 +93,19 @@ export const UnitInput: React.FC<UnitInputProps> = ({
     setVal1(e.target.value);
   };
   const handleSingleBlur = () => {
-    const num = parseFloat(val1) || 0;
+    if (val1.trim() === '') {
+      if (metricValue !== null) {
+        onChange(null);
+      }
+      return;
+    }
+    const num = parseFloat(val1);
+    if (Number.isNaN(num)) {
+      if (metricValue !== null) {
+        onChange(null);
+      }
+      return;
+    }
     let converted = num;
     if (unit === 'lbs') converted = lbsToKg(num);
     if (unit === 'inches') converted = inchesToCm(num);
@@ -102,6 +120,12 @@ export const UnitInput: React.FC<UnitInputProps> = ({
   };
 
   const handleSplitBlur = () => {
+    if (val1.trim() === '' && val2.trim() === '') {
+      if (metricValue !== null) {
+        onChange(null);
+      }
+      return;
+    }
     const n1 = parseFloat(val1) || 0;
     const n2 = parseFloat(val2) || 0;
     let converted = 0;
@@ -172,6 +196,7 @@ export const UnitInput: React.FC<UnitInputProps> = ({
         onBlur={handleSingleBlur}
         placeholder={placeholder}
         className={`pr-9 ${inputClassName}`}
+        aria-label={ariaLabel}
       />
       <span className="absolute right-2 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
         {unit}

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInForm.tsx
@@ -90,7 +90,9 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
                 type="weight"
                 unit={defaultWeightUnit}
                 value={weight}
-                onChange={(val) => setWeight(val.toString())}
+                onChange={(val) =>
+                  setWeight(val !== null ? val.toString() : '')
+                }
               />
             </div>
 
@@ -101,7 +103,9 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
                 type="height"
                 unit={defaultMeasurementUnit}
                 value={height}
-                onChange={(val) => setHeight(val.toString())}
+                onChange={(val) =>
+                  setHeight(val !== null ? val.toString() : '')
+                }
               />
             </div>
 
@@ -125,7 +129,7 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
                 type="measurement"
                 unit={defaultMeasurementUnit}
                 value={neck}
-                onChange={(val) => setNeck(val.toString())}
+                onChange={(val) => setNeck(val !== null ? val.toString() : '')}
               />
             </div>
 
@@ -136,7 +140,7 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
                 type="measurement"
                 unit={defaultMeasurementUnit}
                 value={waist}
-                onChange={(val) => setWaist(val.toString())}
+                onChange={(val) => setWaist(val !== null ? val.toString() : '')}
               />
             </div>
 
@@ -147,7 +151,7 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
                 type="measurement"
                 unit={defaultMeasurementUnit}
                 value={hips}
-                onChange={(val) => setHips(val.toString())}
+                onChange={(val) => setHips(val !== null ? val.toString() : '')}
               />
             </div>
             <div>
@@ -236,7 +240,7 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
                       onChange={(val) => {
                         setCustomValues((prev) => ({
                           ...prev,
-                          [category.id]: val.toString(),
+                          [category.id]: val !== null ? val.toString() : '',
                         }));
                       }}
                     />

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
@@ -1,6 +1,7 @@
 import { useState, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown } from 'lucide-react';
+import type { WeightUnit } from '@/contexts/PreferencesContext';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import {
   WORKOUT_PLAYBACK_SET_GRID_CLASSES,
@@ -24,7 +25,7 @@ interface WorkoutPlaybackExercisesListProps {
   onOpenRestEditor: (pointer: WorkoutSetPointer) => void;
   onRemoveSet: (pointer: WorkoutSetPointer) => void;
   onAddSet: (exerciseIndex: number) => void;
-  weightUnit: string;
+  weightUnit: WeightUnit;
 }
 
 const WorkoutPlaybackExercisesList = ({

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
@@ -24,6 +24,7 @@ interface WorkoutPlaybackExercisesListProps {
   onOpenRestEditor: (pointer: WorkoutSetPointer) => void;
   onRemoveSet: (pointer: WorkoutSetPointer) => void;
   onAddSet: (exerciseIndex: number) => void;
+  weightUnit: string;
 }
 
 const WorkoutPlaybackExercisesList = ({
@@ -37,6 +38,7 @@ const WorkoutPlaybackExercisesList = ({
   onOpenRestEditor,
   onRemoveSet,
   onAddSet,
+  weightUnit,
 }: WorkoutPlaybackExercisesListProps) => {
   const { t } = useTranslation();
   const [expandedCompletedExercises, setExpandedCompletedExercises] = useState<
@@ -160,6 +162,7 @@ const WorkoutPlaybackExercisesList = ({
                         onOpenRestEditor={onOpenRestEditor}
                         onRemoveSet={onRemoveSet}
                         canRemove={exercise.sets.length > 1}
+                        weightUnit={weightUnit}
                       />
                     );
                   })}

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackPage.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackPage.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardDescription, CardHeader } from '@/components/ui/card';
 import { useCreatePresetSessionMutation } from '@/hooks/Exercises/useExerciseEntries';
+import { usePreferences } from '@/contexts/PreferencesContext';
 import {
   DEFAULT_REST_SECONDS,
   addWorkoutSetToExercise,
@@ -110,6 +111,7 @@ function startRestTimer(
 
 const WorkoutPlaybackPage = () => {
   const { t } = useTranslation();
+  const { weightUnit } = usePreferences();
   const navigate = useNavigate();
   const location = useLocation();
   const [searchParams] = useSearchParams();
@@ -559,6 +561,7 @@ const WorkoutPlaybackPage = () => {
         onOpenRestEditor={handleOpenRestEditor}
         onRemoveSet={handleRemoveSet}
         onAddSet={handleAddSet}
+        weightUnit={weightUnit}
       />
 
       <WorkoutPlaybackDialogs

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSetRow.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSetRow.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
+import { UnitInput } from '@/components/ui/UnitInput';
 import {
   Select,
   SelectContent,
@@ -38,15 +39,6 @@ function parseNullableInteger(raw: string): number | null {
   return Number.isNaN(parsed) ? null : parsed;
 }
 
-function parseNullableDecimal(raw: string): number | null {
-  if (raw.trim() === '') {
-    return null;
-  }
-
-  const parsed = Number(raw);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
 interface WorkoutPlaybackSetRowProps {
   exerciseName: string;
   exerciseKey: string;
@@ -72,6 +64,7 @@ interface WorkoutPlaybackSetRowProps {
   onOpenRestEditor: (pointer: WorkoutSetPointer) => void;
   onRemoveSet: (pointer: WorkoutSetPointer) => void;
   canRemove: boolean;
+  weightUnit: string;
 }
 
 const WorkoutPlaybackSetRow = ({
@@ -95,6 +88,7 @@ const WorkoutPlaybackSetRow = ({
   onOpenRestEditor,
   onRemoveSet,
   canRemove,
+  weightUnit,
 }: WorkoutPlaybackSetRowProps) => {
   const { t } = useTranslation();
   const pointer: WorkoutSetPointer = { exerciseIndex, setIndex };
@@ -186,24 +180,19 @@ const WorkoutPlaybackSetRow = ({
             className="col-span-1 w-full focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:col-start-3"
           />
 
-          <Input
-            type="number"
-            inputMode="decimal"
-            min={0}
-            step={0.5}
-            aria-label={`Weight set ${setNumber}`}
-            value={weight ?? ''}
+          <div
+            className="col-span-1 w-full sm:col-start-4"
             onClick={(event) => event.stopPropagation()}
-            onChange={(event) =>
-              onSetFieldChange(
-                pointer,
-                'weight',
-                parseNullableDecimal(event.target.value)
-              )
-            }
-            placeholder={t('common.weight', 'Weight')}
-            className="col-span-1 w-full focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:col-start-4"
-          />
+          >
+            <UnitInput
+              value={weight ?? ''}
+              unit={weightUnit}
+              type="weight"
+              placeholder={t('common.weight', 'Weight')}
+              onChange={(value) => onSetFieldChange(pointer, 'weight', value)}
+              inputClassName="focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+            />
+          </div>
 
           <Button
             type="button"

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSetRow.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSetRow.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { memo } from 'react';
+import type { WeightUnit } from '@/contexts/PreferencesContext';
 import { MessageSquare, Timer, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -64,7 +65,7 @@ interface WorkoutPlaybackSetRowProps {
   onOpenRestEditor: (pointer: WorkoutSetPointer) => void;
   onRemoveSet: (pointer: WorkoutSetPointer) => void;
   canRemove: boolean;
-  weightUnit: string;
+  weightUnit: WeightUnit;
 }
 
 const WorkoutPlaybackSetRow = ({
@@ -191,6 +192,7 @@ const WorkoutPlaybackSetRow = ({
               placeholder={t('common.weight', 'Weight')}
               onChange={(value) => onSetFieldChange(pointer, 'weight', value)}
               inputClassName="focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+              aria-label={`Weight set ${setNumber}`}
             />
           </div>
 

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
@@ -44,6 +44,7 @@ import {
 import { useLogWorkoutPresetMutation } from '@/hooks/Exercises/useExerciseEntries';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { createWorkoutPlaybackRouteState } from '@/utils/workoutPlayback';
+import { formatWeight } from '@/utils/numberFormatting';
 import WorkoutPresetSelector from './WorkoutPresetSelector';
 
 import { useBulkSelection } from '@/hooks/useBulkSelection';
@@ -267,10 +268,7 @@ const WorkoutPresetsManager = () => {
               </div>
               <div className="flex items-center gap-1">
                 <Dumbbell className="w-3 h-3 text-indigo-500" />
-                <span>
-                  {totalWeight}
-                  {weightUnit}
-                </span>
+                <span>{formatWeight(totalWeight, weightUnit)}</span>
               </div>
             </div>
           );

--- a/SparkyFitnessFrontend/src/tests/components/WorkoutPlaybackPage.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/WorkoutPlaybackPage.test.tsx
@@ -21,6 +21,10 @@ jest.mock('react-router-dom', () => ({
   useSearchParams: () => [mockSearchParams],
 }));
 
+jest.mock('@/contexts/PreferencesContext', () => ({
+  usePreferences: () => ({ weightUnit: 'kg' }),
+}));
+
 jest.mock('@/hooks/Exercises/useExerciseEntries', () => ({
   useCreatePresetSessionMutation: () => ({
     mutateAsync: (...args: unknown[]) => mockCreatePresetSession(...args),


### PR DESCRIPTION
…

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

Fixes weight unit display discrepancies where active workout playback weight values and preset statistics columns were rendered directly as metric database values (kg) without converting to the user's preferred unit (lbs/stones).



**How did you implement the solution?**
(Brief technical approach.)
Replaced standard weight text inputs in 

WorkoutPlaybackSetRow.tsx
 with the 

UnitInput
 component, and wrapped preset tonnage rendering in 

WorkoutPresetsManager.tsx
 using the formatWeight helper.



Linked Issue: Closes # https://github.com/CodeWithCJ/SparkyFitness/issues/1384

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
