### PR TITLE
Backup setting fixes for web

### DIFF
--- a/SparkyFitnessFrontend/src/hooks/Admin/useBackups.ts
+++ b/SparkyFitnessFrontend/src/hooks/Admin/useBackups.ts
@@ -35,11 +35,13 @@ export const useUpdateBackupSettings = () => {
     },
     meta: {
       successMessage: (data: unknown) => {
-        const response = data as { warning?: string };
-        return (
-          response?.warning ??
-          t('admin.backupSettings.backupSettingsSaved', 'Saved')
-        );
+        const response = data as { schedulerFailed?: boolean };
+        return response?.schedulerFailed
+          ? t(
+              'admin.backupSettings.saveWarningSchedulerFailed',
+              'Settings saved, but the live scheduler could not be updated. Changes will take effect on next server restart.'
+            )
+          : t('admin.backupSettings.backupSettingsSaved', 'Saved');
       },
       errorMessage: t('error', 'Error'),
     },

--- a/SparkyFitnessFrontend/src/hooks/Admin/useBackups.ts
+++ b/SparkyFitnessFrontend/src/hooks/Admin/useBackups.ts
@@ -34,7 +34,13 @@ export const useUpdateBackupSettings = () => {
       return queryClient.invalidateQueries({ queryKey: backupKeys.all });
     },
     meta: {
-      successMessage: t('admin.backupSettings.backupSettingsSaved', 'Saved'),
+      successMessage: (data: unknown) => {
+        const response = data as { warning?: string };
+        return (
+          response?.warning ??
+          t('admin.backupSettings.backupSettingsSaved', 'Saved')
+        );
+      },
       errorMessage: t('error', 'Error'),
     },
   });

--- a/SparkyFitnessFrontend/src/pages/Admin/BackupSettingsForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/Admin/BackupSettingsForm.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { BackupSettings, BackupSettingsMutator } from '@workspace/shared';
+import { getLocalTimeString } from './backupTimeUtils';
 
 interface BackupSettingsFormProps {
   initialSettings: BackupSettings;
@@ -29,20 +30,6 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
   backupLocation,
 }) => {
   const { t } = useTranslation();
-
-  const getLocalTimeString = (utcTimeStr?: string) => {
-    if (!utcTimeStr) return '02:00';
-    const [hours, minutes] = utcTimeStr.split(':').map(Number);
-    const date = new Date();
-    if (hours && minutes) {
-      date.setUTCHours(hours, minutes, 0, 0);
-    }
-    return date.toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-      hourCycle: 'h23',
-    });
-  };
 
   const getStatusText = (status?: string | null, timestamp?: Date | null) => {
     if (status && timestamp) {
@@ -81,9 +68,16 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
   };
 
   const handleSubmit = () => {
-    const [hours, minutes] = backupTime.split(':').map(Number);
+    const parts = backupTime.split(':').map(Number);
+    const hours = parts[0];
+    const minutes = parts[1];
     const localDate = new Date();
-    if (hours && minutes) {
+    if (
+      hours !== undefined &&
+      minutes !== undefined &&
+      !isNaN(hours) &&
+      !isNaN(minutes)
+    ) {
       localDate.setHours(hours, minutes, 0, 0);
     }
     const utcTime = localDate.toISOString().substring(11, 16);
@@ -106,7 +100,7 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
   return (
     <div className="p-4 pt-0 space-y-6">
       <div className="mb-4">
-        <label className="block text-gray-700 text-sm font-bold mb-2">
+        <label className="block text-foreground text-sm font-bold mb-2">
           {t(
             'admin.backupSettings.enableScheduledBackups',
             'Enable Scheduled Backups:'
@@ -118,7 +112,7 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
       {backupEnabled && (
         <>
           <div className="mb-4">
-            <label className="block text-gray-700 text-sm font-bold mb-2">
+            <label className="block text-foreground text-sm font-bold mb-2">
               {t('admin.backupSettings.backupDays', 'Backup Days:')}
             </label>
             <div className="flex flex-wrap gap-2">
@@ -130,7 +124,7 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
                     onChange={() => handleDayChange(day)}
                     className=" form-checkbox h-4 w-4 text-blue-600"
                   />
-                  <span className="ml-2 text-gray-700">
+                  <span className="ml-2 text-foreground">
                     {t(`common.${day.toLowerCase()}`, day)}
                   </span>
                 </label>
@@ -140,7 +134,7 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
 
           <div className="mb-4">
             <label
-              className="block text-gray-700 text-sm font-bold mb-2"
+              className="block text-foreground text-sm font-bold mb-2"
               htmlFor="backupTime"
             >
               {t('admin.backupSettings.backupTime', {
@@ -159,7 +153,7 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
           </div>
 
           <div className="mb-4">
-            <label className="block text-gray-700 text-sm font-bold mb-2">
+            <label className="block text-foreground text-sm font-bold mb-2">
               {t(
                 'admin.backupSettings.retentionDays',
                 'Keep backups for (days):'
@@ -177,17 +171,17 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
       )}
 
       <div className="mb-4">
-        <label className="block text-gray-700 text-sm font-bold mb-2">
+        <label className="block text-foreground text-sm font-bold mb-2">
           {t('admin.backupSettings.backupLocation', 'Backup Location:')}
         </label>
-        <p className="text-gray-900 break-all">{backupLocation}</p>
+        <p className="text-foreground break-all">{backupLocation}</p>
       </div>
 
       <div className="mb-4">
-        <label className="block text-gray-700 text-sm font-bold mb-2">
+        <label className="block text-foreground text-sm font-bold mb-2">
           {t('admin.backupSettings.lastBackupStatus', 'Last Backup Status:')}
         </label>
-        <p className="text-gray-900">
+        <p className="text-foreground">
           {getStatusText(
             initialSettings.lastBackupStatus,
             initialSettings.lastBackupTimestamp
@@ -249,7 +243,7 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
         </p>
         <div className="relative">
           {isRestoring && (
-            <div className="absolute inset-0 bg-white/50 z-10 flex items-center justify-center">
+            <div className="absolute inset-0 bg-background/50 z-10 flex items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-blue-600" />
             </div>
           )}
@@ -258,7 +252,7 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
             accept=".tar.gz"
             disabled={isRestoring}
             onChange={handleFileChange}
-            className="block w-full h-15 text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-violet-50 file:text-violet-700 hover:file:bg-violet-100 disabled:opacity-50"
+            className="block w-full h-15 text-sm text-muted-foreground file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-violet-50 file:text-violet-700 hover:file:bg-violet-100 disabled:opacity-50"
           />
         </div>
       </div>

--- a/SparkyFitnessFrontend/src/pages/Admin/BackupSettingsForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/Admin/BackupSettingsForm.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { BackupSettings, BackupSettingsMutator } from '@workspace/shared';
+import { toast } from '@/hooks/use-toast';
 import { getLocalTimeString } from './backupTimeUtils';
 
 interface BackupSettingsFormProps {
@@ -71,13 +72,32 @@ export const BackupSettingsForm: React.FC<BackupSettingsFormProps> = ({
     const parts = backupTime.split(':').map(Number);
     const hours = parts[0];
     const minutes = parts[1];
-    const localDate = new Date();
     if (
-      hours !== undefined &&
-      minutes !== undefined &&
-      !isNaN(hours) &&
-      !isNaN(minutes)
+      backupEnabled &&
+      (hours === undefined ||
+        minutes === undefined ||
+        isNaN(hours) ||
+        isNaN(minutes) ||
+        hours < 0 ||
+        hours > 23 ||
+        minutes < 0 ||
+        minutes > 59)
     ) {
+      toast({
+        title: t(
+          'admin.backupSettings.invalidTimeTitle',
+          'Invalid backup time'
+        ),
+        description: t(
+          'admin.backupSettings.invalidTimeDescription',
+          'Please enter a valid time in HH:MM format before saving.'
+        ),
+        variant: 'destructive',
+      });
+      return;
+    }
+    const localDate = new Date();
+    if (hours !== undefined && minutes !== undefined) {
       localDate.setHours(hours, minutes, 0, 0);
     }
     const utcTime = localDate.toISOString().substring(11, 16);

--- a/SparkyFitnessFrontend/src/pages/Admin/backupTimeUtils.ts
+++ b/SparkyFitnessFrontend/src/pages/Admin/backupTimeUtils.ts
@@ -1,0 +1,20 @@
+export const getLocalTimeString = (
+  utcTimeStr?: string,
+  now: Date = new Date()
+): string => {
+  if (!utcTimeStr) return '02:00';
+  const rawParts = utcTimeStr.split(':');
+  if (rawParts.length !== 2 || rawParts[0] === '' || rawParts[1] === '')
+    return '02:00';
+  const h = Number(rawParts[0]);
+  const m = Number(rawParts[1]);
+  if (isNaN(h) || isNaN(m) || h < 0 || h > 23 || m < 0 || m > 59)
+    return '02:00';
+  const date = new Date(now);
+  date.setUTCHours(h, m, 0, 0);
+  return date.toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    hourCycle: 'h23',
+  });
+};

--- a/SparkyFitnessFrontend/src/pages/Admin/backupTimeUtils.ts
+++ b/SparkyFitnessFrontend/src/pages/Admin/backupTimeUtils.ts
@@ -12,9 +12,5 @@ export const getLocalTimeString = (
     return '02:00';
   const date = new Date(now);
   date.setUTCHours(h, m, 0, 0);
-  return date.toLocaleTimeString([], {
-    hour: '2-digit',
-    minute: '2-digit',
-    hourCycle: 'h23',
-  });
+  return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
 };

--- a/SparkyFitnessFrontend/src/tests/utils/backupTimeUtils.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/backupTimeUtils.test.ts
@@ -1,0 +1,67 @@
+import { getLocalTimeString } from '@/pages/Admin/backupTimeUtils';
+
+// Fixed reference date: 2024-01-15 at UTC midnight.
+// Using a fixed date makes results independent of the test machine's local timezone
+// because toLocaleTimeString with hourCycle:'h23' returns the local equivalent of the UTC time we set.
+const FIXED_DATE = new Date('2024-01-15T00:00:00.000Z');
+
+describe('getLocalTimeString', () => {
+  it('returns 02:00 when utcTimeStr is undefined', () => {
+    expect(getLocalTimeString(undefined, FIXED_DATE)).toBe('02:00');
+  });
+
+  it('returns 02:00 when utcTimeStr is empty string', () => {
+    expect(getLocalTimeString('', FIXED_DATE)).toBe('02:00');
+  });
+
+  it('returns 02:00 for malformed input', () => {
+    expect(getLocalTimeString('bad', FIXED_DATE)).toBe('02:00');
+    expect(getLocalTimeString('99:99', FIXED_DATE)).toBe('02:00');
+    expect(getLocalTimeString(':', FIXED_DATE)).toBe('02:00');
+  });
+
+  it('handles midnight UTC (00:00) without corrupting to current time', () => {
+    const expected = new Date(FIXED_DATE);
+    expected.setUTCHours(0, 0, 0, 0);
+    const expectedStr = expected.toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    });
+    expect(getLocalTimeString('00:00', FIXED_DATE)).toBe(expectedStr);
+  });
+
+  it('handles times with zero minutes (e.g. 01:00) correctly', () => {
+    const expected = new Date(FIXED_DATE);
+    expected.setUTCHours(1, 0, 0, 0);
+    const expectedStr = expected.toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    });
+    expect(getLocalTimeString('01:00', FIXED_DATE)).toBe(expectedStr);
+  });
+
+  it('handles end-of-day UTC time (23:59)', () => {
+    const expected = new Date(FIXED_DATE);
+    expected.setUTCHours(23, 59, 0, 0);
+    const expectedStr = expected.toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23',
+    });
+    expect(getLocalTimeString('23:59', FIXED_DATE)).toBe(expectedStr);
+  });
+
+  it('returns a consistent result for the same input on multiple calls', () => {
+    const a = getLocalTimeString('14:30', FIXED_DATE);
+    const b = getLocalTimeString('14:30', FIXED_DATE);
+    expect(a).toBe(b);
+  });
+
+  it('produces different results for different UTC times', () => {
+    const morning = getLocalTimeString('08:00', FIXED_DATE);
+    const evening = getLocalTimeString('20:00', FIXED_DATE);
+    expect(morning).not.toBe(evening);
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/utils/backupTimeUtils.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/backupTimeUtils.test.ts
@@ -23,33 +23,21 @@ describe('getLocalTimeString', () => {
   it('handles midnight UTC (00:00) without corrupting to current time', () => {
     const expected = new Date(FIXED_DATE);
     expected.setUTCHours(0, 0, 0, 0);
-    const expectedStr = expected.toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-      hourCycle: 'h23',
-    });
+    const expectedStr = `${String(expected.getHours()).padStart(2, '0')}:${String(expected.getMinutes()).padStart(2, '0')}`;
     expect(getLocalTimeString('00:00', FIXED_DATE)).toBe(expectedStr);
   });
 
   it('handles times with zero minutes (e.g. 01:00) correctly', () => {
     const expected = new Date(FIXED_DATE);
     expected.setUTCHours(1, 0, 0, 0);
-    const expectedStr = expected.toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-      hourCycle: 'h23',
-    });
+    const expectedStr = `${String(expected.getHours()).padStart(2, '0')}:${String(expected.getMinutes()).padStart(2, '0')}`;
     expect(getLocalTimeString('01:00', FIXED_DATE)).toBe(expectedStr);
   });
 
   it('handles end-of-day UTC time (23:59)', () => {
     const expected = new Date(FIXED_DATE);
     expected.setUTCHours(23, 59, 0, 0);
-    const expectedStr = expected.toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-      hourCycle: 'h23',
-    });
+    const expectedStr = `${String(expected.getHours()).padStart(2, '0')}:${String(expected.getMinutes()).padStart(2, '0')}`;
     expect(getLocalTimeString('23:59', FIXED_DATE)).toBe(expectedStr);
   });
 

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -66,10 +66,7 @@ import backupRoutes from './routes/backupRoutes.js';
 import errorHandler from './middleware/errorHandler.js';
 import reviewRoutes from './routes/reviewRoutes.js';
 import cron from 'node-cron';
-import {
-  performBackup,
-  applyRetentionPolicy,
-} from './services/backupService.js';
+import { scheduleBackupsOnStartup } from './services/backupScheduler.js';
 import externalProviderRepository from './models/externalProviderRepository.js';
 import garminService from './services/garminService.js';
 import fitbitService from './services/fitbitService.js';
@@ -458,14 +455,7 @@ app.get(
 );
 app.get('/api/api-docs/json', (_req, res) => res.json(swaggerSpecs));
 app.get('/api/api-docs', (_req, res) => res.redirect('/api/api-docs/swagger'));
-// Backup scheduling
-const scheduleBackups = async () => {
-  cron.schedule('0 2 * * *', async () => {
-    const result = await performBackup();
-    // @ts-expect-error TS2554
-    if (result.success) await applyRetentionPolicy(7);
-  });
-};
+// Backup scheduling is handled by services/backupScheduler.ts
 // Session cleanup scheduling
 const scheduleSessionCleanup = async () => {
   // Run every day at 3 AM
@@ -635,7 +625,7 @@ applyMigrations()
         console.error('[AUTH] Post-init SSO sync failed:', err)
       );
     }
-    scheduleBackups();
+    scheduleBackupsOnStartup();
     scheduleSessionCleanup();
     scheduleWithingsSyncs();
     scheduleGarminSyncs();

--- a/SparkyFitnessServer/routes/backupRoutes.ts
+++ b/SparkyFitnessServer/routes/backupRoutes.ts
@@ -1,12 +1,31 @@
 import express from 'express';
+import { z } from 'zod';
 import { log } from '../config/logging.js';
 import {
   performBackup,
   performRestore,
   BACKUP_DIR,
 } from '../services/backupService.js';
+import { rescheduleBackups } from '../services/backupScheduler.js';
 import { authenticate, isAdmin } from '../middleware/authMiddleware.js';
 import backupSettingsRepository from '../models/backupSettingsRepository.js';
+
+const backupSettingsBodySchema = z.object({
+  backupEnabled: z.boolean(),
+  backupDays: z.array(
+    z.enum([
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+      'Sunday',
+    ])
+  ),
+  backupTime: z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/),
+  retentionDays: z.number().int().positive(),
+});
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'mult... Remove this comment to see the full error message
 import multer from 'multer';
 import path from 'path';
@@ -292,8 +311,16 @@ router.get('/settings', authenticate, isAdmin, async (req, res) => {
  *         description: Server error.
  */
 router.post('/settings', authenticate, isAdmin, async (req, res) => {
+  const parsed = backupSettingsBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({
+      message: 'Invalid backup settings.',
+      errors: parsed.error.flatten(),
+    });
+    return;
+  }
+  const { backupEnabled, backupDays, backupTime, retentionDays } = parsed.data;
   try {
-    const { backupEnabled, backupDays, backupTime, retentionDays } = req.body;
     const updatedSettings = await backupSettingsRepository.updateBackupSettings(
       {
         backup_enabled: backupEnabled,
@@ -302,10 +329,24 @@ router.post('/settings', authenticate, isAdmin, async (req, res) => {
         retention_days: retentionDays,
       }
     );
-    // TODO: Re-schedule cron jobs based on new settings
+
+    let schedulerWarning: string | undefined;
+    try {
+      await rescheduleBackups();
+    } catch (schedErr) {
+      log(
+        'error',
+        '[CRON] Settings saved but live reschedule failed:',
+        schedErr
+      );
+      schedulerWarning =
+        'Settings saved, but the live scheduler could not be updated. Changes will take effect on next server restart.';
+    }
+
     res.status(200).json({
-      message: 'Backup settings saved successfully.',
+      message: schedulerWarning ?? 'Backup settings saved successfully.',
       settings: updatedSettings,
+      ...(schedulerWarning ? { warning: schedulerWarning } : {}),
     });
   } catch (error) {
     log('error', 'Error saving backup settings:', error);

--- a/SparkyFitnessServer/routes/backupRoutes.ts
+++ b/SparkyFitnessServer/routes/backupRoutes.ts
@@ -330,7 +330,7 @@ router.post('/settings', authenticate, isAdmin, async (req, res) => {
       }
     );
 
-    let schedulerWarning: string | undefined;
+    let schedulerFailed = false;
     try {
       await rescheduleBackups();
     } catch (schedErr) {
@@ -339,14 +339,13 @@ router.post('/settings', authenticate, isAdmin, async (req, res) => {
         '[CRON] Settings saved but live reschedule failed:',
         schedErr
       );
-      schedulerWarning =
-        'Settings saved, but the live scheduler could not be updated. Changes will take effect on next server restart.';
+      schedulerFailed = true;
     }
 
     res.status(200).json({
-      message: schedulerWarning ?? 'Backup settings saved successfully.',
+      message: 'Backup settings saved successfully.',
       settings: updatedSettings,
-      ...(schedulerWarning ? { warning: schedulerWarning } : {}),
+      ...(schedulerFailed ? { schedulerFailed: true } : {}),
     });
   } catch (error) {
     log('error', 'Error saving backup settings:', error);

--- a/SparkyFitnessServer/services/backupScheduler.ts
+++ b/SparkyFitnessServer/services/backupScheduler.ts
@@ -27,7 +27,18 @@ export const buildCronExpression = (
   backupTime: string,
   backupDays: string[]
 ): string => {
-  const [hour, minute] = backupTime.split(':').map(Number);
+  let [hour, minute] = backupTime.split(':').map(Number);
+  if (
+    isNaN(hour) ||
+    isNaN(minute) ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    hour = 2;
+    minute = 0;
+  }
   const days = backupDays
     .map((d) => DOW_MAP[d])
     .filter((n) => n !== undefined && !isNaN(n));

--- a/SparkyFitnessServer/services/backupScheduler.ts
+++ b/SparkyFitnessServer/services/backupScheduler.ts
@@ -1,0 +1,80 @@
+import cron, { type ScheduledTask } from 'node-cron';
+import backupSettingsRepository from '../models/backupSettingsRepository.js';
+import { performBackup, applyRetentionPolicy } from './backupService.js';
+import { log } from '../config/logging.js';
+
+let scheduledTask: ScheduledTask | null = null;
+
+const clearScheduledTask = (): void => {
+  if (scheduledTask) {
+    scheduledTask.stop();
+    scheduledTask.destroy();
+    scheduledTask = null;
+  }
+};
+
+const DOW_MAP: Record<string, number> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6,
+};
+
+export const buildCronExpression = (
+  backupTime: string,
+  backupDays: string[]
+): string => {
+  const [hour, minute] = backupTime.split(':').map(Number);
+  const days = backupDays
+    .map((d) => DOW_MAP[d])
+    .filter((n) => n !== undefined && !isNaN(n));
+  const dowField = days.length > 0 ? days.join(',') : '*';
+  return `${minute} ${hour} * * ${dowField}`;
+};
+
+const buildNewTask = async (): Promise<ScheduledTask | null> => {
+  const settings = await backupSettingsRepository.getBackupSettings();
+  if (!settings?.backup_enabled) {
+    log('info', '[CRON] Scheduled backups disabled — skipping schedule');
+    return null;
+  }
+  const expr = buildCronExpression(
+    settings.backup_time ?? '02:00',
+    settings.backup_days ?? []
+  );
+  if (!cron.validate(expr)) {
+    throw new Error(
+      `[CRON] Invalid backup cron expression: ${expr} — cannot schedule`
+    );
+  }
+  log('info', `[CRON] Scheduling backup with expression: ${expr}`);
+  return cron.schedule(
+    expr,
+    async () => {
+      const result = await performBackup();
+      if (result.success) await applyRetentionPolicy();
+    },
+    { timezone: 'UTC' }
+  );
+};
+
+export const scheduleBackups = async (): Promise<void> => {
+  const newTask = await buildNewTask();
+  clearScheduledTask();
+  scheduledTask = newTask;
+};
+
+export const scheduleBackupsOnStartup = async (): Promise<void> => {
+  try {
+    await scheduleBackups();
+  } catch (err) {
+    log('error', '[CRON] Failed to schedule backups at startup:', err);
+  }
+};
+
+export const rescheduleBackups = async (): Promise<void> => {
+  await scheduleBackups();
+};

--- a/SparkyFitnessServer/tests/backupScheduler.test.ts
+++ b/SparkyFitnessServer/tests/backupScheduler.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildCronExpression } from '../services/backupScheduler.js';
+
+describe('buildCronExpression', () => {
+  it('builds expression for a single day', () => {
+    expect(buildCronExpression('14:30', ['Wednesday'])).toBe('30 14 * * 3');
+  });
+
+  it('maps all days of week correctly', () => {
+    expect(buildCronExpression('00:00', ['Sunday'])).toBe('0 0 * * 0');
+    expect(buildCronExpression('00:00', ['Monday'])).toBe('0 0 * * 1');
+    expect(buildCronExpression('00:00', ['Tuesday'])).toBe('0 0 * * 2');
+    expect(buildCronExpression('00:00', ['Wednesday'])).toBe('0 0 * * 3');
+    expect(buildCronExpression('00:00', ['Thursday'])).toBe('0 0 * * 4');
+    expect(buildCronExpression('00:00', ['Friday'])).toBe('0 0 * * 5');
+    expect(buildCronExpression('00:00', ['Saturday'])).toBe('0 0 * * 6');
+  });
+
+  it('uses * for DOW when backupDays is empty', () => {
+    expect(buildCronExpression('02:00', [])).toBe('0 2 * * *');
+  });
+
+  it('joins multiple days with comma', () => {
+    expect(
+      buildCronExpression('08:00', ['Monday', 'Wednesday', 'Friday'])
+    ).toBe('0 8 * * 1,3,5');
+  });
+
+  it('handles midnight correctly (00:00)', () => {
+    expect(buildCronExpression('00:00', ['Monday'])).toBe('0 0 * * 1');
+  });
+
+  it('handles times with zero minutes', () => {
+    expect(buildCronExpression('01:00', ['Tuesday'])).toBe('0 1 * * 2');
+  });
+
+  it('handles end-of-day time (23:59)', () => {
+    expect(buildCronExpression('23:59', ['Saturday'])).toBe('59 23 * * 6');
+  });
+
+  it('filters out unknown day names', () => {
+    expect(buildCronExpression('10:00', ['Monday', 'Funday' as string])).toBe(
+      '0 10 * * 1'
+    );
+  });
+
+  it('uses * for DOW when all day names are unknown', () => {
+    expect(buildCronExpression('10:00', ['Funday' as string])).toBe(
+      '0 10 * * *'
+    );
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
1. The backup setting text was not correctly changing in dark mode so it was hard to read
2. Backups were hardcoded to a specific time, so it didn't matter what time you set (I saw there was a todo in there, so I went ahead with it)
3. The displayed time that you would choose would randomly change due to a bug with UTC to local time with times that ended in 00.

**How did you implement the solution?**
Replaced the hardcoded cron expression with a dynamic scheduler that reads `backup_time` and `backup_days` from the database on startup and after every settings save.

The UTC→local time conversion had a bug where times ending in :00 (like 01:00) were treated as false and skipped, causing the function to fall back to the current wall clock time. Fixed the guard condition and extracted the helper so it could be properly tested.

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
