### PR TITLE
added supported for USDA to import multiple unit type variants

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -146,8 +146,34 @@ export function VariantCard({
   onDuplicate,
   onRemove,
 }: VariantCardProps) {
-  const equivalents = variant.equivalents ?? [];
+  const equivalents = useMemo(
+    () => variant.equivalents ?? [],
+    [variant.equivalents]
+  );
   const [allergenInput, setAllergenInput] = useState('');
+
+  const customUnitsForDropdown = useMemo(() => {
+    const standardUnits = new Set(UNIT_GROUPS.flatMap((group) => group.units));
+    const custom = new Set<string>();
+
+    const checkAndAdd = (unit: string | undefined | null) => {
+      if (unit && !standardUnits.has(unit)) {
+        custom.add(unit);
+      }
+    };
+
+    checkAndAdd(variant.serving_unit);
+    equivalents.forEach((eq) => checkAndAdd(eq.serving_unit));
+
+    if (_defaultVariant) {
+      checkAndAdd(_defaultVariant.serving_unit);
+      _defaultVariant.equivalents?.forEach((eq) =>
+        checkAndAdd(eq.serving_unit)
+      );
+    }
+
+    return Array.from(custom);
+  }, [variant.serving_unit, equivalents, _defaultVariant]);
 
   const currentAllergens: string[] = variant.allergens ?? [];
 
@@ -260,19 +286,9 @@ export function VariantCard({
                     <SelectGroup key={group.label}>
                       <SelectLabel>{group.label}</SelectLabel>
                       {group.units.map((unit) => {
-                        // AI rows never advertise compatible-unit checkmarks
-                        // — once a unit is AI-estimated for a food, sibling
-                        // units in the same category should be AI-estimated
-                        // too (not math-derived from the AI value). Keeps the
-                        // "what's real vs AI" line clear for the user.
                         const compatible =
                           showCompatibleUnitIndicators &&
                           compatibleUnits.includes(unit);
-                        // Cross-row AI marker: any unit that has a SAVED AI
-                        // variant on this food shows the sparkle inside the
-                        // option — even in OTHER rows' dropdowns. So opening
-                        // the default `g` row's dropdown still flags `cup`
-                        // if another row saved cup as an AI variant.
                         const matchedAi = savedAiUnits?.find(
                           (entry) => entry.unit === unit
                         );
@@ -302,6 +318,42 @@ export function VariantCard({
                       })}
                     </SelectGroup>
                   ))}
+                  {customUnitsForDropdown.length > 0 && (
+                    <SelectGroup key="custom-units">
+                      <SelectLabel>Custom</SelectLabel>
+                      {customUnitsForDropdown.map((unit) => {
+                        const compatible =
+                          showCompatibleUnitIndicators &&
+                          compatibleUnits.includes(unit);
+                        const matchedAi = savedAiUnits?.find(
+                          (entry) => entry.unit === unit
+                        );
+                        const showCompatibilityCheck = compatible && !matchedAi;
+                        return (
+                          <SelectItem key={unit} value={unit}>
+                            <span className="flex items-center gap-1.5">
+                              {unit}
+                              {showCompatibilityCheck && (
+                                <Check
+                                  data-testid={`compatible-unit-option-${index}-${unit}`}
+                                  className="h-3 w-3 text-green-500"
+                                />
+                              )}
+                              {matchedAi && (
+                                <Sparkles
+                                  data-testid={`ai-unit-option-indicator-${index}-${unit}`}
+                                  className={`h-3 w-3 ${AI_SPARKLE_TONE_CLASSES[CONFIDENCE_TONES[matchedAi.confidence]]}`}
+                                  aria-label={`AI estimate (${OVERALL_CONFIDENCE_LABELS[matchedAi.confidence]} confidence)`}
+                                  fill="currentColor"
+                                  strokeWidth={0.75}
+                                />
+                              )}
+                            </span>
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectGroup>
+                  )}
                 </SelectContent>
               </Select>
             </div>
@@ -420,6 +472,16 @@ export function VariantCard({
                       ))}
                     </SelectGroup>
                   ))}
+                  {customUnitsForDropdown.length > 0 && (
+                    <SelectGroup key="custom-units">
+                      <SelectLabel>Custom</SelectLabel>
+                      {customUnitsForDropdown.map((unit) => (
+                        <SelectItem key={unit} value={unit}>
+                          {unit}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  )}
                 </SelectContent>
               </Select>
             </div>

--- a/SparkyFitnessServer/integrations/usda/usdaService.ts
+++ b/SparkyFitnessServer/integrations/usda/usdaService.ts
@@ -6,6 +6,29 @@ import {
 // Using native fetch (standard in Node 22+)
 const USDA_API_BASE_URL = 'https://api.nal.usda.gov/fdc/v1';
 
+const STANDARD_UNITS = new Set([
+  'g',
+  'ml',
+  'oz',
+  'tbsp',
+  'tsp',
+  'cup',
+  'slice',
+  'serving',
+  'portion',
+  'can',
+  'bottle',
+  'packet',
+  'bag',
+  'bowl',
+  'plate',
+  'handful',
+  'scoop',
+  'bar',
+  'stick',
+  'whole',
+]);
+
 export interface UsdaNutrient {
   nutrientId?: number;
   nutrient?: {
@@ -160,7 +183,9 @@ function evaluateFraction(fractionStr: string | null | undefined): number {
       const [num, den] = part.split('/');
       const n = parseFloat(num);
       const d = parseFloat(den);
-      if (d !== 0) total += n / d;
+      if (!isNaN(n) && !isNaN(d) && d !== 0) {
+        total += n / d;
+      }
     } else {
       const val = parseFloat(part);
       if (!isNaN(val)) total += val;
@@ -204,23 +229,23 @@ function parseMixedPortionDescription(desc: string | null | undefined) {
 
 function parsePackageWeight(packageWeight: string | null | undefined) {
   if (!packageWeight) return null;
-  // Match metric first: e.g. "31.2 g", "450 ml"
+  // Match metric first: e.g. "31.2 g", "1,000 ml"
   const metricMatch = packageWeight.match(
-    /(\d+(?:\.\d+)?)\s*(g|grm|gm|grams?|ml|milliliters?|l|liters?)\b/i
+    /\b(\d+(?:,\d{3})*(?:\.\d+)?)\s*(g|grm|gm|grams?|ml|milliliters?|l|liters?)\b/i
   );
   if (metricMatch) {
     return {
-      size: parseFloat(metricMatch[1]),
+      size: parseFloat(metricMatch[1].replace(/,/g, '')),
       unit: metricMatch[2],
     };
   }
-  // Match imperial: e.g. "1.10 oz", "1 lb"
+  // Match imperial: e.g. "1.10 oz", "1,200 lb"
   const imperialMatch = packageWeight.match(
-    /(\d+(?:\.\d+)?)\s*(oz|ounce|ounces|lb|lbs|pounds?)\b/i
+    /\b(\d+(?:,\d{3})*(?:\.\d+)?)\s*(oz|ounce|ounces|lb|lbs|pounds?)\b/i
   );
   if (imperialMatch) {
     return {
-      size: parseFloat(imperialMatch[1]),
+      size: parseFloat(imperialMatch[1].replace(/,/g, '')),
       unit: imperialMatch[2],
     };
   }
@@ -321,29 +346,7 @@ function mapUsdaBarcodeProduct(food: UsdaFood) {
       let unit = mixed.unit;
       if (food.dataType === 'Branded') {
         const normalized = normalizeServingUnit(unit);
-        const standardUnits = new Set([
-          'g',
-          'ml',
-          'oz',
-          'tbsp',
-          'tsp',
-          'cup',
-          'slice',
-          'serving',
-          'portion',
-          'can',
-          'bottle',
-          'packet',
-          'bag',
-          'bowl',
-          'plate',
-          'handful',
-          'scoop',
-          'bar',
-          'stick',
-          'whole',
-        ]);
-        if (!standardUnits.has(normalized)) {
+        if (!STANDARD_UNITS.has(normalized)) {
           unit = 'piece';
         }
       }
@@ -356,29 +359,7 @@ function mapUsdaBarcodeProduct(food: UsdaFood) {
         if (parsedSize > 0 && parsedUnit) {
           if (food.dataType === 'Branded') {
             const normalized = normalizeServingUnit(parsedUnit);
-            const standardUnits = new Set([
-              'g',
-              'ml',
-              'oz',
-              'tbsp',
-              'tsp',
-              'cup',
-              'slice',
-              'serving',
-              'portion',
-              'can',
-              'bottle',
-              'packet',
-              'bag',
-              'bowl',
-              'plate',
-              'handful',
-              'scoop',
-              'bar',
-              'stick',
-              'whole',
-            ]);
-            if (!standardUnits.has(normalized)) {
+            if (!STANDARD_UNITS.has(normalized)) {
               parsedUnit = 'piece';
             }
           }

--- a/SparkyFitnessServer/integrations/usda/usdaService.ts
+++ b/SparkyFitnessServer/integrations/usda/usdaService.ts
@@ -6,16 +6,69 @@ import {
 // Using native fetch (standard in Node 22+)
 const USDA_API_BASE_URL = 'https://api.nal.usda.gov/fdc/v1';
 
+export interface UsdaNutrient {
+  nutrientId?: number;
+  nutrient?: {
+    id?: number;
+    name?: string;
+    unitName?: string;
+  };
+  value?: number;
+  amount?: number;
+}
+
+export interface UsdaMeasureUnit {
+  id?: number;
+  name?: string;
+}
+
+export interface UsdaPortion {
+  gramWeight: number;
+  amount: number;
+  measureUnit?: UsdaMeasureUnit;
+  portionDescription?: string;
+  modifier?: string;
+}
+
+export interface UsdaFood {
+  description: string;
+  brandName?: string;
+  brandOwner?: string;
+  gtinUpc?: string;
+  fdcId: number | string;
+  dataType?: string;
+  servingSize?: number;
+  servingSizeUnit?: string;
+  householdServingFullText?: string;
+  packageWeight?: string;
+  foodNutrients?: UsdaNutrient[];
+  foodPortions?: UsdaPortion[];
+}
+
+export interface UsdaSearchResponse {
+  foods: UsdaFood[];
+  currentPage?: number;
+  totalPages?: number;
+  totalHits?: number;
+}
+
 async function searchUsdaFoods(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  query: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  apiKey: any,
+  query: string,
+  apiKey: string | undefined,
   page = 1,
   pageSize = 50
-) {
+): Promise<
+  UsdaSearchResponse & {
+    pagination: {
+      page: number;
+      pageSize: number;
+      totalCount: number;
+      hasMore: boolean;
+    };
+  }
+> {
   try {
-    const searchUrl = `${USDA_API_BASE_URL}/foods/search?query=${encodeURIComponent(query)}&pageNumber=${page}&pageSize=${pageSize}&api_key=${apiKey}`;
+    const searchUrl = `${USDA_API_BASE_URL}/foods/search?query=${encodeURIComponent(query)}&pageNumber=${page}&pageSize=${pageSize}&api_key=${apiKey || ''}`;
     const response = await fetch(searchUrl, { method: 'GET' });
     log('debug', 'USDA API Search Response Status:', response.status);
     if (!response.ok) {
@@ -43,10 +96,13 @@ async function searchUsdaFoods(
     throw error;
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function searchUsdaFoodsByBarcode(barcode: any, apiKey: any) {
+
+async function searchUsdaFoodsByBarcode(
+  barcode: string,
+  apiKey: string | undefined
+): Promise<{ foods: UsdaFood[] }> {
   try {
-    const searchUrl = `${USDA_API_BASE_URL}/foods/search?query=${encodeURIComponent(barcode)}&dataType=Branded&api_key=${apiKey}`;
+    const searchUrl = `${USDA_API_BASE_URL}/foods/search?query=${encodeURIComponent(barcode)}&dataType=Branded&api_key=${apiKey || ''}`;
     const response = await fetch(searchUrl, { method: 'GET' });
     log('debug', 'USDA API Barcode Search Response Status:', response.status);
     if (!response.ok) {
@@ -66,10 +122,13 @@ async function searchUsdaFoodsByBarcode(barcode: any, apiKey: any) {
     throw error;
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getUsdaFoodDetails(fdcId: any, apiKey: any) {
+
+async function getUsdaFoodDetails(
+  fdcId: string | number,
+  apiKey: string | undefined
+): Promise<UsdaFood> {
   try {
-    const detailsUrl = `${USDA_API_BASE_URL}/food/${fdcId}?api_key=${apiKey}`;
+    const detailsUrl = `${USDA_API_BASE_URL}/food/${fdcId}?api_key=${apiKey || ''}`;
     const response = await fetch(detailsUrl, { method: 'GET' });
     log('debug', 'USDA API Details Response Status:', response.status);
     if (!response.ok) {
@@ -89,57 +148,327 @@ async function getUsdaFoodDetails(fdcId: any, apiKey: any) {
     throw error;
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mapUsdaBarcodeProduct(food: any) {
-  const nutrients = {};
+
+function evaluateFraction(fractionStr: string | null | undefined): number {
+  if (!fractionStr) return 0;
+  const match = fractionStr.trim().match(/^([\d\s./]+)/);
+  if (!match) return 0;
+  const parts = match[1].trim().split(/\s+/);
+  let total = 0;
+  for (const part of parts) {
+    if (part.includes('/')) {
+      const [num, den] = part.split('/');
+      const n = parseFloat(num);
+      const d = parseFloat(den);
+      if (d !== 0) total += n / d;
+    } else {
+      const val = parseFloat(part);
+      if (!isNaN(val)) total += val;
+    }
+  }
+  return total || 0;
+}
+
+function parseMixedPortionDescription(desc: string | null | undefined) {
+  if (!desc) return null;
+  const trimmed = desc.trim();
+
+  // Pattern A/B: "<weight> g or/( <amount> <unit>)"
+  const patternAB =
+    /^(\d+(?:\.\d+)?)\s*g\b\s*(?:or|\()\s*([\d\s./]+)\s*([a-zA-Z\s-]+)\)?$/i;
+  const matchAB = trimmed.match(patternAB);
+  if (matchAB) {
+    const weight = parseFloat(matchAB[1]);
+    const amount = evaluateFraction(matchAB[2]);
+    const unit = matchAB[3].trim();
+    if (amount > 0 && unit) {
+      return { amount, unit, weight };
+    }
+  }
+
+  // Pattern C/D: "<amount> <unit> (/, <weight> g)"
+  const patternCD =
+    /^([\d\s./]+)\s*([a-zA-Z\s-]+)\s*(?:,|\()\s*(\d+(?:\.\d+)?)\s*g\b\s*\)?$/i;
+  const matchCD = trimmed.match(patternCD);
+  if (matchCD) {
+    const amount = evaluateFraction(matchCD[1]);
+    const unit = matchCD[2].trim();
+    const weight = parseFloat(matchCD[3]);
+    if (amount > 0 && unit) {
+      return { amount, unit, weight };
+    }
+  }
+
+  return null;
+}
+
+function parsePackageWeight(packageWeight: string | null | undefined) {
+  if (!packageWeight) return null;
+  // Match metric first: e.g. "31.2 g", "450 ml"
+  const metricMatch = packageWeight.match(
+    /(\d+(?:\.\d+)?)\s*(g|grm|gm|grams?|ml|milliliters?|l|liters?)\b/i
+  );
+  if (metricMatch) {
+    return {
+      size: parseFloat(metricMatch[1]),
+      unit: metricMatch[2],
+    };
+  }
+  // Match imperial: e.g. "1.10 oz", "1 lb"
+  const imperialMatch = packageWeight.match(
+    /(\d+(?:\.\d+)?)\s*(oz|ounce|ounces|lb|lbs|pounds?)\b/i
+  );
+  if (imperialMatch) {
+    return {
+      size: parseFloat(imperialMatch[1]),
+      unit: imperialMatch[2],
+    };
+  }
+  return null;
+}
+
+function mapUsdaBarcodeProduct(food: UsdaFood) {
+  const nutrients: Record<string | number, number> = {};
   for (const n of food.foodNutrients || []) {
     const id = n.nutrientId ?? n.nutrient?.id;
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    nutrients[id] = n.value ?? n.amount ?? 0;
+    if (id !== undefined && id !== null) {
+      nutrients[id] = n.value ?? n.amount ?? 0;
+    }
   }
-  const servingSize = food.servingSize > 0 ? food.servingSize : 100;
-  const scale = servingSize / 100;
-  const defaultVariant = {
-    serving_size: servingSize,
-    serving_unit: normalizeServingUnit(food.servingSizeUnit),
-    calories: Math.round(
-      // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-      (nutrients[1008] ?? nutrients[2048] ?? nutrients[2047] ?? 0) * scale
-    ),
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    protein: Math.round((nutrients[1003] || 0) * scale * 10) / 10,
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    carbs: Math.round((nutrients[1005] || 0) * scale * 10) / 10,
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    fat: Math.round((nutrients[1004] || 0) * scale * 10) / 10,
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    saturated_fat: Math.round((nutrients[1258] || 0) * scale * 10) / 10,
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    trans_fat: Math.round((nutrients[1257] || 0) * scale * 10) / 10,
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    cholesterol: Math.round((nutrients[1253] || 0) * scale),
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    sodium: Math.round((nutrients[1093] || 0) * scale),
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    potassium: Math.round((nutrients[1092] || 0) * scale),
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    dietary_fiber: Math.round((nutrients[1079] || 0) * scale * 10) / 10,
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    sugars: Math.round((nutrients[2000] || 0) * scale * 10) / 10,
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    calcium: Math.round((nutrients[1087] || 0) * scale),
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    iron: Math.round((nutrients[1089] || 0) * scale * 10) / 10,
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    polyunsaturated_fat: Math.round((nutrients[1293] || 0) * scale * 10) / 10,
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    monounsaturated_fat: Math.round((nutrients[1292] || 0) * scale * 10) / 10,
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    vitamin_a: Math.round((nutrients[1104] || 0) * 0.3 * scale),
-    // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-    vitamin_c: Math.round((nutrients[1162] || 0) * scale * 10) / 10,
-    is_default: true,
+
+  const variantsMap = new Map();
+
+  const addVariant = (
+    serving_size: number,
+    serving_unit: string,
+    scale: number,
+    is_default: boolean
+  ) => {
+    if (
+      isNaN(serving_size) ||
+      serving_size <= 0 ||
+      !serving_unit ||
+      isNaN(scale) ||
+      scale <= 0
+    ) {
+      return;
+    }
+    const normalizedUnit = normalizeServingUnit(serving_unit);
+    const roundedServingSize = Math.round(serving_size * 100) / 100;
+    const key = `${roundedServingSize}_${normalizedUnit}`.toLowerCase();
+
+    if (!variantsMap.has(key) || is_default) {
+      variantsMap.set(key, {
+        serving_size: roundedServingSize,
+        serving_unit: normalizedUnit,
+        calories: Math.round(
+          (nutrients[1008] ?? nutrients[2048] ?? nutrients[2047] ?? 0) * scale
+        ),
+        protein: Math.round((nutrients[1003] || 0) * scale * 10) / 10,
+        carbs: Math.round((nutrients[1005] || 0) * scale * 10) / 10,
+        fat: Math.round((nutrients[1004] || 0) * scale * 10) / 10,
+        saturated_fat: Math.round((nutrients[1258] || 0) * scale * 10) / 10,
+        trans_fat: Math.round((nutrients[1257] || 0) * scale * 10) / 10,
+        cholesterol: Math.round((nutrients[1253] || 0) * scale),
+        sodium: Math.round((nutrients[1093] || 0) * scale),
+        potassium: Math.round((nutrients[1092] || 0) * scale),
+        dietary_fiber: Math.round((nutrients[1079] || 0) * scale * 10) / 10,
+        sugars: Math.round((nutrients[2000] || 0) * scale * 10) / 10,
+        calcium: Math.round((nutrients[1087] || 0) * scale),
+        iron: Math.round((nutrients[1089] || 0) * scale * 10) / 10,
+        polyunsaturated_fat:
+          Math.round((nutrients[1293] || 0) * scale * 10) / 10,
+        monounsaturated_fat:
+          Math.round((nutrients[1292] || 0) * scale * 10) / 10,
+        vitamin_a: Math.round((nutrients[1104] || 0) * 0.3 * scale),
+        vitamin_c: Math.round((nutrients[1162] || 0) * scale * 10) / 10,
+        is_default,
+      });
+    }
   };
+
+  // 1. Base metric variant
+  let servingSize: number = food.servingSize ?? 0;
+  let servingSizeUnit = food.servingSizeUnit || 'g';
+
+  if (!(servingSize > 0)) {
+    const parsed = parsePackageWeight(food.packageWeight);
+    if (parsed) {
+      servingSize = parsed.size;
+      servingSizeUnit = parsed.unit;
+    } else {
+      servingSize = 100;
+    }
+  }
+
+  addVariant(servingSize, servingSizeUnit, servingSize / 100, true);
+
+  // 2. 100g/ml variant (if default serving is not already 100g/ml)
+  const normalizedBaseUnit = normalizeServingUnit(servingSizeUnit);
+  if (
+    (normalizedBaseUnit === 'g' || normalizedBaseUnit === 'ml') &&
+    servingSize !== 100
+  ) {
+    addVariant(100, servingSizeUnit, 1.0, false);
+  }
+
+  // 3. Branded Household variant from householdServingFullText
+  if (food.householdServingFullText) {
+    const desc = food.householdServingFullText.trim();
+    const mixed = parseMixedPortionDescription(desc);
+    if (mixed) {
+      const scale = mixed.weight > 0 ? mixed.weight / 100 : servingSize / 100;
+      let unit = mixed.unit;
+      if (food.dataType === 'Branded') {
+        const normalized = normalizeServingUnit(unit);
+        const standardUnits = new Set([
+          'g',
+          'ml',
+          'oz',
+          'tbsp',
+          'tsp',
+          'cup',
+          'slice',
+          'serving',
+          'portion',
+          'can',
+          'bottle',
+          'packet',
+          'bag',
+          'bowl',
+          'plate',
+          'handful',
+          'scoop',
+          'bar',
+          'stick',
+          'whole',
+        ]);
+        if (!standardUnits.has(normalized)) {
+          unit = 'piece';
+        }
+      }
+      addVariant(mixed.amount, unit, scale, false);
+    } else {
+      const match = desc.match(/^([\d\s./]+)\s+(.+)$/);
+      if (match) {
+        const parsedSize = evaluateFraction(match[1]);
+        let parsedUnit = match[2].trim();
+        if (parsedSize > 0 && parsedUnit) {
+          if (food.dataType === 'Branded') {
+            const normalized = normalizeServingUnit(parsedUnit);
+            const standardUnits = new Set([
+              'g',
+              'ml',
+              'oz',
+              'tbsp',
+              'tsp',
+              'cup',
+              'slice',
+              'serving',
+              'portion',
+              'can',
+              'bottle',
+              'packet',
+              'bag',
+              'bowl',
+              'plate',
+              'handful',
+              'scoop',
+              'bar',
+              'stick',
+              'whole',
+            ]);
+            if (!standardUnits.has(normalized)) {
+              parsedUnit = 'piece';
+            }
+          }
+          addVariant(parsedSize, parsedUnit, servingSize / 100, false);
+        }
+      }
+    }
+  }
+
+  // 4. Portions from foodPortions (for SR Legacy, Foundation, and Survey foods)
+  if (Array.isArray(food.foodPortions)) {
+    for (const portion of food.foodPortions) {
+      const gramWeight = portion.gramWeight;
+      if (gramWeight > 0) {
+        let amount = portion.amount > 0 ? portion.amount : 1.0;
+        let unit = 'serving';
+
+        const measureUnitName = portion.measureUnit?.name;
+        if (
+          measureUnitName &&
+          measureUnitName.toLowerCase() !== 'undetermined' &&
+          measureUnitName.toLowerCase() !== 'quantity not specified' &&
+          measureUnitName.toLowerCase() !== 'not specified'
+        ) {
+          unit = measureUnitName;
+        } else if (portion.portionDescription) {
+          unit = portion.portionDescription;
+        } else if (portion.modifier) {
+          unit = portion.modifier;
+        }
+
+        // Check if description has a mixed weight/count pattern (e.g. "30g or 1 piece", "1 piece (30g)")
+        const mixed = parseMixedPortionDescription(
+          portion.portionDescription || portion.modifier
+        );
+        if (mixed) {
+          amount = mixed.amount;
+          unit = mixed.unit;
+          const finalGramWeight =
+            gramWeight > 0 ? gramWeight : mixed.weight > 0 ? mixed.weight : 0;
+          addVariant(amount, unit, finalGramWeight / 100, false);
+          continue;
+        }
+
+        // Parse quantity prefix from unit text if present (e.g. "1 cup", "1/2 cup")
+        const match = unit.trim().match(/^([\d\s./]+)\s+(.+)$/);
+        if (match) {
+          const parsedSize = evaluateFraction(match[1]);
+          const parsedUnit = match[2].trim();
+          if (parsedSize > 0 && parsedUnit) {
+            amount = parsedSize;
+            unit = parsedUnit;
+          }
+        }
+
+        // Guard against numeric IDs (like "10205" or "90000") that sometimes populate the modifier field
+        if (/^\d+$/.test(unit)) {
+          if (
+            portion.portionDescription &&
+            !/^\d+$/.test(portion.portionDescription)
+          ) {
+            unit = portion.portionDescription;
+            const descMatch = unit.trim().match(/^([\d\s./]+)\s+(.+)$/);
+            if (descMatch) {
+              const parsedSize = evaluateFraction(descMatch[1]);
+              const parsedUnit = descMatch[2].trim();
+              if (parsedSize > 0 && parsedUnit && !/^\d+$/.test(parsedUnit)) {
+                amount = parsedSize;
+                unit = parsedUnit;
+              }
+            }
+          } else {
+            unit = 'serving';
+          }
+        }
+
+        addVariant(amount, unit, gramWeight / 100, false);
+      }
+    }
+  }
+
+  const mappedVariants = Array.from(variantsMap.values());
+
+  // Ensure exactly one default
+  let defaultVariant = mappedVariants.find((v) => v.is_default);
+  if (!defaultVariant && mappedVariants.length > 0) {
+    defaultVariant = mappedVariants[0];
+    defaultVariant.is_default = true;
+  }
+
   return {
     name: food.description,
     brand: food.brandName || food.brandOwner || '',
@@ -148,6 +477,7 @@ function mapUsdaBarcodeProduct(food: any) {
     provider_type: 'usda',
     is_custom: false,
     default_variant: defaultVariant,
+    variants: mappedVariants,
   };
 }
 export { searchUsdaFoods };

--- a/SparkyFitnessServer/models/foodVariant.ts
+++ b/SparkyFitnessServer/models/foodVariant.ts
@@ -232,7 +232,7 @@ async function bulkCreateFoodVariants(variantsData: any, userId: any) {
       variant.iron,
       variant.is_default || false,
       sanitizeGlycemicIndex(variant.glycemic_index),
-      variant.custom_nutrients ?? {},
+      JSON.stringify(variant.custom_nutrients ?? {}),
       variant.source ?? 'manual',
       variant.ai_confidence ?? null,
       'now()',

--- a/SparkyFitnessServer/models/foodVariant.ts
+++ b/SparkyFitnessServer/models/foodVariant.ts
@@ -202,7 +202,7 @@ async function bulkCreateFoodVariants(variantsData: any, userId: any) {
   try {
     const query = `
       INSERT INTO food_variants (
-        user_id, food_id, serving_size, serving_unit, calories, protein, carbs, fat,
+        food_id, serving_size, serving_unit, calories, protein, carbs, fat,
         saturated_fat, polyunsaturated_fat, monounsaturated_fat, trans_fat,
         cholesterol, sodium, potassium, dietary_fiber, sugars,
         vitamin_a, vitamin_c, calcium, iron, is_default, glycemic_index, custom_nutrients,
@@ -210,7 +210,6 @@ async function bulkCreateFoodVariants(variantsData: any, userId: any) {
       ) VALUES %L RETURNING id`;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const values = variantsData.map((variant: any) => [
-      userId,
       variant.food_id,
       variant.serving_size,
       variant.serving_unit,

--- a/SparkyFitnessServer/routes/foodIntegrationRoutes.ts
+++ b/SparkyFitnessServer/routes/foodIntegrationRoutes.ts
@@ -947,7 +947,12 @@ router.get('/usda/search', authenticate, async (req, res, next) => {
     Math.max(1, parseInt(req.query.pageSize, 10) || 50)
   );
   try {
-    const data = await searchUsdaFoods(query, usdaApiKey, page, pageSize);
+    const data = await searchUsdaFoods(
+      query as string,
+      usdaApiKey,
+      page,
+      pageSize
+    );
     res.json(data);
   } catch (error) {
     next(error);
@@ -1001,7 +1006,7 @@ router.get('/usda/details', authenticate, async (req, res, next) => {
     return res.status(400).json({ error: 'Missing FDC ID' });
   }
   try {
-    const data = await getUsdaFoodDetails(fdcId, usdaApiKey);
+    const data = await getUsdaFoodDetails(fdcId as string, usdaApiKey);
     res.json(data);
   } catch (error) {
     next(error);

--- a/SparkyFitnessServer/tests/barcodeLookup.test.ts
+++ b/SparkyFitnessServer/tests/barcodeLookup.test.ts
@@ -401,6 +401,177 @@ describe('mapUsdaBarcodeProduct', () => {
         vitamin_c: 0,
         is_default: true,
       },
+      variants: [
+        {
+          serving_size: 37,
+          serving_unit: 'g',
+          calories: 199,
+          protein: 2.3,
+          carbs: 21.3,
+          fat: 11.4,
+          saturated_fat: 3.9,
+          trans_fat: 0,
+          cholesterol: 2,
+          sodium: 15,
+          potassium: 74,
+          dietary_fiber: 1.3,
+          sugars: 20.8,
+          calcium: 44,
+          iron: 0.9,
+          polyunsaturated_fat: 0,
+          monounsaturated_fat: 0,
+          vitamin_a: 0,
+          vitamin_c: 0,
+          is_default: true,
+        },
+        {
+          serving_size: 100,
+          serving_unit: 'g',
+          calories: 539,
+          protein: 6.3,
+          carbs: 57.5,
+          fat: 30.9,
+          saturated_fat: 10.6,
+          trans_fat: 0,
+          cholesterol: 5,
+          sodium: 41,
+          potassium: 200,
+          dietary_fiber: 3.4,
+          sugars: 56.3,
+          calcium: 120,
+          iron: 2.3,
+          polyunsaturated_fat: 0,
+          monounsaturated_fat: 0,
+          vitamin_a: 0,
+          vitamin_c: 0,
+          is_default: false,
+        },
+      ],
+    });
+  });
+
+  it('should map multiple variants from householdServingFullText', () => {
+    const usdaFood = makeUsdaFood({
+      servingSize: 30,
+      servingSizeUnit: 'g',
+      householdServingFullText: '2 tbsp',
+      foodNutrients: [{ nutrientId: 1008, value: 500 }],
+    });
+    const result = mapUsdaBarcodeProduct(usdaFood);
+
+    expect(result.variants).toHaveLength(3);
+
+    expect(result.variants[0]).toMatchObject({
+      serving_size: 30,
+      serving_unit: 'g',
+      calories: 150,
+      is_default: true,
+    });
+
+    expect(result.variants[1]).toMatchObject({
+      serving_size: 100,
+      serving_unit: 'g',
+      calories: 500,
+      is_default: false,
+    });
+
+    expect(result.variants[2]).toMatchObject({
+      serving_size: 2,
+      serving_unit: 'tbsp',
+      calories: 150,
+      is_default: false,
+    });
+  });
+
+  it('should map multiple variants from foodPortions', () => {
+    const usdaFood = makeUsdaFood({
+      servingSize: 0,
+      servingSizeUnit: undefined,
+      foodNutrients: [{ nutrientId: 1008, value: 900 }],
+      foodPortions: [
+        {
+          amount: 1,
+          measureUnit: { name: 'undetermined' },
+          modifier: '10205',
+          portionDescription: '1 cup',
+          gramWeight: 218,
+        },
+        {
+          amount: 1,
+          measureUnit: { name: 'quantity not specified' },
+          modifier: 'tbsp',
+          portionDescription: '1 tbsp',
+          gramWeight: 14,
+        },
+      ],
+    });
+    const result = mapUsdaBarcodeProduct(usdaFood);
+
+    expect(result.variants).toHaveLength(3);
+
+    expect(result.variants[0]).toMatchObject({
+      serving_size: 100,
+      serving_unit: 'g',
+      calories: 900,
+      is_default: true,
+    });
+
+    expect(result.variants[1]).toMatchObject({
+      serving_size: 1,
+      serving_unit: 'cup',
+      calories: 1962,
+      is_default: false,
+    });
+
+    expect(result.variants[2]).toMatchObject({
+      serving_size: 1,
+      serving_unit: 'tbsp',
+      calories: 126,
+      is_default: false,
+    });
+  });
+  it('should correctly parse mixed portion descriptions (e.g. "30g or 1 piece") and map to the count and unit instead of the gram count as amount', () => {
+    const usdaFood = makeUsdaFood({
+      servingSize: 30,
+      servingSizeUnit: 'g',
+      foodNutrients: [{ nutrientId: 1008, value: 500 }],
+      foodPortions: [
+        {
+          amount: 30,
+          measureUnit: { name: 'piece' },
+          portionDescription: '30g or 1 piece',
+          gramWeight: 30,
+        },
+      ],
+    });
+    const result = mapUsdaBarcodeProduct(usdaFood);
+
+    expect(result.variants).toHaveLength(3);
+
+    expect(result.variants[2]).toMatchObject({
+      serving_size: 1,
+      serving_unit: 'piece',
+      calories: 150,
+      is_default: false,
+    });
+  });
+
+  it('should correctly parse mixed householdServingFullText descriptions (e.g. "30 g or 1 piece")', () => {
+    const usdaFood = makeUsdaFood({
+      servingSize: 30,
+      servingSizeUnit: 'g',
+      householdServingFullText: '30 g or 1 piece',
+      foodNutrients: [{ nutrientId: 1008, value: 500 }],
+    });
+    const result = mapUsdaBarcodeProduct(usdaFood);
+
+    expect(result.variants).toHaveLength(3);
+
+    expect(result.variants[2]).toMatchObject({
+      serving_size: 1,
+      serving_unit: 'piece',
+      calories: 150,
+      is_default: false,
     });
   });
   it('should default missing nutrients to 0', () => {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>
<img width="862" height="1062" alt="image" src="https://github.com/user-attachments/assets/4bd4531e-50ae-4409-a860-721fff2e315f" />

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
