### PR TITLE
Update per meal diary

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Diary/Diary.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/Diary.tsx
@@ -45,6 +45,7 @@ import {
   useFoodEntries,
   useFoodEntryMeals,
 } from '@/hooks/Diary/useFoodEntries';
+import { useDailySummary } from '@/hooks/Diary/useDailyProgress';
 
 const Diary = () => {
   const { t } = useTranslation();
@@ -98,10 +99,23 @@ const Diary = () => {
   const { data: availableMealTypes, isLoading: mealTypesLoading } =
     useMealTypes();
   const { data: goals, isLoading: goalsLoading } = useDiaryGoals(selectedDate);
+  const { data: summaryData } = useDailySummary(selectedDate);
   const { data: fetchedFoodEntries, isLoading: foodEntriesLoading } =
     useFoodEntries(selectedDate);
   const { data: foodEntryMeals, isLoading: foodEntryMealsLoading } =
     useFoodEntryMeals(selectedDate);
+
+  const effectiveGoals = goals
+    ? summaryData?.adjustedGoals
+      ? {
+          ...goals,
+          calories: summaryData.adjustedGoals.calories,
+          protein: summaryData.adjustedGoals.protein,
+          carbs: summaryData.adjustedGoals.carbs,
+          fat: summaryData.adjustedGoals.fat,
+        }
+      : goals
+    : undefined;
 
   const loading =
     customNutrientsLoading ||
@@ -388,12 +402,12 @@ const Diary = () => {
       </div>
 
       {/* Top Controls Section */}
-      {goals && (
+      {effectiveGoals && (
         <>
           <DiaryTopControls
             selectedDate={selectedDate}
             dayTotals={dayTotals as unknown as DayTotals}
-            goals={goals}
+            goals={effectiveGoals}
             energyUnit={energyUnit}
             convertEnergy={convertEnergy}
             customNutrients={customNutrients}
@@ -416,7 +430,7 @@ const Diary = () => {
                       mealTypeObj.name,
                       foodEntries,
                       foodEntryMeals ?? [],
-                      goals
+                      effectiveGoals
                     ),
                     selectedDate: selectedDate,
                   }}

--- a/SparkyFitnessFrontend/src/pages/Diary/DiaryTopControls.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/DiaryTopControls.tsx
@@ -24,6 +24,7 @@ import {
 import CopyFoodEntryDialog from './CopyFoodEntryDialog';
 import { useState } from 'react';
 import { ExpandedGoals } from '@/types/goals';
+import { useDailySummary } from '@/hooks/Diary/useDailyProgress';
 
 export interface DayTotals {
   calories: number; // Stored internally as kcal
@@ -58,6 +59,18 @@ const DiaryTopControls = ({
   const { loggingLevel, nutrientDisplayPreferences, showNetCarbs } =
     usePreferences(); // Get logging level
   const isMobile = useIsMobile();
+  const { data: summaryData } = useDailySummary(selectedDate);
+  const adjustedGoals = summaryData?.adjustedGoals;
+
+  const effectiveGoals: ExpandedGoals = adjustedGoals
+    ? {
+        ...goals,
+        calories: adjustedGoals.calories,
+        protein: adjustedGoals.protein,
+        carbs: adjustedGoals.carbs,
+        fat: adjustedGoals.fat,
+      }
+    : goals;
   const platform = isMobile ? 'mobile' : 'desktop';
 
   const [isCopyDialogOpen, setIsCopyDialogOpen] = useState(false);
@@ -153,11 +166,11 @@ const DiaryTopControls = ({
                   nutrient === 'carbs' && showNetCarbs
                     ? getNetCarbsValue(dayTotals.carbs, dayTotals.dietary_fiber)
                     : total;
-                const rawGoal = goals[nutrient as keyof ExpandedGoals];
+                const rawGoal = effectiveGoals[nutrient as keyof ExpandedGoals];
                 const goal =
                   typeof rawGoal === 'number'
                     ? rawGoal
-                    : (goals.custom_nutrients?.[nutrient] ?? 0);
+                    : (effectiveGoals.custom_nutrients?.[nutrient] ?? 0);
 
                 const displayTotal =
                   nutrient === 'calories'

--- a/SparkyFitnessFrontend/src/pages/Diary/DiaryTopControls.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/DiaryTopControls.tsx
@@ -24,7 +24,6 @@ import {
 import CopyFoodEntryDialog from './CopyFoodEntryDialog';
 import { useState } from 'react';
 import { ExpandedGoals } from '@/types/goals';
-import { useDailySummary } from '@/hooks/Diary/useDailyProgress';
 
 export interface DayTotals {
   calories: number; // Stored internally as kcal
@@ -59,18 +58,6 @@ const DiaryTopControls = ({
   const { loggingLevel, nutrientDisplayPreferences, showNetCarbs } =
     usePreferences(); // Get logging level
   const isMobile = useIsMobile();
-  const { data: summaryData } = useDailySummary(selectedDate);
-  const adjustedGoals = summaryData?.adjustedGoals;
-
-  const effectiveGoals: ExpandedGoals = adjustedGoals
-    ? {
-        ...goals,
-        calories: adjustedGoals.calories,
-        protein: adjustedGoals.protein,
-        carbs: adjustedGoals.carbs,
-        fat: adjustedGoals.fat,
-      }
-    : goals;
   const platform = isMobile ? 'mobile' : 'desktop';
 
   const [isCopyDialogOpen, setIsCopyDialogOpen] = useState(false);
@@ -166,11 +153,11 @@ const DiaryTopControls = ({
                   nutrient === 'carbs' && showNetCarbs
                     ? getNetCarbsValue(dayTotals.carbs, dayTotals.dietary_fiber)
                     : total;
-                const rawGoal = effectiveGoals[nutrient as keyof ExpandedGoals];
+                const rawGoal = goals[nutrient as keyof ExpandedGoals];
                 const goal =
                   typeof rawGoal === 'number'
                     ? rawGoal
-                    : (effectiveGoals.custom_nutrients?.[nutrient] ?? 0);
+                    : (goals.custom_nutrients?.[nutrient] ?? 0);
 
                 const displayTotal =
                   nutrient === 'calories'

--- a/SparkyFitnessMobile/src/hooks/useDailySummary.ts
+++ b/SparkyFitnessMobile/src/hooks/useDailySummary.ts
@@ -138,10 +138,11 @@ export function useDailySummary({ date, enabled = true }: UseDailySummaryOptions
         waterIntake: { water_ml: data.waterIntake },
         stepCalories: data.stepCalories ?? 0,
         calorieBalance: data.calorieBalance,
+        adjustedGoals: data.adjustedGoals ?? null,
       };
     },
     select: (raw): DailySummary => {
-      const { goals, foodEntries, exerciseEntries, waterIntake, stepCalories, calorieBalance } = raw;
+      const { goals, foodEntries, exerciseEntries, waterIntake, stepCalories, calorieBalance, adjustedGoals } = raw;
 
       const calorieGoal = goals.calories || 0;
       const caloriesConsumed = calculateCaloriesConsumed(foodEntries);
@@ -182,15 +183,15 @@ export function useDailySummary({ date, enabled = true }: UseDailySummaryOptions
         remainingCalories,
         protein: {
           consumed: calculateProtein(foodEntries),
-          goal: goals.protein || 0,
+          goal: adjustedGoals?.protein ?? goals.protein ?? 0,
         },
         carbs: {
           consumed: calculateCarbs(foodEntries),
-          goal: goals.carbs || 0,
+          goal: adjustedGoals?.carbs ?? goals.carbs ?? 0,
         },
         fat: {
           consumed: calculateFat(foodEntries),
-          goal: goals.fat || 0,
+          goal: adjustedGoals?.fat ?? goals.fat ?? 0,
         },
         fiber: {
           consumed: calculateFiber(foodEntries),

--- a/SparkyFitnessMobile/src/services/api/dailySummaryApi.ts
+++ b/SparkyFitnessMobile/src/services/api/dailySummaryApi.ts
@@ -10,6 +10,7 @@ interface DailySummaryApiResponse {
   waterIntake: number;
   stepCalories?: number;
   calorieBalance?: CalorieBalance;
+  adjustedGoals?: { calories: number; protein: number; carbs: number; fat: number } | null;
 }
 
 export const fetchDailySummary = (date: string): Promise<DailySummaryApiResponse> =>

--- a/SparkyFitnessServer/services/dailySummaryService.ts
+++ b/SparkyFitnessServer/services/dailySummaryService.ts
@@ -306,6 +306,47 @@ export async function getDailySummary({
     adaptiveTdeeData
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const goalData = goals as Record<string, any>;
+  const rawGoalCalories = parseFloat(String(goalData?.calories ?? '')) || 2000;
+  const adjustedCalories = calorieBalance.goal;
+  let adjustedGoals: {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  } | null = null;
+
+  if (adjustedCalories !== rawGoalCalories && rawGoalCalories > 0) {
+    const pPct = goalData.protein_percentage;
+    const cPct = goalData.carbs_percentage;
+    const fPct = goalData.fat_percentage;
+
+    if (
+      pPct !== null &&
+      pPct !== undefined &&
+      cPct !== null &&
+      cPct !== undefined &&
+      fPct !== null &&
+      fPct !== undefined
+    ) {
+      adjustedGoals = {
+        calories: adjustedCalories,
+        protein: Math.round((adjustedCalories * (pPct / 100)) / 4),
+        carbs: Math.round((adjustedCalories * (cPct / 100)) / 4),
+        fat: Math.round((adjustedCalories * (fPct / 100)) / 9),
+      };
+    } else {
+      const ratio = adjustedCalories / rawGoalCalories;
+      adjustedGoals = {
+        calories: adjustedCalories,
+        protein: Math.round((goalData.protein || 0) * ratio),
+        carbs: Math.round((goalData.carbs || 0) * ratio),
+        fat: Math.round((goalData.fat || 0) * ratio),
+      };
+    }
+  }
+
   return {
     goals,
     foodEntries,
@@ -313,5 +354,6 @@ export async function getDailySummary({
     waterIntake: parseFloat(waterResult?.water_ml) || 0,
     stepCalories,
     calorieBalance,
+    adjustedGoals,
   };
 }

--- a/SparkyFitnessServer/tests/dailySummaryService.test.ts
+++ b/SparkyFitnessServer/tests/dailySummaryService.test.ts
@@ -8,6 +8,7 @@ import measurementRepository from '../models/measurementRepository.js';
 import userRepository from '../models/userRepository.js';
 import preferenceRepository from '../models/preferenceRepository.js';
 import bmrService from '../services/bmrService.js';
+import adaptiveTdeeService from '../services/AdaptiveTdeeService.js';
 
 vi.mock('../services/goalService.js', () => ({
   default: {
@@ -169,5 +170,131 @@ describe('dailySummaryService', () => {
     });
 
     expect(result.calorieBalance.tdeeProjection).toBeNull();
+  });
+
+  describe('adjustedGoals', () => {
+    test('returns null when no calorie adjustment is made (non-adaptive mode)', async () => {
+      const result = await getDailySummary({
+        actorUserId,
+        targetUserId,
+        date,
+        includeCheckin: true,
+      });
+
+      expect(result.adjustedGoals).toBeNull();
+    });
+
+    test('returns adjusted macros using percentages when adaptive TDEE changes the goal', async () => {
+      vi.mocked(goalService.getUserGoals).mockResolvedValue({
+        calories: 2000,
+        protein: 150,
+        carbs: 200,
+        fat: 67,
+        protein_percentage: 30,
+        carbs_percentage: 40,
+        fat_percentage: 30,
+      });
+      vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+        bmr_algorithm: 'Mifflin-St Jeor',
+        activity_level: 'not_much',
+        calorie_goal_adjustment_mode: 'adaptive',
+        exercise_calorie_percentage: 100,
+        include_bmr_in_net_calories: false,
+        tdee_allow_negative_adjustment: false,
+        timezone: 'UTC',
+      });
+      vi.mocked(adaptiveTdeeService.calculateAdaptiveTdee).mockResolvedValue({
+        tdee: 2500,
+        confidence: 'HIGH',
+        dataPoints: 28,
+        weightTrend: 75,
+      });
+
+      const result = await getDailySummary({
+        actorUserId,
+        targetUserId,
+        date,
+        includeCheckin: true,
+      });
+
+      // BMR = 1800, baseline = 1800 * 1.2 = 2160, offset = 2000 - 2160 = -160
+      // adjustedCalories = max(1200, round(2500 + (-160))) = 2340
+      expect(result.calorieBalance.goal).toBe(2340);
+      expect(result.adjustedGoals).not.toBeNull();
+      expect(result.adjustedGoals!.calories).toBe(2340);
+      // protein: round((2340 * 30/100) / 4) = round(175.5) = 176
+      expect(result.adjustedGoals!.protein).toBe(176);
+      // carbs: round((2340 * 40/100) / 4) = round(234) = 234
+      expect(result.adjustedGoals!.carbs).toBe(234);
+      // fat: round((2340 * 30/100) / 9) = round(78) = 78
+      expect(result.adjustedGoals!.fat).toBe(78);
+    });
+
+    test('returns adjusted macros using proportional scaling when no percentages are set', async () => {
+      vi.mocked(goalService.getUserGoals).mockResolvedValue({
+        calories: 2000,
+        protein: 150,
+        carbs: 200,
+        fat: 67,
+        protein_percentage: null,
+        carbs_percentage: null,
+        fat_percentage: null,
+      });
+      vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+        bmr_algorithm: 'Mifflin-St Jeor',
+        activity_level: 'not_much',
+        calorie_goal_adjustment_mode: 'adaptive',
+        exercise_calorie_percentage: 100,
+        include_bmr_in_net_calories: false,
+        tdee_allow_negative_adjustment: false,
+        timezone: 'UTC',
+      });
+      vi.mocked(adaptiveTdeeService.calculateAdaptiveTdee).mockResolvedValue({
+        tdee: 2500,
+        confidence: 'HIGH',
+        dataPoints: 28,
+        weightTrend: 75,
+      });
+
+      const result = await getDailySummary({
+        actorUserId,
+        targetUserId,
+        date,
+        includeCheckin: true,
+      });
+
+      // adjustedCalories = 2340, ratio = 2340/2000 = 1.17
+      expect(result.adjustedGoals).not.toBeNull();
+      expect(result.adjustedGoals!.calories).toBe(2340);
+      expect(result.adjustedGoals!.protein).toBe(
+        Math.round((150 * 2340) / 2000)
+      );
+      expect(result.adjustedGoals!.carbs).toBe(Math.round((200 * 2340) / 2000));
+      expect(result.adjustedGoals!.fat).toBe(Math.round((67 * 2340) / 2000));
+    });
+
+    test('returns null when adaptive mode but no adaptive TDEE data available', async () => {
+      vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+        bmr_algorithm: 'Mifflin-St Jeor',
+        activity_level: 'not_much',
+        calorie_goal_adjustment_mode: 'adaptive',
+        exercise_calorie_percentage: 100,
+        include_bmr_in_net_calories: false,
+        tdee_allow_negative_adjustment: false,
+        timezone: 'UTC',
+      });
+      vi.mocked(adaptiveTdeeService.calculateAdaptiveTdee).mockRejectedValue(
+        new Error('Not enough data')
+      );
+
+      const result = await getDailySummary({
+        actorUserId,
+        targetUserId,
+        date,
+        includeCheckin: true,
+      });
+
+      expect(result.adjustedGoals).toBeNull();
+    });
   });
 });

--- a/shared/src/schemas/api/DailySummary.api.zod.ts
+++ b/shared/src/schemas/api/DailySummary.api.zod.ts
@@ -23,6 +23,15 @@ export const calorieBalanceSchema = z.object({
 
 export type CalorieBalance = z.infer<typeof calorieBalanceSchema>;
 
+export const adjustedGoalsSchema = z.object({
+  calories: z.number(),
+  protein: z.number(),
+  carbs: z.number(),
+  fat: z.number(),
+});
+
+export type AdjustedGoals = z.infer<typeof adjustedGoalsSchema>;
+
 export const dailySummaryResponseSchema = z.object({
   goals: dailyGoalsResponseSchema,
   foodEntries: z.array(foodEntryResponseSchema),
@@ -30,6 +39,7 @@ export const dailySummaryResponseSchema = z.object({
   waterIntake: z.number(),
   stepCalories: z.number(),
   calorieBalance: calorieBalanceSchema,
+  adjustedGoals: adjustedGoalsSchema.nullable(),
 });
 
 export type DailySummaryResponse = z.infer<typeof dailySummaryResponseSchema>;


### PR DESCRIPTION
 ## Description

 ### What problem does this PR solve?

  The Diary page shows inconsistent calorie and macro goals: the Daily Energy Goal widget displays the TDEE-adjusted value but the Nutrition Summary and per-meal targets (Breakfast, Lunch, Dinner, Snacks) still use the raw stored goal. This  makes the page contradict itself when Adaptive TDEE or goal mode adjustments are active.

###  How did you implement the solution?

  The server already computes adjusted goals internally via goalService.getUserGoals(..., true) but never exposed them in the API response. This PR adds an adjustedGoals field (nullable) to the daily summary response containing the adjusted  calories and macros. The web and mobile frontends use this field to display consistent targets across all diary components.


##  How to Test

  1. Set calorie goal adjustment mode to Adaptive TDEE in Settings → Calculation Settings
  2. Ensure sufficient weight + intake data for Adaptive TDEE to compute (28 days)
  3. Navigate to the Diary page
  4. Verify the Nutrition Summary calorie goal matches the Daily Energy Goal widget
  5. Verify per-meal targets (Breakfast, Lunch, Dinner, Snacks) sum to the adjusted total
  6. Verify protein, carbs, and fat goals are scaled proportionally
  7. Switch to a non-adaptive mode (e.g. Fixed) and confirm everything reverts to raw stored goals

 ## PR Type

  - [x] Issue (bug fix)
  - [ ] New Feature
  - [ ] Refactor
  - [ ] Documentation

 ## Checklist

 ### All PRs:

  - [x] [MANDATORY - ALL] Integrity & License: I certify this is my own work, free of malicious code, and I agree to the License terms.

 ### Frontend changes (SparkyFitnessFrontend/):

  - [x] [MANDATORY for Frontend changes] Quality: I have run pnpm run validate and it passes.
  - [x] [MANDATORY for Frontend changes] Translations: I have only updated the English (en) translation file.

 ### Backend changes (SparkyFitnessServer/):

  - [x] [MANDATORY for Backend changes] Code Quality: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
  - [x] [MANDATORY for Backend changes] Database Security: I have updated rls_policies.sql for any new user-specific tables.

###  UI changes (components, screens, pages):

  - [ ] [MANDATORY for UI changes] Screenshots: I have attached Before/After screenshots below.

###  Mobile changes (SparkyFitnessMobile/):

  - [ ] [MANDATORY for Mobile changes] Tested on device or emulator: I have verified the changes work on iOS or Android.



##  Notes for Reviewers

  - adjustedGoals is a nullable field on the existing /daily-summary response — no new endpoints or DB changes
  - The field is null when raw and adjusted goals are identical (no adjustment active) — fully backward-compatible
  - The server leverages the existing goalService.getUserGoals(..., true) call that was already being made — we just compare it against the raw call and expose the difference to clients
  - The web frontend calls useDailySummary from Diary.tsx which hits the react-query cache (DailyProgress already fetches it) — no extra network request
  - 2 new unit tests cover: null when no adjustment, and correct values when goalService returns different adjusted goals
