### PR TITLE
Use adjusted calorie goal for summary and per meal targets

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Diary/Diary.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/Diary.tsx
@@ -38,6 +38,7 @@ import {
   useFoodEntryMeals,
 } from '@/hooks/Diary/useFoodEntries';
 import { todayInZone } from '@workspace/shared';
+import { useDailySummary } from '@/hooks/Diary/useDailyProgress';
 
 const Diary = () => {
   const { t } = useTranslation();
@@ -83,15 +84,30 @@ const Diary = () => {
   const { data: availableMealTypes, isLoading: mealTypesLoading } =
     useMealTypes();
   const { data: goals, isLoading: goalsLoading } = useDiaryGoals(selectedDate);
+  const { data: summaryData, isLoading: summaryLoading } =
+    useDailySummary(selectedDate);
   const { data: fetchedFoodEntries, isLoading: foodEntriesLoading } =
     useFoodEntries(selectedDate);
   const { data: foodEntryMeals, isLoading: foodEntryMealsLoading } =
     useFoodEntryMeals(selectedDate);
 
+  const effectiveGoals = goals
+    ? summaryData?.adjustedGoals
+      ? {
+          ...goals,
+          calories: summaryData.adjustedGoals.calories,
+          protein: summaryData.adjustedGoals.protein,
+          carbs: summaryData.adjustedGoals.carbs,
+          fat: summaryData.adjustedGoals.fat,
+        }
+      : goals
+    : undefined;
+
   const loading =
     customNutrientsLoading ||
     mealTypesLoading ||
     goalsLoading ||
+    summaryLoading ||
     foodEntriesLoading ||
     foodEntryMealsLoading;
 
@@ -297,12 +313,12 @@ const Diary = () => {
       />
 
       {/* Top Controls Section */}
-      {goals && (
+      {effectiveGoals && (
         <>
           <DiaryTopControls
             selectedDate={selectedDate}
             dayTotals={dayTotals as unknown as DayTotals}
-            goals={goals}
+            goals={effectiveGoals}
             energyUnit={energyUnit}
             convertEnergy={convertEnergy}
             customNutrients={customNutrients}
@@ -325,7 +341,7 @@ const Diary = () => {
                       mealTypeObj.name,
                       foodEntries,
                       foodEntryMeals ?? [],
-                      goals
+                      effectiveGoals
                     ),
                     selectedDate: selectedDate,
                   }}

--- a/SparkyFitnessFrontend/src/pages/Diary/DiaryTopControls.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/DiaryTopControls.tsx
@@ -24,6 +24,7 @@ import {
 import CopyFoodEntryDialog from './CopyFoodEntryDialog';
 import { useState } from 'react';
 import { ExpandedGoals } from '@/types/goals';
+import { useDailySummary } from '@/hooks/Diary/useDailyProgress';
 
 export interface DayTotals {
   calories: number; // Stored internally as kcal
@@ -58,6 +59,18 @@ const DiaryTopControls = ({
   const { loggingLevel, nutrientDisplayPreferences, showNetCarbs } =
     usePreferences(); // Get logging level
   const isMobile = useIsMobile();
+  const { data: summaryData } = useDailySummary(selectedDate);
+  const adjustedGoals = summaryData?.adjustedGoals;
+
+  const effectiveGoals: ExpandedGoals = adjustedGoals
+    ? {
+        ...goals,
+        calories: adjustedGoals.calories,
+        protein: adjustedGoals.protein,
+        carbs: adjustedGoals.carbs,
+        fat: adjustedGoals.fat,
+      }
+    : goals;
   const platform = isMobile ? 'mobile' : 'desktop';
 
   const [isCopyDialogOpen, setIsCopyDialogOpen] = useState(false);
@@ -153,11 +166,11 @@ const DiaryTopControls = ({
                   nutrient === 'carbs' && showNetCarbs
                     ? getNetCarbsValue(dayTotals.carbs, dayTotals.dietary_fiber)
                     : total;
-                const rawGoal = goals[nutrient as keyof ExpandedGoals];
+                const rawGoal = effectiveGoals[nutrient as keyof ExpandedGoals];
                 const goal =
                   typeof rawGoal === 'number'
                     ? rawGoal
-                    : (goals.custom_nutrients?.[nutrient] ?? 0);
+                    : (effectiveGoals.custom_nutrients?.[nutrient] ?? 0);
 
                 const displayTotal =
                   nutrient === 'calories'

--- a/SparkyFitnessFrontend/src/pages/Diary/DiaryTopControls.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/DiaryTopControls.tsx
@@ -24,7 +24,6 @@ import {
 import CopyFoodEntryDialog from './CopyFoodEntryDialog';
 import { useState } from 'react';
 import { ExpandedGoals } from '@/types/goals';
-import { useDailySummary } from '@/hooks/Diary/useDailyProgress';
 
 export interface DayTotals {
   calories: number; // Stored internally as kcal
@@ -59,18 +58,6 @@ const DiaryTopControls = ({
   const { loggingLevel, nutrientDisplayPreferences, showNetCarbs } =
     usePreferences(); // Get logging level
   const isMobile = useIsMobile();
-  const { data: summaryData } = useDailySummary(selectedDate);
-  const adjustedGoals = summaryData?.adjustedGoals;
-
-  const effectiveGoals: ExpandedGoals = adjustedGoals
-    ? {
-        ...goals,
-        calories: adjustedGoals.calories,
-        protein: adjustedGoals.protein,
-        carbs: adjustedGoals.carbs,
-        fat: adjustedGoals.fat,
-      }
-    : goals;
   const platform = isMobile ? 'mobile' : 'desktop';
 
   const [isCopyDialogOpen, setIsCopyDialogOpen] = useState(false);
@@ -166,11 +153,11 @@ const DiaryTopControls = ({
                   nutrient === 'carbs' && showNetCarbs
                     ? getNetCarbsValue(dayTotals.carbs, dayTotals.dietary_fiber)
                     : total;
-                const rawGoal = effectiveGoals[nutrient as keyof ExpandedGoals];
+                const rawGoal = goals[nutrient as keyof ExpandedGoals];
                 const goal =
                   typeof rawGoal === 'number'
                     ? rawGoal
-                    : (effectiveGoals.custom_nutrients?.[nutrient] ?? 0);
+                    : (goals.custom_nutrients?.[nutrient] ?? 0);
 
                 const displayTotal =
                   nutrient === 'calories'

--- a/SparkyFitnessMobile/src/hooks/useDailySummary.ts
+++ b/SparkyFitnessMobile/src/hooks/useDailySummary.ts
@@ -144,7 +144,7 @@ export function useDailySummary({ date, enabled = true }: UseDailySummaryOptions
     select: (raw): DailySummary => {
       const { goals, foodEntries, exerciseEntries, waterIntake, stepCalories, calorieBalance, adjustedGoals } = raw;
 
-      const calorieGoal = goals.calories || 0;
+      const calorieGoal = adjustedGoals?.calories ?? goals.calories ?? 0;
       const caloriesConsumed = calculateCaloriesConsumed(foodEntries);
       const exerciseStats = calculateExerciseStats(exerciseEntries);
       const { caloriesBurned, activeCalories, otherExerciseCalories } = exerciseStats;

--- a/SparkyFitnessMobile/src/hooks/useDailySummary.ts
+++ b/SparkyFitnessMobile/src/hooks/useDailySummary.ts
@@ -138,10 +138,11 @@ export function useDailySummary({ date, enabled = true }: UseDailySummaryOptions
         waterIntake: { water_ml: data.waterIntake },
         stepCalories: data.stepCalories ?? 0,
         calorieBalance: data.calorieBalance,
+        adjustedGoals: data.adjustedGoals ?? null,
       };
     },
     select: (raw): DailySummary => {
-      const { goals, foodEntries, exerciseEntries, waterIntake, stepCalories, calorieBalance } = raw;
+      const { goals, foodEntries, exerciseEntries, waterIntake, stepCalories, calorieBalance, adjustedGoals } = raw;
 
       const calorieGoal = goals.calories || 0;
       const caloriesConsumed = calculateCaloriesConsumed(foodEntries);
@@ -182,15 +183,15 @@ export function useDailySummary({ date, enabled = true }: UseDailySummaryOptions
         remainingCalories,
         protein: {
           consumed: calculateProtein(foodEntries),
-          goal: goals.protein || 0,
+          goal: adjustedGoals?.protein ?? goals.protein ?? 0,
         },
         carbs: {
           consumed: calculateCarbs(foodEntries),
-          goal: goals.carbs || 0,
+          goal: adjustedGoals?.carbs ?? goals.carbs ?? 0,
         },
         fat: {
           consumed: calculateFat(foodEntries),
-          goal: goals.fat || 0,
+          goal: adjustedGoals?.fat ?? goals.fat ?? 0,
         },
         fiber: {
           consumed: calculateFiber(foodEntries),

--- a/SparkyFitnessMobile/src/services/api/dailySummaryApi.ts
+++ b/SparkyFitnessMobile/src/services/api/dailySummaryApi.ts
@@ -10,6 +10,7 @@ interface DailySummaryApiResponse {
   waterIntake: number;
   stepCalories?: number;
   calorieBalance?: CalorieBalance;
+  adjustedGoals?: { calories: number; protein: number; carbs: number; fat: number } | null;
 }
 
 export const fetchDailySummary = (date: string): Promise<DailySummaryApiResponse> =>

--- a/SparkyFitnessServer/services/dailySummaryService.ts
+++ b/SparkyFitnessServer/services/dailySummaryService.ts
@@ -279,6 +279,35 @@ export async function getDailySummary({
     measurements
   );
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rawGoalData = goals as Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const adjustedGoalData = adjustedGoals as Record<string, any>;
+  const rawCalories = parseFloat(String(rawGoalData?.calories ?? '')) || 2000;
+  const adjCalories =
+    parseFloat(String(adjustedGoalData?.calories ?? '')) || rawCalories;
+
+  const computedAdjustedGoals: {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  } | null =
+    adjCalories !== rawCalories
+      ? {
+          calories: Math.round(adjCalories),
+          protein: Math.round(
+            parseFloat(String(adjustedGoalData?.protein ?? '')) || 0
+          ),
+          carbs: Math.round(
+            parseFloat(String(adjustedGoalData?.carbs ?? '')) || 0
+          ),
+          fat: Math.round(
+            parseFloat(String(adjustedGoalData?.fat ?? '')) || 0
+          ),
+        }
+      : null;
+
   return {
     goals,
     foodEntries,
@@ -286,5 +315,6 @@ export async function getDailySummary({
     waterIntake: parseFloat(waterResult?.water_ml) || 0,
     stepCalories,
     calorieBalance,
+    adjustedGoals: computedAdjustedGoals,
   };
 }

--- a/SparkyFitnessServer/services/dailySummaryService.ts
+++ b/SparkyFitnessServer/services/dailySummaryService.ts
@@ -271,21 +271,16 @@ export async function getDailySummary({
     exerciseSessions as ExerciseSessionResponse[],
     stepCalories,
     goals,
-    (adjustedGoals as any)?.calories
-      ? parseFloat(String((adjustedGoals as any).calories))
-      : 2000,
+    Number((adjustedGoals as Record<string, unknown> | null)?.calories) || 2000,
     userProfile,
     userPreferences,
     measurements
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const rawGoalData = goals as Record<string, any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const adjustedGoalData = adjustedGoals as Record<string, any>;
-  const rawCalories = parseFloat(String(rawGoalData?.calories ?? '')) || 2000;
-  const adjCalories =
-    parseFloat(String(adjustedGoalData?.calories ?? '')) || rawCalories;
+  const rawGoalData = goals as Record<string, unknown> | null;
+  const adjustedGoalData = adjustedGoals as Record<string, unknown> | null;
+  const rawCalories = Number(rawGoalData?.calories) || 2000;
+  const adjCalories = Number(adjustedGoalData?.calories) || rawCalories;
 
   const computedAdjustedGoals: {
     calories: number;
@@ -296,15 +291,9 @@ export async function getDailySummary({
     adjCalories !== rawCalories
       ? {
           calories: Math.round(adjCalories),
-          protein: Math.round(
-            parseFloat(String(adjustedGoalData?.protein ?? '')) || 0
-          ),
-          carbs: Math.round(
-            parseFloat(String(adjustedGoalData?.carbs ?? '')) || 0
-          ),
-          fat: Math.round(
-            parseFloat(String(adjustedGoalData?.fat ?? '')) || 0
-          ),
+          protein: Math.round(Number(adjustedGoalData?.protein) || 0),
+          carbs: Math.round(Number(adjustedGoalData?.carbs) || 0),
+          fat: Math.round(Number(adjustedGoalData?.fat) || 0),
         }
       : null;
 

--- a/SparkyFitnessServer/tests/dailySummaryService.test.ts
+++ b/SparkyFitnessServer/tests/dailySummaryService.test.ts
@@ -212,9 +212,6 @@ describe('dailySummaryService', () => {
       includeCheckin: true,
     });
 
-    // Baseline goal from goalService.getUserGoals mock is 2000 kcal
-    // recomp is a 10% deficit under manual calculation method.
-    // 2000 * (1 - 0.10) = 1800 kcal
     expect(result.calorieBalance.goal).toBe(1800);
   });
 
@@ -236,12 +233,6 @@ describe('dailySummaryService', () => {
       calories: 1944,
     });
 
-    // bmr is mocked to 1800. activity multiplier for 'not_much' is 1.2.
-    // baselineTdee = 1800 * 1.2 = 2160
-    // recomp is 10% deficit -> 2160 * 0.9 = 1944.
-    // Safety floors:
-    // Mifflin-St Jeor rmr calculates to 1800 because bmrService.calculateBmr is mocked to return 1800.
-    // Target 1944 is >= 1800, so final target is 1944.
     const result = await getDailySummary({
       actorUserId,
       targetUserId,
@@ -261,7 +252,7 @@ describe('dailySummaryService', () => {
       include_bmr_in_net_calories: false,
       tdee_allow_negative_adjustment: false,
       timezone: 'UTC',
-      goal_mode: 'high_cut', // 20% deficit
+      goal_mode: 'high_cut',
       goal_mode_calculation_method: 'adaptive',
       goal_mode_custom_percentage: 0,
     });
@@ -270,9 +261,6 @@ describe('dailySummaryService', () => {
       calories: 1800,
     });
 
-    // bmr is mocked to 1800. activity multiplier is 1.2 -> baselineTdee = 2160.
-    // high_cut is 20% deficit -> 2160 * 0.8 = 1728.
-    // Since it falls below RMR (1800), adaptive mode auto-raises target to 1800.
     const result = await getDailySummary({
       actorUserId,
       targetUserId,
@@ -281,5 +269,52 @@ describe('dailySummaryService', () => {
     });
 
     expect(result.calorieBalance.goal).toBe(1800);
+  });
+
+  describe('adjustedGoals', () => {
+    test('returns null when raw and adjusted goals have the same calories', async () => {
+      const result = await getDailySummary({
+        actorUserId,
+        targetUserId,
+        date,
+        includeCheckin: true,
+      });
+
+      expect(result.adjustedGoals).toBeNull();
+    });
+
+    test('returns adjusted macros when goalService returns different adjusted values', async () => {
+      vi.mocked(goalService.getUserGoals).mockImplementation(
+        (_userId, _date, _endDate, adjust) => {
+          if (adjust) {
+            return Promise.resolve({
+              calories: 2340,
+              protein: 176,
+              carbs: 234,
+              fat: 78,
+            });
+          }
+          return Promise.resolve({
+            calories: 2000,
+            protein: 150,
+            carbs: 200,
+            fat: 67,
+          });
+        }
+      );
+
+      const result = await getDailySummary({
+        actorUserId,
+        targetUserId,
+        date,
+        includeCheckin: true,
+      });
+
+      expect(result.adjustedGoals).not.toBeNull();
+      expect(result.adjustedGoals!.calories).toBe(2340);
+      expect(result.adjustedGoals!.protein).toBe(176);
+      expect(result.adjustedGoals!.carbs).toBe(234);
+      expect(result.adjustedGoals!.fat).toBe(78);
+    });
   });
 });

--- a/shared/src/schemas/api/DailySummary.api.zod.ts
+++ b/shared/src/schemas/api/DailySummary.api.zod.ts
@@ -23,6 +23,15 @@ export const calorieBalanceSchema = z.object({
 
 export type CalorieBalance = z.infer<typeof calorieBalanceSchema>;
 
+export const adjustedGoalsSchema = z.object({
+  calories: z.number(),
+  protein: z.number(),
+  carbs: z.number(),
+  fat: z.number(),
+});
+
+export type AdjustedGoals = z.infer<typeof adjustedGoalsSchema>;
+
 export const dailySummaryResponseSchema = z.object({
   goals: dailyGoalsResponseSchema,
   foodEntries: z.array(foodEntryResponseSchema),
@@ -30,6 +39,7 @@ export const dailySummaryResponseSchema = z.object({
   waterIntake: z.number(),
   stepCalories: z.number(),
   calorieBalance: calorieBalanceSchema,
+  adjustedGoals: adjustedGoalsSchema.nullable(),
 });
 
 export type DailySummaryResponse = z.infer<typeof dailySummaryResponseSchema>;


### PR DESCRIPTION
 ## Description

###  What problem does this PR solve?

The Diary page shows inconsistent calorie and macro goals: the Daily Energy Goal widget displays the TDEE-adjusted value but the Nutrition Summary and per-meal targets (Breakfast, Lunch, Dinner, Snacks) still use the raw stored goal. This makes the page contradict itself when Adaptive TDEE or goal mode adjustments are active.

 ### How did you implement the solution?

The server already computes adjusted goals internally via goalService.getUserGoals(..., true) but never exposed them in the API response. This PR adds an adjustedGoals field (nullable) to the daily summary response containing the adjusted  calories and macros. The web and mobile frontends use this field to display consistent targets across all diary components.

##  How to Test

  1. Set calorie goal adjustment mode to Adaptive TDEE in Settings → Calculation Settings
  2. Ensure sufficient weight + intake data for Adaptive TDEE to compute (28 days)
  3. Navigate to the Diary page
  4. Verify the Nutrition Summary calorie goal matches the Daily Energy Goal widget
  5. Verify per-meal targets (Breakfast, Lunch, Dinner, Snacks) sum to the adjusted total
  6. Verify protein, carbs, and fat goals are scaled proportionally
  7. Switch to a non-adaptive mode (e.g. Fixed) and confirm everything reverts to raw stored goals

 ## PR Type

  - [x] Issue (bug fix)
  - [ ] New Feature
  - [ ] Refactor
  - [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [X] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [X] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [X] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [X] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [X] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.



##  Notes for Reviewers

  - adjustedGoals is a nullable field on the existing /daily-summary response — no new endpoints or DB changes
  - The field is null when raw and adjusted goals are identical (no adjustment active) — fully backward-compatible
  - The server leverages the existing goalService.getUserGoals(..., true) call that was already being made — we just compare it against the raw call and expose the difference to clients
  - The web frontend calls useDailySummary from Diary.tsx which hits the react-query cache (DailyProgress already fetches it) — no extra network request
  - 2 new unit tests cover: null when no adjustment, and correct values when goalService returns different adjusted goals
