### PR TITLE
Fix garmin nutrition sync data loss

### DIFF
--- a/SparkyFitnessServer/models/foodEntry.ts
+++ b/SparkyFitnessServer/models/foodEntry.ts
@@ -944,32 +944,6 @@ async function getFoodEntriesBatch(
   }
 }
 
-async function deleteFoodEntriesByProviderTypeAndDateRange(
-  userId: string,
-  providerType: string,
-  startDate: string,
-  endDate: string
-) {
-  const client = await getClient(userId);
-  try {
-    const result = await client.query(
-      `DELETE FROM food_entries
-       WHERE user_id = $1
-         AND entry_date BETWEEN $2 AND $3
-         AND food_id IN (
-           SELECT id FROM foods
-           WHERE provider_type = $4
-             AND user_id = $1
-         )
-       RETURNING id`,
-      [userId, startDate, endDate, providerType]
-    );
-    return result.rows.length;
-  } finally {
-    client.release();
-  }
-}
-
 // Most recent food entries with catalog name/brand. Backs the chatbot
 // sparky_get_recent_food_entries tool.
 async function getRecentFoodEntries(userId: string, limit: number) {
@@ -1027,11 +1001,37 @@ async function getFoodUsage(
   }
 }
 
+async function deleteStaleProviderEntries(
+  userId: string,
+  source: string,
+  startDate: string,
+  endDate: string,
+  activeSourceIds: string[]
+) {
+  if (activeSourceIds.length === 0) return 0;
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `DELETE FROM food_entries
+       WHERE user_id = $1
+         AND source = $2
+         AND entry_date BETWEEN $3 AND $4
+         AND source_id IS NOT NULL
+         AND source_id != ALL($5)
+       RETURNING id`,
+      [userId, source, startDate, endDate, activeSourceIds]
+    );
+    return result.rows.length;
+  } finally {
+    client.release();
+  }
+}
+
 export { createFoodEntry };
 export { getFoodEntryOwnerId };
 export { updateFoodEntry };
 export { deleteFoodEntry };
-export { deleteFoodEntriesByProviderTypeAndDateRange };
+export { deleteStaleProviderEntries };
 export { getFoodEntriesByDate };
 export { getFoodEntriesByDateAndMealType };
 export { getFoodEntriesByDateRange };
@@ -1048,7 +1048,7 @@ export default {
   getFoodEntryOwnerId,
   updateFoodEntry,
   deleteFoodEntry,
-  deleteFoodEntriesByProviderTypeAndDateRange,
+  deleteStaleProviderEntries,
   getFoodEntriesByDate,
   getFoodEntriesByDateAndMealType,
   getFoodEntriesByDateRange,

--- a/SparkyFitnessServer/services/garminService.ts
+++ b/SparkyFitnessServer/services/garminService.ts
@@ -947,18 +947,9 @@ async function processGarminNutritionData(
     `[garminService] Processing Garmin nutrition data for user ${userId} from ${startDate} to ${endDate}. Days: ${nutritionData.length}`
   );
 
-  // Step 1: Idempotency — delete existing Garmin food entries for this date range
-  const deletedCount =
-    await foodEntryRepository.deleteFoodEntriesByProviderTypeAndDateRange(
-      userId,
-      'garmin',
-      startDate,
-      endDate
-    );
-  log(
-    'info',
-    `[garminService] Deleted ${deletedCount} existing Garmin food entries for date range.`
-  );
+  // Idempotency is handled by the (user_id, source, source_id) upsert on
+  // food_entries — no range-delete needed. Each entry gets a deterministic
+  // source_id derived from the Garmin payload so re-syncs update in place.
 
   // Resolve meal types once
   const allMealTypes = await mealTypeRepository.getAllMealTypes(userId);
@@ -970,6 +961,7 @@ async function processGarminNutritionData(
   let processedFoods = 0;
   let processedEntries = 0;
   const errors: string[] = [];
+  const syncedSourceIds: string[] = [];
 
   // Step 2: Process each day
   for (const dayLog of nutritionData) {
@@ -1002,7 +994,8 @@ async function processGarminNutritionData(
       const loggedFoods = mealDetail.loggedFoods;
       if (!Array.isArray(loggedFoods)) continue;
 
-      for (const loggedFood of loggedFoods) {
+      for (let foodIdx = 0; foodIdx < loggedFoods.length; foodIdx++) {
+        const loggedFood = loggedFoods[foodIdx];
         try {
           const foodMeta = loggedFood.foodMetaData;
           const nutritionContent = loggedFood.nutritionContent;
@@ -1052,7 +1045,10 @@ async function processGarminNutritionData(
           const foodId = food.id;
           const variantId = food.default_variant_id || food.default_variant?.id;
 
-          // Create food entry
+          // Deterministic key: date + meal + garmin food id + position within meal
+          const sourceId = `${mealDate}:${mappedMealType}:${garminFoodId}:${foodIdx}`;
+
+          // Upsert food entry via (user_id, source, source_id) unique index
           await foodEntryRepository.createFoodEntry(
             {
               user_id: userId,
@@ -1067,9 +1063,12 @@ async function processGarminNutritionData(
               food_name: foodMeta.foodName,
               brand_name: foodMeta.brandName || null,
               ...mappedNutrition,
+              source: 'garmin',
+              source_id: sourceId,
             },
             userId
           );
+          syncedSourceIds.push(sourceId);
           processedEntries++;
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error);
@@ -1083,16 +1082,36 @@ async function processGarminNutritionData(
     }
   }
 
+  // Remove entries that Garmin no longer returns (e.g. deleted from Garmin
+  // Connect). Only runs when we successfully processed at least one entry —
+  // an empty response (no subscription, API error) won't wipe existing data.
+  let removedStale = 0;
+  if (syncedSourceIds.length > 0) {
+    removedStale = await foodEntryRepository.deleteStaleProviderEntries(
+      userId,
+      'garmin',
+      startDate,
+      endDate,
+      syncedSourceIds
+    );
+    if (removedStale > 0) {
+      log(
+        'info',
+        `[garminService] Removed ${removedStale} stale Garmin entries no longer in payload.`
+      );
+    }
+  }
+
   log(
     'info',
-    `[garminService] Nutrition sync complete. Foods created: ${processedFoods}, Entries created: ${processedEntries}, Errors: ${errors.length}`
+    `[garminService] Nutrition sync complete. Foods created: ${processedFoods}, Entries created: ${processedEntries}, Removed: ${removedStale}, Errors: ${errors.length}`
   );
 
   return {
     message: 'Garmin nutrition diary sync completed.',
     processedFoods,
     processedEntries,
-    deletedEntries: deletedCount,
+    removedStale,
     errors,
   };
 }

--- a/SparkyFitnessServer/tests/garminNutritionSync.integration.test.ts
+++ b/SparkyFitnessServer/tests/garminNutritionSync.integration.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import foodRepository from '../models/food.js';
+import foodEntryRepository from '../models/foodEntry.js';
+import mealTypeRepository from '../models/mealType.js';
+
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+vi.mock('../models/exerciseEntry.js');
+vi.mock('../models/exercise.js');
+vi.mock('../models/activityDetailsRepository.js');
+vi.mock('../models/exercisePresetEntryRepository.js');
+vi.mock('../models/workoutPresetRepository.js');
+vi.mock('./measurementService.js');
+vi.mock('../models/moodRepository.js');
+vi.mock('../integrations/garminconnect/garminConnectService.js');
+vi.mock('../integrations/garminconnect/garminMeasurementMapping.js');
+vi.mock('../utils/timezoneLoader.js', () => ({
+  loadUserTimezone: vi.fn().mockResolvedValue('UTC'),
+}));
+vi.mock('../models/sleepRepository.js');
+
+vi.mock('../models/food.js', () => ({
+  default: {
+    findFoodByProviderExternalId: vi.fn(),
+    updateFoodVariantNutrition: vi.fn(),
+    createFood: vi.fn(),
+  },
+}));
+vi.mock('../models/foodEntry.js', () => ({
+  default: {
+    createFoodEntry: vi.fn(),
+    deleteStaleProviderEntries: vi.fn(),
+  },
+}));
+vi.mock('../models/mealType.js', () => ({
+  default: {
+    getAllMealTypes: vi.fn(),
+  },
+}));
+
+const MOCK_MEAL_TYPES = [
+  { id: 'mt-breakfast', name: 'Breakfast' },
+  { id: 'mt-lunch', name: 'Lunch' },
+  { id: 'mt-dinner', name: 'Dinner' },
+  { id: 'mt-snacks', name: 'Snacks' },
+];
+
+const sampleDay = {
+  mealDate: '2024-06-15',
+  mealDetails: [
+    {
+      meal: { mealName: 'BREAKFAST' },
+      loggedFoods: [
+        {
+          servingQty: 1,
+          foodMetaData: {
+            foodId: 12345,
+            foodName: 'Oatmeal',
+            brandName: 'Quaker',
+          },
+          nutritionContent: {
+            calories: 150,
+            protein: 5,
+            carbs: 27,
+            fat: 3,
+            servingUnit: 'serving',
+          },
+        },
+        {
+          servingQty: 0.5,
+          foodMetaData: {
+            foodId: 67890,
+            foodName: 'Banana',
+            brandName: null,
+          },
+          nutritionContent: {
+            calories: 105,
+            protein: 1.3,
+            carbs: 27,
+            fat: 0.4,
+            servingUnit: 'medium',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+describe('processGarminNutritionData integration', () => {
+  let processGarminNutritionData: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    (mealTypeRepository.getAllMealTypes as any).mockResolvedValue(
+      MOCK_MEAL_TYPES
+    );
+    (foodRepository.findFoodByProviderExternalId as any).mockResolvedValue(
+      null
+    );
+    (foodRepository.createFood as any).mockResolvedValue({
+      id: 'food-new',
+      default_variant_id: 'variant-new',
+    });
+    (foodEntryRepository.createFoodEntry as any).mockResolvedValue({
+      id: 'entry-new',
+    });
+    (foodEntryRepository.deleteStaleProviderEntries as any).mockResolvedValue(
+      0
+    );
+
+    const garminService = await import('../services/garminService.js');
+    processGarminNutritionData = garminService.processGarminNutritionData;
+  });
+
+  it('creates entries with source=garmin and deterministic source_id', async () => {
+    await processGarminNutritionData(
+      'user-1',
+      [sampleDay],
+      '2024-06-15',
+      '2024-06-15'
+    );
+
+    const calls = (foodEntryRepository.createFoodEntry as any).mock.calls;
+    expect(calls).toHaveLength(2);
+
+    expect(calls[0][0]).toMatchObject({
+      source: 'garmin',
+      source_id: '2024-06-15:breakfast:12345:0',
+      food_name: 'Oatmeal',
+      calories: 150,
+    });
+    expect(calls[1][0]).toMatchObject({
+      source: 'garmin',
+      source_id: '2024-06-15:breakfast:67890:1',
+      food_name: 'Banana',
+      calories: 105,
+    });
+  });
+
+  it('produces identical source_ids on re-sync (idempotent)', async () => {
+    await processGarminNutritionData(
+      'user-1',
+      [sampleDay],
+      '2024-06-15',
+      '2024-06-15'
+    );
+    const firstCalls = (
+      foodEntryRepository.createFoodEntry as any
+    ).mock.calls.map((c: any) => c[0].source_id);
+
+    vi.clearAllMocks();
+    (mealTypeRepository.getAllMealTypes as any).mockResolvedValue(
+      MOCK_MEAL_TYPES
+    );
+    (foodRepository.findFoodByProviderExternalId as any).mockResolvedValue({
+      id: 'food-existing',
+      default_variant_id: 'variant-existing',
+    });
+    (foodEntryRepository.createFoodEntry as any).mockResolvedValue({
+      id: 'entry-2',
+    });
+
+    await processGarminNutritionData(
+      'user-1',
+      [sampleDay],
+      '2024-06-15',
+      '2024-06-15'
+    );
+    const secondCalls = (
+      foodEntryRepository.createFoodEntry as any
+    ).mock.calls.map((c: any) => c[0].source_id);
+
+    expect(firstCalls).toEqual(secondCalls);
+  });
+
+  it('assigns distinct source_ids to different foods in same meal', async () => {
+    const dayWithThreeFoods = {
+      mealDate: '2024-06-15',
+      mealDetails: [
+        {
+          meal: { mealName: 'LUNCH' },
+          loggedFoods: [
+            {
+              servingQty: 1,
+              foodMetaData: { foodId: 111, foodName: 'Rice', brandName: null },
+              nutritionContent: { calories: 200, servingUnit: 'cup' },
+            },
+            {
+              servingQty: 1,
+              foodMetaData: {
+                foodId: 222,
+                foodName: 'Chicken',
+                brandName: null,
+              },
+              nutritionContent: { calories: 250, servingUnit: 'piece' },
+            },
+            {
+              servingQty: 1,
+              foodMetaData: { foodId: 333, foodName: 'Salad', brandName: null },
+              nutritionContent: { calories: 50, servingUnit: 'bowl' },
+            },
+          ],
+        },
+      ],
+    };
+
+    await processGarminNutritionData(
+      'user-1',
+      [dayWithThreeFoods],
+      '2024-06-15',
+      '2024-06-15'
+    );
+
+    const sourceIds = (
+      foodEntryRepository.createFoodEntry as any
+    ).mock.calls.map((c: any) => c[0].source_id);
+    expect(sourceIds).toEqual([
+      '2024-06-15:lunch:111:0',
+      '2024-06-15:lunch:222:1',
+      '2024-06-15:lunch:333:2',
+    ]);
+    const unique = new Set(sourceIds);
+    expect(unique.size).toBe(3);
+  });
+
+  it('reuses existing food by provider_external_id and refreshes variant', async () => {
+    (foodRepository.findFoodByProviderExternalId as any).mockResolvedValue({
+      id: 'food-existing',
+      default_variant_id: 'variant-existing',
+    });
+
+    await processGarminNutritionData(
+      'user-1',
+      [sampleDay],
+      '2024-06-15',
+      '2024-06-15'
+    );
+
+    expect(foodRepository.createFood).not.toHaveBeenCalled();
+    expect(foodRepository.updateFoodVariantNutrition).toHaveBeenCalledTimes(2);
+
+    const entryData = (foodEntryRepository.createFoodEntry as any).mock
+      .calls[0][0];
+    expect(entryData.food_id).toBe('food-existing');
+    expect(entryData.variant_id).toBe('variant-existing');
+  });
+
+  it('continues processing when one entry fails', async () => {
+    (foodEntryRepository.createFoodEntry as any)
+      .mockRejectedValueOnce(new Error('DB constraint violation'))
+      .mockResolvedValueOnce({ id: 'entry-ok' });
+
+    const result = await processGarminNutritionData(
+      'user-1',
+      [sampleDay],
+      '2024-06-15',
+      '2024-06-15'
+    );
+
+    expect(foodEntryRepository.createFoodEntry).toHaveBeenCalledTimes(2);
+    expect(result.processedEntries).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('DB constraint violation');
+  });
+
+  it('reconciles stale entries after successful sync', async () => {
+    (foodEntryRepository.deleteStaleProviderEntries as any).mockResolvedValue(
+      1
+    );
+
+    await processGarminNutritionData(
+      'user-1',
+      [sampleDay],
+      '2024-06-15',
+      '2024-06-15'
+    );
+
+    expect(foodEntryRepository.deleteStaleProviderEntries).toHaveBeenCalledWith(
+      'user-1',
+      'garmin',
+      '2024-06-15',
+      '2024-06-15',
+      ['2024-06-15:breakfast:12345:0', '2024-06-15:breakfast:67890:1']
+    );
+  });
+
+  it('skips reconciliation when no entries were synced (empty response)', async () => {
+    const emptyDay = { mealDate: '2024-06-15', mealDetails: [] };
+
+    await processGarminNutritionData(
+      'user-1',
+      [emptyDay],
+      '2024-06-15',
+      '2024-06-15'
+    );
+
+    expect(
+      foodEntryRepository.deleteStaleProviderEntries
+    ).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
##  Description

 ### What problem does this PR solve?

Garmin nutrition sync wipes food journal entries linked to Garmin-imported foods before processing the API response, this is to support food removal from Garmin Connect. However, a side effect is taht If a user synced a food item via Garmin connect and saved it to the local database, and then manually logged that same food, the next sync with Garmin would delete the manual entry.

###  How did you implement the solution?

Replaced the range-delete with idempotent upserts using source='garmin' and a deterministic source_id (same pattern Health Connect uses).


##  How to Test

  1. Check out this branch and run cd SparkyFitnessServer && pnpm test
  2. Trigger a Garmin nutrition sync (manual or scheduled)
  3. Manually log an extra food items imported from Garmin, delete one from Garmin Connect
  4. Re-trigger the sync and verify the manual log is still there and the one deleted from Connect is not

##  PR Type

  - [x] Issue (bug fix)
  - [ ] New Feature
  - [ ] Refactor
  - [ ] Documentation


## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [X] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [X] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

##  Notes for Reviewers

This needs an active Garmin COnnect subscription.
