### PR TITLE
feat(ai): add exponential backoff for Gemini quota errors (429)

### DIFF
--- a/SparkyFitnessServer/ai/providerDispatch.ts
+++ b/SparkyFitnessServer/ai/providerDispatch.ts
@@ -82,6 +82,22 @@ const ANTHROPIC_VERSION = '2023-06-01';
 const DEFAULT_SCHEMA_NAME = 'structured_output';
 const MAX_DETAIL_BODY_CHARS = 500;
 
+const MAX_FETCH_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 2_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Gemini embeds the wait time in the error body: "Please retry in 11.69562819s"
+function parseRetryAfterMs(body: string): number | null {
+  const match = body.match(/retry in (\d+(?:\.\d+)?)s/i);
+  if (match) {
+    return Math.ceil(parseFloat(match[1]) * 1000) + 500;
+  }
+  return null;
+}
+
 type ProviderFamily = 'google' | 'openai' | 'anthropic' | 'ollama';
 
 // Providers whose vision APIs reject HEIC/HEIF (only Gemini accepts them).
@@ -635,28 +651,47 @@ async function performFetch(
   built: BuiltRequest,
   timeoutMs: number
 ): Promise<HttpOutcome> {
-  let response: Response;
-  try {
-    response = await fetch(built.url, {
-      method: 'POST',
-      headers: built.headers,
-      body: JSON.stringify(built.body),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-  } catch (error) {
-    const name = (error as { name?: string } | null)?.name;
-    if (name === 'TimeoutError' || name === 'AbortError') {
-      return { error: timeoutError() };
+  let response: Response | undefined;
+
+  for (let attempt = 0; attempt <= MAX_FETCH_RETRIES; attempt++) {
+    try {
+      response = await fetch(built.url, {
+        method: 'POST',
+        headers: built.headers,
+        body: JSON.stringify(built.body),
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      const name = (error as { name?: string } | null)?.name;
+      if (name === 'TimeoutError' || name === 'AbortError') {
+        return { error: timeoutError() };
+      }
+      return {
+        error: {
+          ok: false,
+          category: 'upstream_error',
+          detail: `Failed to reach the AI service: ${(error as Error)?.message ?? 'unknown error'}`,
+        },
+      };
     }
-    return {
-      error: {
-        ok: false,
-        category: 'upstream_error',
-        detail: `Failed to reach the AI service: ${(error as Error)?.message ?? 'unknown error'}`,
-      },
-    };
+
+    if (response.status === 429 && attempt < MAX_FETCH_RETRIES) {
+      let body = '';
+      try {
+        body = await response.text();
+      } catch {
+        // best-effort
+      }
+      await sleep(
+        parseRetryAfterMs(body) ?? INITIAL_BACKOFF_MS * Math.pow(2, attempt)
+      );
+      continue;
+    }
+
+    break;
   }
-  return readResponse(response);
+
+  return readResponse(response!);
 }
 
 async function performOllama(

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -586,6 +586,7 @@ async function processChatMessage(
       >,
       tools,
       stopWhen: stepCountIs(50),
+      maxRetries: 5,
       onStepFinish({ toolCalls }) {
         if (toolCalls && toolCalls.length > 0) {
           toolCalls.forEach((call) => {
@@ -980,6 +981,7 @@ async function processChatMessageStream(
       >,
       tools,
       stopWhen: stepCountIs(50),
+      maxRetries: 5,
       onFinish: async ({ text, finishReason }) => {
         // Get the last user message from conversationMessages to ensure parts are captured
         const lastUserMessage = [...conversationMessages]

--- a/SparkyFitnessServer/tests/foodOptionsService.test.ts
+++ b/SparkyFitnessServer/tests/foodOptionsService.test.ts
@@ -361,12 +361,19 @@ describe('processFoodOptionsRequest', () => {
     });
 
     it('returns upstream_error when the API returns a non-OK status', async () => {
-      mockFetch('Rate limit exceeded', { ok: false, status: 429 });
-      const result = await runFoodOptions();
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.category).toBe('upstream_error');
-        expect(result.error).toContain('status 429');
+      vi.useFakeTimers();
+      try {
+        mockFetch('Rate limit exceeded', { ok: false, status: 429 });
+        const promise = runFoodOptions();
+        await vi.runAllTimersAsync();
+        const result = await promise;
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.category).toBe('upstream_error');
+          expect(result.error).toContain('status 429');
+        }
+      } finally {
+        vi.useRealTimers();
       }
     });
 

--- a/SparkyFitnessServer/tests/labelScanService.test.ts
+++ b/SparkyFitnessServer/tests/labelScanService.test.ts
@@ -324,16 +324,23 @@ describe('extractNutritionFromLabel', () => {
     });
 
     it('returns upstream_error when the API returns a non-OK status', async () => {
-      mockFetch('Rate limit exceeded', { ok: false, status: 429 });
-      const result = await extractNutritionFromLabel(
-        TEST_BASE64,
-        TEST_MIME,
-        TEST_USER_ID
-      );
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.category).toBe('upstream_error');
-        expect(result.error).toContain('status 429');
+      vi.useFakeTimers();
+      try {
+        mockFetch('Rate limit exceeded', { ok: false, status: 429 });
+        const promise = extractNutritionFromLabel(
+          TEST_BASE64,
+          TEST_MIME,
+          TEST_USER_ID
+        );
+        await vi.runAllTimersAsync();
+        const result = await promise;
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(result.category).toBe('upstream_error');
+          expect(result.error).toContain('status 429');
+        }
+      } finally {
+        vi.useRealTimers();
       }
     });
 

--- a/SparkyFitnessServer/tests/providerDispatch.test.ts
+++ b/SparkyFitnessServer/tests/providerDispatch.test.ts
@@ -1010,6 +1010,130 @@ describe('dispatchAiRequest — temperature', () => {
   });
 });
 
+describe('dispatchAiRequest — 429 rate-limit retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries after a 429 and succeeds on the second attempt', async () => {
+    let calls = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls === 1) {
+        return Promise.resolve({
+          ok: false,
+          status: 429,
+          text: async () => 'Rate limit exceeded',
+          json: async () => ({}),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => openAiBody(JSON.stringify(SAMPLE)),
+      });
+    }) as typeof global.fetch;
+
+    const promise = dispatchAiRequest(baseRequest());
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.ok).toBe(true);
+    expect(calls).toBe(2);
+  });
+
+  it('parses "retry in Xs" from the error body and uses it as the sleep delay', async () => {
+    let calls = 0;
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+    global.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls === 1) {
+        return Promise.resolve({
+          ok: false,
+          status: 429,
+          text: async () => 'Please retry in 11.69562819s',
+          json: async () => ({}),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => openAiBody(JSON.stringify(SAMPLE)),
+      });
+    }) as typeof global.fetch;
+
+    const promise = dispatchAiRequest(baseRequest());
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // Math.ceil(11.69562819 * 1000) + 500 = 12196
+    const sleepCall = setTimeoutSpy.mock.calls.find(
+      ([, ms]) => typeof ms === 'number' && (ms as number) >= 12000
+    );
+    expect(sleepCall).toBeDefined();
+  });
+
+  it('falls back to exponential backoff when no retry hint is in the body', async () => {
+    let calls = 0;
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+    global.fetch = vi.fn().mockImplementation(() => {
+      calls++;
+      if (calls === 1) {
+        return Promise.resolve({
+          ok: false,
+          status: 429,
+          text: async () => 'Too Many Requests',
+          json: async () => ({}),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => openAiBody(JSON.stringify(SAMPLE)),
+      });
+    }) as typeof global.fetch;
+
+    const promise = dispatchAiRequest(baseRequest());
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // First backoff: INITIAL_BACKOFF_MS * 2^0 = 2000
+    const sleepCall = setTimeoutSpy.mock.calls.find(([, ms]) => ms === 2000);
+    expect(sleepCall).toBeDefined();
+  });
+
+  it('returns upstream_error after exhausting all retries', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => 'Quota exceeded',
+      json: async () => ({}),
+    }) as typeof global.fetch;
+
+    const promise = dispatchAiRequest(baseRequest());
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.category).toBe('upstream_error');
+      expect(result.status).toBe(429);
+    }
+    // 1 initial + MAX_FETCH_RETRIES(3) retries = 4 total calls
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      4
+    );
+  });
+});
+
 describe('toStrictJsonSchema', () => {
   it('adds additionalProperties:false to every object node and strips propertyOrdering', () => {
     const strict = toStrictJsonSchema(SCHEMA);


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Users on the Gemini free tier hit repeated 429 quota errors because the default retry delays (2 s, 4 s) are shorter than Google's cooldown window (~12 s). The direct-fetch path in `providerDispatch.ts` had no retry at all.

**How did you implement the solution?**
`performFetch` now retries up to 3 times on 429, using Google's `"retry in Xs"` hint from the response body when available, or exponential backoff (2 s → 4 s → 8 s) otherwise. `generateText`/`streamText` in `chatService.ts` get `maxRetries: 5` so the AI SDK's backoff has enough headroom to outlast the quota window.

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `pnpm exec vitest run tests/providerDispatch.test.ts` in `SparkyFitnessServer/`
2. Configure a Gemini free-tier API key and send several chat messages in rapid succession
3. Verify requests eventually succeed instead of failing with "Failed after 3 attempts"

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

Not applicable — backend-only change, no UI impact.

## Notes for Reviewers

> `MAX_FETCH_RETRIES = 3` and `INITIAL_BACKOFF_MS = 2_000` are named constants at the top of `providerDispatch.ts` for easy tuning. Zero overhead when no 429 occurs — the retry loop exits immediately on success.