### PR TITLE
split child RLS policies and enforce ownership check on variant deletion

### DIFF
--- a/SparkyFitnessServer/db/rls_policies.sql
+++ b/SparkyFitnessServer/db/rls_policies.sql
@@ -424,12 +424,20 @@ WITH CHECK (has_diary_access(user_id));
 CREATE POLICY delete_policy ON public.food_entries FOR DELETE TO PUBLIC
 USING (has_diary_access(user_id));
 
-CREATE POLICY select_and_modify_policy ON public.food_variants FOR ALL TO PUBLIC
+CREATE POLICY select_policy ON public.food_variants FOR SELECT TO PUBLIC
 USING (
   EXISTS (
     SELECT 1 FROM public.foods f
     WHERE f.id = food_variants.food_id
       AND has_library_access_with_public(f.user_id, f.shared_with_public, ARRAY['can_view_food_library', 'can_manage_diary'])
+  )
+);
+CREATE POLICY modify_policy ON public.food_variants FOR ALL TO PUBLIC
+USING (
+  EXISTS (
+    SELECT 1 FROM public.foods f
+    WHERE f.id = food_variants.food_id
+      AND has_diary_access(f.user_id)
   )
 )
 WITH CHECK (
@@ -462,13 +470,35 @@ CREATE POLICY owner_policy ON public.workout_plan_template_assignments FOR ALL T
 USING (EXISTS (SELECT 1 FROM public.workout_plan_templates wpt WHERE wpt.id = workout_plan_template_assignments.template_id AND current_user_id() = wpt.user_id))
 WITH CHECK (EXISTS (SELECT 1 FROM public.workout_plan_templates wpt WHERE wpt.id = workout_plan_template_assignments.template_id AND current_user_id() = wpt.user_id));
 
-CREATE POLICY owner_policy ON public.workout_preset_exercise_sets FOR ALL TO PUBLIC
-USING (EXISTS (SELECT 1 FROM public.workout_preset_exercises wpe WHERE wpe.id = workout_preset_exercise_sets.workout_preset_exercise_id))
-WITH CHECK (EXISTS (SELECT 1 FROM public.workout_preset_exercises wpe WHERE wpe.id = workout_preset_exercise_sets.workout_preset_exercise_id));
+CREATE POLICY select_policy ON public.workout_preset_exercise_sets FOR SELECT TO PUBLIC
+USING (EXISTS (SELECT 1 FROM public.workout_preset_exercises wpe WHERE wpe.id = workout_preset_exercise_sets.workout_preset_exercise_id));
+CREATE POLICY modify_policy ON public.workout_preset_exercise_sets FOR ALL TO PUBLIC
+USING (EXISTS (
+  SELECT 1 FROM public.workout_preset_exercises wpe
+  JOIN public.workout_presets wp ON wp.id = wpe.workout_preset_id
+  WHERE wpe.id = workout_preset_exercise_sets.workout_preset_exercise_id
+    AND current_user_id() = wp.user_id
+))
+WITH CHECK (EXISTS (
+  SELECT 1 FROM public.workout_preset_exercises wpe
+  JOIN public.workout_presets wp ON wp.id = wpe.workout_preset_id
+  WHERE wpe.id = workout_preset_exercise_sets.workout_preset_exercise_id
+    AND current_user_id() = wp.user_id
+));
 
-CREATE POLICY owner_policy ON public.workout_preset_exercises FOR ALL TO PUBLIC
-USING (EXISTS (SELECT 1 FROM public.workout_presets wp WHERE wp.id = workout_preset_exercises.workout_preset_id))
-WITH CHECK (EXISTS (SELECT 1 FROM public.workout_presets wp WHERE wp.id = workout_preset_exercises.workout_preset_id));
+CREATE POLICY select_policy ON public.workout_preset_exercises FOR SELECT TO PUBLIC
+USING (EXISTS (SELECT 1 FROM public.workout_presets wp WHERE wp.id = workout_preset_exercises.workout_preset_id));
+CREATE POLICY modify_policy ON public.workout_preset_exercises FOR ALL TO PUBLIC
+USING (EXISTS (
+  SELECT 1 FROM public.workout_presets wp
+  WHERE wp.id = workout_preset_exercises.workout_preset_id
+    AND current_user_id() = wp.user_id
+))
+WITH CHECK (EXISTS (
+  SELECT 1 FROM public.workout_presets wp
+  WHERE wp.id = workout_preset_exercises.workout_preset_id
+    AND current_user_id() = wp.user_id
+));
 
 SELECT create_owner_policy('user_ignored_updates');
 SELECT create_owner_policy('fasting_logs');

--- a/SparkyFitnessServer/services/foodCoreService.ts
+++ b/SparkyFitnessServer/services/foodCoreService.ts
@@ -491,6 +491,11 @@ async function deleteFoodVariant(authenticatedUserId: any, variantId: any) {
     if (!foodOwnerId) {
       throw new Error('Associated food not found.');
     }
+    if (foodOwnerId !== authenticatedUserId) {
+      throw new Error(
+        'Forbidden: You do not have permission to delete this food variant.'
+      );
+    }
     const success = await foodRepository.deleteFoodVariant(
       variantId,
       authenticatedUserId

--- a/SparkyFitnessServer/tests/foodCoreService.test.ts
+++ b/SparkyFitnessServer/tests/foodCoreService.test.ts
@@ -188,3 +188,73 @@ describe('foodCoreService.updateFood', () => {
     expect(passedData.shared_with_public).toBe(false);
   });
 });
+
+describe('foodCoreService.deleteFoodVariant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should successfully delete a food variant if authenticated user owns the parent food', async () => {
+    const variant = { id: 'variant-789', food_id: 'food-456' };
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodVariantById.mockResolvedValue(variant);
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodOwnerId.mockResolvedValue(TEST_USER_ID);
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.deleteFoodVariant.mockResolvedValue(true);
+
+    const result = await foodCoreService.deleteFoodVariant(
+      TEST_USER_ID,
+      'variant-789'
+    );
+
+    expect(foodRepository.getFoodVariantById).toHaveBeenCalledWith(
+      'variant-789',
+      TEST_USER_ID
+    );
+    expect(foodRepository.getFoodOwnerId).toHaveBeenCalledWith(
+      'food-456',
+      TEST_USER_ID
+    );
+    expect(foodRepository.deleteFoodVariant).toHaveBeenCalledWith(
+      'variant-789',
+      TEST_USER_ID
+    );
+    expect(result).toBe(true);
+  });
+
+  it('should throw an error if variant is not found', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodVariantById.mockResolvedValue(null);
+
+    await expect(
+      foodCoreService.deleteFoodVariant(TEST_USER_ID, 'variant-789')
+    ).rejects.toThrow('Food variant not found.');
+  });
+
+  it('should throw an error if parent food is not found', async () => {
+    const variant = { id: 'variant-789', food_id: 'food-456' };
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodVariantById.mockResolvedValue(variant);
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodOwnerId.mockResolvedValue(null);
+
+    await expect(
+      foodCoreService.deleteFoodVariant(TEST_USER_ID, 'variant-789')
+    ).rejects.toThrow('Associated food not found.');
+  });
+
+  it('should throw a Forbidden error if user does not own the parent food', async () => {
+    const variant = { id: 'variant-789', food_id: 'food-456' };
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodVariantById.mockResolvedValue(variant);
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodOwnerId.mockResolvedValue('another-user-123');
+
+    await expect(
+      foodCoreService.deleteFoodVariant(TEST_USER_ID, 'variant-789')
+    ).rejects.toThrow(
+      'Forbidden: You do not have permission to delete this food variant.'
+    );
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

@dizconnectz identified some issues on unwanted DELETE access that was introduced in 

https://github.com/CodeWithCJ/SparkyFitness/commit/7c4e04dacf8ab7db3c95ef8d79d5e5fbeeb8bd6b

.

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
