### PR TITLE
fix(mobile): only show updated measurements on diary

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/measurementsApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/measurementsApi.test.ts
@@ -51,17 +51,17 @@ describe('measurementsApi', () => {
       );
     });
 
-    test('sends GET request to /api/measurements/check-in/:date', async () => {
+    test('sends GET request to the single-day range endpoint', async () => {
       mockGetActiveServerConfig.mockResolvedValue(testConfig);
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ entry_date: testDate, weight: 75 }),
+        json: () => Promise.resolve([{ entry_date: testDate, weight: 75 }]),
       });
 
       await fetchMeasurements(testDate);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://example.com/api/measurements/check-in/2024-06-15',
+        'https://example.com/api/measurements/check-in-measurements-range/2024-06-15/2024-06-15',
         expect.objectContaining({
           method: 'GET',
           headers: {
@@ -80,19 +80,19 @@ describe('measurementsApi', () => {
       });
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ entry_date: testDate }),
+        json: () => Promise.resolve([{ entry_date: testDate }]),
       });
 
       await fetchMeasurements(testDate);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://example.com/api/measurements/check-in/2024-06-15',
+        'https://example.com/api/measurements/check-in-measurements-range/2024-06-15/2024-06-15',
         expect.anything()
       );
     });
 
-    test('returns parsed JSON response on success', async () => {
-      const responseData = {
+    test('returns the single day row from the range response', async () => {
+      const row = {
         entry_date: testDate,
         weight: 75,
         neck: 38,
@@ -103,12 +103,38 @@ describe('measurementsApi', () => {
       mockGetActiveServerConfig.mockResolvedValue(testConfig);
       mockFetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(responseData),
+        json: () => Promise.resolve([row]),
       });
 
       const result = await fetchMeasurements(testDate);
 
-      expect(result).toEqual(responseData);
+      expect(result).toEqual(row);
+    });
+
+    test('returns {} when no row exists for the date', async () => {
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+
+      const result = await fetchMeasurements(testDate);
+
+      expect(result).toEqual({});
+    });
+
+    test('returns the first row when the range returns more than one', async () => {
+      const firstRow = { entry_date: testDate, weight: 75 };
+      const secondRow = { entry_date: testDate, weight: 80 };
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([firstRow, secondRow]),
+      });
+
+      const result = await fetchMeasurements(testDate);
+
+      expect(result).toEqual(firstRow);
     });
 
     test('throws error on non-OK response', async () => {

--- a/SparkyFitnessMobile/src/services/api/measurementsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/measurementsApi.ts
@@ -11,7 +11,7 @@ import type { CheckInMeasurement, CheckInMeasurementRange, WaterIntake, WaterCon
  */
 export const fetchMeasurements = async (date: string): Promise<CheckInMeasurement> => {
   const rows = await fetchMeasurementsRange(date, date);
-  return (rows[0] ?? {}) as CheckInMeasurement;
+  return (rows?.[0] ?? {}) as CheckInMeasurement;
 };
 
 /**

--- a/SparkyFitnessMobile/src/services/api/measurementsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/measurementsApi.ts
@@ -3,13 +3,15 @@ import type { CheckInMeasurement, CheckInMeasurementRange, WaterIntake, WaterCon
 
 /**
  * Fetches measurements for a given date.
+ *
+ * The `/check-in/:date` endpoint carries forward the latest value per field
+ * (intentional server behavior for the web editor). The mobile diary/editor
+ * need exactly what was recorded on this day, so query the range endpoint for
+ * a single day — a plain `WHERE entry_date = date` with no carry-forward.
  */
 export const fetchMeasurements = async (date: string): Promise<CheckInMeasurement> => {
-  return apiFetch<CheckInMeasurement>({
-    endpoint: `/api/measurements/check-in/${date}`,
-    serviceName: 'Measurements API',
-    operation: 'fetch measurements',
-  });
+  const rows = await fetchMeasurementsRange(date, date);
+  return (rows[0] ?? {}) as CheckInMeasurement;
 };
 
 /**


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Measurements always showing for every date on diary

**How did you implement the solution?**
Use the range endpoint which has the old behavior.

Linked Issue: Closes #

## How to Test

1. Navigate to diary screen
2. See measurements only show up when changed

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
