### PR TITLE
feat(mobile): copy a logged meal to another day

### DIFF
--- a/SparkyFitnessMobile/__tests__/hooks/useCopyFoodEntries.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useCopyFoodEntries.test.ts
@@ -1,0 +1,90 @@
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+import { useCopyFoodEntries } from '../../src/hooks/useCopyFoodEntries';
+import { copyFoodEntries } from '../../src/services/api/foodEntriesApi';
+import { createTestQueryClient, createQueryWrapper, type QueryClient } from './queryTestUtils';
+
+jest.mock('../../src/services/api/foodEntriesApi', () => ({
+  copyFoodEntries: jest.fn(),
+}));
+
+jest.mock('react-native-toast-message', () => ({
+  show: jest.fn(),
+}));
+
+const mockCopyFoodEntries = copyFoodEntries as jest.MockedFunction<typeof copyFoodEntries>;
+
+const payload = {
+  sourceDate: '2026-05-15',
+  sourceMealType: 'breakfast',
+  targetDate: '2026-05-16',
+  targetMealType: 'lunch',
+};
+
+describe('useCopyFoodEntries', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = createTestQueryClient();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  test('invalidates the target day summary after a successful copy', async () => {
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    mockCopyFoodEntries.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useCopyFoodEntries(), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.copyMeal(payload);
+    });
+
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['dailySummary', '2026-05-16'],
+      });
+    });
+
+    invalidateSpy.mockRestore();
+  });
+
+  test('calls onSuccess with the payload after a successful copy', async () => {
+    mockCopyFoodEntries.mockResolvedValue(undefined);
+    const onSuccess = jest.fn();
+
+    const { result } = renderHook(() => useCopyFoodEntries({ onSuccess }), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.copyMeal(payload);
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(payload);
+    });
+  });
+
+  test('does not call onSuccess when the copy fails', async () => {
+    mockCopyFoodEntries.mockRejectedValue(new Error('boom'));
+    const onSuccess = jest.fn();
+
+    const { result } = renderHook(() => useCopyFoodEntries({ onSuccess }), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    act(() => {
+      result.current.copyMeal(payload);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/services/foodEntriesApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/foodEntriesApi.test.ts
@@ -3,6 +3,7 @@ import {
   createFoodEntry,
   updateFoodEntry,
   deleteFoodEntry,
+  copyFoodEntries,
   calculateCaloriesConsumed,
   calculateProtein,
   calculateCarbs,
@@ -435,6 +436,73 @@ describe('foodEntriesApi', () => {
       mockGetActiveServerConfig.mockResolvedValue(null);
 
       await expect(deleteFoodEntry('entry-1')).rejects.toThrow(
+        'Server configuration not found.'
+      );
+    });
+  });
+
+  describe('copyFoodEntries', () => {
+    const testConfig: ServerConfig = {
+      id: 'test-id',
+      url: 'https://example.com',
+      apiKey: 'test-api-key-12345',
+    };
+
+    const payload = {
+      sourceDate: '2024-06-15',
+      sourceMealType: 'breakfast',
+      targetDate: '2024-06-16',
+      targetMealType: 'lunch',
+    };
+
+    test('sends POST to /api/food-entries/copy with JSON body', async () => {
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([]),
+      });
+
+      await copyFoodEntries(payload);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com/api/food-entries/copy',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify(payload),
+        })
+      );
+    });
+
+    test('resolves on success (returns void)', async () => {
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve([{ id: 'copied-1' }]),
+      });
+
+      await expect(copyFoodEntries(payload)).resolves.toBeUndefined();
+    });
+
+    test('throws on non-OK response', async () => {
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Forbidden'),
+      });
+
+      await expect(copyFoodEntries(payload)).rejects.toThrow(
+        'Server error: 403 - Forbidden'
+      );
+    });
+
+    test('throws when no server config', async () => {
+      mockGetActiveServerConfig.mockResolvedValue(null);
+
+      await expect(copyFoodEntries(payload)).rejects.toThrow(
         'Server configuration not found.'
       );
     });

--- a/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
+++ b/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
@@ -92,14 +92,20 @@ const CopyMealSheet = forwardRef<CopyMealSheetRef, CopyMealSheetProps>(
 
     const handleDateChange = useCallback(({ date }: { date: DateType }) => {
       if (!date) return;
-      // The picker hands back a dayjs object; convert via its own toDate() rather
-      // than relying on Date coercion.
-      const jsDate =
-        date instanceof Date
-          ? date
-          : typeof date === 'object' && 'toDate' in date
-            ? date.toDate()
-            : new Date(date);
+      // The picker hands back a dayjs object; convert via its own toDate(). A
+      // 'YYYY-MM-DD' string is parsed with local components so it does not shift
+      // a day in timezones behind UTC (new Date(str) would parse as UTC midnight).
+      let jsDate: Date;
+      if (date instanceof Date) {
+        jsDate = date;
+      } else if (typeof date === 'object' && 'toDate' in date) {
+        jsDate = date.toDate();
+      } else if (typeof date === 'string') {
+        const [year, month, day] = date.split('-').map(Number);
+        jsDate = new Date(year, month - 1, day);
+      } else {
+        jsDate = new Date(date);
+      }
       setTargetDate(toLocalDateString(jsDate));
     }, []);
 

--- a/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
+++ b/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
@@ -20,7 +20,8 @@ import Button from './ui/Button';
 import Icon from './Icon';
 import { useMealTypes } from '../hooks/useMealTypes';
 import { getMealTypeLabel } from '../constants/meals';
-import { formatDateLabel, toLocalDateString } from '../utils/dateUtils';
+import { formatDateLabel } from '../utils/dateUtils';
+import { dayToPickerDate, localDateToDay } from '@workspace/shared';
 import type { CopyFoodEntriesPayload } from '../services/api/foodEntriesApi';
 
 // Render the sheet inside an iOS UIWindow so it sits above any native modal
@@ -92,28 +93,26 @@ const CopyMealSheet = forwardRef<CopyMealSheetRef, CopyMealSheetProps>(
 
     const handleDateChange = useCallback(({ date }: { date: DateType }) => {
       if (!date) return;
-      // The picker hands back a dayjs object; convert via its own toDate(). A
-      // 'YYYY-MM-DD' string is parsed with local components so it does not shift
-      // a day in timezones behind UTC (new Date(str) would parse as UTC midnight).
+      // The picker hands back a dayjs object; convert it to a Date, then to a
+      // local YYYY-MM-DD day string via the shared helper so there is no
+      // timezone day shift. A YYYY-MM-DD string is parsed with the same helper.
       let jsDate: Date;
       if (date instanceof Date) {
         jsDate = date;
       } else if (typeof date === 'object' && 'toDate' in date) {
         jsDate = date.toDate();
       } else if (typeof date === 'string') {
-        const [year, month, day] = date.split('-').map(Number);
-        jsDate = new Date(year, month - 1, day);
+        jsDate = dayToPickerDate(date);
       } else {
         jsDate = new Date(date);
       }
-      setTargetDate(toLocalDateString(jsDate));
+      setTargetDate(localDateToDay(jsDate));
     }, []);
 
-    const dateValue = useMemo(() => {
-      if (!targetDate) return new Date();
-      const [year, month, day] = targetDate.split('-').map(Number);
-      return new Date(year, month - 1, day);
-    }, [targetDate]);
+    const dateValue = useMemo(
+      () => (targetDate ? dayToPickerDate(targetDate) : new Date()),
+      [targetDate],
+    );
 
     const handleCopy = useCallback(() => {
       if (!source || !targetDate || !targetMealType) return;

--- a/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
+++ b/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
@@ -1,0 +1,212 @@
+import React, {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Platform, Text, TouchableOpacity, View } from 'react-native';
+import {
+  BottomSheetModal,
+  BottomSheetScrollView,
+  BottomSheetBackdrop,
+  type BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet';
+import { FullWindowOverlay } from 'react-native-screens';
+import { useUniwind, useCSSVariable } from 'uniwind';
+import DateTimePicker, { type DateType } from 'react-native-ui-datepicker';
+import Button from './ui/Button';
+import Icon from './Icon';
+import { useMealTypes } from '../hooks/useMealTypes';
+import { getMealTypeLabel } from '../constants/meals';
+import { formatDateLabel, toLocalDateString } from '../utils/dateUtils';
+import type { CopyFoodEntriesPayload } from '../services/api/foodEntriesApi';
+
+// Render the sheet inside an iOS UIWindow so it sits above any native modal
+// presentation. No-op on Android.
+const sheetContainer =
+  Platform.OS === 'ios'
+    ? ({ children }: React.PropsWithChildren) => <FullWindowOverlay>{children}</FullWindowOverlay>
+    : undefined;
+
+export interface CopyMealSheetRef {
+  present: (sourceDate: string, sourceMealType: string) => void;
+  dismiss: () => void;
+}
+
+interface CopyMealSheetProps {
+  isPending?: boolean;
+  onCopy: (payload: CopyFoodEntriesPayload) => void;
+}
+
+const CopyMealSheet = forwardRef<CopyMealSheetRef, CopyMealSheetProps>(
+  ({ isPending = false, onCopy }, ref) => {
+    const bottomSheetRef = useRef<BottomSheetModal>(null);
+    const { theme } = useUniwind();
+    const isDarkMode = theme === 'dark' || theme === 'amoled';
+
+    const [
+      surfaceBg,
+      textMuted,
+      accentPrimary,
+      textPrimary,
+      textSecondary,
+    ] = useCSSVariable([
+      '--color-surface',
+      '--color-text-muted',
+      '--color-accent-primary',
+      '--color-text-primary',
+      '--color-text-secondary',
+    ]) as [string, string, string, string, string];
+
+    const [source, setSource] = useState<{ date: string; mealType: string } | null>(null);
+    const [targetDate, setTargetDate] = useState<string>('');
+    const [targetMealType, setTargetMealType] = useState<string>('');
+
+    const { mealTypes } = useMealTypes();
+
+    useImperativeHandle(ref, () => ({
+      present: (sourceDate: string, sourceMealType: string) => {
+        setSource({ date: sourceDate, mealType: sourceMealType });
+        // Default to the same slot the user is viewing; they pick a new date/meal
+        // before copying.
+        setTargetDate(sourceDate);
+        setTargetMealType(sourceMealType);
+        bottomSheetRef.current?.present();
+      },
+      dismiss: () => bottomSheetRef.current?.dismiss(),
+    }));
+
+    const renderBackdrop = useCallback(
+      (props: BottomSheetBackdropProps) => (
+        <BottomSheetBackdrop
+          {...props}
+          opacity={isDarkMode ? 0.7 : 0.5}
+          disappearsOnIndex={-1}
+          appearsOnIndex={0}
+        />
+      ),
+      [isDarkMode]
+    );
+
+    const handleDateChange = useCallback(({ date }: { date: DateType }) => {
+      if (!date) return;
+      setTargetDate(toLocalDateString(new Date(date as string | number | Date)));
+    }, []);
+
+    const dateValue = useMemo(() => {
+      if (!targetDate) return new Date();
+      const [year, month, day] = targetDate.split('-').map(Number);
+      return new Date(year, month - 1, day);
+    }, [targetDate]);
+
+    const handleCopy = useCallback(() => {
+      if (!source || !targetDate || !targetMealType) return;
+      onCopy({
+        sourceDate: source.date,
+        sourceMealType: source.mealType,
+        targetDate,
+        targetMealType,
+      });
+    }, [source, targetDate, targetMealType, onCopy]);
+
+    return (
+      <BottomSheetModal
+        ref={bottomSheetRef}
+        enableDynamicSizing
+        backdropComponent={renderBackdrop}
+        containerComponent={sheetContainer}
+        backgroundStyle={{ backgroundColor: surfaceBg }}
+        handleIndicatorStyle={{ backgroundColor: textMuted }}
+      >
+        <BottomSheetScrollView contentContainerClassName="px-5 pb-safe-or-8">
+          {source && (
+            <>
+              <View className="items-center mb-4">
+                <Text className="text-text-primary text-lg font-semibold text-center">
+                  Copy {getMealTypeLabel(source.mealType)}
+                </Text>
+                <Text className="text-text-secondary text-sm mt-1 text-center">
+                  From {formatDateLabel(source.date)}
+                </Text>
+              </View>
+
+              {/* Target date */}
+              <Text className="text-xs font-semibold uppercase text-text-muted mb-1">
+                Target date
+              </Text>
+              <DateTimePicker
+                mode="single"
+                date={dateValue}
+                onChange={handleDateChange}
+                components={{
+                  IconPrev: <Icon name="chevron-back" size={18} color={textPrimary} />,
+                  IconNext: <Icon name="chevron-forward" size={18} color={textPrimary} />,
+                }}
+                styles={{
+                  selected: { backgroundColor: accentPrimary },
+                  selected_label: { color: '#FFFFFF' },
+                  today: { borderColor: accentPrimary, borderWidth: 1 },
+                  day_label: { color: textPrimary },
+                  weekday_label: { color: textSecondary },
+                  month_selector_label: { color: textPrimary, fontWeight: '600' },
+                  year_selector_label: { color: textPrimary, fontWeight: '600' },
+                  disabled_label: { color: textMuted },
+                  month_label: { color: textPrimary },
+                  year_label: { color: textPrimary },
+                  selected_month: { backgroundColor: accentPrimary },
+                  selected_month_label: { color: '#FFFFFF' },
+                  selected_year: { backgroundColor: accentPrimary },
+                  selected_year_label: { color: '#FFFFFF' },
+                }}
+              />
+
+              {/* Target meal type */}
+              <Text className="text-xs font-semibold uppercase text-text-muted mt-4 mb-2">
+                Target meal
+              </Text>
+              <View className="flex-row flex-wrap gap-2 mb-6">
+                {mealTypes.map((mt) => {
+                  const isSelected = mt.name.toLowerCase() === targetMealType.toLowerCase();
+                  return (
+                    <TouchableOpacity
+                      key={mt.id}
+                      onPress={() => setTargetMealType(mt.name)}
+                      activeOpacity={0.7}
+                      className={`px-4 py-2 rounded-full border ${
+                        isSelected
+                          ? 'bg-accent-primary border-accent-primary'
+                          : 'bg-raised border-border-subtle'
+                      }`}
+                    >
+                      <Text
+                        className={`text-sm ${
+                          isSelected ? 'text-white font-semibold' : 'text-text-primary'
+                        }`}
+                      >
+                        {getMealTypeLabel(mt.name)}
+                      </Text>
+                    </TouchableOpacity>
+                  );
+                })}
+              </View>
+
+              <Button
+                variant="primary"
+                onPress={handleCopy}
+                disabled={isPending || !targetDate || !targetMealType}
+              >
+                {isPending ? 'Copying...' : 'Copy'}
+              </Button>
+            </>
+          )}
+        </BottomSheetScrollView>
+      </BottomSheetModal>
+    );
+  }
+);
+
+CopyMealSheet.displayName = 'CopyMealSheet';
+
+export default CopyMealSheet;

--- a/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
+++ b/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
@@ -195,7 +195,13 @@ const CopyMealSheet = forwardRef<CopyMealSheetRef, CopyMealSheetProps>(
               <Button
                 variant="primary"
                 onPress={handleCopy}
-                disabled={isPending || !targetDate || !targetMealType}
+                disabled={
+                  isPending ||
+                  !targetDate ||
+                  !targetMealType ||
+                  (source.date === targetDate &&
+                    source.mealType.toLowerCase() === targetMealType.toLowerCase())
+                }
               >
                 {isPending ? 'Copying...' : 'Copy'}
               </Button>

--- a/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
+++ b/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
@@ -133,9 +133,9 @@ const CopyMealSheet = forwardRef<CopyMealSheetRef, CopyMealSheetProps>(
         backgroundStyle={{ backgroundColor: surfaceBg }}
         handleIndicatorStyle={{ backgroundColor: textMuted }}
       >
-        <BottomSheetScrollView contentContainerClassName="px-5 pb-safe-or-8">
+        <BottomSheetScrollView contentContainerClassName="pb-safe-or-8">
           {source && (
-            <>
+            <View className="px-5">
               <View className="items-center mb-4">
                 <Text className="text-text-primary text-lg font-semibold text-center">
                   Copy {getMealTypeLabel(source.mealType)}
@@ -218,7 +218,7 @@ const CopyMealSheet = forwardRef<CopyMealSheetRef, CopyMealSheetProps>(
               >
                 {isPending ? 'Copying...' : 'Copy'}
               </Button>
-            </>
+            </View>
           )}
         </BottomSheetScrollView>
       </BottomSheetModal>

--- a/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
+++ b/SparkyFitnessMobile/src/components/CopyMealSheet.tsx
@@ -92,7 +92,15 @@ const CopyMealSheet = forwardRef<CopyMealSheetRef, CopyMealSheetProps>(
 
     const handleDateChange = useCallback(({ date }: { date: DateType }) => {
       if (!date) return;
-      setTargetDate(toLocalDateString(new Date(date as string | number | Date)));
+      // The picker hands back a dayjs object; convert via its own toDate() rather
+      // than relying on Date coercion.
+      const jsDate =
+        date instanceof Date
+          ? date
+          : typeof date === 'object' && 'toDate' in date
+            ? date.toDate()
+            : new Date(date);
+      setTargetDate(toLocalDateString(jsDate));
     }, []);
 
     const dateValue = useMemo(() => {

--- a/SparkyFitnessMobile/src/hooks/useCopyFoodEntries.ts
+++ b/SparkyFitnessMobile/src/hooks/useCopyFoodEntries.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import Toast from 'react-native-toast-message';
+import {
+  copyFoodEntries,
+  type CopyFoodEntriesPayload,
+} from '../services/api/foodEntriesApi';
+import { dailySummaryQueryKey } from './queryKeys';
+
+interface UseCopyFoodEntriesOptions {
+  onSuccess?: (payload: CopyFoodEntriesPayload) => void;
+}
+
+export function useCopyFoodEntries(options?: UseCopyFoodEntriesOptions) {
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (payload: CopyFoodEntriesPayload) => copyFoodEntries(payload),
+    onSuccess: (_data, payload) => {
+      // Only the target day changes; the source day is left untouched.
+      queryClient.invalidateQueries({ queryKey: dailySummaryQueryKey(payload.targetDate) });
+      Toast.show({ type: 'success', text1: 'Meal copied' });
+      options?.onSuccess?.(payload);
+    },
+    onError: () => {
+      Toast.show({ type: 'error', text1: 'Failed to copy meal', text2: 'Please try again.' });
+    },
+  });
+
+  return {
+    copyMeal: mutation.mutate,
+    isPending: mutation.isPending,
+  };
+}

--- a/SparkyFitnessMobile/src/screens/MealTypeDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MealTypeDetailScreen.tsx
@@ -52,7 +52,10 @@ const MealTypeDetailScreen: React.FC<MealTypeDetailScreenProps> = ({ navigation,
   const { copyMeal, isPending: isCopying } = useCopyFoodEntries({
     onSuccess: () => copySheetRef.current?.dismiss(),
   });
-  const canCopy = isConnected && entries.length > 0;
+  // "other" is a synthetic bucket that aggregates every non-standard meal type,
+  // so it has no single real meal type to copy from (the server would match
+  // nothing). Only offer copy for concrete meal types.
+  const canCopy = isConnected && entries.length > 0 && mealType !== 'other';
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);

--- a/SparkyFitnessMobile/src/screens/MealTypeDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MealTypeDetailScreen.tsx
@@ -6,10 +6,12 @@ import Icon from '../components/Icon';
 import Button from '../components/ui/Button';
 import FoodNutritionSummary from '../components/FoodNutritionSummary';
 import ServingAdjustSheet, { type ServingAdjustSheetRef } from '../components/ServingAdjustSheet';
+import CopyMealSheet, { type CopyMealSheetRef } from '../components/CopyMealSheet';
 import SwipeableFoodRow from '../components/SwipeableFoodRow';
 import StatusView from '../components/StatusView';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { useDailySummary, useServerConnection } from '../hooks';
+import { useCopyFoodEntries } from '../hooks/useCopyFoodEntries';
 import { usePreferences } from '../hooks/usePreferences';
 import { formatDateLabel } from '../utils/dateUtils';
 import {
@@ -27,6 +29,7 @@ const MealTypeDetailScreen: React.FC<MealTypeDetailScreenProps> = ({ navigation,
   const insets = useSafeAreaInsets();
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
   const servingSheetRef = useRef<ServingAdjustSheetRef>(null);
+  const copySheetRef = useRef<CopyMealSheetRef>(null);
   const accentColor = useCSSVariable('--color-accent-primary') as string;
 
   const { isConnected, isLoading: isConnectionLoading } = useServerConnection();
@@ -45,6 +48,11 @@ const MealTypeDetailScreen: React.FC<MealTypeDetailScreenProps> = ({ navigation,
     [summary?.foodEntries, mealType],
   );
   const nutrition = useMemo(() => calculateMealNutrition(entries), [entries]);
+
+  const { copyMeal, isPending: isCopying } = useCopyFoodEntries({
+    onSuccess: () => copySheetRef.current?.dismiss(),
+  });
+  const canCopy = isConnected && entries.length > 0;
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -154,11 +162,23 @@ const MealTypeDetailScreen: React.FC<MealTypeDetailScreenProps> = ({ navigation,
         >
           <Icon name="chevron-back" size={22} color={accentColor} />
         </TouchableOpacity>
+        <View className="flex-1" />
+        {canCopy && (
+          <TouchableOpacity
+            onPress={() => copySheetRef.current?.present(date, mealType)}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityRole="button"
+            accessibilityLabel="Copy meal to another day"
+          >
+            <Icon name="copy" size={20} color={accentColor} />
+          </TouchableOpacity>
+        )}
       </View>
 
       {renderContent()}
 
       <ServingAdjustSheet ref={servingSheetRef} onViewEntry={(entry) => navigation.navigate('FoodEntryView', { entry })} />
+      <CopyMealSheet ref={copySheetRef} isPending={isCopying} onCopy={copyMeal} />
     </View>
   );
 };

--- a/SparkyFitnessMobile/src/services/api/foodEntriesApi.ts
+++ b/SparkyFitnessMobile/src/services/api/foodEntriesApi.ts
@@ -99,6 +99,28 @@ export const deleteFoodEntry = async (id: string): Promise<void> => {
   });
 };
 
+export interface CopyFoodEntriesPayload {
+  sourceDate: string;
+  sourceMealType: string;
+  targetDate: string;
+  targetMealType: string;
+}
+
+/**
+ * Copies the food entries from one date/meal type into another date/meal type.
+ * Meal types are matched by name (case-insensitive) server-side. The source
+ * entries are left untouched.
+ */
+export const copyFoodEntries = async (payload: CopyFoodEntriesPayload): Promise<void> => {
+  await apiFetch<unknown>({
+    endpoint: '/api/food-entries/copy',
+    serviceName: 'Food Entries API',
+    operation: 'copy food entries',
+    method: 'POST',
+    body: payload,
+  });
+};
+
 /**
  * Fetches food entries for a given date.
  */


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The web diary can copy a full meal to another date, but the mobile app cannot, so mobile users have to switch to the web app to do it (issue #1361).

**How did you implement the solution?**
The backend copy endpoint (`POST /food-entries/copy`) already exists, so this is mobile-client only: a copy action on the meal-type detail screen opens a bottom sheet to choose a target date and meal, then calls that endpoint through a new react-query mutation that invalidates the target day. The sheet reuses existing primitives (the diary's date picker and the app's bottom-sheet pattern), and the copy button only appears when the meal has entries and stays disabled until the target differs from the source.

Linked Issue: Closes #1361

## How to Test

1. Log some foods into a meal (for example Dinner) on any day.
2. Open that meal from the diary to reach the Meal Type Detail screen. A copy icon appears at the top-right of the header.
3. Tap it, pick a different target date and/or meal in the sheet, and tap Copy.
4. Verify a "Meal copied" toast appears, the entries now show on the target day and meal, and the source meal is unchanged.
5. Confirm the Copy button is disabled while the target date and meal still match the source.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the License terms.

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: Raised as issue #1361 and approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- Not applicable: no frontend changes.

**Backend changes (`SparkyFitnessServer/`):**

- Not applicable: no backend changes.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: Before/After screenshots attached below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: Verified on a physical Android device (Samsung Galaxy S26 Ultra). Copied both a set of standalone food entries and a built/logged meal from one date to another; the target day populated correctly, the source was unchanged, and the toast fired.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="480" height="976" alt="Screenshot_20260616_140418_SparkyFitness" src="https://github.com/user-attachments/assets/482c9fe8-6c96-4c0c-a29f-08d6fee8aa13" />

### After

<img width="480" height="976" alt="Screenshot_20260616_140156_SparkyFitness" src="https://github.com/user-attachments/assets/b0713841-4943-41df-a510-1cf0449e1254" />

<img width="480" height="976" alt="Screenshot_20260616_140205_SparkyFitness" src="https://github.com/user-attachments/assets/bf75d9cb-10f4-461b-9b7d-8874f4c4ccba" />

<img width="480" height="976" alt="Screenshot_20260616_140214_SparkyFitness" src="https://github.com/user-attachments/assets/732fccfc-01ea-46f7-9d1e-740355c54b28" />

</details>

## Notes for Reviewers

Mobile-only change; no server or schema changes. Meal types are matched by name (case-insensitive) by the existing endpoint, which maps cleanly to the mobile meal-type keys, so no id translation is needed. Scope is intentionally limited to the per-meal copy-to-another-day flow (the core ask in #1361). The web app also has copy-from-yesterday and copy-entire-day; those can be follow-ups.

Verification: 39 unit tests pass (4 new API cases in `foodEntriesApi.test.ts`, 3 new hook cases in `useCopyFoodEntries.test.ts`); `tsc --noEmit` adds no new errors from the changed files; eslint is clean on all changed files.

Interaction with the recent mobile meal-ingredient editing feature (EditLoggedMealScreen): the two are independent. When a copied slot contains a logged meal (a `food_entry_meal` container), the server duplicates the container with a fresh id and links the copied entries to it, so the copy is independently editable and never shares state with the original.
