### PR TITLE
fix: do not count both active calories and workouts 

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Diary/ExerciseCard.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/ExerciseCard.tsx
@@ -33,6 +33,7 @@ import {
   useDeleteExercisePresetEntryMutation,
   useExerciseEntries,
 } from '@/hooks/Exercises/useExerciseEntries';
+import { resolveExerciseCalories } from '@workspace/shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { exerciseByIdOptions } from '@/hooks/Exercises/useExercises';
 import { createWorkoutPlaybackRouteState } from '@/utils/workoutPlayback';
@@ -321,7 +322,8 @@ const ExerciseCard = ({
   };
 
   const stats = useMemo(() => {
-    let calories = 0;
+    let activeCalories = 0;
+    let otherCalories = 0;
     let duration = 0;
     let setsCount = 0;
     let hrSum = 0;
@@ -344,10 +346,16 @@ const ExerciseCard = ({
           : [groupedEntry];
 
       items.forEach((entry: ExerciseEntry) => {
-        // Calories
+        // Calories — keep the device-wide "Active Calories" summary separate
+        // from logged workouts so the total can be deduped, not summed (the
+        // summary already includes the workouts it overlaps with).
         const cal = entry.calories_burned;
-        if (cal) {
-          if (!isNaN(cal)) calories += cal;
+        if (cal && !isNaN(cal)) {
+          if (entry.exercise_snapshot?.name === 'Active Calories') {
+            activeCalories += cal;
+          } else {
+            otherCalories += cal;
+          }
         }
 
         // Duration & Sets
@@ -369,8 +377,17 @@ const ExerciseCard = ({
       });
     });
 
+    // "Active Calories" is a device-wide summary that already includes logged
+    // workouts, so take the larger of the two instead of adding both. Steps are
+    // intentionally excluded here so the total matches the listed rows.
+    const { calories: totalCalories } = resolveExerciseCalories(
+      otherCalories,
+      activeCalories,
+      0
+    );
+
     return {
-      totalCalories: calories,
+      totalCalories,
       totalDuration: duration,
       totalSets: setsCount,
       averageHeartRate: hrCount > 0 ? hrSum / hrCount : 0,


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Active Calories was contributing to the total calories burnt of the day on the diary page.

**How did you implement the solution?**
Use the same deduplication logic the server users from the shared package to calculate total calories for the day

Linked Issue: Closes #1491

## How to Test

1. Sync workout from apple health and it's active calories from app
2. Verify they are not both counted in total on web

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
