### PR TITLE
refactor: remove hardcoded external data provider types from mobile client

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -109,6 +109,7 @@ const EnhancedFoodSearch = ({
     convertEnergy,
     getEnergyUnitString,
     autoScaleOpenFoodFactsImports,
+    saveAllPreferences,
   } = usePreferences();
   const isMobile = useIsMobile();
   const platform = isMobile ? 'mobile' : 'desktop';
@@ -621,6 +622,7 @@ const EnhancedFoodSearch = ({
             onValueChange={(value) => {
               setManualProviderId(value);
               setDefaultFoodDataProviderId(value);
+              saveAllPreferences({ defaultFoodDataProviderId: value });
             }}
           >
             <SelectTrigger className="w-[180px]">

--- a/SparkyFitnessFrontend/src/pages/Chat/SparkyChat.tsx
+++ b/SparkyFitnessFrontend/src/pages/Chat/SparkyChat.tsx
@@ -48,8 +48,7 @@ const SparkyChat = () => {
   // Chatbot is available if the user has any service they can actually use:
   // - their own active service
   // - an admin global (is_public) service
-  const usableServices =
-    services?.filter((service) => service.is_active || service.is_public) ?? [];
+  const usableServices = services?.filter((service) => service.is_active) ?? [];
 
   const hasEnabledServices = usableServices.length > 0;
 

--- a/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
@@ -330,8 +330,10 @@ const ExternalProviderList = ({
             data.provider_type === 'yazio')
         ) {
           setDefaultFoodDataProviderId(data.id);
+          saveAllPreferences({ defaultFoodDataProviderId: data.id });
         } else if (data && defaultFoodDataProviderId === data.id) {
           setDefaultFoodDataProviderId(null);
+          saveAllPreferences({ defaultFoodDataProviderId: null });
         }
 
         if (data && !data.is_active && defaultBarcodeProviderId === data.id) {

--- a/SparkyFitnessFrontend/src/pages/Settings/ProviderCard.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ProviderCard.tsx
@@ -251,8 +251,10 @@ export const ProviderCard = ({
             data.provider_type === 'yazio')
         ) {
           setDefaultFoodDataProviderId(data.id);
+          saveAllPreferences({ defaultFoodDataProviderId: data.id });
         } else if (data && defaultFoodDataProviderId === data.id) {
           setDefaultFoodDataProviderId(null);
+          saveAllPreferences({ defaultFoodDataProviderId: null });
         }
         if (data && !data.is_active && defaultBarcodeProviderId === data.id) {
           setDefaultBarcodeProviderId(null);
@@ -279,6 +281,7 @@ export const ProviderCard = ({
           await deleteExternalProvider(providerId);
           if (defaultFoodDataProviderId === providerId) {
             setDefaultFoodDataProviderId(null);
+            saveAllPreferences({ defaultFoodDataProviderId: null });
           }
           if (defaultBarcodeProviderId === providerId) {
             setDefaultBarcodeProviderId(null);

--- a/SparkyFitnessMobile/__tests__/hooks/useExternalProviders.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useExternalProviders.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { useExternalProviders } from '../../src/hooks/useExternalProviders';
 import { fetchExternalProviders } from '../../src/services/api/externalProvidersApi';
-import { ExternalProvider, FOOD_PROVIDER_TYPES } from '../../src/types/externalProviders';
+import { ExternalProvider } from '../../src/types/externalProviders';
 import { createTestQueryClient, createQueryWrapper, type QueryClient } from './queryTestUtils';
 
 jest.mock('../../src/services/api/externalProvidersApi', () => ({
@@ -14,6 +14,8 @@ const makeProvider = (overrides: Partial<ExternalProvider> & { id: string }): Ex
   provider_name: 'Test Provider',
   provider_type: 'openfoodfacts',
   is_active: true,
+  categories: ['food'],
+  supports_barcode: false,
   ...overrides,
 });
 
@@ -32,9 +34,9 @@ describe('useExternalProviders', () => {
   describe('filtering', () => {
     test('filters out non-food provider types', async () => {
       mockFetchExternalProviders.mockResolvedValue([
-        makeProvider({ id: '1', provider_name: 'OpenFoodFacts', provider_type: 'openfoodfacts' }),
-        makeProvider({ id: '2', provider_name: 'Free Exercise DB', provider_type: 'free-exercise-db' }),
-        makeProvider({ id: '3', provider_name: 'USDA', provider_type: 'usda' }),
+        makeProvider({ id: '1', provider_name: 'OpenFoodFacts', provider_type: 'openfoodfacts', categories: ['food'] }),
+        makeProvider({ id: '2', provider_name: 'Free Exercise DB', provider_type: 'free-exercise-db', categories: ['exercise'] }),
+        makeProvider({ id: '3', provider_name: 'USDA', provider_type: 'usda', categories: ['food'] }),
       ]);
 
       const { result } = renderHook(() => useExternalProviders(), {
@@ -72,7 +74,7 @@ describe('useExternalProviders', () => {
 
     test('returns empty array when no providers match', async () => {
       mockFetchExternalProviders.mockResolvedValue([
-        makeProvider({ id: '1', provider_type: 'free-exercise-db', is_active: true }),
+        makeProvider({ id: '1', provider_type: 'free-exercise-db', is_active: true, categories: ['exercise'] }),
         makeProvider({ id: '2', provider_type: 'openfoodfacts', is_active: false }),
       ]);
 
@@ -88,10 +90,10 @@ describe('useExternalProviders', () => {
     });
 
     test('includes all food provider types', async () => {
-      const foodTypes = [...FOOD_PROVIDER_TYPES];
+      const foodTypes = ['openfoodfacts', 'fatsecret', 'usda', 'mealie', 'tandoor', 'norish', 'yazio', 'swissfood'];
       mockFetchExternalProviders.mockResolvedValue(
         foodTypes.map((type, i) =>
-          makeProvider({ id: String(i), provider_name: type, provider_type: type }),
+          makeProvider({ id: String(i), provider_name: type, provider_type: type, categories: ['food'] }),
         ),
       );
 
@@ -104,6 +106,41 @@ describe('useExternalProviders', () => {
       });
 
       expect(result.current.providers).toHaveLength(foodTypes.length);
+    });
+
+    test('dynamically filters by category field returned from server', async () => {
+      mockFetchExternalProviders.mockResolvedValue([
+        makeProvider({ id: '1', provider_name: 'Custom Food Provider', provider_type: 'custom-food', categories: ['food'] }),
+        makeProvider({ id: '2', provider_name: 'Custom Exercise Provider', provider_type: 'custom-ex', categories: ['exercise'] }),
+      ]);
+
+      const { result: foodResult } = renderHook(() => useExternalProviders({ category: 'food' }), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+      await waitFor(() => expect(foodResult.current.isLoading).toBe(false));
+      expect(foodResult.current.providers).toHaveLength(1);
+      expect(foodResult.current.providers[0].provider_name).toBe('Custom Food Provider');
+
+      const { result: exResult } = renderHook(() => useExternalProviders({ category: 'exercise' }), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+      await waitFor(() => expect(exResult.current.isLoading).toBe(false));
+      expect(exResult.current.providers).toHaveLength(1);
+      expect(exResult.current.providers[0].provider_name).toBe('Custom Exercise Provider');
+    });
+
+    test('dynamically filters by supports_barcode field returned from server', async () => {
+      mockFetchExternalProviders.mockResolvedValue([
+        makeProvider({ id: '1', provider_name: 'USDA', provider_type: 'usda', supports_barcode: true }),
+        makeProvider({ id: '2', provider_name: 'Mealie', provider_type: 'mealie', supports_barcode: false }),
+      ]);
+
+      const { result } = renderHook(() => useExternalProviders({ supportsBarcode: true }), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.providers).toHaveLength(1);
+      expect(result.current.providers[0].provider_name).toBe('USDA');
     });
   });
 

--- a/SparkyFitnessMobile/src/hooks/useExternalFoodSearch.ts
+++ b/SparkyFitnessMobile/src/hooks/useExternalFoodSearch.ts
@@ -6,8 +6,6 @@ import { externalFoodSearchQueryKey } from './queryKeys';
 import { useDebounce } from './useDebounce';
 import { RateLimiter } from '../utils/rateLimiter';
 
-const SUPPORTED_PROVIDERS = new Set(['openfoodfacts', 'usda', 'fatsecret', 'mealie', 'tandoor', 'norish', 'yazio', 'swissfood']);
-
 // Open Food Facts allows 10 req/min; use 8 for headroom
 const offRateLimiter = new RateLimiter(8, 60_000);
 
@@ -19,7 +17,7 @@ export function useExternalFoodSearch(
   const { enabled = true, providerId, autoScale } = options ?? {};
   const debouncedSearch = useDebounce(searchText.trim(), 600);
   const isSearchActive = debouncedSearch.length >= 3;
-  const isProviderSupported = SUPPORTED_PROVIDERS.has(providerType);
+  const isProviderSupported = !!providerType;
 
   const query = useInfiniteQuery({
     queryKey: externalFoodSearchQueryKey(providerType, debouncedSearch, providerId, autoScale),

--- a/SparkyFitnessMobile/src/hooks/useExternalProviders.ts
+++ b/SparkyFitnessMobile/src/hooks/useExternalProviders.ts
@@ -1,10 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchExternalProviders } from '../services/api/externalProvidersApi';
-import { FOOD_PROVIDER_TYPES } from '../types/externalProviders';
 import { externalProvidersQueryKey } from './queryKeys';
 
-export function useExternalProviders(options?: { enabled?: boolean; filterSet?: Set<string> }) {
-  const { enabled = true, filterSet = FOOD_PROVIDER_TYPES } = options ?? {};
+export function useExternalProviders(options?: {
+  enabled?: boolean;
+  category?: 'food' | 'exercise' | 'other';
+  supportsBarcode?: boolean;
+  filterSet?: Set<string>;
+}) {
+  const { enabled = true, category = 'food', supportsBarcode, filterSet } = options ?? {};
 
   const query = useQuery({
     queryKey: externalProvidersQueryKey,
@@ -12,9 +16,29 @@ export function useExternalProviders(options?: { enabled?: boolean; filterSet?: 
     staleTime: 1000 * 60 * 5, // 5 minutes
     enabled,
     select: (data) =>
-      data.filter(
-        (p) => p.is_active && filterSet.has(p.provider_type),
-      ),
+      data.filter((p) => {
+        if (!p.is_active) return false;
+
+        // If filterSet is explicitly provided, respect it (legacy/fallback support)
+        if (filterSet) {
+          return filterSet.has(p.provider_type);
+        }
+
+        // Filter by category
+        if (category) {
+          const cats = p.categories ?? [];
+          if (!cats.includes(category)) {
+            return false;
+          }
+        }
+
+        // Filter by barcode support
+        if (supportsBarcode) {
+          if (!p.supports_barcode) return false;
+        }
+
+        return true;
+      }),
   });
 
   return {

--- a/SparkyFitnessMobile/src/screens/ExerciseSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ExerciseSearchScreen.tsx
@@ -22,7 +22,6 @@ import { useServerConnection, useExternalProviders, useSuggestedExercises, useEx
 import { suggestedExercisesQueryKey } from '../hooks/queryKeys';
 import { useExternalExerciseSearch } from '../hooks/useExternalExerciseSearch';
 import { importExercise } from '../services/api/externalExerciseSearchApi';
-import { EXERCISE_PROVIDER_TYPES } from '../types/externalProviders';
 import type { Exercise } from '../types/exercise';
 import type { ExternalExerciseItem } from '../types/externalExercises';
 import type { RootStackScreenProps } from '../types/navigation';
@@ -69,7 +68,7 @@ const ExerciseSearchScreen: React.FC<ExerciseSearchScreenProps> = ({ navigation,
     refetch: refetchProviders,
   } = useExternalProviders({
     enabled: isConnected && activeTab === 'online',
-    filterSet: EXERCISE_PROVIDER_TYPES,
+    category: 'exercise',
   });
 
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);

--- a/SparkyFitnessMobile/src/screens/FoodSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSettingsScreen.tsx
@@ -11,7 +11,6 @@ import BottomSheetPicker from '../components/BottomSheetPicker';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { usePreferences } from '../hooks/usePreferences';
 import { useExternalProviders } from '../hooks/useExternalProviders';
-import { BARCODE_PROVIDER_TYPES } from '../types/externalProviders';
 import { updatePreferences } from '../services/api/preferencesApi';
 import { preferencesQueryKey } from '../hooks/queryKeys';
 import type { UserPreferences } from '../types/preferences';
@@ -32,7 +31,7 @@ const FoodSettingsScreen: React.FC<FoodSettingsScreenProps> = ({ navigation }) =
   const { preferences } = usePreferences();
   const { providers } = useExternalProviders();
   const { providers: barcodeProviders } = useExternalProviders({
-    filterSet: BARCODE_PROVIDER_TYPES,
+    supportsBarcode: true,
   });
 
   const providerOptions = useMemo(

--- a/SparkyFitnessMobile/src/types/externalProviders.ts
+++ b/SparkyFitnessMobile/src/types/externalProviders.ts
@@ -3,17 +3,6 @@ export interface ExternalProvider {
   provider_name: string;
   provider_type: string;
   is_active: boolean;
+  categories?: string[];
+  supports_barcode?: boolean;
 }
-
-// Allowlist of provider_type values relevant to food search
-export const FOOD_PROVIDER_TYPES = new Set([
-  'openfoodfacts', 'fatsecret', 'usda', 'mealie', 'tandoor', 'norish', 'yazio', 'swissfood',
-]);
-
-// Allowlist of provider_type values that support barcode lookup
-export const BARCODE_PROVIDER_TYPES = new Set(['usda', 'openfoodfacts', 'fatsecret']);
-
-// Allowlist of provider_type values relevant to exercise search
-export const EXERCISE_PROVIDER_TYPES = new Set([
-  'wger', 'free-exercise-db',
-]);

--- a/SparkyFitnessServer/db/migrations/20260620143300_public_sharing_and_dynamic_provider_types.sql
+++ b/SparkyFitnessServer/db/migrations/20260620143300_public_sharing_and_dynamic_provider_types.sql
@@ -176,10 +176,14 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql SECURITY DEFINER;
 
+
+
 DROP TRIGGER IF EXISTS seed_global_providers_on_first_admin ON public."user";
+
 CREATE TRIGGER seed_global_providers_on_first_admin
-  AFTER INSERT ON public."user"
+  AFTER INSERT OR UPDATE OF role ON public."user"
   FOR EACH ROW EXECUTE FUNCTION public.seed_global_providers_for_first_admin();
+
 
 -- ──────────────────────────────────────────────────────────────────────────────
 -- 5. Seed global providers for EXISTING installations.

--- a/SparkyFitnessServer/db/rls_policies.sql
+++ b/SparkyFitnessServer/db/rls_policies.sql
@@ -404,13 +404,13 @@ DROP POLICY IF EXISTS delete_policy ON public.external_data_providers;
 -- SELECT: admin-global (authenticated users), own, or explicit family delegation
 CREATE POLICY select_policy ON public.external_data_providers FOR SELECT TO PUBLIC
 USING (
-  -- Admin-created global providers: all authenticated users can see them
-  (is_public = TRUE AND authenticated_user_id() IS NOT NULL)
+  -- Admin-created global providers: all authenticated users can see them if active
+  (is_public = TRUE AND is_active = TRUE AND authenticated_user_id() IS NOT NULL)
   -- Owner always sees their own providers
   OR (is_public = FALSE AND current_user_id() = user_id)
   OR (
-    -- Explicit family delegation: share_external_providers permission, non-strictly-private only
-    is_public = FALSE AND has_family_access(user_id, 'share_external_providers') AND EXISTS (
+    -- Explicit family delegation: share_external_providers permission, non-strictly-private only, must be active
+    is_public = FALSE AND is_active = TRUE AND has_family_access(user_id, 'share_external_providers') AND EXISTS (
       SELECT 1 FROM public.external_provider_types ept
       WHERE ept.id = external_data_providers.provider_type
       AND ept.is_strictly_private = FALSE

--- a/SparkyFitnessServer/models/chatRepository.ts
+++ b/SparkyFitnessServer/models/chatRepository.ts
@@ -80,7 +80,7 @@ async function getAiServiceSettingForBackend(id: string, userId: string) {
   try {
     // Try to get setting (can be user-specific or global)
     const result = await client.query(
-      'SELECT * FROM ai_service_settings WHERE id = $1',
+      'SELECT * FROM ai_service_settings WHERE id = $1 AND is_active = TRUE',
       [id]
     );
     const setting = result.rows[0];
@@ -177,7 +177,7 @@ async function getActiveAiServiceSetting(userId: string) {
         `SELECT ai.id, ai.service_name, ai.service_type, ai.custom_url, ai.is_active, ai.model_name, ai.is_public, ai.system_prompt, ai.user_id, u.name as creator_name
          FROM ai_service_settings ai
          LEFT JOIN public."user" u ON ai.user_id = u.id
-         WHERE ai.id = $1`,
+         WHERE ai.id = $1 AND ai.is_active = TRUE`,
         [activeId]
       );
       if (settingResult.rows.length > 0) {

--- a/SparkyFitnessServer/models/externalProviderRepository.ts
+++ b/SparkyFitnessServer/models/externalProviderRepository.ts
@@ -13,8 +13,11 @@ async function getExternalDataProviders(userId: any) {
               ept.is_strictly_private, ept.categories, ept.required_fields, ept.field_labels, ept.supports_barcode
        FROM external_data_providers edp
        LEFT JOIN external_provider_types ept ON edp.provider_type = ept.id
+       WHERE edp.user_id = $1 
+          OR (edp.is_public = TRUE AND edp.is_active = TRUE)
+          OR (edp.is_public = FALSE AND edp.is_active = TRUE AND public.has_family_access(edp.user_id, 'share_external_providers') AND ept.is_strictly_private = FALSE)
        ORDER BY edp.sort_order ASC NULLS LAST, edp.created_at DESC`,
-      []
+      [userId]
     );
     // log('debug', `getExternalDataProviders: Raw query results for user ${userId}:`, result.rows);
     const providers = await Promise.all(
@@ -311,7 +314,7 @@ async function updateExternalDataProvider(
         sync_frequency = COALESCE($18, sync_frequency),
         sort_order = COALESCE($21, sort_order),
         updated_at = now()
-      WHERE id = $17
+      WHERE id = $17 AND user_id = $22
       RETURNING *`,
       [
         updateData.provider_name,
@@ -335,6 +338,7 @@ async function updateExternalDataProvider(
         clearAppId,
         clearAppKey,
         updateData.sort_order,
+        userId,
       ]
     );
     return result.rows[0];
@@ -454,8 +458,12 @@ async function getExternalDataProviderByUserIdAndProviderName(
         ept.is_strictly_private, ept.categories, ept.required_fields, ept.field_labels, ept.supports_barcode
       FROM external_data_providers edp
       LEFT JOIN external_provider_types ept ON edp.provider_type = ept.id
-      WHERE edp.provider_name = $1`,
-      [providerName]
+      WHERE edp.provider_name = $1 AND (
+        edp.user_id = $2
+        OR (edp.is_public = TRUE AND edp.is_active = TRUE)
+        OR (edp.is_public = FALSE AND edp.is_active = TRUE AND public.has_family_access(edp.user_id, 'share_external_providers') AND ept.is_strictly_private = FALSE)
+      )`,
+      [providerName, userId]
     );
     const data = result.rows[0];
     if (!data) {
@@ -543,8 +551,14 @@ async function checkExternalDataProviderOwnership(
   const client = await getClient(userId); // User-specific operation
   try {
     const checkOwnership = await client.query(
-      'SELECT 1 FROM external_data_providers WHERE id = $1',
-      [providerId]
+      `SELECT 1 FROM external_data_providers edp
+       LEFT JOIN external_provider_types ept ON edp.provider_type = ept.id
+       WHERE edp.id = $1 AND (
+         edp.user_id = $2
+         OR (edp.is_public = TRUE AND edp.is_active = TRUE)
+         OR (edp.is_public = FALSE AND edp.is_active = TRUE AND public.has_family_access(edp.user_id, 'share_external_providers') AND ept.is_strictly_private = FALSE)
+       )`,
+      [providerId, userId]
     );
     return checkOwnership.rowCount > 0;
   } finally {
@@ -557,8 +571,8 @@ async function deleteExternalDataProvider(id: any, userId: any) {
   const client = await getClient(userId);
   try {
     const result = await client.query(
-      'DELETE FROM external_data_providers WHERE id = $1 RETURNING id',
-      [id]
+      'DELETE FROM external_data_providers WHERE id = $1 AND user_id = $2 RETURNING id',
+      [id, userId]
     );
     return result.rowCount > 0;
   } finally {
@@ -613,11 +627,17 @@ async function getActiveProvidersByTypes(
   const client = await getClient(userId);
   try {
     const result = await client.query(
-      `SELECT id, provider_type, provider_name
-       FROM external_data_providers
-       WHERE user_id = $1 AND is_active = TRUE
-         AND provider_type = ANY($2::text[])
-       ORDER BY sort_order ASC NULLS LAST, created_at DESC`,
+      `SELECT edp.id, edp.provider_type, edp.provider_name
+       FROM external_data_providers edp
+       LEFT JOIN external_provider_types ept ON edp.provider_type = ept.id
+       WHERE (
+         edp.user_id = $1
+         OR (edp.is_public = TRUE AND edp.is_active = TRUE)
+         OR (edp.is_public = FALSE AND edp.is_active = TRUE AND public.has_family_access(edp.user_id, 'share_external_providers') AND ept.is_strictly_private = FALSE)
+       )
+       AND edp.is_active = TRUE
+       AND edp.provider_type = ANY($2::text[])
+       ORDER BY edp.sort_order ASC NULLS LAST, edp.created_at DESC`,
       [userId, providerTypes]
     );
     return result.rows;

--- a/SparkyFitnessServer/models/externalProviderRepository.ts
+++ b/SparkyFitnessServer/models/externalProviderRepository.ts
@@ -542,6 +542,29 @@ async function getExternalDataProviderByUserIdAndProviderName(
   }
 }
 
+async function checkExternalDataProviderAccess(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  providerId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userId: any
+) {
+  const client = await getClient(userId); // User-specific operation
+  try {
+    const checkAccess = await client.query(
+      `SELECT 1 FROM external_data_providers edp
+       LEFT JOIN external_provider_types ept ON edp.provider_type = ept.id
+       WHERE edp.id = $1 AND (
+         edp.user_id = $2
+         OR (edp.is_public = TRUE AND edp.is_active = TRUE)
+         OR (edp.is_public = FALSE AND edp.is_active = TRUE AND public.has_family_access(edp.user_id, 'share_external_providers') AND ept.is_strictly_private = FALSE)
+       )`,
+      [providerId, userId]
+    );
+    return checkAccess.rowCount > 0;
+  } finally {
+    client.release();
+  }
+}
 async function checkExternalDataProviderOwnership(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   providerId: any,
@@ -551,13 +574,8 @@ async function checkExternalDataProviderOwnership(
   const client = await getClient(userId); // User-specific operation
   try {
     const checkOwnership = await client.query(
-      `SELECT 1 FROM external_data_providers edp
-       LEFT JOIN external_provider_types ept ON edp.provider_type = ept.id
-       WHERE edp.id = $1 AND (
-         edp.user_id = $2
-         OR (edp.is_public = TRUE AND edp.is_active = TRUE)
-         OR (edp.is_public = FALSE AND edp.is_active = TRUE AND public.has_family_access(edp.user_id, 'share_external_providers') AND ept.is_strictly_private = FALSE)
-       )`,
+      `SELECT 1 FROM external_data_providers
+       WHERE id = $1 AND user_id = $2`,
       [providerId, userId]
     );
     return checkOwnership.rowCount > 0;
@@ -865,6 +883,7 @@ export { createExternalDataProvider };
 export { updateExternalDataProvider };
 export { getExternalDataProviderById };
 export { checkExternalDataProviderOwnership };
+export { checkExternalDataProviderAccess };
 export { deleteExternalDataProvider };
 export { getExternalDataProviderByUserIdAndProviderName };
 export { updateProviderLastSync };
@@ -882,6 +901,7 @@ export default {
   updateExternalDataProvider,
   getExternalDataProviderById,
   checkExternalDataProviderOwnership,
+  checkExternalDataProviderAccess,
   deleteExternalDataProvider,
   getExternalDataProviderByUserIdAndProviderName,
   updateProviderLastSync,

--- a/SparkyFitnessServer/services/externalProviderService.ts
+++ b/SparkyFitnessServer/services/externalProviderService.ts
@@ -388,12 +388,12 @@ async function getExternalDataProviderDetails(
   providerId: any
 ) {
   try {
-    const isOwner =
-      await externalProviderRepository.checkExternalDataProviderOwnership(
+    const hasAccess =
+      await externalProviderRepository.checkExternalDataProviderAccess(
         providerId,
         authenticatedUserId
       );
-    if (!isOwner) {
+    if (!hasAccess) {
       throw new Error(
         'Forbidden: You do not have permission to access this external data provider.'
       );

--- a/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolRepositories.test.ts
@@ -564,7 +564,7 @@ describe('externalProviderRepository.getActiveProvidersByTypes', () => {
     expect(sql).toContain('is_active = TRUE');
     expect(sql).toContain('provider_type = ANY($2::text[])');
     expect(sql).toContain(
-      'ORDER BY sort_order ASC NULLS LAST, created_at DESC'
+      'ORDER BY edp.sort_order ASC NULLS LAST, edp.created_at DESC'
     );
     expect(params).toEqual(['user-1', ['usda', 'openfoodfacts']]);
     expect(mockClient.release).toHaveBeenCalled();

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict An5z6sBcQOfgBzFVi36YAdXlYU7MpGLD8Uc07KOvjAzQTJeORZ2n2hmwBNeQou9
+\restrict lc3qZTmVwHjRhLrsOKT3sCB2eXezhIy0E6bqayfJo7AE849JFdcIoihKSr3lZF1
 
 -- Dumped from database version 18.3
 -- Dumped by pg_dump version 18.4 (Homebrew)
@@ -4044,7 +4044,7 @@ COMMENT ON TRIGGER on_public_user_created ON public."user" IS 'Initializes onboa
 -- Name: user seed_global_providers_on_first_admin; Type: TRIGGER; Schema: public; Owner: -
 --
 
-CREATE TRIGGER seed_global_providers_on_first_admin AFTER INSERT ON public."user" FOR EACH ROW EXECUTE FUNCTION public.seed_global_providers_for_first_admin();
+CREATE TRIGGER seed_global_providers_on_first_admin AFTER INSERT OR UPDATE OF role ON public."user" FOR EACH ROW EXECUTE FUNCTION public.seed_global_providers_for_first_admin();
 
 
 --
@@ -7242,5 +7242,5 @@ ALTER DEFAULT PRIVILEGES FOR ROLE sparky IN SCHEMA public GRANT SELECT,INSERT,DE
 -- PostgreSQL database dump complete
 --
 
-\unrestrict An5z6sBcQOfgBzFVi36YAdXlYU7MpGLD8Uc07KOvjAzQTJeORZ2n2hmwBNeQou9
+\unrestrict lc3qZTmVwHjRhLrsOKT3sCB2eXezhIy0E6bqayfJo7AE849JFdcIoihKSr3lZF1
 

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict latWcymJ5jLQTMuxBZ7lYHMjOy6NDN4WK9hOkbMYocOXKYkMbmFQaKk8L8BYNwU
+\restrict An5z6sBcQOfgBzFVi36YAdXlYU7MpGLD8Uc07KOvjAzQTJeORZ2n2hmwBNeQou9
 
 -- Dumped from database version 18.3
 -- Dumped by pg_dump version 18.4 (Homebrew)
@@ -164,33 +164,9 @@ CREATE FUNCTION public.create_default_external_data_providers(p_user_id uuid) RE
     LANGUAGE plpgsql
     AS $$
 BEGIN
-  -- Insert default 'free-exercise-db' provider
-  INSERT INTO public.external_data_providers (
-    user_id, provider_name, provider_type, is_active, shared_with_public, created_at, updated_at
-  ) VALUES (
-    p_user_id, 'Free Exercise DB', 'free-exercise-db', TRUE, FALSE, now(), now()
-  ) ON CONFLICT (user_id, provider_name) DO NOTHING;
-
-  -- Insert default 'wger' provider
-  INSERT INTO public.external_data_providers (
-    user_id, provider_name, provider_type, is_active, shared_with_public, created_at, updated_at
-  ) VALUES (
-    p_user_id, 'Wger', 'wger', TRUE, FALSE, now(), now()
-  ) ON CONFLICT (user_id, provider_name) DO NOTHING;
-
-  -- Insert default 'openfoodfacts' provider
-  INSERT INTO public.external_data_providers (
-    user_id, provider_name, provider_type, is_active, shared_with_public, created_at, updated_at
-  ) VALUES (
-    p_user_id, 'Open Food Facts', 'openfoodfacts', TRUE, FALSE, now(), now()
-  ) ON CONFLICT (user_id, provider_name) DO NOTHING;
-
-  -- Insert default 'swissfood' provider
-  INSERT INTO public.external_data_providers (
-    user_id, provider_name, provider_type, is_active, shared_with_public, created_at, updated_at
-  ) VALUES (
-    p_user_id, 'Swiss Food Database', 'swissfood', TRUE, FALSE, now(), now()
-  ) ON CONFLICT (user_id, provider_name) DO NOTHING;
+  -- No-op: default providers are now instance-level global records (is_public = TRUE).
+  -- See create_global_default_providers() for the one-time seeding logic.
+  NULL;
 END;
 $$;
 
@@ -210,6 +186,45 @@ BEGIN
     USING (has_diary_access(user_id))
     WITH CHECK (has_diary_access(user_id));
   ', table_name, table_name);
+END;
+$$;
+
+
+--
+-- Name: create_global_default_providers(uuid); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.create_global_default_providers(p_admin_user_id uuid) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  -- Free Exercise DB
+  INSERT INTO public.external_data_providers (
+    user_id, provider_name, provider_type, is_active, is_public, created_at, updated_at
+  ) VALUES (
+    p_admin_user_id, 'Free Exercise DB', 'free-exercise-db', TRUE, TRUE, now(), now()
+  ) ON CONFLICT (user_id, provider_name) DO UPDATE SET is_public = TRUE;
+
+  -- Wger
+  INSERT INTO public.external_data_providers (
+    user_id, provider_name, provider_type, is_active, is_public, created_at, updated_at
+  ) VALUES (
+    p_admin_user_id, 'Wger', 'wger', TRUE, TRUE, now(), now()
+  ) ON CONFLICT (user_id, provider_name) DO UPDATE SET is_public = TRUE;
+
+  -- Open Food Facts
+  INSERT INTO public.external_data_providers (
+    user_id, provider_name, provider_type, is_active, is_public, created_at, updated_at
+  ) VALUES (
+    p_admin_user_id, 'Open Food Facts', 'openfoodfacts', TRUE, TRUE, now(), now()
+  ) ON CONFLICT (user_id, provider_name) DO UPDATE SET is_public = TRUE;
+
+  -- Swiss Food Database
+  INSERT INTO public.external_data_providers (
+    user_id, provider_name, provider_type, is_active, is_public, created_at, updated_at
+  ) VALUES (
+    p_admin_user_id, 'Swiss Food Database', 'swissfood', TRUE, TRUE, now(), now()
+  ) ON CONFLICT (user_id, provider_name) DO UPDATE SET is_public = TRUE;
 END;
 $$;
 
@@ -484,13 +499,13 @@ CREATE FUNCTION public.handle_new_user() RETURNS trigger
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
 BEGIN
-  -- Ensure onboarding_status exists (using ON CONFLICT to avoid errors if app-level init already did this)
+  -- Ensure onboarding_status exists
   INSERT INTO public.onboarding_status (user_id)
   VALUES (new.id)
   ON CONFLICT (user_id) DO NOTHING;
 
-  -- Create default external data providers
-  PERFORM public.create_default_external_data_providers(new.id);
+  -- NOTE: default external data providers are now global (is_public = TRUE).
+  -- They are seeded once when the first admin is created; no per-user rows needed.
 
   RETURN new;
 END;
@@ -654,6 +669,26 @@ BEGIN
   -- Remove the default goal (NULL goal_date) to avoid conflicts
   DELETE FROM public.user_goals
   WHERE user_id = p_user_id AND goal_date IS NULL;
+END;
+$$;
+
+
+--
+-- Name: seed_global_providers_for_first_admin(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.seed_global_providers_for_first_admin() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    AS $$
+BEGIN
+  -- Only seed if this user is the admin (first ever user)
+  IF NEW.role = 'admin' AND NOT EXISTS (
+    SELECT 1 FROM public.external_data_providers WHERE is_public = TRUE LIMIT 1
+  ) THEN
+    PERFORM public.create_global_default_providers(NEW.id);
+    RAISE NOTICE 'Global default providers seeded for first admin: %', NEW.id;
+  END IF;
+  RETURN NEW;
 END;
 $$;
 
@@ -869,7 +904,6 @@ CREATE TABLE public.ai_service_settings (
     api_key_iv text,
     api_key_tag text,
     is_public boolean DEFAULT false NOT NULL,
-    shared_with_public boolean DEFAULT false NOT NULL,
     CONSTRAINT check_public_settings_user_id_null CHECK ((((is_public = true) AND (user_id IS NULL)) OR ((is_public = false) AND (user_id IS NOT NULL))))
 );
 
@@ -4007,6 +4041,13 @@ COMMENT ON TRIGGER on_public_user_created ON public."user" IS 'Initializes onboa
 
 
 --
+-- Name: user seed_global_providers_on_first_admin; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER seed_global_providers_on_first_admin AFTER INSERT ON public."user" FOR EACH ROW EXECUTE FUNCTION public.seed_global_providers_for_first_admin();
+
+
+--
 -- Name: mood_entries set_timestamp; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -5794,7 +5835,7 @@ CREATE POLICY select_policy ON public.exercises FOR SELECT USING (public.has_lib
 -- Name: external_data_providers select_policy; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY select_policy ON public.external_data_providers FOR SELECT USING ((((is_public = true) AND (public.authenticated_user_id() IS NOT NULL)) OR ((is_public = false) AND (public.current_user_id() = user_id)) OR ((is_public = false) AND public.has_family_access(user_id, 'share_external_providers'::text) AND (EXISTS ( SELECT 1
+CREATE POLICY select_policy ON public.external_data_providers FOR SELECT USING ((((is_public = true) AND (is_active = true) AND (public.authenticated_user_id() IS NOT NULL)) OR ((is_public = false) AND (public.current_user_id() = user_id)) OR ((is_public = false) AND (is_active = true) AND public.has_family_access(user_id, 'share_external_providers'::text) AND (EXISTS ( SELECT 1
    FROM public.external_provider_types ept
   WHERE (((ept.id)::text = external_data_providers.provider_type) AND (ept.is_strictly_private = false)))))));
 
@@ -6163,6 +6204,15 @@ GRANT ALL ON FUNCTION public.create_diary_policy(table_name text) TO "sparky uat
 
 
 --
+-- Name: FUNCTION create_global_default_providers(p_admin_user_id uuid); Type: ACL; Schema: public; Owner: -
+--
+
+GRANT ALL ON FUNCTION public.create_global_default_providers(p_admin_user_id uuid) TO "sparky uat";
+GRANT ALL ON FUNCTION public.create_global_default_providers(p_admin_user_id uuid) TO "sparky-uat";
+GRANT ALL ON FUNCTION public.create_global_default_providers(p_admin_user_id uuid) TO sparky_uat;
+
+
+--
 -- Name: FUNCTION create_library_policy(table_name text, shared_column text, permissions text[]); Type: ACL; Schema: public; Owner: -
 --
 
@@ -6331,6 +6381,15 @@ GRANT ALL ON FUNCTION public.is_admin() TO "sparky uat";
 GRANT ALL ON FUNCTION public.manage_goal_timeline(p_user_id uuid, p_start_date date, p_calories numeric, p_protein numeric, p_carbs numeric, p_fat numeric, p_water_goal integer, p_saturated_fat numeric, p_polyunsaturated_fat numeric, p_monounsaturated_fat numeric, p_trans_fat numeric, p_cholesterol numeric, p_sodium numeric, p_potassium numeric, p_dietary_fiber numeric, p_sugars numeric, p_vitamin_a numeric, p_vitamin_c numeric, p_calcium numeric, p_iron numeric) TO sparky_uat;
 GRANT ALL ON FUNCTION public.manage_goal_timeline(p_user_id uuid, p_start_date date, p_calories numeric, p_protein numeric, p_carbs numeric, p_fat numeric, p_water_goal integer, p_saturated_fat numeric, p_polyunsaturated_fat numeric, p_monounsaturated_fat numeric, p_trans_fat numeric, p_cholesterol numeric, p_sodium numeric, p_potassium numeric, p_dietary_fiber numeric, p_sugars numeric, p_vitamin_a numeric, p_vitamin_c numeric, p_calcium numeric, p_iron numeric) TO "sparky-uat";
 GRANT ALL ON FUNCTION public.manage_goal_timeline(p_user_id uuid, p_start_date date, p_calories numeric, p_protein numeric, p_carbs numeric, p_fat numeric, p_water_goal integer, p_saturated_fat numeric, p_polyunsaturated_fat numeric, p_monounsaturated_fat numeric, p_trans_fat numeric, p_cholesterol numeric, p_sodium numeric, p_potassium numeric, p_dietary_fiber numeric, p_sugars numeric, p_vitamin_a numeric, p_vitamin_c numeric, p_calcium numeric, p_iron numeric) TO "sparky uat";
+
+
+--
+-- Name: FUNCTION seed_global_providers_for_first_admin(); Type: ACL; Schema: public; Owner: -
+--
+
+GRANT ALL ON FUNCTION public.seed_global_providers_for_first_admin() TO "sparky uat";
+GRANT ALL ON FUNCTION public.seed_global_providers_for_first_admin() TO "sparky-uat";
+GRANT ALL ON FUNCTION public.seed_global_providers_for_first_admin() TO sparky_uat;
 
 
 --
@@ -7183,5 +7242,5 @@ ALTER DEFAULT PRIVILEGES FOR ROLE sparky IN SCHEMA public GRANT SELECT,INSERT,DE
 -- PostgreSQL database dump complete
 --
 
-\unrestrict latWcymJ5jLQTMuxBZ7lYHMjOy6NDN4WK9hOkbMYocOXKYkMbmFQaKk8L8BYNwU
+\unrestrict An5z6sBcQOfgBzFVi36YAdXlYU7MpGLD8Uc07KOvjAzQTJeORZ2n2hmwBNeQou9
 


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description
This change replaces the static client-side lists of food, barcode, and exercise provider types in the mobile app with a dynamic approach. The client now evaluates the database-driven categories and supports_barcode properties supplied by the backend provider API.

 
**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Updated ExternalProvider and the useExternalProviders hook to filter items dynamically based on the API's categories array and supports_barcode boolean.
Removed all hardcoded sets from externalProviders.ts and simplified useExternalFoodSearch to run queries without a static allowlist check.
Updated the mobile screens and test configurations to utilize the dynamic category selectors (category: 'exercise' and supportsBarcode: true).


Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
