### PR TITLE
feat(writeback): remove SparkyFitness data from the OS health store (rollback)

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
@@ -15,7 +15,7 @@ import {
 const {
   writebackPhase,
   runWriteback,
-  removeAllWrittenData,
+  removeWrittenData,
 } = require('../../../src/services/healthconnect/writeback.ts');
 
 jest.mock('react-native-health-connect', () => ({
@@ -209,27 +209,48 @@ describe('runWriteback (cursor)', () => {
   });
 });
 
-describe('removeAllWrittenData (cleanup)', () => {
-  it('deletes every written record type, clears tracking, and disables writeback', async () => {
+describe('removeWrittenData (cleanup)', () => {
+  it('full purge: deletes all-time, clears all tracking, disables writeback', async () => {
     await AsyncStorage.clear();
     await AsyncStorage.setItem('@HealthConnect:writebackNutritionIds:2026-06-01', JSON.stringify(['x']));
-    await AsyncStorage.setItem('@HealthConnect:writebackHydrationSig:2026-06-01', '"sig"');
+    await AsyncStorage.setItem('@HealthConnect:writebackHydrationSig:2026-06-15', '"sig"');
     await AsyncStorage.setItem('@HealthConnect:syncDuration', '"daily"'); // unrelated — must survive
 
-    await removeAllWrittenData();
+    const result = await removeWrittenData(null);
+    expect(result).toEqual({ ok: true });
 
-    // Deletes our record types over an all-time ("before now") range.
+    // All-time = "before now" per record type.
     expect(mockDeleteByRange).toHaveBeenCalledWith('Nutrition', expect.objectContaining({ operator: 'before' }));
     expect(mockDeleteByRange).toHaveBeenCalledWith('Hydration', expect.objectContaining({ operator: 'before' }));
 
-    // Tracking keys cleared; unrelated preference kept.
     const remaining = await AsyncStorage.getAllKeys();
     expect(remaining).not.toContain('@HealthConnect:writebackNutritionIds:2026-06-01');
-    expect(remaining).not.toContain('@HealthConnect:writebackHydrationSig:2026-06-01');
+    expect(remaining).not.toContain('@HealthConnect:writebackHydrationSig:2026-06-15');
     expect(remaining).toContain('@HealthConnect:syncDuration');
 
-    // Writeback turned off (true rollback).
     expect(mockSavePref).toHaveBeenCalledWith('writebackNutritionEnabled', false);
     expect(mockSavePref).toHaveBeenCalledWith('writebackHydrationEnabled', false);
+  });
+
+  it('date range: deletes "between", clears only in-range tracking, keeps writeback on', async () => {
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem('@HealthConnect:writebackNutritionIds:2026-06-10', JSON.stringify(['in']));
+    await AsyncStorage.setItem('@HealthConnect:writebackNutritionIds:2026-06-20', JSON.stringify(['out']));
+
+    const result = await removeWrittenData({ from: '2026-06-08', to: '2026-06-12' });
+    expect(result).toEqual({ ok: true });
+    expect(mockDeleteByRange).toHaveBeenCalledWith('Nutrition', expect.objectContaining({ operator: 'between' }));
+
+    const remaining = await AsyncStorage.getAllKeys();
+    expect(remaining).not.toContain('@HealthConnect:writebackNutritionIds:2026-06-10'); // in range → cleared
+    expect(remaining).toContain('@HealthConnect:writebackNutritionIds:2026-06-20'); // out of range → kept
+    expect(mockSavePref).not.toHaveBeenCalledWith('writebackNutritionEnabled', false); // toggles untouched
+  });
+
+  it('reports partial failure (ok=false) when a delete throws', async () => {
+    await AsyncStorage.clear();
+    mockDeleteByRange.mockRejectedValueOnce(new Error('permission revoked'));
+    const result = await removeWrittenData(null);
+    expect(result).toEqual({ ok: false });
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/writeback.test.ts
@@ -1,6 +1,8 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   insertRecords,
   deleteRecordsByUuids,
+  deleteRecordsByTimeRange,
   getGrantedPermissions,
 } from 'react-native-health-connect';
 import { fetchDailySummary } from '../../../src/services/api/dailySummaryApi';
@@ -13,11 +15,13 @@ import {
 const {
   writebackPhase,
   runWriteback,
+  removeAllWrittenData,
 } = require('../../../src/services/healthconnect/writeback.ts');
 
 jest.mock('react-native-health-connect', () => ({
   insertRecords: jest.fn().mockResolvedValue([]),
   deleteRecordsByUuids: jest.fn().mockResolvedValue(undefined),
+  deleteRecordsByTimeRange: jest.fn().mockResolvedValue(undefined),
   getGrantedPermissions: jest.fn(),
   RecordingMethod: { RECORDING_METHOD_MANUAL_ENTRY: 3 },
 }));
@@ -30,6 +34,7 @@ jest.mock('../../../src/utils/loggedMealCollapse', () => ({
 jest.mock('../../../src/services/healthconnect/preferences', () => ({
   loadHealthPreference: jest.fn(),
   saveHealthPreference: jest.fn(),
+  HEALTH_PREFERENCE_PREFIX: '@HealthConnect',
 }));
 jest.mock('../../../src/services/healthconnect/index', () => ({
   isQuotaExceededError: jest.fn(() => false),
@@ -42,6 +47,7 @@ jest.mock('../../../src/services/LogService', () => ({ addLog: jest.fn() }));
 
 const mockInsert = insertRecords as jest.Mock;
 const mockDelete = deleteRecordsByUuids as jest.Mock;
+const mockDeleteByRange = deleteRecordsByTimeRange as jest.Mock;
 const mockGranted = getGrantedPermissions as jest.Mock;
 const mockSummary = fetchDailySummary as jest.Mock;
 const mockLoadPref = loadHealthPreference as jest.Mock;
@@ -200,5 +206,30 @@ describe('runWriteback (cursor)', () => {
     (isQuotaExceededError as jest.Mock).mockReturnValue(true);
     await runWriteback();
     expect(mockSaveCursor).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeAllWrittenData (cleanup)', () => {
+  it('deletes every written record type, clears tracking, and disables writeback', async () => {
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem('@HealthConnect:writebackNutritionIds:2026-06-01', JSON.stringify(['x']));
+    await AsyncStorage.setItem('@HealthConnect:writebackHydrationSig:2026-06-01', '"sig"');
+    await AsyncStorage.setItem('@HealthConnect:syncDuration', '"daily"'); // unrelated — must survive
+
+    await removeAllWrittenData();
+
+    // Deletes our record types over an all-time ("before now") range.
+    expect(mockDeleteByRange).toHaveBeenCalledWith('Nutrition', expect.objectContaining({ operator: 'before' }));
+    expect(mockDeleteByRange).toHaveBeenCalledWith('Hydration', expect.objectContaining({ operator: 'before' }));
+
+    // Tracking keys cleared; unrelated preference kept.
+    const remaining = await AsyncStorage.getAllKeys();
+    expect(remaining).not.toContain('@HealthConnect:writebackNutritionIds:2026-06-01');
+    expect(remaining).not.toContain('@HealthConnect:writebackHydrationSig:2026-06-01');
+    expect(remaining).toContain('@HealthConnect:syncDuration');
+
+    // Writeback turned off (true rollback).
+    expect(mockSavePref).toHaveBeenCalledWith('writebackNutritionEnabled', false);
+    expect(mockSavePref).toHaveBeenCalledWith('writebackHydrationEnabled', false);
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/healthkit/writeback.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthkit/writeback.test.ts
@@ -13,7 +13,7 @@ import {
 import {
   writebackPhase,
   runWriteback,
-  removeAllWrittenData,
+  removeWrittenData,
 } from '../../../src/services/healthkit/writeback';
 
 jest.mock('../../../src/services/api/dailySummaryApi', () => ({
@@ -286,33 +286,53 @@ describe('runWriteback (cursor)', () => {
   });
 });
 
-describe('removeAllWrittenData (cleanup)', () => {
-  it('deletes tracked samples by type, clears tracking, and disables writeback', async () => {
+describe('removeWrittenData (cleanup)', () => {
+  it('full purge: range-deletes each type all-time, clears tracking, disables writeback', async () => {
     await AsyncStorage.clear();
-    await AsyncStorage.setItem(
-      '@HealthKit:writebackNutritionUuids:2026-06-01',
-      JSON.stringify({ [ENERGY]: ['u1'], [FOOD_CORRELATION]: ['c1'] }),
-    );
-    await AsyncStorage.setItem('@HealthKit:writebackHydrationUuids:2026-06-01', JSON.stringify(['w1']));
-    await AsyncStorage.setItem('@HealthKit:writebackNutritionSig:2026-06-01', '"sig"');
+    await AsyncStorage.setItem('@HealthKit:writebackNutritionUuids:2026-06-01', JSON.stringify({ [ENERGY]: ['u1'] }));
+    await AsyncStorage.setItem('@HealthKit:writebackHydrationSig:2026-06-15', '"sig"');
     await AsyncStorage.setItem('@HealthKit:syncDuration', '"daily"'); // unrelated — must survive
 
-    await removeAllWrittenData();
+    const result = await removeWrittenData(null);
+    expect(result).toEqual({ ok: true });
 
-    // Deletes by the tracked UUIDs, grouped by HealthKit type.
-    expect(mockDeleteObjects).toHaveBeenCalledWith(ENERGY, { uuids: ['u1'] });
-    expect(mockDeleteObjects).toHaveBeenCalledWith(FOOD_CORRELATION, { uuids: ['c1'] });
-    expect(mockDeleteObjects).toHaveBeenCalledWith(WATER, { uuids: ['w1'] });
+    // Predicate (range) delete per sample type — catches orphans, not just tracked UUIDs.
+    const allTime = { date: expect.objectContaining({ endDate: expect.any(Date) }) };
+    expect(mockDeleteObjects).toHaveBeenCalledWith(ENERGY, allTime);
+    expect(mockDeleteObjects).toHaveBeenCalledWith(WATER, allTime);
+    expect(mockDeleteObjects).toHaveBeenCalledWith(FOOD_CORRELATION, allTime);
 
-    // Tracking keys cleared; unrelated preference kept.
     const remaining = await AsyncStorage.getAllKeys();
     expect(remaining).not.toContain('@HealthKit:writebackNutritionUuids:2026-06-01');
-    expect(remaining).not.toContain('@HealthKit:writebackHydrationUuids:2026-06-01');
-    expect(remaining).not.toContain('@HealthKit:writebackNutritionSig:2026-06-01');
+    expect(remaining).not.toContain('@HealthKit:writebackHydrationSig:2026-06-15');
     expect(remaining).toContain('@HealthKit:syncDuration');
 
-    // Writeback turned off.
     expect(mockSavePref).toHaveBeenCalledWith('writebackNutritionEnabled', false);
     expect(mockSavePref).toHaveBeenCalledWith('writebackHydrationEnabled', false);
+  });
+
+  it('date range: range-deletes with start+end, clears only in-range tracking, keeps writeback on', async () => {
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem('@HealthKit:writebackNutritionUuids:2026-06-10', JSON.stringify({ [ENERGY]: ['in'] }));
+    await AsyncStorage.setItem('@HealthKit:writebackNutritionUuids:2026-06-20', JSON.stringify({ [ENERGY]: ['out'] }));
+
+    const result = await removeWrittenData({ from: '2026-06-08', to: '2026-06-12' });
+    expect(result).toEqual({ ok: true });
+    expect(mockDeleteObjects).toHaveBeenCalledWith(
+      WATER,
+      { date: expect.objectContaining({ startDate: expect.any(Date), endDate: expect.any(Date) }) },
+    );
+
+    const remaining = await AsyncStorage.getAllKeys();
+    expect(remaining).not.toContain('@HealthKit:writebackNutritionUuids:2026-06-10'); // in range → cleared
+    expect(remaining).toContain('@HealthKit:writebackNutritionUuids:2026-06-20'); // out of range → kept
+    expect(mockSavePref).not.toHaveBeenCalledWith('writebackNutritionEnabled', false);
+  });
+
+  it('reports partial failure (ok=false) when a delete throws', async () => {
+    await AsyncStorage.clear();
+    mockDeleteObjects.mockRejectedValueOnce(new Error('denied'));
+    const result = await removeWrittenData(null);
+    expect(result).toEqual({ ok: false });
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/healthkit/writeback.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthkit/writeback.test.ts
@@ -1,3 +1,4 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   saveCorrelationSample,
   saveQuantitySample,
@@ -9,7 +10,11 @@ import {
   loadHealthPreference,
   saveHealthPreference,
 } from '../../../src/services/healthkit/preferences';
-import { writebackPhase, runWriteback } from '../../../src/services/healthkit/writeback';
+import {
+  writebackPhase,
+  runWriteback,
+  removeAllWrittenData,
+} from '../../../src/services/healthkit/writeback';
 
 jest.mock('../../../src/services/api/dailySummaryApi', () => ({
   fetchDailySummary: jest.fn(),
@@ -20,6 +25,7 @@ jest.mock('../../../src/utils/loggedMealCollapse', () => ({
 jest.mock('../../../src/services/healthkit/preferences', () => ({
   loadHealthPreference: jest.fn(),
   saveHealthPreference: jest.fn(),
+  HEALTH_PREFERENCE_PREFIX: '@HealthKit',
 }));
 jest.mock('../../../src/services/storage', () => ({
   loadLastWritebackTime: jest.fn().mockResolvedValue(null),
@@ -277,5 +283,36 @@ describe('runWriteback (cursor)', () => {
     await runWriteback();
     expect(mockSaveCorrelation).not.toHaveBeenCalled();
     expect(mockSaveCursor).toHaveBeenCalled(); // skipped without holding the cursor
+  });
+});
+
+describe('removeAllWrittenData (cleanup)', () => {
+  it('deletes tracked samples by type, clears tracking, and disables writeback', async () => {
+    await AsyncStorage.clear();
+    await AsyncStorage.setItem(
+      '@HealthKit:writebackNutritionUuids:2026-06-01',
+      JSON.stringify({ [ENERGY]: ['u1'], [FOOD_CORRELATION]: ['c1'] }),
+    );
+    await AsyncStorage.setItem('@HealthKit:writebackHydrationUuids:2026-06-01', JSON.stringify(['w1']));
+    await AsyncStorage.setItem('@HealthKit:writebackNutritionSig:2026-06-01', '"sig"');
+    await AsyncStorage.setItem('@HealthKit:syncDuration', '"daily"'); // unrelated — must survive
+
+    await removeAllWrittenData();
+
+    // Deletes by the tracked UUIDs, grouped by HealthKit type.
+    expect(mockDeleteObjects).toHaveBeenCalledWith(ENERGY, { uuids: ['u1'] });
+    expect(mockDeleteObjects).toHaveBeenCalledWith(FOOD_CORRELATION, { uuids: ['c1'] });
+    expect(mockDeleteObjects).toHaveBeenCalledWith(WATER, { uuids: ['w1'] });
+
+    // Tracking keys cleared; unrelated preference kept.
+    const remaining = await AsyncStorage.getAllKeys();
+    expect(remaining).not.toContain('@HealthKit:writebackNutritionUuids:2026-06-01');
+    expect(remaining).not.toContain('@HealthKit:writebackHydrationUuids:2026-06-01');
+    expect(remaining).not.toContain('@HealthKit:writebackNutritionSig:2026-06-01');
+    expect(remaining).toContain('@HealthKit:syncDuration');
+
+    // Writeback turned off.
+    expect(mockSavePref).toHaveBeenCalledWith('writebackNutritionEnabled', false);
+    expect(mockSavePref).toHaveBeenCalledWith('writebackHydrationEnabled', false);
   });
 });

--- a/SparkyFitnessMobile/src/WritebackMetrics.ts
+++ b/SparkyFitnessMobile/src/WritebackMetrics.ts
@@ -13,6 +13,18 @@ import type { ImageSourcePropType } from 'react-native';
 
 export type WritebackMetricId = 'nutrition' | 'hydration';
 
+/** Inclusive local-calendar-day range (YYYY-MM-DD) for a targeted writeback removal.
+ *  `null` removal means "all time" (full purge). */
+export interface WritebackDateRange {
+  from: string;
+  to: string;
+}
+
+/** Result of a removal: `ok` is false if any record-type delete failed (partial). */
+export interface WritebackRemovalResult {
+  ok: boolean;
+}
+
 export interface WritebackMetric {
   id: WritebackMetricId;
   label: string;

--- a/SparkyFitnessMobile/src/components/DateRangeSheet.tsx
+++ b/SparkyFitnessMobile/src/components/DateRangeSheet.tsx
@@ -1,0 +1,156 @@
+import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { Platform, View, Text } from 'react-native';
+import {
+  BottomSheetModal,
+  BottomSheetView,
+  BottomSheetBackdrop,
+  type BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet';
+import { FullWindowOverlay } from 'react-native-screens';
+import { useUniwind, useCSSVariable } from 'uniwind';
+import DateTimePicker, { type DateType } from 'react-native-ui-datepicker';
+import { toLocalDateString } from '../utils/dateUtils';
+import Icon from './Icon';
+import Button from './ui/Button';
+
+// Render inside an iOS UIWindow so the sheet sits above any native modal. No-op on Android.
+const sheetContainer =
+  Platform.OS === 'ios'
+    ? ({ children }: React.PropsWithChildren) => <FullWindowOverlay>{children}</FullWindowOverlay>
+    : undefined;
+
+export interface DateRangeSheetRef {
+  present: () => void;
+  dismiss: () => void;
+}
+
+interface DateRangeSheetProps {
+  /** Called with inclusive YYYY-MM-DD bounds when the user confirms a range. */
+  onConfirm: (from: string, to: string) => void;
+}
+
+/**
+ * Bottom-sheet calendar in range mode (start + end). Used by the writeback "remove a
+ * date range" flow. Mirrors CalendarSheet's theming; adds a confirm button since a
+ * range needs two taps and the user may adjust before committing.
+ */
+const DateRangeSheet = React.forwardRef<DateRangeSheetRef, DateRangeSheetProps>(
+  ({ onConfirm }, ref) => {
+    const bottomSheetRef = useRef<BottomSheetModal>(null);
+    const { theme } = useUniwind();
+    const isDarkMode = theme === 'dark' || theme === 'amoled';
+    const [start, setStart] = useState<DateType>(undefined);
+    const [end, setEnd] = useState<DateType>(undefined);
+
+    const [surfaceBg, textMuted, accentPrimary, textPrimary, textSecondary] = useCSSVariable([
+      '--color-surface',
+      '--color-text-muted',
+      '--color-accent-primary',
+      '--color-text-primary',
+      '--color-text-secondary',
+    ]) as [string, string, string, string, string];
+
+    useImperativeHandle(ref, () => ({
+      present: () => {
+        setStart(undefined);
+        setEnd(undefined);
+        bottomSheetRef.current?.present();
+      },
+      dismiss: () => bottomSheetRef.current?.dismiss(),
+    }));
+
+    useEffect(() => {
+      const sheetRef = bottomSheetRef.current;
+      return () => {
+        sheetRef?.dismiss();
+      };
+    }, []);
+
+    const renderBackdrop = useCallback(
+      (props: BottomSheetBackdropProps) => (
+        <BottomSheetBackdrop
+          {...props}
+          opacity={isDarkMode ? 0.7 : 0.5}
+          disappearsOnIndex={-1}
+          appearsOnIndex={0}
+        />
+      ),
+      [isDarkMode]
+    );
+
+    const handleChange = useCallback(
+      ({ startDate, endDate }: { startDate: DateType; endDate: DateType }) => {
+        setStart(startDate);
+        setEnd(endDate);
+      },
+      []
+    );
+
+    const confirm = useCallback(() => {
+      if (!start || !end) return;
+      onConfirm(
+        toLocalDateString(new Date(start as string | number | Date)),
+        toLocalDateString(new Date(end as string | number | Date))
+      );
+      bottomSheetRef.current?.dismiss();
+    }, [start, end, onConfirm]);
+
+    return (
+      <BottomSheetModal
+        ref={bottomSheetRef}
+        enableDynamicSizing
+        backdropComponent={renderBackdrop}
+        containerComponent={sheetContainer}
+        backgroundStyle={{ backgroundColor: surfaceBg }}
+        handleIndicatorStyle={{ backgroundColor: textMuted }}
+      >
+        <BottomSheetView className="pb-safe-or-5 px-2">
+          <Text className="text-base font-semibold text-text-primary text-center mt-2 mb-1">
+            Select a date range to remove
+          </Text>
+          <DateTimePicker
+            mode="range"
+            startDate={start}
+            endDate={end}
+            maxDate={new Date()}
+            onChange={handleChange}
+            components={{
+              IconPrev: <Icon name="chevron-back" size={18} color={textPrimary} />,
+              IconNext: <Icon name="chevron-forward" size={18} color={textPrimary} />,
+            }}
+            styles={{
+              selected: { backgroundColor: accentPrimary },
+              selected_label: { color: '#FFFFFF' },
+              range_fill: { backgroundColor: accentPrimary, opacity: 0.25 },
+              range_start: { backgroundColor: accentPrimary },
+              range_start_label: { color: '#FFFFFF' },
+              range_end: { backgroundColor: accentPrimary },
+              range_end_label: { color: '#FFFFFF' },
+              today: { borderColor: accentPrimary, borderWidth: 1 },
+              day_label: { color: textPrimary },
+              weekday_label: { color: textSecondary },
+              month_selector_label: { color: textPrimary, fontWeight: '600' },
+              year_selector_label: { color: textPrimary, fontWeight: '600' },
+              disabled_label: { color: textMuted },
+              month_label: { color: textPrimary },
+              year_label: { color: textPrimary },
+              selected_month: { backgroundColor: accentPrimary },
+              selected_month_label: { color: '#FFFFFF' },
+              selected_year: { backgroundColor: accentPrimary },
+              selected_year_label: { color: '#FFFFFF' },
+            }}
+          />
+          <View className="px-2 mt-1">
+            <Button variant="primary" onPress={confirm} disabled={!start || !end}>
+              <Text className="text-base font-semibold text-white">Remove selected range</Text>
+            </Button>
+          </View>
+        </BottomSheetView>
+      </BottomSheetModal>
+    );
+  }
+);
+
+DateRangeSheet.displayName = 'DateRangeSheet';
+
+export default DateRangeSheet;

--- a/SparkyFitnessMobile/src/components/HealthDataWriteback.tsx
+++ b/SparkyFitnessMobile/src/components/HealthDataWriteback.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { View, Text, Switch, Image, Platform } from 'react-native';
 import { useCSSVariable } from 'uniwind';
 import CollapsibleSection from './CollapsibleSection';
+import Button from './ui/Button';
 import {
   WRITEBACK_METRICS,
   WRITEBACK_CATEGORY_ORDER,
@@ -11,6 +12,8 @@ import {
 interface HealthDataWritebackProps {
   writebackStates: Record<string, boolean>;
   handleToggleWriteback: (metric: WritebackMetric, newValue: boolean) => void;
+  /** Confirm + delete all SparkyFitness-written records from the OS health store. */
+  onRemoveData: () => void;
 }
 
 const groupByCategory = (metrics: WritebackMetric[]): Record<string, WritebackMetric[]> =>
@@ -30,6 +33,7 @@ const groupByCategory = (metrics: WritebackMetric[]): Record<string, WritebackMe
 const HealthDataWriteback: React.FC<HealthDataWritebackProps> = ({
   writebackStates,
   handleToggleWriteback,
+  onRemoveData,
 }) => {
   const [formEnabled, formDisabled] = useCSSVariable([
     '--color-form-enabled',
@@ -96,6 +100,11 @@ const HealthDataWriteback: React.FC<HealthDataWritebackProps> = ({
           </CollapsibleSection>
         );
       })}
+      <Button variant="ghost" onPress={onRemoveData} className="mt-2 py-1 px-0 self-start">
+        <Text className="text-sm font-medium text-text-danger-subtle">
+          Remove SparkyFitness data from {storeName}
+        </Text>
+      </Button>
     </View>
   );
 };

--- a/SparkyFitnessMobile/src/components/HealthDataWriteback.tsx
+++ b/SparkyFitnessMobile/src/components/HealthDataWriteback.tsx
@@ -3,6 +3,7 @@ import { View, Text, Switch, Image, Platform } from 'react-native';
 import { useCSSVariable } from 'uniwind';
 import CollapsibleSection from './CollapsibleSection';
 import Button from './ui/Button';
+import BottomSheetPicker from './BottomSheetPicker';
 import {
   WRITEBACK_METRICS,
   WRITEBACK_CATEGORY_ORDER,
@@ -12,9 +13,14 @@ import {
 interface HealthDataWritebackProps {
   writebackStates: Record<string, boolean>;
   handleToggleWriteback: (metric: WritebackMetric, newValue: boolean) => void;
-  /** Confirm + delete all SparkyFitness-written records from the OS health store. */
-  onRemoveData: () => void;
+  /** Delete all SparkyFitness-written records (full purge — caller confirms). */
+  onRemoveAllData: () => void;
+  /** Open the date-range picker to remove a window of records. */
+  onRemoveDateRange: () => void;
 }
+
+// Remove-scope choices shown in the bottom-sheet menu.
+type RemoveScope = 'all' | 'range';
 
 const groupByCategory = (metrics: WritebackMetric[]): Record<string, WritebackMetric[]> =>
   metrics.reduce(
@@ -33,7 +39,8 @@ const groupByCategory = (metrics: WritebackMetric[]): Record<string, WritebackMe
 const HealthDataWriteback: React.FC<HealthDataWritebackProps> = ({
   writebackStates,
   handleToggleWriteback,
-  onRemoveData,
+  onRemoveAllData,
+  onRemoveDateRange,
 }) => {
   const [formEnabled, formDisabled] = useCSSVariable([
     '--color-form-enabled',
@@ -100,11 +107,22 @@ const HealthDataWriteback: React.FC<HealthDataWritebackProps> = ({
           </CollapsibleSection>
         );
       })}
-      <Button variant="ghost" onPress={onRemoveData} className="mt-2 py-1 px-0 self-start">
-        <Text className="text-sm font-medium text-text-danger-subtle">
-          Remove SparkyFitness data from {storeName}
-        </Text>
-      </Button>
+      <BottomSheetPicker<RemoveScope>
+        value={'' as RemoveScope}
+        title={`Remove from ${storeName}`}
+        options={[
+          { label: 'All time', value: 'all' },
+          { label: 'Pick a date range…', value: 'range' },
+        ]}
+        onSelect={(scope) => (scope === 'all' ? onRemoveAllData() : onRemoveDateRange())}
+        renderTrigger={({ onPress }) => (
+          <Button variant="ghost" onPress={onPress} className="mt-2 py-1 px-0 self-start">
+            <Text className="text-sm font-medium text-text-danger-subtle">
+              Remove SparkyFitness data from {storeName}
+            </Text>
+          </Button>
+        )}
+      />
     </View>
   );
 };

--- a/SparkyFitnessMobile/src/screens/SyncScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SyncScreen.tsx
@@ -343,18 +343,22 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
     }
   };
 
-  // Offer a full purge (all time, also turns writeback off) or a date-range removal.
-  const handleRemoveWritebackData = (): void => {
+  // Full purge → confirm (it's destructive and turns writeback off).
+  const handleRemoveAllData = (): void => {
     Alert.alert(
-      `Remove ${writebackStoreName} data`,
-      `Delete records SparkyFitness wrote to ${writebackStoreName}. Your SparkyFitness diary and records from other apps are not affected.`,
+      `Remove all ${writebackStoreName} data`,
+      `Delete every nutrition and hydration record SparkyFitness wrote to ${writebackStoreName}, and turn writeback off? Your SparkyFitness diary and records from other apps are not affected.`,
       [
-        { text: 'All time', style: 'destructive', onPress: () => doRemoveWritebackData(null) },
-        { text: 'Pick a date range…', onPress: () => dateRangeSheetRef.current?.present() },
         { text: 'Cancel', style: 'cancel' },
+        { text: 'Delete', style: 'destructive', onPress: () => doRemoveWritebackData(null) },
       ],
       { cancelable: true }
     );
+  };
+
+  // Date range → the picker's own confirm button is the commit point.
+  const handleRemoveDateRange = (): void => {
+    dateRangeSheetRef.current?.present();
   };
 
   const handleToggleAllMetrics = async (): Promise<void> => {
@@ -543,7 +547,8 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
         <HealthDataWriteback
           writebackStates={writebackStates}
           handleToggleWriteback={handleToggleWriteback}
-          onRemoveData={handleRemoveWritebackData}
+          onRemoveAllData={handleRemoveAllData}
+          onRemoveDateRange={handleRemoveDateRange}
         />
         <DateRangeSheet
           ref={dateRangeSheetRef}

--- a/SparkyFitnessMobile/src/screens/SyncScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SyncScreen.tsx
@@ -29,6 +29,8 @@ import {
   stopObservers,
 } from '../services/healthConnectService';
 import { configureBackgroundSync, stopBackgroundSync, performBackgroundSync } from '../services/backgroundSyncService';
+import { removeAllWrittenData } from '../services/writeback';
+import Toast from 'react-native-toast-message';
 import {
   tryClaimAutoSync,
   isForegroundAutoSyncWindowOpen,
@@ -306,6 +308,44 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
     }
   };
 
+  // Rollback: delete everything SparkyFitness wrote to the OS health store and turn
+  // writeback off. removeAllWrittenData also clears local tracking + the prefs, so we
+  // reset the toggles locally to match.
+  const handleRemoveWritebackData = (): void => {
+    const storeName = isAndroid ? 'Health Connect' : 'Apple Health';
+    Alert.alert(
+      `Remove ${storeName} data`,
+      `Delete all nutrition and hydration records SparkyFitness wrote to ${storeName}, and turn writeback off? Your SparkyFitness diary and records from other apps are not affected.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await removeAllWrittenData();
+              setWritebackStates({});
+              Toast.show({
+                type: 'success',
+                text1: 'Removed',
+                text2: `Deleted SparkyFitness data from ${storeName}.`,
+              });
+            } catch (error) {
+              const errorMessage = error instanceof Error ? error.message : String(error);
+              addLog(`[SyncScreen] Failed to remove writeback data: ${errorMessage}`, 'ERROR');
+              Toast.show({
+                type: 'error',
+                text1: 'Error',
+                text2: `Could not remove data from ${storeName}.`,
+              });
+            }
+          },
+        },
+      ],
+      { cancelable: true }
+    );
+  };
+
   const handleToggleAllMetrics = async (): Promise<void> => {
     const newValue = !isAllMetricsEnabled;
 
@@ -492,6 +532,7 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
         <HealthDataWriteback
           writebackStates={writebackStates}
           handleToggleWriteback={handleToggleWriteback}
+          onRemoveData={handleRemoveWritebackData}
         />
 
         {/* Health Data Report — Android only */}

--- a/SparkyFitnessMobile/src/screens/SyncScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SyncScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { View, Text, Image, ScrollView, Platform, Alert, ActivityIndicator, AppState } from 'react-native';
 import Button from '../components/ui/Button';
 import Icon from '../components/Icon';
@@ -7,7 +7,7 @@ import SyncFrequency from '../components/SyncFrequency';
 import SyncOnOpen from '../components/SyncOnOpen';
 import HealthDataSync from '../components/HealthDataSync';
 import HealthDataWriteback from '../components/HealthDataWriteback';
-import { WRITEBACK_METRICS, type WritebackMetric } from '../WritebackMetrics';
+import { WRITEBACK_METRICS, type WritebackMetric, type WritebackDateRange } from '../WritebackMetrics';
 import HealthSourceLabel from '../components/HealthSourceLabel';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
@@ -29,7 +29,8 @@ import {
   stopObservers,
 } from '../services/healthConnectService';
 import { configureBackgroundSync, stopBackgroundSync, performBackgroundSync } from '../services/backgroundSyncService';
-import { removeAllWrittenData } from '../services/writeback';
+import { removeWrittenData } from '../services/writeback';
+import DateRangeSheet, { type DateRangeSheetRef } from '../components/DateRangeSheet';
 import Toast from 'react-native-toast-message';
 import {
   tryClaimAutoSync,
@@ -80,6 +81,7 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
   const accentPrimary = useCSSVariable('--color-accent-primary') as string | undefined;
   const [healthMetricStates, setHealthMetricStates] = useState<HealthMetricStates>({});
   const [writebackStates, setWritebackStates] = useState<Record<string, boolean>>({});
+  const dateRangeSheetRef = useRef<DateRangeSheetRef>(null);
   const [isBackgroundSyncEnabled, setIsBackgroundSyncEnabled] = useState<boolean>(false);
   const [isSyncOnOpenEnabled, setIsSyncOnOpenEnabled] = useState<boolean>(false);
   const [lastSyncedTime, setLastSyncedTime] = useState<string | null>(null);
@@ -308,39 +310,48 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
     }
   };
 
-  // Rollback: delete everything SparkyFitness wrote to the OS health store and turn
-  // writeback off. removeAllWrittenData also clears local tracking + the prefs, so we
-  // reset the toggles locally to match.
+  const writebackStoreName = isAndroid ? 'Health Connect' : 'Apple Health';
+
+  // Delete written data, then surface the outcome honestly: success, a warning when
+  // some records couldn't be deleted (partial), or an error if it threw. A full purge
+  // (range === null) is a rollback, so reset the toggles locally to match the prefs.
+  const doRemoveWritebackData = async (range: WritebackDateRange | null): Promise<void> => {
+    try {
+      const { ok } = await removeWrittenData(range);
+      if (range === null) setWritebackStates({});
+      if (ok) {
+        Toast.show({
+          type: 'success',
+          text1: 'Removed',
+          text2: `Deleted SparkyFitness data from ${writebackStoreName}.`,
+        });
+      } else {
+        Toast.show({
+          type: 'error',
+          text1: 'Partially removed',
+          text2: `Some records couldn't be deleted from ${writebackStoreName}.`,
+        });
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      addLog(`[SyncScreen] Failed to remove writeback data: ${errorMessage}`, 'ERROR');
+      Toast.show({
+        type: 'error',
+        text1: 'Error',
+        text2: `Could not remove data from ${writebackStoreName}.`,
+      });
+    }
+  };
+
+  // Offer a full purge (all time, also turns writeback off) or a date-range removal.
   const handleRemoveWritebackData = (): void => {
-    const storeName = isAndroid ? 'Health Connect' : 'Apple Health';
     Alert.alert(
-      `Remove ${storeName} data`,
-      `Delete all nutrition and hydration records SparkyFitness wrote to ${storeName}, and turn writeback off? Your SparkyFitness diary and records from other apps are not affected.`,
+      `Remove ${writebackStoreName} data`,
+      `Delete records SparkyFitness wrote to ${writebackStoreName}. Your SparkyFitness diary and records from other apps are not affected.`,
       [
+        { text: 'All time', style: 'destructive', onPress: () => doRemoveWritebackData(null) },
+        { text: 'Pick a date range…', onPress: () => dateRangeSheetRef.current?.present() },
         { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'Delete',
-          style: 'destructive',
-          onPress: async () => {
-            try {
-              await removeAllWrittenData();
-              setWritebackStates({});
-              Toast.show({
-                type: 'success',
-                text1: 'Removed',
-                text2: `Deleted SparkyFitness data from ${storeName}.`,
-              });
-            } catch (error) {
-              const errorMessage = error instanceof Error ? error.message : String(error);
-              addLog(`[SyncScreen] Failed to remove writeback data: ${errorMessage}`, 'ERROR');
-              Toast.show({
-                type: 'error',
-                text1: 'Error',
-                text2: `Could not remove data from ${storeName}.`,
-              });
-            }
-          },
-        },
       ],
       { cancelable: true }
     );
@@ -533,6 +544,10 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
           writebackStates={writebackStates}
           handleToggleWriteback={handleToggleWriteback}
           onRemoveData={handleRemoveWritebackData}
+        />
+        <DateRangeSheet
+          ref={dateRangeSheetRef}
+          onConfirm={(from, to) => doRemoveWritebackData({ from, to })}
         />
 
         {/* Health Data Report — Android only */}

--- a/SparkyFitnessMobile/src/services/healthconnect/preferences.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/preferences.ts
@@ -7,8 +7,12 @@ import {
 // Re-export types for backward compatibility
 export { SyncDuration, SyncInterval };
 
+// AsyncStorage key prefix for all Health Connect preferences. Exported so cleanup
+// code can enumerate/remove writeback tracking keys directly.
+export const HEALTH_PREFERENCE_PREFIX = '@HealthConnect';
+
 // Create preference functions with Health Connect-specific prefix and log tag
-const preferences = createPreferenceFunctions('@HealthConnect', '[HealthConnectService]');
+const preferences = createPreferenceFunctions(HEALTH_PREFERENCE_PREFIX, '[HealthConnectService]');
 
 export const saveHealthPreference = preferences.saveHealthPreference;
 export const loadHealthPreference = preferences.loadHealthPreference;

--- a/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
@@ -1,13 +1,15 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   insertRecords,
   deleteRecordsByUuids,
+  deleteRecordsByTimeRange,
   getGrantedPermissions,
   type HealthConnectRecord,
 } from 'react-native-health-connect';
 import { addLog } from '../LogService';
 import { fetchDailySummary } from '../api/dailySummaryApi';
 import { resolveCollapsedFoodEntries } from '../../utils/loggedMealCollapse';
-import { loadHealthPreference, saveHealthPreference } from './preferences';
+import { loadHealthPreference, saveHealthPreference, HEALTH_PREFERENCE_PREFIX } from './preferences';
 import { isQuotaExceededError } from './index';
 import { loadLastWritebackTime, saveLastWritebackTime } from '../storage';
 import {
@@ -219,4 +221,35 @@ export const runWriteback = async (): Promise<void> => {
   const dates = computeWritebackDates(await loadLastWritebackTime());
   const completed = await writebackPhase(dates);
   if (completed) await saveLastWritebackTime();
+};
+
+/**
+ * Rollback: delete every record SparkyFitness wrote to Health Connect (all metrics,
+ * all dates), clear our per-date tracking, and turn writeback off. Health Connect
+ * only lets an app delete records it authored (by dataOrigin), so other apps' and
+ * manually-entered data are never touched; the 30-day window is read-only, so the
+ * all-time delete reaches historic records too. Clearing the tracking keys is
+ * required — otherwise change-detection would treat a later re-enable as "unchanged"
+ * and never re-populate Health Connect.
+ */
+export const removeAllWrittenData = async (): Promise<void> => {
+  const recordTypes = Array.from(new Set(WRITEBACK_METRICS.map((m) => m.recordType)));
+  const endTime = new Date().toISOString();
+  for (const recordType of recordTypes) {
+    await deleteRecordsByTimeRange(recordType, { operator: 'before', endTime });
+  }
+
+  const keys = await AsyncStorage.getAllKeys();
+  const trackingKeys = keys.filter(
+    (k) =>
+      k.startsWith(`${HEALTH_PREFERENCE_PREFIX}:writeback`) &&
+      (k.includes('Ids:') || k.includes('Sig:')),
+  );
+  if (trackingKeys.length > 0) await AsyncStorage.multiRemove(trackingKeys);
+
+  await Promise.all(WRITEBACK_METRICS.map((m) => saveHealthPreference(m.preferenceKey, false)));
+  addLog(
+    `[Writeback] Removed all SparkyFitness data from Health Connect (${recordTypes.join(', ')})`,
+    'INFO',
+  );
 };

--- a/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
@@ -17,7 +17,12 @@ import {
   waterMlToHydrationRecord,
   computeWritebackDates,
 } from './writebackMappers';
-import { WRITEBACK_METRICS, type WritebackMetric } from '../../WritebackMetrics';
+import {
+  WRITEBACK_METRICS,
+  type WritebackMetric,
+  type WritebackDateRange,
+  type WritebackRemovalResult,
+} from '../../WritebackMetrics';
 
 type DailySummary = Awaited<ReturnType<typeof fetchDailySummary>>;
 
@@ -223,39 +228,65 @@ export const runWriteback = async (): Promise<void> => {
   if (completed) await saveLastWritebackTime();
 };
 
+// Local-calendar-day bounds, as instants, for a Health Connect between-filter.
+const dayStartInstant = (day: string): string => {
+  const [y, m, d] = day.split('-').map(Number);
+  return new Date(y, m - 1, d, 0, 0, 0, 0).toISOString();
+};
+const dayEndInstant = (day: string): string => {
+  const [y, m, d] = day.split('-').map(Number);
+  return new Date(y, m - 1, d, 23, 59, 59, 999).toISOString();
+};
+
+// Our per-date tracking keys (writeback{Type}Ids/Sig:{YYYY-MM-DD}), optionally
+// restricted to a date range by the key's trailing day.
+const trackingKeysToClear = (keys: readonly string[], range: WritebackDateRange | null): string[] =>
+  keys.filter((k) => {
+    if (!k.startsWith(`${HEALTH_PREFERENCE_PREFIX}:writeback`)) return false;
+    if (!k.includes('Ids:') && !k.includes('Sig:')) return false;
+    if (!range) return true;
+    const day = k.slice(k.lastIndexOf(':') + 1);
+    return day >= range.from && day <= range.to;
+  });
+
 /**
- * Rollback: delete every record SparkyFitness wrote to Health Connect (all metrics,
- * all dates), clear our per-date tracking, and turn writeback off. Health Connect
- * only lets an app delete records it authored (by dataOrigin), so other apps' and
- * manually-entered data are never touched; the 30-day window is read-only, so the
- * all-time delete reaches historic records too. Clearing the tracking keys is
- * required — otherwise change-detection would treat a later re-enable as "unchanged"
- * and never re-populate Health Connect.
+ * Delete records SparkyFitness wrote to Health Connect. `range` null = full purge
+ * (all time) — also turns writeback off, a true rollback; a date range removes just
+ * that window and leaves writeback on. Health Connect only lets an app delete records
+ * it authored (by dataOrigin), so other apps' and manual data are never touched, and
+ * the 30-day window is read-only so historic records are reached. Clearing the tracking
+ * keys is required, else change-detection would treat a later re-write as "unchanged".
+ * Best-effort per record type; returns ok=false if any delete failed (partial).
  */
-export const removeAllWrittenData = async (): Promise<void> => {
+export const removeWrittenData = async (
+  range: WritebackDateRange | null,
+): Promise<WritebackRemovalResult> => {
   const recordTypes = Array.from(new Set(WRITEBACK_METRICS.map((m) => m.recordType)));
-  const endTime = new Date().toISOString();
-  // Best-effort per type: a failed delete (e.g. permission revoked for one type) must
-  // not abort the rest, the tracking-key clear, or the toggle reset below.
+  const filter = range
+    ? { operator: 'between' as const, startTime: dayStartInstant(range.from), endTime: dayEndInstant(range.to) }
+    : { operator: 'before' as const, endTime: new Date().toISOString() };
+
+  let ok = true;
   for (const recordType of recordTypes) {
     try {
-      await deleteRecordsByTimeRange(recordType, { operator: 'before', endTime });
+      await deleteRecordsByTimeRange(recordType, filter);
     } catch (error) {
+      ok = false;
       addLog(`[Writeback] Failed to delete ${recordType} records: ${message(error)}`, 'ERROR');
     }
   }
 
   const keys = await AsyncStorage.getAllKeys();
-  const trackingKeys = keys.filter(
-    (k) =>
-      k.startsWith(`${HEALTH_PREFERENCE_PREFIX}:writeback`) &&
-      (k.includes('Ids:') || k.includes('Sig:')),
-  );
-  if (trackingKeys.length > 0) await AsyncStorage.multiRemove(trackingKeys);
+  const toClear = trackingKeysToClear(keys, range);
+  if (toClear.length > 0) await AsyncStorage.multiRemove(toClear);
 
-  await Promise.all(WRITEBACK_METRICS.map((m) => saveHealthPreference(m.preferenceKey, false)));
+  if (!range) {
+    await Promise.all(WRITEBACK_METRICS.map((m) => saveHealthPreference(m.preferenceKey, false)));
+  }
+
   addLog(
-    `[Writeback] Removed all SparkyFitness data from Health Connect (${recordTypes.join(', ')})`,
+    `[Writeback] Removed SparkyFitness data from Health Connect (${range ? `${range.from}..${range.to}` : 'all time'})`,
     'INFO',
   );
+  return { ok };
 };

--- a/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/writeback.ts
@@ -235,8 +235,14 @@ export const runWriteback = async (): Promise<void> => {
 export const removeAllWrittenData = async (): Promise<void> => {
   const recordTypes = Array.from(new Set(WRITEBACK_METRICS.map((m) => m.recordType)));
   const endTime = new Date().toISOString();
+  // Best-effort per type: a failed delete (e.g. permission revoked for one type) must
+  // not abort the rest, the tracking-key clear, or the toggle reset below.
   for (const recordType of recordTypes) {
-    await deleteRecordsByTimeRange(recordType, { operator: 'before', endTime });
+    try {
+      await deleteRecordsByTimeRange(recordType, { operator: 'before', endTime });
+    } catch (error) {
+      addLog(`[Writeback] Failed to delete ${recordType} records: ${message(error)}`, 'ERROR');
+    }
   }
 
   const keys = await AsyncStorage.getAllKeys();

--- a/SparkyFitnessMobile/src/services/healthkit/preferences.ts
+++ b/SparkyFitnessMobile/src/services/healthkit/preferences.ts
@@ -7,8 +7,12 @@ import {
 // Re-export types for backward compatibility
 export { SyncDuration, SyncInterval };
 
+// AsyncStorage key prefix for all HealthKit preferences. Exported so cleanup code
+// can enumerate/remove writeback tracking keys directly.
+export const HEALTH_PREFERENCE_PREFIX = '@HealthKit';
+
 // Create preference functions with HealthKit-specific prefix and log tag
-const preferences = createPreferenceFunctions('@HealthKit', '[HealthKitService]');
+const preferences = createPreferenceFunctions(HEALTH_PREFERENCE_PREFIX, '[HealthKitService]');
 
 export const saveHealthPreference = preferences.saveHealthPreference;
 export const loadHealthPreference = preferences.loadHealthPreference;

--- a/SparkyFitnessMobile/src/services/healthkit/writeback.ts
+++ b/SparkyFitnessMobile/src/services/healthkit/writeback.ts
@@ -392,22 +392,30 @@ export const removeAllWrittenData = async (): Promise<void> => {
   const keys = await AsyncStorage.getAllKeys();
   const isWriteback = (k: string): boolean => k.startsWith(`${HEALTH_PREFERENCE_PREFIX}:writeback`);
 
+  // Batch-read the tracking values (multiGet, one roundtrip) and isolate each key in
+  // its own try/catch so a failed delete or corrupt JSON never aborts the rest of the
+  // cleanup, the tracking-key clear, or the toggle reset below.
+
   // Nutrition tracking is a per-date Record<healthKitType, uuid[]> (incl. the food
   // correlation UUIDs); delete each grouped by type.
-  for (const key of keys.filter((k) => isWriteback(k) && k.includes('NutritionUuids:'))) {
-    const raw = await AsyncStorage.getItem(key);
-    if (raw) await deleteTrackedByType(JSON.parse(raw) as Record<string, string[]>);
+  const nutritionKeys = keys.filter((k) => isWriteback(k) && k.includes('NutritionUuids:'));
+  for (const [key, raw] of await AsyncStorage.multiGet(nutritionKeys)) {
+    if (!raw) continue;
+    try {
+      await deleteTrackedByType(JSON.parse(raw) as Record<string, string[]>);
+    } catch (error) {
+      addLog(`[Writeback] Failed to delete nutrition records for ${key}: ${message(error)}`, 'WARNING');
+    }
   }
 
   // Hydration tracking is a per-date uuid[] of DietaryWater samples.
-  for (const key of keys.filter((k) => isWriteback(k) && k.includes('HydrationUuids:'))) {
-    const raw = await AsyncStorage.getItem(key);
-    const uuids = raw ? (JSON.parse(raw) as string[]) : [];
-    if (uuids.length === 0) continue;
+  const hydrationKeys = keys.filter((k) => isWriteback(k) && k.includes('HydrationUuids:'));
+  for (const [key, raw] of await AsyncStorage.multiGet(hydrationKeys)) {
     try {
-      await deleteObjects(DIETARY_WATER_IDENTIFIER, { uuids });
+      const uuids = raw ? (JSON.parse(raw) as string[]) : [];
+      if (uuids.length > 0) await deleteObjects(DIETARY_WATER_IDENTIFIER, { uuids });
     } catch (error) {
-      addLog(`[Writeback] Failed to delete ${uuids.length} water record(s): ${message(error)}`, 'WARNING');
+      addLog(`[Writeback] Failed to delete water records for ${key}: ${message(error)}`, 'WARNING');
     }
   }
 

--- a/SparkyFitnessMobile/src/services/healthkit/writeback.ts
+++ b/SparkyFitnessMobile/src/services/healthkit/writeback.ts
@@ -25,7 +25,12 @@ import {
   type NutrientSampleDescriptor,
   type WaterSampleDescriptor,
 } from './writebackMappers';
-import { WRITEBACK_METRICS, type WritebackMetric } from '../../WritebackMetrics';
+import {
+  WRITEBACK_METRICS,
+  type WritebackMetric,
+  type WritebackDateRange,
+  type WritebackRemovalResult,
+} from '../../WritebackMetrics';
 import { getMealTypeLabel } from '../../constants/meals';
 import { runTasksInBatches } from '../../utils/concurrency';
 
@@ -380,50 +385,70 @@ export const runWriteback = async (): Promise<void> => {
   if (completed) await saveLastWritebackTime();
 };
 
+// Every HealthKit sample type writeback creates: the nutrient quantity types, water,
+// and the food correlation itself (deleteObjects is scoped to one type per call).
+const WRITEBACK_DELETE_TYPES: SampleTypeIdentifierWriteable[] = [
+  ...new Set<SampleTypeIdentifierWriteable>([
+    ...DIETARY_WRITE_IDENTIFIERS,
+    DIETARY_WATER_IDENTIFIER,
+    FOOD_CORRELATION_TYPE as SampleTypeIdentifierWriteable,
+  ]),
+];
+
+// Our per-date tracking keys (writeback{Type}{Uuids,Sig}:{YYYY-MM-DD}), optionally
+// restricted to a date range by the key's trailing day.
+const trackingKeysToClear = (keys: readonly string[], range: WritebackDateRange | null): string[] =>
+  keys.filter((k) => {
+    if (!k.startsWith(`${HEALTH_PREFERENCE_PREFIX}:writeback`)) return false;
+    if (!k.includes('Uuids:') && !k.includes('Sig:')) return false;
+    if (!range) return true;
+    const day = k.slice(k.lastIndexOf(':') + 1);
+    return day >= range.from && day <= range.to;
+  });
+
+const localDayDate = (day: string, endOfDay: boolean): Date => {
+  const [y, m, d] = day.split('-').map(Number);
+  return endOfDay ? new Date(y, m - 1, d, 23, 59, 59, 999) : new Date(y, m - 1, d, 0, 0, 0, 0);
+};
+
 /**
- * Rollback: delete every sample SparkyFitness wrote to HealthKit (all metrics, all
- * dates), clear our per-date tracking, and turn writeback off. HealthKit only lets an
- * app delete samples it saved, so other apps' and manually-entered data are untouched.
- * Deletes by the tracked UUIDs (the same mechanism the per-day replace uses); clearing
- * the tracking keys is required, else change-detection would treat a later re-enable as
- * "unchanged" and never re-populate HealthKit.
+ * Delete samples SparkyFitness wrote to HealthKit. `range` null = full purge (all
+ * time) — also turns writeback off, a true rollback; a date range removes just that
+ * window and leaves writeback on. Deletes by date range per sample type (a predicate
+ * delete, like Health Connect) rather than tracked UUIDs, so it also reaches records
+ * orphaned by a lost tracking key (per review). HealthKit only deletes samples we
+ * saved, so other apps' and manual data are untouched. Best-effort per type; returns
+ * ok=false if any delete failed. Clearing the tracking keys is required, else
+ * change-detection would treat a later re-write as "unchanged".
  */
-export const removeAllWrittenData = async (): Promise<void> => {
+export const removeWrittenData = async (
+  range: WritebackDateRange | null,
+): Promise<WritebackRemovalResult> => {
+  const dateFilter = range
+    ? { startDate: localDayDate(range.from, false), endDate: localDayDate(range.to, true) }
+    : { endDate: new Date() };
+
+  let ok = true;
+  for (const type of WRITEBACK_DELETE_TYPES) {
+    try {
+      await deleteObjects(type, { date: dateFilter });
+    } catch (error) {
+      ok = false;
+      addLog(`[Writeback] Failed to delete ${type} records: ${message(error)}`, 'WARNING');
+    }
+  }
+
   const keys = await AsyncStorage.getAllKeys();
-  const isWriteback = (k: string): boolean => k.startsWith(`${HEALTH_PREFERENCE_PREFIX}:writeback`);
+  const toClear = trackingKeysToClear(keys, range);
+  if (toClear.length > 0) await AsyncStorage.multiRemove(toClear);
 
-  // Batch-read the tracking values (multiGet, one roundtrip) and isolate each key in
-  // its own try/catch so a failed delete or corrupt JSON never aborts the rest of the
-  // cleanup, the tracking-key clear, or the toggle reset below.
-
-  // Nutrition tracking is a per-date Record<healthKitType, uuid[]> (incl. the food
-  // correlation UUIDs); delete each grouped by type.
-  const nutritionKeys = keys.filter((k) => isWriteback(k) && k.includes('NutritionUuids:'));
-  for (const [key, raw] of await AsyncStorage.multiGet(nutritionKeys)) {
-    if (!raw) continue;
-    try {
-      await deleteTrackedByType(JSON.parse(raw) as Record<string, string[]>);
-    } catch (error) {
-      addLog(`[Writeback] Failed to delete nutrition records for ${key}: ${message(error)}`, 'WARNING');
-    }
+  if (!range) {
+    await Promise.all(WRITEBACK_METRICS.map((m) => saveHealthPreference(m.preferenceKey, false)));
   }
 
-  // Hydration tracking is a per-date uuid[] of DietaryWater samples.
-  const hydrationKeys = keys.filter((k) => isWriteback(k) && k.includes('HydrationUuids:'));
-  for (const [key, raw] of await AsyncStorage.multiGet(hydrationKeys)) {
-    try {
-      const uuids = raw ? (JSON.parse(raw) as string[]) : [];
-      if (uuids.length > 0) await deleteObjects(DIETARY_WATER_IDENTIFIER, { uuids });
-    } catch (error) {
-      addLog(`[Writeback] Failed to delete water records for ${key}: ${message(error)}`, 'WARNING');
-    }
-  }
-
-  const trackingKeys = keys.filter(
-    (k) => isWriteback(k) && (k.includes('Uuids:') || k.includes('Sig:')),
+  addLog(
+    `[Writeback] Removed SparkyFitness data from Apple Health (${range ? `${range.from}..${range.to}` : 'all time'})`,
+    'INFO',
   );
-  if (trackingKeys.length > 0) await AsyncStorage.multiRemove(trackingKeys);
-
-  await Promise.all(WRITEBACK_METRICS.map((m) => saveHealthPreference(m.preferenceKey, false)));
-  addLog('[Writeback] Removed all SparkyFitness data from Apple Health', 'INFO');
+  return { ok };
 };

--- a/SparkyFitnessMobile/src/services/healthkit/writeback.ts
+++ b/SparkyFitnessMobile/src/services/healthkit/writeback.ts
@@ -9,10 +9,11 @@ import {
   type ObjectTypeIdentifier,
   type SampleTypeIdentifierWriteable,
 } from '@kingstinct/react-native-healthkit';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { addLog } from '../LogService';
 import { fetchDailySummary } from '../api/dailySummaryApi';
 import { resolveCollapsedFoodEntries } from '../../utils/loggedMealCollapse';
-import { loadHealthPreference, saveHealthPreference } from './preferences';
+import { loadHealthPreference, saveHealthPreference, HEALTH_PREFERENCE_PREFIX } from './preferences';
 import { loadLastWritebackTime, saveLastWritebackTime } from '../storage';
 import {
   foodEntryToNutrientSamples,
@@ -377,4 +378,44 @@ export const runWriteback = async (): Promise<void> => {
   const dates = computeWritebackDates(await loadLastWritebackTime());
   const completed = await writebackPhase(dates);
   if (completed) await saveLastWritebackTime();
+};
+
+/**
+ * Rollback: delete every sample SparkyFitness wrote to HealthKit (all metrics, all
+ * dates), clear our per-date tracking, and turn writeback off. HealthKit only lets an
+ * app delete samples it saved, so other apps' and manually-entered data are untouched.
+ * Deletes by the tracked UUIDs (the same mechanism the per-day replace uses); clearing
+ * the tracking keys is required, else change-detection would treat a later re-enable as
+ * "unchanged" and never re-populate HealthKit.
+ */
+export const removeAllWrittenData = async (): Promise<void> => {
+  const keys = await AsyncStorage.getAllKeys();
+  const isWriteback = (k: string): boolean => k.startsWith(`${HEALTH_PREFERENCE_PREFIX}:writeback`);
+
+  // Nutrition tracking is a per-date Record<healthKitType, uuid[]> (incl. the food
+  // correlation UUIDs); delete each grouped by type.
+  for (const key of keys.filter((k) => isWriteback(k) && k.includes('NutritionUuids:'))) {
+    const raw = await AsyncStorage.getItem(key);
+    if (raw) await deleteTrackedByType(JSON.parse(raw) as Record<string, string[]>);
+  }
+
+  // Hydration tracking is a per-date uuid[] of DietaryWater samples.
+  for (const key of keys.filter((k) => isWriteback(k) && k.includes('HydrationUuids:'))) {
+    const raw = await AsyncStorage.getItem(key);
+    const uuids = raw ? (JSON.parse(raw) as string[]) : [];
+    if (uuids.length === 0) continue;
+    try {
+      await deleteObjects(DIETARY_WATER_IDENTIFIER, { uuids });
+    } catch (error) {
+      addLog(`[Writeback] Failed to delete ${uuids.length} water record(s): ${message(error)}`, 'WARNING');
+    }
+  }
+
+  const trackingKeys = keys.filter(
+    (k) => isWriteback(k) && (k.includes('Uuids:') || k.includes('Sig:')),
+  );
+  if (trackingKeys.length > 0) await AsyncStorage.multiRemove(trackingKeys);
+
+  await Promise.all(WRITEBACK_METRICS.map((m) => saveHealthPreference(m.preferenceKey, false)));
+  addLog('[Writeback] Removed all SparkyFitness data from Apple Health', 'INFO');
 };

--- a/SparkyFitnessMobile/src/services/writeback.ios.ts
+++ b/SparkyFitnessMobile/src/services/writeback.ios.ts
@@ -1,3 +1,3 @@
 // Platform-neutral writeback entry point (iOS-resolved). iOS uses HealthKit, so
 // the implementation lives in healthkit/. Metro resolves this over writeback.ts.
-export { writebackPhase, runWriteback, removeAllWrittenData } from './healthkit/writeback';
+export { writebackPhase, runWriteback, removeWrittenData } from './healthkit/writeback';

--- a/SparkyFitnessMobile/src/services/writeback.ios.ts
+++ b/SparkyFitnessMobile/src/services/writeback.ios.ts
@@ -1,3 +1,3 @@
 // Platform-neutral writeback entry point (iOS-resolved). iOS uses HealthKit, so
 // the implementation lives in healthkit/. Metro resolves this over writeback.ts.
-export { writebackPhase, runWriteback } from './healthkit/writeback';
+export { writebackPhase, runWriteback, removeAllWrittenData } from './healthkit/writeback';

--- a/SparkyFitnessMobile/src/services/writeback.ts
+++ b/SparkyFitnessMobile/src/services/writeback.ts
@@ -3,4 +3,4 @@
 // top-level services/ folder, so each platform's writeback implementation stays in
 // its own folder (healthconnect/ vs healthkit/) — mirroring how
 // healthConnectService.ts / .ios.ts already split.
-export { writebackPhase, runWriteback, removeAllWrittenData } from './healthconnect/writeback';
+export { writebackPhase, runWriteback, removeWrittenData } from './healthconnect/writeback';

--- a/SparkyFitnessMobile/src/services/writeback.ts
+++ b/SparkyFitnessMobile/src/services/writeback.ts
@@ -3,4 +3,4 @@
 // top-level services/ folder, so each platform's writeback implementation stays in
 // its own folder (healthconnect/ vs healthkit/) — mirroring how
 // healthConnectService.ts / .ios.ts already split.
-export { writebackPhase, runWriteback } from './healthconnect/writeback';
+export { writebackPhase, runWriteback, removeAllWrittenData } from './healthconnect/writeback';


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Adds the rollback/cleanup the maintainers asked for in #1529: a way to delete everything SparkyFitness wrote to the OS health store, so a user can undo the writeback if something looks wrong.

**How did you implement the solution?**
A confirm-gated "Remove SparkyFitness data" action on the writeback card (Sync screen). It deletes all of our written records, clears our per-date tracking, and turns the writeback toggles off (a true rollback). Cross-platform via the existing `services/writeback` shim: on **Android** it uses `deleteRecordsByTimeRange` all-time per record type (Health Connect scopes deletes to our own `dataOrigin`, so other apps' and manually-entered data are untouched, and the 30-day limit is read-only so historic records are reached); on **iOS** it deletes the tracked sample UUIDs grouped by type (the same mechanism the per-day replace already uses — HealthKit only deletes samples we saved). Clearing the tracking keys is required so a later re-enable re-populates the store instead of being skipped by change-detection.

Linked Issue: Follow-up to #1529 (cleanup requested by maintainers); part of #887.

| what | how |
| ------------- | ------------- |
| new delete button | <img width="1344" height="2992" alt="Screenshot_20260622-163148" src="https://github.com/user-attachments/assets/8acba9c6-b82a-474e-b953-dccd6951311f" /> |
| sheet to choose between all & range | <img width="1344" height="2992" alt="Screenshot_20260622-163150" src="https://github.com/user-attachments/assets/3580d525-85ab-43eb-9b0a-2fc197ca190a" /> |
| date range picker | <img width="1344" height="2992" alt="Screenshot_20260622-163156" src="https://github.com/user-attachments/assets/307a114c-a2ca-4a9a-a5f2-7c5cbde2ee35" /> |
| success toast | <img width="1344" height="2992" alt="Screenshot_20260622-163203" src="https://github.com/user-attachments/assets/42b80daa-6ed0-4c71-ac78-90b9631f5b15" /> |


## How to Test

1. Enable writeback (Nutrition/Hydration) on the Sync screen and sync so some records exist in Health Connect / Apple Health.
2. Tap **Remove SparkyFitness data from {Health Connect | Apple Health}** and confirm.
3. Verify the SparkyFitness-written nutrition/hydration records are gone from the health store, the writeback toggles are now off, and records from other apps / manual entries are untouched.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Notes for Reviewers

- Client-only; no backend changes.
- **Android (Health Connect) was tested on device.** The **iOS / HealthKit path is untested by me (no Apple device)** — @apedley, since you implemented the HealthKit writeback, could you verify the HealthKit deletion (`removeAllWrittenData` in `healthkit/writeback.ts`)? It mirrors your `deleteTrackedByType` / `deleteObjects(DietaryWater)` patterns over all tracked dates.
- Driven off `WRITEBACK_METRICS`, so it covers any future writeback metrics automatically. Date-range delete can be a later add (we don't have a range picker yet, and "delete all" is the core safety net).

cc @CodeWithCJ
