### PR TITLE
feat: add exercise water loss to daily goal and activity report stats

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -492,7 +492,9 @@
       "milliliters": "Milliliters (ml)",
       "fluidOunces": "Fluid Ounces (oz)",
       "cups": "Cups",
-      "saveWaterDisplayUnit": "Save Water Display Unit"
+      "saveWaterDisplayUnit": "Save Water Display Unit",
+      "addExerciseWater": "Add exercise water loss to daily goal",
+      "addExerciseWaterHint": "Increases your daily water goal by the estimated sweat loss from activities."
     },
     "nutrientDisplay": {
       "title": "Nutrient Display",
@@ -1583,6 +1585,8 @@
       "totalAscent": "Total Ascent",
       "calories": "Calories",
       "heartRate": "Heart Rate",
+      "cadence": "Cadence",
+      "waterLoss": "Water Loss",
       "runningDynamics": "Running Dynamics",
       "xAxis": "X-Axis:",
       "timeOfDay": "Time of Day",

--- a/SparkyFitnessFrontend/src/api/Diary/waterIntakteService.ts
+++ b/SparkyFitnessFrontend/src/api/Diary/waterIntakteService.ts
@@ -20,7 +20,7 @@ export interface WaterIntakeLogEntry {
 }
 
 export const getWaterGoalForDate = async (date: string, userId: string) => {
-  return apiCall(`/goals/for-date?date=${date}&userId=${userId}`);
+  return apiCall(`/goals/for-date?date=${date}&userId=${userId}&adjust=true`);
 };
 
 export const getWaterIntakeForDate = async (date: string, userId: string) => {

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityStatsGrid.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityStatsGrid.tsx
@@ -8,6 +8,7 @@ import {
   FaFire,
   FaHeartbeat,
   FaRunning,
+  FaTint,
 } from 'react-icons/fa';
 
 interface ActivityStatsGridProps {
@@ -18,6 +19,7 @@ interface ActivityStatsGridProps {
   calories: string | null;
   heartRate: string | null;
   cadence: string | null;
+  waterLoss: string | null;
 }
 
 export const ActivityStatsGrid = ({
@@ -28,6 +30,7 @@ export const ActivityStatsGrid = ({
   calories,
   heartRate,
   cadence,
+  waterLoss,
 }: ActivityStatsGridProps) => {
   const { t } = useTranslation();
 
@@ -121,6 +124,19 @@ export const ActivityStatsGrid = ({
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold">{cadence}</div>
+          </CardContent>
+        </Card>
+      )}
+      {waterLoss !== null && (
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-1">
+            <CardTitle className="text-sm font-medium">
+              {t('reports.activityReport.waterLoss', 'Water Loss')}
+            </CardTitle>
+            <FaTint className="h-5 w-5 text-cyan-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{waterLoss}</div>
           </CardContent>
         </Card>
       )}

--- a/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
@@ -92,6 +92,7 @@ interface PreferencesContextType {
   autoScaleOnlineImports: boolean;
   nutrientDisplayPreferences: NutrientPreference[];
   water_display_unit: WaterDisplayUnit;
+  addExerciseWaterToGoal: boolean;
   language: string;
   bmrAlgorithm: BmrAlgorithm;
   bodyFatAlgorithm: BodyFatAlgorithm;
@@ -133,6 +134,7 @@ interface PreferencesContextType {
   setAutoScaleOnlineImports: (enabled: boolean) => void;
   loadNutrientDisplayPreferences: () => Promise<void>;
   setWaterDisplayUnit: (unit: WaterDisplayUnit) => void;
+  setAddExerciseWaterToGoal: (enabled: boolean) => void;
   setLanguage: (language: string) => void;
   setBmrAlgorithm: (algorithm: BmrAlgorithm) => void;
   setBodyFatAlgorithm: (algorithm: BodyFatAlgorithm) => void;
@@ -189,6 +191,7 @@ export interface DefaultPreferences {
   item_display_limit: number;
   food_display_limit: number;
   water_display_unit: WaterDisplayUnit;
+  add_exercise_water_to_goal: boolean;
   language: string;
   calorie_goal_adjustment_mode: calorieGoalAdjustmentMode;
   energy_unit: EnergyUnit;
@@ -292,6 +295,8 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
   const [includeBmrInNetCalories, setIncludeBmrInNetCaloriesState] =
     useState<boolean>(false);
   const [showNetCarbs, setShowNetCarbsState] = useState<boolean>(false);
+  const [addExerciseWaterToGoal, setAddExerciseWaterToGoalState] =
+    useState<boolean>(false);
   // AI-Assisted Unit Conversions: per-user toggle for the diary/food-form AI
   // estimate path. Default true matches the server migration (DEFAULT TRUE).
   const [aiAssistedConversions, setAiAssistedConversionsState] =
@@ -670,6 +675,9 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
           data.include_bmr_in_net_calories ?? false
         );
         setShowNetCarbsState(data.show_net_carbs ?? false);
+        setAddExerciseWaterToGoalState(
+          data.add_exercise_water_to_goal ?? false
+        );
         setAiAssistedConversionsState(data.ai_assisted_conversions ?? true);
         setFatBreakdownAlgorithmState(
           data.fat_breakdown_algorithm || FatBreakdownAlgorithm.AHA_GUIDELINES
@@ -834,6 +842,8 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         include_bmr_in_net_calories:
           newPrefs?.includeBmrInNetCalories ?? includeBmrInNetCalories,
         show_net_carbs: newPrefs?.showNetCarbs ?? showNetCarbs,
+        add_exercise_water_to_goal:
+          newPrefs?.addExerciseWaterToGoal ?? addExerciseWaterToGoal,
         ai_assisted_conversions:
           newPrefs?.aiAssistedConversions ?? aiAssistedConversions,
         fat_breakdown_algorithm:
@@ -883,6 +893,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       itemDisplayLimit,
       foodDisplayLimit,
       waterDisplayUnit,
+      addExerciseWaterToGoal,
       language,
       calorieGoalAdjustmentMode,
       exerciseCaloriePercentage,
@@ -1123,6 +1134,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       autoScaleOnlineImports,
       nutrientDisplayPreferences,
       water_display_unit: waterDisplayUnit,
+      addExerciseWaterToGoal,
       language,
       bmrAlgorithm,
       bodyFatAlgorithm,
@@ -1161,6 +1173,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       setAutoScaleOnlineImports,
       loadNutrientDisplayPreferences,
       setWaterDisplayUnit: setWaterDisplayUnitState,
+      setAddExerciseWaterToGoal: setAddExerciseWaterToGoalState,
       setLanguage: setLanguageState,
       setBmrAlgorithm: setBmrAlgorithmState,
       setBodyFatAlgorithm: setBodyFatAlgorithmState,
@@ -1207,6 +1220,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       autoScaleOnlineImports,
       nutrientDisplayPreferences,
       waterDisplayUnit,
+      addExerciseWaterToGoal,
       language,
       bmrAlgorithm,
       bodyFatAlgorithm,

--- a/SparkyFitnessFrontend/src/pages/Reports/ActivityReportVisualizer.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/ActivityReportVisualizer.tsx
@@ -15,7 +15,10 @@ import {
   formatDuration,
 } from '@/utils/activityReportUtil';
 import { info } from '@/utils/logging';
-import { getEnergyUnitString } from '@/utils/nutritionCalculations';
+import {
+  convertMlToSelectedUnit,
+  getEnergyUnitString,
+} from '@/utils/nutritionCalculations';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import ActivityReportLapTable from './ActivityReportLapTable';
@@ -54,6 +57,7 @@ const ActivityReportVisualizer = ({
     loggingLevel,
     energyUnit,
     convertEnergy,
+    water_display_unit,
   } = usePreferences();
 
   const allChartData = activityData
@@ -204,6 +208,11 @@ const ActivityReportVisualizer = ({
       ? `${stats.cadence.toFixed(0)} spm`
       : null;
 
+  const waterLossFormatted =
+    stats.waterEstimated != null && stats.waterEstimated > 0
+      ? `${convertMlToSelectedUnit(stats.waterEstimated, water_display_unit).toFixed(water_display_unit === 'ml' ? 0 : 1)} ${water_display_unit}`
+      : null;
+
   const getXAxisDataKey = () => {
     switch (effectiveXAxisMode) {
       case 'activityDuration':
@@ -317,6 +326,7 @@ const ActivityReportVisualizer = ({
                 calories={caloriesFormatted}
                 heartRate={heartRateFormatted}
                 cadence={cadenceFormatted}
+                waterLoss={waterLossFormatted}
               />
             </div>
 

--- a/SparkyFitnessFrontend/src/pages/Settings/WaterTrackingSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/WaterTrackingSettings.tsx
@@ -8,6 +8,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
+import { Switch } from '@/components/ui/switch';
 import { Save, Droplet } from 'lucide-react';
 import WaterContainerManager from './WaterContainerManager';
 import { AccordionTrigger, AccordionContent } from '@/components/ui/accordion'; // Import Accordion components
@@ -20,8 +21,13 @@ import { toast } from '@/hooks/use-toast';
 export const WaterTrackingSettings = () => {
   const { t } = useTranslation();
   const { user } = useAuth();
-  const { water_display_unit, saveAllPreferences, setWaterDisplayUnit } =
-    usePreferences();
+  const {
+    water_display_unit,
+    saveAllPreferences,
+    setWaterDisplayUnit,
+    addExerciseWaterToGoal,
+    setAddExerciseWaterToGoal,
+  } = usePreferences();
   const [localWaterUnit, setLocalWaterUnit] = useState(water_display_unit);
 
   const [loading, setLoading] = useState<boolean>(false);
@@ -101,6 +107,31 @@ export const WaterTrackingSettings = () => {
                 'Save Water Display Unit'
               )}
         </Button>
+        <Separator />
+        <div className="flex items-center justify-between py-2">
+          <div className="space-y-0.5">
+            <Label htmlFor="add-exercise-water-to-goal">
+              {t(
+                'settings.waterTracking.addExerciseWater',
+                'Add exercise water loss to daily goal'
+              )}
+            </Label>
+            <p className="text-sm text-muted-foreground">
+              {t(
+                'settings.waterTracking.addExerciseWaterHint',
+                'Increases your daily water goal by the estimated sweat loss from activities.'
+              )}
+            </p>
+          </div>
+          <Switch
+            id="add-exercise-water-to-goal"
+            checked={addExerciseWaterToGoal}
+            onCheckedChange={(checked) => {
+              setAddExerciseWaterToGoal(checked);
+              saveAllPreferences({ addExerciseWaterToGoal: checked });
+            }}
+          />
+        </div>
         <Separator />
         <WaterContainerManager />
       </AccordionContent>

--- a/SparkyFitnessFrontend/src/tests/utils/activityReportUtil.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/activityReportUtil.test.ts
@@ -22,6 +22,7 @@ import {
   extractElevationGain,
   getActivityIcon,
   getEventTypeLabel,
+  readActivityStats,
 } from '@/utils/activityReportUtil';
 import { ActivityDetailsResponse } from '@/types/exercises';
 import { ChartDataPoint } from '@/types/reports';
@@ -510,5 +511,59 @@ describe('getEventTypeLabel – hide uncategorized events', () => {
 
   it('returns typeKey for a valid object event type', () => {
     expect(getEventTypeLabel({ typeKey: 'race' })).toBe('race');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// 9. readActivityStats – waterEstimated extraction
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('readActivityStats – waterEstimated', () => {
+  it('extracts waterEstimated from Garmin activity data', () => {
+    const activityData = {
+      activity: {
+        activity: {
+          waterEstimated: 4358,
+          distance: 7.16,
+          duration: 285,
+          calories: 2001,
+          averageHR: 134,
+          activityName: 'Hiking',
+          activityType: { typeKey: 'hiking' },
+        },
+      },
+    } as unknown as ActivityDetailsResponse;
+
+    const stats = readActivityStats(activityData);
+    expect(stats.waterEstimated).toBe(4358);
+  });
+
+  it('returns null when waterEstimated is absent', () => {
+    const activityData = {
+      activity: {
+        activity: {
+          distance: 5.0,
+          duration: 30,
+          calories: 300,
+        },
+      },
+    } as unknown as ActivityDetailsResponse;
+
+    const stats = readActivityStats(activityData);
+    expect(stats.waterEstimated).toBeNull();
+  });
+
+  it('returns null when waterEstimated is 0', () => {
+    const activityData = {
+      activity: {
+        activity: {
+          waterEstimated: 0,
+          distance: 2.0,
+        },
+      },
+    } as unknown as ActivityDetailsResponse;
+
+    const stats = readActivityStats(activityData);
+    expect(stats.waterEstimated).toBeNull();
   });
 });

--- a/SparkyFitnessFrontend/src/utils/activityReportUtil.ts
+++ b/SparkyFitnessFrontend/src/utils/activityReportUtil.ts
@@ -334,6 +334,8 @@ export interface ActivityStats {
   pace: number | null;
   /** metres */
   ascent: number | null;
+  /** ml */
+  waterEstimated: number | null;
   activityName: string | null;
   activityTypeKey: string | null;
 }
@@ -436,6 +438,8 @@ export function readActivityStats(
     pos(a['elevationGain']) ??
     pos(a['total_elevation_gain']);
 
+  const waterEstimated = pos(a['waterEstimated']);
+
   // activity name / type
   const activityName =
     (a['activityName'] as string | undefined) ??
@@ -456,6 +460,7 @@ export function readActivityStats(
     cadence,
     pace,
     ascent,
+    waterEstimated,
     activityName,
     activityTypeKey,
   };

--- a/SparkyFitnessServer/db/migrations/20260622120000_add_water_estimated_to_exercise_entries.sql
+++ b/SparkyFitnessServer/db/migrations/20260622120000_add_water_estimated_to_exercise_entries.sql
@@ -1,0 +1,14 @@
+ALTER TABLE public.exercise_entries
+  ADD COLUMN water_estimated integer;
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN add_exercise_water_to_goal boolean NOT NULL DEFAULT false;
+
+-- Backfill existing Garmin activities from the raw JSONB data
+UPDATE exercise_entries ee
+SET water_estimated = ROUND((ead.detail_data->'activity'->>'waterEstimated')::numeric)
+FROM exercise_entry_activity_details ead
+WHERE ead.exercise_entry_id = ee.id
+  AND ead.provider_name = 'garmin'
+  AND ead.detail_data->'activity'->>'waterEstimated' IS NOT NULL
+  AND ee.water_estimated IS NULL;

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -298,6 +298,10 @@ async function _updateExerciseEntryWithClient(
       updateData.secondary_muscles || currentEntry.secondary_muscles,
     instructions: updateData.instructions || currentEntry.instructions,
     images: updateData.images || currentEntry.images,
+    water_estimated:
+      updateData.water_estimated !== undefined
+        ? updateData.water_estimated
+        : currentEntry.water_estimated,
   };
   // If exercise_id is explicitly updated, re-fetch snapshot data from the exercise
   if (
@@ -351,8 +355,9 @@ async function _updateExerciseEntryWithClient(
       images = $23,
       sort_order = $24,
       steps = $25,
+      water_estimated = $26,
       updated_at = now()
-    WHERE id = $26 AND user_id = $27
+    WHERE id = $27 AND user_id = $28
     RETURNING id`,
     [
       mergedData.exercise_id,
@@ -384,6 +389,7 @@ async function _updateExerciseEntryWithClient(
       mergedData.images ? JSON.stringify(mergedData.images) : null,
       mergedData.sort_order || 0,
       mergedData.steps || null,
+      mergedData.water_estimated || null,
       id,
       userId,
     ]
@@ -513,8 +519,8 @@ async function _createExerciseEntryWithClient(
            workout_plan_assignment_id, image_url, created_by_user_id,
            exercise_name, calories_per_hour, category, source, source_id, force, level, mechanic,
            equipment, primary_muscles, secondary_muscles, instructions, images,
-           distance, avg_heart_rate, exercise_preset_entry_id, sort_order, steps
-         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27) RETURNING id`,
+           distance, avg_heart_rate, exercise_preset_entry_id, sort_order, steps, water_estimated
+         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28) RETURNING id`,
         [
           userId,
           entryData.exercise_id,
@@ -543,6 +549,7 @@ async function _createExerciseEntryWithClient(
           exercisePresetEntryId, // New parameter
           entryData.sort_order || 0,
           entryData.steps || null,
+          entryData.water_estimated || null,
         ]
       );
       newEntryId = entryResult.rows[0].id;
@@ -1371,6 +1378,46 @@ async function getExerciseUsage(
   }
 }
 
+async function getWaterEstimatedSumForDate(
+  userId: string,
+  date: string
+): Promise<number> {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      'SELECT COALESCE(SUM(water_estimated), 0) as total FROM exercise_entries WHERE user_id = $1 AND entry_date = $2 AND water_estimated IS NOT NULL',
+      [userId, date]
+    );
+    return parseInt(result.rows[0].total, 10);
+  } finally {
+    client.release();
+  }
+}
+
+async function getWaterEstimatedSumForDateRange(
+  userId: string,
+  startDate: string,
+  endDate: string
+): Promise<Record<string, number>> {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT TO_CHAR(entry_date, 'YYYY-MM-DD') as date, COALESCE(SUM(water_estimated), 0) as total
+       FROM exercise_entries
+       WHERE user_id = $1 AND entry_date BETWEEN $2 AND $3 AND water_estimated IS NOT NULL
+       GROUP BY entry_date`,
+      [userId, startDate, endDate]
+    );
+    const map: Record<string, number> = {};
+    for (const row of result.rows) {
+      map[row.date] = parseInt(row.total, 10);
+    }
+    return map;
+  } finally {
+    client.release();
+  }
+}
+
 export { upsertExerciseEntryData };
 export { _createExerciseEntryWithClient };
 export { createExerciseEntry };
@@ -1390,6 +1437,8 @@ export { getDailyExerciseTotalsRange };
 export { getExerciseDiaryRange };
 export { getRecentExerciseEntries };
 export { getExerciseUsage };
+export { getWaterEstimatedSumForDate };
+export { getWaterEstimatedSumForDateRange };
 export default {
   upsertExerciseEntryData,
   _createExerciseEntryWithClient,
@@ -1413,4 +1462,6 @@ export default {
   getExerciseDiaryRange,
   getRecentExerciseEntries,
   getExerciseUsage,
+  getWaterEstimatedSumForDate,
+  getWaterEstimatedSumForDateRange,
 };

--- a/SparkyFitnessServer/models/preferenceRepository.ts
+++ b/SparkyFitnessServer/models/preferenceRepository.ts
@@ -39,6 +39,7 @@ async function updateUserPreferences(userId: any, preferenceData: any) {
         goal_mode_calculation_method = COALESCE($35, goal_mode_calculation_method),
         goal_mode_custom_percentage = COALESCE($36, goal_mode_custom_percentage),
         use_external_bmr = COALESCE($37, use_external_bmr),
+        add_exercise_water_to_goal = COALESCE($40, add_exercise_water_to_goal),
         default_barcode_provider_id = CASE WHEN $28 THEN $27 ELSE default_barcode_provider_id END,
         active_ai_service_id = CASE WHEN $39 THEN $38 ELSE active_ai_service_id END,
         updated_at = now()
@@ -84,6 +85,7 @@ async function updateUserPreferences(userId: any, preferenceData: any) {
         preferenceData.use_external_bmr,
         preferenceData.active_ai_service_id,
         'active_ai_service_id' in preferenceData,
+        preferenceData.add_exercise_water_to_goal,
       ]
     );
     return result.rows[0];
@@ -165,6 +167,7 @@ async function upsertUserPreferences(preferenceData: any) {
        goal_mode_calculation_method,
        goal_mode_custom_percentage,
        use_external_bmr,
+       add_exercise_water_to_goal,
        active_ai_service_id,
        created_at, updated_at
      ) VALUES (
@@ -186,6 +189,7 @@ async function upsertUserPreferences(preferenceData: any) {
        COALESCE($35, 'manual'),
        COALESCE($36, 0),
        COALESCE($37, false),
+       COALESCE($40, false),
        $38,
        now(), now()
      )
@@ -224,6 +228,7 @@ async function upsertUserPreferences(preferenceData: any) {
        goal_mode_calculation_method = COALESCE(EXCLUDED.goal_mode_calculation_method, user_preferences.goal_mode_calculation_method),
        goal_mode_custom_percentage = COALESCE(EXCLUDED.goal_mode_custom_percentage, user_preferences.goal_mode_custom_percentage),
        use_external_bmr = COALESCE(EXCLUDED.use_external_bmr, user_preferences.use_external_bmr),
+       add_exercise_water_to_goal = COALESCE(EXCLUDED.add_exercise_water_to_goal, user_preferences.add_exercise_water_to_goal),
        default_barcode_provider_id = CASE WHEN $29 THEN EXCLUDED.default_barcode_provider_id ELSE user_preferences.default_barcode_provider_id END,
        active_ai_service_id = CASE WHEN $39 THEN EXCLUDED.active_ai_service_id ELSE user_preferences.active_ai_service_id END,
        updated_at = now()
@@ -268,6 +273,7 @@ async function upsertUserPreferences(preferenceData: any) {
         preferenceData.use_external_bmr,
         preferenceData.active_ai_service_id,
         'active_ai_service_id' in preferenceData,
+        preferenceData.add_exercise_water_to_goal,
       ]
     );
     return result.rows[0];

--- a/SparkyFitnessServer/services/garminService.ts
+++ b/SparkyFitnessServer/services/garminService.ts
@@ -820,6 +820,9 @@ async function processGarminSimpleActivity(
     steps: Math.round(
       activity.steps || activity.totalSteps || activity.stepCount || 0
     ),
+    water_estimated: activity.waterEstimated
+      ? Math.round(activity.waterEstimated)
+      : null,
   };
   const newEntry = await exerciseEntryRepository.createExerciseEntry(
     userId,

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -4,6 +4,7 @@ import goalPresetRepository from '../models/goalPresetRepository.js';
 import userRepository from '../models/userRepository.js';
 import preferenceRepository from '../models/preferenceRepository.js';
 import measurementRepository from '../models/measurementRepository.js';
+import exerciseEntryRepository from '../models/exerciseEntry.js';
 import bmrService from './bmrService.js';
 import adaptiveTdeeService from './AdaptiveTdeeService.js';
 import { userAge } from '../utils/dateHelpers.js';
@@ -125,6 +126,7 @@ async function getUserGoalsForRange(
     );
   }
 
+  let waterEstimatedMap: Record<string, number> = {};
   let adaptiveTdeeMap: Record<string, any> = {};
   if (adjust && userPreferences) {
     const adjustmentMode =
@@ -147,6 +149,14 @@ async function getUserGoalsForRange(
           `goalService: Failed to bulk fetch adaptive TDEE range for ${userId} [${startDate}, ${endDate}]: ${(err as Error).message}`
         );
       }
+    }
+    if (userPreferences.add_exercise_water_to_goal) {
+      waterEstimatedMap =
+        await exerciseEntryRepository.getWaterEstimatedSumForDateRange(
+          userId,
+          startDate,
+          endDate
+        );
     }
   }
 
@@ -330,6 +340,19 @@ async function getUserGoalsForRange(
         carbs: carbs_grams,
         fat: fat_grams,
       };
+    }
+
+    // Adjust water goal by exercise water loss if preference is enabled
+    if (adjust && userPreferences?.add_exercise_water_to_goal) {
+      const waterLoss = waterEstimatedMap[dateStr] || 0;
+      if (waterLoss > 0) {
+        const baseWaterGoal =
+          processedGoals.water_goal_ml ?? DEFAULT_GOALS.water_goal_ml ?? 1920;
+        processedGoals = {
+          ...processedGoals,
+          water_goal_ml: Number(baseWaterGoal) + waterLoss,
+        };
+      }
     }
 
     result[dateStr] = processedGoals;

--- a/SparkyFitnessServer/tests/waterEstimatedGoalAdjustment.test.ts
+++ b/SparkyFitnessServer/tests/waterEstimatedGoalAdjustment.test.ts
@@ -1,0 +1,144 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import goalService from '../services/goalService.js';
+import goalRepository from '../models/goalRepository.js';
+import weeklyGoalPlanRepository from '../models/weeklyGoalPlanRepository.js';
+import preferenceRepository from '../models/preferenceRepository.js';
+import userRepository from '../models/userRepository.js';
+import measurementRepository from '../models/measurementRepository.js';
+import exerciseEntryRepository from '../models/exerciseEntry.js';
+
+vi.mock('../models/goalRepository');
+vi.mock('../models/weeklyGoalPlanRepository');
+vi.mock('../models/goalPresetRepository');
+vi.mock('../models/userRepository');
+vi.mock('../models/preferenceRepository');
+vi.mock('../models/measurementRepository');
+vi.mock('../models/exerciseEntry');
+vi.mock('../services/bmrService');
+vi.mock('../services/AdaptiveTdeeService');
+vi.mock('../utils/timezoneLoader');
+
+const userId = 'user-123';
+const testDate = '2026-06-22';
+
+describe('Water goal adjustment by exercise water loss', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(
+      weeklyGoalPlanRepository.getActiveWeeklyGoalPlan
+    ).mockResolvedValue(null);
+    vi.mocked(goalRepository.getGoalsInRange).mockResolvedValue([]);
+    vi.mocked(goalRepository.getMostRecentGoalBeforeDate).mockResolvedValue({
+      water_goal_ml: 2000,
+      calories: 2000,
+      protein_percentage: null,
+      carbs_percentage: null,
+      fat_percentage: null,
+    });
+    vi.mocked(userRepository.getUserProfile).mockResolvedValue(null);
+    vi.mocked(
+      measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
+    ).mockResolvedValue(null);
+    vi.mocked(
+      measurementRepository.getCheckInMeasurementsByDateRange
+    ).mockResolvedValue([]);
+  });
+
+  it('adjusts water_goal_ml when adjust=true and preference is enabled', async () => {
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      add_exercise_water_to_goal: true,
+      calorie_goal_adjustment_mode: 'dynamic',
+    });
+    vi.mocked(
+      exerciseEntryRepository.getWaterEstimatedSumForDateRange
+    ).mockResolvedValue({ [testDate]: 500 });
+
+    const result = await goalService.getUserGoalsForRange(
+      userId,
+      testDate,
+      testDate,
+      true
+    );
+
+    expect((result[testDate] as Record<string, unknown>).water_goal_ml).toBe(
+      2500
+    );
+    expect(
+      exerciseEntryRepository.getWaterEstimatedSumForDateRange
+    ).toHaveBeenCalledWith(userId, testDate, testDate);
+  });
+
+  it('does not adjust water_goal_ml when preference is disabled', async () => {
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      add_exercise_water_to_goal: false,
+      calorie_goal_adjustment_mode: 'dynamic',
+    });
+
+    const result = await goalService.getUserGoalsForRange(
+      userId,
+      testDate,
+      testDate,
+      true
+    );
+
+    expect((result[testDate] as Record<string, unknown>).water_goal_ml).toBe(
+      2000
+    );
+    expect(
+      exerciseEntryRepository.getWaterEstimatedSumForDateRange
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not adjust when adjust=false even if preference is enabled', async () => {
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      add_exercise_water_to_goal: true,
+      calorie_goal_adjustment_mode: 'dynamic',
+    });
+    vi.mocked(
+      exerciseEntryRepository.getWaterEstimatedSumForDateRange
+    ).mockResolvedValue({ [testDate]: 500 });
+
+    const result = await goalService.getUserGoalsForRange(
+      userId,
+      testDate,
+      testDate,
+      false
+    );
+
+    expect((result[testDate] as Record<string, unknown>).water_goal_ml).toBe(
+      2000
+    );
+    expect(
+      exerciseEntryRepository.getWaterEstimatedSumForDateRange
+    ).not.toHaveBeenCalled();
+  });
+
+  it('uses default water goal (1920) when no base goal is set', async () => {
+    vi.mocked(goalRepository.getMostRecentGoalBeforeDate).mockResolvedValue({
+      calories: 2000,
+      protein_percentage: null,
+      carbs_percentage: null,
+      fat_percentage: null,
+    });
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      add_exercise_water_to_goal: true,
+      calorie_goal_adjustment_mode: 'dynamic',
+    });
+    vi.mocked(
+      exerciseEntryRepository.getWaterEstimatedSumForDateRange
+    ).mockResolvedValue({ [testDate]: 300 });
+
+    const result = await goalService.getUserGoalsForRange(
+      userId,
+      testDate,
+      testDate,
+      true
+    );
+
+    // Should use 1920 (default) + 300
+    expect((result[testDate] as Record<string, unknown>).water_goal_ml).toBe(
+      2220
+    );
+  });
+});

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -1179,7 +1179,8 @@ CREATE TABLE public.exercise_entries (
     avg_heart_rate integer,
     exercise_preset_entry_id uuid,
     sort_order integer DEFAULT 0,
-    steps integer
+    steps integer,
+    water_estimated integer
 );
 
 
@@ -1188,6 +1189,13 @@ CREATE TABLE public.exercise_entries (
 --
 
 COMMENT ON COLUMN public.exercise_entries.steps IS 'Number of steps recorded during this activity, sourced from Garmin or other providers.';
+
+
+--
+-- Name: COLUMN exercise_entries.water_estimated; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.exercise_entries.water_estimated IS 'Estimated water loss in ml during this activity, sourced from Garmin or other providers.';
 
 
 --
@@ -2414,6 +2422,7 @@ CREATE TABLE public.user_preferences (
     goal_mode_calculation_method character varying(50) DEFAULT 'manual'::character varying NOT NULL,
     goal_mode_custom_percentage integer DEFAULT 0 NOT NULL,
     use_external_bmr boolean DEFAULT false NOT NULL,
+    add_exercise_water_to_goal boolean DEFAULT false NOT NULL,
     active_ai_service_id uuid,
     CONSTRAINT check_energy_unit CHECK (((energy_unit)::text = ANY (ARRAY[('kcal'::character varying)::text, ('kJ'::character varying)::text]))),
     CONSTRAINT logging_level_check CHECK ((logging_level = ANY (ARRAY['DEBUG'::text, 'INFO'::text, 'WARN'::text, 'ERROR'::text, 'SILENT'::text]))),


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Water intake does not account for water lost during excercise

**How did you implement the solution?**

Surface the Garmin `waterEstimated` field (sweat loss in ml) in two places:
1. New user preference toggle in Settings > Water Tracking that allows user to add exercise water loss to the daily water intake goal. Defautl is false.
2. New "Water Loss" stat card on the activity report, respecting the user's chosen water display unit.


## How to Test

1. Check out this branch and run 
2. Enable `Add exercise water loss to daily goal` in `Settings > Water Tracking`
3. Have an activity with sweat data
4. See that the daily goal has been updated

## PR Type

- [ ] Issue (bug fix)
- [X] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [X] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [X] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [X] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [X] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [X] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="291" height="724" alt="Screenshot 2026-06-22 at 10 16 56" src="https://github.com/user-attachments/assets/21209880-b0f8-4120-a648-d4bb466670df" />


### After

<img width="299" height="700" alt="image" src="https://github.com/user-attachments/assets/582ea3c6-00e2-4f43-9dba-51c9fd26f53b" />
<img width="1325" height="282" alt="image" src="https://github.com/user-attachments/assets/6be0356f-8a88-44fb-83cd-9eacac0fe015" />
<img width="1397" height="363" alt="image" src="https://github.com/user-attachments/assets/ad53cec7-3b1b-48a3-8ead-689c81590b68" />


</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
