### PR TITLE
Check-in numbers rounding

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -467,6 +467,7 @@
       "kilograms": "Kilograms (kg)",
       "pounds": "Pounds (lbs)",
       "measurementUnit": "Measurement Unit",
+      "measurementDecimalPlaces": "Measurement Decimal Places",
       "centimeters": "Centimeters (cm)",
       "inches": "Inches (in)",
       "distanceUnit": "Distance Unit",

--- a/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
@@ -108,9 +108,11 @@ interface PreferencesContextType {
   tdeeAllowNegativeAdjustment: boolean;
   selectedDiet: string;
   firstDayOfWeek: DayOfWeek;
+  measurementDecimalPlaces: number;
   goalMode: GoalMode;
   goalModeCalculationMethod: GoalModeCalculationMethod;
   goalModeCustomPercentage: number;
+  setMeasurementDecimalPlaces: (places: number) => void;
   setGoalMode: (mode: GoalMode) => void;
   setGoalModeCalculationMethod: (method: GoalModeCalculationMethod) => void;
   setGoalModeCustomPercentage: (pct: number) => void;
@@ -215,6 +217,7 @@ export interface DefaultPreferences {
   vitamin_calculation_algorithm: VitaminCalculationAlgorithm;
   sugar_calculation_algorithm: SugarCalculationAlgorithm;
   first_day_of_week: number;
+  measurement_decimal_places: number;
   goal_mode: GoalMode;
   goal_mode_calculation_method: GoalModeCalculationMethod;
   goal_mode_custom_percentage: number;
@@ -317,6 +320,8 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
     );
   const [selectedDiet, setSelectedDietState] = useState<string>('balanced');
   const [firstDayOfWeek, setFirstDayOfWeekState] = useState<DayOfWeek>(0);
+  const [measurementDecimalPlaces, setMeasurementDecimalPlacesState] =
+    useState<number>(0);
   const [goalMode, setGoalModeState] = useState<GoalMode>('maintain');
   const [goalModeCalculationMethod, setGoalModeCalculationMethodState] =
     useState<GoalModeCalculationMethod>('manual');
@@ -696,6 +701,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         );
         setSelectedDietState(data.selected_diet || 'balanced');
         setFirstDayOfWeekState(data.first_day_of_week ?? 0);
+        setMeasurementDecimalPlacesState(data.measurement_decimal_places ?? 0);
         setGoalModeState(data.goal_mode || 'maintain');
         setGoalModeCalculationMethodState(
           data.goal_mode_calculation_method || 'manual'
@@ -856,6 +862,8 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
           newPrefs?.sugarCalculationAlgorithm ?? sugarCalculationAlgorithm,
         selected_diet: newPrefs?.selectedDiet ?? selectedDiet,
         first_day_of_week: newPrefs?.firstDayOfWeek ?? firstDayOfWeek,
+        measurement_decimal_places:
+          newPrefs?.measurementDecimalPlaces ?? measurementDecimalPlaces,
         goal_mode: newPrefs?.goalMode ?? goalMode,
         goal_mode_calculation_method:
           newPrefs?.goalModeCalculationMethod ?? goalModeCalculationMethod,
@@ -913,6 +921,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       sugarCalculationAlgorithm,
       selectedDiet,
       firstDayOfWeek,
+      measurementDecimalPlaces,
       goalMode,
       goalModeCalculationMethod,
       goalModeCustomPercentage,
@@ -1147,9 +1156,11 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       sugarCalculationAlgorithm,
       selectedDiet,
       firstDayOfWeek,
+      measurementDecimalPlaces,
       goalMode,
       goalModeCalculationMethod,
       goalModeCustomPercentage,
+      setMeasurementDecimalPlaces: setMeasurementDecimalPlacesState,
       setGoalMode,
       setGoalModeCalculationMethod,
       setGoalModeCustomPercentage,
@@ -1233,6 +1244,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       sugarCalculationAlgorithm,
       selectedDiet,
       firstDayOfWeek,
+      measurementDecimalPlaces,
       goalMode,
       goalModeCalculationMethod,
       goalModeCustomPercentage,

--- a/SparkyFitnessFrontend/src/pages/CheckIn/RecentActivity.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/RecentActivity.tsx
@@ -95,7 +95,16 @@ export const RecentActivity: React.FC<RecentActivityProps> = ({
                           defaultMeasurementUnit
                         );
                   } else {
-                    displayString = `${measurement.value} ${measurement.custom_categories.measurement_type}`;
+                    const unit =
+                      measurement.custom_categories.measurement_type === 'N/A'
+                        ? ''
+                        : measurement.custom_categories.measurement_type;
+                    const num = Number(measurement.value);
+                    const val =
+                      measurement.value === '' || isNaN(num)
+                        ? measurement.value
+                        : Math.round(num);
+                    displayString = `${val} ${unit}`.trim();
                   }
                 } else if (measurement.type === 'standard') {
                   if (measurement.display_name === 'Weight') {
@@ -113,7 +122,16 @@ export const RecentActivity: React.FC<RecentActivityProps> = ({
                       defaultMeasurementUnit
                     );
                   } else {
-                    displayString = `${measurement.value} ${measurement.display_unit || ''}`;
+                    const unit =
+                      measurement.display_unit === 'N/A'
+                        ? ''
+                        : measurement.display_unit || '';
+                    const num = Number(measurement.value);
+                    const val =
+                      measurement.value === '' || isNaN(num)
+                        ? measurement.value
+                        : Math.round(num);
+                    displayString = `${val} ${unit}`.trim();
                   }
                 } else if (measurement.type === 'stress') {
                   measurementName = t('checkIn.stressLevel', 'Stress Level');
@@ -128,7 +146,16 @@ export const RecentActivity: React.FC<RecentActivityProps> = ({
                     ? `${Math.floor(measurement.duration_minutes / 60)}h ${measurement.duration_minutes % 60}m`
                     : '0h 0m';
                 } else {
-                  displayString = `${measurement.value} ${measurement.display_unit || ''}`;
+                  const unit =
+                    measurement.display_unit === 'N/A'
+                      ? ''
+                      : measurement.display_unit || '';
+                  const num = Number(measurement.value);
+                  const val =
+                    measurement.value === '' || isNaN(num)
+                      ? measurement.value
+                      : Math.round(num);
+                  displayString = `${val} ${unit}`.trim();
                 }
 
                 return (

--- a/SparkyFitnessFrontend/src/pages/CheckIn/RecentActivity.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/RecentActivity.tsx
@@ -44,6 +44,7 @@ export const RecentActivity: React.FC<RecentActivityProps> = ({
   const {
     weightUnit: defaultWeightUnit,
     measurementUnit: defaultMeasurementUnit,
+    measurementDecimalPlaces,
   } = usePreferences();
   const { t } = useTranslation();
 
@@ -103,7 +104,7 @@ export const RecentActivity: React.FC<RecentActivityProps> = ({
                     const val =
                       measurement.value === '' || isNaN(num)
                         ? measurement.value
-                        : Math.round(num);
+                        : Number(num.toFixed(measurementDecimalPlaces));
                     displayString = `${val} ${unit}`.trim();
                   }
                 } else if (measurement.type === 'standard') {
@@ -130,7 +131,7 @@ export const RecentActivity: React.FC<RecentActivityProps> = ({
                     const val =
                       measurement.value === '' || isNaN(num)
                         ? measurement.value
-                        : Math.round(num);
+                        : Number(num.toFixed(measurementDecimalPlaces));
                     displayString = `${val} ${unit}`.trim();
                   }
                 } else if (measurement.type === 'stress') {

--- a/SparkyFitnessFrontend/src/pages/Settings/PreferenceSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/PreferenceSettings.tsx
@@ -3,6 +3,7 @@ import {
   getLanguageDisplayName,
 } from '@/utils/languageUtils'; // Import language utilities
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
   Select,
@@ -51,6 +52,8 @@ export const PreferenceSettings = () => {
     loggingLevel,
     firstDayOfWeek,
     setFirstDayOfWeek,
+    measurementDecimalPlaces,
+    setMeasurementDecimalPlaces,
     timezone,
     setTimezone,
     saveAllPreferences,
@@ -78,6 +81,7 @@ export const PreferenceSettings = () => {
         autoScaleOnlineImports,
         language,
         firstDayOfWeek,
+        measurementDecimalPlaces,
         timezone,
         loggingLevel: localLoggingLevel,
       });
@@ -229,6 +233,25 @@ export const PreferenceSettings = () => {
                 </SelectItem>
               </SelectContent>
             </Select>
+          </div>
+          <div>
+            <Label htmlFor="measurement_decimal_places">
+              {t(
+                'settings.preferences.measurementDecimalPlaces',
+                'Measurement Decimal Places'
+              )}
+            </Label>
+            <Input
+              id="measurement_decimal_places"
+              type="number"
+              min={0}
+              value={measurementDecimalPlaces}
+              onChange={(e) =>
+                setMeasurementDecimalPlaces(
+                  Math.max(0, parseInt(e.target.value, 10) || 0)
+                )
+              }
+            />
           </div>
           <div>
             <Label htmlFor="first_day_of_week">

--- a/SparkyFitnessFrontend/src/tests/components/RecentActivity.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/RecentActivity.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { RecentActivity } from '@/pages/CheckIn/RecentActivity';
+import { CombinedMeasurement } from '@/types/checkin';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: string) => defaultValue,
+  }),
+}));
+
+jest.mock('@/contexts/PreferencesContext', () => ({
+  usePreferences: () => ({
+    weightUnit: 'kg',
+    measurementUnit: 'cm',
+  }),
+}));
+
+const baseMeasurement: CombinedMeasurement = {
+  id: '1',
+  entry_date: '2026-06-22',
+  entry_hour: 14,
+  entry_timestamp: '2026-06-22T14:00:00Z',
+  value: '72',
+  type: 'custom',
+  display_name: 'Body Battery Charged',
+};
+
+const defaultProps = {
+  convertMeasurement: jest.fn((v: number) => v),
+  convertWeight: jest.fn((v: number) => v),
+  handleDeleteMeasurementClick: jest.fn(),
+  recentMeasurements: [] as CombinedMeasurement[],
+  shouldConvertCustomMeasurement: jest.fn(() => false),
+};
+
+describe('RecentActivity', () => {
+  it('hides N/A unit for custom measurements', () => {
+    const measurements: CombinedMeasurement[] = [
+      {
+        ...baseMeasurement,
+        value: '72',
+        custom_categories: {
+          id: 'cat1',
+          name: 'Body Battery Charged',
+          measurement_type: 'N/A',
+          frequency: 'daily',
+          data_type: null,
+          display_name: 'Body Battery Charged',
+        },
+      },
+    ];
+
+    render(
+      <RecentActivity {...defaultProps} recentMeasurements={measurements} />
+    );
+
+    expect(screen.getByText('72')).toBeInTheDocument();
+    expect(screen.queryByText(/N\/A/)).not.toBeInTheDocument();
+  });
+
+  it('rounds decimal values for custom measurements with N/A unit', () => {
+    const measurements: CombinedMeasurement[] = [
+      {
+        ...baseMeasurement,
+        display_name: 'BMI',
+        value: '23.700000762939453',
+        custom_categories: {
+          id: 'cat2',
+          name: 'BMI',
+          measurement_type: 'N/A',
+          frequency: 'daily',
+          data_type: null,
+          display_name: 'BMI',
+        },
+      },
+    ];
+
+    render(
+      <RecentActivity {...defaultProps} recentMeasurements={measurements} />
+    );
+
+    expect(screen.getByText('24')).toBeInTheDocument();
+    expect(screen.queryByText(/23\.7/)).not.toBeInTheDocument();
+  });
+
+  it('rounds decimal values for standard measurements with non-standard units', () => {
+    const measurements: CombinedMeasurement[] = [
+      {
+        ...baseMeasurement,
+        type: 'standard',
+        display_name: 'Fitness Age',
+        value: '29.322887991352367',
+        display_unit: 'years',
+      },
+    ];
+
+    render(
+      <RecentActivity {...defaultProps} recentMeasurements={measurements} />
+    );
+
+    expect(screen.getByText('29 years')).toBeInTheDocument();
+    expect(screen.queryByText(/29\.3/)).not.toBeInTheDocument();
+  });
+
+  it('hides N/A unit for standard measurements', () => {
+    const measurements: CombinedMeasurement[] = [
+      {
+        ...baseMeasurement,
+        type: 'standard',
+        display_name: 'Body Battery Current',
+        value: '93',
+        display_unit: 'N/A',
+      },
+    ];
+
+    render(
+      <RecentActivity {...defaultProps} recentMeasurements={measurements} />
+    );
+
+    expect(screen.getByText('93')).toBeInTheDocument();
+    expect(screen.queryByText(/N\/A/)).not.toBeInTheDocument();
+  });
+
+  it('preserves valid units for custom measurements', () => {
+    const measurements: CombinedMeasurement[] = [
+      {
+        ...baseMeasurement,
+        display_name: 'Steps',
+        value: '813',
+        custom_categories: {
+          id: 'cat3',
+          name: 'Steps',
+          measurement_type: 'steps',
+          frequency: 'daily',
+          data_type: null,
+          display_name: 'Steps',
+        },
+      },
+    ];
+
+    render(
+      <RecentActivity {...defaultProps} recentMeasurements={measurements} />
+    );
+
+    expect(screen.getByText('813 steps')).toBeInTheDocument();
+  });
+
+  it('preserves valid units for standard measurements', () => {
+    const measurements: CombinedMeasurement[] = [
+      {
+        ...baseMeasurement,
+        type: 'standard',
+        display_name: 'Lactate Threshold HR',
+        value: '172',
+        display_unit: 'bpm',
+      },
+    ];
+
+    render(
+      <RecentActivity {...defaultProps} recentMeasurements={measurements} />
+    );
+
+    expect(screen.getByText('172 bpm')).toBeInTheDocument();
+  });
+
+  it('falls back to raw value when value is not a valid number', () => {
+    const measurements: CombinedMeasurement[] = [
+      {
+        ...baseMeasurement,
+        display_name: 'Some Metric',
+        value: 'abc',
+        custom_categories: {
+          id: 'cat4',
+          name: 'Some Metric',
+          measurement_type: 'N/A',
+          frequency: 'daily',
+          data_type: null,
+          display_name: 'Some Metric',
+        },
+      },
+    ];
+
+    render(
+      <RecentActivity {...defaultProps} recentMeasurements={measurements} />
+    );
+
+    expect(screen.getByText('abc')).toBeInTheDocument();
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/components/RecentActivity.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/RecentActivity.test.tsx
@@ -9,11 +9,14 @@ jest.mock('react-i18next', () => ({
   }),
 }));
 
+const mockPreferences = {
+  weightUnit: 'kg',
+  measurementUnit: 'cm',
+  measurementDecimalPlaces: 0,
+};
+
 jest.mock('@/contexts/PreferencesContext', () => ({
-  usePreferences: () => ({
-    weightUnit: 'kg',
-    measurementUnit: 'cm',
-  }),
+  usePreferences: () => mockPreferences,
 }));
 
 const baseMeasurement: CombinedMeasurement = {
@@ -186,5 +189,33 @@ describe('RecentActivity', () => {
     );
 
     expect(screen.getByText('abc')).toBeInTheDocument();
+  });
+
+  it('respects measurementDecimalPlaces preference', () => {
+    mockPreferences.measurementDecimalPlaces = 1;
+
+    const measurements: CombinedMeasurement[] = [
+      {
+        ...baseMeasurement,
+        display_name: 'BMI',
+        value: '23.700000762939453',
+        custom_categories: {
+          id: 'cat5',
+          name: 'BMI',
+          measurement_type: 'N/A',
+          frequency: 'daily',
+          data_type: null,
+          display_name: 'BMI',
+        },
+      },
+    ];
+
+    render(
+      <RecentActivity {...defaultProps} recentMeasurements={measurements} />
+    );
+
+    expect(screen.getByText('23.7')).toBeInTheDocument();
+
+    mockPreferences.measurementDecimalPlaces = 0;
   });
 });

--- a/SparkyFitnessServer/db/migrations/20260623000000_add_measurement_decimal_places.sql
+++ b/SparkyFitnessServer/db/migrations/20260623000000_add_measurement_decimal_places.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.user_preferences
+  ADD COLUMN measurement_decimal_places integer NOT NULL DEFAULT 0;

--- a/SparkyFitnessServer/models/preferenceRepository.ts
+++ b/SparkyFitnessServer/models/preferenceRepository.ts
@@ -42,6 +42,7 @@ async function updateUserPreferences(userId: any, preferenceData: any) {
         add_exercise_water_to_goal = COALESCE($40, add_exercise_water_to_goal),
         default_barcode_provider_id = CASE WHEN $28 THEN $27 ELSE default_barcode_provider_id END,
         active_ai_service_id = CASE WHEN $39 THEN $38 ELSE active_ai_service_id END,
+        measurement_decimal_places = COALESCE($41, measurement_decimal_places),
         updated_at = now()
       WHERE user_id = $29
       RETURNING *`,
@@ -86,6 +87,7 @@ async function updateUserPreferences(userId: any, preferenceData: any) {
         preferenceData.active_ai_service_id,
         'active_ai_service_id' in preferenceData,
         preferenceData.add_exercise_water_to_goal,
+        preferenceData.measurement_decimal_places,
       ]
     );
     return result.rows[0];
@@ -169,6 +171,7 @@ async function upsertUserPreferences(preferenceData: any) {
        use_external_bmr,
        add_exercise_water_to_goal,
        active_ai_service_id,
+       measurement_decimal_places,
        created_at, updated_at
      ) VALUES (
        $1, COALESCE($2, 'yyyy-MM-dd'), COALESCE($3, 'lbs'), COALESCE($4, 'in'), COALESCE($5, 'km'),
@@ -191,6 +194,7 @@ async function upsertUserPreferences(preferenceData: any) {
        COALESCE($37, false),
        COALESCE($40, false),
        $38,
+       COALESCE($41, 0),
        now(), now()
      )
      ON CONFLICT (user_id) DO UPDATE SET
@@ -231,6 +235,7 @@ async function upsertUserPreferences(preferenceData: any) {
        add_exercise_water_to_goal = COALESCE(EXCLUDED.add_exercise_water_to_goal, user_preferences.add_exercise_water_to_goal),
        default_barcode_provider_id = CASE WHEN $29 THEN EXCLUDED.default_barcode_provider_id ELSE user_preferences.default_barcode_provider_id END,
        active_ai_service_id = CASE WHEN $39 THEN EXCLUDED.active_ai_service_id ELSE user_preferences.active_ai_service_id END,
+       measurement_decimal_places = COALESCE(EXCLUDED.measurement_decimal_places, user_preferences.measurement_decimal_places),
        updated_at = now()
      RETURNING *`,
       [
@@ -274,6 +279,7 @@ async function upsertUserPreferences(preferenceData: any) {
         preferenceData.active_ai_service_id,
         'active_ai_service_id' in preferenceData,
         preferenceData.add_exercise_water_to_goal,
+        preferenceData.measurement_decimal_places,
       ]
     );
     return result.rows[0];

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -2436,6 +2436,7 @@ CREATE TABLE public.user_preferences (
     goal_mode character varying(50) DEFAULT 'maintain'::character varying NOT NULL,
     goal_mode_calculation_method character varying(50) DEFAULT 'manual'::character varying NOT NULL,
     goal_mode_custom_percentage integer DEFAULT 0 NOT NULL,
+    measurement_decimal_places integer DEFAULT 0 NOT NULL,
     use_external_bmr boolean DEFAULT false NOT NULL,
     add_exercise_water_to_goal boolean DEFAULT false NOT NULL,
     active_ai_service_id uuid,

--- a/shared/src/schemas/database/UserPreferences.zod.ts
+++ b/shared/src/schemas/database/UserPreferences.zod.ts
@@ -40,6 +40,7 @@ export const userPreferencesSchema = z.object({
   goal_mode: z.enum(['maintain', 'recomp', 'cut', 'high_cut', 'manual']),
   goal_mode_calculation_method: z.enum(['adaptive', 'manual']),
   goal_mode_custom_percentage: z.number().int().min(0).max(40),
+  measurement_decimal_places: z.number().int().min(0),
   // Manually added (file is ts-to-zod generated; precedent: MealFoods.zod.ts). Keep on regen.
   use_external_bmr: z.boolean(),
   active_ai_service_id: z.string().uuid().nullable().optional(),
@@ -84,6 +85,7 @@ export const userPreferencesInitializerSchema = z.object({
   goal_mode: z.enum(['maintain', 'recomp', 'cut', 'high_cut', 'manual']).optional(),
   goal_mode_calculation_method: z.enum(['adaptive', 'manual']).optional(),
   goal_mode_custom_percentage: z.number().int().min(0).max(40).optional(),
+  measurement_decimal_places: z.number().int().min(0).optional(),
   use_external_bmr: z.boolean().optional(),
   active_ai_service_id: z.string().uuid().nullable().optional(),
 });
@@ -127,6 +129,7 @@ export const userPreferencesMutatorSchema = z.object({
   goal_mode: z.enum(['maintain', 'recomp', 'cut', 'high_cut', 'manual']).optional(),
   goal_mode_calculation_method: z.enum(['adaptive', 'manual']).optional(),
   goal_mode_custom_percentage: z.number().int().min(0).max(40).optional(),
+  measurement_decimal_places: z.number().int().min(0).optional(),
   use_external_bmr: z.boolean().optional(),
   active_ai_service_id: z.string().uuid().nullable().optional(),
 });


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Garmin-synced measurements displayed raw floating-point values (e.g. 23.700000762939453) and showed "N/A" as a unit string. Round values to the nearest integer and suppress "N/A" display units in all fallback rendering paths.


**How did you implement the solution?**
Rounded them

Linked Issue: Closes #

## How to Test

1. Check out this branch and run 
2. Navigate to check in
3. Verify that the number make sense

## PR Type

- [X] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [X] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [X] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [X] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [X] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [X] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [X] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="1300" height="225" alt="image" src="https://github.com/user-attachments/assets/a7e3b50b-632b-43ac-9438-077ccb88cef0" />

### After

<img width="1309" height="379" alt="image" src="https://github.com/user-attachments/assets/cc67157c-3842-4eea-8595-9929855f7197" />

</details>


