### PR TITLE
fix: migration names match rls policy

### DIFF
--- a/SparkyFitnessServer/db/migrations/20260620143300_public_sharing_and_dynamic_provider_types.sql
+++ b/SparkyFitnessServer/db/migrations/20260620143300_public_sharing_and_dynamic_provider_types.sql
@@ -64,7 +64,14 @@ ALTER TABLE public.user_preferences ADD COLUMN IF NOT EXISTS active_ai_service_i
 
 
 
--- Drop old policies that depend on the old column
+-- Drop old policies that depend on the old column.
+-- The migration chain creates these policies with the external_data_providers_*
+-- prefix (20251021025423, 20251023120500); rls_policies.sql later renames them to
+-- the generic names below. Both sets must be dropped so DROP COLUMN succeeds on a
+-- fresh install (where only the prefixed names exist yet) as well as on an existing
+-- install (where applyRlsPolicies has already renamed them).
+DROP POLICY IF EXISTS external_data_providers_select_policy ON public.external_data_providers;
+DROP POLICY IF EXISTS external_data_providers_modify_policy ON public.external_data_providers;
 DROP POLICY IF EXISTS select_policy ON public.external_data_providers;
 DROP POLICY IF EXISTS modify_policy ON public.external_data_providers;
 DROP POLICY IF EXISTS insert_policy ON public.external_data_providers;


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

The migration name for external providers does not match the rls name for the same rls policy. This naming drift causes issues in fresh installs when only migration era names exist. This PR adds DROP POLICY before DROP COLUMN to drop the block.

Linked Issue: Closes #1614

## How to Test

Verified this works for fresh installs as well as the error state the user reported in.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
