### PR TITLE
fix: coerce string-typed pagination fields in food search response (#1619)

### DIFF
--- a/SparkyFitnessServer/schemas/foodSchemas.ts
+++ b/SparkyFitnessServer/schemas/foodSchemas.ts
@@ -58,10 +58,11 @@ export const PaginationSchema = z.object({
   // these pagination values as strings, and the same field can switch between a
   // string and a number across requests. Coerce them so any provider that sends
   // string-typed numeric pagination is normalized rather than failing response
-  // validation. `hasMore` stays a strict boolean.
-  page: z.coerce.number(),
-  pageSize: z.coerce.number(),
-  totalCount: z.coerce.number(),
+  // validation. `.int()` makes the integer intent explicit and rejects
+  // non-integer floats (e.g. "1.5"). `hasMore` stays a strict boolean.
+  page: z.coerce.number().int(),
+  pageSize: z.coerce.number().int(),
+  totalCount: z.coerce.number().int(),
   hasMore: z.boolean(),
 });
 

--- a/SparkyFitnessServer/schemas/foodSchemas.ts
+++ b/SparkyFitnessServer/schemas/foodSchemas.ts
@@ -54,9 +54,14 @@ export const NormalizedFoodSchema = z.object({
 export type NormalizedFood = z.infer<typeof NormalizedFoodSchema>;
 
 export const PaginationSchema = z.object({
-  page: z.number(),
-  pageSize: z.number(),
-  totalCount: z.number(),
+  // Some providers (e.g. Open Food Facts' legacy cgi/search.pl endpoint) report
+  // these pagination values as strings, and the same field can switch between a
+  // string and a number across requests. Coerce them so any provider that sends
+  // string-typed numeric pagination is normalized rather than failing response
+  // validation. `hasMore` stays a strict boolean.
+  page: z.coerce.number(),
+  pageSize: z.coerce.number(),
+  totalCount: z.coerce.number(),
   hasMore: z.boolean(),
 });
 

--- a/SparkyFitnessServer/tests/foodSchemas.test.ts
+++ b/SparkyFitnessServer/tests/foodSchemas.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PaginationSchema,
+  SearchResponseSchema,
+} from '../schemas/foodSchemas.js';
+
+const validVariant = {
+  serving_size: 100,
+  serving_unit: 'g',
+  calories: 50,
+  protein: 1,
+  carbs: 10,
+  fat: 0,
+  is_default: true,
+};
+
+const validFood = {
+  name: 'Yam',
+  brand: null,
+  is_custom: false,
+  default_variant: validVariant,
+};
+
+describe('PaginationSchema', () => {
+  it('accepts numeric pagination fields and keeps them as numbers', () => {
+    const result = PaginationSchema.safeParse({
+      page: 1,
+      pageSize: 20,
+      totalCount: 42,
+      hasMore: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.page).toBe(1);
+      expect(result.data.pageSize).toBe(20);
+      expect(result.data.totalCount).toBe(42);
+    }
+  });
+
+  it('coerces string-typed numeric pagination fields to numbers', () => {
+    // Open Food Facts' legacy cgi/search.pl endpoint returns page (and at times
+    // page_size/count) as strings, which previously threw a ZodError and
+    // surfaced as a 500 "Internal response validation failed".
+    const result = PaginationSchema.safeParse({
+      page: '1',
+      pageSize: '20',
+      totalCount: '42',
+      hasMore: false,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.page).toBe(1);
+      expect(result.data.pageSize).toBe(20);
+      expect(result.data.totalCount).toBe(42);
+      expect(typeof result.data.page).toBe('number');
+      expect(typeof result.data.pageSize).toBe('number');
+      expect(typeof result.data.totalCount).toBe('number');
+    }
+  });
+
+  it('still rejects a non-boolean hasMore', () => {
+    const result = PaginationSchema.safeParse({
+      page: 1,
+      pageSize: 20,
+      totalCount: 42,
+      hasMore: 'true',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('SearchResponseSchema', () => {
+  it('validates a search response whose pagination fields arrive as strings', () => {
+    const result = SearchResponseSchema.safeParse({
+      foods: [validFood],
+      pagination: {
+        page: '1',
+        pageSize: '20',
+        totalCount: '1',
+        hasMore: false,
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.pagination.page).toBe(1);
+      expect(result.data.pagination.totalCount).toBe(1);
+    }
+  });
+});

--- a/SparkyFitnessServer/tests/foodSchemas.test.ts
+++ b/SparkyFitnessServer/tests/foodSchemas.test.ts
@@ -58,6 +58,16 @@ describe('PaginationSchema', () => {
     }
   });
 
+  it('rejects a non-integer float string like "1.5" in pagination fields', () => {
+    const result = PaginationSchema.safeParse({
+      page: '1.5',
+      pageSize: 20,
+      totalCount: 42,
+      hasMore: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
   it('still rejects a non-boolean hasMore', () => {
     const result = PaginationSchema.safeParse({
       page: 1,


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.

## Description

**What problem does this PR solve?**
Online food search returns a 500 (`Internal response validation failed`) for providers that report pagination fields as strings — most visibly Open Food Facts, which is seeded as an active provider on every install. This drops all results for those providers.

**How did you implement the solution?**
`PaginationSchema` in `SparkyFitnessServer/schemas/foodSchemas.ts` declared `page`/`pageSize`/`totalCount` as `z.number()`. Open Food Facts' legacy `cgi/search.pl` endpoint returns those as strings (inconsistently — the same field flips between string and number across requests), so `SearchResponseSchema.parse()` in the v2 food search route threw a `ZodError` that the route mapped to a 500. The fix coerces those three numeric pagination fields with `z.coerce.number()` at the schema boundary (`hasMore` stays a strict boolean). Coercing at the schema rather than in a single adapter normalizes string-typed pagination defensively for every provider, and does not regress providers that already return numbers.

Linked Issue: Closes #1619

## How to Test

1. Check out this branch, then in `SparkyFitnessServer/` run `pnpm install`.
2. Run the new regression test: `pnpm exec vitest run tests/foodSchemas.test.ts` — 4 tests pass.
3. To confirm the test exercises the fix, temporarily revert the three `z.coerce.number()` calls back to `z.number()` in `schemas/foodSchemas.ts` and re-run: the two string-pagination cases fail with the same `invalid_type` ZodError seen in the issue.
4. End to end: with Open Food Facts selected as the provider, search a common term (e.g. `yam`) against `GET /api/v2/foods/search/openfoodfacts` and confirm it returns 200 with results instead of the `Internal response validation failed` toast.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

N/A — backend-only change, no UI.

## Notes for Reviewers

- Scope is intentionally minimal: the schema change plus a regression test. No new tables, so `rls_policies.sql` is unchanged (Database Security box left unchecked as N/A).
- `pnpm exec eslint schemas/foodSchemas.ts tests/foodSchemas.test.ts` passes clean, and `prettier --check` passes for both files.
- `pnpm run typecheck` currently reports pre-existing errors on `main` (e.g. in `auth.ts` and `tests/exerciseService.groupedWorkouts.test.ts`) that are unrelated to this change; this PR introduces no new typecheck errors in the touched files.
- I considered normalizing in the Open Food Facts adapter instead, but coercing at `PaginationSchema` covers any provider that reports string pagination, which the issue notes is a recurring shape. Happy to move it into the adapter if you'd prefer per-provider handling.