### PR TITLE
fix(food-search): coerce provider pagination numerics to integers

### DIFF
--- a/SparkyFitnessServer/schemas/foodSchemas.ts
+++ b/SparkyFitnessServer/schemas/foodSchemas.ts
@@ -54,9 +54,16 @@ export const NormalizedFoodSchema = z.object({
 export type NormalizedFood = z.infer<typeof NormalizedFoodSchema>;
 
 export const PaginationSchema = z.object({
-  page: z.number(),
-  pageSize: z.number(),
-  totalCount: z.number(),
+  // Some providers (for example Open Food Facts) return pagination fields as
+  // strings. Coerce the numerics so a string page/pageSize/totalCount does not
+  // fail response validation. .int() keeps the integer intent explicit and (in
+  // zod v4, where z.coerce.number() already rejects NaN) rejects non-numeric
+  // junk. Value-range constraints are intentionally omitted so a provider that
+  // reports a 0 does not reintroduce a hard failure. hasMore stays a strict
+  // boolean.
+  page: z.coerce.number().int(),
+  pageSize: z.coerce.number().int(),
+  totalCount: z.coerce.number().int(),
   hasMore: z.boolean(),
 });
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Provider food search returns a 500 (`Internal response validation failed`) for any provider whose search API reports pagination fields as strings. Open Food Facts is the common case; USDA and other numeric-pagination providers are unaffected.

**How did you implement the solution?**
`PaginationSchema` (used by `SearchResponseSchema` to validate the v2 search response) declared `page`, `pageSize`, and `totalCount` as `z.number()`, but Open Food Facts (`cgi/search.pl`) returns those as strings at least some of the time, so the parse throws. This coerces the three fields with `z.coerce.number().int()` so string-typed integers validate while non-numeric values are still rejected (`z.coerce.number()` rejects `NaN` in zod v4). Value-range constraints are intentionally omitted so a provider that reports a `0` does not reintroduce a hard failure; `hasMore` stays a strict boolean.

Linked Issue: Closes #1619

## How to Test

1. Configure Open Food Facts as a food data provider (it is seeded active by default).
2. Search for a common term, for example `yam`.
3. Before this change, `GET /api/v2/foods/search/openfoodfacts?query=yam` can return 500 with `Internal response validation failed`; after it, the search returns results with a valid pagination object.
4. Confirm USDA search is unchanged.

Automated: `pnpm run validate` (typecheck, lint, format) is clean, and `tests/foodRoutesV2.test.ts` and `tests/swissFoodService.test.ts` pass.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.

## Notes for Reviewers

Backend-only, single-line schema change: no new tables, endpoints, migrations, frontend, UI, or mobile changes, so the Database Security, Frontend, UI, and Mobile items are not applicable (`rls_policies.sql` is unchanged).

The string-vs-number typing is inconsistent on the Open Food Facts side (the same `page=1` request was observed returning `page` as both a string and a number), which is why coercing at the schema is preferred over patching a single adapter: it covers every provider defensively. `.int()` keeps the integer intent explicit; `.positive()`/`.nonnegative()` were deliberately left off so a provider reporting a `0` does not hard-fail the search