### PR TITLE
fix(reports): make maximized charts fit the viewport and stop Y-axis label clipping

### DIFF
--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityCadenceChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityCadenceChart.tsx
@@ -44,7 +44,7 @@ export const ActivityCadenceChart = ({
           >
             <ResponsiveContainer
               width={`${100 * zoomLevel}%`}
-              height={isMaximized ? `${100 * zoomLevel}%` : 300 * zoomLevel}
+              height={isMaximized ? '100%' : 300 * zoomLevel}
               minWidth={0}
               minHeight={0}
               debounce={100}

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityElevationChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityElevationChart.tsx
@@ -45,7 +45,7 @@ export const ActivityElevationChart = ({
           >
             <ResponsiveContainer
               width={`${100 * zoomLevel}%`}
-              height={isMaximized ? `${100 * zoomLevel}%` : 300 * zoomLevel}
+              height={isMaximized ? '100%' : 300 * zoomLevel}
               minWidth={0}
               minHeight={0}
               debounce={100}

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityHeartRateChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityHeartRateChart.tsx
@@ -44,7 +44,7 @@ export const ActivityHeartRateChart = ({
           >
             <ResponsiveContainer
               width={`${100 * zoomLevel}%`}
-              height={isMaximized ? `${100 * zoomLevel}%` : 300 * zoomLevel}
+              height={isMaximized ? '100%' : 300 * zoomLevel}
               minWidth={0}
               minHeight={0}
               debounce={100}

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityHeartRateZoneChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityHeartRateZoneChart.tsx
@@ -41,7 +41,7 @@ export const ActivityHeartRateZonesChart = ({
           >
             <ResponsiveContainer
               width={`${100 * zoomLevel}%`}
-              height={isMaximized ? `${100 * zoomLevel}%` : 300 * zoomLevel}
+              height={isMaximized ? '100%' : 300 * zoomLevel}
               minWidth={0}
               minHeight={0}
               debounce={100}

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityPaceChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/ActivityPaceChart.tsx
@@ -44,7 +44,7 @@ export const ActivityPaceChart = ({
           >
             <ResponsiveContainer
               width={`${100 * zoomLevel}%`}
-              height={isMaximized ? `${100 * zoomLevel}%` : 300 * zoomLevel}
+              height={isMaximized ? '100%' : 300 * zoomLevel}
               minWidth={0}
               minHeight={0}
               debounce={100}

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/BestSetRepRangeChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/BestSetRepRangeChart.tsx
@@ -43,35 +43,45 @@ export const BestSetRepRangeChart = ({
             'Best Set by Rep Range'
           )}
         >
-          <ResponsiveContainer
-            width="100%"
-            height={300}
-            minWidth={0}
-            minHeight={0}
-            debounce={100}
-          >
-            <BarChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="range" />
-              <YAxis
-                label={{
-                  value: t(
-                    'exerciseReportsDashboard.maxWeight',
-                    `Weight (${weightUnit})`,
-                    { weightUnit }
-                  ),
-                  angle: -90,
-                  position: 'insideLeft',
-                  offset: 10,
-                }}
-              />
-              <Tooltip
-                contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
-              />
-              <Legend />
-              <Bar dataKey="weight" fill="#8884d8" isAnimationActive={false} />
-            </BarChart>
-          </ResponsiveContainer>
+          {(isMaximized, zoomLevel) => (
+            <ResponsiveContainer
+              width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+              height={isMaximized ? '100%' : 300}
+              minWidth={0}
+              minHeight={0}
+              debounce={100}
+            >
+              <BarChart
+                data={data}
+                margin={{ top: 20, right: 30, bottom: 20, left: 20 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="range" />
+                <YAxis
+                  label={{
+                    value: t(
+                      'exerciseReportsDashboard.maxWeight',
+                      `Weight (${weightUnit})`,
+                      { weightUnit }
+                    ),
+                    angle: -90,
+                    position: 'insideLeft',
+                    offset: 10,
+                    style: { textAnchor: 'middle' },
+                  }}
+                />
+                <Tooltip
+                  contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
+                />
+                <Legend />
+                <Bar
+                  dataKey="weight"
+                  fill="#8884d8"
+                  isAnimationActive={false}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </ZoomableChart>
       </CardContent>
     </Card>

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/Estimated1RMTrendChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/Estimated1RMTrendChart.tsx
@@ -48,59 +48,65 @@ export const Estimated1RMTrendChart = ({
             'Estimated 1RM Trend'
           )}
         >
-          <ResponsiveContainer
-            width="100%"
-            height={300}
-            minWidth={0}
-            minHeight={0}
-            debounce={100}
-          >
-            <BarChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="date" />
-              <YAxis
-                tickFormatter={(value) => formatWeight(value, weightUnit)}
-                label={{
-                  value: t(
-                    'exerciseReportsDashboard.estimated1RMCurrent',
-                    `Estimated 1RM (${weightUnit})`,
-                    { weightUnit }
-                  ),
-                  angle: -90,
-                  position: 'insideLeft',
-                  offset: 10,
-                }}
-              />
-              <Tooltip
-                formatter={(value: TooltipValueType | undefined) =>
-                  value ? formatWeight(Number(value), weightUnit) : 0
-                }
-                contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
-              />
-              <Legend />
-              <Bar
-                dataKey="estimated1RM"
-                fill="#ffc658"
-                name={t(
-                  'exerciseReportsDashboard.estimated1RMCurrent',
-                  'Estimated 1RM (Current)'
-                )}
-                isAnimationActive={false}
-              />
-              {comparisonPeriod && (
+          {(isMaximized, zoomLevel) => (
+            <ResponsiveContainer
+              width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+              height={isMaximized ? '100%' : 300}
+              minWidth={0}
+              minHeight={0}
+              debounce={100}
+            >
+              <BarChart
+                data={data}
+                margin={{ top: 20, right: 30, bottom: 20, left: 20 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis
+                  tickFormatter={(value) => formatWeight(value, weightUnit)}
+                  label={{
+                    value: t(
+                      'exerciseReportsDashboard.estimated1RMCurrent',
+                      `Estimated 1RM (${weightUnit})`,
+                      { weightUnit }
+                    ),
+                    angle: -90,
+                    position: 'insideLeft',
+                    offset: 10,
+                    style: { textAnchor: 'middle' },
+                  }}
+                />
+                <Tooltip
+                  formatter={(value: TooltipValueType | undefined) =>
+                    value ? formatWeight(Number(value), weightUnit) : 0
+                  }
+                  contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
+                />
+                <Legend />
                 <Bar
-                  dataKey="comparisonEstimated1RM"
+                  dataKey="estimated1RM"
                   fill="#ffc658"
-                  opacity={0.6}
                   name={t(
-                    'exerciseReportsDashboard.estimated1RMComparison',
-                    'Estimated 1RM (Comparison)'
+                    'exerciseReportsDashboard.estimated1RMCurrent',
+                    'Estimated 1RM (Current)'
                   )}
                   isAnimationActive={false}
                 />
-              )}
-            </BarChart>
-          </ResponsiveContainer>
+                {comparisonPeriod && (
+                  <Bar
+                    dataKey="comparisonEstimated1RM"
+                    fill="#ffc658"
+                    opacity={0.6}
+                    name={t(
+                      'exerciseReportsDashboard.estimated1RMComparison',
+                      'Estimated 1RM (Comparison)'
+                    )}
+                    isAnimationActive={false}
+                  />
+                )}
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </ZoomableChart>
       </CardContent>
     </Card>

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/MaxWeightTrendChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/MaxWeightTrendChart.tsx
@@ -41,59 +41,65 @@ export const MaxWeightTrendChart = ({
             'Max Weight Trend'
           )}
         >
-          <ResponsiveContainer
-            width="100%"
-            height={300}
-            minWidth={0}
-            minHeight={0}
-            debounce={100}
-          >
-            <BarChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="date" />
-              <YAxis
-                tickFormatter={(value) => formatWeight(value, weightUnit)}
-                label={{
-                  value: t(
-                    'exerciseReportsDashboard.maxWeightCurrent',
-                    `Max Weight (${weightUnit})`,
-                    { weightUnit }
-                  ),
-                  angle: -90,
-                  position: 'insideLeft',
-                  offset: 10,
-                }}
-              />
-              <Tooltip
-                formatter={(value: TooltipValueType | undefined) =>
-                  value ? formatWeight(Number(value), weightUnit) : 0
-                }
-                contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
-              />
-              <Legend />
-              <Bar
-                dataKey="maxWeight"
-                fill="#82ca9d"
-                name={t(
-                  'exerciseReportsDashboard.maxWeightCurrent',
-                  'Max Weight (Current)'
-                )}
-                isAnimationActive={false}
-              />
-              {comparisonPeriod && (
+          {(isMaximized, zoomLevel) => (
+            <ResponsiveContainer
+              width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+              height={isMaximized ? '100%' : 300}
+              minWidth={0}
+              minHeight={0}
+              debounce={100}
+            >
+              <BarChart
+                data={data}
+                margin={{ top: 20, right: 30, bottom: 20, left: 20 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis
+                  tickFormatter={(value) => formatWeight(value, weightUnit)}
+                  label={{
+                    value: t(
+                      'exerciseReportsDashboard.maxWeightCurrent',
+                      `Max Weight (${weightUnit})`,
+                      { weightUnit }
+                    ),
+                    angle: -90,
+                    position: 'insideLeft',
+                    offset: 10,
+                    style: { textAnchor: 'middle' },
+                  }}
+                />
+                <Tooltip
+                  formatter={(value: TooltipValueType | undefined) =>
+                    value ? formatWeight(Number(value), weightUnit) : 0
+                  }
+                  contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
+                />
+                <Legend />
                 <Bar
-                  dataKey="comparisonMaxWeight"
+                  dataKey="maxWeight"
                   fill="#82ca9d"
-                  opacity={0.6}
                   name={t(
-                    'exerciseReportsDashboard.maxWeightComparison',
-                    'Max Weight (Comparison)'
+                    'exerciseReportsDashboard.maxWeightCurrent',
+                    'Max Weight (Current)'
                   )}
                   isAnimationActive={false}
                 />
-              )}
-            </BarChart>
-          </ResponsiveContainer>
+                {comparisonPeriod && (
+                  <Bar
+                    dataKey="comparisonMaxWeight"
+                    fill="#82ca9d"
+                    opacity={0.6}
+                    name={t(
+                      'exerciseReportsDashboard.maxWeightComparison',
+                      'Max Weight (Comparison)'
+                    )}
+                    isAnimationActive={false}
+                  />
+                )}
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </ZoomableChart>
       </CardContent>
     </Card>

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/RepsVsWeightChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/RepsVsWeightChart.tsx
@@ -42,47 +42,50 @@ export const RepsVsWeightChart = ({
             exerciseName: '',
           })}
         >
-          <ResponsiveContainer
-            width="100%"
-            height={300}
-            minWidth={0}
-            minHeight={0}
-            debounce={100}
-          >
-            <BarChart
-              margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
-              data={data}
+          {(isMaximized, zoomLevel) => (
+            <ResponsiveContainer
+              width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+              height={isMaximized ? '100%' : 300}
+              minWidth={0}
+              minHeight={0}
+              debounce={100}
             >
-              <CartesianGrid />
-              <XAxis
-                dataKey="reps"
-                name={t('exerciseReportsDashboard.reps', 'Reps')}
-              />
-              <YAxis
-                label={{
-                  value: t(
-                    'exerciseReportsDashboard.averageWeight',
-                    `Average Weight (${weightUnit})`,
-                    { weightUnit }
-                  ),
-                  angle: -90,
-                  position: 'insideLeft',
-                  offset: 10,
-                }}
-              />
-              <Tooltip
-                cursor={{ strokeDasharray: '3 3' }}
-                contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
-              />
-              <Legend />
-              <Bar
-                dataKey="averageWeight"
-                name={exerciseName}
-                fill="#a4de6c"
-                isAnimationActive={false}
-              />
-            </BarChart>
-          </ResponsiveContainer>
+              <BarChart
+                margin={{ top: 20, right: 20, bottom: 20, left: 20 }}
+                data={data}
+              >
+                <CartesianGrid />
+                <XAxis
+                  dataKey="reps"
+                  name={t('exerciseReportsDashboard.reps', 'Reps')}
+                />
+                <YAxis
+                  label={{
+                    value: t(
+                      'exerciseReportsDashboard.averageWeight',
+                      `Average Weight (${weightUnit})`,
+                      { weightUnit }
+                    ),
+                    angle: -90,
+                    position: 'insideLeft',
+                    offset: 10,
+                    style: { textAnchor: 'middle' },
+                  }}
+                />
+                <Tooltip
+                  cursor={{ strokeDasharray: '3 3' }}
+                  contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
+                />
+                <Legend />
+                <Bar
+                  dataKey="averageWeight"
+                  name={exerciseName}
+                  fill="#a4de6c"
+                  isAnimationActive={false}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </ZoomableChart>
       </CardContent>
     </Card>

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/TimeUnderTensionChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/TimeUnderTensionChart.tsx
@@ -41,39 +41,45 @@ export const TimeUnderTensionChart = ({
             'Time Under Tension Trend'
           )}
         >
-          <ResponsiveContainer
-            width="100%"
-            height={300}
-            minWidth={0}
-            minHeight={0}
-            debounce={100}
-          >
-            <BarChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="date" />
-              <YAxis
-                label={{
-                  value: t(
-                    'exerciseReportsDashboard.timeUnderTensionMin',
-                    'Time Under Tension (min)'
-                  ),
-                  angle: -90,
-                  position: 'insideLeft',
-                  offset: 10,
-                }}
-              />
-              <Tooltip
-                contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
-              />
-              <Legend />
-              <Bar
-                dataKey="timeUnderTension"
-                fill="#d0ed57"
-                name={exerciseName}
-                isAnimationActive={false}
-              />
-            </BarChart>
-          </ResponsiveContainer>
+          {(isMaximized, zoomLevel) => (
+            <ResponsiveContainer
+              width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+              height={isMaximized ? '100%' : 300}
+              minWidth={0}
+              minHeight={0}
+              debounce={100}
+            >
+              <BarChart
+                data={data}
+                margin={{ top: 20, right: 30, bottom: 20, left: 20 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis
+                  label={{
+                    value: t(
+                      'exerciseReportsDashboard.timeUnderTensionMin',
+                      'Time Under Tension (min)'
+                    ),
+                    angle: -90,
+                    position: 'insideLeft',
+                    offset: 10,
+                    style: { textAnchor: 'middle' },
+                  }}
+                />
+                <Tooltip
+                  contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
+                />
+                <Legend />
+                <Bar
+                  dataKey="timeUnderTension"
+                  fill="#d0ed57"
+                  name={exerciseName}
+                  isAnimationActive={false}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </ZoomableChart>
       </CardContent>
     </Card>

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/TrainingVolumeByMuscleGroupChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/TrainingVolumeByMuscleGroupChart.tsx
@@ -41,7 +41,10 @@ export const TrainingVolumeByMuscleGroupChart = ({
             minHeight={0}
             debounce={100}
           >
-            <BarChart data={data}>
+            <BarChart
+              data={data}
+              margin={{ top: 20, right: 30, bottom: 20, left: 20 }}
+            >
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="muscle" />
               <YAxis
@@ -54,6 +57,7 @@ export const TrainingVolumeByMuscleGroupChart = ({
                   angle: -90,
                   position: 'insideLeft',
                   offset: 10,
+                  style: { textAnchor: 'middle' },
                 }}
               />
               <Tooltip

--- a/SparkyFitnessFrontend/src/components/ExerciseCharts/VolumeTrendChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ExerciseCharts/VolumeTrendChart.tsx
@@ -38,59 +38,65 @@ export const VolumeTrendChart = ({
         <ZoomableChart
           title={t('exerciseReportsDashboard.volumeTrend', 'Volume Trend')}
         >
-          <ResponsiveContainer
-            width="100%"
-            height={300}
-            minWidth={0}
-            minHeight={0}
-            debounce={100}
-          >
-            <BarChart data={data}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="date" />
-              <YAxis
-                tickFormatter={(value) => formatWeight(value, weightUnit)}
-                label={{
-                  value: t(
-                    'exerciseReportsDashboard.volumeCurrent',
-                    `Volume (${weightUnit})`,
-                    { weightUnit }
-                  ),
-                  angle: -90,
-                  position: 'insideLeft',
-                  offset: 10,
-                }}
-              />
-              <Tooltip
-                formatter={(value: TooltipValueType | undefined) =>
-                  value ? formatWeight(Number(value), weightUnit) : 0
-                }
-                contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
-              />
-              <Legend />
-              <Bar
-                dataKey="volume"
-                fill="#8884d8"
-                name={t(
-                  'exerciseReportsDashboard.volumeCurrent',
-                  'Volume (Current)'
-                )}
-                isAnimationActive={false}
-              />
-              {comparisonPeriod && (
+          {(isMaximized, zoomLevel) => (
+            <ResponsiveContainer
+              width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+              height={isMaximized ? '100%' : 300}
+              minWidth={0}
+              minHeight={0}
+              debounce={100}
+            >
+              <BarChart
+                data={data}
+                margin={{ top: 20, right: 30, bottom: 20, left: 20 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis
+                  tickFormatter={(value) => formatWeight(value, weightUnit)}
+                  label={{
+                    value: t(
+                      'exerciseReportsDashboard.volumeCurrent',
+                      `Volume (${weightUnit})`,
+                      { weightUnit }
+                    ),
+                    angle: -90,
+                    position: 'insideLeft',
+                    offset: 10,
+                    style: { textAnchor: 'middle' },
+                  }}
+                />
+                <Tooltip
+                  formatter={(value: TooltipValueType | undefined) =>
+                    value ? formatWeight(Number(value), weightUnit) : 0
+                  }
+                  contentStyle={{ backgroundColor: 'hsl(var(--background))' }}
+                />
+                <Legend />
                 <Bar
-                  dataKey="comparisonVolume"
+                  dataKey="volume"
                   fill="#8884d8"
-                  opacity={0.6}
                   name={t(
-                    'exerciseReportsDashboard.volumeComparison',
-                    'Volume (Comparison)'
+                    'exerciseReportsDashboard.volumeCurrent',
+                    'Volume (Current)'
                   )}
                   isAnimationActive={false}
                 />
-              )}
-            </BarChart>
-          </ResponsiveContainer>
+                {comparisonPeriod && (
+                  <Bar
+                    dataKey="comparisonVolume"
+                    fill="#8884d8"
+                    opacity={0.6}
+                    name={t(
+                      'exerciseReportsDashboard.volumeComparison',
+                      'Volume (Comparison)'
+                    )}
+                    isAnimationActive={false}
+                  />
+                )}
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </ZoomableChart>
       </CardContent>
     </Card>

--- a/SparkyFitnessFrontend/src/components/ZoomableChart.tsx
+++ b/SparkyFitnessFrontend/src/components/ZoomableChart.tsx
@@ -26,7 +26,7 @@ const ZoomableChart = ({ children, title, className }: ZoomableChartProps) => {
   };
 
   const handleZoomOut = () => {
-    setZoomLevel((prev) => Math.max(prev - 0.25, 0.5));
+    setZoomLevel((prev) => Math.max(prev - 0.25, 1));
   };
 
   const resetZoom = () => {
@@ -53,7 +53,7 @@ const ZoomableChart = ({ children, title, className }: ZoomableChartProps) => {
             variant="outline"
             size="sm"
             onClick={handleZoomOut}
-            disabled={zoomLevel <= 0.5}
+            disabled={zoomLevel <= 1}
             className="p-1 h-8 w-8"
           >
             <ZoomOut className="h-3 w-3" />
@@ -93,7 +93,7 @@ const ZoomableChart = ({ children, title, className }: ZoomableChartProps) => {
                 variant="outline"
                 size="sm"
                 onClick={handleZoomOut}
-                disabled={zoomLevel <= 0.5}
+                disabled={zoomLevel <= 1}
               >
                 <ZoomOut className="h-4 w-4" />
               </Button>
@@ -117,7 +117,7 @@ const ZoomableChart = ({ children, title, className }: ZoomableChartProps) => {
               </Button>
             </div>
           </div>
-          <div className="w-full h-[calc(100%-110px)] overflow-auto">
+          <div className="w-full flex-1 min-h-0 overflow-auto">
             {maximizedChildren}
           </div>
         </DialogContent>

--- a/SparkyFitnessFrontend/src/pages/Reports/MeasurementChartsGrid.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/MeasurementChartsGrid.tsx
@@ -256,10 +256,12 @@ const MeasurementChartsGrid = ({
                   </CardTitle>
                 </CardHeader>
                 <CardContent
-                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                  className={`grow min-h-0 ${isMaximized ? 'flex flex-col' : ''}`}
                 >
                   <div
-                    className={(isMaximized ? 'h-full' : 'h-48') + ' min-w-0'}
+                    className={
+                      (isMaximized ? 'grow min-h-0' : 'h-48') + ' min-w-0'
+                    }
                   >
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
@@ -347,9 +349,11 @@ const MeasurementChartsGrid = ({
               </CardTitle>
             </CardHeader>
             <CardContent
-              className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+              className={`grow min-h-0 ${isMaximized ? 'flex flex-col' : ''}`}
             >
-              <div className={(isMaximized ? 'h-full' : 'h-80') + ' min-w-0'}>
+              <div
+                className={(isMaximized ? 'grow min-h-0' : 'h-80') + ' min-w-0'}
+              >
                 <ResponsiveContainer
                   width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
                   height="100%"

--- a/SparkyFitnessFrontend/src/pages/Reports/MeasurementChartsGrid.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/MeasurementChartsGrid.tsx
@@ -248,23 +248,22 @@ const MeasurementChartsGrid = ({
             title={`${t(metric.titleKey, metric.defaultTitle)} (${metric.unit})`}
           >
             {(isMaximized, zoomLevel) => (
-              <Card>
+              <Card className={isMaximized ? 'h-full flex flex-col' : ''}>
                 <CardHeader className="pb-2">
                   <CardTitle className="text-sm flex items-center">
                     {metric.icon && metric.icon}
                     {t(metric.titleKey, metric.defaultTitle)} ({metric.unit})
                   </CardTitle>
                 </CardHeader>
-                <CardContent>
+                <CardContent
+                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                >
                   <div
-                    className={
-                      (isMaximized ? 'h-[calc(95vh-150px)]' : 'h-48') +
-                      ' min-w-0'
-                    }
+                    className={(isMaximized ? 'h-full' : 'h-48') + ' min-w-0'}
                   >
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                      height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                      height="100%"
                       minWidth={0}
                       minHeight={0}
                       debounce={100}
@@ -340,22 +339,20 @@ const MeasurementChartsGrid = ({
       {/* Steps Chart */}
       <ZoomableChart title={t('reports.dailySteps', 'Daily Steps')}>
         {(isMaximized, zoomLevel) => (
-          <Card>
+          <Card className={isMaximized ? 'h-full flex flex-col' : ''}>
             <CardHeader>
               <CardTitle className="flex items-center">
                 <Activity className="w-5 h-5 mr-2" />
                 {t('reports.dailySteps', 'Daily Steps')}
               </CardTitle>
             </CardHeader>
-            <CardContent>
-              <div
-                className={
-                  (isMaximized ? 'h-[calc(95vh-150px)]' : 'h-80') + ' min-w-0'
-                }
-              >
+            <CardContent
+              className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+            >
+              <div className={(isMaximized ? 'h-full' : 'h-80') + ' min-w-0'}>
                 <ResponsiveContainer
                   width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                  height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                  height="100%"
                   minWidth={0}
                   minHeight={0}
                   debounce={100}

--- a/SparkyFitnessFrontend/src/pages/Reports/NutritionChartsGrid.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/NutritionChartsGrid.tsx
@@ -186,7 +186,7 @@ const NutritionChartsGrid = ({
             title={`${chart.label} (${chart.unit})`}
           >
             {(isMaximized, zoomLevel) => (
-              <Card>
+              <Card className={isMaximized ? 'h-full flex flex-col' : ''}>
                 <CardHeader className="pb-2">
                   <div className="flex items-center justify-between">
                     <CardTitle className="text-sm">
@@ -198,16 +198,15 @@ const NutritionChartsGrid = ({
                     </span>
                   </div>
                 </CardHeader>
-                <CardContent>
+                <CardContent
+                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                >
                   <div
-                    className={
-                      (isMaximized ? 'h-[calc(95vh-150px)]' : 'h-48') +
-                      ' min-w-0'
-                    }
+                    className={(isMaximized ? 'h-full' : 'h-48') + ' min-w-0'}
                   >
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                      height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                      height="100%"
                       minWidth={0}
                       minHeight={0}
                       debounce={100}

--- a/SparkyFitnessFrontend/src/pages/Reports/NutritionChartsGrid.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/NutritionChartsGrid.tsx
@@ -199,10 +199,12 @@ const NutritionChartsGrid = ({
                   </div>
                 </CardHeader>
                 <CardContent
-                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                  className={`grow min-h-0 ${isMaximized ? 'flex flex-col' : ''}`}
                 >
                   <div
-                    className={(isMaximized ? 'h-full' : 'h-48') + ' min-w-0'}
+                    className={
+                      (isMaximized ? 'grow min-h-0' : 'h-48') + ' min-w-0'
+                    }
                   >
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}

--- a/SparkyFitnessFrontend/src/pages/Reports/NutritionPeriodSummary.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/NutritionPeriodSummary.tsx
@@ -399,15 +399,8 @@ const NutritionPeriodSummary = ({
                     </span>
                   </div>
                 </CardHeader>
-                <CardContent
-                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''} flex-1 min-h-0 p-0`}
-                >
-                  <div
-                    className={
-                      (isMaximized ? 'h-full' : 'h-full') +
-                      ' min-w-0 w-full px-4 pb-4'
-                    }
-                  >
+                <CardContent className="flex-1 min-h-0 p-0 flex flex-col">
+                  <div className="grow min-h-0 min-w-0 w-full px-4 pb-4">
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
                       height="100%"
@@ -546,9 +539,13 @@ const NutritionPeriodSummary = ({
                 <CardTitle className="text-sm">{chartTitle}</CardTitle>
               </CardHeader>
               <CardContent
-                className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                className={`grow min-h-0 ${isMaximized ? 'flex flex-col' : ''}`}
               >
-                <div className={(isMaximized ? 'h-full' : 'h-64') + ' min-w-0'}>
+                <div
+                  className={
+                    (isMaximized ? 'grow min-h-0' : 'h-64') + ' min-w-0'
+                  }
+                >
                   <ResponsiveContainer
                     width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
                     height="100%"

--- a/SparkyFitnessFrontend/src/pages/Reports/NutritionPeriodSummary.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/NutritionPeriodSummary.tsx
@@ -399,16 +399,18 @@ const NutritionPeriodSummary = ({
                     </span>
                   </div>
                 </CardHeader>
-                <CardContent className="flex-1 min-h-0 p-0">
+                <CardContent
+                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''} flex-1 min-h-0 p-0`}
+                >
                   <div
                     className={
-                      (isMaximized ? 'h-[calc(95vh-150px)]' : 'h-full') +
+                      (isMaximized ? 'h-full' : 'h-full') +
                       ' min-w-0 w-full px-4 pb-4'
                     }
                   >
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                      height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                      height="100%"
                       minWidth={0}
                       minHeight={0}
                       debounce={100}
@@ -539,19 +541,17 @@ const NutritionPeriodSummary = ({
       {showCumulativeChart && (
         <ZoomableChart title={chartTitle}>
           {(isMaximized, zoomLevel) => (
-            <Card>
+            <Card className={isMaximized ? 'h-full flex flex-col' : ''}>
               <CardHeader className="pb-2">
                 <CardTitle className="text-sm">{chartTitle}</CardTitle>
               </CardHeader>
-              <CardContent>
-                <div
-                  className={
-                    (isMaximized ? 'h-[calc(95vh-150px)]' : 'h-64') + ' min-w-0'
-                  }
-                >
+              <CardContent
+                className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+              >
+                <div className={(isMaximized ? 'h-full' : 'h-64') + ' min-w-0'}>
                   <ResponsiveContainer
                     width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                    height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                    height="100%"
                     minWidth={0}
                     minHeight={0}
                     debounce={100}

--- a/SparkyFitnessFrontend/src/pages/Reports/SetPerformanceAnalysisChart.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SetPerformanceAnalysisChart.tsx
@@ -79,15 +79,17 @@ const SetPerformanceAnalysisChart = ({
   return (
     <ZoomableChart title={chartTitle}>
       {(isMaximized, zoomLevel) => (
-        <Card>
+        <Card className={isMaximized ? 'h-full flex flex-col' : ''}>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm">{chartTitle}</CardTitle>
           </CardHeader>
-          <CardContent>
-            <div className={isMaximized ? 'h-[calc(95vh-150px)]' : 'h-48'}>
+          <CardContent
+            className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+          >
+            <div className={isMaximized ? 'h-full' : 'h-48'}>
               <ResponsiveContainer
                 width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                height="100%"
                 minWidth={0}
                 minHeight={0}
                 debounce={100}

--- a/SparkyFitnessFrontend/src/pages/Reports/SetPerformanceAnalysisChart.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SetPerformanceAnalysisChart.tsx
@@ -84,9 +84,9 @@ const SetPerformanceAnalysisChart = ({
             <CardTitle className="text-sm">{chartTitle}</CardTitle>
           </CardHeader>
           <CardContent
-            className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+            className={`grow min-h-0 ${isMaximized ? 'flex flex-col' : ''}`}
           >
-            <div className={isMaximized ? 'h-full' : 'h-48'}>
+            <div className={isMaximized ? 'grow min-h-0' : 'h-48'}>
               <ResponsiveContainer
                 width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
                 height="100%"

--- a/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsCharts.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsCharts.tsx
@@ -341,9 +341,9 @@ const SleepAnalyticsCharts = ({
                   </CardTitle>
                 </CardHeader>
                 <CardContent
-                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                  className={`grow min-h-0 ${isMaximized ? 'flex flex-col' : ''}`}
                 >
-                  <div className={isMaximized ? 'h-full' : 'h-48'}>
+                  <div className={isMaximized ? 'grow min-h-0' : 'h-48'}>
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
                       height="100%"
@@ -426,9 +426,9 @@ const SleepAnalyticsCharts = ({
                   </CardTitle>
                 </CardHeader>
                 <CardContent
-                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                  className={`grow min-h-0 ${isMaximized ? 'flex flex-col' : ''}`}
                 >
-                  <div className={isMaximized ? 'h-full' : 'h-48'}>
+                  <div className={isMaximized ? 'grow min-h-0' : 'h-48'}>
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
                       height="100%"
@@ -531,9 +531,9 @@ const SleepAnalyticsCharts = ({
                   </CardTitle>
                 </CardHeader>
                 <CardContent
-                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                  className={`grow min-h-0 ${isMaximized ? 'flex flex-col' : ''}`}
                 >
-                  <div className={isMaximized ? 'h-full' : 'h-48'}>
+                  <div className={isMaximized ? 'grow min-h-0' : 'h-48'}>
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
                       height="100%"
@@ -651,9 +651,9 @@ const SleepAnalyticsCharts = ({
                   </CardTitle>
                 </CardHeader>
                 <CardContent
-                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                  className={`grow min-h-0 ${isMaximized ? 'flex flex-col' : ''}`}
                 >
-                  <div className={isMaximized ? 'h-full' : 'h-48'}>
+                  <div className={isMaximized ? 'grow min-h-0' : 'h-48'}>
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
                       height="100%"

--- a/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsCharts.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsCharts.tsx
@@ -334,19 +334,19 @@ const SleepAnalyticsCharts = ({
             title={t('sleepAnalyticsCharts.sleepStages', 'Sleep Stages')}
           >
             {(isMaximized, zoomLevel) => (
-              <Card>
+              <Card className={isMaximized ? 'h-full flex flex-col' : ''}>
                 <CardHeader>
                   <CardTitle>
                     {t('sleepAnalyticsCharts.sleepStages', 'Sleep Stages')}
                   </CardTitle>
                 </CardHeader>
-                <CardContent>
-                  <div
-                    className={isMaximized ? 'h-[calc(95vh-150px)]' : 'h-48'}
-                  >
+                <CardContent
+                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                >
+                  <div className={isMaximized ? 'h-full' : 'h-48'}>
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                      height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                      height="100%"
                       minWidth={0}
                       minHeight={0}
                       debounce={100}
@@ -416,7 +416,7 @@ const SleepAnalyticsCharts = ({
             )}
           >
             {(isMaximized, zoomLevel) => (
-              <Card>
+              <Card className={isMaximized ? 'h-full flex flex-col' : ''}>
                 <CardHeader>
                   <CardTitle>
                     {t(
@@ -425,13 +425,13 @@ const SleepAnalyticsCharts = ({
                     )}
                   </CardTitle>
                 </CardHeader>
-                <CardContent>
-                  <div
-                    className={isMaximized ? 'h-[calc(95vh-150px)]' : 'h-48'}
-                  >
+                <CardContent
+                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                >
+                  <div className={isMaximized ? 'h-full' : 'h-48'}>
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                      height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                      height="100%"
                       minWidth={0}
                       minHeight={0}
                       debounce={100}
@@ -524,19 +524,19 @@ const SleepAnalyticsCharts = ({
             title={t('sleepAnalyticsCharts.sleepDebt', 'Sleep Debt')}
           >
             {(isMaximized, zoomLevel) => (
-              <Card>
+              <Card className={isMaximized ? 'h-full flex flex-col' : ''}>
                 <CardHeader>
                   <CardTitle>
                     {t('sleepAnalyticsCharts.sleepDebt', 'Sleep Debt')}
                   </CardTitle>
                 </CardHeader>
-                <CardContent>
-                  <div
-                    className={isMaximized ? 'h-[calc(95vh-150px)]' : 'h-48'}
-                  >
+                <CardContent
+                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                >
+                  <div className={isMaximized ? 'h-full' : 'h-48'}>
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                      height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                      height="100%"
                       minWidth={0}
                       minHeight={0}
                       debounce={100}
@@ -641,7 +641,7 @@ const SleepAnalyticsCharts = ({
             )}
           >
             {(isMaximized, zoomLevel) => (
-              <Card>
+              <Card className={isMaximized ? 'h-full flex flex-col' : ''}>
                 <CardHeader>
                   <CardTitle>
                     {t(
@@ -650,13 +650,13 @@ const SleepAnalyticsCharts = ({
                     )}
                   </CardTitle>
                 </CardHeader>
-                <CardContent>
-                  <div
-                    className={isMaximized ? 'h-[calc(95vh-150px)]' : 'h-48'}
-                  >
+                <CardContent
+                  className={`grow ${isMaximized ? 'min-h-0 h-full' : ''}`}
+                >
+                  <div className={isMaximized ? 'h-full' : 'h-48'}>
                     <ResponsiveContainer
                       width={isMaximized ? `${100 * zoomLevel}%` : '100%'}
-                      height={isMaximized ? `${100 * zoomLevel}%` : '100%'}
+                      height="100%"
                       minWidth={0}
                       minHeight={0}
                       debounce={100}

--- a/SparkyFitnessFrontend/src/pages/Reports/SleepStageChart.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SleepStageChart.tsx
@@ -280,14 +280,16 @@ const SleepStageChart = ({ sleepChartData }: SleepStageChartProps) => {
   return (
     <ZoomableChart title={t('sleepReport.sleepHypnogram', 'Sleep Hypnogram')}>
       {(isMaximized) => (
-        <Card>
+        <Card className={isMaximized ? 'h-full flex flex-col' : ''}>
           <CardHeader>
             <CardTitle>
               {t('sleepReport.sleepHypnogram', 'Sleep Hypnogram')} -{' '}
               {formatDateInUserTimezone(sleepChartData.date, dateFormat)}
             </CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent
+            className={`${isMaximized ? 'grow min-h-0 flex flex-col' : ''}`}
+          >
             <div className="mb-4 flex flex-wrap justify-center gap-x-4 gap-y-2">
               {Object.entries(stageLabels).map(([stageKey, stageLabel]) => {
                 const totalDurationSeconds = sortedSegments
@@ -330,9 +332,7 @@ const SleepStageChart = ({ sleepChartData }: SleepStageChartProps) => {
               })}
             </div>
             <div
-              className={
-                (isMaximized ? 'h-[calc(95vh-200px)]' : 'h-48') + ' w-full'
-              }
+              className={(isMaximized ? 'grow min-h-0' : 'h-48') + ' w-full'}
             >
               <svg
                 width="100%"


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Maximizing a chart in Reports left it partly hidden behind a vertical scrollbar so the X-axis and legend were cut off (issue #1625), and on exercise charts the rotated Y-axis title was clipped at the left edge.

**How did you implement the solution?**
Each chart sized its maximized height with a viewport-relative calc that did not account for the dialog header and toolbar, and zoom scaled both width and height. This replaces that with a flex height chain (Card `h-full flex flex-col`, CardContent `flex flex-col`, inner chart `grow min-h-0`) so the chart fills the dialog with no vertical scrollbar, locks maximized height to 100% and scales only width with zoom (floored at the fitted size), switches the fixed-height exercise charts to the same render-prop pattern so they fill the dialog instead of staying 300px tall, and adds chart margins plus centered rotated Y-axis titles so they no longer clip.

Linked Issue: Closes #1625

## How to Test

1. Run the frontend (`pnpm --filter sparkyfitnessfrontend dev`) or use a build, then open Reports.
2. Click the maximize (expand) icon on any chart.
3. The whole chart, including the X-axis and legend, is visible with no vertical scrollbar. Zoom in widens the chart with a horizontal scrollbar; zoom out stops at the fitted size.
4. On Exercise Progress (for example Time Under Tension), the rotated Y-axis title is fully visible and not clipped at the left edge.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: No translation files were changed by this PR.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: Before/After are attached below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="1834" height="875" alt="2026-06-24 10_35_37-Greenshot" src="https://github.com/user-attachments/assets/37a721a8-378d-4871-8134-5c29fe3bf337" />

<img width="1834" height="873" alt="2026-06-24 10_35_06-Greenshot" src="https://github.com/user-attachments/assets/be2c566e-2b14-4ab2-8810-9df9c1bd8922" />

### After

<img width="1835" height="876" alt="2026-06-24 10_35_52-_Bug Fixes_ _ ccshuttle - Discord" src="https://github.com/user-attachments/assets/d67485d0-9d26-408f-a9aa-3734d3e0590b" />

<img width="1832" height="875" alt="2026-06-24 10_34_46-Greenshot" src="https://github.com/user-attachments/assets/dcaf52e7-1274-417e-a5d1-9d6a85657a68" />

</details>

## Notes for Reviewers

This fixes the layout/behavior shell shared by the charts; it does not change any chart type or data encoding.
Verified by deploying the build to a staging instance and driving it against real data (the captures above), plus `pnpm run validate` (CI green), ESLint, and Prettier.
The maximize, zoom, and fit boilerplate is still duplicated across each chart, which is what allowed this bug to drift in. A natural follow-up is to fold it into a single `ChartFrame` shell so the layout lives in one place, but that is a larger refactor kept out of this PR.
