### PR TITLE
fix(fatsecret, proxy): use Basic Auth for OAuth token request & fix native fetch proxy dispatcher

### DIFF
--- a/SparkyFitnessServer/integrations/fatsecret/fatsecretService.ts
+++ b/SparkyFitnessServer/integrations/fatsecret/fatsecretService.ts
@@ -148,16 +148,18 @@ async function getFatSecretAccessToken(
       'info',
       `Attempting to get FatSecret Access Token for scope "${requestedScope}" from: ${FATSECRET_OAUTH_TOKEN_URL}`
     );
+    const authHeader = Buffer.from(`${clientId}:${clientSecret}`).toString(
+      'base64'
+    );
     const response = await fetch(FATSECRET_OAUTH_TOKEN_URL, {
       method: 'POST',
       headers: {
+        Authorization: `Basic ${authHeader}`,
         'Content-Type': 'application/x-www-form-urlencoded',
       },
       body: new URLSearchParams({
         grant_type: 'client_credentials',
         scope: requestedScope,
-        client_id: clientId,
-        client_secret: clientSecret,
       }).toString(),
     });
     if (!response.ok) {

--- a/SparkyFitnessServer/utils/outboundProxy.ts
+++ b/SparkyFitnessServer/utils/outboundProxy.ts
@@ -52,7 +52,14 @@ function configureOutboundProxy() {
 
   // Native fetch: undici's env-aware dispatcher honors HTTP(S)_PROXY and
   // NO_PROXY per request and tunnels HTTPS targets via CONNECT.
-  setGlobalDispatcher(new EnvHttpProxyAgent());
+  const dispatcher = new EnvHttpProxyAgent();
+  setGlobalDispatcher(dispatcher);
+
+  // Set the dispatcher on global symbols to ensure Node's native fetch (which uses internal undici) respects it
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const g = globalThis as any;
+  g[Symbol.for('undici.globalDispatcher.1')] = dispatcher;
+  g[Symbol.for('undici.globalDispatcher.2')] = dispatcher;
 
   // Axios: its built-in proxy handling cannot tunnel HTTPS targets, so
   // disable it and attach CONNECT-capable agents per request instead.


### PR DESCRIPTION
### Description
This PR resolves two related network issues on the backend server that affect self-hosted installations:

1. **FatSecret API Authentication Failure:**
   The `getFatSecretAccessToken` function originally passed the `client_id` and `client_secret` in the POST request body. However, the FatSecret Platform OAuth 2.0 token endpoint (`https://oauth.fatsecret.com/connect/token`) requires these credentials to be passed in an HTTP Basic Authentication header (`Authorization: Basic <base64(client_id:client_secret)>`). 
   - This caused all FatSecret calls (search, details, barcode lookup) to fail silent-authentications.
   - This resolves the root cause for silent empty search results reported in issues #1320 and #1355.

2. **Native Fetch Outbound Proxy Bypass:**
   In Node.js 18+ / v20+, the built-in native `fetch` uses a bundled, internal copy of `undici`. Calling `setGlobalDispatcher` imported from the project's external `node_modules/undici` package does not affect the internal undici copy, causing native `fetch` calls to bypass the configured outbound proxy.
   - We now assign the agent to both standard `Symbol.for('undici.globalDispatcher.1')` and `Symbol.for('undici.globalDispatcher.2')` slots on `globalThis` as well to ensure Node's native `fetch` respects the proxy settings correctly.

### Testing & Verification
I ran the test suites to ensure these changes do not introduce regressions:
- **Outbound proxy test suite:** `npx vitest run tests/outboundProxy.test.ts` (All 5/5 tests passed, including the previously failing native fetch test).
- **FatSecret service unit tests:** `npx vitest run tests/fatsecretService.test.ts` (All 11/11 tests passed).
- **Barcode lookup integration tests:** `npx vitest run tests/barcodeLookup.test.ts` (All 62/62 tests passed).