### PR TITLE
fix: sync HealthKit workout heart rate

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/healthkit/dataTransformation.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthkit/dataTransformation.test.ts
@@ -361,6 +361,23 @@ describe('transformHealthRecords', () => {
       expect(exerciseResult.source).toBe('HealthKit');
     });
 
+    test('passes average heart rate through to exercise sessions', () => {
+      const records = [
+        {
+          startTime: '2024-01-15T08:00:00Z',
+          endTime: '2024-01-15T09:00:00Z',
+          activityType: 37,
+          duration: 3600,
+          totalEnergyBurned: 500,
+          totalDistance: 5000,
+          averageHeartRate: 138,
+        },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'ExerciseSession', unit: '', type: 'exercise' });
+
+      expect((result[0] as TransformedExerciseSession).avg_heart_rate).toBe(138);
+    });
+
     test('includes sets array with duration in minutes', () => {
       const records = [
         {

--- a/SparkyFitnessMobile/__tests__/services/healthkit/index.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthkit/index.test.ts
@@ -663,6 +663,45 @@ describe('readHealthRecords', () => {
       expect((result[0] as { totalDistance: number }).totalDistance).toBe(6000);
     });
 
+    test('averages heart-rate samples that fall inside the workout window', async () => {
+      await initHealthConnect();
+
+      const mockGetStatistic = jest.fn().mockResolvedValue(undefined);
+      mockQueryWorkoutSamples.mockResolvedValue([
+        {
+          startDate: '2024-01-15T08:00:00Z',
+          endDate: '2024-01-15T09:00:00Z',
+          workoutActivityType: 37,
+          duration: 3600,
+          totalEnergyBurned: { unit: 'kcal', quantity: 500 },
+          totalDistance: { unit: 'm', quantity: 5000 },
+          getStatistic: mockGetStatistic,
+        },
+      ]);
+      mockQueryQuantitySamples.mockResolvedValue([
+        { startDate: '2024-01-15T08:10:00Z', quantity: 130 },
+        { startDate: '2024-01-15T08:20:00Z', quantity: 140 },
+        { startDate: '2024-01-15T08:30:00Z', quantity: 150 },
+        { startDate: '2024-01-15T09:30:00Z', quantity: 80 },
+      ]);
+
+      const result = await readHealthRecords(
+        'Workout',
+        new Date('2024-01-15T00:00:00Z'),
+        new Date('2024-01-15T23:59:59Z')
+      );
+
+      expect(mockQueryQuantitySamples).toHaveBeenCalledWith(
+        'HKQuantityTypeIdentifierHeartRate',
+        expect.objectContaining({
+          ascending: false,
+          limit: 0,
+          unit: 'count/min',
+        })
+      );
+      expect((result[0] as { averageHeartRate: number }).averageHeartRate).toBe(140);
+    });
+
     test('pins units to kcal and meters on getStatistic calls (regression: user-preferred units leaked through)', async () => {
       await initHealthConnect();
 

--- a/SparkyFitnessMobile/src/services/healthkit/dataTransformation.ts
+++ b/SparkyFitnessMobile/src/services/healthkit/dataTransformation.ts
@@ -563,6 +563,7 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
       activityType: activityTypeName,
       title: activityTypeName,
       caloriesBurned: rec.totalEnergyBurned as number || 0,
+      avg_heart_rate: typeof rec.averageHeartRate === 'number' ? rec.averageHeartRate : undefined,
       distance: parseFloat((totalDistanceMeters / 1000).toFixed(2)),
       notes: 'Source: HealthKit',
       raw_data: record,

--- a/SparkyFitnessMobile/src/services/healthkit/index.ts
+++ b/SparkyFitnessMobile/src/services/healthkit/index.ts
@@ -721,6 +721,7 @@ const handleWorkout: RecordHandler = async (_identifier, startDate, endDate) => 
     let totalDistance = typeof workoutAny.totalDistance === 'object'
       ? (workoutAny.totalDistance?.quantity ?? 0)
       : (workoutAny.totalDistance ?? 0);
+    let averageHeartRate: number | undefined;
 
     // Pin units explicitly on each getStatistic call. getAllStatistics returns
     // values in the user's HealthKit-preferred unit (often miles / kJ), but the
@@ -753,6 +754,33 @@ const handleWorkout: RecordHandler = async (_identifier, startDate, endDate) => 
       // Stats fetch failed - keep using direct properties from workout
     }
 
+    try {
+      const heartRateSamples = await queryQuantitySamples('HKQuantityTypeIdentifierHeartRate', {
+        filter: { date: { startDate: new Date(w.startDate), endDate: new Date(w.endDate) } },
+        ascending: false,
+        limit: 0,
+        unit: 'count/min',
+      });
+
+      const bpmValues = Array.isArray(heartRateSamples)
+        ? heartRateSamples
+            .filter(sample => {
+              const sampleStart = new Date(sample.startDate);
+              return isInDateRange(sampleStart, new Date(w.startDate), new Date(w.endDate));
+            })
+            .map(sample => Number(sample.quantity))
+            .filter(value => Number.isFinite(value) && value > 0)
+        : [];
+
+      if (bpmValues.length > 0) {
+        averageHeartRate = Math.round(
+          bpmValues.reduce((sum, value) => sum + value, 0) / bpmValues.length
+        );
+      }
+    } catch {
+      // Heart-rate samples are optional; keep importing the workout without HR.
+    }
+
     const record: Record<string, unknown> = {
       startTime: w.startDate,
       endTime: w.endDate,
@@ -760,6 +788,7 @@ const handleWorkout: RecordHandler = async (_identifier, startDate, endDate) => 
       duration: w.duration,
       totalEnergyBurned,
       totalDistance,
+      averageHeartRate,
       uuid: (w as unknown as { uuid?: string }).uuid,
     };
     // Forward timezone metadata so the transform layer can attach it to output records

--- a/SparkyFitnessMobile/src/types/healthRecords.ts
+++ b/SparkyFitnessMobile/src/types/healthRecords.ts
@@ -106,6 +106,7 @@ export interface TransformedExerciseSession extends RecordTimezoneMetadata {
   activityType: string;
   title: string;
   caloriesBurned?: number;
+  avg_heart_rate?: number;
   /** Stored in kilometers to match exercise entry API/storage. */
   distance?: number;
   notes?: string;

--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -861,6 +861,7 @@ async function processHealthData(
               caloriesBurned,
               distance,
               duration,
+              avg_heart_rate,
               raw_data,
               source_id,
             } = dataEntry;
@@ -891,6 +892,7 @@ async function processHealthData(
                 entry_date: parsedDate,
                 notes: `Source: ${source}, Activity Type: ${activityType}`,
                 distance: distance,
+                avg_heart_rate: avg_heart_rate ?? null,
                 sets: dataEntry.sets || null, // Pass sets if present for mobile workout sync
                 source_id: source_id || null,
               },
@@ -1283,6 +1285,7 @@ async function processMobileHealthData(
               entry_date: parsedDate,
               notes: `Source: ${source}, Activity Type: ${activityType}`,
               distance: distance,
+              avg_heart_rate: dataEntry.avg_heart_rate ?? null,
               sets: dataEntry.sets || null, // Pass sets if present for mobile workout sync
               // Add other exercise-related fields from mobileHealthData if available
             },

--- a/SparkyFitnessServer/tests/measurementService.timezone.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.timezone.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import measurementService from '../services/measurementService.js';
 import measurementRepository from '../models/measurementRepository.js';
 import preferenceRepository from '../models/preferenceRepository.js';
+import exerciseDb from '../models/exercise.js';
+import exerciseEntryDb from '../models/exerciseEntry.js';
+import activityDetailsRepository from '../models/activityDetailsRepository.js';
 import { log } from '../config/logging.js';
 vi.mock('../models/measurementRepository');
 vi.mock('../models/preferenceRepository');
@@ -316,6 +319,20 @@ describe('processHealthData timezone resolution', () => {
     measurementRepository.upsertCustomMeasurement = vi
       .fn()
       .mockResolvedValue({ id: 'entry-1' });
+    exerciseEntryDb.deleteExerciseEntriesByEntrySourceAndDate = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    exerciseDb.findExerciseByNameAndUserId = vi.fn().mockResolvedValue({
+      id: 'exercise-1',
+      name: 'Other',
+    });
+    exerciseDb.createExercise = vi.fn();
+    exerciseEntryDb.createExerciseEntry = vi
+      .fn()
+      .mockResolvedValue({ id: 'entry-exercise-1' });
+    activityDetailsRepository.createActivityDetail = vi
+      .fn()
+      .mockResolvedValue({ id: 'detail-1' });
   });
   it('record_timezone overrides account timezone for parsedDate', async () => {
     // Account timezone is UTC. Record says Asia/Tokyo.
@@ -436,6 +453,40 @@ describe('processHealthData timezone resolution', () => {
     expect(log).toHaveBeenCalledWith(
       'DEBUG',
       expect.stringContaining('heart_rate=1')
+    );
+  });
+
+  it('passes ExerciseSession average heart rate through to exercise entries', async () => {
+    const healthData = [
+      {
+        type: 'ExerciseSession',
+        source: 'HealthKit',
+        timestamp: '2024-06-15T11:44:00Z',
+        activityType: 'Other',
+        duration: 1054,
+        caloriesBurned: 136,
+        avg_heart_rate: 138,
+        source_id: 'hk-workout-1',
+        record_timezone: 'Australia/Adelaide',
+      },
+    ];
+
+    await measurementService.processHealthData(
+      healthData,
+      userId,
+      actingUserId
+    );
+
+    expect(exerciseEntryDb.createExerciseEntry).toHaveBeenCalledWith(
+      userId,
+      expect.objectContaining({
+        duration_minutes: 1054 / 60,
+        calories_burned: 136,
+        avg_heart_rate: 138,
+        source_id: 'hk-workout-1',
+      }),
+      actingUserId,
+      'HealthKit'
     );
   });
 });


### PR DESCRIPTION
## Summary
- query HealthKit heart-rate samples within each workout window and calculate an average BPM
- include the average heart rate in transformed ExerciseSession records
- persist ExerciseSession avg_heart_rate when the server creates exercise entries

## Tests
- npx pnpm test -- __tests__/services/healthkit/index.test.ts __tests__/services/healthkit/dataTransformation.test.ts --runInBand
- npx pnpm exec vitest run tests/measurementService.timezone.test.ts
- npx pnpm run typecheck (SparkyFitnessMobile)
- npx pnpm run typecheck (SparkyFitnessServer)

Related context: existing issues cover HealthKit workout calorie double counting and missing workout details, but I did not find a specific open issue for HealthKit workout average heart-rate import.