### PR TITLE
feat(ai): add xAI (Grok) as an AI service provider

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -694,6 +694,7 @@
         "groq": "Groq",
         "ollama": "Ollama",
         "openrouter": "OpenRouter",
+        "xai": "xAI (Grok)",
         "custom": "Custom"
       }
     },

--- a/SparkyFitnessFrontend/src/utils/aiServiceUtils.ts
+++ b/SparkyFitnessFrontend/src/utils/aiServiceUtils.ts
@@ -21,6 +21,7 @@ export const getServiceTypes = (t: (key: string) => string): ServiceType[] => [
     value: 'openrouter',
     label: t('settings.aiService.serviceTypes.openrouter'),
   },
+  { value: 'xai', label: t('settings.aiService.serviceTypes.xai') },
   { value: 'custom', label: t('settings.aiService.serviceTypes.custom') },
 ];
 
@@ -72,6 +73,16 @@ export const getModelOptions = (serviceType: string): string[] => {
         'anthropic/claude-sonnet-4.6',
         'deepseek/deepseek-chat',
         'meta-llama/llama-3.1-8b-instruct:free',
+      ];
+    case 'xai':
+      // grok-4.3 is multimodal (handles vision + text), so it leads as the
+      // all-round recommendation. The fast/non-reasoning and build variants
+      // follow. grok-4 / grok-4-fast were retired (redirect to grok-4.3).
+      return [
+        'grok-4.3',
+        'grok-4.20-0309-non-reasoning',
+        'grok-4.20-0309-reasoning',
+        'grok-build-0.1',
       ];
     default:
       return [];

--- a/SparkyFitnessServer/ai/config.ts
+++ b/SparkyFitnessServer/ai/config.ts
@@ -14,6 +14,8 @@ function getDefaultModel(serviceType: any) {
       return 'llama-3.3-70b-versatile';
     case 'openrouter':
       return 'google/gemini-2.5-flash';
+    case 'xai':
+      return 'grok-4.3';
     case 'ollama':
       return 'llama3.2';
     default:
@@ -36,6 +38,8 @@ function getDefaultVisionModel(serviceType: any) {
       return 'meta-llama/llama-4-scout-17b-16e-instruct';
     case 'openrouter':
       return 'google/gemini-2.5-flash';
+    case 'xai':
+      return 'grok-4.3';
     case 'ollama':
       return 'llava';
     default:

--- a/SparkyFitnessServer/ai/providerDispatch.ts
+++ b/SparkyFitnessServer/ai/providerDispatch.ts
@@ -112,6 +112,7 @@ const STRICT_SCHEMA_PROVIDERS = new Set([
   'mistral',
   'groq',
   'openrouter',
+  'xai',
 ]);
 
 function providerFamily(serviceType: string): ProviderFamily | null {
@@ -123,6 +124,7 @@ function providerFamily(serviceType: string): ProviderFamily | null {
     case 'mistral':
     case 'groq':
     case 'openrouter':
+    case 'xai':
     case 'custom':
       return 'openai';
     case 'anthropic':
@@ -240,6 +242,8 @@ function openAiFamilyUrl(provider: ProviderConfig): string {
       return 'https://api.groq.com/openai/v1/chat/completions';
     case 'openrouter':
       return 'https://openrouter.ai/api/v1/chat/completions';
+    case 'xai':
+      return 'https://api.x.ai/v1/chat/completions';
     default:
       // 'custom' uses the user-supplied URL as-is.
       return provider.custom_url as string;

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -462,7 +462,8 @@ async function processChatMessage(
       aiService.service_type === 'custom' ||
       aiService.service_type === 'mistral' ||
       aiService.service_type === 'groq' ||
-      aiService.service_type === 'openrouter'
+      aiService.service_type === 'openrouter' ||
+      aiService.service_type === 'xai'
     ) {
       // Connect as OpenAI-compatible
       let baseURL = aiService.custom_url;
@@ -474,6 +475,8 @@ async function processChatMessage(
         baseURL = 'https://openrouter.ai/api/v1';
       } else if (aiService.service_type === 'mistral') {
         baseURL = 'https://api.mistral.ai/v1';
+      } else if (aiService.service_type === 'xai') {
+        baseURL = 'https://api.x.ai/v1';
       }
       const provider = createOpenAI({
         baseURL,
@@ -884,7 +887,8 @@ async function processChatMessageStream(
       aiService.service_type === 'custom' ||
       aiService.service_type === 'mistral' ||
       aiService.service_type === 'groq' ||
-      aiService.service_type === 'openrouter'
+      aiService.service_type === 'openrouter' ||
+      aiService.service_type === 'xai'
     ) {
       let baseURL = aiService.custom_url;
       if (aiService.service_type === 'ollama') {
@@ -895,6 +899,8 @@ async function processChatMessageStream(
         baseURL = 'https://openrouter.ai/api/v1';
       } else if (aiService.service_type === 'mistral') {
         baseURL = 'https://api.mistral.ai/v1';
+      } else if (aiService.service_type === 'xai') {
+        baseURL = 'https://api.x.ai/v1';
       }
       const provider = createOpenAI({
         baseURL,

--- a/SparkyFitnessServer/tests/providerDispatch.test.ts
+++ b/SparkyFitnessServer/tests/providerDispatch.test.ts
@@ -244,6 +244,17 @@ describe('dispatchAiRequest — text-only structured request shapes', () => {
     expect(body.provider).toBeUndefined();
   });
 
+  it('xai routes to api.x.ai and mirrors openai strict json_schema without provider.require_parameters', async () => {
+    const m = mockFetch(openAiBody(JSON.stringify(SAMPLE)));
+    await dispatchAiRequest(
+      baseRequest({ provider: makeProvider({ service_type: 'xai' }) })
+    );
+    const { url, body } = captured(m);
+    expect(url).toBe('https://api.x.ai/v1/chat/completions');
+    expect((body.response_format as { type: string }).type).toBe('json_schema');
+    expect(body.provider).toBeUndefined();
+  });
+
   it('openrouter sends strict json_schema, provider.require_parameters, and attribution headers', async () => {
     const m = mockFetch(openAiBody(JSON.stringify(SAMPLE)));
     await dispatchAiRequest(


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Adds Grok (the xAI model family) as a selectable AI service provider, which users have asked for. It is separate from the existing groq.com provider.

**How did you implement the solution?**
xAI exposes an OpenAI-compatible API, so `xai` reuses the existing openai-family transport path rather than adding new transport code. Backend: `providerDispatch` routes `xai` to `https://api.x.ai/v1/chat/completions` and joins the openai family plus `STRICT_SCHEMA_PROVIDERS`; `chatService` handles `xai` in both the `generateText` and `streamText` paths; `config` defaults to `grok-4.3` (multimodal) for text and vision. Frontend: adds the "xAI (Grok)" dropdown option, a model list, and the English label. No DB migration is needed because `service_type` is a free-text column.

Linked Issue: Closes #1642

## How to Test

1. Check out this branch, build and run the stack, and sign in.
2. Open Settings then AI Service (or Global Services) and add a service with Service Type "xAI (Grok)".
3. Paste an xAI API key (format `xai-...`) and pick a model (`grok-4.3` for chat and vision). Set it active.
4. Verify the Sparky AI Coach chat responds, and that the photo meal estimator returns an estimate (this exercises `grok-4.3` vision).

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="1242" height="403" alt="2026-06-25 16_23_52-_# Hemp Oatmeal - Notepad" src="https://github.com/user-attachments/assets/e0e89464-7411-44c2-9207-74111d9bc491" />

### After

<img width="1251" height="541" alt="grok_provider" src="https://github.com/user-attachments/assets/a9368f89-2aa7-473e-a6db-f7728d3eae5a" />

</details>

## Notes for Reviewers

`groq` and `xai` are deliberately separate service types: `groq` is groq.com inference, `xai` is the xAI Grok model family.

Backend: typecheck, eslint (`--max-warnings 0`), prettier, and vitest all pass; the provider dispatch suite has 74 passing tests including a new `xai` case. There are no new endpoints or tables, so no Zod schemas or `rls_policies.sql` changes were required.

Frontend: only the `en` translation file is touched. `pnpm run validate` passes in a clean install; the production frontend Docker build runs `pnpm run validate` as the first half of `pnpm run build` and completes successfully.

Model IDs in the dropdown were verified against the live xAI `/language-models` endpoint: `grok-4.3`, `grok-4.20-0309-non-reasoning`, `grok-4.20-0309-reasoning`, and `grok-build-0.1` all exist and accept text and image input. The existing "Use Custom Model Name" field covers any model not in the list.
