### PR TITLE
fix(oidc): persist admin_group on provider update

### DIFF
--- a/SparkyFitnessServer/models/oidcProviderRepository.ts
+++ b/SparkyFitnessServer/models/oidcProviderRepository.ts
@@ -276,6 +276,7 @@ async function updateOidcProvider(id: any, providerData: any) {
         providerData.profile_signing_algorithm || 'none',
       timeout: providerData.timeout || 30000,
       is_env_configured: providerData.is_env_configured || false,
+      admin_group: providerData.admin_group || null,
     });
     const discoveryEndpoint =
       providerData.issuer_url.replace(/\/$/, '') +

--- a/SparkyFitnessServer/models/oidcProviderRepository.ts
+++ b/SparkyFitnessServer/models/oidcProviderRepository.ts
@@ -276,7 +276,10 @@ async function updateOidcProvider(id: any, providerData: any) {
         providerData.profile_signing_algorithm || 'none',
       timeout: providerData.timeout || 30000,
       is_env_configured: providerData.is_env_configured || false,
-      admin_group: providerData.admin_group || null,
+      admin_group:
+        providerData.admin_group !== undefined
+          ? providerData.admin_group
+          : existing?.admin_group || null,
     });
     const discoveryEndpoint =
       providerData.issuer_url.replace(/\/$/, '') +


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The updateOidcProvider function would nullify the admin_group in the db. The result was that admin_group was simply forgotten even if the oidc provider was sending it.

**How did you implement the solution?**
Added admin_group to the config in updateOidcProvider(). The field was simply missing.

Linked Issue: Closes #807 

## How to Test

1. Set SPARKY_FITNESS_OIDC_ADMIN_GROUP.
2. Login via OIDC to a user belonging to the same group -> user should get admin role.
3. Restart the container -> login again -> admin role should persist.
4. Remove user from admin group -> user should lose admin rights

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.


## Notes for Reviewers
As far as i understand, the other two issues in #807 were already fixed.
In my testing both entering and exiting the admin group had the expected results. 