### PR TITLE
fix(ai): drop Zod email() from the published manage_profile tool schema

### DIFF
--- a/SparkyFitnessServer/ai/tools/schemas/profile.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/profile.ts
@@ -84,11 +84,11 @@ export const manageProfileInput = z.object({
     .max(200)
     .optional()
     .describe("update_profile: user's display name"),
-  email: z
-    .string()
-    .email()
-    .optional()
-    .describe("update_profile: user's email address"),
+  // No .email() here: Zod v4's email regex uses lookahead, which is invalid
+  // under the RE2-style validators some providers (e.g. Groq) apply to tool
+  // parameter schemas, and it breaks the whole request. Email format is still
+  // enforced server-side by manageProfileSchema.safeParse in the handler.
+  email: z.string().optional().describe("update_profile: user's email address"),
   image: z
     .string()
     .url()

--- a/SparkyFitnessServer/tests/chatbotToolSchemas.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolSchemas.test.ts
@@ -358,6 +358,32 @@ describe('published (flat) chatbot tool schemas', () => {
       }
     }
   );
+
+  // Regex lookaround (e.g. Zod v4's .email() pattern) is rejected by the
+  // RE2-style validators some providers (Groq, xAI) apply to tool parameter
+  // schemas, which fails the whole request. Keep published schemas RE2-safe.
+  // Only actual `pattern` values are checked (recursively), so lookaround-like
+  // text in a description or example can't cause a false positive.
+  function collectPatterns(node: unknown, seen = new Set<object>()): string[] {
+    if (!node || typeof node !== 'object' || seen.has(node)) return [];
+    seen.add(node);
+    const obj = node as Record<string, unknown>;
+    const patterns: string[] = [];
+    if (typeof obj.pattern === 'string') patterns.push(obj.pattern);
+    for (const value of Object.values(obj)) {
+      patterns.push(...collectPatterns(value, seen));
+    }
+    return patterns;
+  }
+
+  it.each(flatCases)(
+    '$name has no regex lookaround in its published JSON schema patterns',
+    ({ schema }) => {
+      for (const pattern of collectPatterns(toJson(schema))) {
+        expect(pattern).not.toMatch(/\(\?[=!<]/);
+      }
+    }
+  );
 });
 
 describe('strict discriminated-union validation schemas', () => {


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Sparky AI chat fails with "invalid JSON schema for tool sparky_manage_profile" on providers that strictly validate tool parameter schemas with an RE2-style regex engine (for example Groq). The request is rejected before any model runs, so the whole chat is unusable on those providers.

**How did you implement the solution?**
The published manage_profile tool schema declared its email field with Zod's `.email()`, and Zod v4's email validator emits a JSON-schema `pattern` that uses regex lookahead (`^(?!\.)(?!.*\.\.)...`). RE2-style validators reject lookahead as an invalid regex, which fails the entire tool-calling request. This drops `.email()` from the published (flat) `manageProfileInput`, so the email field is a plain string with its description. Email format is still validated server-side by `manageProfileSchema.safeParse` in the tool handler, so behavior for valid input is unchanged. A regression test is added that asserts no published tool schema contains regex lookaround.

Linked Issue: Closes #1649

## How to Test

1. Configure a Groq AI service (or any provider that strictly validates tool schemas) and set it active.
2. Open the Sparky AI Coach chat and send a message that can trigger a tool, for example "log two eggs for breakfast".
3. Before this change the chat errors with "invalid JSON schema for tool sparky_manage_profile ... is not valid 'regex'".
4. After this change the request is accepted and the tool calls run normally.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Notes for Reviewers

This is a backend-only bug fix, so the frontend, UI, and mobile checklist items do not apply.

Root cause: Zod v4's `.email()` emits a JSON-schema pattern using regex lookahead. Serializing `manageProfileInput` confirms `.email()` produced exactly the `^(?!\.)(?!.*\.\.)...` pattern from the error, and that the fix removes all lookaround from the published schema. Only the published (model-facing) schema changed; the strict per-action discriminated union used for server-side validation is untouched, so email is still validated.

Backend: typecheck, eslint (`--max-warnings 0`), prettier, and the full vitest suite (1446 tests) pass. The added regression test scans every published tool schema and fails if any contains regex lookaround, so this cannot silently regress for any future provider, including the recently added xAI.

No new endpoints or tables, so no Zod request schemas or `rls_policies.sql` changes were required.
