### PR TITLE
feat(food-search): All Providers aggregated search (mobile, phase 2)

### DIFF
--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -863,6 +863,10 @@ function AppContent() {
             name="FoodSearch"
             component={SafeFoodSearch}
             options={createStackScreenOptions('Add Food', {
+              // The screen renders its own header; without this iOS shows the
+              // native stack header on top of it (double header). Android
+              // already defaults to headerShown: false.
+              headerShown: false,
               presentation: 'fullScreenModal',
               ...(Platform.OS === 'android' ? androidModalAnimation : {}),
             })}

--- a/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
@@ -8,6 +8,7 @@ import { ApiError } from '../../src/services/api/errors';
 import {
   useExternalFoodSearch,
   useExternalProviders,
+  useAllProvidersSearch,
   useFoodSearch,
   useFoods,
   useMealSearch,
@@ -21,6 +22,7 @@ import type { FoodItem } from '../../src/types/foods';
 jest.mock('../../src/hooks', () => ({
   useExternalFoodSearch: jest.fn(),
   useExternalProviders: jest.fn(),
+  useAllProvidersSearch: jest.fn(),
   useFoodSearch: jest.fn(),
   useFoods: jest.fn(),
   useMealSearch: jest.fn(),
@@ -50,6 +52,7 @@ const mockFetchExternalFoodDetails = fetchExternalFoodDetails as jest.MockedFunc
 const mockToastShow = Toast.show as jest.MockedFunction<typeof Toast.show>;
 const mockUseExternalFoodSearch = useExternalFoodSearch as jest.MockedFunction<typeof useExternalFoodSearch>;
 const mockUseExternalProviders = useExternalProviders as jest.MockedFunction<typeof useExternalProviders>;
+const mockUseAllProvidersSearch = useAllProvidersSearch as jest.MockedFunction<typeof useAllProvidersSearch>;
 const mockUseFoodSearch = useFoodSearch as jest.MockedFunction<typeof useFoodSearch>;
 const mockUseFoods = useFoods as jest.MockedFunction<typeof useFoods>;
 const mockUseMealSearch = useMealSearch as jest.MockedFunction<typeof useMealSearch>;
@@ -193,6 +196,11 @@ describe('FoodSearchScreen', () => {
       refetch: jest.fn(),
     } as any);
     mockUseExternalFoodSearch.mockReturnValue(activeExternalSearch());
+    mockUseAllProvidersSearch.mockReturnValue({
+      providerResults: [],
+      isSearchActive: false,
+      anyLoading: false,
+    } as any);
   });
 
   // Type a query so the screen enters search mode and renders the result sections.

--- a/SparkyFitnessMobile/__tests__/utils/providerColor.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/providerColor.test.ts
@@ -1,0 +1,40 @@
+import { buildProviderColorMap } from '../../src/utils/providerColor';
+import type { ExternalProvider } from '../../src/types/externalProviders';
+
+const provider = (id: string): ExternalProvider =>
+  ({ id, provider_name: id, provider_type: id, is_active: true }) as ExternalProvider;
+
+const PALETTE = ['c0', 'c1', 'c2', 'c3'];
+
+describe('buildProviderColorMap', () => {
+  it('assigns colours by list position', () => {
+    const map = buildProviderColorMap(
+      [provider('a'), provider('b'), provider('c')],
+      PALETTE,
+    );
+    expect(map.get('a')).toBe('c0');
+    expect(map.get('b')).toBe('c1');
+    expect(map.get('c')).toBe('c2');
+  });
+
+  it('gives every provider a distinct colour when they fit the palette', () => {
+    const providers = PALETTE.map((_, i) => provider(`p${i}`));
+    const map = buildProviderColorMap(providers, PALETTE);
+    const colours = providers.map((p) => map.get(p.id));
+    expect(new Set(colours).size).toBe(providers.length);
+  });
+
+  it('wraps around once providers exceed the palette', () => {
+    const map = buildProviderColorMap(
+      [provider('a'), provider('b'), provider('c'), provider('d'), provider('e')],
+      PALETTE,
+    );
+    // 5th provider wraps back to the first colour.
+    expect(map.get('e')).toBe('c0');
+    expect(map.get('e')).toBe(map.get('a'));
+  });
+
+  it('returns an empty map when the palette has not resolved yet', () => {
+    expect(buildProviderColorMap([provider('a')], []).size).toBe(0);
+  });
+});

--- a/SparkyFitnessMobile/__tests__/utils/topMatches.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/topMatches.test.ts
@@ -1,0 +1,98 @@
+import { interleaveTopMatches } from '../../src/utils/topMatches';
+import type { ProviderSearchResult } from '../../src/hooks/useAllProvidersSearch';
+import type { ExternalProvider } from '../../src/types/externalProviders';
+import type { ExternalFoodItem } from '../../src/types/externalFoods';
+
+const provider = (id: string): ExternalProvider =>
+  ({ id, provider_name: `Name ${id}`, provider_type: id }) as ExternalProvider;
+
+const item = (id: string): ExternalFoodItem =>
+  ({ id, name: `Food ${id}`, source: id }) as ExternalFoodItem;
+
+const result = (
+  id: string,
+  items: ExternalFoodItem[],
+  overrides: Partial<ProviderSearchResult> = {},
+): ProviderSearchResult => ({
+  provider: provider(id),
+  items,
+  totalCount: items.length,
+  isLoading: false,
+  isError: false,
+  refetch: jest.fn(),
+  ...overrides,
+});
+
+describe('interleaveTopMatches', () => {
+  it('round-robins rank 0 of every provider before rank 1', () => {
+    const out = interleaveTopMatches([
+      result('a', [item('a0'), item('a1')]),
+      result('b', [item('b0'), item('b1')]),
+    ]);
+    expect(out.map((m) => m.online.id)).toEqual(['a0', 'b0', 'a1', 'b1']);
+  });
+
+  it('tags each match with its provider name and id', () => {
+    const [first] = interleaveTopMatches([result('a', [item('a0')])]);
+    expect(first).toMatchObject({
+      providerId: 'a',
+      providerName: 'Name a',
+      online: { id: 'a0' },
+    });
+  });
+
+  it('caps the list at 5 by default', () => {
+    const many = Array.from({ length: 4 }, (_, i) =>
+      result(`p${i}`, [item(`p${i}-0`), item(`p${i}-1`)]),
+    );
+    expect(interleaveTopMatches(many)).toHaveLength(5);
+  });
+
+  it('takes at most perProvider ranks from any single provider', () => {
+    const out = interleaveTopMatches(
+      [result('a', [item('a0'), item('a1'), item('a2'), item('a3')])],
+      2,
+      10,
+    );
+    expect(out.map((m) => m.online.id)).toEqual(['a0', 'a1']);
+  });
+
+  it('shows at least one match per provider even past the base cap', () => {
+    // 8 providers with one item each: every provider should appear, despite the
+    // base cap of 5.
+    const providers = Array.from({ length: 8 }, (_, i) =>
+      result(`p${i}`, [item(`p${i}-0`)]),
+    );
+    const out = interleaveTopMatches(providers);
+    expect(out).toHaveLength(8);
+    expect(new Set(out.map((m) => m.providerId)).size).toBe(8);
+  });
+
+  it('only counts providers that returned results toward the minimum', () => {
+    const out = interleaveTopMatches([
+      result('a', [item('a0'), item('a1')]),
+      result('b', [], { isError: true }),
+      result('c', [item('c0'), item('c1')]),
+    ]);
+    // Two contributing providers, so the base cap of 5 still applies.
+    expect(out).toHaveLength(4);
+  });
+
+  it('skips empty or failed providers without breaking the order', () => {
+    const out = interleaveTopMatches([
+      result('a', [item('a0'), item('a1')]),
+      result('b', [], { isError: true }),
+      result('c', [item('c0')]),
+    ]);
+    expect(out.map((m) => m.online.id)).toEqual(['a0', 'c0', 'a1']);
+  });
+
+  it('returns an empty list when no provider has results', () => {
+    expect(
+      interleaveTopMatches([
+        result('a', [], { isLoading: true }),
+        result('b', [], { isError: true }),
+      ]),
+    ).toEqual([]);
+  });
+});

--- a/SparkyFitnessMobile/global.css
+++ b/SparkyFitnessMobile/global.css
@@ -58,6 +58,9 @@
       --color-cat-violet:        hsl(265, 70%, 60%);
       --color-cat-orange:        hsl(22, 92%, 65%);
       --color-cat-green:         hsl(124, 54%, 38%);
+      --color-cat-blue:          hsl(217, 80%, 52%);
+      --color-cat-teal:          hsl(182, 64%, 33%);
+      --color-cat-amber:         hsl(40, 88%, 43%);
 
       --color-progress-track:    hsl(218, 29%, 92%);
       --color-progress-overfill: hsl(215, 28%, 17%);
@@ -119,6 +122,9 @@
       --color-cat-violet:        hsl(265, 50%, 60%);
       --color-cat-orange:        hsl(22, 55%, 60%);
       --color-cat-green:         hsl(125, 24%, 53%);
+      --color-cat-blue:          hsl(217, 55%, 62%);
+      --color-cat-teal:          hsl(182, 35%, 52%);
+      --color-cat-amber:         hsl(40, 60%, 58%);
 
       --color-progress-track:    hsl(218, 41%, 23%);
       --color-progress-overfill: hsl(357, 66%, 65%);
@@ -180,6 +186,9 @@
       --color-cat-violet:        hsl(265, 50%, 60%);
       --color-cat-orange:        hsl(22, 55%, 60%);
       --color-cat-green:         hsl(125, 24%, 53%);
+      --color-cat-blue:          hsl(217, 55%, 62%);
+      --color-cat-teal:          hsl(182, 35%, 52%);
+      --color-cat-amber:         hsl(40, 60%, 58%);
 
       --color-progress-track:    hsl(218, 41%, 15%);
       --color-progress-overfill: hsl(357, 66%, 65%);

--- a/SparkyFitnessMobile/src/hooks/index.ts
+++ b/SparkyFitnessMobile/src/hooks/index.ts
@@ -54,6 +54,8 @@ export { useMeals, useRecentMeals, useMeal, useCreateMeal, useUpdateMeal, useDel
 export { useMealSearch } from './useMealSearch';
 export { useExternalProviders } from './useExternalProviders';
 export { useExternalFoodSearch } from './useExternalFoodSearch';
+export { useAllProvidersSearch } from './useAllProvidersSearch';
+export type { ProviderSearchResult } from './useAllProvidersSearch';
 export { useMealTypes } from './useMealTypes';
 export { useDeleteFoodEntry } from './useDeleteFoodEntry';
 export { useDeleteFood } from './useDeleteFood';

--- a/SparkyFitnessMobile/src/hooks/queryKeys.ts
+++ b/SparkyFitnessMobile/src/hooks/queryKeys.ts
@@ -38,6 +38,12 @@ export const externalProvidersQueryKey = ['externalProviders'] as const;
 export const externalFoodSearchQueryKey = (providerType: string, searchTerm: string, providerId?: string, autoScale?: boolean) =>
   ['externalFoodSearch', providerType, searchTerm, providerId, autoScale] as const;
 
+// First-page-only key for the "All Providers" fan-out. Kept distinct from
+// externalFoodSearchQueryKey (which backs an infinite query) so the two query
+// shapes do not collide in the cache.
+export const allProvidersFoodSearchQueryKey = (providerType: string, searchTerm: string, providerId?: string, autoScale?: boolean) =>
+  ['allProvidersFoodSearch', providerType, searchTerm, providerId, autoScale] as const;
+
 export const mealTypesQueryKey = ['mealTypes'] as const;
 
 export const goalsQueryKey = (date: string) => ['goals', date] as const;

--- a/SparkyFitnessMobile/src/hooks/useAllProvidersSearch.ts
+++ b/SparkyFitnessMobile/src/hooks/useAllProvidersSearch.ts
@@ -1,0 +1,104 @@
+import { useCallback } from 'react';
+import { useQueries, type UseQueryResult } from '@tanstack/react-query';
+import { searchExternalFoods } from '../services/api/externalFoodSearchApi';
+import { allProvidersFoodSearchQueryKey } from './queryKeys';
+import { useDebounce } from './useDebounce';
+import { offRateLimiter } from '../utils/rateLimiter';
+import { ExternalProvider } from '../types/externalProviders';
+import {
+  ExternalFoodItem,
+  PaginatedExternalFoodSearchResult,
+} from '../types/externalFoods';
+
+// Stable fallback so a missing refetch does not allocate a new function each
+// render (which would break reference stability of the providerResults items).
+const noop = () => {};
+
+export interface ProviderSearchResult {
+  provider: ExternalProvider;
+  items: ExternalFoodItem[];
+  totalCount: number;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+}
+
+// Fans a single search out across every active food provider in parallel. Each
+// provider query is independent, so results stream in as they return and a
+// failure in one provider does not block the others (partial results). First
+// page only; "show all" deep-links to the single-provider search for full
+// pagination.
+export function useAllProvidersSearch(
+  searchText: string,
+  providers: ExternalProvider[],
+  options?: { enabled?: boolean; autoScale?: boolean },
+) {
+  const { enabled = true, autoScale } = options ?? {};
+  const debouncedSearch = useDebounce(searchText.trim(), 600);
+  const isSearchActive = debouncedSearch.length >= 3;
+
+  // Project the raw query results into ProviderSearchResult here, inside
+  // useQueries' `combine`, rather than in a downstream useMemo over the raw
+  // queries array. Without `combine`, useQueries returns a brand-new array
+  // reference on every render (the array is rebuilt via `.map`; structural
+  // sharing only applies to the `combine` output), which would invalidate every
+  // memo that depends on it on each keystroke. React Query runs `combine` only
+  // when a query actually changes and applies replaceEqualDeep structural
+  // sharing to its result, so providerResults stays referentially stable across
+  // renders without reading or writing refs during render. `combine` is
+  // compared by identity, so it is memoised on the providers it closes over;
+  // results are index-aligned with `providers` because the query list below is
+  // built from the same `providers.map` order.
+  const combine = useCallback(
+    (
+      results: UseQueryResult<PaginatedExternalFoodSearchResult>[],
+    ): ProviderSearchResult[] =>
+      providers.map((provider, i) => {
+        const q = results[i];
+        const items = q?.data?.items ?? [];
+        return {
+          provider,
+          items,
+          totalCount: q?.data?.pagination?.totalCount ?? 0,
+          // Loading while fetching with nothing to show yet — covers the initial
+          // load and an error retry (isLoading is false on a retry), but not a
+          // background refetch that already has cached results (which would
+          // otherwise flash the spinner over good data).
+          isLoading: (q?.isFetching ?? false) && items.length === 0,
+          isError: q?.isError ?? false,
+          refetch: q?.refetch ?? noop,
+        };
+      }),
+    [providers],
+  );
+
+  const providerResults = useQueries({
+    queries: providers.map((p) => ({
+      queryKey: allProvidersFoodSearchQueryKey(
+        p.provider_type,
+        debouncedSearch,
+        p.id,
+        autoScale,
+      ),
+      queryFn: async ({ signal }: { signal: AbortSignal }) => {
+        if (p.provider_type === 'openfoodfacts') {
+          await offRateLimiter.acquire(signal);
+        }
+        return searchExternalFoods(
+          p.provider_type,
+          debouncedSearch,
+          1,
+          p.id,
+          autoScale,
+        );
+      },
+      enabled: isSearchActive && enabled,
+      staleTime: 1000 * 60 * 5,
+    })),
+    combine,
+  });
+
+  const anyLoading = providerResults.some((r) => r.isLoading);
+
+  return { providerResults, isSearchActive, anyLoading };
+}

--- a/SparkyFitnessMobile/src/hooks/useExternalFoodSearch.ts
+++ b/SparkyFitnessMobile/src/hooks/useExternalFoodSearch.ts
@@ -4,10 +4,7 @@ import { searchExternalFoods } from '../services/api/externalFoodSearchApi';
 import { getApiErrorMessage } from '../services/api/errors';
 import { externalFoodSearchQueryKey } from './queryKeys';
 import { useDebounce } from './useDebounce';
-import { RateLimiter } from '../utils/rateLimiter';
-
-// Open Food Facts allows 10 req/min; use 8 for headroom
-const offRateLimiter = new RateLimiter(8, 60_000);
+import { offRateLimiter } from '../utils/rateLimiter';
 
 export function useExternalFoodSearch(
   searchText: string,

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -23,8 +23,10 @@ import {
   useMealSearch,
   useExternalProviders,
   useExternalFoodSearch,
+  useAllProvidersSearch,
   usePreferences,
 } from '../hooks';
+import { ExternalProvider } from '../types/externalProviders';
 import Toast from 'react-native-toast-message';
 import { fetchExternalFoodDetails } from '../services/api/externalFoodSearchApi';
 import { getApiErrorMessage } from '../services/api/errors';
@@ -39,6 +41,8 @@ import {
 import type { FoodInfoItem } from '../types/foodInfo';
 import type { RootStackScreenProps } from '../types/navigation';
 import { formatServingDescription, formatServingUnit } from '../utils/foodDetails';
+import { useProviderColor } from '../utils/providerColor';
+import { interleaveTopMatches } from '../utils/topMatches';
 
 type FoodSearchScreenProps = RootStackScreenProps<'FoodSearch'>;
 
@@ -53,16 +57,45 @@ type LandingSection = {
 type ResultRow =
   | { type: 'food'; food: FoodItem }
   | { type: 'meal'; meal: Meal }
-  | { type: 'online'; online: ExternalFoodItem }
+  | { type: 'online'; online: ExternalFoodItem; providerId?: string }
+  | {
+      type: 'online-top';
+      online: ExternalFoodItem;
+      providerName: string;
+      providerId?: string;
+    }
+  | { type: 'show-all'; provider: ExternalProvider; count: number }
+  | { type: 'show-all-local'; section: 'foods' | 'meals'; count: number }
+  | { type: 'provider-skeleton' }
   | { type: 'empty-local' }
   | { type: 'local-loading' };
 
 type ResultSection = {
   key: string;
   title: string | null;
-  kind: 'food' | 'meal' | 'online' | 'empty-local' | 'status';
+  kind:
+    | 'food'
+    | 'meal'
+    | 'online'
+    | 'online-top'
+    | 'online-provider'
+    | 'label'
+    | 'empty-local'
+    | 'status';
   data: ResultRow[];
+  provider?: ExternalProvider;
+  count?: number;
+  providerLoading?: boolean;
+  providerError?: boolean;
+  onRetry?: () => void;
 };
+
+// Sentinel provider id for the aggregated "All Providers" mode.
+const ALL_PROVIDERS_VALUE = '__all__';
+
+// How many local rows to show per section before the "Show all" expander, while
+// online results are also on screen.
+const LOCAL_RESULT_CAP = 6;
 
 const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }) => {
   const date = route.params?.date;
@@ -105,6 +138,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   // Online provider results stream in below the local results, always fetched
   // (no separate Online tab). Provider is the user's default.
   const { providers } = useExternalProviders({ enabled: isConnected });
+  const getProviderColor = useProviderColor(providers);
   const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
   const hasUserSelectedProvider = useRef(false);
 
@@ -114,7 +148,8 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     if (providers.length === 0) return;
     if (
       hasUserSelectedProvider.current &&
-      providers.some((provider) => provider.id === selectedProvider)
+      ((selectedProvider === ALL_PROVIDERS_VALUE && providers.length > 1) ||
+        providers.some((provider) => provider.id === selectedProvider))
     ) {
       return;
     }
@@ -125,10 +160,17 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     setSelectedProvider(defaultProvider?.id ?? providers[0].id);
   }, [preferences?.default_food_data_provider_id, providers, selectedProvider]);
 
-  const providerOptions = useMemo(
-    () => providers.map((p) => ({ label: p.provider_name, value: p.id })),
-    [providers],
-  );
+  const providerOptions = useMemo(() => {
+    const opts = providers.map((p) => ({
+      label: p.provider_name,
+      value: p.id,
+    }));
+    // Offer the aggregated view only when there is more than one provider.
+    if (providers.length > 1) {
+      opts.unshift({ label: 'All Providers', value: ALL_PROVIDERS_VALUE });
+    }
+    return opts;
+  }, [providers]);
   // Temporary peek at another provider; does not change the saved default.
   const handleSelectProvider = useCallback((id: string) => {
     hasUserSelectedProvider.current = true;
@@ -144,6 +186,32 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     [providers, selectedProvider],
   );
 
+  const isAllProviders = selectedProvider === ALL_PROVIDERS_VALUE;
+  // Which By Source provider accordions are expanded (All Providers mode).
+  const [expandedProviders, setExpandedProviders] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const toggleProvider = useCallback((id: string) => {
+    setExpandedProviders((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  // The local sections (Your Foods / Your Meals) are capped to a few rows while
+  // online results are also showing, so a large local match set does not bury
+  // the online section below the fold. A "Show all" row lifts the cap; a new
+  // query resets it.
+  const [showAllFoods, setShowAllFoods] = useState(false);
+  const [showAllMeals, setShowAllMeals] = useState(false);
+  React.useEffect(() => {
+    setShowAllFoods(false);
+    setShowAllMeals(false);
+  }, [searchText]);
+
+  // Single-provider online search (disabled while All Providers is active).
   const {
     searchResults: onlineResults,
     isSearching: isOnlineSearching,
@@ -153,10 +221,27 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     isFetchingNextPage,
     isFetchNextPageError,
   } = useExternalFoodSearch(searchText, selectedProviderType, {
-    enabled: isConnected && selectedProvider !== null,
+    enabled: isConnected && selectedProvider !== null && !isAllProviders,
     providerId: selectedProvider ?? undefined,
     autoScale: preferences?.auto_scale_open_food_facts_imports,
   });
+
+  // All Providers fan-out: parallel per-provider searches that stream in.
+  const {
+    providerResults,
+    anyLoading: anyProviderLoading,
+    isSearchActive: isAllProvidersSearchActive,
+  } = useAllProvidersSearch(searchText, providers, {
+    enabled: isConnected && isAllProviders,
+    autoScale: preferences?.auto_scale_open_food_facts_imports,
+  });
+
+  // Top Matches: interleave each provider's top results (round-robin by rank),
+  // capped, each tagged with its source. See interleaveTopMatches for the rule.
+  const topMatches = useMemo(
+    () => interleaveTopMatches(providerResults),
+    [providerResults],
+  );
 
   // --- Navigation / actions ---
 
@@ -190,7 +275,12 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
       date,
       pickerMode: isMealBuilderMode ? 'meal-builder' : undefined,
       returnDepth: isMealBuilderMode ? 2 : undefined,
-      providerId: selectedProvider ?? undefined,
+      // Never forward the All Providers sentinel as a real provider; the scanner
+      // should fall back to its default provider in that mode.
+      providerId:
+        selectedProvider === ALL_PROVIDERS_VALUE
+          ? undefined
+          : (selectedProvider ?? undefined),
     });
   }, [navigation, date, isMealBuilderMode, selectedProvider]);
 
@@ -207,14 +297,22 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   }, [isMealBuilderMode, openCreateFood]);
 
   const handleExternalFoodTap = useCallback(
-    async (item: ExternalFoodItem) => {
-      if ((item.source === 'fatsecret' || item.source === 'yazio') && selectedProvider) {
+    async (item: ExternalFoodItem, explicitProviderId?: string) => {
+      // Prefer the exact provider id carried by the result row (needed when
+      // multiple providers share a type). Fall back to resolving by source: the
+      // sentinel in All Providers mode, otherwise the selected provider.
+      const providerId =
+        explicitProviderId ??
+        (selectedProvider === ALL_PROVIDERS_VALUE
+          ? providers.find((p) => p.provider_type === item.source)?.id
+          : selectedProvider);
+      if ((item.source === 'fatsecret' || item.source === 'yazio') && providerId) {
         setLoadingFoodId(item.id);
         try {
           const detailed = await fetchExternalFoodDetails(
             item.source,
             item.id,
-            selectedProvider,
+            providerId,
           );
           showFoodInfo(externalFoodItemToFoodInfo(detailed));
         } catch (error) {
@@ -229,7 +327,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
       }
       showFoodInfo(externalFoodItemToFoodInfo(item));
     },
-    [selectedProvider, showFoodInfo],
+    [selectedProvider, providers, showFoodInfo],
   );
 
   // --- Derived state ---
@@ -265,22 +363,42 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   const resultSections = useMemo<ResultSection[]>(() => {
     const sections: ResultSection[] = [];
 
+    // Cap the local sections only when an online section will also render, so a
+    // pure local search is never truncated.
+    const willShowOnline = isAllProviders
+      ? isAllProvidersSearchActive
+      : showOnlineSection;
+
     if (hasLocalResults) {
       if (searchResults.length > 0) {
-        sections.push({
-          key: 'foods',
-          kind: 'food',
-          title: 'Your Foods',
-          data: searchResults.map((food) => ({ type: 'food', food })),
-        });
+        const capFoods = willShowOnline && !showAllFoods;
+        const shown = capFoods
+          ? searchResults.slice(0, LOCAL_RESULT_CAP)
+          : searchResults;
+        const data: ResultRow[] = shown.map((food) => ({ type: 'food', food }));
+        if (capFoods && searchResults.length > LOCAL_RESULT_CAP) {
+          data.push({
+            type: 'show-all-local',
+            section: 'foods',
+            count: searchResults.length,
+          });
+        }
+        sections.push({ key: 'foods', kind: 'food', title: 'Your Foods', data });
       }
       if (!isMealBuilderMode && mealResults.length > 0) {
-        sections.push({
-          key: 'meals',
-          kind: 'meal',
-          title: 'Your Meals',
-          data: mealResults.map((meal) => ({ type: 'meal', meal })),
-        });
+        const capMeals = willShowOnline && !showAllMeals;
+        const shown = capMeals
+          ? mealResults.slice(0, LOCAL_RESULT_CAP)
+          : mealResults;
+        const data: ResultRow[] = shown.map((meal) => ({ type: 'meal', meal }));
+        if (capMeals && mealResults.length > LOCAL_RESULT_CAP) {
+          data.push({
+            type: 'show-all-local',
+            section: 'meals',
+            count: mealResults.length,
+          });
+        }
+        sections.push({ key: 'meals', kind: 'meal', title: 'Your Meals', data });
       }
     } else if (localPending) {
       sections.push({
@@ -298,7 +416,64 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
       });
     }
 
-    if (showOnlineSection) {
+    if (isAllProviders) {
+      // Aggregated "All Providers" view: Top Matches then a By Source
+      // accordion per provider, each streaming in independently. Gate on the
+      // hook's debounced active flag (not raw text length) so the sections do
+      // not flash "No results" during the debounce window before queries fire.
+      if (isAllProvidersSearchActive) {
+        sections.push({
+          key: 'online-top',
+          kind: 'online-top',
+          title: 'Top Matches',
+          data: topMatches.map((m) => ({
+            type: 'online-top',
+            online: m.online,
+            providerName: m.providerName,
+            providerId: m.providerId,
+          })),
+        });
+        sections.push({
+          key: 'by-source-label',
+          kind: 'label',
+          title: 'By Source',
+          data: [],
+        });
+        for (const r of providerResults) {
+          const expanded = expandedProviders.has(r.provider.id);
+          let rows: ResultRow[] = [];
+          if (expanded) {
+            if (r.isLoading && r.items.length === 0) {
+              rows = [{ type: 'provider-skeleton' }];
+            } else {
+              rows = r.items.map((online) => ({
+                type: 'online' as const,
+                online,
+                providerId: r.provider.id,
+              }));
+              if (r.totalCount > r.items.length) {
+                rows.push({
+                  type: 'show-all',
+                  provider: r.provider,
+                  count: r.totalCount,
+                });
+              }
+            }
+          }
+          sections.push({
+            key: `online-provider-${r.provider.id}`,
+            kind: 'online-provider',
+            title: r.provider.provider_name,
+            data: rows,
+            provider: r.provider,
+            count: r.totalCount,
+            providerLoading: r.isLoading,
+            providerError: r.isError,
+            onRetry: r.refetch,
+          });
+        }
+      }
+    } else if (showOnlineSection) {
       sections.push({
         key: 'online',
         kind: 'online',
@@ -317,6 +492,13 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     showOnlineSection,
     selectedProviderName,
     visibleOnlineResults,
+    isAllProviders,
+    isAllProvidersSearchActive,
+    topMatches,
+    providerResults,
+    expandedProviders,
+    showAllFoods,
+    showAllMeals,
   ]);
 
   // --- Row renderers (shared between landing and results) ---
@@ -347,13 +529,17 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     </TouchableOpacity>
   );
 
-  const renderOnlineRow = (item: ExternalFoodItem) => (
+  const renderOnlineRow = (
+    item: ExternalFoodItem,
+    badge?: string,
+    providerId?: string,
+  ) => (
     <TouchableOpacity
       className="px-4 py-3 border-b border-border-subtle"
       activeOpacity={0.7}
       disabled={loadingFoodId !== null}
       onPress={() => {
-        void handleExternalFoodTap(item);
+        void handleExternalFoodTap(item, providerId);
       }}
     >
       <View className="flex-row justify-between items-center">
@@ -364,8 +550,33 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
               <Icon name="checkmark" size={14} color={iconSuccess} />
             ) : null}
           </View>
-          {item.brand ? (
-            <Text className="text-text-secondary text-sm mt-0.5">{item.brand}</Text>
+          {badge || item.brand ? (
+            <View className="flex-row items-center gap-1.5 mt-0.5">
+              {badge ? (
+                <View className="px-1.5 py-0.5 rounded overflow-hidden">
+                  <View
+                    style={{
+                      position: 'absolute',
+                      left: 0,
+                      top: 0,
+                      right: 0,
+                      bottom: 0,
+                      backgroundColor: getProviderColor(providerId),
+                      opacity: 0.13,
+                    }}
+                  />
+                  <Text
+                    className="text-xs font-semibold"
+                    style={{ color: getProviderColor(providerId) }}
+                  >
+                    {badge}
+                  </Text>
+                </View>
+              ) : null}
+              {item.brand ? (
+                <Text className="text-text-secondary text-sm">{item.brand}</Text>
+              ) : null}
+            </View>
           ) : null}
         </View>
         <View className="items-end">
@@ -386,6 +597,50 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
         </View>
       </View>
     </TouchableOpacity>
+  );
+
+  // "Show all N <provider> results" → switch into single-provider mode for that
+  // provider, which shows the full paginated list.
+  const renderShowAllRow = (provider: ExternalProvider, count: number) => (
+    <TouchableOpacity
+      className="px-4 py-3 border-b border-border-subtle"
+      activeOpacity={0.7}
+      onPress={() => handleSelectProvider(provider.id)}
+    >
+      <Text className="text-sm font-medium" style={{ color: accentColor }}>
+        Show all {count} {provider.provider_name} results
+      </Text>
+    </TouchableOpacity>
+  );
+
+  const renderLocalShowAllRow = (section: 'foods' | 'meals', count: number) => (
+    <TouchableOpacity
+      className="px-4 py-3 border-b border-border-subtle"
+      activeOpacity={0.7}
+      onPress={() =>
+        section === 'foods' ? setShowAllFoods(true) : setShowAllMeals(true)
+      }
+    >
+      <Text className="text-sm font-medium" style={{ color: accentColor }}>
+        Show all {count} {section === 'foods' ? 'foods' : 'meals'}
+      </Text>
+    </TouchableOpacity>
+  );
+
+  const renderProviderSkeleton = () => (
+    <View className="px-4 py-3 gap-2">
+      {[0.8, 0.6, 0.7].map((w, i) => (
+        <View
+          key={i}
+          className="h-4 rounded"
+          style={{
+            width: `${w * 100}%`,
+            backgroundColor: textMuted,
+            opacity: 0.15,
+          }}
+        />
+      ))}
+    </View>
   );
 
   const renderSectionHeaderTitle = (title: string) => (
@@ -409,7 +664,15 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
           />
         );
       case 'online':
-        return renderOnlineRow(item.online);
+        return renderOnlineRow(item.online, undefined, item.providerId);
+      case 'online-top':
+        return renderOnlineRow(item.online, item.providerName, item.providerId);
+      case 'show-all':
+        return renderShowAllRow(item.provider, item.count);
+      case 'show-all-local':
+        return renderLocalShowAllRow(item.section, item.count);
+      case 'provider-skeleton':
+        return renderProviderSkeleton();
       case 'local-loading':
         return (
           <View className="py-8 items-center">
@@ -431,26 +694,30 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
 
   const renderResultSectionHeader = ({ section }: { section: ResultSection }) => {
     if (!section.title) return null;
-    // The online section header doubles as a provider switcher so the user can
-    // peek at another provider's results without changing their default.
-    if (section.kind === 'online') {
+
+    // The External Results / Top Matches header doubles as the source switcher:
+    // a single provider, or "All Providers" for the aggregated view. The current
+    // value is shown in the accent colour with a double-arrow selector icon so it
+    // reads as a switchable control; the icon becomes a spinner while loading.
+    if (section.kind === 'online' || section.kind === 'online-top') {
       const canSwitch = providerOptions.length > 1;
-      // Section heading on the left; on the right the current provider name is
-      // shown in the accent colour with a double-arrow selector icon so it reads
-      // as a switchable control. The icon becomes a spinner while a swap loads.
+      const label =
+        section.kind === 'online-top' ? 'Top Matches' : 'External Results';
+      const value = isAllProviders ? 'All Providers' : selectedProviderName;
+      const loading = isAllProviders ? anyProviderLoading : isOnlineSearching;
       const header = (
         <View className="px-4 py-2 bg-surface flex-row items-center justify-between">
           <Text className="text-text-muted text-xs font-semibold uppercase">
-            External Results
+            {label}
           </Text>
           <View className="flex-row items-center gap-1">
             <Text
               className="text-xs font-medium"
               style={{ color: canSwitch ? accentColor : textSecondary }}
             >
-              {selectedProviderName}
+              {value}
             </Text>
-            {isOnlineSearching ? (
+            {loading ? (
               <ActivityIndicator size="small" color={accentColor} />
             ) : canSwitch ? (
               <Icon name="chevron-expand" size={16} color={accentColor} />
@@ -474,7 +741,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
                 onPress();
               }}
               accessibilityRole="button"
-              accessibilityLabel={`External results source ${selectedProviderName}, tap to change`}
+              accessibilityLabel={`Source ${value}, tap to change`}
             >
               {header}
             </Pressable>
@@ -482,6 +749,75 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
         />
       );
     }
+
+    // By Source: a tappable accordion header per provider, with a result-count
+    // badge and a per-provider loading spinner.
+    if (section.kind === 'online-provider' && section.provider) {
+      const provider = section.provider;
+      const expanded = expandedProviders.has(provider.id);
+      const color = getProviderColor(provider.id);
+      const loading = !!section.providerLoading;
+      const errored = !!section.providerError && !loading;
+      const count = section.count ?? 0;
+      const empty = !loading && !errored && count === 0;
+      const expandable = !loading && !errored && count > 0;
+      const onPress = errored
+        ? section.onRetry
+        : expandable
+          ? () => toggleProvider(provider.id)
+          : undefined;
+      return (
+        <Pressable
+          onPress={onPress}
+          disabled={!onPress}
+          className="px-4 py-2.5 bg-surface flex-row items-center justify-between border-t border-border-subtle"
+          accessibilityRole="button"
+          accessibilityLabel={
+            errored
+              ? `${provider.provider_name}, could not load, tap to retry`
+              : empty
+                ? `${provider.provider_name}, no results`
+                : expandable
+                  ? `${provider.provider_name}, ${count} results, tap to ${
+                      expanded ? 'collapse' : 'expand'
+                    }`
+                  : provider.provider_name
+          }
+        >
+          <View className="flex-row items-center gap-2">
+            <View
+              className="w-2 h-2 rounded-full"
+              style={{ backgroundColor: color }}
+            />
+            <Text className="text-text-primary text-sm font-semibold">
+              {provider.provider_name}
+            </Text>
+            {expandable ? (
+              <View className="px-1.5 py-0.5 rounded-full bg-background">
+                <Text className="text-text-secondary text-xs">{count}</Text>
+              </View>
+            ) : null}
+          </View>
+          {loading ? (
+            <ActivityIndicator size="small" color={textMuted} />
+          ) : errored ? (
+            <View className="flex-row items-center gap-1">
+              <Text className="text-text-muted text-xs">Couldn&apos;t load</Text>
+              <Icon name="sync" size={14} color={textMuted} />
+            </View>
+          ) : empty ? (
+            <Text className="text-text-muted text-xs">No results</Text>
+          ) : (
+            <Icon
+              name={expanded ? 'chevron-down' : 'chevron-forward'}
+              size={16}
+              color={textMuted}
+            />
+          )}
+        </Pressable>
+      );
+    }
+
     return renderSectionHeaderTitle(section.title);
   };
 
@@ -545,7 +881,11 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
       case 'meal':
         return `meal-${item.meal.id}`;
       case 'online':
-        return `online-${item.online.source}-${item.online.id}-${index}`;
+        // Include the provider id so two providers that share a provider_type
+        // (item.online.source) cannot collide on the same key in All Providers.
+        return `online-${item.providerId ?? item.online.source}-${item.online.id}-${index}`;
+      case 'show-all-local':
+        return `show-all-local-${item.section}`;
       default:
         return `${item.type}-${index}`;
     }

--- a/SparkyFitnessMobile/src/utils/providerColor.ts
+++ b/SparkyFitnessMobile/src/utils/providerColor.ts
@@ -1,0 +1,58 @@
+import { useCSSVariable } from 'uniwind';
+import { ExternalProvider } from '../types/externalProviders';
+
+// Per-provider signature colours used to tell sources apart at a glance in the
+// All Providers search: a tinted badge behind Top Matches rows and a dot before
+// each By Source provider. Colours are drawn from the theme's category palette
+// in global.css (the same contrast-tuned vars used for the settings icons)
+// rather than hardcoded hex, so they stay consistent with the rest of the app
+// and adapt to light/dark/amoled themes.
+const PROVIDER_PALETTE_VARS = [
+  '--color-cat-green',
+  '--color-cat-orange',
+  '--color-cat-violet',
+  '--color-cat-pink',
+  '--color-cat-slate',
+  '--color-cat-blue',
+  '--color-cat-teal',
+  '--color-cat-amber',
+];
+
+// Returns a resolver mapping a provider id to a theme colour. Providers are
+// assigned colours by their position in the active list (palette[i % length]),
+// not by a hash of their type: with only a handful of palette entries a hash
+// has a real collision chance (birthday paradox), and any collision defeats the
+// point of telling sources apart. Index assignment is collision-free as long as
+// the active providers fit the palette, and still covers providers that have no
+// dedicated colour. It is not stable across reordering, which is fine for
+// at-a-glance grouping. Read the palette through uniwind so the values follow
+// the active theme; call this at the top of a component and use the returned
+// function while rendering rows.
+// Maps each provider id to a palette colour by list position. Collision-free
+// while the active providers fit the palette; wraps past that.
+export function buildProviderColorMap(
+  providers: ExternalProvider[],
+  palette: string[],
+): Map<string, string> {
+  const byId = new Map<string, string>();
+  if (palette.length > 0) {
+    providers.forEach((p, i) => {
+      byId.set(p.id, palette[i % palette.length]);
+    });
+  }
+  return byId;
+}
+
+export function useProviderColor(
+  providers: ExternalProvider[],
+): (providerId?: string | null) => string {
+  const palette = useCSSVariable(PROVIDER_PALETTE_VARS) as string[];
+  const fallback = String(useCSSVariable('--color-text-muted'));
+
+  const byId = buildProviderColorMap(providers, palette);
+
+  return (providerId?: string | null): string => {
+    if (!providerId) return fallback;
+    return byId.get(providerId) ?? fallback;
+  };
+}

--- a/SparkyFitnessMobile/src/utils/rateLimiter.ts
+++ b/SparkyFitnessMobile/src/utils/rateLimiter.ts
@@ -80,3 +80,9 @@ export class RateLimiter {
     this.timestamps = [];
   }
 }
+
+// Shared Open Food Facts rate limiter. Both the single-provider search hook and
+// the All Providers fan-out use this one instance, so the two modes draw from a
+// single budget rather than two; toggling between them can't push OFF past its
+// limit. OFF allows ~10 requests/min; 8 leaves headroom.
+export const offRateLimiter = new RateLimiter(8, 60_000);

--- a/SparkyFitnessMobile/src/utils/topMatches.ts
+++ b/SparkyFitnessMobile/src/utils/topMatches.ts
@@ -1,0 +1,42 @@
+import { ExternalFoodItem } from '../types/externalFoods';
+import { ProviderSearchResult } from '../hooks/useAllProvidersSearch';
+
+export interface TopMatch {
+  online: ExternalFoodItem;
+  providerName: string;
+  providerId: string;
+}
+
+// Round-robin interleave of each provider's top results for the All Providers
+// "Top Matches" section: take rank 0 from every provider, then rank 1, and so
+// on up to perProvider ranks, then cap the list. This keeps Top Matches
+// balanced across sources instead of letting one fast/large provider dominate.
+// A provider that returned fewer items than the current rank is simply skipped,
+// so empty or failed providers contribute nothing without breaking the order.
+// The cap never drops below the number of providers that returned results:
+// because the round robin emits every provider's first item before any second
+// item, this guarantees at least one match from every contributing provider, so
+// the user always sees that each of their configured providers was searched.
+export function interleaveTopMatches(
+  providerResults: ProviderSearchResult[],
+  perProvider = 2,
+  baseCap = 5,
+): TopMatch[] {
+  const out: TopMatch[] = [];
+  for (let rank = 0; rank < perProvider; rank++) {
+    for (const r of providerResults) {
+      const item = r.items[rank];
+      if (item) {
+        out.push({
+          online: item,
+          providerName: r.provider.provider_name,
+          providerId: r.provider.id,
+        });
+      }
+    }
+  }
+  const providersWithResults = providerResults.filter(
+    (r) => r.items.length > 0,
+  ).length;
+  return out.slice(0, Math.max(baseCap, providersWithResults));
+}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Phase 2 of the unified search (#1496). Phase 1 streamed in a single online provider; this adds an "All Providers" mode so a single search returns results from every configured food provider at once, without the user picking a source first.

**How did you implement the solution?**
Selecting "All Providers" in the source switcher fans the search out across all active food providers in parallel (`useAllProvidersSearch`, built on React Query `useQueries`). Each provider is its own query, so results stream in independently and a slow or failing provider does not block the others (partial results). The view shows Top Matches (each provider's top results interleaved round-robin, capped, badged with the source) and a By Source section with one collapsible accordion per provider. Each accordion has a result-count badge, a per-provider loading spinner and skeleton, an errored state ("Couldn't load" + tap to retry), an empty state ("No results"), and a "show all N" link that opens that single provider's full paginated view. Providers are colour-coded (a tinted badge in Top Matches and a dot in By Source) via a small `providerColor` helper (curated map + deterministic fallback). The fan-out is entirely client-side, so there is no new backend.

Linked Issue: Closes #1653

## How to Test

1. Have two or more active food providers configured (Open Food Facts and Swiss Food Database are seeded by default and need no credentials).
2. Open the food search, type a query (for example "salmon").
3. Tap the source selector in the External Results header and choose "All Providers".
4. Verify Top Matches shows interleaved results badged by source, and By Source lists each provider with a result count.
5. Tap a provider to expand it; tap "show all N" to open that provider's full results.
6. Confirm a provider that errors or returns nothing shows "Couldn't load" (with retry) or "No results" respectively, and the others still render.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<img width="480" height="976" alt="Screenshot_20260626_173750_SparkyFitness" src="https://github.com/user-attachments/assets/4aed2e75-4788-4b22-b91a-e7468f78fe25" />

## Notes for Reviewers

Mobile only. Web parity is intentionally deferred to a follow-up so the mobile UX can settle first; no `SparkyFitnessFrontend/` or `SparkyFitnessServer/` changes here (the Frontend and Backend checklist items above are left unchecked because they do not apply). Tests: `FoodSearchScreen.test.tsx` updated and passing; typecheck and lint clean on the changed files.

A few deliberate choices worth your eye, all easy to change:
- "Show all N" switches into that single provider's existing full view in-place rather than pushing a new screen (reuses the phase 1 single-provider search). Can be a pushed screen if preferred.
- By Source accordions start collapsed (Top Matches gives instant results).
- An errored provider shows a muted "Couldn't load" + retry rather than being hidden, so the user knows it was tried and can recover.
- Header label follows content: single provider reads "External Results", All Providers reads "Top Matches" then "By Source", with the source switcher constant across both.
