### PR TITLE
fix: preserve external data credentials on edit

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
@@ -16,6 +16,7 @@ import {
   decodeYazioAppId,
   encodeYazioAppId,
   encodeYazioAppKey,
+  resolveProviderCredentialPayload,
 } from '@/utils/settings';
 
 import {
@@ -168,7 +169,10 @@ const ExternalProviderList = ({
     let yazioAppId: string | undefined;
     let yazioAppKey: string | undefined;
 
-    if (editData.provider_type === 'yazio' && existingProvider) {
+    if (
+      editData.provider_type === 'yazio' &&
+      existingProvider?.provider_type === 'yazio'
+    ) {
       // Decode existing stored credentials
       const existingAppId = decodeYazioAppId(existingProvider.app_id);
       const existingAppKey = (() => {
@@ -205,7 +209,9 @@ const ExternalProviderList = ({
       yazioAppId = encodeYazioAppId(mergedUsername, mergedClientId);
       yazioAppKey = encodeYazioAppKey(mergedPassword, mergedClientSecret);
     } else if (editData.provider_type === 'yazio') {
-      // Fallback for new provider (shouldn't happen in update path, but safe)
+      // New provider, or the type was just changed to YAZIO. Use only the
+      // entered values — never merge from a non-YAZIO row, or the old
+      // provider's credentials would be carried into the new YAZIO provider.
       yazioAppId = encodeYazioAppId(editData.app_id, editData.yazio_client_id);
       yazioAppKey = encodeYazioAppKey(
         editData.app_key,
@@ -213,48 +219,17 @@ const ExternalProviderList = ({
       );
     }
 
+    const { app_id, app_key } = resolveProviderCredentialPayload(
+      editData,
+      yazioAppId,
+      yazioAppKey,
+      existingProvider?.provider_type
+    );
     const providerUpdateData: Partial<ExternalDataProvider> = {
       provider_name: editData.provider_name,
       provider_type: editData.provider_type,
-      app_id:
-        editData.provider_type === 'mealie' ||
-        editData.provider_type === 'tandoor' ||
-        editData.provider_type === 'norish' ||
-        editData.provider_type === 'free-exercise-db' ||
-        editData.provider_type === 'wger'
-          ? null
-          : editData.provider_type === 'openfoodfacts' ||
-              editData.provider_type === 'yazio'
-            ? editData.provider_type === 'yazio'
-              ? yazioAppId
-              : editData.app_id || undefined
-            : // OAuth providers store credentials encrypted server-side and never echo them back.
-              // Send undefined (not null) when empty so COALESCE preserves the existing value.
-              // null would trigger clearAppId=true and wipe the encrypted credential.
-              [
-                  'googlehealth',
-                  'fitbit',
-                  'withings',
-                  'strava',
-                  'polar',
-                ].includes(editData.provider_type || '')
-              ? editData.app_id?.trim() || undefined
-              : editData.app_id || null,
-      app_key:
-        editData.provider_type === 'yazio'
-          ? yazioAppKey
-          : editData.provider_type === 'openfoodfacts'
-            ? editData.app_key || undefined
-            : // Same reasoning as app_id above: undefined preserves, null wipes.
-              [
-                  'googlehealth',
-                  'fitbit',
-                  'withings',
-                  'strava',
-                  'polar',
-                ].includes(editData.provider_type || '')
-              ? editData.app_key?.trim() || undefined
-              : editData.app_key || null,
+      app_id,
+      app_key,
       is_active: editData.is_active,
       base_url:
         editData.provider_type === 'mealie' ||

--- a/SparkyFitnessFrontend/src/tests/services/validateProvider.test.ts
+++ b/SparkyFitnessFrontend/src/tests/services/validateProvider.test.ts
@@ -1,5 +1,8 @@
 import { ExternalDataProvider } from '@/pages/Settings/ExternalProviderSettings';
-import { validateProvider } from '@/utils/settings';
+import {
+  resolveProviderCredentialPayload,
+  validateProvider,
+} from '@/utils/settings';
 
 describe('validateProvider', () => {
   it('returns error if provider_name is missing', () => {
@@ -85,5 +88,136 @@ describe('validateProvider', () => {
         yazio_client_secret: 'client-secret',
       })
     ).toBeNull();
+  });
+});
+
+describe('resolveProviderCredentialPayload', () => {
+  // The edit form mirrors `startEditing`: the Client ID (app_id) is pre-filled
+  // with the stored value, but the secret (app_key) is intentionally never
+  // pre-filled, so it is blank unless the user re-types it.
+  const editFormState = (
+    provider_type: string,
+    overrides: Partial<ExternalDataProvider> = {}
+  ): Partial<ExternalDataProvider> => ({
+    provider_name: provider_type,
+    provider_type,
+    app_id: 'stored-client-id',
+    app_key: '',
+    ...overrides,
+  });
+
+  // A same-type edit: the stored row already has this provider type, so a blank
+  // secret should preserve the existing credential.
+  const resolveSameType = (
+    provider_type: string,
+    overrides: Partial<ExternalDataProvider> = {}
+  ) =>
+    resolveProviderCredentialPayload(
+      editFormState(provider_type, overrides),
+      undefined,
+      undefined,
+      provider_type
+    );
+
+  describe('preserves the stored secret on a same-type edit (regression)', () => {
+    // A blank app_key must serialize to `undefined` (server COALESCE preserves),
+    // never `null` (server clears). Sending `null` silently wiped the FatSecret
+    // Client Secret whenever the provider was saved without re-typing it.
+    it.each([
+      'fatsecret',
+      'usda',
+      'nutritionix',
+      'mealie',
+      'tandoor',
+      'norish',
+    ])(
+      'returns undefined app_key for %s when the secret field is left blank',
+      (providerType) => {
+        const { app_key } = resolveSameType(providerType);
+        expect(app_key).toBeUndefined();
+        expect(app_key).not.toBeNull();
+      }
+    );
+
+    it('keeps the pre-filled app_id while preserving the blank secret', () => {
+      const result = resolveSameType('fatsecret');
+      expect(result.app_id).toBe('stored-client-id');
+      expect(result.app_key).toBeUndefined();
+    });
+
+    it('treats a whitespace-only secret as blank (preserve, not store)', () => {
+      const { app_key } = resolveSameType('fatsecret', { app_key: '   ' });
+      expect(app_key).toBeUndefined();
+    });
+  });
+
+  // Changing provider_type resets the credential fields to '', and the stored
+  // secret belongs to the OLD provider. A blank field must then clear (null),
+  // not preserve, so one provider's secret can't leak into another type.
+  describe('clears credentials when the provider type changes (regression)', () => {
+    // The edit form clears app_id/app_key when the type changes.
+    const changedTypeEdit = (
+      newType: string,
+      overrides: Partial<ExternalDataProvider> = {}
+    ) =>
+      resolveProviderCredentialPayload(
+        editFormState(newType, { app_id: '', app_key: '', ...overrides }),
+        undefined,
+        undefined,
+        'fatsecret'
+      );
+
+    it.each(['usda', 'nutritionix', 'mealie', 'tandoor', 'norish'])(
+      'clears app_key (null) when changing fatsecret -> %s with a blank secret',
+      (newType) => {
+        expect(changedTypeEdit(newType).app_key).toBeNull();
+      }
+    );
+
+    it('clears both app_id and app_key when changing fatsecret -> openfoodfacts blank', () => {
+      // openfoodfacts has no required fields, so validation does not block this.
+      const result = changedTypeEdit('openfoodfacts');
+      expect(result.app_id).toBeNull();
+      expect(result.app_key).toBeNull();
+    });
+
+    it('still stores a freshly entered secret on a type change', () => {
+      const { app_key } = changedTypeEdit('usda', { app_key: 'brand-new-key' });
+      expect(app_key).toBe('brand-new-key');
+    });
+  });
+
+  it('stores a newly typed secret, trimmed', () => {
+    const { app_key } = resolveSameType('fatsecret', {
+      app_key: '  new-secret  ',
+    });
+    expect(app_key).toBe('new-secret');
+  });
+
+  it('preserves a blank secret for OAuth token providers (unchanged behavior)', () => {
+    const { app_id, app_key } = resolveSameType('fitbit');
+    expect(app_id).toBe('stored-client-id');
+    expect(app_key).toBeUndefined();
+  });
+
+  it('preserves a blank secret for openfoodfacts', () => {
+    const { app_key } = resolveSameType('openfoodfacts');
+    expect(app_key).toBeUndefined();
+  });
+
+  it('nulls app_id for providers that do not use it', () => {
+    const { app_id } = resolveSameType('mealie');
+    expect(app_id).toBeNull();
+  });
+
+  it('uses the pre-merged packed credentials for yazio', () => {
+    const result = resolveProviderCredentialPayload(
+      editFormState('yazio'),
+      'packed-app-id',
+      'packed-app-key',
+      'yazio'
+    );
+    expect(result.app_id).toBe('packed-app-id');
+    expect(result.app_key).toBe('packed-app-key');
   });
 });

--- a/SparkyFitnessFrontend/src/utils/settings.ts
+++ b/SparkyFitnessFrontend/src/utils/settings.ts
@@ -27,6 +27,30 @@ const providerFieldLabels: Record<string, Record<string, string>> = {
   },
 };
 
+// Per-type credential-shape exceptions consumed by
+// `resolveProviderCredentialPayload`. Any provider NOT listed here is handled as
+// a standard app_id + app_key pair, which is the safe default — so a new
+// provider that is forgotten here still preserves/clears credentials correctly,
+// it just misses these refinements.
+//   - PROVIDERS_WITHOUT_APP_ID: no app_id field, so app_id is always cleared
+//     on save.
+//   - OAUTH_TOKEN_PROVIDERS: app_id is managed by the OAuth connect flow, so a
+//     blank app_id must preserve (undefined) rather than clear (null) on edit.
+const PROVIDERS_WITHOUT_APP_ID = [
+  'mealie',
+  'tandoor',
+  'norish',
+  'free-exercise-db',
+  'wger',
+];
+const OAUTH_TOKEN_PROVIDERS = [
+  'googlehealth',
+  'fitbit',
+  'withings',
+  'strava',
+  'polar',
+];
+
 export const encodeYazioAppId = (
   username?: string | null,
   clientId?: string | null
@@ -107,6 +131,63 @@ export const validateProvider = (
   }
 
   return null;
+};
+
+// Resolve the encrypted credential fields (app_id / app_key) for an external
+// provider update payload. The edit form never pre-fills secrets, and the
+// server interprets each field as:
+//   undefined -> COALESCE, preserve the stored value
+//   null      -> clear the stored credential
+//   a value   -> encrypt and store the new value
+// On a same-type edit a blank field resolves to `undefined` so the existing
+// secret is preserved (sending `null` here silently wiped credentials whenever
+// a provider was saved without re-typing the secret). When the provider type is
+// changed mid-edit, the stored credentials belong to the OLD provider, so a
+// blank field instead resolves to `null` to clear them — preservation would
+// otherwise leak one provider's secret into another. `yazioAppId`/`yazioAppKey`
+// are the packed credentials the caller pre-merges for YAZIO; pass
+// `existingProviderType` (the stored row's type) so a type change can be
+// detected.
+export const resolveProviderCredentialPayload = (
+  editData: Partial<ExternalDataProvider>,
+  yazioAppId?: string,
+  yazioAppKey?: string,
+  existingProviderType?: string
+): {
+  app_id: string | null | undefined;
+  app_key: string | null | undefined;
+} => {
+  const type = editData.provider_type || '';
+
+  // The stored secret belongs to the row's current type. If the type changed,
+  // a blank field clears (null) rather than preserves (undefined).
+  const typeChanged =
+    existingProviderType !== undefined && type !== existingProviderType;
+  const blankCredential = typeChanged ? null : undefined;
+
+  let app_id: string | null | undefined;
+  if (PROVIDERS_WITHOUT_APP_ID.includes(type)) {
+    app_id = null;
+  } else if (type === 'yazio') {
+    app_id = yazioAppId;
+  } else if (type === 'openfoodfacts') {
+    app_id = editData.app_id || blankCredential;
+  } else if (OAUTH_TOKEN_PROVIDERS.includes(type)) {
+    app_id = editData.app_id?.trim() || blankCredential;
+  } else {
+    app_id = editData.app_id || null;
+  }
+
+  let app_key: string | null | undefined;
+  if (type === 'yazio') {
+    app_key = yazioAppKey;
+  } else if (type === 'openfoodfacts') {
+    app_key = editData.app_key || blankCredential;
+  } else {
+    app_key = editData.app_key?.trim() || blankCredential;
+  }
+
+  return { app_id, app_key };
 };
 
 export const getInitials = (name: string | null) => {

--- a/SparkyFitnessServer/services/externalProviderService.ts
+++ b/SparkyFitnessServer/services/externalProviderService.ts
@@ -301,23 +301,28 @@ async function updateExternalDataProvider(
       existingProvider?.provider_type === 'yazio' ||
       updateData.provider_type === 'yazio';
     if (isYazio) {
+      // Only preserve stored credentials when the row is already YAZIO. When the
+      // type is being changed to YAZIO from another provider, the stored
+      // app_id/app_key belong to that old provider and must not be merged in, or
+      // the old provider's secret would leak into the new YAZIO credentials.
+      const existingYazio =
+        existingProvider?.provider_type === 'yazio'
+          ? existingProvider
+          : undefined;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const resolveField = (nextVal: any, currentVal: any) => {
         if (nextVal === null) return null;
         if (nextVal === undefined) return currentVal;
         return nextVal;
       };
-      const nextAppId = resolveField(
-        updateData.app_id,
-        existingProvider?.app_id
-      );
+      const nextAppId = resolveField(updateData.app_id, existingYazio?.app_id);
       const nextAppKey = resolveField(
         updateData.app_key,
-        existingProvider?.app_key
+        existingYazio?.app_key
       );
       const currentCredentials = resolveYazioCredentials({
-        username: existingProvider?.app_id ?? undefined,
-        password: existingProvider?.app_key ?? undefined,
+        username: existingYazio?.app_id ?? undefined,
+        password: existingYazio?.app_key ?? undefined,
       });
       const nextCredentials = resolveYazioCredentials({
         username: nextAppId,

--- a/SparkyFitnessServer/tests/externalProviderService.test.ts
+++ b/SparkyFitnessServer/tests/externalProviderService.test.ts
@@ -361,6 +361,72 @@ describe('updateExternalDataProvider - mutual exclusion + invalidation', () => {
     );
   });
 
+  it("does not merge a non-YAZIO row's credentials when the type is changed to YAZIO", async () => {
+    // The stored row is FatSecret; its app_key is a FatSecret secret, not a
+    // packed YAZIO credential. Switching the type to YAZIO must not pull that
+    // secret in to satisfy a blank password — the update is rejected so the
+    // user has to supply real YAZIO credentials.
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderRepository.getExternalDataProviderById.mockResolvedValue({
+      id: PROVIDER_ID,
+      provider_type: 'fatsecret',
+      is_public: false,
+      app_id: 'fs-client-id',
+      app_key: 'fs-secret',
+    });
+
+    await expectBadRequest(
+      externalProviderService.updateExternalDataProvider(OWNER, PROVIDER_ID, {
+        provider_type: 'yazio',
+        app_id: JSON.stringify({ username: 'me@example.com', clientId: 'cid' }),
+        app_key: JSON.stringify({ password: '', clientSecret: 'csecret' }),
+      }),
+      /YAZIO credentials must include/i
+    );
+
+    expect(
+      externalProviderRepository.updateExternalDataProvider
+    ).not.toHaveBeenCalled();
+  });
+
+  it('stores only the entered YAZIO credentials when changing type from a non-YAZIO row', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderRepository.getExternalDataProviderById.mockResolvedValue({
+      id: PROVIDER_ID,
+      provider_type: 'fatsecret',
+      is_public: false,
+      app_id: 'fs-client-id',
+      app_key: 'fs-secret',
+    });
+
+    await externalProviderService.updateExternalDataProvider(
+      OWNER,
+      PROVIDER_ID,
+      {
+        provider_type: 'yazio',
+        app_id: JSON.stringify({ username: 'me@example.com', clientId: 'cid' }),
+        app_key: JSON.stringify({
+          password: 'newpass',
+          clientSecret: 'csecret',
+        }),
+      }
+    );
+
+    expect(
+      externalProviderRepository.updateExternalDataProvider
+    ).toHaveBeenCalledWith(
+      PROVIDER_ID,
+      OWNER,
+      expect.objectContaining({
+        app_id: JSON.stringify({ username: 'me@example.com', clientId: 'cid' }),
+        app_key: JSON.stringify({
+          password: 'newpass',
+          clientSecret: 'csecret',
+        }),
+      })
+    );
+  });
+
   it('allows setting credentials on a private OFF row and invalidates the session', async () => {
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     externalProviderRepository.getExternalDataProviderById.mockResolvedValue({


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Editing or toggling several of the external providers was wiping application keys due to the empty field sendding null. The server treats null as clear. Fatsecret, USDA, yazio, and Nutritionix were affected.

**How did you implement the solution?**
Blank secret now resolves to undefined (preserve) instead of null (clear), via a new helper.

Linked Issue: Closes #

## How to Test

1. Toggle off of the affected providers
2. Toggle it back on
3. Verify it still works

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
