### PR TITLE
feat(openfoodfacts): support self-hosted OFF via provider settings

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -900,7 +900,11 @@
     "foodExerciseDataProviders": {
       "title": "Food & Exercise Data Providers",
       "description": "Configure external food and exercise data sources and synchronize data with Garmin Connect",
-      "invalidKeyLengthWarning": "If you encounter an \"Invalid key length\" error, ensure your encryption key in the server's env variables are 64 hex."
+      "invalidKeyLengthWarning": "If you encounter an \"Invalid key length\" error, ensure your encryption key in the server's env variables are 64 hex.",
+      "openFoodFacts": {
+        "baseUrlLabel": "Base URL (Optional)",
+        "baseUrlHelp": "Leave blank to use the public Open Food Facts server, or point this at your own self-hosted instance."
+      }
     },
     "aiService": {
       "title": "AI Service",

--- a/SparkyFitnessFrontend/src/pages/Settings/EditProviderForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/EditProviderForm.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Clipboard } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { ExternalDataProvider } from './ExternalProviderSettings';
 import { toast } from '@/hooks/use-toast';
 import { useExternalProviderTypesQuery } from '@/hooks/Settings/useExternalProviderSettings';
@@ -35,6 +36,7 @@ export const EditProviderForm = ({
   loading,
   isAdminMode = false,
 }: EditProviderFormProps) => {
+  const { t } = useTranslation();
   const { data: providerTypes } = useExternalProviderTypesQuery();
   return (
     <form
@@ -96,6 +98,28 @@ export const EditProviderForm = ({
       </div>
       {editData.provider_type === 'openfoodfacts' && (
         <>
+          <div>
+            <Label>
+              {t(
+                'settings.foodExerciseDataProviders.openFoodFacts.baseUrlLabel'
+              )}
+            </Label>
+            <Input
+              type="text"
+              value={editData.base_url || ''}
+              onChange={(e) =>
+                setEditData((prev) => ({
+                  ...prev,
+                  base_url: e.target.value,
+                }))
+              }
+              placeholder="https://world.openfoodfacts.org"
+              autoComplete="off"
+            />
+          </div>
+          <p className="text-sm text-muted-foreground col-span-2">
+            {t('settings.foodExerciseDataProviders.openFoodFacts.baseUrlHelp')}
+          </p>
           <div>
             <Label>Open Food Facts Username (Optional)</Label>
             <Input

--- a/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderList.tsx
@@ -235,7 +235,8 @@ const ExternalProviderList = ({
         editData.provider_type === 'mealie' ||
         editData.provider_type === 'tandoor' ||
         editData.provider_type === 'norish' ||
-        editData.provider_type === 'free-exercise-db'
+        editData.provider_type === 'free-exercise-db' ||
+        editData.provider_type === 'openfoodfacts'
           ? editData.base_url || null
           : null,
       withings_last_sync_at:

--- a/SparkyFitnessFrontend/src/pages/Settings/ProviderSpecificFields.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ProviderSpecificFields.tsx
@@ -3,6 +3,7 @@ import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Clipboard } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { ExternalDataProvider } from './ExternalProviderSettings';
 
 interface ProviderSpecificFieldsProps {
@@ -22,6 +23,7 @@ export const ProviderSpecificFields = ({
   setFullSyncOnConnect,
   onCopy,
 }: ProviderSpecificFieldsProps) => {
+  const { t } = useTranslation();
   const needsBaseUrl = ['mealie', 'tandoor', 'norish'].includes(
     provider.provider_type || ''
   );
@@ -124,6 +126,26 @@ export const ProviderSpecificFields = ({
 
       {provider.provider_type === 'openfoodfacts' && (
         <>
+          <div>
+            <Label htmlFor="add-openfoodfacts-base-url">
+              {t(
+                'settings.foodExerciseDataProviders.openFoodFacts.baseUrlLabel'
+              )}
+            </Label>
+            <Input
+              id="add-openfoodfacts-base-url"
+              type="text"
+              value={provider.base_url || ''}
+              onChange={(e) =>
+                setProvider((prev) => ({ ...prev, base_url: e.target.value }))
+              }
+              placeholder="https://world.openfoodfacts.org"
+              autoComplete="off"
+            />
+          </div>
+          <p className="text-sm text-muted-foreground col-span-2">
+            {t('settings.foodExerciseDataProviders.openFoodFacts.baseUrlHelp')}
+          </p>
           <div>
             <Label htmlFor="add-openfoodfacts-username">
               Open Food Facts Username (Optional)

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsAuth.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsAuth.ts
@@ -3,6 +3,7 @@ import pkg from '../../package.json' with { type: 'json' };
 
 interface SessionCacheEntry {
   session: string | null;
+  baseUrl: string;
   expiresAt: number;
 }
 
@@ -10,6 +11,19 @@ interface OpenFoodFactsProviderDetails {
   provider_type?: string;
   app_id?: string | null;
   app_key?: string | null;
+  base_url?: string | null;
+}
+
+export interface ResolvedOpenFoodFactsProvider {
+  session: string | null;
+  baseUrl: string;
+}
+
+export const DEFAULT_OFF_BASE_URL = 'https://world.openfoodfacts.org';
+
+export function normalizeBaseUrl(url?: string | null): string {
+  const trimmed = url?.trim();
+  return trimmed ? trimmed.replace(/\/+$/, '') : DEFAULT_OFF_BASE_URL;
 }
 
 // Per-process in-memory cache of OFF session cookies. Keyed by
@@ -20,11 +34,13 @@ const sessionCache = new Map<string, SessionCacheEntry>();
 // Coalesce concurrent logins for the same cache key into a single in-flight
 // promise, so a burst of requests after TTL expiry only triggers one login
 // against OFF rather than a stampede.
-const inFlightLogins = new Map<string, Promise<string | null>>();
+const inFlightLogins = new Map<
+  string,
+  Promise<ResolvedOpenFoodFactsProvider>
+>();
 
 const POSITIVE_TTL_MS = 12 * 60 * 60 * 1000; // 12 hours
 const NEGATIVE_TTL_MS = 30 * 1000; // 30 seconds
-const LOGIN_URL = 'https://world.openfoodfacts.org/cgi/session.pl';
 const USER_AGENT = `${pkg.name}/${pkg.version} (https://github.com/CodeWithCJ/SparkyFitness)`;
 
 function cacheKey(userId: string, providerId: string): string {
@@ -66,7 +82,8 @@ function parseSessionCookie(response: Response): string | null {
 
 async function loginToOpenFoodFacts(
   userId: string,
-  password: string
+  password: string,
+  baseUrl: string = DEFAULT_OFF_BASE_URL
 ): Promise<string | null> {
   const body = new URLSearchParams({
     user_id: userId,
@@ -75,7 +92,7 @@ async function loginToOpenFoodFacts(
   }).toString();
 
   log('info', `OpenFoodFacts: attempting login for user_id="${userId}"`);
-  const response = await fetch(LOGIN_URL, {
+  const response = await fetch(`${baseUrl}/cgi/session.pl`, {
     method: 'POST',
     headers: {
       'User-Agent': USER_AGENT,
@@ -109,18 +126,35 @@ async function loginToOpenFoodFacts(
   return session;
 }
 
-async function getOpenFoodFactsSessionCookie(
+function negativeCacheSet(
+  key: string,
+  baseUrl: string
+): ResolvedOpenFoodFactsProvider {
+  sessionCache.set(key, {
+    session: null,
+    baseUrl,
+    expiresAt: Date.now() + NEGATIVE_TTL_MS,
+  });
+  return { session: null, baseUrl };
+}
+
+// Resolves both the session cookie (if the provider has credentials) and the
+// base URL (self-hosted or the public default) for a single OFF provider
+// lookup. Session-cookie auth and base-URL customization are independent —
+// a self-hosted provider with no login credentials still resolves its
+// base_url here, it just gets `session: null`.
+async function resolveOpenFoodFactsProvider(
   authenticatedUserId: string,
   providerId: string
-): Promise<string | null> {
+): Promise<ResolvedOpenFoodFactsProvider> {
   if (!authenticatedUserId || !providerId) {
-    return null;
+    return { session: null, baseUrl: DEFAULT_OFF_BASE_URL };
   }
   const key = cacheKey(authenticatedUserId, providerId);
 
   const cached = getCachedEntry(key);
   if (cached) {
-    return cached.session;
+    return { session: cached.session, baseUrl: cached.baseUrl };
   }
 
   const existing = inFlightLogins.get(key);
@@ -132,7 +166,7 @@ async function getOpenFoodFactsSessionCookie(
   //   externalProviderService → openFoodFactsAuth (invalidate hook)
   //   openFoodFactsAuth → externalProviderService (cred fetch)
 
-  const loginPromise: Promise<string | null> = (async () => {
+  const loginPromise: Promise<ResolvedOpenFoodFactsProvider> = (async () => {
     let providerDetails: OpenFoodFactsProviderDetails | null;
     try {
       const { default: externalProviderService } =
@@ -148,49 +182,40 @@ async function getOpenFoodFactsSessionCookie(
         'debug',
         `OpenFoodFacts: provider lookup rejected for user ${authenticatedUserId}, provider ${providerId}: ${message}`
       );
-      sessionCache.set(key, {
-        session: null,
-        expiresAt: Date.now() + NEGATIVE_TTL_MS,
-      });
-      return null;
+      return negativeCacheSet(key, DEFAULT_OFF_BASE_URL);
     }
 
-    if (
-      !providerDetails ||
-      providerDetails.provider_type !== 'openfoodfacts' ||
-      !providerDetails.app_id ||
-      !providerDetails.app_key
-    ) {
-      sessionCache.set(key, {
-        session: null,
-        expiresAt: Date.now() + NEGATIVE_TTL_MS,
-      });
-      return null;
+    if (!providerDetails || providerDetails.provider_type !== 'openfoodfacts') {
+      return negativeCacheSet(key, DEFAULT_OFF_BASE_URL);
+    }
+
+    const baseUrl = normalizeBaseUrl(providerDetails.base_url);
+
+    if (!providerDetails.app_id || !providerDetails.app_key) {
+      return negativeCacheSet(key, baseUrl);
     }
 
     let session: string | null = null;
     try {
       session = await loginToOpenFoodFacts(
         providerDetails.app_id,
-        providerDetails.app_key
+        providerDetails.app_key,
+        baseUrl
       );
     } catch (error) {
       log('warn', `OpenFoodFacts login threw for ${key}:`, error);
     }
 
     if (!session) {
-      sessionCache.set(key, {
-        session: null,
-        expiresAt: Date.now() + NEGATIVE_TTL_MS,
-      });
-      return null;
+      return negativeCacheSet(key, baseUrl);
     }
 
     sessionCache.set(key, {
       session,
+      baseUrl,
       expiresAt: Date.now() + POSITIVE_TTL_MS,
     });
-    return session;
+    return { session, baseUrl };
   })();
 
   inFlightLogins.set(key, loginPromise);
@@ -199,6 +224,17 @@ async function getOpenFoodFactsSessionCookie(
   } finally {
     inFlightLogins.delete(key);
   }
+}
+
+async function getOpenFoodFactsSessionCookie(
+  authenticatedUserId: string,
+  providerId: string
+): Promise<string | null> {
+  const { session } = await resolveOpenFoodFactsProvider(
+    authenticatedUserId,
+    providerId
+  );
+  return session;
 }
 
 function invalidateOpenFoodFactsSession(
@@ -218,6 +254,7 @@ function __resetForTests(): void {
 
 export {
   getOpenFoodFactsSessionCookie,
+  resolveOpenFoodFactsProvider,
   invalidateOpenFoodFactsSession,
   loginToOpenFoodFacts,
   __resetForTests,

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -1,6 +1,7 @@
 import {
-  getOpenFoodFactsSessionCookie,
+  resolveOpenFoodFactsProvider,
   invalidateOpenFoodFactsSession,
+  DEFAULT_OFF_BASE_URL,
 } from './openFoodFactsAuth.js';
 import { log } from '../../config/logging.js';
 import { normalizeNutrientUnit } from '@workspace/shared';
@@ -43,6 +44,28 @@ interface OffSearchResponse {
   count?: number;
 }
 
+// Resolves the session cookie (if the provider has login credentials) and
+// the base URL (self-hosted or the public default) for a single OFF
+// provider lookup, so callers only hit the provider row once per request.
+async function resolveOffRequestContext(
+  authenticatedUserId?: string,
+  providerId?: string
+): Promise<{ sessionCookie: string | null; baseUrl: string }> {
+  if (!authenticatedUserId || !providerId) {
+    return { sessionCookie: null, baseUrl: DEFAULT_OFF_BASE_URL };
+  }
+  try {
+    const { session, baseUrl } = await resolveOpenFoodFactsProvider(
+      authenticatedUserId,
+      providerId
+    );
+    return { sessionCookie: session, baseUrl };
+  } catch (error) {
+    log('debug', 'OpenFoodFacts: provider resolution failed:', error);
+    return { sessionCookie: null, baseUrl: DEFAULT_OFF_BASE_URL };
+  }
+}
+
 // Wraps fetch with optional session-cookie authentication for OFF endpoints.
 // On 429/5xx with an attached cookie, invalidates the session and retries once
 // without the cookie. OFF returns 200 on stale cookies (no 401 signal), so we
@@ -53,21 +76,14 @@ async function fetchOpenFoodFacts(
   {
     authenticatedUserId,
     providerId,
-  }: { authenticatedUserId?: string; providerId?: string } = {}
+    sessionCookie,
+  }: {
+    authenticatedUserId?: string;
+    providerId?: string;
+    sessionCookie?: string | null;
+  } = {}
 ) {
   const baseHeaders = { ...OFF_HEADERS };
-  let sessionCookie = null;
-
-  if (authenticatedUserId && providerId) {
-    try {
-      sessionCookie = await getOpenFoodFactsSessionCookie(
-        authenticatedUserId,
-        providerId
-      );
-    } catch (error) {
-      log('debug', 'OpenFoodFacts: session cookie lookup failed:', error);
-    }
-  }
 
   const headers = sessionCookie
     ? { ...baseHeaders, Cookie: `session=${sessionCookie}` }
@@ -110,10 +126,15 @@ async function searchOpenFoodFacts(
       fieldSet.add(`product_name_${language}`);
     }
     const fields = [...fieldSet];
-    const searchUrl = `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=20&page=${page}&fields=${fields.join(',')}&lc=${language}`;
+    const { sessionCookie, baseUrl } = await resolveOffRequestContext(
+      authenticatedUserId,
+      providerId
+    );
+    const searchUrl = `${baseUrl}/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=20&page=${page}&fields=${fields.join(',')}&lc=${language}`;
     const response = await fetchOpenFoodFacts(searchUrl, {
       authenticatedUserId,
       providerId,
+      sessionCookie,
     });
     if (!response.ok) {
       const errorText = await response.text();
@@ -159,10 +180,15 @@ async function searchOpenFoodFactsByBarcodeFields(
     }
     const finalFields = [...fieldSet];
     const fieldsParam = finalFields.join(',');
-    const searchUrl = `https://world.openfoodfacts.org/api/v2/product/${barcode}.json?fields=${fieldsParam}&lc=${language}`;
+    const { sessionCookie, baseUrl } = await resolveOffRequestContext(
+      authenticatedUserId,
+      providerId
+    );
+    const searchUrl = `${baseUrl}/api/v2/product/${barcode}.json?fields=${fieldsParam}&lc=${language}`;
     const response = await fetchOpenFoodFacts(searchUrl, {
       authenticatedUserId,
       providerId,
+      sessionCookie,
     });
     if (!response.ok) {
       if (response.status === 404) {

--- a/SparkyFitnessServer/models/externalProviderRepository.ts
+++ b/SparkyFitnessServer/models/externalProviderRepository.ts
@@ -272,6 +272,7 @@ async function updateExternalDataProvider(
     let appKeyTag = updateData.app_key_tag || null;
     let clearAppId = false;
     let clearAppKey = false;
+    const clearBaseUrl = updateData.base_url === null;
 
     const encryptedGarthDump = updateData.encrypted_garth_dump || null;
     const garthDumpIv = updateData.garth_dump_iv || null;
@@ -298,7 +299,7 @@ async function updateExternalDataProvider(
         provider_name = COALESCE($1, provider_name),
         provider_type = COALESCE($2, provider_type),
         is_active = COALESCE($3, is_active),
-        base_url = COALESCE($4, base_url),
+        base_url = CASE WHEN $23 THEN NULL ELSE COALESCE($4, base_url) END,
         is_public = COALESCE($5, is_public),
         encrypted_app_id = CASE WHEN $19 THEN NULL ELSE COALESCE($6, encrypted_app_id) END,
         app_id_iv = CASE WHEN $19 THEN NULL ELSE COALESCE($7, app_id_iv) END,
@@ -339,6 +340,7 @@ async function updateExternalDataProvider(
         clearAppKey,
         updateData.sort_order,
         userId,
+        clearBaseUrl,
       ]
     );
     return result.rows[0];
@@ -808,6 +810,7 @@ async function updateGlobalExternalDataProvider(id: any, updateData: any) {
       appKeyTag = null;
     let clearAppId = false,
       clearAppKey = false;
+    const clearBaseUrl = updateData.base_url === null;
     if (updateData.app_id === null) {
       clearAppId = true;
     } else if (updateData.app_id !== undefined) {
@@ -829,7 +832,7 @@ async function updateGlobalExternalDataProvider(id: any, updateData: any) {
         provider_name = COALESCE($1, provider_name),
         provider_type = COALESCE($2, provider_type),
         is_active = COALESCE($3, is_active),
-        base_url = COALESCE($4, base_url),
+        base_url = CASE WHEN $15 THEN NULL ELSE COALESCE($4, base_url) END,
         encrypted_app_id = CASE WHEN $5 THEN NULL ELSE COALESCE($6, encrypted_app_id) END,
         app_id_iv = CASE WHEN $5 THEN NULL ELSE COALESCE($7, app_id_iv) END,
         app_id_tag = CASE WHEN $5 THEN NULL ELSE COALESCE($8, app_id_tag) END,
@@ -855,6 +858,7 @@ async function updateGlobalExternalDataProvider(id: any, updateData: any) {
         appKeyTag,
         updateData.sync_frequency,
         id,
+        clearBaseUrl,
       ]
     );
     return result.rows[0];

--- a/SparkyFitnessServer/services/externalFoodSearchService.ts
+++ b/SparkyFitnessServer/services/externalFoodSearchService.ts
@@ -49,11 +49,12 @@ export interface ProviderCredentials {
   is_active?: boolean;
 }
 
-// Resolve an OFF providerId for session-cookie auth. Unlike other providers,
-// OFF does not need credentials to function — this just opts into the
-// authenticated request path when the user has configured an OFF account.
-// Returns the provided id (validated for ownership) or the user's first
-// credentialed OFF provider, or null.
+// Resolve an OFF providerId for session-cookie auth and base_url resolution.
+// Unlike other providers, OFF does not need credentials to function — a
+// provider row may carry login credentials, a custom base_url, both, or
+// neither (the seeded public default). Returns the provided id (validated
+// for ownership and active status) or the user's first active OFF provider,
+// or null.
 export async function resolveOpenFoodFactsProviderId(
   userId: string,
   providerId: string | undefined
@@ -68,9 +69,7 @@ export async function resolveOpenFoodFactsProviderId(
       if (
         details &&
         details.is_active &&
-        details.provider_type === 'openfoodfacts' &&
-        details.app_id &&
-        details.app_key
+        details.provider_type === 'openfoodfacts'
       ) {
         return providerId;
       }

--- a/SparkyFitnessServer/services/externalProviderService.ts
+++ b/SparkyFitnessServer/services/externalProviderService.ts
@@ -457,10 +457,13 @@ async function deleteExternalDataProvider(
   }
 }
 
-// Returns the id of the first active OFF provider owned by the user that has
-// populated encrypted credentials, or null. The seeded default OFF row has no
-// credentials — this filter ensures we don't add pointless session lookups for
-// users who never configured a username/password.
+// Returns the id of the first active OFF provider owned by (or shared with)
+// the user, preferring one with populated login credentials — those enable
+// authenticated requests, which helps with rate limiting. Falls back to the
+// first active OFF provider without credentials (e.g. the seeded global
+// default row, or a self-hosted row configured with only a custom base_url
+// and no login) so a self-hosted-only setup is still selected: base_url
+// must be resolved for every OFF call now, not just credentialed ones.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getActiveOpenFoodFactsProviderId(userId: any) {
   try {
@@ -469,13 +472,11 @@ async function getActiveOpenFoodFactsProviderId(userId: any) {
         userId,
         userId
       );
-    const match = providers.find(
-      (p) =>
-        p.provider_type === 'openfoodfacts' &&
-        p.is_active &&
-        p.app_id &&
-        p.app_key
-    );
+    const isActiveOff = (p: { provider_type: string; is_active: boolean }) =>
+      p.provider_type === 'openfoodfacts' && p.is_active;
+    const match =
+      providers.find((p) => isActiveOff(p) && p.app_id && p.app_key) ||
+      providers.find((p) => isActiveOff(p));
     return match ? match.id : null;
   } catch (error) {
     log(

--- a/SparkyFitnessServer/tests/externalFoodSearchService.openFoodFacts.test.ts
+++ b/SparkyFitnessServer/tests/externalFoodSearchService.openFoodFacts.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/foodIntegrationService.js', () => ({
+  getFatSecretNutrients: vi.fn(),
+  searchFatSecretFoods: vi.fn(),
+  searchMealieFoods: vi.fn(),
+  searchTandoorFoods: vi.fn(),
+  searchNorishFoods: vi.fn(),
+}));
+
+vi.mock('../integrations/fatsecret/fatsecretService.js', () => ({
+  mapFatSecretSearchItem: vi.fn((item) => item),
+  mapFatSecretFood: vi.fn(),
+  foodNutrientCache: new Map(),
+  getFatSecretAccessToken: vi.fn(),
+}));
+
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+vi.mock('../services/externalProviderService.js', () => ({
+  default: {
+    getExternalDataProviderDetails: vi.fn(),
+    getActiveOpenFoodFactsProviderId: vi.fn(),
+  },
+}));
+vi.mock('../services/preferenceService.js', () => ({
+  default: { getUserPreferences: vi.fn() },
+}));
+vi.mock('../integrations/openfoodfacts/openFoodFactsService.js', () => ({
+  searchOpenFoodFacts: vi.fn(),
+  mapOpenFoodFactsProduct: vi.fn(),
+}));
+vi.mock('../integrations/usda/usdaService.js', () => ({
+  searchUsdaFoods: vi.fn(),
+  mapUsdaBarcodeProduct: vi.fn(),
+}));
+vi.mock('../integrations/yazio/yazioService.js', () => ({
+  searchYazioFoods: vi.fn(),
+}));
+vi.mock('../integrations/swissfood/swissFoodService.js', () => ({
+  searchSwissFoods: vi.fn(),
+}));
+
+import externalProviderService from '../services/externalProviderService.js';
+import { resolveOpenFoodFactsProviderId } from '../services/externalFoodSearchService.js';
+
+const mockGetDetails = vi.mocked(
+  externalProviderService.getExternalDataProviderDetails
+);
+const mockGetActiveId = vi.mocked(
+  externalProviderService.getActiveOpenFoodFactsProviderId
+);
+
+const USER_ID = 'user-A';
+const PROVIDER_ID = 'prov-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('resolveOpenFoodFactsProviderId', () => {
+  it('accepts an explicit providerId for a self-hosted provider with no credentials', async () => {
+    // @ts-expect-error test doubles only need the fields the code under test reads
+    mockGetDetails.mockResolvedValue({
+      is_active: true,
+      provider_type: 'openfoodfacts',
+      app_id: null,
+      app_key: null,
+      base_url: 'http://sparkyfitness-foodfacts:8080',
+    });
+
+    const id = await resolveOpenFoodFactsProviderId(USER_ID, PROVIDER_ID);
+
+    expect(id).toBe(PROVIDER_ID);
+    expect(mockGetActiveId).not.toHaveBeenCalled();
+  });
+
+  it('rejects an explicit providerId that is inactive', async () => {
+    // @ts-expect-error test doubles only need the fields the code under test reads
+    mockGetDetails.mockResolvedValue({
+      is_active: false,
+      provider_type: 'openfoodfacts',
+    });
+
+    const id = await resolveOpenFoodFactsProviderId(USER_ID, PROVIDER_ID);
+
+    expect(id).toBe(null);
+  });
+
+  it('rejects an explicit providerId of the wrong provider type', async () => {
+    // @ts-expect-error test doubles only need the fields the code under test reads
+    mockGetDetails.mockResolvedValue({
+      is_active: true,
+      provider_type: 'fatsecret',
+    });
+
+    const id = await resolveOpenFoodFactsProviderId(USER_ID, PROVIDER_ID);
+
+    expect(id).toBe(null);
+  });
+
+  it('falls back to getActiveOpenFoodFactsProviderId when no providerId is given', async () => {
+    mockGetActiveId.mockResolvedValue('active-id');
+
+    const id = await resolveOpenFoodFactsProviderId(USER_ID, undefined);
+
+    expect(id).toBe('active-id');
+    expect(mockGetDetails).not.toHaveBeenCalled();
+  });
+});

--- a/SparkyFitnessServer/tests/externalProviderRepository.baseUrl.test.ts
+++ b/SparkyFitnessServer/tests/externalProviderRepository.baseUrl.test.ts
@@ -1,0 +1,93 @@
+import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  updateExternalDataProvider,
+  updateGlobalExternalDataProvider,
+} from '../models/externalProviderRepository.js';
+import { getClient, getSystemClient } from '../db/poolManager.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+
+vi.mock('../security/encryption.js', () => ({
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+  ENCRYPTION_KEY: 'test-key',
+}));
+
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+describe('externalProviderRepository base_url clearing', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn().mockResolvedValue({ rows: [{ id: 'provider-1' }] }),
+      release: vi.fn(),
+    };
+    // @ts-expect-error mock typing
+    getClient.mockResolvedValue(mockClient);
+    // @ts-expect-error mock typing
+    getSystemClient.mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('updateExternalDataProvider passes clearBaseUrl=true when base_url is explicitly null', async () => {
+    await updateExternalDataProvider('provider-1', 'user-1', {
+      base_url: null,
+    });
+
+    const [query, params] = mockClient.query.mock.calls[0];
+    expect(query).toContain(
+      'base_url = CASE WHEN $23 THEN NULL ELSE COALESCE($4, base_url) END'
+    );
+    expect(params[3]).toBeNull(); // $4 base_url value
+    expect(params[22]).toBe(true); // $23 clearBaseUrl flag
+  });
+
+  it('updateExternalDataProvider passes clearBaseUrl=false when base_url is left untouched', async () => {
+    await updateExternalDataProvider('provider-1', 'user-1', {
+      is_active: true,
+    });
+
+    const [, params] = mockClient.query.mock.calls[0];
+    expect(params[3]).toBeUndefined(); // $4 base_url value
+    expect(params[22]).toBe(false); // $23 clearBaseUrl flag
+  });
+
+  it('updateExternalDataProvider passes the new value and clearBaseUrl=false when setting a custom base_url', async () => {
+    await updateExternalDataProvider('provider-1', 'user-1', {
+      base_url: 'http://sparkyfitness-foodfacts:8080',
+    });
+
+    const [, params] = mockClient.query.mock.calls[0];
+    expect(params[3]).toBe('http://sparkyfitness-foodfacts:8080');
+    expect(params[22]).toBe(false);
+  });
+
+  it('updateGlobalExternalDataProvider passes clearBaseUrl=true when base_url is explicitly null', async () => {
+    await updateGlobalExternalDataProvider('provider-1', { base_url: null });
+
+    const [query, params] = mockClient.query.mock.calls[0];
+    expect(query).toContain(
+      'base_url = CASE WHEN $15 THEN NULL ELSE COALESCE($4, base_url) END'
+    );
+    expect(params[3]).toBeNull(); // $4 base_url value
+    expect(params[14]).toBe(true); // $15 clearBaseUrl flag
+  });
+
+  it('updateGlobalExternalDataProvider passes clearBaseUrl=false when setting a custom base_url', async () => {
+    await updateGlobalExternalDataProvider('provider-1', {
+      base_url: 'http://sparkyfitness-foodfacts:8080',
+    });
+
+    const [, params] = mockClient.query.mock.calls[0];
+    expect(params[3]).toBe('http://sparkyfitness-foodfacts:8080');
+    expect(params[14]).toBe(false);
+  });
+});

--- a/SparkyFitnessServer/tests/externalProviderService.test.ts
+++ b/SparkyFitnessServer/tests/externalProviderService.test.ts
@@ -561,7 +561,7 @@ describe('getActiveOpenFoodFactsProviderId', () => {
     expect(id).toBe('p2');
   });
 
-  it('returns null when no credentialed OFF provider exists', async () => {
+  it('falls back to the credential-less active provider when none has credentials', async () => {
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     externalProviderRepository.getExternalDataProvidersByUserId.mockResolvedValue(
       [
@@ -573,6 +573,35 @@ describe('getActiveOpenFoodFactsProviderId', () => {
           app_key: null,
         },
       ]
+    );
+    const id =
+      await externalProviderService.getActiveOpenFoodFactsProviderId(OWNER);
+    expect(id).toBe('p1');
+  });
+
+  it('falls back to a self-hosted provider with only a base_url and no credentials', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderRepository.getExternalDataProvidersByUserId.mockResolvedValue(
+      [
+        {
+          id: 'p1',
+          provider_type: 'openfoodfacts',
+          is_active: true,
+          app_id: null,
+          app_key: null,
+          base_url: 'http://sparkyfitness-foodfacts:8080',
+        },
+      ]
+    );
+    const id =
+      await externalProviderService.getActiveOpenFoodFactsProviderId(OWNER);
+    expect(id).toBe('p1');
+  });
+
+  it('returns null when no active OFF provider exists at all', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderRepository.getExternalDataProvidersByUserId.mockResolvedValue(
+      []
     );
     const id =
       await externalProviderService.getActiveOpenFoodFactsProviderId(OWNER);

--- a/SparkyFitnessServer/tests/openFoodFactsAuth.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsAuth.test.ts
@@ -2,7 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import externalProviderService from '../services/externalProviderService.js';
 import {
   getOpenFoodFactsSessionCookie,
+  resolveOpenFoodFactsProvider,
   invalidateOpenFoodFactsSession,
+  DEFAULT_OFF_BASE_URL,
+  normalizeBaseUrl,
   __resetForTests,
 } from '../integrations/openfoodfacts/openFoodFactsAuth.js';
 
@@ -187,5 +190,100 @@ describe('invalidateOpenFoodFactsSession', () => {
     expect(a).toBe('one');
     expect(b).toBe('two');
     expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('normalizeBaseUrl', () => {
+  it('returns the default public URL when no url is given', () => {
+    expect(normalizeBaseUrl(undefined)).toBe(DEFAULT_OFF_BASE_URL);
+    expect(normalizeBaseUrl(null)).toBe(DEFAULT_OFF_BASE_URL);
+    expect(normalizeBaseUrl('')).toBe(DEFAULT_OFF_BASE_URL);
+    expect(normalizeBaseUrl('   ')).toBe(DEFAULT_OFF_BASE_URL);
+  });
+
+  it('strips trailing slashes from a custom url', () => {
+    expect(normalizeBaseUrl('http://sparkyfitness-foodfacts:8080/')).toBe(
+      'http://sparkyfitness-foodfacts:8080'
+    );
+    expect(normalizeBaseUrl('http://sparkyfitness-foodfacts:8080///')).toBe(
+      'http://sparkyfitness-foodfacts:8080'
+    );
+  });
+
+  it('passes through a custom url with no trailing slash unchanged', () => {
+    expect(normalizeBaseUrl('http://sparkyfitness-foodfacts:8080')).toBe(
+      'http://sparkyfitness-foodfacts:8080'
+    );
+  });
+});
+
+describe('resolveOpenFoodFactsProvider', () => {
+  it('builds the login URL from the resolved base_url', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue({
+      provider_type: 'openfoodfacts',
+      app_id: 'me',
+      app_key: 'pw',
+      base_url: 'http://sparkyfitness-foodfacts:8080/',
+    });
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    fetch.mockResolvedValue(makeOffLoginResponse({ session: 'XYZ' }));
+
+    const result = await resolveOpenFoodFactsProvider(USER_ID, PROVIDER_ID);
+
+    expect(result).toEqual({
+      session: 'XYZ',
+      baseUrl: 'http://sparkyfitness-foodfacts:8080',
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'http://sparkyfitness-foodfacts:8080/cgi/session.pl',
+      expect.any(Object)
+    );
+  });
+
+  it('resolves base_url even when the provider has no login credentials', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue({
+      provider_type: 'openfoodfacts',
+      app_id: null,
+      app_key: null,
+      base_url: 'http://sparkyfitness-foodfacts:8080',
+    });
+
+    const result = await resolveOpenFoodFactsProvider(USER_ID, PROVIDER_ID);
+
+    expect(result).toEqual({
+      session: null,
+      baseUrl: 'http://sparkyfitness-foodfacts:8080',
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default base_url when the provider has none set', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderService.getExternalDataProviderDetails.mockResolvedValue({
+      provider_type: 'openfoodfacts',
+      app_id: null,
+      app_key: null,
+      base_url: null,
+    });
+
+    const result = await resolveOpenFoodFactsProvider(USER_ID, PROVIDER_ID);
+
+    expect(result).toEqual({ session: null, baseUrl: DEFAULT_OFF_BASE_URL });
+  });
+
+  it('falls back to the default base_url when provider lookup fails', async () => {
+    // @ts-expect-error TS(2339): Property 'mockRejectedValue' does not exist on typ... Remove this comment to see the full error message
+    externalProviderService.getExternalDataProviderDetails.mockRejectedValue(
+      new Error('Forbidden: not owner')
+    );
+
+    const result = await resolveOpenFoodFactsProvider(
+      USER_ID,
+      OTHER_PROVIDER_ID
+    );
+
+    expect(result).toEqual({ session: null, baseUrl: DEFAULT_OFF_BASE_URL });
   });
 });

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  getOpenFoodFactsSessionCookie,
+  resolveOpenFoodFactsProvider,
   invalidateOpenFoodFactsSession,
+  DEFAULT_OFF_BASE_URL,
 } from '../integrations/openfoodfacts/openFoodFactsAuth.js';
 import {
   mapOpenFoodFactsProduct,
@@ -10,8 +11,9 @@ import {
 } from '../integrations/openfoodfacts/openFoodFactsService.js';
 
 vi.mock('../integrations/openfoodfacts/openFoodFactsAuth.js', () => ({
-  getOpenFoodFactsSessionCookie: vi.fn(),
+  resolveOpenFoodFactsProvider: vi.fn(),
   invalidateOpenFoodFactsSession: vi.fn(),
+  DEFAULT_OFF_BASE_URL: 'https://world.openfoodfacts.org',
 }));
 
 global.fetch = vi.fn();
@@ -20,7 +22,10 @@ describe('openFoodFactsService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-    getOpenFoodFactsSessionCookie.mockResolvedValue(null);
+    resolveOpenFoodFactsProvider.mockResolvedValue({
+      session: null,
+      baseUrl: DEFAULT_OFF_BASE_URL,
+    });
   });
 
   describe('searchOpenFoodFacts', () => {
@@ -82,7 +87,10 @@ describe('openFoodFactsService', () => {
   describe('authenticated request path', () => {
     it('attaches a session cookie when providerId+userId are supplied', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-      getOpenFoodFactsSessionCookie.mockResolvedValue('SESS_TOKEN');
+      resolveOpenFoodFactsProvider.mockResolvedValue({
+        session: 'SESS_TOKEN',
+        baseUrl: DEFAULT_OFF_BASE_URL,
+      });
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       fetch.mockResolvedValue({
         ok: true,
@@ -97,7 +105,7 @@ describe('openFoodFactsService', () => {
         'prov-1'
       );
 
-      expect(getOpenFoodFactsSessionCookie).toHaveBeenCalledWith(
+      expect(resolveOpenFoodFactsProvider).toHaveBeenCalledWith(
         'user-A',
         'prov-1'
       );
@@ -117,7 +125,7 @@ describe('openFoodFactsService', () => {
 
       await searchOpenFoodFactsByBarcodeFields('12345678');
 
-      expect(getOpenFoodFactsSessionCookie).not.toHaveBeenCalled();
+      expect(resolveOpenFoodFactsProvider).not.toHaveBeenCalled();
       // @ts-expect-error TS(2339): Property 'mock' does not exist on type '{ (input: ... Remove this comment to see the full error message
       const headers = fetch.mock.calls[0][1].headers;
       expect(headers.Cookie).toBeUndefined();
@@ -125,7 +133,10 @@ describe('openFoodFactsService', () => {
 
     it('on 429 with cookie, invalidates and retries unauthenticated once', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-      getOpenFoodFactsSessionCookie.mockResolvedValue('SESS_TOKEN');
+      resolveOpenFoodFactsProvider.mockResolvedValue({
+        session: 'SESS_TOKEN',
+        baseUrl: DEFAULT_OFF_BASE_URL,
+      });
       fetch
         // @ts-expect-error TS(2339): Property 'mockResolvedValueOnce' does not exist on... Remove this comment to see the full error message
         .mockResolvedValueOnce({
@@ -161,7 +172,10 @@ describe('openFoodFactsService', () => {
 
     it('on 503 with cookie, retries unauthenticated and returns final response', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-      getOpenFoodFactsSessionCookie.mockResolvedValue('SESS_TOKEN');
+      resolveOpenFoodFactsProvider.mockResolvedValue({
+        session: 'SESS_TOKEN',
+        baseUrl: DEFAULT_OFF_BASE_URL,
+      });
       fetch
         // @ts-expect-error TS(2339): Property 'mockResolvedValueOnce' does not exist on... Remove this comment to see the full error message
         .mockResolvedValueOnce({
@@ -193,6 +207,74 @@ describe('openFoodFactsService', () => {
         searchOpenFoodFactsByBarcodeFields('12345678')
       ).rejects.toThrow('OpenFoodFacts API error');
       expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('self-hosted base_url resolution', () => {
+    it('builds the search URL from a resolved custom base_url', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      resolveOpenFoodFactsProvider.mockResolvedValue({
+        session: null,
+        baseUrl: 'http://sparkyfitness-foodfacts:8080',
+      });
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ products: [], count: 0 }),
+      });
+
+      await searchOpenFoodFacts('pizza', 1, 'en', 'user-A', 'prov-1');
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^http:\/\/sparkyfitness-foodfacts:8080\/cgi\/search\.pl/
+        ),
+        expect.any(Object)
+      );
+    });
+
+    it('builds the barcode URL from a resolved custom base_url', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      resolveOpenFoodFactsProvider.mockResolvedValue({
+        session: null,
+        baseUrl: 'http://sparkyfitness-foodfacts:8080',
+      });
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ status: 1, product: {} }),
+      });
+
+      await searchOpenFoodFactsByBarcodeFields(
+        '12345678',
+        undefined,
+        'en',
+        'user-A',
+        'prov-1'
+      );
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^http:\/\/sparkyfitness-foodfacts:8080\/api\/v2\/product\/12345678\.json/
+        ),
+        expect.any(Object)
+      );
+    });
+
+    it('falls back to the public default URL when no provider/base_url is configured', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      fetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ products: [], count: 0 }),
+      });
+
+      await searchOpenFoodFacts('pizza', 1, 'en');
+
+      expect(resolveOpenFoodFactsProvider).not.toHaveBeenCalled();
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(DEFAULT_OFF_BASE_URL),
+        expect.any(Object)
+      );
     });
   });
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The Open Food Facts integration hardcoded `https://world.openfoodfacts.org` for the search, product-by-barcode, and session-login endpoints, so deployments running a self-hosted instance (or hit by rate limits) couldn't redirect lookups there.

**How did you implement the solution?**
Per the discussion on #1657, this no longer uses an env var. Instead it reuses the existing `external_data_providers.base_url` column — the same field already used by the `mealie`/`tandoor`/`norish` providers — for `provider_type = 'openfoodfacts'` too, configurable per provider row in Settings, defaulting to the public `world.openfoodfacts.org` instance when unset.

- `openFoodFactsAuth.ts` gains a combined `resolveOpenFoodFactsProvider()` that resolves both the session cookie and the base URL from a single provider lookup (session-cookie auth and self-hosting are independent — a self-hosted provider with no login credentials still resolves its `base_url`).
- `openFoodFactsService.ts`'s search and barcode-lookup URLs are built from the resolved `base_url` instead of the hardcoded host.
- `getActiveOpenFoodFactsProviderId` / `resolveOpenFoodFactsProviderId` no longer require login credentials to select an OFF provider — previously a self-hosted-only provider (custom `base_url`, no login) could never be selected, since the seeded default OFF provider row has no credentials.
- Frontend: adds a "Base URL (Optional)" field to the OpenFoodFacts block in both the Add and Edit provider forms, with a translated label/help string.

No schema change, no new endpoint — `base_url` already exists on the table and is already covered by the existing RLS policy for the row.

Linked Issue: Closes #1657

## How to Test

1. Check out this branch and run `cd SparkyFitnessServer && pnpm install`
2. Run the test suite: `pnpm test` (2127 passed) — `tests/openFoodFactsService.test.ts`, `tests/openFoodFactsAuth.test.ts`, `tests/externalProviderService.test.ts`, and the new `tests/externalFoodSearchService.openFoodFacts.test.ts` cover the base_url resolution and credential-relaxation behaviour.
3. Spot-check the default path (no `base_url` set) by running the server and triggering a barcode lookup — it should still hit `world.openfoodfacts.org`. Then, in Settings → Food & Exercise Data Providers, edit the OpenFoodFacts provider and set Base URL to a local self-hosted instance (e.g. [petermcneil/openfoodfacts-serving](https://github.com/petermcneil/openfoodfacts-serving)) and confirm traffic redirects.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. (See #1657 — the provider-settings approach implemented here is exactly what was agreed in that thread.)

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. `pnpm run validate` is green (`tsc --noEmit`, `eslint . --max-warnings 0`, `prettier --check`), and `pnpm test` is 2127/2127. No new endpoints, so no new Zod schemas required.
- [x] **[MANDATORY for Backend changes] Database Security**: No new table/column — `base_url` already exists on `external_data_providers` and is already covered by the existing row-level RLS policy, so no `rls_policies.sql` change was needed.

**UI changes (components, screens, pages):**

- [X] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.
<img width="1410" height="659" alt="Screenshot 2026-07-13 at 21 20 41" src="https://github.com/user-attachments/assets/332a14b6-b3c8-4f03-b1b3-2bb6e432e1f4" />
<img width="1385" height="592" alt="Screenshot 2026-07-13 at 21 20 30" src="https://github.com/user-attachments/assets/e7a3c040-7849-4cb4-889b-47d5b90944eb" />



**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Notes for Reviewers

This replaces the earlier `OPENFOODFACTS_BASE_URL` env-var approach from this PR's original version, per the discussion on #1657 — the base URL is now configured per-provider through the same Settings UI mechanism `mealie`/`tandoor`/`norish` already use, rather than a global env var.

A reference self-hosted shim (Go + DuckDB, ingests the OFF Parquet) lives at https://github.com/petermcneil/openfoodfacts-serving — useful for reviewing/testing the redirect behaviour end-to-end without depending on the public API.
