### PR TITLE
[Feature]: Allow sub-tenth food quantities (e.g. 0.25 cup)

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/VariantCard.tsx
@@ -253,7 +253,7 @@ export function VariantCard({
               <Label htmlFor={`serving-size-${index}`}>Serving Size</Label>
               <NumericInput
                 id={`serving-size-${index}`}
-                step="0.1"
+                step="any"
                 value={
                   variant.serving_size !== undefined
                     ? variant.serving_size
@@ -435,7 +435,7 @@ export function VariantCard({
               <Input
                 id={`eq-size-${index}-${eqIndex}`}
                 type="number"
-                step="0.1"
+                step="any"
                 value={eq.serving_size}
                 onChange={(e) =>
                   updateEquivalent(

--- a/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
@@ -394,7 +394,7 @@ const FoodUnitSelector = ({
                     id="quantity"
                     type="number"
                     step="any"
-                    min="0.1"
+                    min="0.01"
                     value={quantity}
                     onChange={(e) => {
                       const newQuantity = Number(e.target.value);

--- a/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
@@ -393,7 +393,7 @@ const FoodUnitSelector = ({
                     ref={quantityInputRef}
                     id="quantity"
                     type="number"
-                    step="0.1"
+                    step="any"
                     min="0.1"
                     value={quantity}
                     onChange={(e) => {

--- a/SparkyFitnessFrontend/src/pages/Diary/EditFoodEntryDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/EditFoodEntryDialog.tsx
@@ -310,7 +310,7 @@ const EditFoodEntryDialog = ({
                   <Input
                     id="quantity"
                     type="number"
-                    step="0.1"
+                    step="any"
                     min="0.1"
                     value={quantity}
                     ref={inputRef}

--- a/SparkyFitnessFrontend/src/pages/Diary/EditFoodEntryDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/EditFoodEntryDialog.tsx
@@ -311,7 +311,7 @@ const EditFoodEntryDialog = ({
                     id="quantity"
                     type="number"
                     step="any"
-                    min="0.1"
+                    min="0.01"
                     value={quantity}
                     ref={inputRef}
                     onChange={(e) => setQuantity(Number(e.target.value))}

--- a/SparkyFitnessFrontend/src/pages/Foods/MealUnitSelector.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/MealUnitSelector.tsx
@@ -135,7 +135,7 @@ const MealUnitSelector = ({
                 <Input
                   id="quantity"
                   type="number"
-                  step="0.1"
+                  step="any"
                   min="0.1"
                   value={quantity}
                   ref={focusAndSelect}

--- a/SparkyFitnessFrontend/src/pages/Foods/MealUnitSelector.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/MealUnitSelector.tsx
@@ -136,7 +136,7 @@ const MealUnitSelector = ({
                   id="quantity"
                   type="number"
                   step="any"
-                  min="0.1"
+                  min="0.01"
                   value={quantity}
                   ref={focusAndSelect}
                   onChange={(e) => {


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The food quantity and serving-size inputs only accept multiples of 0.1, so fractional servings like 0.25 (a 1/4 cup) are rejected by HTML5 number validation with "the two nearest valid values are 0.2 and 0.3."

**How did you implement the solution?**
Changed `step="0.1"` to `step="any"` on the affected food quantity and serving-size number inputs. This matches the `step="any"` convention already used by the meal builder (`MealBuilder.tsx`) and the CSV import forms. On the three quantity inputs that also carried `min="0.1"`, the minimum was lowered to `min="0.01"` so the removed granularity floor does not still block small fractional values like 0.05; this matches the `conversionFactor` inputs in the same files. Quantities are stored as floats, so there is no data-layer change.

Linked Issue: Closes #1408

## How to Test

1. Add a food to the diary to open the quantity/unit dialog (or edit an existing diary entry).
2. Enter `0.25` in the Quantity field with a unit such as `cup`.
3. Verify the value is accepted and saves, with no "two nearest valid values are 0.2 and 0.3" error. `0.125` and `0.05` are also accepted.

Verified on a live dev deployment: `1.25` and `0.125` entries save correctly.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](../LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

Quantity field rejects `1.25` with "Please enter a valid value. The two nearest valid values are 1.2 and 1.3."

<img width="565" height="336" alt="2026-06-27 23_22_50-output_ada - File Explorer" src="https://github.com/user-attachments/assets/81f29245-0f32-4472-b92c-ff30c2e674c5" />

### After

`1.25` is accepted and the entry saves.

<img width="317" height="207" alt="2026-06-27 23_28_32-output_ada - File Explorer" src="https://github.com/user-attachments/assets/7576a482-815c-4a65-8638-c408aac2b5bc" />

</details>

## Notes for Reviewers

This changes the input `step` constraint only. Quantities are already stored as floats, so there is no schema or data-layer change.

Scope of the change:
- `step="0.1"` to `step="any"` on the food quantity input (`FoodUnitSelector.tsx`), the diary edit quantity (`EditFoodEntryDialog.tsx`), the meal-add quantity (`MealUnitSelector.tsx`), and the serving-size and equivalent serving-size inputs (`VariantCard.tsx`).
- `min="0.1"` to `min="0.01"` on the three quantity inputs above, so removing the step floor does not leave a 0.1 minimum that still blocks small fractional values. The `VariantCard` serving-size inputs have no `min` attribute and were already unconstrained.

Note on `VariantCard`: the primary serving-size field uses the `NumericInput` wrapper with `decimals={2}`, which rounds to two decimals on blur (so `0.125` becomes `0.13` there). That is the existing display convention for serving-size definitions and is intentionally left unchanged; it does not affect logged entry quantities, which are plain inputs and accept full precision (for example `0.125` for 1/8 tsp).

CI: the frontend `validate` and test jobs and the server test job pass.
