### PR TITLE
feat: openai compat fix, test connection, vision specific ai

### DIFF
--- a/SparkyFitnessFrontend/package.json
+++ b/SparkyFitnessFrontend/package.json
@@ -153,6 +153,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.1",
     "vite": "^8.0.0",
-    "vite-plugin-pwa": "^1.2.0"
+    "vite-plugin-pwa": "^1.2.0",
+    "vite-plugin-react-click-to-component": "^4.2.2"
   }
 }

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -852,7 +852,9 @@
         "errorOriginalNotFound": "Original service not found.",
         "deleteConfirm": "Are you sure you want to delete this global AI service?",
         "fillRequiredFields": "Please fill in all required fields",
-        "enterNewApiKey": "Enter new API key to update"
+        "enterNewApiKey": "Enter new API key to update",
+        "testConnection": "Test Connection",
+        "testing": "Testing…"
       },
       "userSettings": {
         "title": "AI Services",
@@ -946,7 +948,21 @@
         "revertConfirm": "Are you sure you want to delete all your custom AI service settings and use the global settings instead?",
         "successReverting": "Reverted to global settings. Your custom settings have been deleted.",
         "errorReverting": "Failed to revert to global settings",
-        "fillRequiredFields": "Please fill in all required fields"
+        "fillRequiredFields": "Please fill in all required fields",
+        "testConnection": "Test Connection",
+        "testing": "Testing…"
+      },
+      "test": {
+        "successTitle": "Success",
+        "failureTitle": "Failure",
+        "categories": {
+          "api_key_missing": "API key is missing or invalid. Add a valid key and try again.",
+          "custom_url_missing": "A custom URL is required for this service type.",
+          "upstream_error": "The AI service returned an error. Check the API key, model name, and URL.",
+          "timeout": "The AI service did not respond in time. Check the URL and that the server is reachable.",
+          "unsupported_provider": "This service type is not supported.",
+          "unknown": "The connection test failed. Please check the configuration and try again."
+        }
       },
       "serviceTypes": {
         "openai": "OpenAI",

--- a/SparkyFitnessFrontend/src/api/Settings/aiServiceSettingsService.ts
+++ b/SparkyFitnessFrontend/src/api/Settings/aiServiceSettingsService.ts
@@ -9,6 +9,9 @@ import {
   aiServiceSettingsResponseSchema,
   CreateAiServiceSettingsRequest,
   UpdateAiServiceSettingsRequest,
+  TestAiServiceConnectionRequest,
+  TestAiServiceConnectionResponse,
+  testAiServiceConnectionResponseSchema,
 } from '@workspace/shared';
 
 export const getAIServices = async (): Promise<AiServiceSettingsResponse[]> => {
@@ -94,6 +97,19 @@ export const deleteAIService = async (serviceId: string): Promise<void> => {
   return apiCall(`/chat/ai-service-settings/${serviceId}`, {
     method: 'DELETE',
   });
+};
+
+// Test a provider config with a minimal live completion. The endpoint returns
+// HTTP 200 for both pass and provider failure, so apiCall never auto-toasts the
+// failure here — the caller surfaces a category-specific message instead.
+export const testAIServiceConnection = async (
+  payload: TestAiServiceConnectionRequest
+): Promise<TestAiServiceConnectionResponse> => {
+  const response = await apiCall('/chat/ai-service-settings/test', {
+    method: 'POST',
+    body: payload,
+  });
+  return testAiServiceConnectionResponseSchema.parse(response);
 };
 
 export const updateAIServiceStatus = async (

--- a/SparkyFitnessFrontend/src/components/ai/ServiceForm.tsx
+++ b/SparkyFitnessFrontend/src/components/ai/ServiceForm.tsx
@@ -12,7 +12,11 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { Save, X, Plug, Loader2 } from 'lucide-react';
-import { getServiceTypes, getModelOptions } from '@/utils/aiServiceUtils';
+import {
+  getServiceTypes,
+  getModelOptions,
+  requiresApiKey,
+} from '@/utils/aiServiceUtils';
 import { useToast } from '@/hooks/use-toast';
 import {
   AiServiceSettingsFormInput,
@@ -132,9 +136,9 @@ export const ServiceForm = ({
 
       <div>
         <Label htmlFor="api_key">
-          {formData.service_type === 'ollama'
-            ? t(`${translationPrefix}.apiKeyOptional`)
-            : t(`${translationPrefix}.apiKey`)}
+          {requiresApiKey(formData.service_type)
+            ? t(`${translationPrefix}.apiKey`)
+            : t(`${translationPrefix}.apiKeyOptional`)}
         </Label>
         <Input
           id="api_key"

--- a/SparkyFitnessFrontend/src/components/ai/ServiceForm.tsx
+++ b/SparkyFitnessFrontend/src/components/ai/ServiceForm.tsx
@@ -13,6 +13,7 @@ import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { Save, X } from 'lucide-react';
 import { getServiceTypes, getModelOptions } from '@/utils/aiServiceUtils';
+import { useToast } from '@/hooks/use-toast';
 import {
   AiServiceSettingsFormInput,
   UpdateAiServiceSettingsFormInput,
@@ -38,8 +39,16 @@ export const ServiceForm = ({
   translationPrefix = 'settings.aiService.globalSettings',
 }: ServiceFormProps) => {
   const { t } = useTranslation();
+  const { toast } = useToast();
   const serviceTypes = getServiceTypes(t);
   const modelOptions = getModelOptions(formData.service_type ?? '');
+
+  // The effective model is whichever input is active for this service type.
+  const selectedModel = (
+    formData.showCustomModelInput
+      ? formData.custom_model_name
+      : formData.model_name
+  )?.trim();
 
   const requiresCustomUrl =
     formData.service_type === 'custom' ||
@@ -50,6 +59,18 @@ export const ServiceForm = ({
     <form
       onSubmit={(e) => {
         e.preventDefault();
+        // Providers with preset models (openai, anthropic, ...) have a sensible
+        // server-side default, so a blank model is fine. Types without presets
+        // (openai_compatible/custom/ollama) point at user-hosted servers with no
+        // reliable default, so require an explicit model there.
+        if (modelOptions.length === 0 && !selectedModel) {
+          toast({
+            title: t(`${translationPrefix}.error`),
+            description: t(`${translationPrefix}.fillRequiredFields`),
+            variant: 'destructive',
+          });
+          return;
+        }
         onSubmit();
       }}
       className="space-y-4"
@@ -77,6 +98,10 @@ export const ServiceForm = ({
               onFormDataChange({
                 service_type: value,
                 model_name: '',
+                custom_model_name: '',
+                // Types without preset models (openai_compatible/custom/ollama)
+                // have no dropdown, so reveal the custom-model input directly.
+                showCustomModelInput: getModelOptions(value).length === 0,
                 chat_tool_profile: 'full',
               })
             }

--- a/SparkyFitnessFrontend/src/components/ai/ServiceForm.tsx
+++ b/SparkyFitnessFrontend/src/components/ai/ServiceForm.tsx
@@ -11,13 +11,14 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import { Save, X } from 'lucide-react';
+import { Save, X, Plug, Loader2 } from 'lucide-react';
 import { getServiceTypes, getModelOptions } from '@/utils/aiServiceUtils';
 import { useToast } from '@/hooks/use-toast';
 import {
   AiServiceSettingsFormInput,
   UpdateAiServiceSettingsFormInput,
 } from '@/schemas/form/AiServiceSettings.form.zod';
+import type { TestConnectionStatus } from '@/hooks/AI/useTestAIServiceConnection';
 
 interface ServiceFormProps {
   formData: AiServiceSettingsFormInput;
@@ -27,6 +28,12 @@ interface ServiceFormProps {
   loading?: boolean;
   isEdit?: boolean;
   translationPrefix?: string; // 'settings.aiService.globalSettings' or 'settings.aiService.userSettings'
+  // When provided, renders a "Test Connection" button that runs a live check
+  // against the current config. Receives the effective model the form resolves.
+  onTestConnection?: (selectedModel: string) => void;
+  testing?: boolean;
+  // Inline result shown next to the button; hidden while a test is in flight.
+  testStatus?: TestConnectionStatus;
 }
 
 export const ServiceForm = ({
@@ -37,6 +44,9 @@ export const ServiceForm = ({
   loading = false,
   isEdit = false,
   translationPrefix = 'settings.aiService.globalSettings',
+  onTestConnection,
+  testing = false,
+  testStatus = null,
 }: ServiceFormProps) => {
   const { t } = useTranslation();
   const { toast } = useToast();
@@ -283,7 +293,7 @@ export const ServiceForm = ({
         </Label>
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <Button type="submit" disabled={loading}>
           <Save className="h-4 w-4 mr-2" />
           {isEdit
@@ -294,6 +304,45 @@ export const ServiceForm = ({
           <X className="h-4 w-4 mr-2" />
           {t(`${translationPrefix}.cancel`)}
         </Button>
+        {onTestConnection && (
+          // type="button" is critical — the test must not submit the form.
+          // Disabled with the same guard as submit so a config the form would
+          // reject can't be tested either.
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onTestConnection(selectedModel ?? '')}
+            disabled={
+              loading ||
+              testing ||
+              (modelOptions.length === 0 && !selectedModel) ||
+              (requiresCustomUrl && !formData.custom_url?.trim())
+            }
+          >
+            {testing ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Plug className="h-4 w-4 mr-2" />
+            )}
+            {testing
+              ? t(`${translationPrefix}.testing`)
+              : t(`${translationPrefix}.testConnection`)}
+          </Button>
+        )}
+        {/* Inline result next to the button; hidden while a test is running. */}
+        {onTestConnection && !testing && testStatus && (
+          <span
+            className={
+              testStatus.state === 'success'
+                ? 'text-sm font-medium text-green-600 dark:text-green-400'
+                : 'text-sm font-medium text-destructive'
+            }
+          >
+            {testStatus.state === 'success'
+              ? t('settings.aiService.test.successTitle')
+              : `${t('settings.aiService.test.failureTitle')}: ${testStatus.message}`}
+          </span>
+        )}
       </div>
     </form>
   );

--- a/SparkyFitnessFrontend/src/components/ai/ServiceList.tsx
+++ b/SparkyFitnessFrontend/src/components/ai/ServiceList.tsx
@@ -3,6 +3,7 @@ import { Separator } from '@/components/ui/separator';
 import { ServiceListItem } from './ServiceListItem';
 import { AiServiceSettingsResponse } from '@workspace/shared';
 import { UpdateAiServiceSettingsFormInput } from '@/schemas/form/AiServiceSettings.form.zod';
+import type { TestConnectionStatus } from '@/hooks/AI/useTestAIServiceConnection';
 
 interface ServiceListProps {
   services: AiServiceSettingsResponse[];
@@ -16,6 +17,11 @@ interface ServiceListProps {
   loading?: boolean;
   translationPrefix?: string;
   showGlobalBadge?: boolean;
+  // Pure passthrough to each ServiceListItem; binds the model from ServiceForm
+  // to the service being edited. The owning page calls the test hook.
+  onTestConnection?: (serviceId: string, selectedModel: string) => void;
+  testing?: boolean;
+  testStatus?: TestConnectionStatus;
 }
 
 export const ServiceList = ({
@@ -30,6 +36,9 @@ export const ServiceList = ({
   loading = false,
   translationPrefix = 'settings.aiService.globalSettings',
   showGlobalBadge = true,
+  onTestConnection,
+  testing = false,
+  testStatus = null,
 }: ServiceListProps) => {
   const { t } = useTranslation();
 
@@ -59,6 +68,13 @@ export const ServiceList = ({
             loading={loading}
             translationPrefix={translationPrefix}
             showGlobalBadge={showGlobalBadge}
+            onTestConnection={
+              onTestConnection
+                ? (model) => onTestConnection(service.id, model)
+                : undefined
+            }
+            testing={testing}
+            testStatus={testStatus}
           />
         ))}
       </div>

--- a/SparkyFitnessFrontend/src/components/ai/ServiceListItem.tsx
+++ b/SparkyFitnessFrontend/src/components/ai/ServiceListItem.tsx
@@ -6,6 +6,7 @@ import { getServiceTypes } from '@/utils/aiServiceUtils';
 import { ServiceForm } from './ServiceForm';
 import { AiServiceSettingsResponse } from '@workspace/shared';
 import { UpdateAiServiceSettingsFormInput } from '@/schemas/form/AiServiceSettings.form.zod';
+import type { TestConnectionStatus } from '@/hooks/AI/useTestAIServiceConnection';
 
 interface ServiceListItemProps {
   service: AiServiceSettingsResponse;
@@ -19,6 +20,10 @@ interface ServiceListItemProps {
   loading?: boolean;
   translationPrefix?: string;
   showGlobalBadge?: boolean;
+  // Forwarded to ServiceForm; this component never calls the test hook itself.
+  onTestConnection?: (selectedModel: string) => void;
+  testing?: boolean;
+  testStatus?: TestConnectionStatus;
 }
 
 export const ServiceListItem = ({
@@ -33,6 +38,9 @@ export const ServiceListItem = ({
   loading = false,
   translationPrefix = 'settings.aiService.globalSettings',
   showGlobalBadge = true,
+  onTestConnection,
+  testing = false,
+  testStatus = null,
 }: ServiceListItemProps) => {
   const { t } = useTranslation();
   const serviceTypes = getServiceTypes(t);
@@ -70,6 +78,9 @@ export const ServiceListItem = ({
           loading={loading}
           isEdit={true}
           translationPrefix={translationPrefix}
+          onTestConnection={onTestConnection}
+          testing={testing}
+          testStatus={testStatus}
         />
       </div>
     );

--- a/SparkyFitnessFrontend/src/components/ai/UserServiceListItem.tsx
+++ b/SparkyFitnessFrontend/src/components/ai/UserServiceListItem.tsx
@@ -7,6 +7,7 @@ import { getServiceTypes } from '@/utils/aiServiceUtils';
 import { ServiceForm } from './ServiceForm';
 import { AiServiceSettingsResponse } from '@workspace/shared';
 import { UpdateAiServiceSettingsFormInput } from '@/schemas/form/AiServiceSettings.form.zod';
+import type { TestConnectionStatus } from '@/hooks/AI/useTestAIServiceConnection';
 
 interface UserServiceListItemProps {
   service: AiServiceSettingsResponse;
@@ -22,6 +23,11 @@ interface UserServiceListItemProps {
   isUserConfigAllowed: boolean;
   isOwner: boolean;
   isActiveProvider: boolean;
+  // Forwarded to ServiceForm; this component only passes them through and never
+  // calls the test hook itself (query hooks aren't allowed inside components).
+  onTestConnection?: (selectedModel: string) => void;
+  testing?: boolean;
+  testStatus?: TestConnectionStatus;
 }
 
 export const UserServiceListItem = ({
@@ -38,6 +44,9 @@ export const UserServiceListItem = ({
   isUserConfigAllowed,
   isOwner,
   isActiveProvider,
+  onTestConnection,
+  testing = false,
+  testStatus = null,
 }: UserServiceListItemProps) => {
   const { t } = useTranslation();
   const serviceTypes = getServiceTypes(t);
@@ -75,6 +84,9 @@ export const UserServiceListItem = ({
           loading={loading}
           isEdit={true}
           translationPrefix="settings.aiService.userSettings"
+          onTestConnection={onTestConnection}
+          testing={testing}
+          testStatus={testStatus}
         />
       </div>
     );

--- a/SparkyFitnessFrontend/src/hooks/AI/useGlobalAIServiceSettings.ts
+++ b/SparkyFitnessFrontend/src/hooks/AI/useGlobalAIServiceSettings.ts
@@ -6,7 +6,7 @@ import {
   updateGlobalAIService,
   deleteGlobalAIService,
 } from '@/api/Settings/aiServiceSettingsService';
-import { aiServiceKeys } from '@/api/keys/admin';
+import { aiServiceKeys, settingsKeys } from '@/api/keys/admin';
 import {
   CreateAiServiceSettingsRequest,
   UpdateAiServiceSettingsRequest,
@@ -41,6 +41,10 @@ export const useCreateGlobalAIService = () => {
       // Also invalidate user services since they may see global services
       queryClient.invalidateQueries({ queryKey: aiServiceKeys.user() });
       queryClient.invalidateQueries({ queryKey: aiServiceKeys.active() });
+      // Global settings cache the selected vision default. Deleting a service
+      // that is the default nulls default_vision_ai_service_id server-side
+      // (ON DELETE SET NULL), so refetch settings to drop the stale selection.
+      queryClient.invalidateQueries({ queryKey: settingsKeys.all });
     },
     meta: {
       successMessage: t(
@@ -72,6 +76,10 @@ export const useUpdateGlobalAIService = () => {
       // Also invalidate user services since they may see global services
       queryClient.invalidateQueries({ queryKey: aiServiceKeys.user() });
       queryClient.invalidateQueries({ queryKey: aiServiceKeys.active() });
+      // Global settings cache the selected vision default. Deleting a service
+      // that is the default nulls default_vision_ai_service_id server-side
+      // (ON DELETE SET NULL), so refetch settings to drop the stale selection.
+      queryClient.invalidateQueries({ queryKey: settingsKeys.all });
     },
     meta: {
       successMessage: t(
@@ -97,6 +105,10 @@ export const useDeleteGlobalAIService = () => {
       // Also invalidate user services since they may see global services
       queryClient.invalidateQueries({ queryKey: aiServiceKeys.user() });
       queryClient.invalidateQueries({ queryKey: aiServiceKeys.active() });
+      // Global settings cache the selected vision default. Deleting a service
+      // that is the default nulls default_vision_ai_service_id server-side
+      // (ON DELETE SET NULL), so refetch settings to drop the stale selection.
+      queryClient.invalidateQueries({ queryKey: settingsKeys.all });
     },
     meta: {
       successMessage: t(

--- a/SparkyFitnessFrontend/src/hooks/AI/useTestAIServiceConnection.ts
+++ b/SparkyFitnessFrontend/src/hooks/AI/useTestAIServiceConnection.ts
@@ -1,0 +1,49 @@
+import { useMutation } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { testAIServiceConnection } from '@/api/Settings/aiServiceSettingsService';
+import { TestAiServiceConnectionRequest } from '@workspace/shared';
+
+// Inline status rendered next to the Test Connection button.
+export type TestConnectionStatus =
+  | { state: 'success' }
+  | { state: 'error'; message: string }
+  | null;
+
+// Shared hook so the test call + category→message mapping isn't duplicated
+// across the parents that own a ServiceForm. Both pages (per-user + global)
+// invoke this and thread `testConnection`, `isPending`, and `status` down to
+// the form, which renders the result inline rather than via a toast.
+export const useTestAIServiceConnection = () => {
+  const { t } = useTranslation();
+
+  const mutation = useMutation({
+    mutationFn: (payload: TestAiServiceConnectionRequest) =>
+      testAIServiceConnection(payload),
+    // No `meta`: the global MutationCache only toasts when meta.successMessage
+    // exists, and we surface the result inline instead. We also omit onError —
+    // a thrown error (a rare, UI-illegitimate gate/validation reject) keeps the
+    // global MutationCache error toast rather than the inline status.
+  });
+
+  // Cleared while a test is in flight so a stale result never lingers over a
+  // fresh run; otherwise reflects the most recently completed test.
+  let status: TestConnectionStatus = null;
+  if (!mutation.isPending && mutation.data) {
+    status = mutation.data.ok
+      ? { state: 'success' }
+      : {
+          state: 'error',
+          message: t(
+            `settings.aiService.test.categories.${mutation.data.category ?? 'unknown'}`,
+            t('settings.aiService.test.categories.unknown')
+          ),
+        };
+  }
+
+  // No query invalidation: a test mutates nothing.
+  return {
+    testConnection: mutation.mutate,
+    isPending: mutation.isPending,
+    status,
+  };
+};

--- a/SparkyFitnessFrontend/src/hooks/AI/useTestAIServiceConnection.ts
+++ b/SparkyFitnessFrontend/src/hooks/AI/useTestAIServiceConnection.ts
@@ -45,5 +45,8 @@ export const useTestAIServiceConnection = () => {
     testConnection: mutation.mutate,
     isPending: mutation.isPending,
     status,
+    // Parents own a single page-level instance, so they call this when opening,
+    // closing, or switching forms to clear a previous service's stale result.
+    reset: mutation.reset,
   };
 };

--- a/SparkyFitnessFrontend/src/pages/Admin/GlobalAISettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Admin/GlobalAISettings.tsx
@@ -8,6 +8,13 @@ import {
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Plus, Globe } from 'lucide-react';
 import {
   AlertDialog,
@@ -40,6 +47,10 @@ import {
   createAiServiceSettingsFormSchema,
   updateAiServiceSettingsFormSchema,
 } from '@/schemas/form/AiServiceSettings.form.zod';
+
+// Radix Select cannot bind null/'' (an empty SelectItem value throws), so the
+// "None" choice maps to this sentinel and back to null on save.
+const GLOBAL_VISION_NONE = '__none__';
 
 const GlobalAISettings = () => {
   const { t } = useTranslation();
@@ -97,6 +108,44 @@ const GlobalAISettings = () => {
       onSuccess: () => {
         // Invalidate the userAiConfigAllowed query so all users see the updated setting
         invalidateAiConfig();
+        toast({
+          title: t('settings.aiService.globalSettings.success'),
+          description: t(
+            'settings.aiService.globalSettings.successUpdatingConfig'
+          ),
+        });
+      },
+      onError: () => {
+        toast({
+          title: t('settings.aiService.globalSettings.error'),
+          description: t(
+            'settings.aiService.globalSettings.errorUpdatingConfig'
+          ),
+          variant: 'destructive',
+        });
+      },
+    });
+  };
+
+  // Active global services are the only ones the server will resolve as a
+  // vision default (it requires is_active AND is_public), so the dropdown lists
+  // those. A stale pointer (service deactivated/deleted) falls back to "None".
+  const activeGlobalServices = services.filter((s) => s.is_active);
+  const visionDefaultId =
+    activeGlobalServices.find(
+      (s) => s.id === globalSettings?.default_vision_ai_service_id
+    )?.id ?? null;
+
+  const handleVisionDefaultChange = (value: string) => {
+    if (!globalSettings) return;
+
+    const newSettings: GlobalSettings = {
+      ...globalSettings,
+      default_vision_ai_service_id: value === GLOBAL_VISION_NONE ? null : value,
+    };
+
+    updateSettings(newSettings, {
+      onSuccess: () => {
         toast({
           title: t('settings.aiService.globalSettings.success'),
           description: t(
@@ -262,6 +311,47 @@ const GlobalAISettings = () => {
                 onCheckedChange={handleAllowUserConfigChange}
                 disabled={settingsLoading}
               />
+            </div>
+          )}
+
+          {/* Global vision default: writes default_vision_ai_service_id, the
+              service the server routes vision tasks to for users who are on the
+              global default (no personal service configured). "None" clears it
+              so those users fall back to the global text default. */}
+          {globalSettings && activeGlobalServices.length > 0 && (
+            <div className="space-y-2 mb-4">
+              <Label htmlFor="global-vision-ai-service-select">
+                {t(
+                  'settings.aiService.globalSettings.visionService',
+                  'Global vision AI service'
+                )}
+              </Label>
+              <Select
+                value={visionDefaultId ?? GLOBAL_VISION_NONE}
+                onValueChange={handleVisionDefaultChange}
+              >
+                <SelectTrigger
+                  id="global-vision-ai-service-select"
+                  className="max-w-sm"
+                >
+                  <SelectValue
+                    placeholder={t(
+                      'settings.aiService.globalSettings.visionService',
+                      'Global vision AI service'
+                    )}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={GLOBAL_VISION_NONE}>
+                    {t('settings.aiService.globalSettings.visionNone', 'None')}
+                  </SelectItem>
+                  {activeGlobalServices.map((service) => (
+                    <SelectItem key={service.id} value={service.id}>
+                      {service.service_name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           )}
 

--- a/SparkyFitnessFrontend/src/pages/Admin/GlobalAISettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Admin/GlobalAISettings.tsx
@@ -31,7 +31,7 @@ import { useSettings, useUpdateSettings } from '@/hooks/Admin/useSettings';
 import { useTranslation } from 'react-i18next';
 import { ServiceForm } from '@/components/ai/ServiceForm';
 import { ServiceList } from '@/components/ai/ServiceList';
-import { getModelOptions } from '@/utils/aiServiceUtils';
+import { getModelOptions, requiresApiKey } from '@/utils/aiServiceUtils';
 import {
   useGlobalAIServices,
   useCreateGlobalAIService,
@@ -73,6 +73,7 @@ const GlobalAISettings = () => {
     testConnection,
     isPending: isTesting,
     status: testStatus,
+    reset: resetTestStatus,
   } = useTestAIServiceConnection();
   const invalidateAiConfig = useAiConfigInvalidation();
 
@@ -174,7 +175,7 @@ const GlobalAISettings = () => {
   const handleAddService = async () => {
     if (
       !newService.service_name ||
-      (newService.service_type !== 'ollama' && !newService.api_key)
+      (requiresApiKey(newService.service_type) && !newService.api_key)
     ) {
       toast({
         title: t('settings.aiService.globalSettings.error'),
@@ -257,6 +258,8 @@ const GlobalAISettings = () => {
   };
 
   const startEditing = (service: AiServiceSettingsResponse) => {
+    // Clear any prior service's test result so it never lingers on this form.
+    resetTestStatus();
     setEditingService(service.id);
     const isCustomModel = service.model_name
       ? !getModelOptions(service.service_type ?? '').includes(
@@ -278,6 +281,7 @@ const GlobalAISettings = () => {
   };
 
   const cancelEditing = () => {
+    resetTestStatus();
     setEditingService(null);
     setEditData({ showCustomModelInput: false, custom_model_name: '' });
   };
@@ -362,7 +366,13 @@ const GlobalAISettings = () => {
           )}
 
           {!showAddForm && (
-            <Button onClick={() => setShowAddForm(true)} variant="outline">
+            <Button
+              onClick={() => {
+                resetTestStatus();
+                setShowAddForm(true);
+              }}
+              variant="outline"
+            >
               <Plus className="h-4 w-4 mr-2" />
               {t('settings.aiService.globalSettings.addNewService')}
             </Button>
@@ -379,7 +389,10 @@ const GlobalAISettings = () => {
                   setNewService((prev) => ({ ...prev, ...data }))
                 }
                 onSubmit={handleAddService}
-                onCancel={() => setShowAddForm(false)}
+                onCancel={() => {
+                  resetTestStatus();
+                  setShowAddForm(false);
+                }}
                 loading={loading}
                 translationPrefix="settings.aiService.globalSettings"
                 onTestConnection={(model) =>

--- a/SparkyFitnessFrontend/src/pages/Admin/GlobalAISettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Admin/GlobalAISettings.tsx
@@ -38,6 +38,7 @@ import {
   useUpdateGlobalAIService,
   useDeleteGlobalAIService,
 } from '@/hooks/AI/useGlobalAIServiceSettings';
+import { useTestAIServiceConnection } from '@/hooks/AI/useTestAIServiceConnection';
 import { GlobalSettings } from '@/types/admin';
 import { useAiConfigInvalidation } from '@/hooks/useInvalidateKeys';
 import { AiServiceSettingsResponse } from '@workspace/shared';
@@ -68,6 +69,11 @@ const GlobalAISettings = () => {
     useUpdateGlobalAIService();
   const { mutateAsync: deleteService, isPending: isDeleting } =
     useDeleteGlobalAIService();
+  const {
+    testConnection,
+    isPending: isTesting,
+    status: testStatus,
+  } = useTestAIServiceConnection();
   const invalidateAiConfig = useAiConfigInvalidation();
 
   const loading = isCreating || isUpdating || isDeleting;
@@ -376,6 +382,16 @@ const GlobalAISettings = () => {
                 onCancel={() => setShowAddForm(false)}
                 loading={loading}
                 translationPrefix="settings.aiService.globalSettings"
+                onTestConnection={(model) =>
+                  testConnection({
+                    service_type: newService.service_type,
+                    api_key: newService.api_key,
+                    custom_url: newService.custom_url ?? undefined,
+                    model_name: model,
+                  })
+                }
+                testing={isTesting}
+                testStatus={testStatus}
               />
             </div>
           )}
@@ -394,6 +410,19 @@ const GlobalAISettings = () => {
             loading={loading}
             translationPrefix="settings.aiService.globalSettings"
             showGlobalBadge={true}
+            onTestConnection={(serviceId, model) => {
+              const original = services.find((s) => s.id === serviceId);
+              testConnection({
+                id: serviceId,
+                service_type:
+                  editData.service_type || original?.service_type || '',
+                api_key: editData.api_key,
+                custom_url: editData.custom_url ?? undefined,
+                model_name: model,
+              });
+            }}
+            testing={isTesting}
+            testStatus={testStatus}
           />
 
           {services.length === 0 && !showAddForm && (

--- a/SparkyFitnessFrontend/src/pages/Settings/AIServiceSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/AIServiceSettings.tsx
@@ -47,6 +47,10 @@ import {
   updateAiServiceSettingsFormSchema,
 } from '@/schemas/form/AiServiceSettings.form.zod';
 
+// Radix Select cannot bind null/'' (an empty SelectItem value throws), so the
+// "Same as default" choice maps to this sentinel and back to null on save.
+const SAME_AS_DEFAULT = '__default__';
+
 const AIServiceSettings = () => {
   const { t } = useTranslation();
   const { user } = useAuth();
@@ -68,6 +72,13 @@ const AIServiceSettings = () => {
       ?.id ??
     enabledServices.find((s) => s.id === activeService?.id)?.id ??
     '';
+
+  // Optional vision override. Validated against enabledServices so a stale or
+  // disabled pointer falls back to "Same as default" rather than a dead value.
+  const visionServiceId =
+    enabledServices.find(
+      (s) => s.id === preferencesData?.active_vision_ai_service_id
+    )?.id ?? null;
 
   // Mutations
   const { mutateAsync: addService, isPending: isAdding } = useAddAIService();
@@ -630,46 +641,96 @@ const AIServiceSettings = () => {
                   : t('settings.aiService.userSettings.availableServices')}
               </h3>
 
-              {/* Global active-provider selector: writes active_ai_service_id,
-                  the single pointer every AI feature (chat, food-photo, label
-                  scan, unit conversion) reads. Mirrors the chat quick-switcher. */}
+              {/* Active-provider + vision-provider selectors share a row.
+                  active_ai_service_id is the single pointer every AI feature
+                  (chat, food-photo, label scan, unit conversion) reads;
+                  active_vision_ai_service_id optionally overrides it for the
+                  vision tasks (food-photo + label scan, and chat's image tools),
+                  falling back to the active provider. "Same as default" clears it. */}
               {enabledServices.length > 0 && (
-                <div className="space-y-2">
-                  <Label htmlFor="active-ai-provider-select">
-                    {t(
-                      'settings.aiService.userSettings.activeProvider',
-                      'Active AI provider'
-                    )}
-                  </Label>
-                  <Select
-                    value={activeServiceId}
-                    onValueChange={(id) =>
-                      updatePreferences({
-                        active_ai_service_id: id,
-                        auto_clear_history:
-                          preferencesData?.auto_clear_history || 'never',
-                      })
-                    }
-                  >
-                    <SelectTrigger
-                      id="active-ai-provider-select"
-                      className="max-w-sm"
+                <div className="flex flex-col gap-4 sm:flex-row sm:gap-6">
+                  <div className="space-y-2 sm:max-w-sm sm:flex-1">
+                    <Label htmlFor="active-ai-provider-select">
+                      {t(
+                        'settings.aiService.userSettings.activeProvider',
+                        'Active AI provider'
+                      )}
+                    </Label>
+                    <Select
+                      value={activeServiceId}
+                      onValueChange={(id) =>
+                        updatePreferences({
+                          active_ai_service_id: id,
+                          auto_clear_history:
+                            preferencesData?.auto_clear_history || 'never',
+                        })
+                      }
                     >
-                      <SelectValue
-                        placeholder={t(
-                          'settings.aiService.userSettings.activeProvider',
-                          'Active AI provider'
-                        )}
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {enabledServices.map((service) => (
-                        <SelectItem key={service.id} value={service.id}>
-                          {service.service_name}
+                      <SelectTrigger
+                        id="active-ai-provider-select"
+                        className="w-full"
+                      >
+                        <SelectValue
+                          placeholder={t(
+                            'settings.aiService.userSettings.activeProvider',
+                            'Active AI provider'
+                          )}
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {enabledServices.map((service) => (
+                          <SelectItem key={service.id} value={service.id}>
+                            {service.service_name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <div className="space-y-2 sm:max-w-sm sm:flex-1">
+                    <Label htmlFor="active-vision-ai-provider-select">
+                      {t(
+                        'settings.aiService.userSettings.activeVisionProvider',
+                        'Active vision AI provider'
+                      )}
+                    </Label>
+                    <Select
+                      value={visionServiceId ?? SAME_AS_DEFAULT}
+                      onValueChange={(v) =>
+                        updatePreferences({
+                          active_vision_ai_service_id:
+                            v === SAME_AS_DEFAULT ? null : v,
+                          auto_clear_history:
+                            preferencesData?.auto_clear_history || 'never',
+                        })
+                      }
+                    >
+                      <SelectTrigger
+                        id="active-vision-ai-provider-select"
+                        className="w-full"
+                      >
+                        <SelectValue
+                          placeholder={t(
+                            'settings.aiService.userSettings.activeVisionProvider',
+                            'Active vision AI provider'
+                          )}
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={SAME_AS_DEFAULT}>
+                          {t(
+                            'settings.aiService.userSettings.sameAsDefault',
+                            'Same as default'
+                          )}
                         </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                        {enabledServices.map((service) => (
+                          <SelectItem key={service.id} value={service.id}>
+                            {service.service_name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
                 </div>
               )}
 

--- a/SparkyFitnessFrontend/src/pages/Settings/AIServiceSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/AIServiceSettings.tsx
@@ -39,6 +39,7 @@ import {
   useUpdateUserAIPreferences,
 } from '@/hooks/AI/useAIServiceSettings';
 import { useUserAiConfigAllowed } from '@/hooks/AI/useUserAiConfigAllowed';
+import { useTestAIServiceConnection } from '@/hooks/AI/useTestAIServiceConnection';
 import { AiServiceSettingsResponse } from '@workspace/shared';
 import {
   CreateAiServiceSettingsFormInput,
@@ -88,6 +89,11 @@ const AIServiceSettings = () => {
     useDeleteAIService();
   const { mutateAsync: updatePreferences, isPending: isUpdatingPrefs } =
     useUpdateUserAIPreferences();
+  const {
+    testConnection,
+    isPending: isTesting,
+    status: testStatus,
+  } = useTestAIServiceConnection();
 
   const loading = isAdding || isUpdating || isDeleting || isUpdatingPrefs;
 
@@ -628,6 +634,16 @@ const AIServiceSettings = () => {
                 onCancel={() => setShowAddForm(false)}
                 loading={loading}
                 translationPrefix="settings.aiService.userSettings"
+                onTestConnection={(model) =>
+                  testConnection({
+                    service_type: newService.service_type,
+                    api_key: newService.api_key,
+                    custom_url: newService.custom_url ?? undefined,
+                    model_name: model,
+                  })
+                }
+                testing={isTesting}
+                testStatus={testStatus}
               />
             </div>
           )}
@@ -760,6 +776,18 @@ const AIServiceSettings = () => {
                         isUserConfigAllowed={isUserConfigAllowed}
                         isOwner={isOwner}
                         isActiveProvider={service.id === activeServiceId}
+                        onTestConnection={(model) =>
+                          testConnection({
+                            id: service.id,
+                            service_type:
+                              editData.service_type || service.service_type,
+                            api_key: editData.api_key,
+                            custom_url: editData.custom_url ?? undefined,
+                            model_name: model,
+                          })
+                        }
+                        testing={isTesting}
+                        testStatus={testStatus}
                       />
                     );
                   })}

--- a/SparkyFitnessFrontend/src/pages/Settings/AIServiceSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/AIServiceSettings.tsx
@@ -28,7 +28,7 @@ import { UserChatPreferences } from '@/components/ai/UserChatPreferences';
 import { GlobalOverrideBanner } from '@/components/ai/GlobalOverrideBanner';
 import { ServiceForm } from '@/components/ai/ServiceForm';
 import { UserServiceListItem } from '@/components/ai/UserServiceListItem';
-import { getModelOptions } from '@/utils/aiServiceUtils';
+import { getModelOptions, requiresApiKey } from '@/utils/aiServiceUtils';
 import {
   useAIServices,
   useActiveAIService,
@@ -93,6 +93,7 @@ const AIServiceSettings = () => {
     testConnection,
     isPending: isTesting,
     status: testStatus,
+    reset: resetTestStatus,
   } = useTestAIServiceConnection();
 
   const loading = isAdding || isUpdating || isDeleting || isUpdatingPrefs;
@@ -245,7 +246,7 @@ const AIServiceSettings = () => {
     if (
       !user ||
       !newService.service_name ||
-      (newService.service_type !== 'ollama' && !newService.api_key)
+      (requiresApiKey(newService.service_type) && !newService.api_key)
     ) {
       toast({
         title: t('settings.aiService.userSettings.error'),
@@ -547,6 +548,8 @@ const AIServiceSettings = () => {
       return;
     }
 
+    // Clear any prior service's test result so it never lingers on this form.
+    resetTestStatus();
     setEditingService(service.id ?? null);
     const isCustomModel = service.model_name
       ? !getModelOptions(service.service_type ?? '').includes(
@@ -568,6 +571,7 @@ const AIServiceSettings = () => {
   };
 
   const cancelEditing = () => {
+    resetTestStatus();
     setEditingService(null);
     setEditData({
       showCustomModelInput: false,
@@ -614,7 +618,13 @@ const AIServiceSettings = () => {
         </CardHeader>
         <CardContent className="space-y-4">
           {isUserConfigAllowed && !showAddForm && (
-            <Button onClick={() => setShowAddForm(true)} variant="outline">
+            <Button
+              onClick={() => {
+                resetTestStatus();
+                setShowAddForm(true);
+              }}
+              variant="outline"
+            >
               <Plus className="h-4 w-4 mr-2" />
               {t('settings.aiService.userSettings.addNewService')}
             </Button>
@@ -631,7 +641,10 @@ const AIServiceSettings = () => {
                   setNewService((prev) => ({ ...prev, ...data }))
                 }
                 onSubmit={handleAddService}
-                onCancel={() => setShowAddForm(false)}
+                onCancel={() => {
+                  resetTestStatus();
+                  setShowAddForm(false);
+                }}
                 loading={loading}
                 translationPrefix="settings.aiService.userSettings"
                 onTestConnection={(model) =>

--- a/SparkyFitnessFrontend/src/tests/components/ServiceForm.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/ServiceForm.test.tsx
@@ -118,3 +118,120 @@ describe('ServiceForm — model validation', () => {
     expect(mockToast).not.toHaveBeenCalled();
   });
 });
+
+describe('ServiceForm — test connection button', () => {
+  function renderWithTest(
+    formData: AiServiceSettingsFormInput,
+    {
+      onTestConnection,
+      testing,
+      testStatus,
+    }: {
+      onTestConnection?: (model: string) => void;
+      testing?: boolean;
+      testStatus?:
+        | { state: 'success' }
+        | { state: 'error'; message: string }
+        | null;
+    } = {}
+  ) {
+    const onSubmit = jest.fn();
+    const utils = renderWithClient(
+      <ServiceForm
+        formData={formData}
+        onFormDataChange={jest.fn()}
+        onSubmit={onSubmit}
+        onCancel={jest.fn()}
+        translationPrefix="settings.aiService.userSettings"
+        onTestConnection={onTestConnection}
+        testing={testing}
+        testStatus={testStatus}
+      />
+    );
+    return { ...utils, onSubmit };
+  }
+
+  const testButton = (
+    utils: ReturnType<typeof renderWithTest>
+  ): HTMLElement | null =>
+    utils.queryByRole('button', {
+      name: /testConnection|\.testing$/,
+    });
+
+  it('does not render the button without the onTestConnection prop', () => {
+    const utils = renderWithTest(makeFormData());
+    expect(testButton(utils)).toBeNull();
+  });
+
+  it('renders the button when onTestConnection is provided', () => {
+    const utils = renderWithTest(makeFormData(), {
+      onTestConnection: jest.fn(),
+    });
+    expect(testButton(utils)).not.toBeNull();
+  });
+
+  it('fires onTestConnection (and not onSubmit) when clicked', () => {
+    const onTestConnection = jest.fn();
+    const utils = renderWithTest(makeFormData(), { onTestConnection });
+
+    fireEvent.click(testButton(utils)!);
+
+    expect(onTestConnection).toHaveBeenCalledTimes(1);
+    expect(utils.onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('disables the button while testing', () => {
+    const utils = renderWithTest(makeFormData(), {
+      onTestConnection: jest.fn(),
+      testing: true,
+    });
+    expect((testButton(utils) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  // Same guard as submit: a no-preset type with no model can't be tested either.
+  it('disables the button for a no-preset type with no model', () => {
+    const utils = renderWithTest(
+      makeFormData({
+        service_type: 'openai_compatible',
+        custom_url: 'http://localhost:1234/v1',
+        showCustomModelInput: true,
+        custom_model_name: '',
+        model_name: '',
+      }),
+      { onTestConnection: jest.fn() }
+    );
+    expect((testButton(utils) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('renders the success status text inline', () => {
+    const utils = renderWithTest(makeFormData(), {
+      onTestConnection: jest.fn(),
+      testStatus: { state: 'success' },
+    });
+    expect(
+      utils.getByText('settings.aiService.test.successTitle')
+    ).toBeTruthy();
+  });
+
+  it('renders the failure status text with the error message inline', () => {
+    const utils = renderWithTest(makeFormData(), {
+      onTestConnection: jest.fn(),
+      testStatus: { state: 'error', message: 'Bad API key' },
+    });
+    expect(
+      utils.getByText('settings.aiService.test.failureTitle: Bad API key')
+    ).toBeTruthy();
+  });
+
+  // The result is cleared while a fresh test is in flight.
+  it('hides the status text while a test is running', () => {
+    const utils = renderWithTest(makeFormData(), {
+      onTestConnection: jest.fn(),
+      testing: true,
+      testStatus: { state: 'success' },
+    });
+    expect(
+      utils.queryByText('settings.aiService.test.successTitle')
+    ).toBeNull();
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/components/ServiceForm.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/ServiceForm.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent } from '@testing-library/react';
+import { renderWithClient } from '../test-utils';
+import { ServiceForm } from '@/components/ai/ServiceForm';
+import type { AiServiceSettingsFormInput } from '@/schemas/form/AiServiceSettings.form.zod';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockToast = jest.fn();
+jest.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+function makeFormData(
+  overrides: Partial<AiServiceSettingsFormInput> = {}
+): AiServiceSettingsFormInput {
+  return {
+    service_name: 'My Service',
+    service_type: 'openai',
+    api_key: 'sk-test',
+    custom_url: '',
+    system_prompt: '',
+    is_active: false,
+    model_name: '',
+    custom_model_name: '',
+    showCustomModelInput: false,
+    chat_tool_profile: 'full',
+    ...overrides,
+  } as AiServiceSettingsFormInput;
+}
+
+function renderForm(
+  formData: AiServiceSettingsFormInput,
+  onSubmit = jest.fn()
+) {
+  const utils = renderWithClient(
+    <ServiceForm
+      formData={formData}
+      onFormDataChange={jest.fn()}
+      onSubmit={onSubmit}
+      onCancel={jest.fn()}
+      translationPrefix="settings.aiService.userSettings"
+    />
+  );
+  return { ...utils, onSubmit };
+}
+
+describe('ServiceForm — model validation', () => {
+  afterEach(() => {
+    mockToast.mockClear();
+  });
+
+  // Regression: types without preset models (openai_compatible/custom/ollama)
+  // point at user-hosted servers with no reliable server-side default, so the
+  // form must not save them without an explicit model.
+  it('blocks submit for a no-preset type with no model', () => {
+    const { container, onSubmit } = renderForm(
+      makeFormData({
+        service_type: 'openai_compatible',
+        custom_url: 'http://localhost:1234/v1',
+        showCustomModelInput: true,
+        custom_model_name: '',
+        model_name: '',
+      })
+    );
+
+    fireEvent.submit(container.querySelector('form')!);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a whitespace-only custom model as missing', () => {
+    const { container, onSubmit } = renderForm(
+      makeFormData({
+        service_type: 'custom',
+        custom_url: 'http://localhost:1234/v1',
+        showCustomModelInput: true,
+        custom_model_name: '   ',
+        model_name: '',
+      })
+    );
+
+    fireEvent.submit(container.querySelector('form')!);
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits a no-preset type when a custom model name is provided', () => {
+    const { container, onSubmit } = renderForm(
+      makeFormData({
+        service_type: 'openai_compatible',
+        custom_url: 'http://localhost:1234/v1',
+        showCustomModelInput: true,
+        custom_model_name: 'llama-3.2',
+        model_name: '',
+      })
+    );
+
+    fireEvent.submit(container.querySelector('form')!);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  // Preset providers (openai, anthropic, ...) have a sensible server-side
+  // default, so a blank model is allowed and must not block submission.
+  it('allows a preset provider to submit without a model', () => {
+    const { container, onSubmit } = renderForm(
+      makeFormData({ service_type: 'openai', model_name: '' })
+    );
+
+    fireEvent.submit(container.querySelector('form')!);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/services/aiServiceSettingsService.test.ts
+++ b/SparkyFitnessFrontend/src/tests/services/aiServiceSettingsService.test.ts
@@ -191,6 +191,47 @@ describe('aiServiceSettingsService', () => {
     });
   });
 
+  describe('testAIServiceConnection', () => {
+    it('posts to the test endpoint and returns the parsed pass response', async () => {
+      const payload = {
+        service_type: 'openai',
+        api_key: 'sk-test',
+        model_name: 'gpt-4o',
+      };
+      mockApiCall.mockResolvedValue({ ok: true });
+
+      const result =
+        await aiServiceSettingsService.testAIServiceConnection(payload);
+
+      expect(mockApiCall).toHaveBeenCalledWith(
+        '/chat/ai-service-settings/test',
+        {
+          method: 'POST',
+          body: payload,
+        }
+      );
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('returns the parsed failure response with its category', async () => {
+      mockApiCall.mockResolvedValue({
+        ok: false,
+        category: 'upstream_error',
+        detail: 'AI service returned status 401',
+      });
+
+      const result = await aiServiceSettingsService.testAIServiceConnection({
+        service_type: 'openai',
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        category: 'upstream_error',
+        detail: 'AI service returned status 401',
+      });
+    });
+  });
+
   describe('updateAIServiceStatus', () => {
     it('updates service active status', async () => {
       const serviceId = '1';

--- a/SparkyFitnessFrontend/src/tests/utils/aiServiceUtils.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/aiServiceUtils.test.ts
@@ -1,4 +1,4 @@
-import { getModelOptions } from '@/utils/aiServiceUtils';
+import { getModelOptions, requiresApiKey } from '@/utils/aiServiceUtils';
 
 describe('getModelOptions', () => {
   // Regression: 'openai_compatible' and 'custom' point at arbitrary user-hosted
@@ -25,5 +25,30 @@ describe('getModelOptions', () => {
 
   it('returns an empty list for an unknown service type', () => {
     expect(getModelOptions('totally-unknown')).toEqual([]);
+  });
+});
+
+describe('requiresApiKey', () => {
+  // Regression: keyless local servers (LM Studio, llama.cpp, Ollama) must be
+  // savable without an API key. The add/edit forms previously exempted only
+  // 'ollama', blocking openai_compatible/custom even though the server's
+  // dispatcher and test-connection path tolerate a blank key.
+  it.each(['ollama', 'openai_compatible', 'custom'])(
+    'does not require a key for keyless local type %s',
+    (serviceType) => {
+      expect(requiresApiKey(serviceType)).toBe(false);
+    }
+  );
+
+  it.each([
+    'openai',
+    'anthropic',
+    'google',
+    'mistral',
+    'groq',
+    'openrouter',
+    'xai',
+  ])('requires a key for cloud provider %s', (serviceType) => {
+    expect(requiresApiKey(serviceType)).toBe(true);
   });
 });

--- a/SparkyFitnessFrontend/src/tests/utils/aiServiceUtils.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/aiServiceUtils.test.ts
@@ -1,0 +1,29 @@
+import { getModelOptions } from '@/utils/aiServiceUtils';
+
+describe('getModelOptions', () => {
+  // Regression: 'openai_compatible' and 'custom' point at arbitrary user-hosted
+  // servers, so the form must NOT suggest OpenAI model names (which won't exist
+  // on most compatible servers). Returning [] makes the form fall back to the
+  // custom-model text input. Previously 'openai_compatible' shared OpenAI's list
+  // and auto-selected 'gpt-4o-mini', which failed against non-OpenAI endpoints.
+  it.each(['openai_compatible', 'custom'])(
+    'returns no preset models for %s',
+    (serviceType) => {
+      expect(getModelOptions(serviceType)).toEqual([]);
+    }
+  );
+
+  it('does not leak OpenAI model names into openai_compatible', () => {
+    expect(getModelOptions('openai_compatible')).not.toContain('gpt-4o-mini');
+  });
+
+  it('still returns the OpenAI list for openai (unchanged)', () => {
+    const options = getModelOptions('openai');
+    expect(options[0]).toBe('gpt-4o-mini');
+    expect(options.length).toBeGreaterThan(1);
+  });
+
+  it('returns an empty list for an unknown service type', () => {
+    expect(getModelOptions('totally-unknown')).toEqual([]);
+  });
+});

--- a/SparkyFitnessFrontend/src/types/admin.ts
+++ b/SparkyFitnessFrontend/src/types/admin.ts
@@ -3,6 +3,7 @@ export interface GlobalSettings {
   is_oidc_active: boolean;
   is_mfa_mandatory: boolean;
   allow_user_ai_config?: boolean;
+  default_vision_ai_service_id?: string | null;
   is_email_login_env_configured?: boolean;
   is_oidc_active_env_configured?: boolean;
 }

--- a/SparkyFitnessFrontend/src/types/settings.ts
+++ b/SparkyFitnessFrontend/src/types/settings.ts
@@ -1,6 +1,7 @@
 export interface UserPreferencesChat {
   auto_clear_history: string;
   active_ai_service_id?: string | null;
+  active_vision_ai_service_id?: string | null;
 }
 
 export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;

--- a/SparkyFitnessFrontend/src/utils/aiServiceUtils.ts
+++ b/SparkyFitnessFrontend/src/utils/aiServiceUtils.ts
@@ -31,7 +31,6 @@ export const getServiceTypes = (t: (key: string) => string): ServiceType[] => [
 export const getModelOptions = (serviceType: string): string[] => {
   switch (serviceType) {
     case 'openai':
-    case 'openai_compatible':
       return [
         'gpt-4o-mini',
         'gpt-5.4-mini',
@@ -84,6 +83,10 @@ export const getModelOptions = (serviceType: string): string[] => {
         'grok-4.20-0309-reasoning',
         'grok-build-0.1',
       ];
+    // 'openai_compatible' and 'custom' point at arbitrary user-hosted servers,
+    // so there is no model name we can suggest — OpenAI's names won't exist on
+    // most of them. Returning [] makes the form fall back to the custom-model
+    // text input where the user supplies their server's own model name.
     default:
       return [];
   }

--- a/SparkyFitnessFrontend/src/utils/aiServiceUtils.ts
+++ b/SparkyFitnessFrontend/src/utils/aiServiceUtils.ts
@@ -25,6 +25,15 @@ export const getServiceTypes = (t: (key: string) => string): ServiceType[] => [
   { value: 'custom', label: t('settings.aiService.serviceTypes.custom') },
 ];
 
+// Local / self-hosted server types (LM Studio, llama.cpp, Ollama) commonly run
+// without an API key, so the add/edit forms must not force one for these types.
+// Cloud providers always need a key. This mirrors the server's requiresApiKey in
+// ai/providerDispatch.ts so the form and the dispatcher stay in agreement.
+export const requiresApiKey = (serviceType: string | undefined): boolean =>
+  serviceType !== 'ollama' &&
+  serviceType !== 'openai_compatible' &&
+  serviceType !== 'custom';
+
 // The first entry in each list is the recommended default — the cheapest model
 // that handles SparkyFitness's tasks well. Keep that ordering when refreshing,
 // since ServiceForm surfaces modelOptions[0] as the recommendation.

--- a/SparkyFitnessFrontend/vite.config.ts
+++ b/SparkyFitnessFrontend/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
 import { VitePWA } from 'vite-plugin-pwa';
+import { reactClickToComponent } from 'vite-plugin-react-click-to-component';
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
@@ -43,6 +44,9 @@ export default defineConfig(({ mode }) => {
     plugins: [
       tailwindcss(),
       react(),
+      // Option+Right Click any element in dev to open its source in your editor.
+      // Self-guards to `command === 'serve'`, so it's a no-op in production builds.
+      reactClickToComponent(),
       // Temporarily disabled for development to debug refresh issue
       // mode === "production" && VitePWA({...})
       mode === 'production' &&

--- a/SparkyFitnessMobile/__tests__/screens/FoodPhotoImproveScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodPhotoImproveScreen.test.tsx
@@ -9,10 +9,6 @@ jest.mock('../../src/hooks/useEstimateFoodPhoto', () => ({
   useEstimateFoodPhoto: jest.fn(),
 }));
 
-jest.mock('../../src/hooks/useActiveAiServiceSetting', () => ({
-  useActiveAiServiceSetting: jest.fn(() => ({ data: null, isLoading: false })),
-}));
-
 const mockBase64 = jest.fn().mockResolvedValue('AAAA-base64');
 jest.mock('expo-file-system', () => ({
   File: jest.fn().mockImplementation(() => ({

--- a/SparkyFitnessMobile/src/screens/FoodPhotoImproveScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodPhotoImproveScreen.tsx
@@ -24,7 +24,6 @@ import SegmentedControl, { type Segment } from '../components/SegmentedControl';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { FoodPhotoFlowScreenProps, RootStackParamList } from '../types/navigation';
 import { useEstimateFoodPhoto } from '../hooks/useEstimateFoodPhoto';
-import { useActiveAiServiceSetting } from '../hooks/useActiveAiServiceSetting';
 import { useHeaderActionColors } from '../hooks/useHeaderActionColors';
 import { activeAiServiceSettingQueryKey } from '../hooks/queryKeys';
 import { addLog } from '../services/LogService';
@@ -140,7 +139,6 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
   );
 
   const mutation = useEstimateFoodPhoto();
-  const { data: aiSetting } = useActiveAiServiceSetting();
 
   const cancelledRef = useRef(false);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -171,26 +169,10 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
   const atImageCap = images.length >= MAX_IMAGES;
 
   const appendImage = (uri: string, mimeType?: string) => {
-    // Fail fast on the client when the active provider can't read HEIC/HEIF,
-    // rather than reading base64 and round-tripping to a guaranteed server
-    // rejection. The service-side guard remains the backstop. Only Gemini
-    // accepts HEIC, so reject for every other provider — but the truthiness
-    // check keeps us from gating while `service_type` is still loading
-    // (undefined), where a bare `!== 'google'` would wrongly reject.
-    const provider = aiSetting?.service_type;
-    const resolved = resolveMimeType({ uri, mimeType });
-    if (
-      provider &&
-      provider !== 'google' &&
-      (resolved === 'image/heic' || resolved === 'image/heif')
-    ) {
-      Toast.show({
-        type: 'error',
-        text1: 'Unsupported format',
-        text2: "This AI provider can't read HEIC/HEIF images. Please pick a JPEG or PNG.",
-      });
-      return;
-    }
+    // HEIC/HEIF support depends on the *vision* provider, which the mobile app
+    // does not fetch. Gating on the active *text* provider's type is wrong once
+    // vision can differ, so the server-side guard owns format rejection (it
+    // returns UNSUPPORTED_MIME_TYPE, surfaced as "Unexpected image format").
     setImages((prev) =>
       prev.length >= MAX_IMAGES ? prev : [...prev, { uri, mimeType }],
     );
@@ -318,27 +300,9 @@ const FoodPhotoImproveScreen: React.FC<Props> = ({ navigation, route }) => {
       return;
     }
 
-    // Fail fast before the memory-intensive base64 reads if any staged image is
-    // HEIC/HEIF and the active provider can't read it. Catches the seed image
-    // from the scan screen, which never passes through appendImage. Only Gemini
-    // accepts HEIC; the truthiness check avoids gating while `service_type` is
-    // still loading (undefined).
-    const provider = aiSetting?.service_type;
-    if (provider && provider !== 'google') {
-      const hasUnsupported = images.some((img) => {
-        const resolved = resolveMimeType(img);
-        return resolved === 'image/heic' || resolved === 'image/heif';
-      });
-      if (hasUnsupported) {
-        Toast.show({
-          type: 'error',
-          text1: 'Unsupported format',
-          text2: "This AI provider can't read HEIC/HEIF images. Please remove them or switch to JPEG/PNG.",
-        });
-        return;
-      }
-    }
-
+    // Format rejection is owned server-side (it returns UNSUPPORTED_MIME_TYPE,
+    // surfaced on the review screen). The client can't reliably pre-screen HEIC
+    // because support depends on the vision provider, which the app never fetches.
     const imagePayloads: { base64Image: string; mimeType: string }[] = [];
     try {
       // Sequential rather than Promise.all: converting several images to base64

--- a/SparkyFitnessServer/ai/providerDispatch.ts
+++ b/SparkyFitnessServer/ai/providerDispatch.ts
@@ -144,6 +144,18 @@ function requiresCustomUrl(serviceType: string): boolean {
   );
 }
 
+// Local / self-hosted server types (LM Studio, llama.cpp, Ollama) commonly run
+// without an API key, so a blank key must not hard-fail them. Cloud providers
+// always need one. This mirrors the chat path, which sends `api_key || 'no-key'`
+// for these same types instead of rejecting the request.
+function requiresApiKey(serviceType: string): boolean {
+  return (
+    serviceType !== 'ollama' &&
+    serviceType !== 'openai_compatible' &&
+    serviceType !== 'custom'
+  );
+}
+
 // Anthropic's Messages API rejects the non-standard 'image/jpg'; normalize it
 // to the canonical 'image/jpeg'. Shared transport concern, so it lives here.
 function normalizeMimeType(mimeType: string): string {
@@ -345,7 +357,9 @@ function buildOpenAiFamilyRequest(ctx: BuildContext): BuiltRequest {
         'HTTP-Referer': 'https://sparky-fitness.com',
         'X-Title': 'Sparky Fitness',
       }),
-      Authorization: `Bearer ${ctx.provider.api_key}`,
+      // Local/self-hosted types may have no key; send the chat path's `no-key`
+      // sentinel so a keyless server sees the same header from both paths.
+      Authorization: `Bearer ${ctx.provider.api_key || 'no-key'}`,
     },
     body,
   };
@@ -768,7 +782,7 @@ export async function dispatchAiRequest(
     };
   }
 
-  if (serviceType !== 'ollama' && !provider.api_key) {
+  if (requiresApiKey(serviceType) && !provider.api_key) {
     return {
       ok: false,
       category: 'api_key_missing',

--- a/SparkyFitnessServer/ai/providerDispatch.ts
+++ b/SparkyFitnessServer/ai/providerDispatch.ts
@@ -148,7 +148,7 @@ function requiresCustomUrl(serviceType: string): boolean {
 // without an API key, so a blank key must not hard-fail them. Cloud providers
 // always need one. This mirrors the chat path, which sends `api_key || 'no-key'`
 // for these same types instead of rejecting the request.
-function requiresApiKey(serviceType: string): boolean {
+export function requiresApiKey(serviceType: string): boolean {
   return (
     serviceType !== 'ollama' &&
     serviceType !== 'openai_compatible' &&

--- a/SparkyFitnessServer/config/swagger.ts
+++ b/SparkyFitnessServer/config/swagger.ts
@@ -1178,6 +1178,13 @@ const options = {
             enable_email_password_login: { type: 'boolean' },
             is_oidc_active: { type: 'boolean' },
             is_mfa_mandatory: { type: 'boolean' },
+            default_vision_ai_service_id: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              description:
+                'Global default AI service used for vision tasks (food-photo, label scan) by users on the global default. Null clears it.',
+            },
           },
         },
         AppReview: {

--- a/SparkyFitnessServer/db/migrations/20260628120000_add_vision_ai_service_pointers.sql
+++ b/SparkyFitnessServer/db/migrations/20260628120000_add_vision_ai_service_pointers.sql
@@ -1,0 +1,21 @@
+-- Migration: Add optional vision AI service pointers
+-- Created at: 2026-06-28 12:00:00
+--
+-- Adds a per-user vision-service pointer and an admin global vision-service
+-- default. Both are nullable; when unset, vision features fall back to the
+-- existing active/default text service, so behavior is unchanged on upgrade.
+
+BEGIN;
+
+-- Per-user override: route vision tasks (food-photo, label scan) to a
+-- dedicated service. Falls back to active_ai_service_id when NULL.
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS active_vision_ai_service_id UUID
+  REFERENCES public.ai_service_settings(id) ON DELETE SET NULL;
+
+-- Admin global default applied to users on the global default text service.
+ALTER TABLE public.global_settings
+  ADD COLUMN IF NOT EXISTS default_vision_ai_service_id UUID
+  REFERENCES public.ai_service_settings(id) ON DELETE SET NULL;
+
+COMMIT;

--- a/SparkyFitnessServer/models/chatRepository.ts
+++ b/SparkyFitnessServer/models/chatRepository.ts
@@ -226,6 +226,90 @@ async function getActiveAiServiceSetting(userId: string) {
     client.release();
   }
 }
+// Resolves the AI service to use for vision tasks (food-photo, label scan).
+// The existing active/default service is the text default; vision falls back to
+// it unless the user (or admin, for defaulted users) points vision elsewhere.
+// See models/chatRepository getActiveAiServiceSetting for the text counterpart.
+async function getActiveVisionAiServiceSetting(userId: string) {
+  const client = await getClient(userId); // User-specific operation
+  try {
+    // Read both pointers up front: step 1 needs the vision pointer, and step 3
+    // compares active_ai_service_id against the resolved base to tell a
+    // genuinely-defaulted user apart from one whose explicit text pick is live.
+    const prefResult = await client.query(
+      'SELECT active_ai_service_id, active_vision_ai_service_id FROM user_preferences WHERE user_id = $1',
+      [userId]
+    );
+    const prefs = prefResult.rows[0];
+
+    // 1. Explicit per-user vision override (mirrors Priority-0 of the text
+    //    resolver) — honored only while the pointed-to service is active.
+    if (prefs && prefs.active_vision_ai_service_id) {
+      const visionId = prefs.active_vision_ai_service_id;
+      const settingResult = await client.query(
+        `SELECT ai.id, ai.service_name, ai.service_type, ai.custom_url, ai.is_active, ai.model_name, ai.is_public, ai.system_prompt, ai.user_id, u.name as creator_name
+         FROM ai_service_settings ai
+         LEFT JOIN public."user" u ON ai.user_id = u.id
+         WHERE ai.id = $1 AND ai.is_active = TRUE`,
+        [visionId]
+      );
+      if (settingResult.rows.length > 0) {
+        const setting = settingResult.rows[0];
+        const source = setting.is_public ? 'global' : 'user';
+        log(
+          'debug',
+          `Using preferred vision AI service setting for user ${userId}: ${setting.id} (source: ${source})`
+        );
+        return { ...setting, source };
+      }
+    }
+
+    // 2. No usable vision override → the text/default service is the baseline.
+    const base = await getActiveAiServiceSetting(userId);
+    if (!base) return null;
+
+    // 3. Apply the admin global vision default only to users effectively on the
+    //    global default: the base resolved as a global service AND the user's
+    //    explicit text pointer did not resolve to it. Keying off whether the
+    //    pointer actually resolved (active_ai_service_id === base.id) — rather
+    //    than merely whether it is set — means a user whose explicitly-chosen
+    //    service was later deactivated (and who has fallen through to the global
+    //    default) still gets the configured vision default, while a live explicit
+    //    pick is never silently redirected. We read global_settings with the
+    //    user-scoped client (the table has no RLS and grants SELECT to the app
+    //    role) to avoid the system-client read in globalSettingsRepository that
+    //    logs every field.
+    if (base.source === 'global' && prefs?.active_ai_service_id !== base.id) {
+      const globalResult = await client.query(
+        'SELECT default_vision_ai_service_id FROM global_settings WHERE id = 1',
+        []
+      );
+      const defaultVisionId =
+        globalResult.rows[0]?.default_vision_ai_service_id;
+      if (defaultVisionId) {
+        // Enforce is_public in the query so the repository upholds the
+        // global-only invariant even though the admin UI only lists globals.
+        const visionResult = await client.query(
+          'SELECT id, service_name, service_type, custom_url, is_active, model_name, is_public, system_prompt, user_id FROM ai_service_settings WHERE id = $1 AND is_active = TRUE AND is_public = TRUE',
+          [defaultVisionId]
+        );
+        if (visionResult.rows.length > 0) {
+          const setting = visionResult.rows[0];
+          log(
+            'debug',
+            `Using global vision AI service default for user ${userId}: ${setting.id}`
+          );
+          return { ...setting, source: 'global' };
+        }
+      }
+    }
+
+    // 4. Otherwise reuse the text service for vision.
+    return base;
+  } finally {
+    client.release();
+  }
+}
 async function clearOldChatHistory(userId: string) {
   const client = await getClient(userId);
   try {
@@ -471,6 +555,7 @@ export { getAiServiceSettingForBackend };
 export { deleteAiServiceSetting };
 export { getAiServiceSettingsByUserId };
 export { getActiveAiServiceSetting };
+export { getActiveVisionAiServiceSetting };
 export { clearOldChatHistory };
 export { getChatHistoryByUserId };
 export { getChatHistoryEntryById };
@@ -490,6 +575,7 @@ export default {
   deleteAiServiceSetting,
   getAiServiceSettingsByUserId,
   getActiveAiServiceSetting,
+  getActiveVisionAiServiceSetting,
   clearOldChatHistory,
   getChatHistoryByUserId,
   getChatHistoryEntryById,

--- a/SparkyFitnessServer/models/chatRepository.ts
+++ b/SparkyFitnessServer/models/chatRepository.ts
@@ -115,6 +115,48 @@ async function getAiServiceSettingForBackend(id: string, userId: string) {
     client.release();
   }
 }
+// Decrypt-and-return a single setting WITHOUT the `is_active = TRUE` filter that
+// getAiServiceSettingForBackend applies — the connection test must work for an
+// inactive service too. The user-scoped client preserves RLS: a user reads only
+// their own private rows plus `is_public` global rows, so this serves both the
+// per-user and admin/global test contexts without leaking other users' keys.
+async function getDecryptedAiServiceSettingById(id: string, userId: string) {
+  const client = await getClient(userId); // User-specific operation (RLS-scoped)
+  try {
+    const result = await client.query(
+      'SELECT * FROM ai_service_settings WHERE id = $1',
+      [id]
+    );
+    const setting = result.rows[0];
+    if (!setting) return null;
+    let decryptedApiKey = null;
+    if (
+      setting.encrypted_api_key &&
+      setting.api_key_iv &&
+      setting.api_key_tag
+    ) {
+      try {
+        decryptedApiKey = await decrypt(
+          setting.encrypted_api_key,
+          setting.api_key_iv,
+          setting.api_key_tag,
+          ENCRYPTION_KEY
+        );
+      } catch (e) {
+        log('error', 'Error decrypting API key for AI service setting:', id, e);
+      }
+    }
+    return {
+      service_type: setting.service_type,
+      api_key: decryptedApiKey,
+      custom_url: setting.custom_url,
+      model_name: setting.model_name,
+      is_public: setting.is_public,
+    };
+  } finally {
+    client.release();
+  }
+}
 async function getAiServiceSettingById(id: string, userId: string) {
   const client = await getClient(userId); // User-specific operation
   try {
@@ -552,6 +594,7 @@ async function deleteGlobalAiServiceSetting(id: string) {
 export { upsertAiServiceSetting };
 export { getAiServiceSettingById };
 export { getAiServiceSettingForBackend };
+export { getDecryptedAiServiceSettingById };
 export { deleteAiServiceSetting };
 export { getAiServiceSettingsByUserId };
 export { getActiveAiServiceSetting };
@@ -572,6 +615,7 @@ export default {
   upsertAiServiceSetting,
   getAiServiceSettingById,
   getAiServiceSettingForBackend,
+  getDecryptedAiServiceSettingById,
   deleteAiServiceSetting,
   getAiServiceSettingsByUserId,
   getActiveAiServiceSetting,

--- a/SparkyFitnessServer/models/globalSettingsRepository.ts
+++ b/SparkyFitnessServer/models/globalSettingsRepository.ts
@@ -65,15 +65,19 @@ async function saveGlobalSettings(settings: any) {
         : true;
     await client.query(
       `UPDATE global_settings
-             SET enable_email_password_login = $1, is_oidc_active = $2, mfa_mandatory = $3, allow_user_ai_config = COALESCE($4, allow_user_ai_config, true)
+             SET enable_email_password_login = $1, is_oidc_active = $2, mfa_mandatory = $3, allow_user_ai_config = COALESCE($4, allow_user_ai_config, true), default_vision_ai_service_id = $5
              WHERE id = 1
              RETURNING *`,
-      // Use 'is_mfa_mandatory' from the incoming settings from the frontend
+      // Use 'is_mfa_mandatory' from the incoming settings from the frontend.
+      // default_vision_ai_service_id uses a plain assignment (not COALESCE) so
+      // selecting "None" can clear it; both save callers spread the full
+      // settings object, so the field always round-trips.
       [
         settings.enable_email_password_login,
         settings.is_oidc_active,
         settings.is_mfa_mandatory,
         allowUserAiConfig,
+        settings.default_vision_ai_service_id ?? null,
       ]
     );
     // Return the full truth (DB + ENV overrides)

--- a/SparkyFitnessServer/models/globalSettingsRepository.ts
+++ b/SparkyFitnessServer/models/globalSettingsRepository.ts
@@ -65,19 +65,21 @@ async function saveGlobalSettings(settings: any) {
         : true;
     await client.query(
       `UPDATE global_settings
-             SET enable_email_password_login = $1, is_oidc_active = $2, mfa_mandatory = $3, allow_user_ai_config = COALESCE($4, allow_user_ai_config, true), default_vision_ai_service_id = $5
+             SET enable_email_password_login = $1, is_oidc_active = $2, mfa_mandatory = $3, allow_user_ai_config = COALESCE($4, allow_user_ai_config, true), default_vision_ai_service_id = CASE WHEN $6 THEN $5 ELSE default_vision_ai_service_id END
              WHERE id = 1
              RETURNING *`,
       // Use 'is_mfa_mandatory' from the incoming settings from the frontend.
-      // default_vision_ai_service_id uses a plain assignment (not COALESCE) so
-      // selecting "None" can clear it; both save callers spread the full
-      // settings object, so the field always round-trips.
+      // default_vision_ai_service_id uses a CASE WHEN existence check (matching
+      // active_vision_ai_service_id in preferenceRepository) so an explicit null
+      // can clear it ("None") while an omitted field leaves the stored value
+      // untouched instead of clobbering it.
       [
         settings.enable_email_password_login,
         settings.is_oidc_active,
         settings.is_mfa_mandatory,
         allowUserAiConfig,
         settings.default_vision_ai_service_id ?? null,
+        'default_vision_ai_service_id' in settings,
       ]
     );
     // Return the full truth (DB + ENV overrides)

--- a/SparkyFitnessServer/models/preferenceRepository.ts
+++ b/SparkyFitnessServer/models/preferenceRepository.ts
@@ -42,6 +42,7 @@ async function updateUserPreferences(userId: any, preferenceData: any) {
         add_exercise_water_to_goal = COALESCE($40, add_exercise_water_to_goal),
         default_barcode_provider_id = CASE WHEN $28 THEN $27 ELSE default_barcode_provider_id END,
         active_ai_service_id = CASE WHEN $39 THEN $38 ELSE active_ai_service_id END,
+        active_vision_ai_service_id = CASE WHEN $43 THEN $42 ELSE active_vision_ai_service_id END,
         measurement_decimal_places = COALESCE($41, measurement_decimal_places),
         updated_at = now()
       WHERE user_id = $29
@@ -88,6 +89,8 @@ async function updateUserPreferences(userId: any, preferenceData: any) {
         'active_ai_service_id' in preferenceData,
         preferenceData.add_exercise_water_to_goal,
         preferenceData.measurement_decimal_places,
+        preferenceData.active_vision_ai_service_id,
+        'active_vision_ai_service_id' in preferenceData,
       ]
     );
     return result.rows[0];
@@ -172,6 +175,7 @@ async function upsertUserPreferences(preferenceData: any) {
        add_exercise_water_to_goal,
        active_ai_service_id,
        measurement_decimal_places,
+       active_vision_ai_service_id,
        created_at, updated_at
      ) VALUES (
        $1, COALESCE($2, 'yyyy-MM-dd'), COALESCE($3, 'lbs'), COALESCE($4, 'in'), COALESCE($5, 'km'),
@@ -195,6 +199,7 @@ async function upsertUserPreferences(preferenceData: any) {
        COALESCE($40, false),
        $38,
        COALESCE($41, 0),
+       $42,
        now(), now()
      )
      ON CONFLICT (user_id) DO UPDATE SET
@@ -235,6 +240,7 @@ async function upsertUserPreferences(preferenceData: any) {
        add_exercise_water_to_goal = COALESCE(EXCLUDED.add_exercise_water_to_goal, user_preferences.add_exercise_water_to_goal),
        default_barcode_provider_id = CASE WHEN $29 THEN EXCLUDED.default_barcode_provider_id ELSE user_preferences.default_barcode_provider_id END,
        active_ai_service_id = CASE WHEN $39 THEN EXCLUDED.active_ai_service_id ELSE user_preferences.active_ai_service_id END,
+       active_vision_ai_service_id = CASE WHEN $43 THEN EXCLUDED.active_vision_ai_service_id ELSE user_preferences.active_vision_ai_service_id END,
        measurement_decimal_places = COALESCE(EXCLUDED.measurement_decimal_places, user_preferences.measurement_decimal_places),
        updated_at = now()
      RETURNING *`,
@@ -280,6 +286,8 @@ async function upsertUserPreferences(preferenceData: any) {
         'active_ai_service_id' in preferenceData,
         preferenceData.add_exercise_water_to_goal,
         preferenceData.measurement_decimal_places,
+        preferenceData.active_vision_ai_service_id,
+        'active_vision_ai_service_id' in preferenceData,
       ]
     );
     return result.rows[0];

--- a/SparkyFitnessServer/routes/adminRoutes.ts
+++ b/SparkyFitnessServer/routes/adminRoutes.ts
@@ -10,6 +10,7 @@ import {
 } from '../schemas/externalProviderSchemas.js';
 import { log } from '../config/logging.js';
 import { logAdminAction } from '../services/authService.js';
+import { requiresApiKey } from '../ai/providerDispatch.js';
 import { auth } from '../auth.js';
 const router = express.Router();
 // Middleware to ensure only admins can access these routes
@@ -597,10 +598,10 @@ router.post('/ai-service-settings/global', async (req, res, next) => {
         .status(400)
         .json({ error: 'service_name and service_type are required.' });
     }
-    if (service_type !== 'ollama' && !api_key) {
+    if (requiresApiKey(service_type) && !api_key) {
       return res
         .status(400)
-        .json({ error: 'api_key is required for non-Ollama services.' });
+        .json({ error: 'api_key is required for this service type.' });
     }
     const settingData = {
       service_name,

--- a/SparkyFitnessServer/routes/chatRoutes.ts
+++ b/SparkyFitnessServer/routes/chatRoutes.ts
@@ -4,6 +4,8 @@ import { authenticate } from '../middleware/authMiddleware.js';
 import chatService from '../services/chatService.js';
 import type { FoodOptionsErrorCategory } from '../services/chatService.js';
 import globalSettingsRepository from '../models/globalSettingsRepository.js';
+import { resolveIsAdmin } from '../utils/adminCheck.js';
+import { testAiServiceConnectionRequestSchema } from '@workspace/shared';
 const router = express.Router();
 /**
  * @swagger
@@ -269,6 +271,85 @@ router.get(
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
         return res.status(404).json({ error: error.message });
       }
+      next(error);
+    }
+  }
+);
+/**
+ * @swagger
+ * /chat/ai-service-settings/test:
+ *   post:
+ *     summary: Test an AI service connection with a minimal live completion
+ *     description: >
+ *       Runs a minimal completion against the supplied provider config without
+ *       persisting anything. Returns HTTP 200 for both pass (`ok: true`) and
+ *       provider failure (`ok: false`, with a `category`), so the client can show
+ *       a friendly, category-specific message instead of a generic API error.
+ *       On edit, a blank `api_key` falls back to the stored encrypted key.
+ *     tags: [AI & Insights]
+ *     security:
+ *       - cookieAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [service_type]
+ *             properties:
+ *               id:
+ *                 type: string
+ *                 format: uuid
+ *               service_type:
+ *                 type: string
+ *               api_key:
+ *                 type: string
+ *               custom_url:
+ *                 type: string
+ *               model_name:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Test result (pass or provider failure).
+ *       400:
+ *         description: Bad request (malformed body or missing required model).
+ *       403:
+ *         description: Forbidden (per-user AI config disabled, or non-admin testing a global service).
+ *       500:
+ *         description: Server error.
+ */
+router.post(
+  '/ai-service-settings/test',
+  authenticate,
+  async (req, res, next) => {
+    const parsed = testAiServiceConnectionRequestSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json({ error: 'Invalid test connection request.' });
+    }
+    try {
+      // Gate #1 (per-user-AI-config): a test fires an outbound provider call, so
+      // it must respect the same admin policy as the save path — non-admins are
+      // rejected unless per-user AI config is enabled. Admins always pass.
+      const isAdmin = await resolveIsAdmin(req.user, req.authenticatedUserId);
+      if (
+        !isAdmin &&
+        !(await globalSettingsRepository.isUserAiConfigAllowed())
+      ) {
+        return res.status(403).json({
+          error:
+            'Per-user AI service configuration is disabled. Please use the global AI service settings configured by your administrator.',
+        });
+      }
+      // Gates #2 (global-key) and #3 (provider-mismatch) live in the service.
+      const result = await chatService.testAiServiceConnection(
+        parsed.data,
+        req.userId,
+        isAdmin
+      );
+      return res.status(200).json(result);
+    } catch (error) {
       next(error);
     }
   }

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -5,6 +5,7 @@ import { log } from '../config/logging.js';
 import { getDefaultModel } from '../ai/config.js';
 import {
   dispatchAiRequest,
+  requiresApiKey,
   type DispatchErrorCategory,
   type ProviderConfig,
 } from '../ai/providerDispatch.js';
@@ -598,7 +599,7 @@ async function processChatMessage(
       `Processing chat message for user ${userId} using AI service from ${source} (ID: ${serviceConfigId})`
     );
 
-    if (aiService.service_type !== 'ollama' && !aiService.api_key) {
+    if (requiresApiKey(aiService.service_type) && !aiService.api_key) {
       throw new Error('API key missing for selected AI service.');
     }
 

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -15,6 +15,7 @@ import {
   AiServiceSettings,
   SparkyChatHistory,
   SparkyChatHistoryMutator,
+  TestAiServiceConnectionRequest,
 } from '@workspace/shared';
 
 interface ChatMessagePart {
@@ -999,6 +1000,109 @@ async function processFoodOptionsRequest(
   }
   return { success: true, content: result.text };
 }
+
+// Minimal completion used only to confirm a provider config actually works.
+const TEST_CONNECTION_PROMPT = 'Reply with the single word: OK.';
+// A short timeout so an unreachable custom URL fails in ~15s rather than hanging
+// for the 90s/120s dispatch defaults. Retry behavior is safe: only HTTP 429 is
+// retried; timeouts and 401/403 return immediately.
+const TEST_CONNECTION_TIMEOUT_MS = 15_000;
+// Types without preset models point at user-hosted servers with no reliable
+// default, so a blank effective model would let dispatch substitute a
+// meaningless getDefaultModel default the UI never intends.
+const NO_PRESET_SERVICE_TYPES = new Set([
+  'ollama',
+  'openai_compatible',
+  'custom',
+]);
+
+export type TestConnectionResult =
+  | { ok: true }
+  | { ok: false; category: DispatchErrorCategory; detail: string };
+
+function statusError(message: string, statusCode: number): Error {
+  const err = new Error(message) as Error & { statusCode?: number };
+  err.statusCode = statusCode;
+  return err;
+}
+
+/**
+ * Run a minimal live completion against a provider config to verify it works,
+ * without persisting anything. Returns `{ ok: true }` or `{ ok: false, category,
+ * detail }`; the route returns HTTP 200 for both so the UI can show a friendly,
+ * category-specific toast. Throws (with `.statusCode`) only for the security
+ * gates the UI never legitimately triggers. See routes/chatRoutes for gate #1.
+ */
+async function testAiServiceConnection(
+  payload: TestAiServiceConnectionRequest,
+  userId: string,
+  isAdmin: boolean
+): Promise<TestConnectionResult> {
+  const serviceType = payload.service_type;
+  let apiKey = payload.api_key?.trim() || undefined;
+  let customUrl = payload.custom_url?.trim() || undefined;
+  let modelName = payload.model_name?.trim() || undefined;
+
+  // Stored-key fallback: the api_key field is blank by design on edit (the key
+  // is encrypted server-side and never sent to the browser), so a test on a
+  // saved service must reuse the stored, decrypted key.
+  if (payload.id && !apiKey) {
+    const stored = await chatRepository.getDecryptedAiServiceSettingById(
+      payload.id,
+      userId
+    );
+    if (stored) {
+      // Gate #2 (global-key protection): /chat is authenticate-only and the RLS
+      // SELECT policy returns every is_public row to any authenticated user, so
+      // a non-admin must not be able to make the server decrypt the operator's
+      // global key and POST it to an attacker-supplied custom_url.
+      if (stored.is_public && !isAdmin) {
+        throw statusError(
+          'Only administrators can test global AI service settings.',
+          403
+        );
+      }
+      // Gate #3 (provider-mismatch protection): only reuse the stored key when
+      // the stored row's provider matches the requested one. Switching a saved
+      // OpenAI service to 'custom' and leaving the key blank must NOT send the
+      // stored OpenAI key to a different provider/URL.
+      if (stored.service_type === serviceType) {
+        apiKey = stored.api_key ?? undefined;
+        customUrl = customUrl ?? stored.custom_url ?? undefined;
+        modelName = modelName ?? stored.model_name ?? undefined;
+      }
+    }
+  }
+
+  // Validate after fallback: a no-preset type with a blank effective model would
+  // otherwise dispatch with a meaningless getDefaultModel default.
+  if (NO_PRESET_SERVICE_TYPES.has(serviceType) && !modelName) {
+    throw statusError('A model name is required for this service type.', 400);
+  }
+
+  const provider: ProviderConfig = {
+    service_type: serviceType,
+    api_key: apiKey,
+    model_name: modelName,
+    custom_url: customUrl,
+  };
+
+  const result = await dispatchAiRequest({
+    provider,
+    prompt: TEST_CONNECTION_PROMPT,
+    temperature: 0,
+    timeoutMs: TEST_CONNECTION_TIMEOUT_MS,
+  });
+
+  if (!result.ok) {
+    log(
+      'warn',
+      `Test connection: ${serviceType} failed for user ${userId} (${result.category}): ${result.detail}`
+    );
+    return { ok: false, category: result.category, detail: result.detail };
+  }
+  return { ok: true };
+}
 const EMPTY_RESPONSE_ERROR_TEXT =
   'The AI service returned an empty response. Please try again.';
 
@@ -1347,6 +1451,7 @@ export { clearAllSparkyChatHistory };
 export { saveSparkyChatHistory };
 export { processChatMessage };
 export { processFoodOptionsRequest };
+export { testAiServiceConnection };
 export { processChatMessageStream };
 export default {
   handleAiServiceSettings,
@@ -1362,5 +1467,6 @@ export default {
   saveSparkyChatHistory,
   processChatMessage,
   processFoodOptionsRequest,
+  testAiServiceConnection,
   processChatMessageStream,
 };

--- a/SparkyFitnessServer/services/foodPhotoEstimationService.ts
+++ b/SparkyFitnessServer/services/foodPhotoEstimationService.ts
@@ -301,7 +301,7 @@ async function estimateFoodPhotoNutrition(
     };
   }
 
-  const setting = await chatRepository.getActiveAiServiceSetting(userId);
+  const setting = await chatRepository.getActiveVisionAiServiceSetting(userId);
   if (!setting) {
     return {
       success: false,

--- a/SparkyFitnessServer/services/labelScanService.ts
+++ b/SparkyFitnessServer/services/labelScanService.ts
@@ -34,7 +34,7 @@ async function extractNutritionFromLabel(
   mimeType: string,
   userId: string
 ): Promise<ExtractNutritionFromLabelResult> {
-  const setting = await chatRepository.getActiveAiServiceSetting(userId);
+  const setting = await chatRepository.getActiveVisionAiServiceSetting(userId);
   if (!setting) {
     return {
       success: false,

--- a/SparkyFitnessServer/tests/aiServiceConnectionTest.test.ts
+++ b/SparkyFitnessServer/tests/aiServiceConnectionTest.test.ts
@@ -1,0 +1,361 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'.
+import request from 'supertest';
+import express from 'express';
+import chatRoutes from '../routes/chatRoutes.js';
+import chatService from '../services/chatService.js';
+import chatRepository from '../models/chatRepository.js';
+import globalSettingsRepository from '../models/globalSettingsRepository.js';
+import { dispatchAiRequest } from '../ai/providerDispatch.js';
+import { resolveIsAdmin } from '../utils/adminCheck.js';
+
+// We exercise the REAL chatService.testAiServiceConnection and the REAL route,
+// mocking only the lower-level seams (repository, dispatch, admin/config gates).
+vi.mock('../models/chatRepository');
+vi.mock('../ai/providerDispatch');
+vi.mock('../utils/adminCheck.js', () => ({
+  resolveIsAdmin: vi.fn(),
+}));
+vi.mock('../models/globalSettingsRepository.js', () => ({
+  default: {
+    isUserAiConfigAllowed: vi.fn(),
+  },
+}));
+vi.mock('../middleware/authMiddleware.js', () => ({
+  authenticate: vi.fn((req, _res, next) => {
+    req.userId = 'user-123';
+    req.authenticatedUserId = 'user-123';
+    req.user = { id: 'user-123' };
+    next();
+  }),
+}));
+vi.mock('../config/logging.js', () => ({
+  log: vi.fn(),
+}));
+// The remaining mocks only keep chatService's heavy module graph loadable; the
+// connection-test path never touches them.
+vi.mock('../models/userRepository');
+vi.mock('../models/measurementRepository');
+vi.mock('../models/preferenceRepository', () => ({
+  default: {
+    getUserPreferences: vi.fn(),
+    updateUserPreferences: vi.fn(),
+  },
+}));
+vi.mock('../utils/timezoneLoader', () => ({
+  loadUserTimezone: vi.fn(async () => 'UTC'),
+}));
+vi.mock('../services/foodEntryService', () => ({
+  default: { createFoodEntry: vi.fn() },
+}));
+vi.mock('../models/foodRepository', () => ({
+  default: {
+    getFoodsWithPagination: vi.fn(),
+    countFoods: vi.fn(),
+    getFoodById: vi.fn(),
+  },
+}));
+vi.mock('../services/preferenceService', () => ({
+  default: { getUserPreferences: vi.fn() },
+}));
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: vi.fn(() => Object.assign(() => ({}), { chat: () => ({}) })),
+}));
+
+const mockDispatch = vi.mocked(dispatchAiRequest);
+const mockGetDecrypted = vi.mocked(
+  chatRepository.getDecryptedAiServiceSettingById
+);
+const mockIsUserAiConfigAllowed = vi.mocked(
+  globalSettingsRepository.isUserAiConfigAllowed
+);
+const mockResolveIsAdmin = vi.mocked(resolveIsAdmin);
+
+const okDispatch = { ok: true as const, text: 'OK', json: null };
+
+const app = express();
+app.use(express.json());
+app.use('/chat', chatRoutes);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+app.use((err: any, _req: any, res: any, _next: any) => {
+  res.status(err.statusCode || 500).json({ error: err.message });
+});
+
+const USER_ID = 'user-123';
+
+describe('POST /chat/ai-service-settings/test — gate #1 (per-user AI config)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a non-admin with 403 and never dispatches when per-user AI config is disabled', async () => {
+    mockResolveIsAdmin.mockResolvedValue(false);
+    mockIsUserAiConfigAllowed.mockResolvedValue(false);
+
+    const res = await request(app)
+      .post('/chat/ai-service-settings/test')
+      .send({ service_type: 'openai', api_key: 'sk-test' });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('lets an admin through even when per-user AI config is disabled', async () => {
+    mockResolveIsAdmin.mockResolvedValue(true);
+    mockIsUserAiConfigAllowed.mockResolvedValue(false);
+    mockDispatch.mockResolvedValue(okDispatch);
+
+    const res = await request(app)
+      .post('/chat/ai-service-settings/test')
+      .send({ service_type: 'openai', api_key: 'sk-test' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 400 on a malformed body (missing service_type)', async () => {
+    mockResolveIsAdmin.mockResolvedValue(true);
+
+    const res = await request(app)
+      .post('/chat/ai-service-settings/test')
+      .send({ api_key: 'sk-test' });
+
+    expect(res.statusCode).toBe(400);
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});
+
+describe('chatService.testAiServiceConnection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns { ok: true } and passes timeoutMs: 15000 on a successful completion', async () => {
+    mockDispatch.mockResolvedValue(okDispatch);
+
+    const result = await chatService.testAiServiceConnection(
+      { service_type: 'openai', api_key: 'sk-test' },
+      USER_ID,
+      false
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch.mock.calls[0][0]).toMatchObject({
+      provider: { service_type: 'openai', api_key: 'sk-test' },
+      temperature: 0,
+      timeoutMs: 15000,
+    });
+  });
+
+  it('passes through api_key_missing for a cloud type with no id and no key', async () => {
+    mockDispatch.mockResolvedValue({
+      ok: false,
+      category: 'api_key_missing',
+      detail: 'API key missing.',
+    });
+
+    const result = await chatService.testAiServiceConnection(
+      { service_type: 'openai' },
+      USER_ID,
+      false
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      category: 'api_key_missing',
+      detail: 'API key missing.',
+    });
+    expect(mockDispatch.mock.calls[0][0].provider.api_key).toBeUndefined();
+  });
+
+  it('passes through custom_url_missing for an ollama service with no url', async () => {
+    mockDispatch.mockResolvedValue({
+      ok: false,
+      category: 'custom_url_missing',
+      detail: 'A custom URL is required.',
+    });
+
+    const result = await chatService.testAiServiceConnection(
+      { service_type: 'ollama', model_name: 'llama3' },
+      USER_ID,
+      false
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      category: 'custom_url_missing',
+      detail: 'A custom URL is required.',
+    });
+  });
+
+  it('passes through upstream_error for a bad key (401)', async () => {
+    mockDispatch.mockResolvedValue({
+      ok: false,
+      category: 'upstream_error',
+      status: 401,
+      detail: 'AI service returned status 401',
+    });
+
+    const result = await chatService.testAiServiceConnection(
+      { service_type: 'openai', api_key: 'bad-key' },
+      USER_ID,
+      false
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      category: 'upstream_error',
+      detail: 'AI service returned status 401',
+    });
+  });
+
+  it('falls back to the stored decrypted key on edit with a blank key (matching provider)', async () => {
+    mockGetDecrypted.mockResolvedValue({
+      service_type: 'openai',
+      api_key: 'decrypted-stored-key',
+      custom_url: null,
+      model_name: 'gpt-4o',
+      is_public: false,
+    });
+    mockDispatch.mockResolvedValue(okDispatch);
+
+    const result = await chatService.testAiServiceConnection(
+      { id: 'svc-1', service_type: 'openai', api_key: '' },
+      USER_ID,
+      false
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockGetDecrypted).toHaveBeenCalledWith('svc-1', USER_ID);
+    expect(mockDispatch.mock.calls[0][0].provider).toMatchObject({
+      service_type: 'openai',
+      api_key: 'decrypted-stored-key',
+      model_name: 'gpt-4o',
+    });
+  });
+
+  it('still dispatches when the stored row is inactive (the helper applies no is_active filter)', async () => {
+    // The repo helper returns a key regardless of is_active (verified in
+    // chatRepository.test.ts), so testing an inactive service still works.
+    mockGetDecrypted.mockResolvedValue({
+      service_type: 'anthropic',
+      api_key: 'stored-anthropic-key',
+      custom_url: null,
+      model_name: null,
+      is_public: false,
+    });
+    mockDispatch.mockResolvedValue(okDispatch);
+
+    const result = await chatService.testAiServiceConnection(
+      { id: 'svc-inactive', service_type: 'anthropic', api_key: '' },
+      USER_ID,
+      false
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockDispatch.mock.calls[0][0].provider.api_key).toBe(
+      'stored-anthropic-key'
+    );
+  });
+
+  it('gate #2: throws 403 and never dispatches when a non-admin tests a stored global row', async () => {
+    mockGetDecrypted.mockResolvedValue({
+      service_type: 'openai',
+      api_key: 'operator-global-key',
+      custom_url: null,
+      model_name: 'gpt-4o',
+      is_public: true,
+    });
+
+    await expect(
+      chatService.testAiServiceConnection(
+        {
+          id: 'global-1',
+          service_type: 'custom',
+          custom_url: 'https://attacker.example/',
+          api_key: '',
+        },
+        USER_ID,
+        false
+      )
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it('gate #2: an admin may test a stored global row', async () => {
+    mockGetDecrypted.mockResolvedValue({
+      service_type: 'openai',
+      api_key: 'operator-global-key',
+      custom_url: null,
+      model_name: 'gpt-4o',
+      is_public: true,
+    });
+    mockDispatch.mockResolvedValue(okDispatch);
+
+    const result = await chatService.testAiServiceConnection(
+      { id: 'global-1', service_type: 'openai', api_key: '' },
+      USER_ID,
+      true
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockDispatch.mock.calls[0][0].provider.api_key).toBe(
+      'operator-global-key'
+    );
+  });
+
+  it('gate #3: does not reuse the stored key when the requested provider differs', async () => {
+    // Saved as OpenAI, switched to custom with a blank key: the stored OpenAI
+    // key must NOT be forwarded to the new (attacker-controllable) URL.
+    mockGetDecrypted.mockResolvedValue({
+      service_type: 'openai',
+      api_key: 'stored-openai-key',
+      custom_url: null,
+      model_name: 'gpt-4o',
+      is_public: false,
+    });
+    mockDispatch.mockResolvedValue({
+      ok: false,
+      category: 'api_key_missing',
+      detail: 'API key missing.',
+    });
+
+    const result = await chatService.testAiServiceConnection(
+      {
+        id: 'svc-1',
+        service_type: 'custom',
+        custom_url: 'https://elsewhere.example/',
+        api_key: '',
+        model_name: 'some-model',
+      },
+      USER_ID,
+      false
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      category: 'api_key_missing',
+      detail: 'API key missing.',
+    });
+    const provider = mockDispatch.mock.calls[0][0].provider;
+    expect(provider.api_key).toBeUndefined();
+    expect(provider.custom_url).toBe('https://elsewhere.example/');
+  });
+
+  it('post-fallback model check: throws 400 and never dispatches for a no-preset type with a blank model', async () => {
+    await expect(
+      chatService.testAiServiceConnection(
+        {
+          service_type: 'openai_compatible',
+          custom_url: 'http://localhost:1234/v1',
+          api_key: 'k',
+        },
+        USER_ID,
+        false
+      )
+    ).rejects.toMatchObject({ statusCode: 400 });
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+});

--- a/SparkyFitnessServer/tests/chatRepository.test.ts
+++ b/SparkyFitnessServer/tests/chatRepository.test.ts
@@ -1,6 +1,7 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
 import chatRepository from '../models/chatRepository.js';
 import { getClient } from '../db/poolManager.js';
+import { decrypt } from '../security/encryption.js';
 
 vi.mock('../db/poolManager', () => ({
   getClient: vi.fn(),
@@ -67,6 +68,67 @@ describe('chatRepository.upsertAiServiceSetting', () => {
     expect(params[2]).toBeNull(); // $3 → custom_url explicitly cleared
     expect(params[3]).toBeNull(); // $4 → system_prompt explicitly cleared
     expect(params[5]).toBeNull(); // $6 → model_name explicitly cleared
+  });
+});
+
+describe('chatRepository.getDecryptedAiServiceSettingById', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    vi.clearAllMocks();
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  it('selects by id WITHOUT the is_active filter so inactive services can be tested', async () => {
+    mockClient.query.mockResolvedValue({
+      rows: [
+        {
+          service_type: 'openai',
+          encrypted_api_key: 'enc',
+          api_key_iv: 'iv',
+          api_key_tag: 'tag',
+          custom_url: null,
+          model_name: 'gpt-4o',
+          is_public: false,
+          is_active: false,
+        },
+      ],
+    });
+    vi.mocked(decrypt).mockResolvedValue('decrypted-key');
+
+    const result = await chatRepository.getDecryptedAiServiceSettingById(
+      'svc-1',
+      'user-1'
+    );
+
+    const [sql, params] = mockClient.query.mock.calls[0];
+    expect(sql).not.toContain('is_active');
+    expect(params).toEqual(['svc-1']);
+    // RLS scoping comes from the user-specific client.
+    expect(getClient).toHaveBeenCalledWith('user-1');
+    expect(result).toEqual({
+      service_type: 'openai',
+      api_key: 'decrypted-key',
+      custom_url: null,
+      model_name: 'gpt-4o',
+      is_public: false,
+    });
+  });
+
+  it('returns null when no row is visible to the user', async () => {
+    mockClient.query.mockResolvedValue({ rows: [] });
+
+    const result = await chatRepository.getDecryptedAiServiceSettingById(
+      'missing',
+      'user-1'
+    );
+
+    expect(result).toBeNull();
   });
 });
 

--- a/SparkyFitnessServer/tests/chatRepository.test.ts
+++ b/SparkyFitnessServer/tests/chatRepository.test.ts
@@ -109,3 +109,224 @@ describe('chatRepository.getChatHistoryByUserId', () => {
     expect(result).toEqual(mockRows);
   });
 });
+
+describe('chatRepository.getActiveVisionAiServiceSetting', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    vi.clearAllMocks();
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  const visionOverrideRow = () => ({
+    id: 'vision-1',
+    service_name: 'My Vision',
+    service_type: 'google',
+    custom_url: null,
+    is_active: true,
+    model_name: 'gemini-2.5-flash',
+    is_public: false,
+    system_prompt: null,
+    user_id: 'user-1',
+    creator_name: 'me',
+  });
+  const globalTextRow = () => ({
+    id: 'global-text-1',
+    service_name: 'Global Text',
+    service_type: 'openai',
+    custom_url: null,
+    is_active: true,
+    model_name: 'gpt-4o',
+    is_public: true,
+    system_prompt: null,
+    user_id: null,
+  });
+  const globalVisionRow = () => ({
+    id: 'global-vision-1',
+    service_name: 'Global Vision',
+    service_type: 'google',
+    custom_url: null,
+    is_active: true,
+    model_name: 'gemini-2.5-flash',
+    is_public: true,
+    system_prompt: null,
+    user_id: null,
+  });
+
+  const consultedGlobalVisionDefault = () =>
+    mockClient.query.mock.calls.some(([sql]: [string]) =>
+      sql.includes('default_vision_ai_service_id FROM global_settings')
+    );
+
+  it('returns the per-user vision override when its service is active', async () => {
+    mockClient.query
+      // outer combined-pointer read
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            active_ai_service_id: null,
+            active_vision_ai_service_id: 'vision-1',
+          },
+        ],
+      })
+      // step 1: the override service is active
+      .mockResolvedValueOnce({ rows: [visionOverrideRow()] });
+
+    const result =
+      await chatRepository.getActiveVisionAiServiceSetting('user-1');
+
+    expect(result.id).toBe('vision-1');
+    expect(result.source).toBe('user');
+    // The text resolver and global default are never consulted.
+    expect(mockClient.query).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the explicit text service and never applies the global vision default', async () => {
+    mockClient.query
+      // outer read: explicit text pointer, no vision override
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            active_ai_service_id: 'global-text-1',
+            active_vision_ai_service_id: null,
+          },
+        ],
+      })
+      // getActiveAiServiceSetting → Priority-0 prefs read
+      .mockResolvedValueOnce({
+        rows: [{ active_ai_service_id: 'global-text-1' }],
+      })
+      // getActiveAiServiceSetting → Priority-0 settings lookup (a global service)
+      .mockResolvedValueOnce({ rows: [globalTextRow()] });
+
+    const result =
+      await chatRepository.getActiveVisionAiServiceSetting('user-1');
+
+    expect(result.id).toBe('global-text-1');
+    expect(result.source).toBe('global');
+    // Even though the base resolved as a global service, the admin global
+    // vision default must NOT override an explicit user pick.
+    expect(consultedGlobalVisionDefault()).toBe(false);
+  });
+
+  it('applies the global vision default when the explicit text pick was deactivated and fell through', async () => {
+    mockClient.query
+      // outer read: explicit text pointer set, no vision override
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            active_ai_service_id: 'dead-text-1',
+            active_vision_ai_service_id: null,
+          },
+        ],
+      })
+      // getActiveAiServiceSetting → Priority-0 prefs read
+      .mockResolvedValueOnce({
+        rows: [{ active_ai_service_id: 'dead-text-1' }],
+      })
+      // Priority-0 settings lookup → the pointed service is inactive, no row
+      .mockResolvedValueOnce({ rows: [] })
+      // Priority-1 user-specific → none
+      .mockResolvedValueOnce({ rows: [] })
+      // Priority-2 global text default (the user has fallen through to it)
+      .mockResolvedValueOnce({ rows: [globalTextRow()] })
+      // step 3: the global default-vision pointer
+      .mockResolvedValueOnce({
+        rows: [{ default_vision_ai_service_id: 'global-vision-1' }],
+      })
+      // step 3: resolve the global vision service
+      .mockResolvedValueOnce({ rows: [globalVisionRow()] });
+
+    const result =
+      await chatRepository.getActiveVisionAiServiceSetting('user-1');
+
+    // The stale active_ai_service_id no longer resolved, so this user is now on
+    // the global default and must get the configured global vision default —
+    // not the text fallback.
+    expect(result.id).toBe('global-vision-1');
+    expect(result.source).toBe('global');
+    expect(consultedGlobalVisionDefault()).toBe(true);
+  });
+
+  it('applies the admin global vision default for a user on the global default', async () => {
+    mockClient.query
+      // outer read: no pointers
+      .mockResolvedValueOnce({
+        rows: [
+          { active_ai_service_id: null, active_vision_ai_service_id: null },
+        ],
+      })
+      // getActiveAiServiceSetting → Priority-0 prefs read (no active id)
+      .mockResolvedValueOnce({ rows: [{ active_ai_service_id: null }] })
+      // Priority-1 user-specific → none
+      .mockResolvedValueOnce({ rows: [] })
+      // Priority-2 global text default
+      .mockResolvedValueOnce({ rows: [globalTextRow()] })
+      // step 3: the global default-vision pointer
+      .mockResolvedValueOnce({
+        rows: [{ default_vision_ai_service_id: 'global-vision-1' }],
+      })
+      // step 3: resolve the global vision service (is_active AND is_public)
+      .mockResolvedValueOnce({ rows: [globalVisionRow()] });
+
+    const result =
+      await chatRepository.getActiveVisionAiServiceSetting('user-1');
+
+    expect(result.id).toBe('global-vision-1');
+    expect(result.source).toBe('global');
+    expect(consultedGlobalVisionDefault()).toBe(true);
+  });
+
+  it('falls back to the text/default service unchanged when no vision pointers exist', async () => {
+    mockClient.query
+      // outer read: no pointers
+      .mockResolvedValueOnce({
+        rows: [
+          { active_ai_service_id: null, active_vision_ai_service_id: null },
+        ],
+      })
+      // getActiveAiServiceSetting → Priority-0 prefs read (no active id)
+      .mockResolvedValueOnce({ rows: [{ active_ai_service_id: null }] })
+      // Priority-1 user-specific → none
+      .mockResolvedValueOnce({ rows: [] })
+      // Priority-2 global text default
+      .mockResolvedValueOnce({ rows: [globalTextRow()] })
+      // step 3: no global default-vision pointer configured
+      .mockResolvedValueOnce({
+        rows: [{ default_vision_ai_service_id: null }],
+      });
+
+    const result =
+      await chatRepository.getActiveVisionAiServiceSetting('user-1');
+
+    // Identical to today's getActiveAiServiceSetting result.
+    expect(result.id).toBe('global-text-1');
+    expect(result.source).toBe('global');
+  });
+
+  it('returns null when there is no text/default service to fall back to', async () => {
+    mockClient.query
+      // outer read: no pointers
+      .mockResolvedValueOnce({
+        rows: [
+          { active_ai_service_id: null, active_vision_ai_service_id: null },
+        ],
+      })
+      // getActiveAiServiceSetting → Priority-0 prefs read (no active id)
+      .mockResolvedValueOnce({ rows: [{ active_ai_service_id: null }] })
+      // Priority-1 user-specific → none
+      .mockResolvedValueOnce({ rows: [] })
+      // Priority-2 global → none
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result =
+      await chatRepository.getActiveVisionAiServiceSetting('user-1');
+
+    expect(result).toBeNull();
+  });
+});

--- a/SparkyFitnessServer/tests/chatService.test.ts
+++ b/SparkyFitnessServer/tests/chatService.test.ts
@@ -619,6 +619,54 @@ describe('chatService', () => {
         expect.stringMatching(/Loaded 35 full tools/)
       );
     });
+
+    // Regression: keyless local servers (LM Studio, llama.cpp) configured as
+    // openai_compatible/custom must work on the non-stream chat path. Previously
+    // an ollama-only guard rejected them with "API key missing" even though the
+    // stream path, test-connection, and dispatcher all tolerate a blank key.
+    it.each(['openai_compatible', 'custom'])(
+      'does NOT require an api_key for keyless %s services',
+      async (serviceType) => {
+        vi.mocked(
+          chatRepository.getAiServiceSettingForBackend
+        ).mockResolvedValue({
+          ...aiServiceSetting,
+          service_type: serviceType,
+          api_key: null,
+          custom_url: 'http://localhost:1234/v1',
+          model_name: 'local-model',
+        });
+        scriptModel([textStep('Hello from a local server!')]);
+
+        const result = await chatService.processChatMessage(
+          [{ role: 'user', content: 'hi' }],
+          'svc-1',
+          activeUserId,
+          actorUserId
+        );
+
+        expect(result.content).toBe('Hello from a local server!');
+      }
+    );
+
+    it('still rejects a cloud service that is missing its api_key', async () => {
+      vi.mocked(chatRepository.getAiServiceSettingForBackend).mockResolvedValue(
+        {
+          ...aiServiceSetting,
+          service_type: 'openai',
+          api_key: null,
+        }
+      );
+
+      await expect(
+        chatService.processChatMessage(
+          [{ role: 'user', content: 'hi' }],
+          'svc-1',
+          activeUserId,
+          actorUserId
+        )
+      ).rejects.toThrow('API key missing for selected AI service.');
+    });
   });
 
   describe('processChatMessageStream (empty completion handling)', () => {

--- a/SparkyFitnessServer/tests/foodPhotoEstimationService.test.ts
+++ b/SparkyFitnessServer/tests/foodPhotoEstimationService.test.ts
@@ -17,8 +17,10 @@ vi.mock('undici', () => {
   return { default: { Agent }, Agent };
 });
 
-const mockGetActiveSetting = vi.mocked(
-  chatRepository.getActiveAiServiceSetting
+// The vision features resolve through the vision pointer, which falls back to
+// the active/default service. The service consults getActiveVisionAiServiceSetting.
+const mockGetVisionSetting = vi.mocked(
+  chatRepository.getActiveVisionAiServiceSetting
 );
 const mockGetBackendSetting = vi.mocked(
   chatRepository.getAiServiceSettingForBackend
@@ -213,7 +215,7 @@ describe('estimateFoodPhotoNutrition', () => {
     it.each(PROVIDER_CASES)(
       'returns the parsed estimate for $service_type',
       async ({ service_type, api_key, custom_url }) => {
-        mockGetActiveSetting.mockResolvedValue(makeSetting({ service_type }));
+        mockGetVisionSetting.mockResolvedValue(makeSetting({ service_type }));
         mockGetBackendSetting.mockResolvedValue(
           makeServiceDetail({
             service_type,
@@ -252,8 +254,8 @@ describe('estimateFoodPhotoNutrition', () => {
       }
     });
 
-    it('returns NO_AI_CONFIGURED when getActiveAiServiceSetting returns null', async () => {
-      mockGetActiveSetting.mockResolvedValue(null);
+    it('returns NO_AI_CONFIGURED when getActiveVisionAiServiceSetting returns null', async () => {
+      mockGetVisionSetting.mockResolvedValue(null);
       const result = await estimateFoodPhotoNutrition({
         base64Image: TEST_BASE64,
         mimeType: TEST_MIME,
@@ -266,7 +268,7 @@ describe('estimateFoodPhotoNutrition', () => {
     });
 
     it('returns NO_AI_CONFIGURED when getAiServiceSettingForBackend returns null', async () => {
-      mockGetActiveSetting.mockResolvedValue(makeSetting());
+      mockGetVisionSetting.mockResolvedValue(makeSetting());
       mockGetBackendSetting.mockResolvedValue(null);
       const result = await estimateFoodPhotoNutrition({
         base64Image: TEST_BASE64,
@@ -280,7 +282,7 @@ describe('estimateFoodPhotoNutrition', () => {
     });
 
     it('returns API_KEY_MISSING when a non-ollama provider has no api_key', async () => {
-      mockGetActiveSetting.mockResolvedValue(makeSetting());
+      mockGetVisionSetting.mockResolvedValue(makeSetting());
       mockGetBackendSetting.mockResolvedValue(
         makeServiceDetail({ api_key: null })
       );
@@ -301,7 +303,7 @@ describe('estimateFoodPhotoNutrition', () => {
 
   describe('prompt building (service-owned)', () => {
     beforeEach(() => {
-      mockGetActiveSetting.mockResolvedValue(makeSetting());
+      mockGetVisionSetting.mockResolvedValue(makeSetting());
       mockGetBackendSetting.mockResolvedValue(makeServiceDetail());
     });
 
@@ -358,11 +360,11 @@ describe('estimateFoodPhotoNutrition', () => {
 
   describe('dispatch category → food-photo code mapping', () => {
     function mockGoogle() {
-      mockGetActiveSetting.mockResolvedValue(makeSetting());
+      mockGetVisionSetting.mockResolvedValue(makeSetting());
       mockGetBackendSetting.mockResolvedValue(makeServiceDetail());
     }
     function mockOpenAi() {
-      mockGetActiveSetting.mockResolvedValue(
+      mockGetVisionSetting.mockResolvedValue(
         makeSetting({ service_type: 'openai' })
       );
       mockGetBackendSetting.mockResolvedValue(
@@ -471,7 +473,7 @@ describe('estimateFoodPhotoNutrition', () => {
     });
 
     it('rejects HEIC to anthropic with UNSUPPORTED_MIME_TYPE before any upstream call', async () => {
-      mockGetActiveSetting.mockResolvedValue(
+      mockGetVisionSetting.mockResolvedValue(
         makeSetting({ service_type: 'anthropic' })
       );
       mockGetBackendSetting.mockResolvedValue(
@@ -489,7 +491,7 @@ describe('estimateFoodPhotoNutrition', () => {
     });
 
     it('maps a blank custom_url on ollama → NO_AI_CONFIGURED', async () => {
-      mockGetActiveSetting.mockResolvedValue(
+      mockGetVisionSetting.mockResolvedValue(
         makeSetting({ service_type: 'ollama' })
       );
       mockGetBackendSetting.mockResolvedValue(
@@ -514,7 +516,7 @@ describe('estimateFoodPhotoNutrition', () => {
 
   describe('domain validation', () => {
     it('returns PARSE_ERROR when the provider payload fails the Zod schema', async () => {
-      mockGetActiveSetting.mockResolvedValue(makeSetting());
+      mockGetVisionSetting.mockResolvedValue(makeSetting());
       mockGetBackendSetting.mockResolvedValue(makeServiceDetail());
       const wrongShape: Record<string, unknown> = { ...sampleEstimate };
       delete wrongShape.totals;

--- a/SparkyFitnessServer/tests/globalSettingsRepository.test.ts
+++ b/SparkyFitnessServer/tests/globalSettingsRepository.test.ts
@@ -76,10 +76,11 @@ describe('globalSettingsRepository', () => {
       mockClient.query.mockResolvedValue({ rows: [savedSettings] });
       const result =
         await globalSettingsRepository.saveGlobalSettings(inputSettings);
-      // 5th param is default_vision_ai_service_id (null when not supplied).
+      // 5th param is default_vision_ai_service_id (null when not supplied); the
+      // 6th is the existence flag, false here so the CASE WHEN leaves it untouched.
       expect(mockClient.query).toHaveBeenCalledWith(
         expect.stringContaining('UPDATE global_settings'),
-        [true, false, true, false, null]
+        [true, false, true, false, null, false]
       );
       expect(result).toEqual({
         ...savedSettings,
@@ -98,10 +99,27 @@ describe('globalSettingsRepository', () => {
       await globalSettingsRepository.saveGlobalSettings(inputSettings);
       const params = mockClient.query.mock.calls[0][1];
       expect(params[4]).toBe('vision-svc-1');
-      // Plain assignment (not COALESCE) so the value round-trips on save.
+      // Present in the payload, so the existence flag is true and the CASE WHEN
+      // writes the supplied value.
+      expect(params[5]).toBe(true);
       expect(mockClient.query.mock.calls[0][0]).toContain(
-        'default_vision_ai_service_id = $5'
+        'default_vision_ai_service_id = CASE WHEN $6 THEN $5 ELSE default_vision_ai_service_id END'
       );
+    });
+    it('leaves the default_vision_ai_service_id pointer untouched when omitted', async () => {
+      const inputSettings = {
+        enable_email_password_login: true,
+        is_oidc_active: false,
+        is_mfa_mandatory: false,
+        allow_user_ai_config: true,
+        // default_vision_ai_service_id intentionally omitted
+      };
+      mockClient.query.mockResolvedValue({ rows: [{ id: 1 }] });
+      await globalSettingsRepository.saveGlobalSettings(inputSettings);
+      // Existence flag false => the CASE WHEN keeps the stored value rather than
+      // clobbering it with null.
+      const params = mockClient.query.mock.calls[0][1];
+      expect(params[5]).toBe(false);
     });
     it('clears the default_vision_ai_service_id pointer when set to null', async () => {
       const inputSettings = {
@@ -113,9 +131,11 @@ describe('globalSettingsRepository', () => {
       };
       mockClient.query.mockResolvedValue({ rows: [{ id: 1 }] });
       await globalSettingsRepository.saveGlobalSettings(inputSettings);
-      // The plain assignment (not COALESCE) makes the "None" clear possible.
+      // Explicit null is present in the payload, so the existence flag is true
+      // and the CASE WHEN clears the pointer ("None").
       const params = mockClient.query.mock.calls[0][1];
       expect(params[4]).toBeNull();
+      expect(params[5]).toBe(true);
     });
     it('should default allow_user_ai_config to true if undefined in update', async () => {
       const inputSettings = {

--- a/SparkyFitnessServer/tests/globalSettingsRepository.test.ts
+++ b/SparkyFitnessServer/tests/globalSettingsRepository.test.ts
@@ -76,14 +76,46 @@ describe('globalSettingsRepository', () => {
       mockClient.query.mockResolvedValue({ rows: [savedSettings] });
       const result =
         await globalSettingsRepository.saveGlobalSettings(inputSettings);
+      // 5th param is default_vision_ai_service_id (null when not supplied).
       expect(mockClient.query).toHaveBeenCalledWith(
         expect.stringContaining('UPDATE global_settings'),
-        [true, false, true, false]
+        [true, false, true, false, null]
       );
       expect(result).toEqual({
         ...savedSettings,
         is_mfa_mandatory: true,
       });
+    });
+    it('persists the default_vision_ai_service_id pointer when supplied', async () => {
+      const inputSettings = {
+        enable_email_password_login: true,
+        is_oidc_active: false,
+        is_mfa_mandatory: false,
+        allow_user_ai_config: true,
+        default_vision_ai_service_id: 'vision-svc-1',
+      };
+      mockClient.query.mockResolvedValue({ rows: [{ id: 1 }] });
+      await globalSettingsRepository.saveGlobalSettings(inputSettings);
+      const params = mockClient.query.mock.calls[0][1];
+      expect(params[4]).toBe('vision-svc-1');
+      // Plain assignment (not COALESCE) so the value round-trips on save.
+      expect(mockClient.query.mock.calls[0][0]).toContain(
+        'default_vision_ai_service_id = $5'
+      );
+    });
+    it('clears the default_vision_ai_service_id pointer when set to null', async () => {
+      const inputSettings = {
+        enable_email_password_login: true,
+        is_oidc_active: false,
+        is_mfa_mandatory: false,
+        allow_user_ai_config: true,
+        default_vision_ai_service_id: null,
+      };
+      mockClient.query.mockResolvedValue({ rows: [{ id: 1 }] });
+      await globalSettingsRepository.saveGlobalSettings(inputSettings);
+      // The plain assignment (not COALESCE) makes the "None" clear possible.
+      const params = mockClient.query.mock.calls[0][1];
+      expect(params[4]).toBeNull();
     });
     it('should default allow_user_ai_config to true if undefined in update', async () => {
       const inputSettings = {

--- a/SparkyFitnessServer/tests/labelScanService.test.ts
+++ b/SparkyFitnessServer/tests/labelScanService.test.ts
@@ -18,8 +18,10 @@ vi.mock('undici', () => {
   return { default: { Agent }, Agent };
 });
 
-const mockGetActiveSetting = vi.mocked(
-  chatRepository.getActiveAiServiceSetting
+// The vision features resolve through the vision pointer, which falls back to
+// the active/default service. The service consults getActiveVisionAiServiceSetting.
+const mockGetVisionSetting = vi.mocked(
+  chatRepository.getActiveVisionAiServiceSetting
 );
 const mockGetBackendSetting = vi.mocked(
   chatRepository.getAiServiceSettingForBackend
@@ -166,7 +168,7 @@ describe('extractNutritionFromLabel', () => {
     it.each(PROVIDER_CASES)(
       'returns the parsed nutrition for $service_type',
       async ({ service_type, api_key, custom_url }) => {
-        mockGetActiveSetting.mockResolvedValue(makeAiSetting({ service_type }));
+        mockGetVisionSetting.mockResolvedValue(makeAiSetting({ service_type }));
         mockGetBackendSetting.mockResolvedValue(
           makeAiServiceDetail({
             service_type,
@@ -191,8 +193,8 @@ describe('extractNutritionFromLabel', () => {
   });
 
   describe('service plumbing', () => {
-    it('returns no_ai_configured when getActiveAiServiceSetting returns null', async () => {
-      mockGetActiveSetting.mockResolvedValue(null);
+    it('returns no_ai_configured when getActiveVisionAiServiceSetting returns null', async () => {
+      mockGetVisionSetting.mockResolvedValue(null);
       const result = await extractNutritionFromLabel(
         TEST_BASE64,
         TEST_MIME,
@@ -206,7 +208,7 @@ describe('extractNutritionFromLabel', () => {
     });
 
     it('returns no_ai_configured when getAiServiceSettingForBackend returns null', async () => {
-      mockGetActiveSetting.mockResolvedValue(makeAiSetting());
+      mockGetVisionSetting.mockResolvedValue(makeAiSetting());
       mockGetBackendSetting.mockResolvedValue(null);
       const result = await extractNutritionFromLabel(
         TEST_BASE64,
@@ -221,7 +223,7 @@ describe('extractNutritionFromLabel', () => {
     });
 
     it('returns api_key_missing when a non-ollama provider has no api_key', async () => {
-      mockGetActiveSetting.mockResolvedValue(makeAiSetting());
+      mockGetVisionSetting.mockResolvedValue(makeAiSetting());
       mockGetBackendSetting.mockResolvedValue(
         makeAiServiceDetail({ api_key: null })
       );
@@ -240,7 +242,7 @@ describe('extractNutritionFromLabel', () => {
     });
 
     it('returns custom_url_missing when ollama has a blank custom_url', async () => {
-      mockGetActiveSetting.mockResolvedValue(
+      mockGetVisionSetting.mockResolvedValue(
         makeAiSetting({ service_type: 'ollama' })
       );
       mockGetBackendSetting.mockResolvedValue(
@@ -265,7 +267,7 @@ describe('extractNutritionFromLabel', () => {
     });
 
     it('returns unsupported_provider for an unknown service type', async () => {
-      mockGetActiveSetting.mockResolvedValue(
+      mockGetVisionSetting.mockResolvedValue(
         makeAiSetting({ service_type: 'unknown_provider' })
       );
       mockGetBackendSetting.mockResolvedValue(
@@ -283,7 +285,7 @@ describe('extractNutritionFromLabel', () => {
     });
 
     it('sends the label-scan prompt the service owns', async () => {
-      mockGetActiveSetting.mockResolvedValue(makeAiSetting());
+      mockGetVisionSetting.mockResolvedValue(makeAiSetting());
       mockGetBackendSetting.mockResolvedValue(makeAiServiceDetail());
       const m = mockFetch(openAiBody(sampleNutrition));
       await extractNutritionFromLabel(TEST_BASE64, TEST_MIME, TEST_USER_ID);
@@ -292,7 +294,7 @@ describe('extractNutritionFromLabel', () => {
     });
 
     it('passes the configured timeout to the Ollama agent', async () => {
-      mockGetActiveSetting.mockResolvedValue(
+      mockGetVisionSetting.mockResolvedValue(
         makeAiSetting({ service_type: 'ollama' })
       );
       mockGetBackendSetting.mockResolvedValue(
@@ -319,7 +321,7 @@ describe('extractNutritionFromLabel', () => {
 
   describe('dispatch error categories', () => {
     beforeEach(() => {
-      mockGetActiveSetting.mockResolvedValue(makeAiSetting());
+      mockGetVisionSetting.mockResolvedValue(makeAiSetting());
       mockGetBackendSetting.mockResolvedValue(makeAiServiceDetail());
     });
 

--- a/SparkyFitnessServer/tests/preferenceRepository.test.ts
+++ b/SparkyFitnessServer/tests/preferenceRepository.test.ts
@@ -75,6 +75,41 @@ describe('preferenceRepository bootstrapUserTimezoneIfUnset', () => {
     ]);
   });
 
+  it('round-trips the active_vision_ai_service_id pointer through save and load', async () => {
+    const row = { user_id: 'user-1', active_vision_ai_service_id: 'svc-99' };
+    mockClient.query.mockResolvedValueOnce({ rows: [row] });
+    mockClient.query.mockResolvedValueOnce({ rows: [row] });
+
+    await preferenceRepository.upsertUserPreferences({
+      user_id: 'user-1',
+      active_vision_ai_service_id: 'svc-99',
+    });
+    const result = await preferenceRepository.getUserPreferences('user-1');
+
+    expect(result.active_vision_ai_service_id).toBe('svc-99');
+    expect(mockClient.query.mock.calls[0][0]).toContain(
+      'active_vision_ai_service_id'
+    );
+    // The 'in'-guard flag ($43, last param) gates the CASE WHEN, and the value
+    // ($42) precedes it; a partial payload that includes the field must write it.
+    const params = mockClient.query.mock.calls[0][1];
+    expect(params[params.length - 1]).toBe(true);
+    expect(params[params.length - 2]).toBe('svc-99');
+  });
+
+  it('leaves active_vision_ai_service_id untouched when the field is omitted', async () => {
+    mockClient.query.mockResolvedValueOnce({ rows: [{ user_id: 'user-1' }] });
+
+    await preferenceRepository.upsertUserPreferences({
+      user_id: 'user-1',
+      show_net_carbs: true,
+    });
+
+    // The guard flag is false, so the CASE WHEN keeps the stored pointer.
+    const params = mockClient.query.mock.calls[0][1];
+    expect(params[params.length - 1]).toBe(false);
+  });
+
   it('round-trips goal_mode preferences through save and load', async () => {
     const row = {
       user_id: 'user-1',

--- a/SparkyFitnessServer/tests/providerDispatch.test.ts
+++ b/SparkyFitnessServer/tests/providerDispatch.test.ts
@@ -161,6 +161,30 @@ describe('dispatchAiRequest — preconditions', () => {
     expect(m).toHaveBeenCalled();
   });
 
+  // Regression: keyless local servers (LM Studio, llama.cpp) must work on the
+  // dispatch path the same way they already do on the chat path. Previously a
+  // blank key hard-failed here with api_key_missing while chat tolerated it,
+  // so chat worked but photo/label-scan/unit-conversion silently failed.
+  it.each(['openai_compatible', 'custom'])(
+    'does NOT require an api_key for %s and sends a no-key bearer',
+    async (serviceType) => {
+      const m = mockFetch(openAiBody(JSON.stringify(SAMPLE)));
+      const result = await dispatchAiRequest(
+        baseRequest({
+          provider: makeProvider({
+            service_type: serviceType,
+            api_key: undefined,
+            custom_url: 'https://example.local/v1',
+          }),
+        })
+      );
+      expect(result.ok).toBe(true);
+      expect(m).toHaveBeenCalled();
+      const { headers } = captured(m);
+      expect(headers.Authorization).toBe('Bearer no-key');
+    }
+  );
+
   it.each(['ollama', 'openai_compatible', 'custom'])(
     'returns custom_url_missing for %s with a blank custom_url',
     async (serviceType) => {

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -1598,6 +1598,7 @@ CREATE TABLE public.global_settings (
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     mfa_mandatory boolean DEFAULT false,
     allow_user_ai_config boolean DEFAULT true NOT NULL,
+    default_vision_ai_service_id uuid,
     CONSTRAINT single_row_check CHECK ((id = 1))
 );
 
@@ -2704,6 +2705,7 @@ CREATE TABLE public.user_preferences (
     goal_mode_custom_percentage integer DEFAULT 0 NOT NULL,
     use_external_bmr boolean DEFAULT false NOT NULL,
     active_ai_service_id uuid,
+    active_vision_ai_service_id uuid,
     add_exercise_water_to_goal boolean DEFAULT false NOT NULL,
     measurement_decimal_places integer DEFAULT 0 NOT NULL,
     CONSTRAINT check_energy_unit CHECK (((energy_unit)::text = ANY (ARRAY[('kcal'::character varying)::text, ('kJ'::character varying)::text]))),
@@ -5210,6 +5212,14 @@ ALTER TABLE ONLY public.food_entry_meals
 
 
 --
+-- Name: global_settings global_settings_default_vision_ai_service_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.global_settings
+    ADD CONSTRAINT global_settings_default_vision_ai_service_id_fkey FOREIGN KEY (default_vision_ai_service_id) REFERENCES public.ai_service_settings(id) ON DELETE SET NULL;
+
+
+--
 -- Name: goal_presets goal_presets_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5719,6 +5729,14 @@ ALTER TABLE ONLY public.user_oidc_links
 
 ALTER TABLE ONLY public.user_preferences
     ADD CONSTRAINT user_preferences_active_ai_service_id_fkey FOREIGN KEY (active_ai_service_id) REFERENCES public.ai_service_settings(id) ON DELETE SET NULL;
+
+
+--
+-- Name: user_preferences user_preferences_active_vision_ai_service_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_preferences
+    ADD CONSTRAINT user_preferences_active_vision_ai_service_id_fkey FOREIGN KEY (active_vision_ai_service_id) REFERENCES public.ai_service_settings(id) ON DELETE SET NULL;
 
 
 --

--- a/docs/content/2.features/13.ai-assistant.md
+++ b/docs/content/2.features/13.ai-assistant.md
@@ -20,3 +20,40 @@
 - **Nutrition Confirmation**: Review and edit AI suggestions before logging
 - **Meal Context**: Understand meal timing and context for accurate logging
 - **Brand Recognition**: Identify specific food brands and products
+
+## Troubleshooting AI Providers
+
+Most "OpenAI Compatible / OpenRouter isn't working" reports come from provider configuration, not from SparkyFitness itself. The most common cases:
+
+### OpenRouter: "No allowed providers are available for the selected model" (HTTP 404)
+
+This is an **OpenRouter account setting**, not a SparkyFitness error. OpenRouter serves each model through one or more upstream providers. If your account is restricted to a subset of providers, a model whose upstream is excluded fails with this 404 — this most often hits the free (`:free`) models, which run on providers you may not have enabled.
+
+The error body shows the mismatch directly:
+
+- `available_providers` — the providers that can actually serve the model
+- `requested_providers` — the providers your account currently allows
+
+**Fix:** In your OpenRouter account settings, review the allowed-providers / data-policy preferences, then either enable the provider that serves your chosen model **or** pick a model served by a provider you already allow (e.g. an `openai/`, `anthropic/`, or `google/` model if those are your allowed upstreams).
+
+### Every request 404s (doubled URL)
+
+If your custom URL already ends in `/chat/completions`, SparkyFitness appends its own path and the request 404s.
+
+**Fix:** Enter only the base URL ending in `/v1` — for example `https://openrouter.ai/api/v1` or `http://localhost:1234/v1`. SparkyFitness adds `/chat/completions` for you.
+
+### "Model not found" or empty/garbled responses
+
+The model name must be one your endpoint actually hosts. OpenAI names like `gpt-4o-mini` will not exist on most compatible servers.
+
+**Fix:** For the **OpenAI Compatible** and **Custom** service types, enable **Use custom model** and enter your server's own model name.
+
+### Chat works, but photo analysis or label scan fails
+
+Food-photo analysis and nutrition-label scanning request **structured JSON output**; plain chat does not. This is done to improve the quality of results. Some models and servers do not support structured output and reject those requests while chat still works.
+
+**Fix:** Choose a model that supports structured outputs / JSON mode. On OpenRouter, a model's page lists whether it supports "structured outputs".
+
+### Local servers (LM Studio, Ollama, llama.cpp)
+
+These usually run without an API key — leave the **API Key** field blank. Use the OpenAI-compatible base URL the server exposes, for example `http://localhost:1234/v1` (LM Studio) or `http://localhost:11434/v1` (Ollama's OpenAI-compatible endpoint).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,13 +51,13 @@ importers:
         version: 0.14.4(@assistant-ui/react@0.14.23(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(ioredis@5.10.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))
       '@better-auth/passkey':
         specifier: ^1.5.6
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)
       '@better-auth/sso':
         specifier: ^1.5.6
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@1.3.2(zod@4.3.6))
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@1.3.2(zod@4.3.6))
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -153,7 +153,7 @@ importers:
         version: 6.0.191(zod@4.3.6)
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
+        version: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -329,6 +329,9 @@ importers:
       vite-plugin-pwa:
         specifier: ^1.2.0
         version: 1.2.0(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.2))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
+      vite-plugin-react-click-to-component:
+        specifier: ^4.2.2
+        version: 4.2.2(react@19.2.4)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.2))
 
   SparkyFitnessMCP:
     dependencies:
@@ -340,7 +343,7 @@ importers:
         version: 3.0.65(zod@3.25.76)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0))(vue@3.5.30(typescript@5.9.3)))
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0))(vue@3.5.30(typescript@5.9.3)))
       '@modelcontextprotocol/sdk':
         specifier: ^1.27.1
         version: 1.29.0(zod@3.25.76)
@@ -355,7 +358,7 @@ importers:
         version: 5.1.1
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0))(vue@3.5.30(typescript@5.9.3))
+        version: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0))(vue@3.5.30(typescript@5.9.3))
       better-call:
         specifier: ^2.0.2
         version: 2.0.2(zod@3.25.76)
@@ -666,13 +669,13 @@ importers:
         version: 3.0.65(zod@4.3.6)
       '@better-auth/api-key':
         specifier: ^1.5.6
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))
       '@better-auth/passkey':
         specifier: ^1.5.6
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@2.0.2(zod@4.3.6))(nanostores@1.1.1)
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@2.0.2(zod@4.3.6))(nanostores@1.1.1)
       '@better-auth/sso':
         specifier: ^1.5.6
-        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@2.0.2(zod@4.3.6))
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@2.0.2(zod@4.3.6))
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
@@ -690,7 +693,7 @@ importers:
         version: 2.4.3
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
+        version: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
       better-call:
         specifier: ^2.0.2
         version: 2.0.2(zod@4.3.6)
@@ -1155,10 +1158,6 @@ packages:
     resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-plugin-utils@7.29.7':
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
@@ -1201,16 +1200,8 @@ packages:
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.27.1':
-    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-wrap-function@7.28.6':
-    resolution: {integrity: sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-wrap-function@7.29.7':
@@ -1335,12 +1326,6 @@ packages:
 
   '@babel/plugin-syntax-import-assertions@7.29.7':
     resolution: {integrity: sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-import-attributes@7.28.6':
-    resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -14213,6 +14198,12 @@ packages:
     resolution: {integrity: sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==}
     engines: {node: '>=20.0.0'}
 
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
   seroval@1.5.1:
     resolution: {integrity: sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==}
     engines: {node: '>=10'}
@@ -14361,6 +14352,9 @@ packages:
   socket.io-parser@4.2.6:
     resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
+
+  solid-js@1.9.13:
+    resolution: {integrity: sha512-6hJeJMOcEX8ktqjpDoJZEmld3ijvcvWBDtiXBm7f4332SiFN66QeAQI1REQshvyUoISsSeJ4PHDauKYbwao9JQ==}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -15562,6 +15556,12 @@ packages:
       '@vite-pwa/assets-generator':
         optional: true
 
+  vite-plugin-react-click-to-component@4.2.2:
+    resolution: {integrity: sha512-m9dLj4hmiInz+XbomttR3YNkAUwl0DnAMYTuZr50Q4yJf7TNd2JeytbzhKdG2A9xpBSjB7V8FkymsmiQsVbpmw==}
+    peerDependencies:
+      react: ^18.3.1 || ^19.0.0
+      vite: ^7 || ^8
+
   vite-plugin-vue-tracer@1.3.0:
     resolution: {integrity: sha512-Cgfce6VikzOw5MUJTpeg50s5rRjzU1Vr61ZjuHunVVHLjZZ5AUlgyExHthZ3r59vtoz9W2rDt23FYG81avYBKw==}
     peerDependencies:
@@ -16594,8 +16594,8 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -16619,7 +16619,7 @@ snapshots:
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/helper-validator-option': 7.29.7
       browserslist: 4.28.1
       lru-cache: 5.1.1
       semver: 6.3.1
@@ -16720,8 +16720,8 @@ snapshots:
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -16737,7 +16737,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -16763,15 +16763,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/helper-plugin-utils@7.28.6': {}
-
   '@babel/helper-plugin-utils@7.29.7': {}
 
   '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-wrap-function': 7.28.6
+      '@babel/helper-wrap-function': 7.29.7
       '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -16828,17 +16826,7 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helper-validator-option@7.27.1': {}
-
   '@babel/helper-validator-option@7.29.7': {}
-
-  '@babel/helper-wrap-function@7.28.6':
-    dependencies:
-      '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-wrap-function@7.29.7':
     dependencies:
@@ -16851,7 +16839,7 @@ snapshots:
   '@babel/helpers@7.28.6':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/helpers@7.29.7':
     dependencies:
@@ -16913,7 +16901,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
@@ -16921,7 +16909,7 @@ snapshots:
   '@babel/plugin-proposal-export-default-from@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)':
     dependencies:
@@ -16960,7 +16948,7 @@ snapshots:
   '@babel/plugin-syntax-export-default-from@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0)':
     dependencies:
@@ -16972,7 +16960,7 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.29.7
@@ -17089,7 +17077,7 @@ snapshots:
   '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
@@ -17172,7 +17160,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17308,7 +17296,7 @@ snapshots:
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -17318,7 +17306,7 @@ snapshots:
   '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
 
   '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
@@ -17406,7 +17394,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17503,10 +17491,10 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17581,7 +17569,7 @@ snapshots:
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -17592,7 +17580,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17618,7 +17606,7 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -17672,7 +17660,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.29.7
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/types': 7.29.7
@@ -17716,7 +17704,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-plugin-utils': 7.29.7
       babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
@@ -17909,8 +17897,8 @@ snapshots:
   '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
@@ -17932,10 +17920,10 @@ snapshots:
   '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
@@ -17951,8 +17939,8 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/template@7.29.7':
     dependencies:
@@ -17965,9 +17953,9 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -18018,25 +18006,25 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/api-key@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))':
+  '@better-auth/api-key@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
-      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
+      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
       zod: 4.3.6
 
-  '@better-auth/api-key@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0))(vue@3.5.30(typescript@5.9.3)))':
+  '@better-auth/api-key@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0))(vue@3.5.30(typescript@5.9.3)))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
-      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0))(vue@3.5.30(typescript@5.9.3))
+      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0))(vue@3.5.30(typescript@5.9.3))
       zod: 4.3.6
 
-  '@better-auth/api-key@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))':
+  '@better-auth/api-key@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
-      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
+      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
       zod: 4.3.6
 
   '@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)':
@@ -18126,26 +18114,26 @@ snapshots:
     optionalDependencies:
       mongodb: 7.1.0
 
-  '@better-auth/passkey@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
+  '@better-auth/passkey@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@1.3.2(zod@4.3.6))(nanostores@1.1.1)':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.2.3
-      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
+      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
       better-call: 1.3.2(zod@4.3.6)
       nanostores: 1.1.1
       zod: 4.3.6
 
-  '@better-auth/passkey@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@2.0.2(zod@4.3.6))(nanostores@1.1.1)':
+  '@better-auth/passkey@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@2.0.2(zod@4.3.6))(nanostores@1.1.1)':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
       '@simplewebauthn/browser': 13.2.2
       '@simplewebauthn/server': 13.2.3
-      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
+      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
       better-call: 2.0.2(zod@4.3.6)
       nanostores: 1.1.1
       zod: 4.3.6
@@ -18160,12 +18148,12 @@ snapshots:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
 
-  '@better-auth/sso@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@1.3.2(zod@4.3.6))':
+  '@better-auth/sso@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@1.3.2(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
+      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
       better-call: 1.3.2(zod@4.3.6)
       fast-xml-parser: 5.5.8
       jose: 6.2.1
@@ -18173,12 +18161,12 @@ snapshots:
       tldts: 6.1.86
       zod: 4.3.6
 
-  '@better-auth/sso@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@2.0.2(zod@4.3.6))':
+  '@better-auth/sso@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)))(better-call@2.0.2(zod@4.3.6))':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/utils': 0.3.1
       '@better-fetch/fetch': 1.1.21
-      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
+      better-auth: 1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3))
       better-call: 2.0.2(zod@4.3.6)
       fast-xml-parser: 5.5.8
       jose: 6.2.1
@@ -19080,7 +19068,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/core': 7.29.0
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -22568,7 +22556,7 @@ snapshots:
       '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
@@ -22639,7 +22627,7 @@ snapshots:
   '@react-native/codegen@0.83.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       glob: 7.2.3
       hermes-parser: 0.32.0
       invariant: 2.2.4
@@ -24429,7 +24417,7 @@ snapshots:
 
   '@vue/babel-plugin-jsx@2.0.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/template': 7.29.7
@@ -25058,7 +25046,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
@@ -25067,7 +25055,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       semver: 6.3.1
@@ -25106,7 +25094,7 @@ snapshots:
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   babel-plugin-react-native-web@0.21.2: {}
 
@@ -25136,7 +25124,7 @@ snapshots:
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.0)
       '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
@@ -25295,7 +25283,7 @@ snapshots:
 
   bcryptjs@2.4.3: {}
 
-  better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0))(vue@3.5.30(typescript@5.9.3)):
+  better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@2.0.2(zod@3.25.76))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
@@ -25319,13 +25307,14 @@ snapshots:
       pg: 8.20.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+      solid-js: 1.9.13
       vitest: 2.1.9(@types/node@22.19.19)(jsdom@26.1.0)(lightningcss@1.32.0)(terser@5.48.0)
       vue: 3.5.30(typescript@5.9.3)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)):
+  better-auth@1.5.6(@opentelemetry/api@1.9.1)(mongodb@7.1.0)(pg@8.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(solid-js@1.9.13)(vitest@4.1.4)(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.1)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)
@@ -25349,6 +25338,7 @@ snapshots:
       pg: 8.20.0
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+      solid-js: 1.9.13
       vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.2))
       vue: 3.5.30(typescript@5.9.3)
     transitivePeerDependencies:
@@ -29103,7 +29093,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -29317,7 +29307,7 @@ snapshots:
       '@babel/generator': 7.29.1
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
@@ -29976,7 +29966,7 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
@@ -30339,8 +30329,8 @@ snapshots:
 
   metro-source-map@0.83.7:
     dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       flow-enums-runtime: 0.0.6
       invariant: 2.2.4
       metro-symbolicate: 0.83.7
@@ -30458,7 +30448,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
@@ -33243,6 +33233,11 @@ snapshots:
 
   serialize-javascript@7.0.4: {}
 
+  seroval-plugins@1.5.4(seroval@1.5.1):
+    dependencies:
+      seroval: 1.5.1
+    optional: true
+
   seroval@1.5.1: {}
 
   serve-placeholder@2.0.2:
@@ -33445,6 +33440,13 @@ snapshots:
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
+
+  solid-js@1.9.13:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.5.1
+      seroval-plugins: 1.5.4(seroval@1.5.1)
+    optional: true
 
   sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -34817,6 +34819,11 @@ snapshots:
       workbox-window: 7.4.0
     transitivePeerDependencies:
       - supports-color
+
+  vite-plugin-react-click-to-component@4.2.2(react@19.2.4)(vite@8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      react: 19.2.4
+      vite: 8.0.0(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.2)
 
   vite-plugin-vue-tracer@1.3.0(vite@8.0.0(@types/node@20.19.37)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.2))(vue@3.5.30(typescript@5.9.3)):
     dependencies:

--- a/shared/src/schemas/api/AiServiceSettings.api.zod.ts
+++ b/shared/src/schemas/api/AiServiceSettings.api.zod.ts
@@ -53,6 +53,25 @@ export const updateAiServiceSettingsRequestSchema =
     .extend({
       api_key: z.string().optional(),
     });
+
+// Test-connection contract. `api_key` is optional because on edit the field is
+// blank by design (the stored key is encrypted server-side and never sent to
+// the browser), so the server falls back to the stored key when an `id` is
+// supplied. The response is HTTP 200 for both pass and fail so the frontend can
+// show a category-specific toast instead of `apiCall`'s generic non-2xx toast.
+export const testAiServiceConnectionRequestSchema = z.object({
+  id: z.string().optional(),
+  service_type: z.string(),
+  api_key: z.string().optional(),
+  custom_url: z.string().optional(),
+  model_name: z.string().optional(),
+});
+
+export const testAiServiceConnectionResponseSchema = z.object({
+  ok: z.boolean(),
+  category: z.string().optional(),
+  detail: z.string().optional(),
+});
 export type AiServiceSettingsResponse = z.infer<
   typeof aiServiceSettingsResponseSchema
 >;
@@ -65,4 +84,11 @@ export type UpdateAiServiceSettingsRequest = z.infer<
 
 export type AiServiceSettingsPostResponse = z.infer<
   typeof aiServiceSettingsPostResponseSchema
+>;
+
+export type TestAiServiceConnectionRequest = z.infer<
+  typeof testAiServiceConnectionRequestSchema
+>;
+export type TestAiServiceConnectionResponse = z.infer<
+  typeof testAiServiceConnectionResponseSchema
 >;

--- a/shared/src/schemas/database/GlobalSettings.zod.ts
+++ b/shared/src/schemas/database/GlobalSettings.zod.ts
@@ -14,6 +14,7 @@ export const globalSettingsSchema = z.object({
   updated_at: z.date().nullable(),
   mfa_mandatory: z.boolean().nullable(),
   allow_user_ai_config: z.boolean(),
+  default_vision_ai_service_id: z.string().uuid().nullable().optional(),
 });
 
 export const globalSettingsInitializerSchema = z.object({
@@ -23,6 +24,7 @@ export const globalSettingsInitializerSchema = z.object({
   updated_at: z.date().optional().nullable(),
   mfa_mandatory: z.boolean().optional().nullable(),
   allow_user_ai_config: z.boolean().optional(),
+  default_vision_ai_service_id: z.string().uuid().nullable().optional(),
 });
 
 export const globalSettingsMutatorSchema = z.object({
@@ -32,6 +34,7 @@ export const globalSettingsMutatorSchema = z.object({
   updated_at: z.date().optional().nullable(),
   mfa_mandatory: z.boolean().optional().nullable(),
   allow_user_ai_config: z.boolean().optional(),
+  default_vision_ai_service_id: z.string().uuid().nullable().optional(),
 });
 
 export type GlobalSettings = z.infer<typeof globalSettingsSchema>;

--- a/shared/src/schemas/database/UserPreferences.zod.ts
+++ b/shared/src/schemas/database/UserPreferences.zod.ts
@@ -44,6 +44,7 @@ export const userPreferencesSchema = z.object({
   // Manually added (file is ts-to-zod generated; precedent: MealFoods.zod.ts). Keep on regen.
   use_external_bmr: z.boolean(),
   active_ai_service_id: z.string().uuid().nullable().optional(),
+  active_vision_ai_service_id: z.string().uuid().nullable().optional(),
 });
 
 export const userPreferencesInitializerSchema = z.object({
@@ -88,6 +89,7 @@ export const userPreferencesInitializerSchema = z.object({
   measurement_decimal_places: z.number().int().min(0).optional(),
   use_external_bmr: z.boolean().optional(),
   active_ai_service_id: z.string().uuid().nullable().optional(),
+  active_vision_ai_service_id: z.string().uuid().nullable().optional(),
 });
 
 export const userPreferencesMutatorSchema = z.object({
@@ -132,6 +134,7 @@ export const userPreferencesMutatorSchema = z.object({
   measurement_decimal_places: z.number().int().min(0).optional(),
   use_external_bmr: z.boolean().optional(),
   active_ai_service_id: z.string().uuid().nullable().optional(),
+  active_vision_ai_service_id: z.string().uuid().nullable().optional(),
 });
 
 export type UserPreferences = z.infer<typeof userPreferencesSchema>;


### PR DESCRIPTION
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

This PR includes several improvements for AI service providers:

- OpenAI Compatible AI Service type is fixed. Added docs for how to configure this as a URL mismatch is common
- Added setting for vision specific ai service
- Test Connection button in settings - sends the lowest amount of data possible to the service
- Allow local models to be registered with no key again

Linked Issue: Closes #1545

## How to Test

1. Set up vision specific LLM
2. Verify it works when sending vision task like before
3. Use test connection button in web sesttings
4. Register local ollama with no key
5. Verify open ai compat type works by using ollama open ai compat endpoint
 
## PR Type

- [x] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [x] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before


<img width="635" height="180" alt="Screenshot 2026-06-28 at 4 54 44 PM" src="https://github.com/user-attachments/assets/fbd701cb-35ff-43df-9c8f-d2da73bcc6b7" />

### After

<img width="660" height="128" alt="image" src="https://github.com/user-attachments/assets/e37816fc-e021-42d2-828e-9e822712bc48" />

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
