### PR TITLE
fix: preserve Garmin sync freshness on phase failure

### DIFF
--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -74,6 +74,7 @@ import cron from 'node-cron';
 import { scheduleBackupsOnStartup } from './services/backupScheduler.js';
 import externalProviderRepository from './models/externalProviderRepository.js';
 import garminService from './services/garminService.js';
+import { getGarminSyncPhaseErrors } from './services/garminSyncResult.js';
 import fitbitService from './services/fitbitService.js';
 import googleHealthService from './services/googleHealthService.js';
 import polarService from './services/polarService.js';
@@ -548,11 +549,21 @@ const scheduleGarminSyncs = async () => {
     for (const provider of providers) {
       if (provider.is_active && provider.sync_frequency !== 'manual') {
         try {
-          await garminService.syncGarminData(provider.user_id, 'scheduled');
-          await externalProviderRepository.updateProviderLastSync(
-            provider.id,
-            new Date()
+          const result = await garminService.syncGarminData(
+            provider.user_id,
+            'scheduled'
           );
+          const failedPhases = getGarminSyncPhaseErrors(result);
+          if (failedPhases.length === 0) {
+            await externalProviderRepository.updateProviderLastSync(
+              provider.id,
+              new Date()
+            );
+          } else {
+            console.warn(
+              `[CRON] Garmin sync completed with failed phases for user ${provider.user_id}; last_sync_at not updated: ${failedPhases.join(', ')}`
+            );
+          }
         } catch (error) {
           console.error(
             `[CRON] Garmin sync failed for user ${provider.user_id}:`,

--- a/SparkyFitnessServer/routes/garminRoutes.ts
+++ b/SparkyFitnessServer/routes/garminRoutes.ts
@@ -7,6 +7,7 @@ import garminMeasurementMapping from '../integrations/garminconnect/garminMeasur
 import { log } from '../config/logging.js';
 import moment from 'moment';
 import garminService from '../services/garminService.js';
+import { getGarminSyncPhaseErrors } from '../services/garminSyncResult.js';
 const router = express.Router();
 router.use(express.json());
 // Date validation constants
@@ -476,16 +477,22 @@ router.post('/sync', authenticate, async (req, res, next) => {
       startDate,
       endDate
     );
+    const failedPhases = getGarminSyncPhaseErrors(result);
     // Update the last sync timestamp
     const provider =
       await externalProviderRepository.getExternalDataProviderByUserIdAndProviderName(
         userId,
         'garmin'
       );
-    if (provider) {
+    if (provider && failedPhases.length === 0) {
       await externalProviderRepository.updateProviderLastSync(
         provider.id,
         new Date()
+      );
+    } else if (failedPhases.length > 0) {
+      log(
+        'warn',
+        `[garminRoutes] Skipping Garmin last_sync_at update for user ${userId}; failed phases: ${failedPhases.join(', ')}`
       );
     }
     res.status(200).json(result);

--- a/SparkyFitnessServer/services/garminService.ts
+++ b/SparkyFitnessServer/services/garminService.ts
@@ -15,6 +15,7 @@ import sleepRepository from '../models/sleepRepository.js';
 import foodRepository from '../models/food.js';
 import foodEntryRepository from '../models/foodEntry.js';
 import mealTypeRepository from '../models/mealType.js';
+import type { GarminSyncResult } from './garminSyncResult.js';
 
 const GARMIN_CARDIO_CATEGORY_INDICATORS = [
   'running',
@@ -1145,11 +1146,7 @@ async function syncGarminData(
     'info',
     `[garminService] Starting Garmin sync (${syncType}) for user ${userId} from ${startDate} to ${endDate}.`
   );
-  const results: {
-    health: Record<string, unknown> | null;
-    activities: Record<string, unknown> | null;
-    nutrition: Record<string, unknown> | null;
-  } = {
+  const results: GarminSyncResult = {
     health: null,
     activities: null,
     nutrition: null,

--- a/SparkyFitnessServer/services/garminSyncResult.ts
+++ b/SparkyFitnessServer/services/garminSyncResult.ts
@@ -1,0 +1,18 @@
+const GARMIN_SYNC_PHASES = ['health', 'activities', 'nutrition'] as const;
+
+type GarminSyncPhase = (typeof GARMIN_SYNC_PHASES)[number];
+type GarminSyncPhaseResult = Record<string, unknown> | null;
+export type GarminSyncResult = Record<GarminSyncPhase, GarminSyncPhaseResult>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getGarminSyncPhaseErrors(result: GarminSyncResult) {
+  return GARMIN_SYNC_PHASES.filter((phase) => {
+    const phaseResult = result[phase];
+    return isRecord(phaseResult) && typeof phaseResult.error === 'string';
+  });
+}
+
+export { getGarminSyncPhaseErrors };

--- a/SparkyFitnessServer/tests/garminRoutes.test.ts
+++ b/SparkyFitnessServer/tests/garminRoutes.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'
+import request from 'supertest';
+import express from 'express';
+import garminRoutes from '../routes/garminRoutes.js';
+import garminService from '../services/garminService.js';
+import externalProviderRepository from '../models/externalProviderRepository.js';
+
+vi.mock('../middleware/authMiddleware.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authenticate: vi.fn((req: any, _res: any, next: any) => {
+    req.userId = 'user-123';
+    next();
+  }),
+}));
+
+vi.mock('../integrations/garminconnect/garminConnectService.js', () => ({
+  default: {
+    garminLogin: vi.fn(),
+    garminResumeLogin: vi.fn(),
+    handleGarminTokens: vi.fn(),
+    syncGarminHealthAndWellness: vi.fn(),
+    fetchGarminActivitiesAndWorkouts: vi.fn(),
+    fetchGarminNutritionDiary: vi.fn(),
+  },
+}));
+
+vi.mock('../models/externalProviderRepository.js', () => ({
+  default: {
+    getExternalDataProviderByUserIdAndProviderName: vi.fn(),
+    updateProviderLastSync: vi.fn(),
+  },
+}));
+
+vi.mock('../services/measurementService.js', () => ({
+  default: {
+    processHealthData: vi.fn(),
+  },
+}));
+
+vi.mock('../services/garminService.js', () => ({
+  default: {
+    processGarminHealthAndWellnessData: vi.fn(),
+    processActivitiesAndWorkouts: vi.fn(),
+    processGarminNutritionData: vi.fn(),
+    syncGarminData: vi.fn(),
+  },
+}));
+
+vi.mock('../integrations/garminconnect/garminMeasurementMapping.js', () => ({
+  default: {},
+}));
+
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+const app = express();
+app.use(express.json());
+app.use('/integrations/garmin', garminRoutes);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+app.use((err: any, _req: any, res: any, _next: any) => {
+  res.status(500).json({ error: err.message });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (
+    externalProviderRepository.getExternalDataProviderByUserIdAndProviderName as any
+  ).mockResolvedValue({ id: 'provider-1' });
+  (externalProviderRepository.updateProviderLastSync as any).mockResolvedValue(
+    true
+  );
+});
+
+describe('POST /integrations/garmin/sync', () => {
+  it('updates provider last_sync_at when all sync phases complete', async () => {
+    const result = {
+      health: { processedEntries: 1 },
+      activities: { processedEntries: 2 },
+      nutrition: { processedEntries: 3 },
+    };
+    (garminService.syncGarminData as any).mockResolvedValue(result);
+
+    const res = await request(app)
+      .post('/integrations/garmin/sync')
+      .send({ startDate: '2026-06-01', endDate: '2026-06-07' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(result);
+    expect(garminService.syncGarminData).toHaveBeenCalledWith(
+      'user-123',
+      'manual',
+      '2026-06-01',
+      '2026-06-07'
+    );
+    expect(
+      externalProviderRepository.updateProviderLastSync
+    ).toHaveBeenCalledWith('provider-1', expect.any(Date));
+  });
+
+  it('does not update provider last_sync_at when a sync phase returns an error', async () => {
+    const result = {
+      health: { error: 'Garmin health API rate limited' },
+      activities: { processedEntries: 2 },
+      nutrition: { processedEntries: 3 },
+    };
+    (garminService.syncGarminData as any).mockResolvedValue(result);
+
+    const res = await request(app)
+      .post('/integrations/garmin/sync')
+      .send({ startDate: '2026-06-01', endDate: '2026-06-07' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(result);
+    expect(
+      externalProviderRepository.updateProviderLastSync
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/SparkyFitnessServer/tests/garminSyncResult.test.ts
+++ b/SparkyFitnessServer/tests/garminSyncResult.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getGarminSyncPhaseErrors } from '../services/garminSyncResult.js';
+
+describe('getGarminSyncPhaseErrors', () => {
+  it('returns phases with top-level sync errors', () => {
+    const result = {
+      health: { error: 'health unavailable' },
+      activities: { processedEntries: 2 },
+      nutrition: { error: 'nutrition unavailable' },
+    };
+
+    expect(getGarminSyncPhaseErrors(result)).toEqual(['health', 'nutrition']);
+  });
+
+  it('does not treat nested processing errors as phase failures', () => {
+    const result = {
+      health: { processedEntries: 1 },
+      activities: { processedEntries: 2 },
+      nutrition: { errors: [{ message: 'one food entry skipped' }] },
+    };
+
+    expect(getGarminSyncPhaseErrors(result)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Manual and scheduled Garmin full syncs can complete with one failed phase while other phases succeed. In that partial-success case, the provider-level `last_sync_at` should not advance because it makes the overall Garmin connection look fresher than the data actually is.

**How did you implement the solution?**
Added a small Garmin sync-result helper that detects top-level phase errors from the `health`, `activities`, and `nutrition` results. The manual sync route and scheduled sync job now update `last_sync_at` only when no phase returned an error; the existing response still carries the per-phase result details.

Linked Issue: N/A (bug fix; no existing issue)

## How to Test

1. `corepack pnpm exec vitest run tests/garminSyncResult.test.ts tests/garminRoutes.test.ts`
2. `corepack pnpm run typecheck`
3. `corepack pnpm run lint`
4. `corepack pnpm run format:check`
5. `corepack pnpm run test`

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

N/A, backend-only change.

## Notes for Reviewers

The helper intentionally checks only top-level phase `error` fields. Nested processing `errors` arrays inside a successful phase keep their existing semantics and do not block the provider timestamp.
