### PR TITLE
Fix: FatSecret search calorie mismatch

### DIFF
--- a/SparkyFitnessServer/services/externalFoodSearchService.ts
+++ b/SparkyFitnessServer/services/externalFoodSearchService.ts
@@ -13,6 +13,7 @@ import {
   mapFatSecretSearchItem,
   mapFatSecretFood,
   foodNutrientCache,
+  getFatSecretAccessToken,
 } from '../integrations/fatsecret/fatsecretService.js';
 import { searchYazioFoods } from '../integrations/yazio/yazioService.js';
 import { searchSwissFoods } from '../integrations/swissfood/swissFoodService.js';
@@ -175,6 +176,7 @@ function applyDetailToItem(
   item: FatSecretSearchItem,
   detailData: unknown
 ): FatSecretSearchItem {
+  if (!detailData) return item;
   const mappedDetail = mapFatSecretFood(detailData);
   if (mappedDetail?.default_variant) {
     return {
@@ -197,6 +199,17 @@ export async function enrichFatSecretResults(
 ): Promise<FatSecretSearchItem[]> {
   const top = items.slice(0, ENRICH_SYNC_COUNT);
   const rest = items.slice(ENRICH_SYNC_COUNT);
+
+  // Prefetch the access token once before firing parallel detail requests, so the
+  // concurrent calls below hit the warm token cache instead of racing to fetch
+  // their own token when the cache is cold or about to expire.
+  if (top.some((item) => item?.provider_external_id)) {
+    try {
+      await getFatSecretAccessToken(appId, appKey);
+    } catch (err) {
+      log('warn', 'FatSecret access token prefetch failed:', err);
+    }
+  }
 
   const enrichedTop = await Promise.all(
     top.map(async (item) => {
@@ -222,7 +235,12 @@ export async function enrichFatSecretResults(
   const enrichedRest = rest.map((item) => {
     if (!item?.provider_external_id) return item;
     const cached = foodNutrientCache.get(item.provider_external_id);
-    if (!cached || Date.now() >= cached.expiry) return item;
+    if (
+      !cached ||
+      typeof cached.expiry !== 'number' ||
+      Date.now() >= cached.expiry
+    )
+      return item;
     try {
       return applyDetailToItem(item, cached.data);
     } catch (err) {
@@ -316,7 +334,9 @@ export async function searchProviderFoods(
           : [];
       const mapped = items
         .map(mapFatSecretSearchItem)
-        .filter((x): x is NonNullable<typeof x> => x != null);
+        .filter(
+          (x): x is NonNullable<typeof x> => x !== null && x !== undefined
+        );
       foods = await enrichFatSecretResults(
         mapped,
         credentials.app_id,

--- a/SparkyFitnessServer/services/externalFoodSearchService.ts
+++ b/SparkyFitnessServer/services/externalFoodSearchService.ts
@@ -9,11 +9,16 @@ import {
   searchUsdaFoods,
   mapUsdaBarcodeProduct,
 } from '../integrations/usda/usdaService.js';
-import { mapFatSecretSearchItem } from '../integrations/fatsecret/fatsecretService.js';
+import {
+  mapFatSecretSearchItem,
+  mapFatSecretFood,
+  foodNutrientCache,
+} from '../integrations/fatsecret/fatsecretService.js';
 import { searchYazioFoods } from '../integrations/yazio/yazioService.js';
 import { searchSwissFoods } from '../integrations/swissfood/swissFoodService.js';
 import {
   searchFatSecretFoods,
+  getFatSecretNutrients,
   searchMealieFoods,
   searchTandoorFoods,
   searchNorishFoods,
@@ -161,6 +166,78 @@ const EMPTY_PAGINATION = (
   hasMore: false,
 });
 
+const ENRICH_SYNC_COUNT = 5;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type FatSecretSearchItem = Record<string, any>;
+
+function applyDetailToItem(
+  item: FatSecretSearchItem,
+  detailData: unknown
+): FatSecretSearchItem {
+  const mappedDetail = mapFatSecretFood(detailData);
+  if (mappedDetail?.default_variant) {
+    return {
+      ...item,
+      default_variant: mappedDetail.default_variant,
+      variants: mappedDetail.variants,
+    };
+  }
+  return item;
+}
+
+// Top ENRICH_SYNC_COUNT results are enriched with a real food.get.v4 call (parallel, all fire
+// at once) so their search-card calories match the edit form. Lower-ranked results fall back
+// to the in-memory cache if warm, otherwise stay as search-mapped. Failed detail fetches
+// log a warning and leave the item unchanged.
+export async function enrichFatSecretResults(
+  items: FatSecretSearchItem[],
+  appId: string | undefined,
+  appKey: string | undefined
+): Promise<FatSecretSearchItem[]> {
+  const top = items.slice(0, ENRICH_SYNC_COUNT);
+  const rest = items.slice(ENRICH_SYNC_COUNT);
+
+  const enrichedTop = await Promise.all(
+    top.map(async (item) => {
+      if (!item?.provider_external_id) return item;
+      try {
+        const detail = await getFatSecretNutrients(
+          item.provider_external_id,
+          appId,
+          appKey
+        );
+        return applyDetailToItem(item, detail);
+      } catch (err) {
+        log(
+          'warn',
+          `FatSecret detail enrichment failed for ${item.provider_external_id}:`,
+          err
+        );
+        return item;
+      }
+    })
+  );
+
+  const enrichedRest = rest.map((item) => {
+    if (!item?.provider_external_id) return item;
+    const cached = foodNutrientCache.get(item.provider_external_id);
+    if (!cached || Date.now() >= cached.expiry) return item;
+    try {
+      return applyDetailToItem(item, cached.data);
+    } catch (err) {
+      log(
+        'warn',
+        `FatSecret cache enrichment failed for ${item.provider_external_id}:`,
+        err
+      );
+      return item;
+    }
+  });
+
+  return [...enrichedTop, ...enrichedRest];
+}
+
 export async function searchProviderFoods(
   userId: string,
   providerType: ProviderType,
@@ -237,7 +314,14 @@ export async function searchProviderFoods(
         : rawFoods
           ? [rawFoods]
           : [];
-      foods = items.map(mapFatSecretSearchItem).filter(Boolean);
+      const mapped = items
+        .map(mapFatSecretSearchItem)
+        .filter((x): x is NonNullable<typeof x> => x != null);
+      foods = await enrichFatSecretResults(
+        mapped,
+        credentials.app_id,
+        credentials.app_key
+      );
       pagination = result.pagination;
       break;
     }

--- a/SparkyFitnessServer/tests/externalFoodSearchService.fatsecret.test.ts
+++ b/SparkyFitnessServer/tests/externalFoodSearchService.fatsecret.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/foodIntegrationService.js', () => ({
+  getFatSecretNutrients: vi.fn(),
+  searchFatSecretFoods: vi.fn(),
+  searchMealieFoods: vi.fn(),
+  searchTandoorFoods: vi.fn(),
+  searchNorishFoods: vi.fn(),
+}));
+
+vi.mock('../integrations/fatsecret/fatsecretService.js', () => ({
+  mapFatSecretSearchItem: vi.fn((item) => item),
+  mapFatSecretFood: vi.fn(),
+  foodNutrientCache: new Map(),
+}));
+
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+vi.mock('../services/externalProviderService.js', () => ({
+  default: { getProviderCredentials: vi.fn() },
+}));
+vi.mock('../services/preferenceService.js', () => ({
+  default: { getUserPreferences: vi.fn() },
+}));
+vi.mock('../integrations/openfoodfacts/openFoodFactsService.js', () => ({
+  searchOpenFoodFacts: vi.fn(),
+  mapOpenFoodFactsProduct: vi.fn(),
+}));
+vi.mock('../integrations/usda/usdaService.js', () => ({
+  searchUsdaFoods: vi.fn(),
+  mapUsdaBarcodeProduct: vi.fn(),
+}));
+vi.mock('../integrations/yazio/yazioService.js', () => ({
+  searchYazioFoods: vi.fn(),
+}));
+vi.mock('../integrations/swissfood/swissFoodService.js', () => ({
+  searchSwissFoods: vi.fn(),
+}));
+
+import { getFatSecretNutrients } from '../services/foodIntegrationService.js';
+import {
+  mapFatSecretFood,
+  foodNutrientCache,
+} from '../integrations/fatsecret/fatsecretService.js';
+import { log } from '../config/logging.js';
+import { enrichFatSecretResults } from '../services/externalFoodSearchService.js';
+
+const mockGetFatSecretNutrients = vi.mocked(getFatSecretNutrients);
+const mockMapFatSecretFood = vi.mocked(mapFatSecretFood);
+const mockLog = vi.mocked(log);
+const mockCache = foodNutrientCache as Map<
+  string,
+  { data: unknown; expiry: number }
+>;
+
+function makeSearchItem(id: string, calories: number) {
+  return {
+    name: `Food ${id}`,
+    brand: null,
+    provider_external_id: id,
+    provider_type: 'fatsecret' as const,
+    is_custom: false,
+    default_variant: {
+      serving_size: 1,
+      serving_unit: 'serving',
+      calories,
+      protein: 10,
+      carbs: 20,
+      fat: 5,
+      is_default: true,
+    },
+  };
+}
+
+function makeDetailVariant(calories: number) {
+  return {
+    serving_size: 57,
+    serving_unit: 'g',
+    calories,
+    protein: 16,
+    carbs: 46,
+    fat: 32,
+    is_default: true,
+  };
+}
+
+function makeDetailResult(id: string, calories: number) {
+  const variant = makeDetailVariant(calories);
+  return {
+    name: `Food ${id}`,
+    brand: null,
+    barcode: undefined,
+    provider_external_id: id,
+    provider_type: 'fatsecret',
+    is_custom: false,
+    default_variant: variant,
+    variants: [variant],
+  };
+}
+
+function seedCache(id: string, calories: number) {
+  mockCache.set(id, {
+    data: { food: { food_id: id } },
+    expiry: Date.now() + 5 * 60 * 1000,
+  });
+  mockMapFatSecretFood.mockReturnValue(
+    makeDetailResult(id, calories) as ReturnType<typeof mapFatSecretFood>
+  );
+}
+
+describe('enrichFatSecretResults', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCache.clear();
+  });
+
+  it('top 5 results are enriched via API call with detail default_variant and variants', async () => {
+    const items = Array.from({ length: 5 }, (_, i) =>
+      makeSearchItem(String(i), 500)
+    );
+    mockGetFatSecretNutrients.mockResolvedValue({ food: {} });
+    mockMapFatSecretFood.mockReturnValue(
+      makeDetailResult('x', 370) as ReturnType<typeof mapFatSecretFood>
+    );
+
+    const result = await enrichFatSecretResults(items, 'app_id', 'app_key');
+
+    expect(mockGetFatSecretNutrients).toHaveBeenCalledTimes(5);
+    result.forEach((item) => {
+      expect(item!.default_variant.calories).toBe(370);
+      expect((item as { variants?: unknown[] }).variants).toHaveLength(1);
+    });
+  });
+
+  it('results beyond top 5 are enriched from cache when warm', async () => {
+    const items = Array.from({ length: 7 }, (_, i) =>
+      makeSearchItem(String(i), 500)
+    );
+    // Top 5 via API
+    mockGetFatSecretNutrients.mockResolvedValue({ food: {} });
+    mockMapFatSecretFood.mockReturnValue(
+      makeDetailResult('x', 370) as ReturnType<typeof mapFatSecretFood>
+    );
+    // Item 5 cached, item 6 not cached
+    seedCache('5', 420);
+
+    const result = await enrichFatSecretResults(items, 'app_id', 'app_key');
+
+    expect(mockGetFatSecretNutrients).toHaveBeenCalledTimes(5);
+    expect(result[5]!.default_variant.calories).toBe(420);
+    expect(result[6]!.default_variant.calories).toBe(500); // unchanged
+  });
+
+  it('results beyond top 5 stay as search-mapped when cache is cold', async () => {
+    const items = Array.from({ length: 7 }, (_, i) =>
+      makeSearchItem(String(i), i * 10)
+    );
+    mockGetFatSecretNutrients.mockResolvedValue({ food: {} });
+    mockMapFatSecretFood.mockReturnValue(
+      makeDetailResult('x', 999) as ReturnType<typeof mapFatSecretFood>
+    );
+
+    const result = await enrichFatSecretResults(items, 'app_id', 'app_key');
+
+    expect(result[5]!.default_variant.calories).toBe(50);
+    expect(result[6]!.default_variant.calories).toBe(60);
+  });
+
+  it('falls back to original item and logs warn when top-5 API call fails', async () => {
+    const items = [makeSearchItem('bad', 300)];
+    mockGetFatSecretNutrients.mockRejectedValue(new Error('timeout'));
+
+    const result = await enrichFatSecretResults(items, 'app_id', 'app_key');
+
+    expect(result[0]!.default_variant.calories).toBe(300);
+    expect(mockLog).toHaveBeenCalledWith(
+      'warn',
+      expect.stringContaining('bad'),
+      expect.any(Error)
+    );
+  });
+
+  it('preserves item order across top-5 and remainder', async () => {
+    const items = Array.from({ length: 8 }, (_, i) =>
+      makeSearchItem(String(i), i * 100)
+    );
+    mockGetFatSecretNutrients.mockResolvedValue({ food: {} });
+    mockMapFatSecretFood.mockReturnValue(
+      makeDetailResult('x', 999) as ReturnType<typeof mapFatSecretFood>
+    );
+
+    const result = await enrichFatSecretResults(items, 'app_id', 'app_key');
+
+    expect(result).toHaveLength(8);
+    // Top 5 enriched
+    result
+      .slice(0, 5)
+      .forEach((item) => expect(item!.default_variant.calories).toBe(999));
+    // Remainder unchanged (no cache)
+    result
+      .slice(5)
+      .forEach((item, i) =>
+        expect(item!.default_variant.calories).toBe((i + 5) * 100)
+      );
+  });
+
+  it('passes through items without provider_external_id untouched', async () => {
+    const item = makeSearchItem('', 100);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (item as any).provider_external_id = undefined;
+
+    const result = await enrichFatSecretResults(
+      [item as never],
+      'app_id',
+      'app_key'
+    );
+
+    expect(result[0]!.default_variant.calories).toBe(100);
+    expect(mockGetFatSecretNutrients).not.toHaveBeenCalled();
+  });
+});

--- a/SparkyFitnessServer/tests/externalFoodSearchService.fatsecret.test.ts
+++ b/SparkyFitnessServer/tests/externalFoodSearchService.fatsecret.test.ts
@@ -12,6 +12,7 @@ vi.mock('../integrations/fatsecret/fatsecretService.js', () => ({
   mapFatSecretSearchItem: vi.fn((item) => item),
   mapFatSecretFood: vi.fn(),
   foodNutrientCache: new Map(),
+  getFatSecretAccessToken: vi.fn(),
 }));
 
 vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
@@ -40,12 +41,14 @@ import { getFatSecretNutrients } from '../services/foodIntegrationService.js';
 import {
   mapFatSecretFood,
   foodNutrientCache,
+  getFatSecretAccessToken,
 } from '../integrations/fatsecret/fatsecretService.js';
 import { log } from '../config/logging.js';
 import { enrichFatSecretResults } from '../services/externalFoodSearchService.js';
 
 const mockGetFatSecretNutrients = vi.mocked(getFatSecretNutrients);
 const mockMapFatSecretFood = vi.mocked(mapFatSecretFood);
+const mockGetFatSecretAccessToken = vi.mocked(getFatSecretAccessToken);
 const mockLog = vi.mocked(log);
 const mockCache = foodNutrientCache as Map<
   string,
@@ -111,6 +114,49 @@ describe('enrichFatSecretResults', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCache.clear();
+    mockGetFatSecretAccessToken.mockResolvedValue('token');
+  });
+
+  it('prefetches the access token once before firing parallel detail requests', async () => {
+    const items = Array.from({ length: 5 }, (_, i) =>
+      makeSearchItem(String(i), 500)
+    );
+    mockGetFatSecretNutrients.mockResolvedValue({ food: {} });
+    mockMapFatSecretFood.mockReturnValue(
+      makeDetailResult('x', 370) as ReturnType<typeof mapFatSecretFood>
+    );
+
+    await enrichFatSecretResults(items, 'app_id', 'app_key');
+
+    expect(mockGetFatSecretAccessToken).toHaveBeenCalledTimes(1);
+    expect(mockGetFatSecretAccessToken).toHaveBeenCalledWith(
+      'app_id',
+      'app_key'
+    );
+  });
+
+  it('does not prefetch the token when there are no items to enrich', async () => {
+    await enrichFatSecretResults([], 'app_id', 'app_key');
+
+    expect(mockGetFatSecretAccessToken).not.toHaveBeenCalled();
+  });
+
+  it('continues enrichment even if the token prefetch fails', async () => {
+    const items = [makeSearchItem('1', 300)];
+    mockGetFatSecretAccessToken.mockRejectedValue(new Error('token error'));
+    mockGetFatSecretNutrients.mockResolvedValue({ food: {} });
+    mockMapFatSecretFood.mockReturnValue(
+      makeDetailResult('1', 370) as ReturnType<typeof mapFatSecretFood>
+    );
+
+    const result = await enrichFatSecretResults(items, 'app_id', 'app_key');
+
+    expect(result[0]!.default_variant.calories).toBe(370);
+    expect(mockLog).toHaveBeenCalledWith(
+      'warn',
+      'FatSecret access token prefetch failed:',
+      expect.any(Error)
+    );
   });
 
   it('top 5 results are enriched via API call with detail default_variant and variants', async () => {
@@ -150,6 +196,22 @@ describe('enrichFatSecretResults', () => {
     expect(result[6]!.default_variant.calories).toBe(500); // unchanged
   });
 
+  it('treats a malformed cache entry (non-numeric expiry) as expired', async () => {
+    const items = Array.from({ length: 6 }, (_, i) =>
+      makeSearchItem(String(i), 500)
+    );
+    mockGetFatSecretNutrients.mockResolvedValue({ food: {} });
+    mockMapFatSecretFood.mockReturnValue(
+      makeDetailResult('x', 370) as ReturnType<typeof mapFatSecretFood>
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockCache.set('5', { data: { food: {} }, expiry: undefined as any });
+
+    const result = await enrichFatSecretResults(items, 'app_id', 'app_key');
+
+    expect(result[5]!.default_variant.calories).toBe(500); // unchanged, treated as expired
+  });
+
   it('results beyond top 5 stay as search-mapped when cache is cold', async () => {
     const items = Array.from({ length: 7 }, (_, i) =>
       makeSearchItem(String(i), i * 10)
@@ -177,6 +239,16 @@ describe('enrichFatSecretResults', () => {
       expect.stringContaining('bad'),
       expect.any(Error)
     );
+  });
+
+  it('returns original item unchanged when detail fetch resolves to null/undefined', async () => {
+    const items = [makeSearchItem('null-detail', 300)];
+    mockGetFatSecretNutrients.mockResolvedValue(null);
+
+    const result = await enrichFatSecretResults(items, 'app_id', 'app_key');
+
+    expect(result[0]!.default_variant.calories).toBe(300);
+    expect(mockMapFatSecretFood).not.toHaveBeenCalled();
   });
 
   it('preserves item order across top-5 and remainder', async () => {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Fatsecret was occassionally returning the wrong calories in the search results. For example if you search "costco hot dog" you would see 580 calories but if you clicked on it, it would then say 370 calories. This has happened to a few foods I've searched. There is no other variants either

**How did you implement the solution?**
The reason it would be incorrect in search sometimes is fat secret has a search and a details api. The search is quicker but sometimes has stale information that hasn't been updated.

Now becuase it uses 2 seperate apis for search, it would take too long to double check all the results. For now I have it double check the top 5 results to make sure the calories match. I think this is the best solution without making it take too long, considering it's only a few random foods that have this mismatch.

Linked Issue: Closes #

## How to Test

1. Go to the foods page
2. search costco hot dog in fatsecret
3. Verify that the search result matches when you click into it

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
