### PR TITLE
Native header screen fixes

### DIFF
--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -962,7 +962,7 @@ function AppContent() {
           <Stack.Screen
             name="Chat"
             component={SafeChat}
-            options={createStackScreenOptions('Sparky', { headerBackTitle: 'Dashboard' })}
+            options={createStackScreenOptions('Sparky', { headerBackButtonDisplayMode: 'minimal' })}
           />
           <Stack.Screen
             name="MealAdd"

--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -875,10 +875,7 @@ function AppContent() {
             name="FoodSearch"
             component={SafeFoodSearch}
             options={createStackScreenOptions('Add Food', {
-              // The screen renders its own header; without this iOS shows the
-              // native stack header on top of it (double header). Android
-              // already defaults to headerShown: false.
-              headerShown: false,
+              headerBackVisible: false,
               // 'modal' (not 'fullScreenModal') so iOS keeps the swipe-down
               // dismiss gesture — UIModalPresentationFullScreen has no
               // interactive dismissal.
@@ -965,10 +962,7 @@ function AppContent() {
           <Stack.Screen
             name="Chat"
             component={SafeChat}
-            options={{
-              headerShown: false,
-              gestureEnabled: true,
-            }}
+            options={createStackScreenOptions('Sparky', { headerBackTitle: 'Dashboard' })}
           />
           <Stack.Screen
             name="MealAdd"

--- a/SparkyFitnessMobile/__tests__/screens/ChatScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ChatScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react-native';
+import { Platform } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Toast from 'react-native-toast-message';
@@ -187,6 +188,18 @@ beforeEach(() => {
 });
 
 describe('ChatScreen config gating', () => {
+  it('offsets keyboard avoidance by the native iOS header height', async () => {
+    const { getByTestId } = renderScreen();
+
+    expect(getByTestId('chat-keyboard-avoiding-view').props.keyboardVerticalOffset).toBe(
+      Platform.OS === 'ios' ? 44 : 0
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+
   it('prompts to set up a server when none is configured', async () => {
     mockGetActiveServerConfig.mockResolvedValue(null);
     const { findByText } = renderScreen();

--- a/SparkyFitnessMobile/__tests__/screens/ChatScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ChatScreen.test.tsx
@@ -147,7 +147,7 @@ const mockUseActiveAiServiceSetting = useActiveAiServiceSetting as jest.MockedFu
 >;
 const mockUseChatHistory = useChatHistory as jest.MockedFunction<typeof useChatHistory>;
 
-const navigation = { goBack: jest.fn() } as any;
+const navigation = { goBack: jest.fn(), setOptions: jest.fn() } as any;
 const route = { params: {} } as any;
 
 const initialMetrics = {

--- a/SparkyFitnessMobile/__tests__/screens/ChatScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ChatScreen.test.tsx
@@ -192,7 +192,7 @@ describe('ChatScreen config gating', () => {
     const { getByTestId } = renderScreen();
 
     expect(getByTestId('chat-keyboard-avoiding-view').props.keyboardVerticalOffset).toBe(
-      Platform.OS === 'ios' ? 44 : 0
+      Platform.OS === 'ios' ? 56 : 12
     );
 
     await act(async () => {

--- a/SparkyFitnessMobile/src/screens/ActivityAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ActivityAddScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect, useState } from 'react';
+import React, { useRef, useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import {
   View,
   Text,
@@ -23,6 +23,7 @@ import { useExerciseImageSource } from '../hooks/useExerciseImageSource';
 import { useHeaderActionColors } from '../hooks/useHeaderActionColors';
 import { useCreateExerciseEntry, useUpdateExerciseEntry } from '../hooks/useExerciseMutations';
 import { usePreferences } from '../hooks/usePreferences';
+import { createNativeHeaderTextButtonItem } from '../utils/nativeHeaderItems';
 import Toast from 'react-native-toast-message';
 import { addLog } from '../services/LogService';
 import { formatDateLabel } from '../utils/dateUtils';
@@ -46,7 +47,7 @@ const ActivityAddScreen: React.FC<Props> = ({ navigation, route }) => {
     '--color-border-subtle',
     '--color-raised',
   ]) as [string, string, string, string, string];
-  const { backColor } = useHeaderActionColors();
+  const { backColor, headerTintColor } = useHeaderActionColors();
 
   const {
     state,
@@ -102,6 +103,24 @@ const ActivityAddScreen: React.FC<Props> = ({ navigation, route }) => {
     }
     navigation.goBack();
   }, [discardDraft, isEditMode, hasDraftData, navigation]);
+
+  useLayoutEffect(() => {
+    if (Platform.OS !== 'ios') return;
+
+    navigation.setOptions({
+      headerBackVisible: false,
+      unstable_headerLeftItems: () => [
+        createNativeHeaderTextButtonItem({
+          label: 'Cancel',
+          identifier: 'activity-add-cancel',
+          tintColor: headerTintColor,
+          onPress: () => {
+            void handleCancel();
+          },
+        }),
+      ],
+    });
+  }, [handleCancel, headerTintColor, navigation]);
 
   const handleSave = useCallback(async () => {
     if (!submission.exerciseId || !submission.canSave) return;

--- a/SparkyFitnessMobile/src/screens/ChatScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ChatScreen.tsx
@@ -58,6 +58,8 @@ const ThreadMessages = ThreadPrimitive.Messages as React.ComponentType<
   React.ComponentProps<typeof ThreadPrimitive.Messages> & { ref?: React.Ref<FlatList> }
 >;
 
+const IOS_SMALL_NATIVE_HEADER_HEIGHT = 44;
+
 /**
  * Sparky chat: the assistant-ui + AI SDK runtime wired to the server's
  * streaming endpoint (`/api/chat/stream`).
@@ -443,6 +445,8 @@ export default function ChatScreen({ navigation }: RootStackScreenProps<'Chat'>)
   const accent = useCSSVariable('--color-accent-primary') as string;
   const { defaultColor: headerActionColor } = useHeaderActionColors();
   const queryClient = useQueryClient();
+  const keyboardVerticalOffset =
+    Platform.OS === 'ios' ? insets.top + IOS_SMALL_NATIVE_HEADER_HEIGHT : 0;
 
   const [baseUrl, setBaseUrl] = useState<string | null>(null);
   const [loadingConfig, setLoadingConfig] = useState(true);
@@ -569,7 +573,12 @@ export default function ChatScreen({ navigation }: RootStackScreenProps<'Chat'>)
           on both platforms (RN-core's needs `undefined` on Android, but this is
           not that component). Padding shrinks the message list by the keyboard
           height so the composer stays pinned just above the keyboard. */}
-      <KeyboardAvoidingView style={{ flex: 1 }} behavior="padding">
+      <KeyboardAvoidingView
+        testID="chat-keyboard-avoiding-view"
+        style={{ flex: 1 }}
+        behavior="padding"
+        keyboardVerticalOffset={keyboardVerticalOffset}
+      >
         {loadingConfig || loadingSetting || loadingHistory ? (
           <View className="flex-1 items-center justify-center">
             <ActivityIndicator color={accent} />

--- a/SparkyFitnessMobile/src/screens/ChatScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ChatScreen.tsx
@@ -59,6 +59,7 @@ const ThreadMessages = ThreadPrimitive.Messages as React.ComponentType<
 >;
 
 const IOS_SMALL_NATIVE_HEADER_HEIGHT = 44;
+const CHAT_KEYBOARD_EXTRA_SPACING = 12;
 
 /**
  * Sparky chat: the assistant-ui + AI SDK runtime wired to the server's
@@ -446,7 +447,9 @@ export default function ChatScreen({ navigation }: RootStackScreenProps<'Chat'>)
   const { defaultColor: headerActionColor } = useHeaderActionColors();
   const queryClient = useQueryClient();
   const keyboardVerticalOffset =
-    Platform.OS === 'ios' ? insets.top + IOS_SMALL_NATIVE_HEADER_HEIGHT : 0;
+    Platform.OS === 'ios'
+      ? insets.top + IOS_SMALL_NATIVE_HEADER_HEIGHT + CHAT_KEYBOARD_EXTRA_SPACING
+      : CHAT_KEYBOARD_EXTRA_SPACING;
 
   const [baseUrl, setBaseUrl] = useState<string | null>(null);
   const [loadingConfig, setLoadingConfig] = useState(true);

--- a/SparkyFitnessMobile/src/screens/ChatScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ChatScreen.tsx
@@ -1,5 +1,14 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { View, Text, ActivityIndicator, Alert, FlatList, TextInput, type TextInputProps } from 'react-native';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Platform,
+  TextInput,
+  type TextInputProps,
+} from 'react-native';
 import { fetch as expoFetch } from 'expo/fetch';
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -32,6 +41,8 @@ import { normalizeUrl } from '../services/api/apiClient';
 import { clearAllChatHistory } from '../services/api/chatApi';
 import { addLog } from '../services/LogService';
 import { useActiveAiServiceSetting, useChatHistory, chatHistoryQueryKey } from '../hooks';
+import { useHeaderActionColors } from '../hooks/useHeaderActionColors';
+import { createNativeHeaderIconButtonItem } from '../utils/nativeHeaderItems';
 import type { RootStackScreenProps } from '../types/navigation';
 
 /** Seed (initial) messages accepted by `useChatRuntime`. */
@@ -430,6 +441,7 @@ function Centered({ text }: { text: string }) {
 export default function ChatScreen({ navigation }: RootStackScreenProps<'Chat'>) {
   const insets = useSafeAreaInsets();
   const accent = useCSSVariable('--color-accent-primary') as string;
+  const { defaultColor: headerActionColor } = useHeaderActionColors();
   const queryClient = useQueryClient();
 
   const [baseUrl, setBaseUrl] = useState<string | null>(null);
@@ -467,7 +479,7 @@ export default function ChatScreen({ navigation }: RootStackScreenProps<'Chat'>)
 
   const serviceConfigId = setting?.id ?? null;
 
-  const handleClear = () => {
+  const handleClear = useCallback(() => {
     Alert.alert(
       'Clear chat',
       'This permanently deletes your Sparky chat history. This cannot be undone.',
@@ -496,14 +508,37 @@ export default function ChatScreen({ navigation }: RootStackScreenProps<'Chat'>)
         },
       ]
     );
-  };
+  }, [queryClient]);
+
+  useLayoutEffect(() => {
+    if (Platform.OS !== 'ios') return;
+
+    navigation.setOptions({
+      unstable_headerRightItems: baseUrl
+        ? () => [
+            createNativeHeaderIconButtonItem({
+              sfSymbol: 'trash',
+              identifier: 'chat-clear',
+              tintColor: headerActionColor,
+              accessibilityLabel: 'Clear chat',
+              disabled: running,
+              onPress: handleClear,
+            }),
+          ]
+        : undefined,
+    });
+  }, [baseUrl, handleClear, headerActionColor, navigation, running]);
 
   return (
     <View
       className="flex-1 bg-background"
-      style={{ paddingTop: insets.top, paddingBottom: insets.bottom }}
+      style={{
+        paddingTop: Platform.OS === 'android' ? insets.top : undefined,
+        paddingBottom: insets.bottom,
+      }}
     >
       {/* Header */}
+      {Platform.OS !== 'ios' && (
       <View className="flex-row items-center px-4 pb-2 border-b border-border-subtle">
         <Button
           variant="ghost"
@@ -528,6 +563,7 @@ export default function ChatScreen({ navigation }: RootStackScreenProps<'Chat'>)
           </Button>
         ) : null}
       </View>
+      )}
 
       {/* keyboard-controller's reworked KeyboardAvoidingView supports `padding`
           on both platforms (RN-core's needs `undefined` on Android, but this is

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -9,6 +9,7 @@ import {
   TextInput,
   Keyboard,
   Platform,
+  useWindowDimensions,
 } from 'react-native';
 import Button from '../components/ui/Button';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -49,6 +50,8 @@ import {
 import { formatServingDescription, formatServingUnit } from '../utils/foodDetails';
 import { useProviderColor } from '../utils/providerColor';
 import { interleaveTopMatches } from '../utils/topMatches';
+import { useHeaderActionColors } from '../hooks/useHeaderActionColors';
+import { createNativeHeaderIconButtonItem } from '../utils/nativeHeaderItems';
 
 type FoodSearchScreenProps = RootStackScreenProps<'FoodSearch'>;
 
@@ -108,11 +111,13 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   const pickerMode = route.params?.pickerMode ?? 'log-entry';
   const isMealBuilderMode = pickerMode === 'meal-builder';
   const insets = useSafeAreaInsets();
+  const { width: windowWidth } = useWindowDimensions();
   const [accentColor, textMuted, textSecondary] = useCSSVariable([
     '--color-accent-primary',
     '--color-text-muted',
     '--color-text-secondary',
   ]) as [string, string, string];
+  const { defaultColor: headerActionColor, headerTintColor } = useHeaderActionColors();
   const iconSuccess = String(useCSSVariable('--color-icon-success'));
 
   const { isConnected } = useServerConnection();
@@ -341,11 +346,54 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
       openCreateFood();
       return;
     }
+    if (Platform.OS === 'ios') {
+      setMenuAnchor({
+        x: windowWidth - 48,
+        y: insets.top,
+        width: 36,
+        height: 36,
+      });
+      setMenuVisible(true);
+      return;
+    }
     addButtonRef.current?.measureInWindow((x, y, width, height) => {
       setMenuAnchor({ x, y, width, height });
       setMenuVisible(true);
     });
-  }, [isMealBuilderMode, openCreateFood]);
+  }, [insets.top, isMealBuilderMode, openCreateFood, windowWidth]);
+
+  useLayoutEffect(() => {
+    navigation.setOptions({ headerTintColor });
+
+    if (Platform.OS !== 'ios') return;
+
+    navigation.setOptions({
+      unstable_headerLeftItems: () => [
+        createNativeHeaderIconButtonItem({
+          sfSymbol: 'xmark',
+          identifier: 'food-search-close',
+          tintColor: headerActionColor,
+          accessibilityLabel: 'Close',
+          onPress: () => navigation.goBack(),
+        }),
+      ],
+      unstable_headerRightItems: () => [
+        createNativeHeaderIconButtonItem({
+          sfSymbol: 'plus',
+          identifier: 'food-search-add',
+          tintColor: headerActionColor,
+          accessibilityLabel: isMealBuilderMode ? 'Add Food' : 'Add Food or Meal',
+          onPress: handleAddPress,
+        }),
+      ],
+    });
+  }, [
+    handleAddPress,
+    headerActionColor,
+    headerTintColor,
+    isMealBuilderMode,
+    navigation,
+  ]);
 
   const handleExternalFoodTap = useCallback(
     async (item: ExternalFoodItem, explicitProviderId?: string) => {
@@ -1028,15 +1076,17 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
 
   const renderHeaderBar = () => (
     <View className="flex-row items-center px-4 py-2 gap-3">
-      <Button
-        variant="ghost"
-        onPress={() => navigation.goBack()}
-        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-        className="p-0"
-        accessibilityLabel="Close"
-      >
-        <Icon name="close" size={22} color={accentColor} />
-      </Button>
+      {Platform.OS !== 'ios' && (
+        <Button
+          variant="ghost"
+          onPress={() => navigation.goBack()}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          className="p-0"
+          accessibilityLabel="Close"
+        >
+          <Icon name="close" size={22} color={accentColor} />
+        </Button>
+      )}
 
       <View
         onLayout={(e) => {
@@ -1099,17 +1149,19 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
         )}
       </View>
 
-      <View ref={addButtonRef} collapsable={false}>
-        <Button
-          variant="ghost"
-          onPress={handleAddPress}
-          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
-          className="p-0"
-          accessibilityLabel={isMealBuilderMode ? 'Add Food' : 'Add Food or Meal'}
-        >
-          <Icon name="add" size={26} color={accentColor} />
-        </Button>
-      </View>
+      {Platform.OS !== 'ios' && (
+        <View ref={addButtonRef} collapsable={false}>
+          <Button
+            variant="ghost"
+            onPress={handleAddPress}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            className="p-0"
+            accessibilityLabel={isMealBuilderMode ? 'Add Food' : 'Add Food or Meal'}
+          >
+            <Icon name="add" size={26} color={accentColor} />
+          </Button>
+        </View>
+      )}
     </View>
   );
 

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -117,7 +117,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     '--color-text-muted',
     '--color-text-secondary',
   ]) as [string, string, string];
-  const { defaultColor: headerActionColor, headerTintColor } = useHeaderActionColors();
+  const { defaultColor: headerActionColor } = useHeaderActionColors();
   const iconSuccess = String(useCSSVariable('--color-icon-success'));
 
   const { isConnected } = useServerConnection();
@@ -363,8 +363,6 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   }, [insets.top, isMealBuilderMode, openCreateFood, windowWidth]);
 
   useLayoutEffect(() => {
-    navigation.setOptions({ headerTintColor });
-
     if (Platform.OS !== 'ios') return;
 
     navigation.setOptions({
@@ -390,7 +388,6 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   }, [
     handleAddPress,
     headerActionColor,
-    headerTintColor,
     isMealBuilderMode,
     navigation,
   ]);

--- a/SparkyFitnessMobile/src/screens/PresetSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/PresetSearchScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useLayoutEffect, useState } from 'react';
 import { Platform, View, Text, TouchableOpacity, TextInput, FlatList } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
@@ -8,6 +8,7 @@ import Icon from '../components/Icon';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { useWorkoutPresets, useWorkoutPresetSearch, useRefetchOnFocus } from '../hooks';
 import { useHeaderActionColors } from '../hooks/useHeaderActionColors';
+import { createNativeHeaderTextButtonItem } from '../utils/nativeHeaderItems';
 import type { WorkoutPreset } from '../types/workoutPresets';
 import type { RootStackScreenProps } from '../types/navigation';
 
@@ -23,7 +24,7 @@ const PresetSearchScreen: React.FC<PresetSearchScreenProps> = ({ navigation, rou
     '--color-text-secondary',
     '--color-border-subtle',
   ]) as [string, string, string, string];
-  const { backColor } = useHeaderActionColors();
+  const { backColor, headerTintColor } = useHeaderActionColors();
 
   const [searchText, setSearchText] = useState('');
   const [isSearchFocused, setIsSearchFocused] = useState(false);
@@ -32,6 +33,26 @@ const PresetSearchScreen: React.FC<PresetSearchScreenProps> = ({ navigation, rou
   const { searchResults, isSearching, isSearchActive, isSearchError } = useWorkoutPresetSearch(searchText);
 
   useRefetchOnFocus(refetch, true);
+
+  const handleCancel = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  useLayoutEffect(() => {
+    if (Platform.OS !== 'ios') return;
+
+    navigation.setOptions({
+      headerBackVisible: false,
+      unstable_headerLeftItems: () => [
+        createNativeHeaderTextButtonItem({
+          label: 'Cancel',
+          identifier: 'preset-search-cancel',
+          tintColor: headerTintColor,
+          onPress: handleCancel,
+        }),
+      ],
+    });
+  }, [handleCancel, headerTintColor, navigation]);
 
   const handleSelectPreset = useCallback((preset: WorkoutPreset) => {
     navigation.navigate('WorkoutAdd', { preset, date, popCount: 2 });
@@ -108,7 +129,7 @@ const PresetSearchScreen: React.FC<PresetSearchScreenProps> = ({ navigation, rou
       <View className="flex-row items-center justify-between px-4 py-3 border-b border-border-subtle">
         <Button
           variant="ghost"
-          onPress={() => navigation.goBack()}
+          onPress={handleCancel}
           hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           className="z-10 p-0"
         >

--- a/SparkyFitnessMobile/src/screens/WorkoutAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutAddScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useCallback, useEffect, useState } from 'react';
+import React, { useRef, useCallback, useEffect, useLayoutEffect, useState } from 'react';
 import {
   View,
   Text,
@@ -23,6 +23,7 @@ import { useWorkoutForm, getWorkoutDraftSubmission } from '../hooks/useWorkoutFo
 import { useSelectedExercise } from '../hooks/useSelectedExercise';
 import { useExerciseSetEditing } from '../hooks/useExerciseSetEditing';
 import { formatDateLabel } from '../utils/dateUtils';
+import { createNativeHeaderTextButtonItem } from '../utils/nativeHeaderItems';
 import { useCreateWorkout, useUpdateWorkout } from '../hooks/useExerciseMutations';
 import { usePreferences } from '../hooks/usePreferences';
 import { useExerciseImageSource } from '../hooks/useExerciseImageSource';
@@ -56,7 +57,7 @@ const WorkoutAddScreen: React.FC<Props> = ({ navigation, route }) => {
     '--color-text-primary',
     '--color-border-subtle',
   ]) as [string, string, string, string];
-  const { backColor } = useHeaderActionColors();
+  const { backColor, headerTintColor } = useHeaderActionColors();
 
   const [isNameEditing, setIsNameEditing] = useState(false);
 
@@ -167,6 +168,24 @@ const WorkoutAddScreen: React.FC<Props> = ({ navigation, route }) => {
     }
     navigation.goBack();
   }, [discardDraft, isEditMode, hasDraftData, navigation]);
+
+  useLayoutEffect(() => {
+    if (Platform.OS !== 'ios') return;
+
+    navigation.setOptions({
+      headerBackVisible: false,
+      unstable_headerLeftItems: () => [
+        createNativeHeaderTextButtonItem({
+          label: 'Cancel',
+          identifier: 'workout-add-cancel',
+          tintColor: headerTintColor,
+          onPress: () => {
+            void handleCancel();
+          },
+        }),
+      ],
+    });
+  }, [handleCancel, headerTintColor, navigation]);
 
   const handleFinish = useCallback(() => {
     if (!submission.canSave) {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

This includes a few fixes for the native navigation so the new tests from #1675 don’t fail.

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

## Summary

Implements native iOS header behavior for the affected screens covered by the new contract.

Changes include:

- Ask Sparky uses the native stack header on iOS
- Ask Sparky mirrors the clear-chat action into a native header button
- Add Food search uses the native stack header on iOS
- Add Food search mirrors close and add actions into native header buttons
- screen-owned React headers are hidden on iOS where native header chrome is used
- Add Workout, Add Activity, and Preset Search use native iOS `Cancel` header items instead of relying on an inherited back button

## Notes

This PR is intended to be stacked on top of the native-header contract test PR.

## Validation

- `pnpm exec jest --watchman=false --runInBand --coverage=false __tests__/navigation/nativeHeaderContract.test.ts __tests__/screens/ChatScreen.test.tsx __tests__/screens/FoodSearchScreen.test.tsx`
  - contract fails only for the remaining unrelated back-title issues
  - Chat/FoodSearch screen tests pass
- `pnpm run typecheck` passes
- ESLint passes for the touched files

**How did you implement the solution?**

explained above

Linked Issue: #1675 

## How to Test

Build iOS app, enable liquid glas in Settings and see the fixes

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Notes for Reviewers
without this the Tests in #1675 will fail.