### PR TITLE
feat(onboarding): Persist skipping onboarding

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2574,5 +2574,8 @@
     "noDataDesc": "Start tracking your sleep to unlock advanced insights.",
     "baselineCalculated": "Sleep need baseline calculated successfully",
     "baselineError": "Failed to calculate sleep need baseline"
+  },
+  "onboarding": {
+    "completeSetup": "Complete Setup"
   }
 }

--- a/SparkyFitnessFrontend/src/api/Onboarding/onboarding.ts
+++ b/SparkyFitnessFrontend/src/api/Onboarding/onboarding.ts
@@ -24,17 +24,34 @@ export const submitOnboardingData = async (data: OnboardingData) => {
 
 /**
  * Fetches the user's onboarding completion status from the backend.
- * @returns {Promise<{ onboardingComplete: boolean }>}
+ * @returns {Promise<{ onboardingComplete: boolean; onboardingSkipped: boolean }>}
  */
 export const getOnboardingStatus = async (): Promise<{
   onboardingComplete: boolean;
+  onboardingSkipped: boolean;
 }> => {
   try {
     const response = await apiCall('/onboarding/status');
     return response;
   } catch (error) {
     console.error('Error fetching onboarding status:', error);
-    return { onboardingComplete: true };
+    return { onboardingComplete: true, onboardingSkipped: false };
+  }
+};
+
+/**
+ * Marks the onboarding wizard as skipped on the backend, so it persists across reloads.
+ * @returns {Promise<any>} The response from the server.
+ */
+export const skipOnboarding = async () => {
+  try {
+    const response = await apiCall('/onboarding/skip', {
+      method: 'POST',
+    });
+    return response;
+  } catch (error) {
+    console.error('Error skipping onboarding:', error);
+    throw error;
   }
 };
 

--- a/SparkyFitnessFrontend/src/components/Onboarding/OnBoardingForm.tsx
+++ b/SparkyFitnessFrontend/src/components/Onboarding/OnBoardingForm.tsx
@@ -9,6 +9,7 @@ import { Profile } from '@/types/settings';
 import { OnboardingData, Sex } from '@/types/onboarding';
 import { RecentCheckInMeasurementsResponse } from '@workspace/shared';
 import { useExternalProvidersQuery } from '@/hooks/Settings/useExternalProviderSettings';
+import { useSkipOnboarding } from '@/hooks/Onboarding/useOnboarding';
 
 interface OnBoardingProps {
   onOnboardingComplete: () => void;
@@ -46,6 +47,8 @@ export const OnBoardingForm = ({
     measurementUnit: preferredMeasurementUnit,
     dateFormat,
   } = usePreferences();
+
+  const skipOnboardingMutation = useSkipOnboarding();
 
   // State management
   const [step, setStep] = useState(1);
@@ -192,9 +195,14 @@ export const OnBoardingForm = ({
 
         {step <= lastInputStep && (
           <Button
-            onClick={onOnboardingComplete}
+            onClick={() => {
+              skipOnboardingMutation.mutate(undefined, {
+                onSettled: onOnboardingComplete,
+              });
+            }}
             variant="ghost"
             className="text-muted-foreground hover:text-foreground font-semibold ml-2 w-16"
+            disabled={skipOnboardingMutation.isPending}
           >
             Skip
           </Button>

--- a/SparkyFitnessFrontend/src/hooks/Onboarding/useOnboarding.ts
+++ b/SparkyFitnessFrontend/src/hooks/Onboarding/useOnboarding.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   getOnboardingStatus,
   resetOnboardingStatus,
+  skipOnboarding,
   submitOnboardingData,
 } from '@/api/Onboarding/onboarding';
 import { onboardingKeys } from '@/api/keys/onboarding';
@@ -60,6 +61,26 @@ export const useResetOnboarding = () => {
       successMessage: t(
         'goals.goalsSettings.resetOnboardingSuccess',
         'Onboarding status has been reset.'
+      ),
+    },
+  });
+};
+
+export const useSkipOnboarding = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+
+  return useMutation({
+    mutationFn: skipOnboarding,
+    onSuccess: () => {
+      return queryClient.invalidateQueries({
+        queryKey: onboardingKeys.status(),
+      });
+    },
+    meta: {
+      errorMessage: t(
+        'onboarding.skipFailed',
+        'Could not skip onboarding. Please try again.'
       ),
     },
   });

--- a/SparkyFitnessFrontend/src/layouts/MainLayout.tsx
+++ b/SparkyFitnessFrontend/src/layouts/MainLayout.tsx
@@ -53,11 +53,13 @@ interface AddCompItem {
 interface MainLayoutProps {
   onShowAboutDialog: () => void;
   onShowNewReleaseDialog: () => void;
+  onStartOnboarding?: () => void;
 }
 
 const MainLayout: React.FC<MainLayoutProps> = ({
   onShowAboutDialog,
   onShowNewReleaseDialog,
+  onStartOnboarding,
 }) => {
   const { t } = useTranslation();
   const { user, signOut } = useAuth();
@@ -418,6 +420,20 @@ const MainLayout: React.FC<MainLayoutProps> = ({
               Welcome {activeUserName}
             </span>
 
+            {onStartOnboarding && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onStartOnboarding}
+                className="flex items-center gap-2"
+                title="Complete your setup"
+              >
+                <span className="hidden sm:inline">
+                  {t('onboarding.completeSetup', 'Complete Setup')}
+                </span>
+                <span className="sm:hidden">Setup</span>
+              </Button>
+            )}
             <GlobalNotificationIcon />
             <GlobalSyncButton />
             <ThemeToggle />

--- a/SparkyFitnessFrontend/src/pages/Index.tsx
+++ b/SparkyFitnessFrontend/src/pages/Index.tsx
@@ -25,11 +25,18 @@ const Index: React.FC<IndexProps> = ({
   const { data, isLoading: queryLoading } = useOnboardingStatus(
     !authLoading && !!user
   );
-  const [hasSkipped, setHasSkipped] = useState(false);
+  // Allows the user to manually re-open the wizard from the main layout
+  const [showOnboardingManually, setShowOnboardingManually] = useState(false);
 
   const isLoading = authLoading || (!!user && queryLoading);
-  const needsOnboarding =
-    !hasSkipped && user && data?.onboardingComplete === false;
+
+  // Show wizard automatically when onboarding is not complete and the user hasn't skipped it
+  const autoShowWizard =
+    !!user && data?.onboardingComplete === false && !data?.onboardingSkipped;
+
+  // Also show if the user explicitly re-opened it via "Complete Setup"
+  const showWizard = autoShowWizard || showOnboardingManually;
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-black flex items-center justify-center">
@@ -38,15 +45,24 @@ const Index: React.FC<IndexProps> = ({
     );
   }
 
-  if (needsOnboarding) {
-    return <OnBoarding onOnboardingComplete={() => setHasSkipped(true)} />;
+  if (showWizard) {
+    return (
+      <OnBoarding
+        onOnboardingComplete={() => setShowOnboardingManually(false)}
+      />
+    );
   }
 
-  // Render MainLayout if onboarding is complete
+  // Render MainLayout; pass a callback to re-open onboarding when not yet complete
+  const onboardingIncomplete = !!user && data?.onboardingComplete === false;
+
   return (
     <MainLayout
       onShowAboutDialog={onShowAboutDialog}
       onShowNewReleaseDialog={onShowNewReleaseDialog}
+      onStartOnboarding={
+        onboardingIncomplete ? () => setShowOnboardingManually(true) : undefined
+      }
     />
   );
 };

--- a/SparkyFitnessFrontend/src/tests/hooks/useOnboarding.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useOnboarding.test.tsx
@@ -1,0 +1,196 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import {
+  useOnboardingStatus,
+  useSkipOnboarding,
+  useSubmitOnboarding,
+  useResetOnboarding,
+} from '@/hooks/Onboarding/useOnboarding';
+import * as onboardingApi from '@/api/Onboarding/onboarding';
+import type { OnboardingData } from '@/types/onboarding';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+jest.mock('@/api/Onboarding/onboarding');
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback: string) => fallback }),
+}));
+
+const mockedGetOnboardingStatus =
+  onboardingApi.getOnboardingStatus as jest.MockedFunction<
+    typeof onboardingApi.getOnboardingStatus
+  >;
+const mockedSkipOnboarding =
+  onboardingApi.skipOnboarding as jest.MockedFunction<
+    typeof onboardingApi.skipOnboarding
+  >;
+const mockedSubmitOnboardingData =
+  onboardingApi.submitOnboardingData as jest.MockedFunction<
+    typeof onboardingApi.submitOnboardingData
+  >;
+const mockedResetOnboardingStatus =
+  onboardingApi.resetOnboardingStatus as jest.MockedFunction<
+    typeof onboardingApi.resetOnboardingStatus
+  >;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { Wrapper, queryClient };
+};
+
+describe('useOnboardingStatus', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns onboardingComplete and onboardingSkipped when both are false', async () => {
+    mockedGetOnboardingStatus.mockResolvedValue({
+      onboardingComplete: false,
+      onboardingSkipped: false,
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useOnboardingStatus(true), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({
+      onboardingComplete: false,
+      onboardingSkipped: false,
+    });
+  });
+
+  it('returns onboardingSkipped=true after user has skipped', async () => {
+    mockedGetOnboardingStatus.mockResolvedValue({
+      onboardingComplete: false,
+      onboardingSkipped: true,
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useOnboardingStatus(true), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.onboardingSkipped).toBe(true);
+    expect(result.current.data?.onboardingComplete).toBe(false);
+  });
+
+  it('does not fetch when disabled', () => {
+    const { Wrapper } = createWrapper();
+    renderHook(() => useOnboardingStatus(false), { wrapper: Wrapper });
+
+    expect(mockedGetOnboardingStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('useSkipOnboarding', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('calls skipOnboarding API and resolves', async () => {
+    mockedSkipOnboarding.mockResolvedValue({
+      message: 'Onboarding skipped successfully.',
+    });
+    // Re-prime the status query so invalidation has something to re-fetch
+    mockedGetOnboardingStatus.mockResolvedValue({
+      onboardingComplete: false,
+      onboardingSkipped: true,
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSkipOnboarding(), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      result.current.mutate(undefined);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedSkipOnboarding).toHaveBeenCalledTimes(1);
+  });
+
+  it('transitions to error state when API call fails', async () => {
+    mockedSkipOnboarding.mockRejectedValue(new Error('Network error'));
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSkipOnboarding(), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      result.current.mutate(undefined);
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeTruthy();
+  });
+});
+
+describe('useSubmitOnboarding', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('calls submitOnboardingData and resolves', async () => {
+    mockedSubmitOnboardingData.mockResolvedValue({
+      message: 'Onboarding completed successfully.',
+    });
+    mockedGetOnboardingStatus.mockResolvedValue({
+      onboardingComplete: true,
+      onboardingSkipped: false,
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useSubmitOnboarding(), {
+      wrapper: Wrapper,
+    });
+
+    const payload: OnboardingData = {
+      sex: 'male' as const,
+      primaryGoal: 'lose_weight',
+      currentWeight: 80,
+      height: 180,
+      birthDate: '1990-01-01',
+      bodyFatRange: '',
+      targetWeight: 75,
+      mealsPerDay: 3,
+      activityLevel: 'moderate',
+      addBurnedCalories: false,
+    };
+
+    await act(async () => {
+      result.current.mutate(payload);
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedSubmitOnboardingData).toHaveBeenCalledWith(payload);
+  });
+});
+
+describe('useResetOnboarding', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('calls resetOnboardingStatus and resolves', async () => {
+    mockedResetOnboardingStatus.mockResolvedValue({ message: 'Reset.' });
+    mockedGetOnboardingStatus.mockResolvedValue({
+      onboardingComplete: false,
+      onboardingSkipped: false,
+    });
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useResetOnboarding(), {
+      wrapper: Wrapper,
+    });
+
+    await act(async () => {
+      result.current.mutate();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockedResetOnboardingStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/services/onboardingApi.test.ts
+++ b/SparkyFitnessFrontend/src/tests/services/onboardingApi.test.ts
@@ -1,0 +1,134 @@
+import {
+  getOnboardingStatus,
+  skipOnboarding,
+  submitOnboardingData,
+  resetOnboardingStatus,
+} from '@/api/Onboarding/onboarding';
+import * as apiModule from '@/api/api';
+import type { OnboardingData } from '@/types/onboarding';
+
+jest.mock('@/api/api');
+
+const mockedApiCall = apiModule.apiCall as jest.MockedFunction<
+  typeof apiModule.apiCall
+>;
+
+describe('onboarding API', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('getOnboardingStatus', () => {
+    it('returns onboardingComplete and onboardingSkipped from the API', async () => {
+      mockedApiCall.mockResolvedValue({
+        onboardingComplete: false,
+        onboardingSkipped: false,
+      });
+
+      const result = await getOnboardingStatus();
+
+      expect(mockedApiCall).toHaveBeenCalledWith('/onboarding/status');
+      expect(result).toEqual({
+        onboardingComplete: false,
+        onboardingSkipped: false,
+      });
+    });
+
+    it('returns onboardingSkipped=true when user has skipped', async () => {
+      mockedApiCall.mockResolvedValue({
+        onboardingComplete: false,
+        onboardingSkipped: true,
+      });
+
+      const result = await getOnboardingStatus();
+
+      expect(result).toEqual({
+        onboardingComplete: false,
+        onboardingSkipped: true,
+      });
+    });
+
+    it('falls back to { onboardingComplete: true, onboardingSkipped: false } on error', async () => {
+      mockedApiCall.mockRejectedValue(new Error('Network error'));
+
+      const result = await getOnboardingStatus();
+
+      expect(result).toEqual({
+        onboardingComplete: true,
+        onboardingSkipped: false,
+      });
+    });
+  });
+
+  describe('skipOnboarding', () => {
+    it('calls POST /onboarding/skip and returns the response', async () => {
+      mockedApiCall.mockResolvedValue({
+        message: 'Onboarding skipped successfully.',
+      });
+
+      const result = await skipOnboarding();
+
+      expect(mockedApiCall).toHaveBeenCalledWith('/onboarding/skip', {
+        method: 'POST',
+      });
+      expect(result).toEqual({ message: 'Onboarding skipped successfully.' });
+    });
+
+    it('propagates errors to the caller', async () => {
+      mockedApiCall.mockRejectedValue(new Error('Server error'));
+
+      await expect(skipOnboarding()).rejects.toThrow('Server error');
+    });
+  });
+
+  describe('submitOnboardingData', () => {
+    it('calls POST /onboarding with JSON body', async () => {
+      mockedApiCall.mockResolvedValue({
+        message: 'Onboarding completed successfully.',
+      });
+
+      const payload: OnboardingData = {
+        sex: 'female' as const,
+        primaryGoal: 'maintain_weight',
+        currentWeight: 65,
+        height: 165,
+        birthDate: '1995-06-15',
+        bodyFatRange: '',
+        targetWeight: 65,
+        mealsPerDay: 3,
+        activityLevel: 'light',
+        addBurnedCalories: false,
+      };
+
+      const result = await submitOnboardingData(payload);
+
+      expect(mockedApiCall).toHaveBeenCalledWith('/onboarding', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      expect(result).toEqual({ message: 'Onboarding completed successfully.' });
+    });
+  });
+
+  describe('resetOnboardingStatus', () => {
+    it('calls POST /onboarding/reset and returns the response', async () => {
+      mockedApiCall.mockResolvedValue({
+        message: 'Onboarding status reset successfully.',
+      });
+
+      const result = await resetOnboardingStatus();
+
+      expect(mockedApiCall).toHaveBeenCalledWith('/onboarding/reset', {
+        method: 'POST',
+      });
+      expect(result).toEqual({
+        message: 'Onboarding status reset successfully.',
+      });
+    });
+
+    it('propagates errors to the caller', async () => {
+      mockedApiCall.mockRejectedValue(new Error('Server error'));
+
+      await expect(resetOnboardingStatus()).rejects.toThrow('Server error');
+    });
+  });
+});

--- a/SparkyFitnessServer/config/swagger.ts
+++ b/SparkyFitnessServer/config/swagger.ts
@@ -1127,6 +1127,7 @@ const options = {
           type: 'object',
           properties: {
             onboarding_complete: { type: 'boolean' },
+            onboarding_skipped: { type: 'boolean' },
           },
         },
         OidcProvider: {

--- a/SparkyFitnessServer/db/migrations/20260630000000_add_onboarding_skipped.sql
+++ b/SparkyFitnessServer/db/migrations/20260630000000_add_onboarding_skipped.sql
@@ -1,0 +1,5 @@
+-- Migration: add onboarding_skipped column to onboarding_status
+-- This persists the "skip" action so the wizard does not reappear after a page reload.
+
+ALTER TABLE public.onboarding_status
+  ADD COLUMN IF NOT EXISTS onboarding_skipped BOOLEAN NOT NULL DEFAULT FALSE;

--- a/SparkyFitnessServer/models/onboardingRepository.ts
+++ b/SparkyFitnessServer/models/onboardingRepository.ts
@@ -1,4 +1,5 @@
 import { getClient } from '../db/poolManager.js';
+import { log } from '../config/logging.js';
 /**
  * Saves onboarding data and updates the user's status to complete.
  * This function uses a transaction to ensure atomicity.
@@ -49,10 +50,10 @@ async function saveOnboardingData(userId: any, data: any) {
       activityLevel,
       addBurnedCalories,
     ]);
-    // Query 2: Mark onboarding as complete in the status table.
+    // Query 2: Mark onboarding as complete and clear any skipped flag.
     const statusQuery = `
       UPDATE onboarding_status
-      SET onboarding_complete = TRUE, updated_at = NOW()
+      SET onboarding_complete = TRUE, onboarding_skipped = FALSE, updated_at = NOW()
       WHERE user_id = $1;
     `;
     await client.query(statusQuery, [userId]);
@@ -75,7 +76,7 @@ async function getOnboardingStatus(userId: any) {
   const client = await getClient(userId);
   try {
     const result = await client.query(
-      'SELECT onboarding_complete FROM onboarding_status WHERE user_id = $1',
+      'SELECT onboarding_complete, onboarding_skipped FROM onboarding_status WHERE user_id = $1',
       [userId]
     );
     return result.rows[0] || null;
@@ -108,11 +109,35 @@ async function resetOnboardingStatus(userId: any) {
     client.release();
   }
 }
+/**
+ * Marks the onboarding wizard as skipped for a given user.
+ * @param {string} userId - The UUID of the user.
+ * @returns {Promise<void>}
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function setOnboardingSkipped(userId: any) {
+  const client = await getClient(userId);
+  try {
+    const query = `
+      UPDATE onboarding_status
+      SET onboarding_skipped = TRUE, updated_at = NOW()
+      WHERE user_id = $1;
+    `;
+    await client.query(query, [userId]);
+  } catch (error) {
+    log('error', 'Error in setOnboardingSkipped repository:', error);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
 export { saveOnboardingData };
 export { getOnboardingStatus };
 export { resetOnboardingStatus };
+export { setOnboardingSkipped };
 export default {
   saveOnboardingData,
   getOnboardingStatus,
   resetOnboardingStatus,
+  setOnboardingSkipped,
 };

--- a/SparkyFitnessServer/routes/onboardingRoutes.ts
+++ b/SparkyFitnessServer/routes/onboardingRoutes.ts
@@ -93,8 +93,32 @@ router.post('/', authenticate, async (req, res, next) => {
 router.get('/status', authenticate, async (req, res, next) => {
   try {
     const userId = req.userId;
-    const isComplete = await onboardingService.checkOnboardingStatus(userId);
-    res.status(200).json({ onboardingComplete: isComplete });
+    const status = await onboardingService.checkOnboardingStatus(userId);
+    res.status(200).json({
+      onboardingComplete: status.onboarding_complete,
+      onboardingSkipped: status.onboarding_skipped,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+/**
+ * @swagger
+ * /onboarding/skip:
+ *   post:
+ *     summary: Mark onboarding as skipped for the user
+ *     tags: [Goals & Personalization]
+ *     security:
+ *       - cookieAuth: []
+ *     responses:
+ *       200:
+ *         description: Onboarding skipped successfully.
+ */
+router.post('/skip', authenticate, async (req, res, next) => {
+  try {
+    const userId = req.userId;
+    await onboardingService.skipOnboarding(userId);
+    res.status(200).json({ message: 'Onboarding skipped successfully.' });
   } catch (error) {
     next(error);
   }

--- a/SparkyFitnessServer/services/onboardingService.ts
+++ b/SparkyFitnessServer/services/onboardingService.ts
@@ -26,12 +26,15 @@ async function checkOnboardingStatus(userId: any) {
   try {
     const statusRecord = await onboardingRepository.getOnboardingStatus(userId);
     if (!statusRecord) {
-      return false;
+      return { onboarding_complete: false, onboarding_skipped: false };
     }
-    return statusRecord.onboarding_complete;
+    return {
+      onboarding_complete: statusRecord.onboarding_complete,
+      onboarding_skipped: statusRecord.onboarding_skipped,
+    };
   } catch (error) {
     log('error', `Error checking onboarding status for user ${userId}:`, error);
-    return true;
+    return { onboarding_complete: true, onboarding_skipped: false };
   }
 }
 /**
@@ -53,11 +56,28 @@ async function resetOnboardingStatus(userId: any) {
     throw new Error('Failed to reset onboarding status.', { cause: error });
   }
 }
+/**
+ * Marks the onboarding wizard as skipped for a given user.
+ * @param {string} userId - The UUID of the user.
+ * @returns {Promise<void>}
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function skipOnboarding(userId: any) {
+  try {
+    await onboardingRepository.setOnboardingSkipped(userId);
+    log('info', `Successfully set onboarding skipped for user: ${userId}`);
+  } catch (error) {
+    log('error', `Error setting onboarding skipped for user ${userId}:`, error);
+    throw new Error('Failed to skip onboarding.', { cause: error });
+  }
+}
 export { processOnboardingData };
 export { checkOnboardingStatus };
 export { resetOnboardingStatus };
+export { skipOnboarding };
 export default {
   processOnboardingData,
   checkOnboardingStatus,
   resetOnboardingStatus,
+  skipOnboarding,
 };

--- a/SparkyFitnessServer/tests/onboardingRoutes.test.ts
+++ b/SparkyFitnessServer/tests/onboardingRoutes.test.ts
@@ -1,0 +1,190 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'
+import request from 'supertest';
+import express from 'express';
+import onboardingRoutes from '../routes/onboardingRoutes.js';
+import onboardingService from '../services/onboardingService.js';
+import errorHandler from '../middleware/errorHandler.js';
+
+vi.mock('../services/onboardingService.js');
+vi.mock('../middleware/authMiddleware', () => ({
+  authenticate: vi.fn((req, res, next) => {
+    req.userId = 'testUserId';
+    next();
+  }),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/onboarding', onboardingRoutes);
+app.use(errorHandler);
+
+describe('Onboarding Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --- POST /onboarding ---
+  describe('POST /onboarding', () => {
+    const validPayload = {
+      sex: 'male',
+      primaryGoal: 'lose_weight',
+      currentWeight: 80,
+      height: 180,
+      birthDate: '1990-01-01',
+      activityLevel: 'moderate',
+      targetWeight: 75,
+    };
+
+    it('should complete onboarding and return 201', async () => {
+      // @ts-expect-error TS(2339)
+      onboardingService.processOnboardingData.mockResolvedValue(undefined);
+
+      const res = await request(app).post('/onboarding').send(validPayload);
+
+      expect(res.statusCode).toEqual(201);
+      expect(res.body).toEqual({
+        message: 'Onboarding completed successfully.',
+      });
+      expect(onboardingService.processOnboardingData).toHaveBeenCalledWith(
+        'testUserId',
+        validPayload
+      );
+    });
+
+    it('should return 400 when required fields are missing', async () => {
+      const res = await request(app)
+        .post('/onboarding')
+        .send({ sex: 'female' }); // missing most required fields
+
+      expect(res.statusCode).toEqual(400);
+      expect(res.body).toHaveProperty('error');
+    });
+
+    it('should return 500 when service throws', async () => {
+      // @ts-expect-error TS(2339)
+      onboardingService.processOnboardingData.mockRejectedValue(
+        new Error('DB failure')
+      );
+
+      const res = await request(app).post('/onboarding').send(validPayload);
+
+      expect(res.statusCode).toEqual(500);
+    });
+  });
+
+  // --- GET /onboarding/status ---
+  describe('GET /onboarding/status', () => {
+    it('should return onboardingComplete and onboardingSkipped when not complete', async () => {
+      // @ts-expect-error TS(2339)
+      onboardingService.checkOnboardingStatus.mockResolvedValue({
+        onboarding_complete: false,
+        onboarding_skipped: false,
+      });
+
+      const res = await request(app).get('/onboarding/status');
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toEqual({
+        onboardingComplete: false,
+        onboardingSkipped: false,
+      });
+    });
+
+    it('should return onboardingComplete=true when complete', async () => {
+      // @ts-expect-error TS(2339)
+      onboardingService.checkOnboardingStatus.mockResolvedValue({
+        onboarding_complete: true,
+        onboarding_skipped: false,
+      });
+
+      const res = await request(app).get('/onboarding/status');
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toEqual({
+        onboardingComplete: true,
+        onboardingSkipped: false,
+      });
+    });
+
+    it('should return onboardingSkipped=true when user has skipped', async () => {
+      // @ts-expect-error TS(2339)
+      onboardingService.checkOnboardingStatus.mockResolvedValue({
+        onboarding_complete: false,
+        onboarding_skipped: true,
+      });
+
+      const res = await request(app).get('/onboarding/status');
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toEqual({
+        onboardingComplete: false,
+        onboardingSkipped: true,
+      });
+    });
+
+    it('should return 500 when service throws', async () => {
+      // @ts-expect-error TS(2339)
+      onboardingService.checkOnboardingStatus.mockRejectedValue(
+        new Error('DB failure')
+      );
+
+      const res = await request(app).get('/onboarding/status');
+
+      expect(res.statusCode).toEqual(500);
+    });
+  });
+
+  // --- POST /onboarding/skip ---
+  describe('POST /onboarding/skip', () => {
+    it('should skip onboarding and return 200', async () => {
+      // @ts-expect-error TS(2339)
+      onboardingService.skipOnboarding.mockResolvedValue(undefined);
+
+      const res = await request(app).post('/onboarding/skip');
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toEqual({ message: 'Onboarding skipped successfully.' });
+      expect(onboardingService.skipOnboarding).toHaveBeenCalledWith(
+        'testUserId'
+      );
+    });
+
+    it('should return 500 when service throws', async () => {
+      // @ts-expect-error TS(2339)
+      onboardingService.skipOnboarding.mockRejectedValue(
+        new Error('DB failure')
+      );
+
+      const res = await request(app).post('/onboarding/skip');
+
+      expect(res.statusCode).toEqual(500);
+    });
+  });
+
+  // --- POST /onboarding/reset ---
+  describe('POST /onboarding/reset', () => {
+    it('should reset onboarding and return 200', async () => {
+      // @ts-expect-error TS(2339)
+      onboardingService.resetOnboardingStatus.mockResolvedValue(undefined);
+
+      const res = await request(app).post('/onboarding/reset');
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toEqual({
+        message: 'Onboarding status reset successfully.',
+      });
+    });
+
+    it('should return 500 when service throws', async () => {
+      // @ts-expect-error TS(2339)
+      onboardingService.resetOnboardingStatus.mockRejectedValue(
+        new Error('DB failure')
+      );
+
+      const res = await request(app).post('/onboarding/reset');
+
+      expect(res.statusCode).toEqual(500);
+    });
+  });
+});

--- a/db_schema_backup.sql
+++ b/db_schema_backup.sql
@@ -2329,6 +2329,7 @@ CREATE TABLE public.onboarding_status (
     user_id uuid NOT NULL,
     full_name text,
     onboarding_complete boolean DEFAULT false NOT NULL,
+    onboarding_skipped boolean DEFAULT false NOT NULL,
     created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
     updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
 );

--- a/shared/src/schemas/database/OnboardingStatus.zod.ts
+++ b/shared/src/schemas/database/OnboardingStatus.zod.ts
@@ -14,6 +14,7 @@ export const onboardingStatusSchema = z.object({
   user_id: userIdSchema,
   full_name: z.string().nullable(),
   onboarding_complete: z.boolean(),
+  onboarding_skipped: z.boolean(),
   created_at: z.date().nullable(),
   updated_at: z.date().nullable(),
 });
@@ -23,6 +24,7 @@ export const onboardingStatusInitializerSchema = z.object({
   user_id: userIdSchema,
   full_name: z.string().optional().nullable(),
   onboarding_complete: z.boolean().optional(),
+  onboarding_skipped: z.boolean().optional(),
   created_at: z.date().optional().nullable(),
   updated_at: z.date().optional().nullable(),
 });
@@ -32,6 +34,7 @@ export const onboardingStatusMutatorSchema = z.object({
   user_id: userIdSchema.optional(),
   full_name: z.string().optional().nullable(),
   onboarding_complete: z.boolean().optional(),
+  onboarding_skipped: z.boolean().optional(),
   created_at: z.date().optional().nullable(),
   updated_at: z.date().optional().nullable(),
 });


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Solves #1685 by persisting the fact that onboarding has been skipped to the database and adding a "Complete Setup" button to the top of the screen.

**How did you implement the solution?**

- Added a new `onboarding_skipped` boolean to the `onboarding_status` table.
- Added a new route that flips the default `FALSE` to `TRUE` and mapped the `Skip` button to call that route.
- Changed the way the wizard chooses to display to base it on `onboardingSkipped` _and_ `onboardingComplete`.
- Added a new button that calls `onStartOnboarding`.

> [!NOTE]
> It may be good for someone besides me who has completed onboarding to test and make sure I didn't miss some corner case.



Linked Issue: Closes #1685 

## How to Test

1. Run this branch.
2. Login with a new user or any user who has not completed onboarding.
3. Click "Skip"
4. Reload the page, observe that the onboarding wizard does not open.
5. Click the "Complete Setup" button at the top and observe that the wizard opens.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

The button in after was missing. Unfortunately that would be challenging to generate now.

### After

<img width="1186" height="642" alt="Screenshot From 2026-06-30 22-27-34" src="https://github.com/user-attachments/assets/b3cc9db1-ff5a-4d0e-8fe4-c4ab6dc689ca" />

</details>

## Notes for Reviewers

@CodeWithCJ mentioned that many things won't work or may break if they skip early in the setup. If I recall, I was able to configure those things in the settings myself after skipping the wizard. I think the "Complete Setup" may be sufficiently obvious if they run into issues but I'm open to doing it a different way.
