### PR TITLE
feat(food-search): All Providers aggregated search on web (phase 3)

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -676,7 +676,13 @@
     "addNewFood": "Add New Food",
     "addNewFoodDescription": "Enter the details for a new food item to add to your database.",
     "scanBarcodeDescription": "Position the product barcode in front of your camera.",
-    "importFromCSVDescription": "Import a CSV file to add multiple foods at once."
+    "importFromCSVDescription": "Import a CSV file to add multiple foods at once.",
+    "allProviders": "All Providers",
+    "topMatches": "Top Matches",
+    "bySource": "By Source",
+    "noResults": "No results",
+    "couldntLoad": "Couldn't load",
+    "showAllResults": "Show all {{count}} {{provider}} results"
   },
   "sync": {
     "syncAll": "Sync all active providers",

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodResultCard.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodResultCard.tsx
@@ -37,6 +37,9 @@ interface FoodResultCardProps {
   isMeal?: boolean;
   isOnline?: boolean;
   providerLabel?: string;
+  // When set, the provider badge is tinted with this colour (used by the All
+  // Providers "Top Matches" section to tell sources apart at a glance).
+  providerBadgeColor?: string;
   imageUrl?: string;
   nutrientConfig: NutrientGridConfig;
   onCardClick?: () => void;
@@ -48,6 +51,7 @@ const FoodResultCard = ({
   isMeal = false,
   isOnline = false,
   providerLabel,
+  providerBadgeColor,
   imageUrl,
   nutrientConfig,
   onCardClick,
@@ -58,6 +62,12 @@ const FoodResultCard = ({
   const isFood = !isMeal;
   const foodItem = item as Food;
   const mealItem = item as Meal;
+  // Hex opacity suffixes are only valid on a full #rrggbb value; other colour
+  // formats (CSS vars, named colours, #rgb) are used as-is without a tint.
+  const badgeIsHex =
+    !!providerBadgeColor &&
+    providerBadgeColor.startsWith('#') &&
+    providerBadgeColor.length === 7;
 
   return (
     <Card
@@ -80,7 +90,23 @@ const FoodResultCard = ({
                 </Badge>
               )}
               {providerLabel && (
-                <Badge variant="outline" className="text-xs">
+                <Badge
+                  variant="outline"
+                  className="text-xs"
+                  style={
+                    providerBadgeColor
+                      ? {
+                          color: providerBadgeColor,
+                          borderColor: badgeIsHex
+                            ? `${providerBadgeColor}55`
+                            : providerBadgeColor,
+                          backgroundColor: badgeIsHex
+                            ? `${providerBadgeColor}1f`
+                            : undefined,
+                        }
+                      : undefined
+                  }
+                >
                   {providerLabel}
                 </Badge>
               )}

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -9,7 +9,15 @@ import {
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Search, Plus, Loader2, Camera } from 'lucide-react';
+import {
+  Search,
+  Plus,
+  Loader2,
+  Camera,
+  ChevronDown,
+  ChevronRight,
+  RotateCw,
+} from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { useIsMobile } from '@/hooks/use-mobile';
@@ -47,6 +55,12 @@ import {
   foodDetailsV2Options,
 } from '@/hooks/Foods/useFoodsV2.ts';
 import { mealSearchOptions } from '@/hooks/Foods/useMeals.ts';
+import {
+  useAllProvidersFoodSearch,
+  type ExternalResultWrapper,
+} from '@/hooks/Foods/useAllProvidersFoodSearch.ts';
+import { interleaveTopMatches } from '@/utils/topMatches.ts';
+import { makeProviderColorResolver } from '@/utils/providerColor.ts';
 import { DataProvider } from '@/types/settings.ts';
 import { getProviderCategory } from '@/utils/settings.ts';
 
@@ -56,44 +70,9 @@ type FoodDataForBackend = Omit<CSVData, 'id'>;
 // (an inline [] default would re-run the online search effect during loading).
 const EMPTY_PROVIDERS: DataProvider[] = [];
 
-export type ExternalResultWrapper =
-  | {
-      provider_type: 'openfoodfacts';
-      food: Food;
-    }
-  | {
-      provider_type: 'nutritionix';
-      raw: NutritionixItem;
-      food: Food;
-    }
-  | {
-      provider_type: 'fatsecret';
-      food: Food;
-    }
-  | {
-      provider_type: 'usda';
-      food: Food;
-    }
-  | {
-      provider_type: 'mealie';
-      food: Food;
-    }
-  | {
-      provider_type: 'tandoor';
-      food: Food;
-    }
-  | {
-      provider_type: 'yazio';
-      food: Food;
-    }
-  | {
-      provider_type: 'norish';
-      food: Food;
-    }
-  | {
-      provider_type: 'swissfood';
-      food: Food;
-    };
+// Sentinel provider id for the aggregated "All Providers" mode (offered only
+// when more than one food provider is active).
+const ALL_PROVIDERS_VALUE = '__all__';
 
 interface EnhancedFoodSearchProps {
   onFoodSelect: (item: Food | Meal, type: 'food' | 'meal') => void;
@@ -225,6 +204,84 @@ const EnhancedFoodSearch = ({
 
   const [hasOnlineSearchBeenPerformed, setHasOnlineSearchBeenPerformed] =
     useState(false);
+
+  // Active food providers (used for the selector, the All Providers fan-out, and
+  // colour coding).
+  const foodProviderOptions = useMemo(
+    () =>
+      foodDataProviders.filter(
+        (provider) =>
+          getProviderCategory(provider).includes('food') && provider.is_active
+      ),
+    [foodDataProviders]
+  );
+
+  // Aggregated "All Providers" mode: offered only when more than one food
+  // provider is active. selectedFoodDataProvider holds the sentinel while it is
+  // active (so the single-provider online effect below no-ops). The
+  // length > 1 guard prevents rendering the aggregated view if providers drop
+  // to one while the sentinel is still selected (its dropdown option is hidden
+  // in that case).
+  const isAllProviders =
+    selectedFoodDataProvider === ALL_PROVIDERS_VALUE &&
+    foodProviderOptions.length > 1;
+
+  // If providers drop to one while the "All Providers" sentinel is still
+  // selected, clear it so we fall back to a real provider instead of stranding
+  // the selector on __all__ (which would show a blank value and no results).
+  useEffect(() => {
+    if (
+      manualProviderId === ALL_PROVIDERS_VALUE &&
+      foodProviderOptions.length <= 1
+    ) {
+      setManualProviderId(null);
+    }
+  }, [manualProviderId, foodProviderOptions.length]);
+
+  // Which By Source provider sections are expanded (All Providers mode). Reset
+  // when the query changes so stale sections don't stay open.
+  const [expandedProviders, setExpandedProviders] = useState<Set<string>>(
+    () => new Set()
+  );
+  const toggleProvider = useCallback((id: string) => {
+    setExpandedProviders((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  // Per-provider signature colour resolver for the All Providers badges/dots.
+  const getProviderColor = useMemo(
+    () => makeProviderColorResolver(foodProviderOptions),
+    [foodProviderOptions]
+  );
+
+  // All Providers fan-out: parallel per-provider searches that stream in.
+  const {
+    providerResults,
+    anyLoading: anyProviderLoading,
+    isSearchActive: isAllProvidersSearchActive,
+    debouncedSearch: allProvidersDebouncedSearch,
+  } = useAllProvidersFoodSearch(searchTerm, foodProviderOptions, {
+    enabled: isAllProviders,
+    autoScale: autoScaleOpenFoodFactsImports,
+    foodDisplayLimit,
+  });
+
+  // Collapse expanded By Source sections when the aggregated query changes.
+  // Keyed on the hook's debounced term (not the faster local debounce) so it
+  // fires in step with the results the sections are showing, not ~300ms early.
+  useEffect(() => {
+    setExpandedProviders(new Set());
+  }, [allProvidersDebouncedSearch]);
+
+  // Top Matches: interleave each provider's top results (round-robin by rank).
+  const topMatches = useMemo(
+    () => interleaveTopMatches(providerResults),
+    [providerResults]
+  );
 
   // --- Local meals: searched alongside foods, guarded against stale resolves ---
 
@@ -527,15 +584,22 @@ const EnhancedFoodSearch = ({
     setShowImportFromCsvDialog(false);
   };
 
-  const handleNutritionixEdit = async (item: NutritionixItem) => {
+  const handleNutritionixEdit = async (
+    item: NutritionixItem,
+    providerIdOverride?: string
+  ) => {
+    // In All Providers mode searchProviderId isn't set (the single-provider
+    // search no-ops), so callers pass the result's own provider id to fetch
+    // detailed nutrients with the right credentials.
+    const providerId = providerIdOverride || searchProviderId;
     let nutrientData: NutritionixItem;
     if (item.brand) {
       nutrientData = await queryClient.fetchQuery(
-        nutritionixBrandedNutrientsOptions(item.id ?? ' ', searchProviderId)
+        nutritionixBrandedNutrientsOptions(item.id ?? ' ', providerId)
       );
     } else {
       nutrientData = await queryClient.fetchQuery(
-        nutritionixNaturalNutrientsOptions(item.name, searchProviderId)
+        nutritionixNaturalNutrientsOptions(item.name, providerId)
       );
     }
 
@@ -551,7 +615,10 @@ const EnhancedFoodSearch = ({
     }
   };
 
-  const handleExternalFoodEdit = async (food: Food) => {
+  const handleExternalFoodEdit = async (
+    food: Food,
+    providerIdOverride?: string
+  ) => {
     const needsDetailFetch =
       (food.provider_type === 'fatsecret' ||
         food.provider_type === 'usda' ||
@@ -560,7 +627,9 @@ const EnhancedFoodSearch = ({
       food.provider_external_id;
 
     if (needsDetailFetch) {
-      const providerId = searchProviderId || undefined;
+      // In All Providers mode searchProviderId isn't set, so callers pass the
+      // result's own provider id to fetch full nutrients with the right creds.
+      const providerId = providerIdOverride || searchProviderId || undefined;
       if (!providerId && food.provider_type !== 'swissfood') {
         // No provider credentials available — data is already complete (barcode flow)
         setEditingProduct(food);
@@ -623,10 +692,6 @@ const EnhancedFoodSearch = ({
 
   // --- Derived render state ---
 
-  const foodProviderOptions = foodDataProviders.filter(
-    (provider) =>
-      getProviderCategory(provider).includes('food') && provider.is_active
-  );
   const isDebouncePending =
     !isSearchEmpty && debouncedSearchTerm !== searchTerm;
   const localPending = isFetchingSearch || isMealLoading || isDebouncePending;
@@ -636,18 +701,30 @@ const EnhancedFoodSearch = ({
   const showLocalSpinner =
     showLocalFoods && !isSearchEmpty && localPending && noLocalResults;
 
-  const renderExternalCard = (result: ExternalResultWrapper) => (
+  const renderExternalCard = (
+    result: ExternalResultWrapper,
+    opts?: {
+      keyPrefix?: string;
+      providerLabel?: string;
+      badgeColor?: string;
+      // Provider id for this specific result, so the edit handler fetches
+      // detailed nutrients with the right credentials in All Providers mode
+      // (where the shared searchProviderId isn't set).
+      providerId?: string;
+    }
+  ) => (
     <FoodResultCard
-      key={`${result.provider_type}-${result.food.provider_external_id}`}
+      key={`${opts?.keyPrefix ?? ''}-${result.provider_type}-${result.food.provider_external_id}`}
       item={result.food}
       isOnline={true}
-      providerLabel={result.provider_type.toUpperCase()}
+      providerLabel={opts?.providerLabel ?? result.provider_type.toUpperCase()}
+      providerBadgeColor={opts?.badgeColor}
       nutrientConfig={nutrientConfig}
       onEditClick={() => {
         if (result.provider_type === 'nutritionix') {
-          handleNutritionixEdit(result.raw);
+          handleNutritionixEdit(result.raw, opts?.providerId);
         } else {
-          handleExternalFoodEdit(result.food);
+          handleExternalFoodEdit(result.food, opts?.providerId);
         }
       }}
     />
@@ -695,7 +772,7 @@ const EnhancedFoodSearch = ({
             className="pl-9"
           />
         </div>
-        {(isOnlineLoading || localPending) && (
+        {(isOnlineLoading || localPending || anyProviderLoading) && (
           <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
         )}
         {foodProviderOptions.length > 0 && (
@@ -720,6 +797,12 @@ const EnhancedFoodSearch = ({
               />
             </SelectTrigger>
             <SelectContent>
+              {/* Aggregated view, offered only with more than one provider. */}
+              {foodProviderOptions.length > 1 && (
+                <SelectItem value={ALL_PROVIDERS_VALUE}>
+                  {t('enhancedFoodSearch.allProviders', 'All Providers')}
+                </SelectItem>
+              )}
               {foodProviderOptions.map((provider) => (
                 <SelectItem key={provider.id} value={provider.id}>
                   {' '}
@@ -851,8 +934,8 @@ const EnhancedFoodSearch = ({
               </div>
             )}
 
-            {/* Online provider results */}
-            {selectedProviderName && (
+            {/* Single-provider online results */}
+            {!isAllProviders && selectedProviderName && (
               <>
                 <SectionHeader>{selectedProviderName}</SectionHeader>
                 {isOnlineLoading && externalResults.length === 0 && (
@@ -860,7 +943,7 @@ const EnhancedFoodSearch = ({
                     <Loader2 className="w-6 h-6 animate-spin mx-auto" />
                   </div>
                 )}
-                {externalResults.map(renderExternalCard)}
+                {externalResults.map((result) => renderExternalCard(result))}
                 {!isOnlineLoading &&
                   hasOnlineSearchBeenPerformed &&
                   externalResults.length === 0 && (
@@ -871,6 +954,134 @@ const EnhancedFoodSearch = ({
                       )}
                     </div>
                   )}
+              </>
+            )}
+
+            {/* Aggregated "All Providers" results: Top Matches + By Source */}
+            {isAllProviders && isAllProvidersSearchActive && (
+              <>
+                <SectionHeader>
+                  <span className="flex items-center justify-between">
+                    {t('enhancedFoodSearch.topMatches', 'Top Matches')}
+                    {anyProviderLoading && (
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                    )}
+                  </span>
+                </SectionHeader>
+                {topMatches.length > 0
+                  ? topMatches.map((match) =>
+                      renderExternalCard(match.result, {
+                        keyPrefix: `top-${match.providerId}`,
+                        providerLabel: match.providerName,
+                        badgeColor: getProviderColor(match.providerId),
+                        providerId: match.providerId,
+                      })
+                    )
+                  : !anyProviderLoading && (
+                      <div className="text-center py-4 text-gray-500 text-sm">
+                        {t('enhancedFoodSearch.noResults', 'No results')}
+                      </div>
+                    )}
+
+                <SectionHeader>
+                  {t('enhancedFoodSearch.bySource', 'By Source')}
+                </SectionHeader>
+                {providerResults.map((r) => {
+                  const expanded = expandedProviders.has(r.provider.id);
+                  const color = getProviderColor(r.provider.id);
+                  const loading = r.isLoading;
+                  const errored = r.isError && !loading;
+                  const count = r.totalCount;
+                  const empty = !loading && !errored && count === 0;
+                  const expandable = !loading && !errored && count > 0;
+                  return (
+                    <div
+                      key={r.provider.id}
+                      className="border rounded-md overflow-hidden"
+                    >
+                      <button
+                        type="button"
+                        disabled={!expandable && !errored}
+                        onClick={() => {
+                          if (errored) r.refetch();
+                          else if (expandable) toggleProvider(r.provider.id);
+                        }}
+                        className="w-full flex items-center justify-between px-3 py-2 text-left disabled:cursor-default"
+                      >
+                        <span className="flex items-center gap-2">
+                          <span
+                            className="w-2 h-2 rounded-full shrink-0"
+                            style={{ backgroundColor: color }}
+                          />
+                          <span className="text-sm font-medium">
+                            {r.provider.provider_name}
+                          </span>
+                          {expandable && (
+                            <span className="text-xs rounded-full bg-muted px-2 py-0.5 text-muted-foreground">
+                              {count}
+                            </span>
+                          )}
+                        </span>
+                        <span className="flex items-center gap-1 text-muted-foreground text-xs">
+                          {loading && (
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                          )}
+                          {errored && (
+                            <>
+                              <span>
+                                {t(
+                                  'enhancedFoodSearch.couldntLoad',
+                                  "Couldn't load"
+                                )}
+                              </span>
+                              <RotateCw className="w-4 h-4" />
+                            </>
+                          )}
+                          {empty && (
+                            <span>
+                              {t('enhancedFoodSearch.noResults', 'No results')}
+                            </span>
+                          )}
+                          {expandable &&
+                            (expanded ? (
+                              <ChevronDown className="w-4 h-4" />
+                            ) : (
+                              <ChevronRight className="w-4 h-4" />
+                            ))}
+                        </span>
+                      </button>
+                      {expanded && expandable && (
+                        <div className="px-2 pb-2 space-y-2">
+                          {r.items.map((item) =>
+                            renderExternalCard(item, {
+                              keyPrefix: r.provider.id,
+                              providerId: r.provider.id,
+                            })
+                          )}
+                          {count > r.items.length && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setExternalResults([]);
+                                setManualProviderId(r.provider.id);
+                              }}
+                              className="text-sm font-medium text-primary px-1 py-2"
+                            >
+                              {t(
+                                'enhancedFoodSearch.showAllResults',
+                                'Show all {{count}} {{provider}} results',
+                                {
+                                  count,
+                                  provider: r.provider.provider_name,
+                                }
+                              )}
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </>
             )}
           </>

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -437,6 +437,15 @@ const EnhancedFoodSearch = ({
   // Online results stream in alongside local results, using the default
   // provider. Online searches start at 3 characters to limit provider calls.
   useEffect(() => {
+    // In All Providers mode the aggregated hook owns the online results, so this
+    // single-provider effect must fully no-op. Without this guard it runs on
+    // every keystroke (searchTerm is a dependency), finds no matching provider
+    // for the __all__ sentinel, and calls setExternalResults([]) each time; a
+    // fresh [] is never === the previous one, so it re-renders the whole
+    // component on every keystroke and lags typing.
+    if (selectedFoodDataProvider === ALL_PROVIDERS_VALUE) {
+      return;
+    }
     const term = searchTerm.trim();
     if (term.length < 3) {
       setExternalResults([]);
@@ -1002,6 +1011,7 @@ const EnhancedFoodSearch = ({
                       <button
                         type="button"
                         disabled={!expandable && !errored}
+                        aria-expanded={expandable ? expanded : undefined}
                         onClick={() => {
                           if (errored) r.refetch();
                           else if (expandable) toggleProvider(r.provider.id);

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -1016,7 +1016,7 @@ const EnhancedFoodSearch = ({
                           if (errored) r.refetch();
                           else if (expandable) toggleProvider(r.provider.id);
                         }}
-                        className="w-full flex items-center justify-between px-3 py-2 text-left disabled:cursor-default"
+                        className="w-full flex items-center justify-between px-3 py-2 text-left hover:bg-muted/50 disabled:hover:bg-transparent disabled:cursor-default"
                       >
                         <span className="flex items-center gap-2">
                           <span
@@ -1071,9 +1071,15 @@ const EnhancedFoodSearch = ({
                           {count > r.items.length && (
                             <button
                               type="button"
-                              onClick={() => {
+                              onClick={(e) => {
                                 setExternalResults([]);
                                 setManualProviderId(r.provider.id);
+                                // Switching to the single-provider view reuses
+                                // the same scroll container; reset it to the top
+                                // so the user isn't left stranded at the bottom.
+                                const container =
+                                  e.currentTarget.closest('.overflow-y-auto');
+                                if (container) container.scrollTop = 0;
                               }}
                               className="text-sm font-medium text-primary px-1 py-2"
                             >

--- a/SparkyFitnessFrontend/src/hooks/Foods/useAllProvidersFoodSearch.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useAllProvidersFoodSearch.ts
@@ -133,8 +133,9 @@ async function fetchProviderResults(
     pageSize,
     provider.provider_type === 'openfoodfacts' ? options.autoScale : undefined
   );
-  // Fall back to an empty list if a provider returns a malformed payload.
-  const items = (data?.foods ?? []).map(
+  // Fall back to an empty list if a provider returns a malformed payload
+  // (foods missing, null, or a non-array), so .map() can't crash the query.
+  const items = (Array.isArray(data?.foods) ? data.foods : []).map(
     (food: Food) =>
       ({
         provider_type: provider.provider_type,

--- a/SparkyFitnessFrontend/src/hooks/Foods/useAllProvidersFoodSearch.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useAllProvidersFoodSearch.ts
@@ -1,0 +1,242 @@
+import { useCallback } from 'react';
+import { useQueries, type UseQueryResult } from '@tanstack/react-query';
+import { searchFoodsV2 } from '@/api/Foods/foodService';
+import { searchNutritionixFoods } from '@/api/Foods/nutrionix';
+import { convertNutritionixToFood } from '@/utils/foodSearch';
+import { useDebounce } from '@/hooks/useDebounce';
+import type { Food, NutritionixItem } from '@/types/food';
+import type { DataProvider } from '@/types/settings';
+
+// A single online provider result, tagged with its source so the UI can render
+// the correct edit/detail flow. Mirrors the per-provider mapping used by the
+// single-provider online search in FoodSearch.tsx. Defined here (rather than in
+// the component) so both the single-provider path and this aggregated hook can
+// share the type.
+export type ExternalResultWrapper =
+  | {
+      provider_type: 'openfoodfacts';
+      food: Food;
+    }
+  | {
+      provider_type: 'nutritionix';
+      raw: NutritionixItem;
+      food: Food;
+    }
+  | {
+      provider_type: 'fatsecret';
+      food: Food;
+    }
+  | {
+      provider_type: 'usda';
+      food: Food;
+    }
+  | {
+      provider_type: 'mealie';
+      food: Food;
+    }
+  | {
+      provider_type: 'tandoor';
+      food: Food;
+    }
+  | {
+      provider_type: 'yazio';
+      food: Food;
+    }
+  | {
+      provider_type: 'norish';
+      food: Food;
+    }
+  | {
+      provider_type: 'swissfood';
+      food: Food;
+    };
+
+// Normalised per-provider payload returned by each fan-out query.
+interface NormalisedProviderResult {
+  items: ExternalResultWrapper[];
+  totalCount: number;
+}
+
+export interface ProviderFoodSearchResult {
+  provider: DataProvider;
+  items: ExternalResultWrapper[];
+  totalCount: number;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+}
+
+// Online search starts at 3 characters (matches the single-provider path) to
+// limit provider calls, debounced by 600ms.
+const MIN_QUERY_LENGTH = 3;
+const DEBOUNCE_MS = 600;
+const STALE_TIME = 1000 * 60 * 5; // 5 minutes
+
+// Stable fallback so a missing refetch does not allocate a new function each
+// render (which would break reference stability of the providerResults items).
+const noop = () => {};
+
+// Dedicated key namespace for the aggregated, normalised per-provider queries.
+// Kept distinct from v2FoodKeys.search / nutritionixKeys.search because those
+// cache the providers' raw response shapes; reusing them here with a different
+// (normalised) shape would corrupt the shared cache.
+const allProvidersFoodSearchKey = (
+  providerType: string,
+  query: string,
+  providerId?: string,
+  autoScale?: boolean
+) =>
+  [
+    'v2',
+    'foods',
+    'allProvidersSearch',
+    providerType,
+    query,
+    providerId,
+    autoScale,
+  ] as const;
+
+// Providers whose single-provider search caps results at the food display
+// limit (see FoodSearch.tsx search handlers); kept in parity here.
+const PAGE_SIZE_PROVIDERS = ['usda', 'yazio'];
+
+async function fetchProviderResults(
+  provider: DataProvider,
+  query: string,
+  options: { autoScale?: boolean; foodDisplayLimit?: number }
+): Promise<NormalisedProviderResult> {
+  if (provider.provider_type === 'nutritionix') {
+    const data: NutritionixItem[] = await searchNutritionixFoods(
+      query,
+      provider.id
+    );
+    // Guard against a non-array response so a provider error can't crash the map.
+    const items = (Array.isArray(data) ? data : []).map(
+      (raw) =>
+        ({
+          provider_type: 'nutritionix' as const,
+          raw,
+          food: convertNutritionixToFood(raw),
+        }) satisfies ExternalResultWrapper
+    );
+    return { items, totalCount: items.length };
+  }
+
+  const pageSize = PAGE_SIZE_PROVIDERS.includes(provider.provider_type)
+    ? options.foodDisplayLimit
+    : undefined;
+  const data = await searchFoodsV2(
+    provider.provider_type,
+    query,
+    provider.id,
+    undefined,
+    pageSize,
+    provider.provider_type === 'openfoodfacts' ? options.autoScale : undefined
+  );
+  // Fall back to an empty list if a provider returns a malformed payload.
+  const items = (data?.foods ?? []).map(
+    (food: Food) =>
+      ({
+        provider_type: provider.provider_type,
+        food,
+      }) as ExternalResultWrapper
+  );
+  return {
+    items,
+    totalCount: data?.pagination?.totalCount ?? items.length,
+  };
+}
+
+// Fans a single search out across every active food provider in parallel. Each
+// provider query is independent, so results stream in as they return and a
+// failure in one provider does not block the others (partial results). First
+// page only; "show all" deep-links to the single-provider search for full
+// pagination.
+export function useAllProvidersFoodSearch(
+  searchTerm: string,
+  providers: DataProvider[],
+  options?: {
+    enabled?: boolean;
+    autoScale?: boolean;
+    foodDisplayLimit?: number;
+  }
+): {
+  providerResults: ProviderFoodSearchResult[];
+  anyLoading: boolean;
+  isSearchActive: boolean;
+  // The debounced term the current providerResults correspond to. Consumers can
+  // key UI resets (e.g. collapsing expanded sections) off this so they fire in
+  // step with the aggregated results rather than a faster local debounce.
+  debouncedSearch: string;
+} {
+  const { enabled = true, autoScale, foodDisplayLimit } = options ?? {};
+  const debouncedSearch = useDebounce(searchTerm.trim(), DEBOUNCE_MS);
+  // Require both the live and the debounced term to clear the threshold. The
+  // debounced check gates the queries; the live check makes backspacing below
+  // the threshold deactivate immediately, instead of leaving stale aggregated
+  // results on screen for the debounce window.
+  const isSearchActive =
+    searchTerm.trim().length >= MIN_QUERY_LENGTH &&
+    debouncedSearch.length >= MIN_QUERY_LENGTH;
+
+  // Project the raw query results into ProviderFoodSearchResult inside
+  // useQueries' `combine`, rather than a downstream useMemo over the raw queries
+  // array. Without `combine`, useQueries returns a brand-new array reference on
+  // every render; `combine` is run only when a query actually changes and its
+  // output gets structural-sharing, so providerResults stays referentially
+  // stable across renders. Results are index-aligned with `providers` because
+  // the query list below is built from the same `providers.map` order.
+  const combine = useCallback(
+    (
+      results: UseQueryResult<NormalisedProviderResult>[]
+    ): ProviderFoodSearchResult[] =>
+      providers.map((provider, i) => {
+        const q = results[i];
+        const items = q?.data?.items ?? [];
+        return {
+          provider,
+          items,
+          totalCount: q?.data?.totalCount ?? 0,
+          // Loading while fetching with nothing to show yet — covers the
+          // initial load and an error retry, but not a background refetch that
+          // already has cached results (which would otherwise flash a spinner
+          // over good data).
+          isLoading: (q?.isFetching ?? false) && items.length === 0,
+          isError: q?.isError ?? false,
+          refetch: q?.refetch ?? noop,
+        };
+      }),
+    [providers]
+  );
+
+  const providerResults = useQueries({
+    queries: providers.map((provider) => ({
+      queryKey: allProvidersFoodSearchKey(
+        provider.provider_type,
+        debouncedSearch,
+        provider.id,
+        autoScale
+      ),
+      queryFn: () =>
+        fetchProviderResults(provider, debouncedSearch, {
+          autoScale,
+          foodDisplayLimit,
+        }),
+      enabled: isSearchActive && enabled,
+      staleTime: STALE_TIME,
+    })),
+    combine,
+  });
+
+  // Treat the debounce window as loading so the input spinner keeps spinning
+  // between the keystroke and the queries actually starting, instead of
+  // briefly stopping (flicker) while the debounced term catches up.
+  const isDebouncePending =
+    enabled &&
+    searchTerm.trim().length >= MIN_QUERY_LENGTH &&
+    searchTerm.trim() !== debouncedSearch;
+  const anyLoading =
+    providerResults.some((r) => r.isLoading) || isDebouncePending;
+
+  return { providerResults, isSearchActive, anyLoading, debouncedSearch };
+}

--- a/SparkyFitnessFrontend/src/tests/utils/providerColor.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/providerColor.test.ts
@@ -1,5 +1,4 @@
 import {
-  buildProviderColorMap,
   makeProviderColorResolver,
   PROVIDER_COLOR_PALETTE,
 } from '@/utils/providerColor';
@@ -15,15 +14,18 @@ const provider = (id: string): DataProvider =>
     app_key: '',
   }) as DataProvider;
 
-describe('buildProviderColorMap', () => {
+describe('makeProviderColorResolver', () => {
   it('assigns colours by list index (collision-free within palette)', () => {
-    const providers = [provider('a'), provider('b'), provider('c')];
-    const map = buildProviderColorMap(providers);
-    expect(map.get('a')).toBe(PROVIDER_COLOR_PALETTE[0]);
-    expect(map.get('b')).toBe(PROVIDER_COLOR_PALETTE[1]);
-    expect(map.get('c')).toBe(PROVIDER_COLOR_PALETTE[2]);
+    const resolve = makeProviderColorResolver([
+      provider('a'),
+      provider('b'),
+      provider('c'),
+    ]);
+    expect(resolve('a')).toBe(PROVIDER_COLOR_PALETTE[0]);
+    expect(resolve('b')).toBe(PROVIDER_COLOR_PALETTE[1]);
+    expect(resolve('c')).toBe(PROVIDER_COLOR_PALETTE[2]);
     // All distinct
-    expect(new Set([map.get('a'), map.get('b'), map.get('c')]).size).toBe(3);
+    expect(new Set([resolve('a'), resolve('b'), resolve('c')]).size).toBe(3);
   });
 
   it('wraps around the palette when providers exceed its length', () => {
@@ -31,16 +33,10 @@ describe('buildProviderColorMap', () => {
       { length: PROVIDER_COLOR_PALETTE.length + 1 },
       (_, i) => provider(`p${i}`)
     );
-    const map = buildProviderColorMap(providers);
-    expect(map.get('p0')).toBe(map.get(`p${PROVIDER_COLOR_PALETTE.length}`));
+    const resolve = makeProviderColorResolver(providers);
+    expect(resolve('p0')).toBe(resolve(`p${PROVIDER_COLOR_PALETTE.length}`));
   });
 
-  it('returns an empty map for an empty palette', () => {
-    expect(buildProviderColorMap([provider('a')], []).size).toBe(0);
-  });
-});
-
-describe('makeProviderColorResolver', () => {
   it('resolves known providers to their assigned colour', () => {
     const resolve = makeProviderColorResolver([provider('a'), provider('b')]);
     expect(resolve('a')).toBe(PROVIDER_COLOR_PALETTE[0]);

--- a/SparkyFitnessFrontend/src/tests/utils/providerColor.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/providerColor.test.ts
@@ -1,0 +1,57 @@
+import {
+  buildProviderColorMap,
+  makeProviderColorResolver,
+  PROVIDER_COLOR_PALETTE,
+} from '@/utils/providerColor';
+import type { DataProvider } from '@/types/settings';
+
+const provider = (id: string): DataProvider =>
+  ({
+    id,
+    name: id,
+    provider_type: id,
+    provider_name: id,
+    is_active: true,
+    app_key: '',
+  }) as DataProvider;
+
+describe('buildProviderColorMap', () => {
+  it('assigns colours by list index (collision-free within palette)', () => {
+    const providers = [provider('a'), provider('b'), provider('c')];
+    const map = buildProviderColorMap(providers);
+    expect(map.get('a')).toBe(PROVIDER_COLOR_PALETTE[0]);
+    expect(map.get('b')).toBe(PROVIDER_COLOR_PALETTE[1]);
+    expect(map.get('c')).toBe(PROVIDER_COLOR_PALETTE[2]);
+    // All distinct
+    expect(new Set([map.get('a'), map.get('b'), map.get('c')]).size).toBe(3);
+  });
+
+  it('wraps around the palette when providers exceed its length', () => {
+    const providers = Array.from(
+      { length: PROVIDER_COLOR_PALETTE.length + 1 },
+      (_, i) => provider(`p${i}`)
+    );
+    const map = buildProviderColorMap(providers);
+    expect(map.get('p0')).toBe(map.get(`p${PROVIDER_COLOR_PALETTE.length}`));
+  });
+
+  it('returns an empty map for an empty palette', () => {
+    expect(buildProviderColorMap([provider('a')], []).size).toBe(0);
+  });
+});
+
+describe('makeProviderColorResolver', () => {
+  it('resolves known providers to their assigned colour', () => {
+    const resolve = makeProviderColorResolver([provider('a'), provider('b')]);
+    expect(resolve('a')).toBe(PROVIDER_COLOR_PALETTE[0]);
+    expect(resolve('b')).toBe(PROVIDER_COLOR_PALETTE[1]);
+  });
+
+  it('falls back for unknown or missing ids', () => {
+    const resolve = makeProviderColorResolver([provider('a')]);
+    const fallback = resolve('unknown');
+    expect(fallback).toBe(resolve(null));
+    expect(fallback).toBe(resolve(undefined));
+    expect(fallback).not.toBe(PROVIDER_COLOR_PALETTE[0]);
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/utils/topMatches.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/topMatches.test.ts
@@ -1,0 +1,78 @@
+import { interleaveTopMatches } from '@/utils/topMatches';
+import type {
+  ExternalResultWrapper,
+  ProviderFoodSearchResult,
+} from '@/hooks/Foods/useAllProvidersFoodSearch';
+import type { DataProvider } from '@/types/settings';
+import type { Food } from '@/types/food';
+
+const provider = (id: string): DataProvider =>
+  ({
+    id,
+    name: id,
+    provider_type: id,
+    provider_name: id.toUpperCase(),
+    is_active: true,
+    app_key: '',
+  }) as DataProvider;
+
+const item = (name: string): ExternalResultWrapper =>
+  ({
+    provider_type: 'usda',
+    food: { name, provider_external_id: name } as Food,
+  }) as ExternalResultWrapper;
+
+const result = (id: string, names: string[]): ProviderFoodSearchResult => ({
+  provider: provider(id),
+  items: names.map(item),
+  totalCount: names.length,
+  isLoading: false,
+  isError: false,
+  refetch: () => {},
+});
+
+describe('interleaveTopMatches', () => {
+  it('round-robins by rank across providers', () => {
+    const out = interleaveTopMatches(
+      [result('a', ['a1', 'a2', 'a3']), result('b', ['b1', 'b2'])],
+      2,
+      10
+    );
+    // rank 0: a1, b1 ; rank 1: a2, b2
+    expect(out.map((m) => m.result.food.name)).toEqual([
+      'a1',
+      'b1',
+      'a2',
+      'b2',
+    ]);
+    expect(out[0]?.providerId).toBe('a');
+    expect(out[1]?.providerId).toBe('b');
+  });
+
+  it('skips providers that ran out of items at a given rank', () => {
+    const out = interleaveTopMatches(
+      [result('a', ['a1', 'a2']), result('b', ['b1'])],
+      2,
+      10
+    );
+    expect(out.map((m) => m.result.food.name)).toEqual(['a1', 'b1', 'a2']);
+  });
+
+  it('caps at baseCap but never below the number of contributing providers', () => {
+    const providers = ['a', 'b', 'c', 'd'].map((id) => result(id, [`${id}1`]));
+    // baseCap 2 but 4 providers returned results -> keep all 4 first-rank items
+    const out = interleaveTopMatches(providers, 2, 2);
+    expect(out).toHaveLength(4);
+    expect(out.map((m) => m.providerId)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('ignores empty providers when computing the floor', () => {
+    const out = interleaveTopMatches(
+      [result('a', ['a1', 'a2', 'a3']), result('b', [])],
+      2,
+      2
+    );
+    // only provider a contributes -> floor is 1, cap stays at baseCap 2
+    expect(out.map((m) => m.result.food.name)).toEqual(['a1', 'a2']);
+  });
+});

--- a/SparkyFitnessFrontend/src/utils/providerColor.ts
+++ b/SparkyFitnessFrontend/src/utils/providerColor.ts
@@ -34,29 +34,18 @@ export const PROVIDER_COLOR_PALETTE = [
 
 const FALLBACK_COLOR = '#94a3b8'; // slate-400, matches muted-foreground tone
 
-// Maps each provider id to a palette colour by list position. Collision-free
-// while the active providers fit the palette; wraps past that.
-export function buildProviderColorMap(
-  providers: DataProvider[],
-  palette: string[] = PROVIDER_COLOR_PALETTE
-): Map<string, string> {
-  const byId = new Map<string, string>();
-  if (palette.length > 0) {
-    providers.forEach((p, i) => {
-      byId.set(p.id, palette[i % palette.length] ?? FALLBACK_COLOR);
-    });
-  }
-  return byId;
-}
-
-// Returns a resolver mapping a provider id to its assigned colour. Build the map
-// once (e.g. via useMemo on the providers list) and call the returned function
-// while rendering rows.
+// Returns a resolver mapping a provider id to its assigned colour, by the
+// provider's position in the active list (palette[i % length]). Collision-free
+// while the active providers fit the palette; wraps past that. Build the
+// resolver once (e.g. via useMemo on the providers list) and call it while
+// rendering rows.
 export function makeProviderColorResolver(
-  providers: DataProvider[],
-  palette: string[] = PROVIDER_COLOR_PALETTE
+  providers: DataProvider[]
 ): (providerId?: string | null) => string {
-  const byId = buildProviderColorMap(providers, palette);
+  const byId = new Map<string, string>();
+  providers.forEach((p, i) => {
+    byId.set(p.id, PROVIDER_COLOR_PALETTE[i % PROVIDER_COLOR_PALETTE.length]);
+  });
   return (providerId?: string | null): string => {
     if (!providerId) return FALLBACK_COLOR;
     return byId.get(providerId) ?? FALLBACK_COLOR;

--- a/SparkyFitnessFrontend/src/utils/providerColor.ts
+++ b/SparkyFitnessFrontend/src/utils/providerColor.ts
@@ -44,7 +44,11 @@ export function makeProviderColorResolver(
 ): (providerId?: string | null) => string {
   const byId = new Map<string, string>();
   providers.forEach((p, i) => {
-    byId.set(p.id, PROVIDER_COLOR_PALETTE[i % PROVIDER_COLOR_PALETTE.length]);
+    byId.set(
+      p.id,
+      PROVIDER_COLOR_PALETTE[i % PROVIDER_COLOR_PALETTE.length] ??
+        FALLBACK_COLOR
+    );
   });
   return (providerId?: string | null): string => {
     if (!providerId) return FALLBACK_COLOR;

--- a/SparkyFitnessFrontend/src/utils/providerColor.ts
+++ b/SparkyFitnessFrontend/src/utils/providerColor.ts
@@ -1,0 +1,57 @@
+import type { DataProvider } from '@/types/settings';
+
+// Per-provider signature colours used to tell sources apart at a glance in the
+// "All Providers" aggregated search: a tinted badge behind Top Matches rows and
+// a dot before each By Source provider. Colours are assigned by the provider's
+// position in the active list (palette[i % length]), not by a hash of its type:
+// with only a handful of palette entries a hash has a real collision chance
+// (birthday paradox), and any collision defeats the point of telling sources
+// apart. Index assignment is collision-free as long as the active providers fit
+// the palette, and still covers providers past that by wrapping. It is not
+// stable across reordering, which is fine for at-a-glance grouping.
+//
+// The palette reuses the hex values already used by the web app's report charts
+// (see NutritionChartsGrid / FastingReport) so provider colours look native to
+// the rest of the UI. These are static hex values (like the existing chart
+// palettes) and intentionally do not adapt to light/dark themes.
+export const PROVIDER_COLOR_PALETTE = [
+  '#6366f1', // Indigo
+  '#06b6d4', // Cyan
+  '#22a6b3', // Teal
+  '#f59e0b', // Amber
+  '#e056fd', // Violet
+  '#22c55e', // Green
+  '#ef4444', // Red
+  '#45B7D1', // Blue
+];
+
+const FALLBACK_COLOR = '#94a3b8'; // slate-400, matches muted-foreground tone
+
+// Maps each provider id to a palette colour by list position. Collision-free
+// while the active providers fit the palette; wraps past that.
+export function buildProviderColorMap(
+  providers: DataProvider[],
+  palette: string[] = PROVIDER_COLOR_PALETTE
+): Map<string, string> {
+  const byId = new Map<string, string>();
+  if (palette.length > 0) {
+    providers.forEach((p, i) => {
+      byId.set(p.id, palette[i % palette.length]);
+    });
+  }
+  return byId;
+}
+
+// Returns a resolver mapping a provider id to its assigned colour. Build the map
+// once (e.g. via useMemo on the providers list) and call the returned function
+// while rendering rows.
+export function makeProviderColorResolver(
+  providers: DataProvider[],
+  palette: string[] = PROVIDER_COLOR_PALETTE
+): (providerId?: string | null) => string {
+  const byId = buildProviderColorMap(providers, palette);
+  return (providerId?: string | null): string => {
+    if (!providerId) return FALLBACK_COLOR;
+    return byId.get(providerId) ?? FALLBACK_COLOR;
+  };
+}

--- a/SparkyFitnessFrontend/src/utils/providerColor.ts
+++ b/SparkyFitnessFrontend/src/utils/providerColor.ts
@@ -36,7 +36,7 @@ export function buildProviderColorMap(
   const byId = new Map<string, string>();
   if (palette.length > 0) {
     providers.forEach((p, i) => {
-      byId.set(p.id, palette[i % palette.length]);
+      byId.set(p.id, palette[i % palette.length] ?? FALLBACK_COLOR);
     });
   }
   return byId;

--- a/SparkyFitnessFrontend/src/utils/providerColor.ts
+++ b/SparkyFitnessFrontend/src/utils/providerColor.ts
@@ -10,19 +10,26 @@ import type { DataProvider } from '@/types/settings';
 // the palette, and still covers providers past that by wrapping. It is not
 // stable across reordering, which is fine for at-a-glance grouping.
 //
-// The palette reuses the hex values already used by the web app's report charts
-// (see NutritionChartsGrid / FastingReport) so provider colours look native to
-// the rest of the UI. These are static hex values (like the existing chart
-// palettes) and intentionally do not adapt to light/dark themes.
+// The palette reuses hex values already used by the web app's report charts and
+// nutrient config (see NutritionChartsGrid / FastingReport / CENTRAL_NUTRIENT_CONFIG)
+// so provider colours look native to the rest of the UI. These are static hex
+// values (like the existing chart palettes) and intentionally do not adapt to
+// light/dark themes.
+//
+// Ordering matters: colours are assigned by list position, so the sequence is
+// arranged to keep *adjacent* entries in clearly different hue families (e.g.
+// indigo -> amber -> green -> pink -> cyan). This avoids the earlier problem
+// where neighbouring providers landed on near-identical cyan/teal swatches that
+// were hard to tell apart, especially as small dots on a dark background.
 export const PROVIDER_COLOR_PALETTE = [
-  '#6366f1', // Indigo
-  '#06b6d4', // Cyan
-  '#22a6b3', // Teal
-  '#f59e0b', // Amber
-  '#e056fd', // Violet
-  '#22c55e', // Green
-  '#ef4444', // Red
-  '#45B7D1', // Blue
+  '#6366f1', // Indigo (indigo-500)
+  '#f59e0b', // Amber (amber-500)
+  '#22c55e', // Green (green-500)
+  '#ec4899', // Pink (pink-500)
+  '#06b6d4', // Cyan (cyan-500)
+  '#a855f7', // Purple (purple-500)
+  '#ef4444', // Red (red-500)
+  '#eab308', // Yellow (yellow-500)
 ];
 
 const FALLBACK_COLOR = '#94a3b8'; // slate-400, matches muted-foreground tone

--- a/SparkyFitnessFrontend/src/utils/topMatches.ts
+++ b/SparkyFitnessFrontend/src/utils/topMatches.ts
@@ -1,0 +1,44 @@
+import type {
+  ExternalResultWrapper,
+  ProviderFoodSearchResult,
+} from '@/hooks/Foods/useAllProvidersFoodSearch';
+
+export interface TopMatch {
+  result: ExternalResultWrapper;
+  providerName: string;
+  providerId: string;
+}
+
+// Round-robin interleave of each provider's top results for the All Providers
+// "Top Matches" section: take rank 0 from every provider, then rank 1, and so
+// on up to perProvider ranks, then cap the list. This keeps Top Matches
+// balanced across sources instead of letting one fast/large provider dominate.
+// A provider that returned fewer items than the current rank is simply skipped,
+// so empty or failed providers contribute nothing without breaking the order.
+// The cap never drops below the number of providers that returned results:
+// because the round robin emits every provider's first item before any second
+// item, this guarantees at least one match from every contributing provider, so
+// the user always sees that each of their configured providers was searched.
+export function interleaveTopMatches(
+  providerResults: ProviderFoodSearchResult[],
+  perProvider = 2,
+  baseCap = 5
+): TopMatch[] {
+  const out: TopMatch[] = [];
+  for (let rank = 0; rank < perProvider; rank++) {
+    for (const r of providerResults) {
+      const item = r.items[rank];
+      if (item) {
+        out.push({
+          result: item,
+          providerName: r.provider.provider_name,
+          providerId: r.provider.id,
+        });
+      }
+    }
+  }
+  const providersWithResults = providerResults.filter(
+    (r) => r.items.length > 0
+  ).length;
+  return out.slice(0, Math.max(baseCap, providersWithResults));
+}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Phase 3 of the unified search (#1496). Phase 2 added an "All Providers" mode to the mobile food search; this brings the same mode to the web `FoodSearch`, so web and mobile behave the same. When more than one food provider is active, a single search can fan out across every active provider at once instead of querying one at a time.

**How did you implement the solution?**
Selecting "All Providers" in the source switcher fans the search out across all active providers in parallel via a new declarative `useAllProvidersFoodSearch` hook (React Query `useQueries`), which runs alongside the existing single-provider search. Each provider is its own query, so results stream in independently and a slow or failing provider does not block the others (partial results). The view shows Top Matches (each provider's top results interleaved round robin, capped, but never below the number of providers that returned results so every source is represented, each row badged with a colour-coded source) and a By Source section with one collapsible accordion per provider (result-count badge, per-provider loading, error state with retry, empty state, and a "Show all N" link that deep-links into the existing single-provider view). Provider colours use an index-assigned palette (collision-free by list position) seeded from the app's existing chart colours. The fan-out is entirely client side, so there is no new backend. The interleave and colour helpers are shared pure functions with unit tests.

Linked Issue: Closes #1694

## How to Test

1. Have two or more active food providers configured (for example Open Food Facts plus another).
2. Open the food search and type a query (for example "salmon").
3. In the source switcher, choose "All Providers".
4. Verify Top Matches shows interleaved results badged by source, and By Source lists each provider with a result count.
5. Expand a provider; use "Show all N" to open that provider's full results.
6. Confirm a provider that errors or returns nothing shows its error (with retry) or empty state respectively, and the others still render.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="811" height="549" alt="2026-07-01 17_16_49-_Search both meals and foods_ _ ccshuttle - Discord" src="https://github.com/user-attachments/assets/3b6169c5-796b-477b-93a7-d6af652804d5" />

</details>

## Notes for Reviewers

Web only; no `SparkyFitnessServer/` or `SparkyFitnessMobile/` changes (the mobile version shipped in phase 2). Tests: unit tests added for the `topMatches` interleave and `providerColor` assignment; the full frontend jest suite passes and typecheck is clean on the changed files.

Two deliberate choices worth surfacing, both easy to change:
- Provider colours reuse the web app's existing chart palette (static hex, index-assigned by list position, ordered so adjacent providers stay in clearly different hue families), rather than theme-aware CSS variables like the mobile version. This keeps them consistent with the report charts, but it means they do not adapt to light/dark. Happy to move them onto theme variables if you would prefer parity with the mobile approach.
- The mobile "cap the local Your Foods / Your Meals list while online results are showing" affordance is not included here, since the web layout presents local and online results differently. If the long-local-list-buries-online problem applies on web too, that is a small follow-up.