### PR TITLE
feat: default food provider selector

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -48,7 +48,10 @@ import {
 } from '@/hooks/Foods/useFoodsV2.ts';
 import { mealSearchOptions } from '@/hooks/Foods/useMeals.ts';
 import { DataProvider } from '@/types/settings.ts';
-import { getProviderCategory } from '@/utils/settings.ts';
+import {
+  getProviderCategory,
+  resolveFoodProviderId,
+} from '@/utils/settings.ts';
 
 type FoodDataForBackend = Omit<CSVData, 'id'>;
 
@@ -203,11 +206,20 @@ const EnhancedFoodSearch = ({
   const topFoods = recentTopData?.topFoods || [];
   const foods = searchData?.searchResults || [];
 
-  const selectedFoodDataProvider =
-    manualProviderId ||
-    defaultFoodDataProviderId ||
-    foodDataProviders[0]?.id ||
-    null;
+  // Active food-category providers: the only valid options for the provider
+  // dropdown, so the resolved default must be drawn from this list (not the raw
+  // provider list) or the shadcn Select renders blank when it falls back to an
+  // inactive/non-food provider that has no matching SelectItem.
+  const foodProviderOptions = foodDataProviders.filter(
+    (provider) =>
+      getProviderCategory(provider).includes('food') && provider.is_active
+  );
+
+  const selectedFoodDataProvider = resolveFoodProviderId(
+    manualProviderId,
+    defaultFoodDataProviderId,
+    foodProviderOptions
+  );
   const selectedProviderName =
     foodDataProviders.find((p) => p.id === selectedFoodDataProvider)
       ?.provider_name ?? '';
@@ -623,10 +635,6 @@ const EnhancedFoodSearch = ({
 
   // --- Derived render state ---
 
-  const foodProviderOptions = foodDataProviders.filter(
-    (provider) =>
-      getProviderCategory(provider).includes('food') && provider.is_active
-  );
   const isDebouncePending =
     !isSearchEmpty && debouncedSearchTerm !== searchTerm;
   const localPending = isFetchingSearch || isMealLoading || isDebouncePending;

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -210,9 +210,13 @@ const EnhancedFoodSearch = ({
   // dropdown, so the resolved default must be drawn from this list (not the raw
   // provider list) or the shadcn Select renders blank when it falls back to an
   // inactive/non-food provider that has no matching SelectItem.
-  const foodProviderOptions = foodDataProviders.filter(
-    (provider) =>
-      getProviderCategory(provider).includes('food') && provider.is_active
+  const foodProviderOptions = useMemo(
+    () =>
+      foodDataProviders.filter(
+        (provider) =>
+          getProviderCategory(provider).includes('food') && provider.is_active
+      ),
+    [foodDataProviders]
   );
 
   const selectedFoodDataProvider = resolveFoodProviderId(

--- a/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
@@ -819,9 +819,13 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         auto_clear_history: newPrefs?.autoClearHistory ?? autoClearHistory,
         logging_level: newPrefs?.loggingLevel ?? loggingLevel,
         default_food_data_provider_id:
-          newPrefs?.defaultFoodDataProviderId ?? defaultFoodDataProviderId,
+          newPrefs?.defaultFoodDataProviderId !== undefined
+            ? newPrefs.defaultFoodDataProviderId
+            : defaultFoodDataProviderId,
         default_barcode_provider_id:
-          newPrefs?.defaultBarcodeProviderId ?? defaultBarcodeProviderId,
+          newPrefs?.defaultBarcodeProviderId !== undefined
+            ? newPrefs.defaultBarcodeProviderId
+            : defaultBarcodeProviderId,
         barcode_fallback_open_food_facts:
           newPrefs?.barcodeFallbackOpenFoodFacts ??
           barcodeFallbackOpenFoodFacts,

--- a/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderSettings.tsx
@@ -134,12 +134,9 @@ const ExternalProviderSettings = () => {
                   </Label>
                   <Select
                     value={
-                      defaultFoodDataProviderId &&
-                      foodProviders.some(
+                      foodProviders.find(
                         (p) => p.id === defaultFoodDataProviderId
-                      )
-                        ? defaultFoodDataProviderId
-                        : ''
+                      )?.id ?? ''
                     }
                     onValueChange={(value) => {
                       const id = value || null;

--- a/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderSettings.tsx
@@ -67,6 +67,8 @@ const ExternalProviderSettings = () => {
     useState<string | null>(null);
   const { user } = useAuth();
   const {
+    defaultFoodDataProviderId,
+    setDefaultFoodDataProviderId,
     defaultBarcodeProviderId,
     setDefaultBarcodeProviderId,
     barcodeFallbackOpenFoodFacts,
@@ -75,6 +77,9 @@ const ExternalProviderSettings = () => {
   } = usePreferences();
   const { data: providers = [] } = useExternalProviders(user?.activeUserId);
 
+  const foodProviders = providers.filter(
+    (p) => p.is_active && (p.categories ?? []).includes('food')
+  );
   const barcodeProviders = providers.filter(
     (p) => p.is_active && p.supports_barcode
   );
@@ -119,6 +124,35 @@ const ExternalProviderSettings = () => {
                   setGarminClientStateFromAddForm(null);
                 }}
               />
+            )}
+
+            {foodProviders.length > 0 && (
+              <div className="flex items-end gap-6">
+                <div className="flex-1 space-y-2">
+                  <Label htmlFor="food-provider">
+                    Default Food Data Provider
+                  </Label>
+                  <Select
+                    value={defaultFoodDataProviderId ?? ''}
+                    onValueChange={(value) => {
+                      const id = value || null;
+                      setDefaultFoodDataProviderId(id);
+                      saveAllPreferences({ defaultFoodDataProviderId: id });
+                    }}
+                  >
+                    <SelectTrigger id="food-provider">
+                      <SelectValue placeholder="Select a food provider" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {foodProviders.map((p) => (
+                        <SelectItem key={p.id} value={p.id}>
+                          {p.provider_name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
             )}
 
             {barcodeProviders.length > 0 && (

--- a/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ExternalProviderSettings.tsx
@@ -133,7 +133,14 @@ const ExternalProviderSettings = () => {
                     Default Food Data Provider
                   </Label>
                   <Select
-                    value={defaultFoodDataProviderId ?? ''}
+                    value={
+                      defaultFoodDataProviderId &&
+                      foodProviders.some(
+                        (p) => p.id === defaultFoodDataProviderId
+                      )
+                        ? defaultFoodDataProviderId
+                        : ''
+                    }
                     onValueChange={(value) => {
                       const id = value || null;
                       setDefaultFoodDataProviderId(id);

--- a/SparkyFitnessFrontend/src/tests/utils/resolveFoodProviderId.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/resolveFoodProviderId.test.ts
@@ -1,0 +1,28 @@
+import { resolveFoodProviderId } from '@/utils/settings';
+
+describe('resolveFoodProviderId', () => {
+  const options = [{ id: 'usda' }, { id: 'openfoodfacts' }];
+
+  it('prefers an explicit manual selection above everything else', () => {
+    expect(resolveFoodProviderId('fatsecret', 'usda', options)).toBe(
+      'fatsecret'
+    );
+  });
+
+  it('uses the persisted default when there is no manual selection', () => {
+    expect(resolveFoodProviderId(null, 'openfoodfacts', options)).toBe(
+      'openfoodfacts'
+    );
+  });
+
+  it('falls back to the first rendered option when no default is set', () => {
+    // Regression: the fallback must come from the filtered option list, not the
+    // raw provider list, so it can never resolve to an id with no SelectItem
+    // (which renders the dropdown blank).
+    expect(resolveFoodProviderId(null, null, options)).toBe('usda');
+  });
+
+  it('returns null when nothing is selectable', () => {
+    expect(resolveFoodProviderId(null, null, [])).toBeNull();
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/utils/resolveFoodProviderId.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/resolveFoodProviderId.test.ts
@@ -3,9 +3,9 @@ import { resolveFoodProviderId } from '@/utils/settings';
 describe('resolveFoodProviderId', () => {
   const options = [{ id: 'usda' }, { id: 'openfoodfacts' }];
 
-  it('prefers an explicit manual selection above everything else', () => {
-    expect(resolveFoodProviderId('fatsecret', 'usda', options)).toBe(
-      'fatsecret'
+  it('prefers a valid explicit manual selection above everything else', () => {
+    expect(resolveFoodProviderId('openfoodfacts', 'usda', options)).toBe(
+      'openfoodfacts'
     );
   });
 
@@ -15,14 +15,21 @@ describe('resolveFoodProviderId', () => {
     );
   });
 
-  it('falls back to the first rendered option when no default is set', () => {
-    // Regression: the fallback must come from the filtered option list, not the
-    // raw provider list, so it can never resolve to an id with no SelectItem
-    // (which renders the dropdown blank).
+  it('ignores a manual selection that is not an active option and falls through to the default', () => {
+    expect(resolveFoodProviderId('fatsecret', 'usda', options)).toBe('usda');
+  });
+
+  it('ignores a persisted default that is not an active option and falls back to the first option', () => {
+    // Regression: a default pointing at a now-inactive/non-food provider must
+    // not be returned, or the shadcn Select renders blank (no matching item).
+    expect(resolveFoodProviderId(null, 'fatsecret', options)).toBe('usda');
+  });
+
+  it('falls back to the first rendered option when nothing valid is selected', () => {
     expect(resolveFoodProviderId(null, null, options)).toBe('usda');
   });
 
   it('returns null when nothing is selectable', () => {
-    expect(resolveFoodProviderId(null, null, [])).toBeNull();
+    expect(resolveFoodProviderId('fatsecret', 'usda', [])).toBeNull();
   });
 });

--- a/SparkyFitnessFrontend/src/utils/settings.ts
+++ b/SparkyFitnessFrontend/src/utils/settings.ts
@@ -212,17 +212,26 @@ export const getProviderCategory = (
 
 /**
  * Resolve the food-search provider to select. Precedence: an explicit manual
- * choice, then the user's persisted default, then the first *rendered* option.
- * The final fallback must come from the filtered option list (active
- * food-category providers) rather than the raw provider list, otherwise it can
- * resolve to an id with no matching SelectItem and the dropdown renders blank.
+ * choice, then the user's persisted default, then the first available option.
+ * Every returned id is validated against the rendered option list (active
+ * food-category providers); a manual pick or persisted default that points at a
+ * now-inactive/non-food provider is ignored rather than returned, since an id
+ * with no matching SelectItem makes the dropdown render blank.
  */
 export const resolveFoodProviderId = (
   manualProviderId: string | null,
   defaultFoodDataProviderId: string | null,
   foodProviderOptions: { id: string }[]
-): string | null =>
-  manualProviderId ||
-  defaultFoodDataProviderId ||
-  foodProviderOptions[0]?.id ||
-  null;
+): string | null => {
+  const optionIds = foodProviderOptions.map((o) => o.id);
+  if (manualProviderId && optionIds.includes(manualProviderId)) {
+    return manualProviderId;
+  }
+  if (
+    defaultFoodDataProviderId &&
+    optionIds.includes(defaultFoodDataProviderId)
+  ) {
+    return defaultFoodDataProviderId;
+  }
+  return foodProviderOptions[0]?.id ?? null;
+};

--- a/SparkyFitnessFrontend/src/utils/settings.ts
+++ b/SparkyFitnessFrontend/src/utils/settings.ts
@@ -209,3 +209,20 @@ export const getProviderCategory = (
       : ['other']
   ) as ('food' | 'exercise' | 'other')[];
 };
+
+/**
+ * Resolve the food-search provider to select. Precedence: an explicit manual
+ * choice, then the user's persisted default, then the first *rendered* option.
+ * The final fallback must come from the filtered option list (active
+ * food-category providers) rather than the raw provider list, otherwise it can
+ * resolve to an id with no matching SelectItem and the dropdown renders blank.
+ */
+export const resolveFoodProviderId = (
+  manualProviderId: string | null,
+  defaultFoodDataProviderId: string | null,
+  foodProviderOptions: { id: string }[]
+): string | null =>
+  manualProviderId ||
+  defaultFoodDataProviderId ||
+  foodProviderOptions[0]?.id ||
+  null;


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Web had no explicit control to pick the default food data provider (mobile does), so the preference was only ever set implicitly, and the food provider box on the Add Food screen could render blank.

**How did you implement the solution?**
Added a Default Food Data Provider select in External Provider Settings mirroring the existing Default Barcode Provider control, and hardened the Add Food provider resolution to draw from the active food-provider option list so it can never resolve to a provider with no matching dropdown item.

Linked Issue: Closes #1696

## How to Test

1. Check out this branch and run the frontend (`pnpm install`, then `pnpm dev` in `SparkyFitnessFrontend/`).
2. Go to Settings and open External Data Providers. With at least one active food-category provider configured, a new Default Food Data Provider dropdown appears above Default Barcode Provider.
3. Pick a provider, reload the page, and confirm the selection persists.
4. Open the Add Food screen and confirm the provider box always shows a valid provider (never blank) whenever at least one active food provider exists, including when no default has been explicitly set.
5. Deactivate the provider currently set as the default, reopen Settings, and confirm the Default Food Data Provider dropdown shows its placeholder rather than a blank box.
6. Confirm the Default Barcode Provider control is unchanged.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="1189" height="278" alt="2026-07-01 18_00_43-Greenshot" src="https://github.com/user-attachments/assets/203ccba2-828d-4052-b32d-5143f891cb47" />

</details>

## Notes for Reviewers

This is a web parity fix: mobile already exposes a Default Food Data Provider selector, web did not. Scope is frontend-only, no server or schema changes.

A few implementation notes:
- Provider resolution is centralised in `resolveFoodProviderId` (`utils/settings.ts`) with unit tests. It validates the resolved id against the active food-provider option list, so a persisted default or manual pick that points at a now-inactive or non-food provider is ignored instead of returning an id with no matching item.
- The new Settings strings are plain inline English, matching the adjacent Default Barcode Provider control (which is not i18n-keyed either), so no translation files change.
- The empty `Select` value uses `''` rather than `undefined`. This is a controlled Radix select and `''` is a valid controlled empty value that renders the placeholder; `undefined` would flip it to uncontrolled and can trigger React's controlled-to-uncontrolled warning.
- The pre-existing Default Barcode Provider `value` binding has the same latent blank-box pattern. I left it untouched to keep this PR scoped to the new feature; happy to address it the same way in a follow-up.
