### PR TITLE
fix(mobile): show over calories as negative

### DIFF
--- a/SparkyFitnessMobile/src/components/CalorieRingCard.tsx
+++ b/SparkyFitnessMobile/src/components/CalorieRingCard.tsx
@@ -38,9 +38,6 @@ const CalorieRingCard: React.FC<CalorieRingCardProps> = ({
   ]) as [string, string];
 
   const displayRemaining = Math.round(remainingCalories);
-  const remainingText = displayRemaining >= 0
-    ? `${displayRemaining.toLocaleString()}`
-    : `+${Math.abs(displayRemaining).toLocaleString()}`;
 
   return (
     <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
@@ -59,10 +56,10 @@ const CalorieRingCard: React.FC<CalorieRingCardProps> = ({
           </View>
           <View className="absolute items-center justify-center">
             <Text className="text-2xl font-bold text-text-primary">
-              {remainingText}
+              {displayRemaining.toLocaleString()}
             </Text>
             <Text className="text-text-secondary text-xs">
-              {displayRemaining >= 0 ? 'remaining' : 'over goal'}
+              remaining
             </Text>
             <Text className="text-text-muted text-[10px] mt-0.5">
               of {calorieGoal.toLocaleString()} kcal

--- a/SparkyFitnessMobile/src/components/CalorieRingCard.tsx
+++ b/SparkyFitnessMobile/src/components/CalorieRingCard.tsx
@@ -37,7 +37,7 @@ const CalorieRingCard: React.FC<CalorieRingCardProps> = ({
     '--color-calories',
   ]) as [string, string];
 
-  const displayRemaining = Math.round(remainingCalories);
+  const displayRemaining = Math.round(remainingCalories) || 0;
 
   return (
     <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
On mobile if you were over calories it was showing "+xxx over goal" but web would should "- xxx remaining", this could be a bit confusing.

**How did you implement the solution?**
Changed the text on mobile to show a negative number if you are over and then say "remaining" below it instead of over goal, to match the web.

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="1320" height="1288" alt="image" src="https://github.com/user-attachments/assets/7fda62d1-3e9e-4b64-94a7-a28abba3319d" />

### After

<img width="1320" height="1045" alt="image" src="https://github.com/user-attachments/assets/93baebcc-9e42-43ce-bcab-e7605154ae46" />

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
