### PR TITLE
feat(food-search): Load more for single-provider online results

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -655,6 +655,8 @@
     "noSavedFoodsOrMeals": "No saved foods or meals found.",
     "searchOnlineToImport": "Search to find foods from your online provider.",
     "onlineSearchFailed": "Failed to search the online provider.",
+    "loadMore": "Load more",
+    "loadMoreFailed": "Failed to load more results.",
     "scannedProduct": "Scanned product",
     "recentFoods": "Recent Foods",
     "private": "Private",

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/hooks/Foods/useNutrionix.ts';
 import { DEFAULT_NUTRIENTS } from '@/constants/nutrients.ts';
 import { convertNutritionixToFood } from '@/utils/foodSearch.ts';
+import { dedupeAppend } from '@/utils/dedupeAppend.ts';
 import FoodResultCard from './FoodResultCard.tsx';
 import { BarcodeScannerDialog } from './BarcodeScannerDialog.tsx';
 import { CsvImportDialog } from './CsvImportDialog.tsx';
@@ -76,6 +77,13 @@ const EMPTY_PROVIDERS: DataProvider[] = [];
 // Sentinel provider id for the aggregated "All Providers" mode (offered only
 // when more than one food provider is active).
 const ALL_PROVIDERS_VALUE = '__all__';
+
+// One page of provider results plus whether the provider reports more pages
+// behind it, so the caller can offer a "Load more" affordance.
+type ProviderSearchPage = {
+  items: ExternalResultWrapper[];
+  hasMore: boolean;
+};
 
 interface EnhancedFoodSearchProps {
   onFoodSelect: (item: Food | Meal, type: 'food' | 'meal') => void;
@@ -155,6 +163,16 @@ const EnhancedFoodSearch = ({
   const [externalResults, setExternalResults] = useState<
     ExternalResultWrapper[]
   >([]);
+  // Pagination for the single-provider online results: the last page fetched,
+  // whether the provider reports more behind it, and a separate spinner for the
+  // "Load more" fetch so it does not swap out the results already on screen.
+  const [externalPage, setExternalPage] = useState(1);
+  const [externalHasMore, setExternalHasMore] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  // Bumped on every new online search (term or provider change). A "Load more"
+  // fetch captures the token at click time and discards its result if the token
+  // has moved on, so a slow page cannot append onto a newer search's results.
+  const searchToken = useRef(0);
   // A product resolved from a barcode scan, shown even with an empty query.
   // Kept separate from live online-search results (which clear on an empty
   // query) so a scan result is not hidden or flickered away.
@@ -220,17 +238,6 @@ const EnhancedFoodSearch = ({
 
   const [hasOnlineSearchBeenPerformed, setHasOnlineSearchBeenPerformed] =
     useState(false);
-
-  // Active food providers (used for the selector, the All Providers fan-out, and
-  // colour coding).
-  const foodProviderOptions = useMemo(
-    () =>
-      foodDataProviders.filter(
-        (provider) =>
-          getProviderCategory(provider).includes('food') && provider.is_active
-      ),
-    [foodDataProviders]
-  );
 
   // Aggregated "All Providers" mode: offered only when more than one food
   // provider is active. selectedFoodDataProvider holds the sentinel while it is
@@ -353,98 +360,157 @@ const EnhancedFoodSearch = ({
       (
         term: string,
         providerId: string,
-        provider: DataProvider
-      ) => Promise<ExternalResultWrapper[]>
+        provider: DataProvider,
+        page?: number
+      ) => Promise<ProviderSearchPage>
     >
   >(
     () => ({
-      openfoodfacts: async (term) => {
+      openfoodfacts: async (term, _id, _provider, page) => {
         const data = await queryClient.fetchQuery(
           searchFoodsV2Options(
             'openfoodfacts',
             term,
             undefined,
             undefined,
-            autoScaleOpenFoodFactsImports
+            autoScaleOpenFoodFactsImports,
+            page
           )
         );
-        return data.foods.map((food: Food) => ({
-          provider_type: 'openfoodfacts' as const,
-          food,
-        }));
+        return {
+          items: data.foods.map((food: Food) => ({
+            provider_type: 'openfoodfacts' as const,
+            food,
+          })),
+          hasMore: data.pagination?.hasMore ?? false,
+        };
       },
       nutritionix: async (term, id) => {
+        // Nutritionix uses a separate endpoint that returns the full result set
+        // in one shot, so there is no further page to load.
         const data: NutritionixItem[] = await queryClient.fetchQuery(
           searchNutritionixOptions(term, id)
         );
-        return data.map((item) => ({
-          provider_type: 'nutritionix' as const,
-          raw: item,
-          food: convertNutritionixToFood(item),
-        }));
+        return {
+          items: data.map((item) => ({
+            provider_type: 'nutritionix' as const,
+            raw: item,
+            food: convertNutritionixToFood(item),
+          })),
+          hasMore: false,
+        };
       },
-      fatsecret: async (term, id) => {
+      fatsecret: async (term, id, _provider, page) => {
         const data = await queryClient.fetchQuery(
-          searchFoodsV2Options('fatsecret', term, id)
+          searchFoodsV2Options(
+            'fatsecret',
+            term,
+            id,
+            undefined,
+            undefined,
+            page
+          )
         );
-        return data.foods.map((food: Food) => ({
-          provider_type: 'fatsecret' as const,
-          food,
-        }));
+        return {
+          items: data.foods.map((food: Food) => ({
+            provider_type: 'fatsecret' as const,
+            food,
+          })),
+          hasMore: data.pagination?.hasMore ?? false,
+        };
       },
-      usda: async (term, id) => {
+      usda: async (term, id, _provider, page) => {
         const data = await queryClient.fetchQuery(
-          searchFoodsV2Options('usda', term, id, foodDisplayLimit)
+          searchFoodsV2Options(
+            'usda',
+            term,
+            id,
+            foodDisplayLimit,
+            undefined,
+            page
+          )
         );
-        return data.foods.map((food: Food) => ({
-          provider_type: 'usda' as const,
-          food,
-        }));
+        return {
+          items: data.foods.map((food: Food) => ({
+            provider_type: 'usda' as const,
+            food,
+          })),
+          hasMore: data.pagination?.hasMore ?? false,
+        };
       },
-      mealie: async (term, id) => {
+      mealie: async (term, id, _provider, page) => {
         const data = await queryClient.fetchQuery(
-          searchFoodsV2Options('mealie', term, id)
+          searchFoodsV2Options('mealie', term, id, undefined, undefined, page)
         );
-        return data.foods.map((food: Food) => ({
-          provider_type: 'mealie' as const,
-          food,
-        }));
+        return {
+          items: data.foods.map((food: Food) => ({
+            provider_type: 'mealie' as const,
+            food,
+          })),
+          hasMore: data.pagination?.hasMore ?? false,
+        };
       },
-      tandoor: async (term, id) => {
+      tandoor: async (term, id, _provider, page) => {
         const data = await queryClient.fetchQuery(
-          searchFoodsV2Options('tandoor', term, id)
+          searchFoodsV2Options('tandoor', term, id, undefined, undefined, page)
         );
-        return data.foods.map((food: Food) => ({
-          provider_type: 'tandoor' as const,
-          food,
-        }));
+        return {
+          items: data.foods.map((food: Food) => ({
+            provider_type: 'tandoor' as const,
+            food,
+          })),
+          hasMore: data.pagination?.hasMore ?? false,
+        };
       },
-      yazio: async (term, id) => {
+      yazio: async (term, id, _provider, page) => {
         const data = await queryClient.fetchQuery(
-          searchFoodsV2Options('yazio', term, id, foodDisplayLimit)
+          searchFoodsV2Options(
+            'yazio',
+            term,
+            id,
+            foodDisplayLimit,
+            undefined,
+            page
+          )
         );
-        return data.foods.map((food: Food) => ({
-          provider_type: 'yazio' as const,
-          food,
-        }));
+        return {
+          items: data.foods.map((food: Food) => ({
+            provider_type: 'yazio' as const,
+            food,
+          })),
+          hasMore: data.pagination?.hasMore ?? false,
+        };
       },
-      norish: async (term, id) => {
+      norish: async (term, id, _provider, page) => {
         const data = await queryClient.fetchQuery(
-          searchFoodsV2Options('norish', term, id)
+          searchFoodsV2Options('norish', term, id, undefined, undefined, page)
         );
-        return data.foods.map((food: Food) => ({
-          provider_type: 'norish' as const,
-          food,
-        }));
+        return {
+          items: data.foods.map((food: Food) => ({
+            provider_type: 'norish' as const,
+            food,
+          })),
+          hasMore: data.pagination?.hasMore ?? false,
+        };
       },
-      swissfood: async (term, id) => {
+      swissfood: async (term, id, _provider, page) => {
         const data = await queryClient.fetchQuery(
-          searchFoodsV2Options('swissfood', term, id)
+          searchFoodsV2Options(
+            'swissfood',
+            term,
+            id,
+            undefined,
+            undefined,
+            page
+          )
         );
-        return data.foods.map((food: Food) => ({
-          provider_type: 'swissfood' as const,
-          food,
-        }));
+        return {
+          items: data.foods.map((food: Food) => ({
+            provider_type: 'swissfood' as const,
+            food,
+          })),
+          hasMore: data.pagination?.hasMore ?? false,
+        };
       },
     }),
     [queryClient, autoScaleOpenFoodFactsImports, foodDisplayLimit]
@@ -463,6 +529,16 @@ const EnhancedFoodSearch = ({
       return;
     }
     const term = searchTerm.trim();
+    // Each new search (or provider switch) starts a fresh page 1, so reset the
+    // paging cursor and "has more" flag alongside the results below, and
+    // invalidate any "Load more" fetch still in flight from the previous search.
+    // Clear isLoadingMore too, so a Load more that was in flight during the
+    // switch does not leave the new search's button stuck disabled/spinning
+    // until the stale request resolves.
+    searchToken.current += 1;
+    setExternalPage(1);
+    setExternalHasMore(false);
+    setIsLoadingMore(false);
     if (term.length < 3) {
       setExternalResults([]);
       setHasOnlineSearchBeenPerformed(false);
@@ -491,11 +567,20 @@ const EnhancedFoodSearch = ({
       setSearchProviderId(provider.id);
       setHasOnlineSearchBeenPerformed(true);
       try {
-        const results = await providerSearch(term, provider.id, provider);
-        if (active) setExternalResults(results);
+        const { items, hasMore } = await providerSearch(
+          term,
+          provider.id,
+          provider,
+          1
+        );
+        if (active) {
+          setExternalResults(items);
+          setExternalHasMore(hasMore);
+        }
       } catch {
         if (active) {
           setExternalResults([]);
+          setExternalHasMore(false);
           toast({
             title: t('common.error'),
             description: t(
@@ -515,6 +600,65 @@ const EnhancedFoodSearch = ({
     };
   }, [
     searchTerm,
+    selectedFoodDataProvider,
+    foodDataProviders,
+    searchHandlers,
+    t,
+  ]);
+
+  // Fetch the next page for the current single-provider search and append it to
+  // the results already on screen. Providers that report no further pages hide
+  // the trigger, so this only runs when there is genuinely more to load.
+  const handleLoadMore = useCallback(async () => {
+    const term = searchTerm.trim();
+    if (term.length < 3 || isLoadingMore) return;
+    const provider = foodDataProviders.find(
+      (p) => p.id === selectedFoodDataProvider
+    );
+    const providerSearch = provider
+      ? searchHandlers[provider.provider_type]
+      : undefined;
+    if (!provider || !providerSearch) return;
+    const nextPage = externalPage + 1;
+    const token = searchToken.current;
+    setIsLoadingMore(true);
+    try {
+      const { items, hasMore } = await providerSearch(
+        term,
+        provider.id,
+        provider,
+        nextPage
+      );
+      // A newer search started while this page was in flight; drop it so it
+      // cannot append onto the newer search's results.
+      if (token !== searchToken.current) return;
+      // Dedupe by external id so an overlapping page boundary cannot produce
+      // duplicate React keys or repeated rows.
+      setExternalResults((prev) =>
+        dedupeAppend(
+          prev,
+          items,
+          (r) => `${r.provider_type}-${r.food.provider_external_id}`
+        )
+      );
+      setExternalHasMore(hasMore);
+      setExternalPage(nextPage);
+    } catch {
+      toast({
+        title: t('common.error'),
+        description: t(
+          'enhancedFoodSearch.loadMoreFailed',
+          'Failed to load more results.'
+        ),
+        variant: 'destructive',
+      });
+    } finally {
+      setIsLoadingMore(false);
+    }
+  }, [
+    searchTerm,
+    isLoadingMore,
+    externalPage,
     selectedFoodDataProvider,
     foodDataProviders,
     searchHandlers,
@@ -808,8 +952,10 @@ const EnhancedFoodSearch = ({
             onValueChange={(value) => {
               // Clear the previous provider's results so the loading spinner
               // shows under the new header instead of stale rows (which reads as
-              // if the swap did nothing on a slow connection).
+              // if the swap did nothing on a slow connection). Hide the paging
+              // trigger too, until the new provider reports its own next page.
               setExternalResults([]);
+              setExternalHasMore(false);
               setManualProviderId(value);
             }}
           >
@@ -969,6 +1115,22 @@ const EnhancedFoodSearch = ({
                   </div>
                 )}
                 {externalResults.map((result) => renderExternalCard(result))}
+                {externalHasMore && !isOnlineLoading && (
+                  <div className="flex justify-center py-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={isLoadingMore}
+                      onClick={handleLoadMore}
+                    >
+                      {isLoadingMore ? (
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                      ) : (
+                        t('enhancedFoodSearch.loadMore', 'Load more')
+                      )}
+                    </Button>
+                  </div>
+                )}
                 {!isOnlineLoading &&
                   hasOnlineSearchBeenPerformed &&
                   externalResults.length === 0 && (

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodsV2.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodsV2.ts
@@ -11,7 +11,8 @@ export const v2FoodKeys = {
     query: string,
     providerId?: string,
     pageSize?: number,
-    autoScale?: boolean
+    autoScale?: boolean,
+    page?: number
   ) =>
     [
       ...v2FoodKeys.all,
@@ -21,6 +22,7 @@ export const v2FoodKeys = {
       providerId,
       pageSize,
       autoScale,
+      page,
     ] as const,
   barcode: (barcode: string, providerId?: string) =>
     [...v2FoodKeys.all, 'barcode', barcode, providerId] as const,
@@ -39,24 +41,19 @@ export const searchFoodsV2Options = (
   query: string,
   providerId?: string,
   pageSize?: number,
-  autoScale?: boolean
+  autoScale?: boolean,
+  page?: number
 ) => ({
   queryKey: v2FoodKeys.search(
     providerType,
     query,
     providerId,
     pageSize,
-    autoScale
+    autoScale,
+    page
   ),
   queryFn: () =>
-    searchFoodsV2(
-      providerType,
-      query,
-      providerId,
-      undefined,
-      pageSize,
-      autoScale
-    ),
+    searchFoodsV2(providerType, query, providerId, page, pageSize, autoScale),
   staleTime: 1000 * 60 * 5,
   enabled: !!query,
   meta: {

--- a/SparkyFitnessFrontend/src/tests/utils/dedupeAppend.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/dedupeAppend.test.ts
@@ -1,0 +1,54 @@
+import { dedupeAppend } from '@/utils/dedupeAppend';
+
+type Row = { id: string; label: string };
+const keyOf = (r: Row) => r.id;
+
+describe('dedupeAppend', () => {
+  it('appends a fully new page in order', () => {
+    const prev = [{ id: 'a', label: 'A' }];
+    const next = [
+      { id: 'b', label: 'B' },
+      { id: 'c', label: 'C' },
+    ];
+    expect(dedupeAppend(prev, next, keyOf).map((r) => r.id)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('drops incoming items whose key already exists (overlapping boundary)', () => {
+    const prev = [
+      { id: 'a', label: 'A' },
+      { id: 'b', label: 'B' },
+    ];
+    const next = [
+      { id: 'b', label: 'B-dup' },
+      { id: 'c', label: 'C' },
+    ];
+    const merged = dedupeAppend(prev, next, keyOf);
+    expect(merged.map((r) => r.id)).toEqual(['a', 'b', 'c']);
+    // Existing item is kept as-is, not replaced by the duplicate.
+    expect(merged.find((r) => r.id === 'b')?.label).toBe('B');
+  });
+
+  it('returns the same array reference when the incoming page is all duplicates', () => {
+    const prev = [{ id: 'a', label: 'A' }];
+    const next = [{ id: 'a', label: 'A-again' }];
+    expect(dedupeAppend(prev, next, keyOf)).toBe(prev);
+  });
+
+  it('returns the same array reference for an empty incoming page', () => {
+    const prev = [{ id: 'a', label: 'A' }];
+    expect(dedupeAppend(prev, [], keyOf)).toBe(prev);
+  });
+
+  it('dedupes within the incoming page too', () => {
+    const next = [
+      { id: 'x', label: 'X' },
+      { id: 'x', label: 'X2' },
+      { id: 'y', label: 'Y' },
+    ];
+    expect(dedupeAppend([], next, keyOf).map((r) => r.id)).toEqual(['x', 'y']);
+  });
+});

--- a/SparkyFitnessFrontend/src/utils/dedupeAppend.ts
+++ b/SparkyFitnessFrontend/src/utils/dedupeAppend.ts
@@ -1,0 +1,20 @@
+// Append a freshly fetched page onto the results already on screen while
+// dropping anything whose key is already present. Provider pagination can
+// overlap at a page boundary (or repeat an item), which would otherwise produce
+// duplicate React keys and repeated rows. Order is preserved: existing items
+// stay put and only genuinely new items are appended.
+export function dedupeAppend<T>(
+  prev: T[],
+  incoming: T[],
+  keyOf: (item: T) => string
+): T[] {
+  const seen = new Set(prev.map(keyOf));
+  const fresh: T[] = [];
+  for (const item of incoming) {
+    const key = keyOf(item);
+    if (seen.has(key)) continue;
+    seen.add(key); // also guards duplicates within the incoming page
+    fresh.push(item);
+  }
+  return fresh.length > 0 ? [...prev, ...fresh] : prev;
+}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Selecting a specific external food provider only ever shows the first page of results (capped by the food_display_limit preference, default 10), so matches past the first page are unreachable from the UI.

**How did you implement the solution?**
The v2 search API and endpoint already return pagination metadata (page, pageSize, totalCount, hasMore), but the frontend hardcoded page=undefined and discarded it. This threads an optional page argument through searchFoodsV2Options into the existing searchFoodsV2 call, has each provider handler surface hasMore, and adds a Load more control under the single-provider online results that fetches and appends the next page. New pages are deduped by external id via a small unit-tested helper (dedupeAppend) so an overlapping page boundary cannot produce duplicate rows or React keys, and a Load more fetch still in flight is discarded via a search token if a newer search supersedes it. Providers that report no further pages, and the one-shot Nutritionix endpoint, do not render the control. Entirely client side: no backend, schema, or mobile changes.

Linked Issue: Closes #1704

## How to Test

1. Configure a specific external provider whose backend returns more results than food_display_limit (for example USDA, with the limit at its default of 10).
2. Open the food search and type a query with many matches (for example "chicken").
3. Confirm the first page of provider results appears, followed by a Load more control.
4. Click Load more and confirm the next page is appended below the existing rows (no duplicates, no jump), and that the control disappears once the provider reports no more pages.
5. While a Load more fetch is in flight, change the search term, and confirm the late page does not append onto the new results.
6. Switch to a provider that returns everything in one shot (or fewer than the page size) and confirm no Load more control shows.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="814" height="553" alt="2026-07-02 10_25_51-Greenshot" src="https://github.com/user-attachments/assets/9df7a214-23ed-45bf-b250-700bcba84f79" />

### After

<img width="812" height="551" alt="2026-07-02 10_24_41-Greenshot" src="https://github.com/user-attachments/assets/f79f77d1-9620-4004-b36b-1d19eb08b45a" />

</details>

## Notes for Reviewers

Web only; no SparkyFitnessServer/ or SparkyFitnessMobile/ changes. The backend already returns pagination metadata for the v2 providers, so this is purely wiring the frontend to use it. dedupeAppend has unit tests; the full frontend jest suite passes (374) and pnpm run validate is clean.

One thing worth an opinion: this pages in food_display_limit-sized chunks on demand (Load more) rather than raising the default page size, to keep the default per-search provider call cost unchanged. Happy to switch to a larger default or a different page size if you would prefer.
