### PR TITLE
fix: locale-dependent date crash

### DIFF
--- a/SparkyFitnessServer/tests/timezone.test.ts
+++ b/SparkyFitnessServer/tests/timezone.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   isDayString,
   dayOfWeek,
@@ -170,6 +170,31 @@ describe('instantToDay', () => {
     const ms = new Date(isoStr).getTime();
     expect(instantToDay(isoStr, 'UTC')).toBe('2024-06-15');
     expect(instantToDay(ms, 'UTC')).toBe('2024-06-15');
+  });
+  it('reads named date parts instead of trusting locale output ordering', () => {
+    const parts: Intl.DateTimeFormatPart[] = [
+      { type: 'month', value: '07' },
+      { type: 'literal', value: '/' },
+      { type: 'day', value: '15' },
+      { type: 'literal', value: '/' },
+      { type: 'year', value: '2026' },
+    ];
+    const dateTimeFormatSpy = vi
+      .spyOn(Intl, 'DateTimeFormat')
+      .mockImplementation(
+        () =>
+          ({
+            format: () => '07/15/2026',
+            formatToParts: () => parts,
+          }) as Intl.DateTimeFormat
+      );
+
+    const ts = new Date('2026-07-15T12:00:00Z');
+    try {
+      expect(instantToDay(ts, 'UTC')).toBe('2026-07-15');
+    } finally {
+      dateTimeFormatSpy.mockRestore();
+    }
   });
 });
 // ---------------------------------------------------------------------------

--- a/shared/src/utils/timezone.ts
+++ b/shared/src/utils/timezone.ts
@@ -84,21 +84,37 @@ export function isValidTimeZone(tz: string): boolean {
 
 /**
  * Returns today's date as YYYY-MM-DD in the given timezone.
- * Uses `Intl.DateTimeFormat` with 'en-CA' locale which natively formats as YYYY-MM-DD.
  */
 export function todayInZone(tz: string): string {
   return instantToDay(new Date(), tz);
 }
 
-/** Converts an arbitrary instant to a YYYY-MM-DD string in the given timezone. */
+/**
+ * Converts an arbitrary instant to a YYYY-MM-DD string in the given timezone.
+ *
+ * Assembles the string from `formatToParts` rather than relying on a locale
+ * (e.g. 'en-CA') to imply YYYY-MM-DD ordering. Some runtimes — notably Firefox
+ * on Linux, which applies OS regional preferences to explicitly-requested
+ * locales — format 'en-CA' as MM/DD/YYYY, which would leak a non-ISO date into
+ * API params and date parsing. Reading named parts is ordering-independent.
+ */
 export function instantToDay(ts: Date | string | number, tz: string): string {
   const date = ts instanceof Date ? ts : new Date(ts);
-  return Intl.DateTimeFormat('en-CA', {
+  const parts = Intl.DateTimeFormat('en-US', {
     timeZone: tz,
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
-  }).format(date);
+  }).formatToParts(date);
+  let year = '';
+  let month = '';
+  let day = '';
+  for (const p of parts) {
+    if (p.type === 'year') year = p.value;
+    if (p.type === 'month') month = p.value;
+    if (p.type === 'day') day = p.value;
+  }
+  return `${year}-${month}-${day}`;
 }
 
 /** Returns the current hour and minute in the given timezone. */


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Front end crashing when locale is set to CA, like on linux firefox

**How did you implement the solution?**


Linked Issue: Closes #1701

## How to Test

1. Linux firefox
2. Visit home page
3. no crash

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
