### PR TITLE
Resolve an HTTP 500 error ("rawBody.startsWith is not a function") on POST /api/measurements/health-data when using Content-Type: application/json.

### DIFF
--- a/SparkyFitnessServer/routes/measurementRoutes.ts
+++ b/SparkyFitnessServer/routes/measurementRoutes.ts
@@ -69,8 +69,7 @@ router.post(
       } else if (rawBody.includes('}{')) {
         const jsonStrings = rawBody
           .split('}{')
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          .map((part: any, index: any, arr: any) => {
+          .map((part: string, index: number, arr: string[]) => {
             if (index === 0) return part + '}';
             if (index === arr.length - 1) return '{' + part;
             return '{' + part + '}';
@@ -96,6 +95,16 @@ router.post(
       }
     } else {
       return res.status(400).json({ error: 'Invalid request body format.' });
+    }
+    if (
+      healthDataArray.some(
+        (item: unknown) => typeof item !== 'object' || item === null
+      )
+    ) {
+      return res.status(400).json({
+        error:
+          'Invalid health data format. All entries must be non-null objects.',
+      });
     }
     try {
       const result = await measurementService.processHealthData(

--- a/SparkyFitnessServer/routes/measurementRoutes.ts
+++ b/SparkyFitnessServer/routes/measurementRoutes.ts
@@ -53,39 +53,49 @@ router.post(
   async (req, res, next) => {
     const rawBody = req.body;
     let healthDataArray = [];
-    if (rawBody.startsWith('[') && rawBody.endsWith(']')) {
-      try {
-        healthDataArray = JSON.parse(rawBody);
-      } catch {
-        return res.status(400).json({ error: 'Invalid JSON array format.' });
+    if (typeof rawBody === 'object' && rawBody !== null) {
+      if (Array.isArray(rawBody)) {
+        healthDataArray = rawBody;
+      } else {
+        healthDataArray = [rawBody];
       }
-    } else if (rawBody.includes('}{')) {
-      const jsonStrings = rawBody
-        .split('}{')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .map((part: any, index: any, arr: any) => {
-          if (index === 0) return part + '}';
-          if (index === arr.length - 1) return '{' + part;
-          return '{' + part + '}';
-        });
-      for (const jsonStr of jsonStrings) {
+    } else if (typeof rawBody === 'string') {
+      if (rawBody.startsWith('[') && rawBody.endsWith(']')) {
         try {
-          healthDataArray.push(JSON.parse(jsonStr));
-        } catch (parseError) {
-          log(
-            'error',
-            'Error parsing individual concatenated JSON string:',
-            jsonStr,
-            parseError
-          );
+          healthDataArray = JSON.parse(rawBody);
+        } catch {
+          return res.status(400).json({ error: 'Invalid JSON array format.' });
+        }
+      } else if (rawBody.includes('}{')) {
+        const jsonStrings = rawBody
+          .split('}{')
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          .map((part: any, index: any, arr: any) => {
+            if (index === 0) return part + '}';
+            if (index === arr.length - 1) return '{' + part;
+            return '{' + part + '}';
+          });
+        for (const jsonStr of jsonStrings) {
+          try {
+            healthDataArray.push(JSON.parse(jsonStr));
+          } catch (parseError) {
+            log(
+              'error',
+              'Error parsing individual concatenated JSON string:',
+              jsonStr,
+              parseError
+            );
+          }
+        }
+      } else {
+        try {
+          healthDataArray.push(JSON.parse(rawBody));
+        } catch {
+          return res.status(400).json({ error: 'Invalid single JSON format.' });
         }
       }
     } else {
-      try {
-        healthDataArray.push(JSON.parse(rawBody));
-      } catch {
-        return res.status(400).json({ error: 'Invalid single JSON format.' });
-      }
+      return res.status(400).json({ error: 'Invalid request body format.' });
     }
     try {
       const result = await measurementService.processHealthData(

--- a/SparkyFitnessServer/tests/measurementRoutes.test.ts
+++ b/SparkyFitnessServer/tests/measurementRoutes.test.ts
@@ -12,13 +12,24 @@ vi.mock('../services/measurementService.js', () => ({
   },
 }));
 
+import type { Request, Response, NextFunction } from 'express';
+
 vi.mock('../middleware/checkPermissionMiddleware.js', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  default: vi.fn(() => (req: any, res: any, next: any) => next()),
+  default: vi.fn(
+    () => (req: Request, res: Response, next: NextFunction) => next()
+  ),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const injectUser = (req: any, res: any, next: any) => {
+vi.mock('../middleware/authMiddleware.js', () => ({
+  authenticate: (req: Request, _res: Response, next: NextFunction) => {
+    req.userId = 'test-user-id';
+    req.authenticatedUserId = 'test-user-id';
+    next();
+  },
+  isAdmin: (req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+const injectUser = (req: Request, res: Response, next: NextFunction) => {
   req.userId = 'test-user-id';
   next();
 };

--- a/SparkyFitnessServer/tests/measurementRoutes.test.ts
+++ b/SparkyFitnessServer/tests/measurementRoutes.test.ts
@@ -143,4 +143,17 @@ describe('Measurement Routes - POST /health-data', () => {
       'test-user-id'
     );
   });
+
+  it('returns 400 when the array contains non-object elements', async () => {
+    const res = await request(app)
+      .post('/api/measurements/health-data')
+      .set('Content-Type', 'application/json')
+      .send([null]);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual({
+      error:
+        'Invalid health data format. All entries must be non-null objects.',
+    });
+  });
 });

--- a/SparkyFitnessServer/tests/measurementRoutes.test.ts
+++ b/SparkyFitnessServer/tests/measurementRoutes.test.ts
@@ -1,0 +1,146 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'.
+import request from 'supertest';
+import express from 'express';
+import measurementService from '../services/measurementService.js';
+import errorHandler from '../middleware/errorHandler.js';
+import measurementRoutes from '../routes/measurementRoutes.js';
+
+vi.mock('../services/measurementService.js', () => ({
+  default: {
+    processHealthData: vi.fn(),
+  },
+}));
+
+vi.mock('../middleware/checkPermissionMiddleware.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: vi.fn(() => (req: any, res: any, next: any) => next()),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const injectUser = (req: any, res: any, next: any) => {
+  req.userId = 'test-user-id';
+  next();
+};
+
+const app = express();
+// Simulate the global JSON parser in SparkyFitnessServer.ts
+app.use(express.json());
+app.use(injectUser);
+app.use('/api/measurements', measurementRoutes);
+app.use(errorHandler);
+
+describe('Measurement Routes - POST /health-data', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('successfully parses valid JSON array when Content-Type is application/json', async () => {
+    const payload = [
+      {
+        type: 'weight',
+        value: 73.05,
+        date: '2026-05-05',
+        source: 'home_assistant',
+      },
+    ];
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist
+    measurementService.processHealthData.mockResolvedValue({
+      success: true,
+      count: 1,
+    });
+
+    const res = await request(app)
+      .post('/api/measurements/health-data')
+      .set('Content-Type', 'application/json')
+      .send(payload);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ success: true, count: 1 });
+    expect(measurementService.processHealthData).toHaveBeenCalledWith(
+      payload,
+      'test-user-id',
+      'test-user-id'
+    );
+  });
+
+  it('successfully parses single JSON object when Content-Type is application/json', async () => {
+    const payload = {
+      type: 'weight',
+      value: 73.05,
+      date: '2026-05-05',
+      source: 'home_assistant',
+    };
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist
+    measurementService.processHealthData.mockResolvedValue({
+      success: true,
+      count: 1,
+    });
+
+    const res = await request(app)
+      .post('/api/measurements/health-data')
+      .set('Content-Type', 'application/json')
+      .send(payload);
+
+    expect(res.statusCode).toBe(200);
+    expect(measurementService.processHealthData).toHaveBeenCalledWith(
+      [payload],
+      'test-user-id',
+      'test-user-id'
+    );
+  });
+
+  it('successfully parses raw text JSON array when Content-Type is text/plain', async () => {
+    const payload =
+      '[{"type":"weight","value":73.05,"date":"2026-05-05","source":"home_assistant"}]';
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist
+    measurementService.processHealthData.mockResolvedValue({
+      success: true,
+      count: 1,
+    });
+
+    const res = await request(app)
+      .post('/api/measurements/health-data')
+      .set('Content-Type', 'text/plain')
+      .send(payload);
+
+    expect(res.statusCode).toBe(200);
+    expect(measurementService.processHealthData).toHaveBeenCalledWith(
+      [
+        {
+          type: 'weight',
+          value: 73.05,
+          date: '2026-05-05',
+          source: 'home_assistant',
+        },
+      ],
+      'test-user-id',
+      'test-user-id'
+    );
+  });
+
+  it('successfully parses concatenated JSON strings when Content-Type is text/plain', async () => {
+    const payload =
+      '{"type":"weight","value":73.05}{"type":"blood_pressure","value":120}';
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist
+    measurementService.processHealthData.mockResolvedValue({
+      success: true,
+      count: 2,
+    });
+
+    const res = await request(app)
+      .post('/api/measurements/health-data')
+      .set('Content-Type', 'text/plain')
+      .send(payload);
+
+    expect(res.statusCode).toBe(200);
+    expect(measurementService.processHealthData).toHaveBeenCalledWith(
+      [
+        { type: 'weight', value: 73.05 },
+        { type: 'blood_pressure', value: 120 },
+      ],
+      'test-user-id',
+      'test-user-id'
+    );
+  });
+});


### PR DESCRIPTION

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)
Because the global express.json() body-parser runs before the measurement router is mounted, any incoming application/json payload is already parsed into a JavaScript object/array. The route-level express.text() middleware skips parsing (since req._body is true), causing a crash when trying to call .startsWith() on the pre-parsed object.

**How did you implement the solution?**
(Brief technical approach.)

- Updated the route controller in routes/measurementRoutes.ts to check if req.body is already parsed as an object/array, bypassing string parsing while retaining compatibility for raw text/plain payloads (e.g., concatenated JSON lines).
- Created a new test suite (tests/measurementRoutes.test.ts) to verify application/json and text/plain requests.


Linked Issue: Closes # https://github.com/CodeWithCJ/SparkyFitness/issues/1267

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
