### PR TITLE
fix: chat messages and keyboard now slide into place

### DIFF
--- a/SparkyFitnessMobile/__tests__/screens/ChatScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ChatScreen.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react-native';
-import { Platform } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import Toast from 'react-native-toast-message';
@@ -148,7 +147,13 @@ const mockUseActiveAiServiceSetting = useActiveAiServiceSetting as jest.MockedFu
 >;
 const mockUseChatHistory = useChatHistory as jest.MockedFunction<typeof useChatHistory>;
 
-const mockNavigation = { goBack: jest.fn(), setOptions: jest.fn() } as any;
+const mockNavigation = {
+  goBack: jest.fn(),
+  setOptions: jest.fn(),
+  // Returns an unsubscribe; ChatScreen subscribes to 'transitionEnd' to defer
+  // the composer's autofocus until the push transition settles.
+  addListener: jest.fn(() => jest.fn()),
+} as any;
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => mockNavigation,
@@ -194,12 +199,10 @@ beforeEach(() => {
 });
 
 describe('ChatScreen config gating', () => {
-  it('offsets keyboard avoidance by the native iOS header height', async () => {
+  it('renders the keyboard avoiding container', async () => {
     const { getByTestId } = renderScreen();
 
-    expect(getByTestId('chat-keyboard-avoiding-view').props.keyboardVerticalOffset).toBe(
-      Platform.OS === 'ios' ? 56 : 12
-    );
+    expect(getByTestId('chat-keyboard-avoiding-view')).toBeTruthy();
 
     await act(async () => {
       await Promise.resolve();
@@ -347,6 +350,20 @@ describe('ChatScreen thread', () => {
 
     requestAnimationFrameSpy.mockRestore();
     cancelAnimationFrameSpy.mockRestore();
+  });
+
+  it('defers composer focus to the push transitionEnd instead of autoFocus', async () => {
+    const { findByPlaceholderText } = renderScreen();
+    const input = await findByPlaceholderText('Message Sparky…');
+
+    // Focusing mid-transition presents the keyboard over the still-sliding
+    // screen, which flashes a dark-grey keyboard until the screen settles. So
+    // the composer must not use autoFocus...
+    expect(input.props.autoFocus).toBeFalsy();
+    // ...it focuses on the screen's entering transitionEnd instead.
+    expect(
+      mockNavigation.addListener.mock.calls.some(([event]: [string]) => event === 'transitionEnd')
+    ).toBe(true);
   });
 });
 

--- a/SparkyFitnessMobile/src/components/ExerciseSummary.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseSummary.tsx
@@ -37,14 +37,14 @@ const ExerciseSummary: React.FC<ExerciseSummaryProps> = ({
           onPress={onAddExercise}
           accessibilityRole="button"
           accessibilityLabel="Add exercise"
-          className="bg-surface rounded-xl p-4 my-2 shadow-sm items-center py-6"
+          className="bg-surface rounded-xl p-4 mb-2 shadow-sm items-center py-6"
         >
           {emptyContent}
         </Pressable>
       );
     }
     return (
-      <View className="bg-surface rounded-xl p-4 my-2 shadow-sm items-center py-6">
+      <View className="bg-surface rounded-xl p-4 mb-2 shadow-sm items-center py-6">
         {emptyContent}
       </View>
     );

--- a/SparkyFitnessMobile/src/components/FoodSummary.tsx
+++ b/SparkyFitnessMobile/src/components/FoodSummary.tsx
@@ -80,7 +80,7 @@ const MealSection: React.FC<MealSectionProps> = ({ mealType, entries, onAdjustSe
 const FoodSummary: React.FC<FoodSummaryProps> = ({ foodEntries, onAddFood, onAdjustServing, onPressMealType }) => {
   if (foodEntries.length === 0) {
     return (
-      <Pressable onPress={onAddFood} className="bg-surface rounded-xl p-4 mt-2 shadow-sm items-center py-6">
+      <Pressable onPress={onAddFood} className="bg-surface rounded-xl p-4 mb-2 shadow-sm items-center py-6">
         <Text className="text-text-muted text-base">Tap to add food</Text>
       </Pressable>
     );
@@ -92,14 +92,14 @@ const FoodSummary: React.FC<FoodSummaryProps> = ({ foodEntries, onAddFood, onAdj
 
   if (mealTypesWithEntries.length === 0 && !hasOther) {
     return (
-      <Pressable onPress={onAddFood} className="bg-surface rounded-xl p-4 mt-2 shadow-sm items-center py-6">
+      <Pressable onPress={onAddFood} className="bg-surface rounded-xl p-4 mb-2 shadow-sm items-center py-6">
         <Text className="text-text-muted text-base">Tap to add food</Text>
       </Pressable>
     );
   }
 
   return (
-    <View className="gap-2 my-2">
+    <View className="gap-2 mb-2">
       {mealTypesWithEntries.map((mealType) => (
         <MealSection
           key={mealType}

--- a/SparkyFitnessMobile/src/components/MeasurementsSummary.tsx
+++ b/SparkyFitnessMobile/src/components/MeasurementsSummary.tsx
@@ -120,7 +120,7 @@ const MeasurementsSummary: React.FC<MeasurementsSummaryProps> = ({
   );
 
   return (
-    <View className="my-2">
+    <View className="mb-2">
       {onPress ? (
         <Pressable
           onPress={onPress}

--- a/SparkyFitnessMobile/src/screens/ChatScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ChatScreen.tsx
@@ -5,11 +5,13 @@ import {
   ActivityIndicator,
   Alert,
   FlatList,
+  KeyboardAvoidingView as RNKeyboardAvoidingView,
+  Platform,
   TextInput,
   type TextInputProps,
 } from 'react-native';
 import { fetch as expoFetch } from 'expo/fetch';
-import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
+import { KeyboardAvoidingView as KeyboardControllerAvoidingView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
 import Toast from 'react-native-toast-message';
@@ -58,6 +60,14 @@ const ThreadMessages = ThreadPrimitive.Messages as React.ComponentType<
 
 const IOS_SMALL_NATIVE_HEADER_HEIGHT = 44;
 const CHAT_KEYBOARD_EXTRA_SPACING = 12;
+
+function ChatKeyboardAvoidingView(props: React.ComponentProps<typeof RNKeyboardAvoidingView>) {
+  if (Platform.OS === 'ios') {
+    return <RNKeyboardAvoidingView {...props} />;
+  }
+
+  return <KeyboardControllerAvoidingView {...props} />;
+}
 
 /**
  * Sparky chat: the assistant-ui + AI SDK runtime wired to the server's
@@ -235,14 +245,29 @@ function MessageBubble({ role }: { role: MessageRole }) {
   );
 }
 
-type LocalComposerInputProps = Omit<TextInputProps, 'value' | 'onChangeText'>;
+type LocalComposerInputProps = Omit<TextInputProps, 'value' | 'onChangeText'> & {
+  /** Focus the input once the screen's push transition has settled. */
+  autoFocusReady: boolean;
+};
 
-function LocalComposerInput(props: LocalComposerInputProps) {
+function LocalComposerInput({ autoFocusReady, ...props }: LocalComposerInputProps) {
   const aui = useAui();
+  const inputRef = useRef<TextInput>(null);
   const composerText = useAuiState((s) => s.composer.text);
   const [localText, setLocalText] = useState(composerText);
   const localTextRef = useRef(composerText);
   const pendingLocalTextsRef = useRef<string[]>([]);
+
+  // Focus once the screen's push transition has settled rather than via
+  // `autoFocus`. Focusing mid-transition presents the keyboard over the
+  // still-animating screen, which renders the keyboard backdrop a dark grey for
+  // the whole slide-in before it snaps to the normal light keyboard. The parent
+  // flips `autoFocusReady` on the entering `transitionEnd`; it may already be
+  // true on mount when slow config/history loads keep the composer unmounted
+  // past the transition, in which case we focus immediately.
+  useEffect(() => {
+    if (autoFocusReady) inputRef.current?.focus();
+  }, [autoFocusReady]);
 
   const applyLocalText = useCallback((value: string) => {
     localTextRef.current = value;
@@ -280,11 +305,11 @@ function LocalComposerInput(props: LocalComposerInputProps) {
     [applyLocalText, aui],
   );
 
-  return <TextInput {...props} value={localText} onChangeText={handleChangeText} />;
+  return <TextInput ref={inputRef} {...props} value={localText} onChangeText={handleChangeText} />;
 }
 
 /** The bottom input row. Send/Cancel stay on assistant-ui actions. */
-function Composer() {
+function Composer({ autoFocusReady }: { autoFocusReady: boolean }) {
   const [muted, raised, textPrimary] = useCSSVariable([
     '--color-text-muted',
     '--color-raised',
@@ -296,9 +321,9 @@ function Composer() {
       style={{ flexDirection: 'row', alignItems: 'flex-end', padding: 12, gap: 8 }}
     >
       <LocalComposerInput
+        autoFocusReady={autoFocusReady}
         placeholder="Message Sparky…"
         placeholderTextColor={muted}
-        autoFocus
         multiline
         style={{
           flex: 1,
@@ -350,11 +375,13 @@ function ChatThread({
   serviceConfigId,
   initialMessages,
   onRunningChange,
+  autoFocusReady,
 }: {
   baseUrl: string;
   serviceConfigId: string;
   initialMessages: InitialMessages;
   onRunningChange: (running: boolean) => void;
+  autoFocusReady: boolean;
 }) {
   const runtime = useSparkyChatRuntime({ baseUrl, serviceConfigId, initialMessages });
 
@@ -429,7 +456,7 @@ function ChatThread({
           </ThreadMessages>
         </View>
 
-        <Composer />
+        <Composer autoFocusReady={autoFocusReady} />
       </ThreadPrimitive.Root>
     </AssistantRuntimeProvider>
   );
@@ -466,6 +493,19 @@ export default function ChatScreen({ navigation }: RootStackScreenProps<'Chat'>)
   // `messages` changes after mount), so bump this to clear the thread.
   const [threadKey, setThreadKey] = useState(0);
   const { data: setting, isLoading: loadingSetting } = useActiveAiServiceSetting();
+
+  // Gate the composer's autofocus on the push transition finishing so the
+  // keyboard doesn't animate in over the still-sliding screen (which renders it
+  // a dark grey until the screen settles). Tracked here — not in the composer —
+  // because the composer mounts behind a loading gate that can outlast the
+  // transition, missing a `transitionEnd` listener attached that late.
+  const [transitionComplete, setTransitionComplete] = useState(false);
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('transitionEnd', (e) => {
+      if (!e.data.closing) setTransitionComplete(true);
+    });
+    return unsubscribe;
+  }, [navigation]);
 
   useEffect(() => {
     let cancelled = false;
@@ -554,11 +594,12 @@ export default function ChatScreen({ navigation }: RootStackScreenProps<'Chat'>)
     >
       {header}
 
-      {/* keyboard-controller's reworked KeyboardAvoidingView supports `padding`
-          on both platforms (RN-core's needs `undefined` on Android, but this is
-          not that component). Padding shrinks the message list by the keyboard
-          height so the composer stays pinned just above the keyboard. */}
-      <KeyboardAvoidingView
+      {/* Padding shrinks the message list by the keyboard height so the composer
+          stays pinned just above the keyboard. On iOS, RN core's
+          KeyboardAvoidingView follows keyboardWillShow with the system layout
+          animation; keyboard-controller's KAV can miss the live progress on iOS
+          26 with the custom header path and snap at keyboardDidShow. */}
+      <ChatKeyboardAvoidingView
         testID="chat-keyboard-avoiding-view"
         style={{ flex: 1 }}
         behavior="padding"
@@ -579,9 +620,10 @@ export default function ChatScreen({ navigation }: RootStackScreenProps<'Chat'>)
             serviceConfigId={serviceConfigId}
             initialMessages={initialMessages}
             onRunningChange={setRunning}
+            autoFocusReady={transitionComplete}
           />
         )}
-      </KeyboardAvoidingView>
+      </ChatKeyboardAvoidingView>
     </View>
   );
 }

--- a/SparkyFitnessMobile/src/screens/DiaryScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DiaryScreen.tsx
@@ -217,6 +217,7 @@ const DiaryScreen: React.FC<DiaryScreenProps> = ({ navigation }) => {
         style={{ flex: 1 }}
         contentContainerStyle={{
           paddingHorizontal: 16,
+          paddingTop: 8,
           paddingBottom: 80 + activeWorkoutBarPadding,
         }}
         showsVerticalScrollIndicator={false}


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
There was an animation glitch when navigating to the chat screen with the keyboard. Only happening on ios devices not simulators

**How did you implement the solution?**
Gate the composers auto focus on the push transition finishing

Linked Issue: Closes #

## How to Test

1. Go to chat screen
2. Go to chat screen again

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
