### PR TITLE
fix: YAZIO error when global provider

### DIFF
--- a/SparkyFitnessServer/services/externalProviderService.ts
+++ b/SparkyFitnessServer/services/externalProviderService.ts
@@ -116,22 +116,22 @@ async function getExternalDataProviders(userId: any) {
       stripCredentialSecret(
         redactCredentialsForNonOwner(
           applyRuntimeAvailability({
-          ...p,
+            ...p,
 
-          visibility: p.is_public
-            ? 'public'
-            : p.user_id === userId
-              ? 'private'
-              : 'family',
+            visibility: p.is_public
+              ? 'public'
+              : p.user_id === userId
+                ? 'private'
+                : 'family',
 
-          is_public: !!p.is_public,
+            is_public: !!p.is_public,
 
-          has_token:
-            p.encrypted_access_token !== null &&
-            p.encrypted_access_token !== undefined,
-           }),
-           userId
-         )
+            has_token:
+              p.encrypted_access_token !== null &&
+              p.encrypted_access_token !== undefined,
+          }),
+          userId
+        )
       )
     );
     // log('debug', `externalProviderService: Providers from repository for user ${userId}:`, providersWithVisibility);

--- a/SparkyFitnessServer/services/externalProviderService.ts
+++ b/SparkyFitnessServer/services/externalProviderService.ts
@@ -114,8 +114,9 @@ async function getExternalDataProviders(userId: any) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const providersWithVisibility = providers.map((p: any) =>
       stripCredentialSecret(
-        applyRuntimeAvailability({
-          ...redactCredentialsForNonOwner(p, userId),
+        redactCredentialsForNonOwner(
+          applyRuntimeAvailability({
+          ...p,
 
           visibility: p.is_public
             ? 'public'
@@ -128,7 +129,9 @@ async function getExternalDataProviders(userId: any) {
           has_token:
             p.encrypted_access_token !== null &&
             p.encrypted_access_token !== undefined,
-        })
+           }),
+           userId
+         )
       )
     );
     // log('debug', `externalProviderService: Providers from repository for user ${userId}:`, providersWithVisibility);


### PR DESCRIPTION
("provider is missing YAZIO Client ID and/or Client Secret" when it worked for the user who was creating it)

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
When trying to add a YAZIO global provider, it'd work for the (admin) user who created it, but for others it'd throw a YAZIO_OAUTH_CONFIG_ERROR ('YAZIO is not available because this provider is missing YAZIO Client ID and/or Client Secret. Configure the YAZIO Client ID and Client Secret in the provider settings.'). This PR fixes that, making it possible to use a global YAZIO provider correctly.

**How did you implement the solution?**
The issue was that the backend redacted the sensitive credentials before checking whether it could be used by an user, therefore checking the redacted YAZIO provider, seeing that it didn't have all options set and rejecting it automatically. By switching the order of the two functions, this issue was resolved.

## How to Test

1. Start up the dev/prod environment as normal
2. Add a first admin user then add a global YAZIO provider as normal
3. Register a second user and navigate to settings > food and exercise data providers
4. See that the YAZIO provider doesn't throw this error anymore (and of course it works as a provider correctly for all users).

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
The error shown on the current latest commit:
<img width="1309" height="159" alt="Screenshot 2026-07-04 at 15 44 35" src="https://github.com/user-attachments/assets/bbeda244-1923-4743-86af-0f533739a5d9" />
After applying this fix:
<img width="1302" height="133" alt="Screenshot 2026-07-04 at 15 45 53" src="https://github.com/user-attachments/assets/28d7b02a-6159-4003-abb3-e4997d5d7960" />

<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
