### PR TITLE
fix: resolve sleep stage overlap and correct time asleep

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/healthkit/dataAggregation.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthkit/dataAggregation.test.ts
@@ -156,13 +156,18 @@ describe('aggregateSleepSessions', () => {
   });
 
   test('maps unknown stage values to unknown', () => {
+    // Two contiguous unknown samples coalesce into one merged 'unknown' segment.
     const records: HKSleepRecord[] = [
       { startTime: '2024-01-15T22:00:00Z', endTime: '2024-01-15T23:00:00Z', value: 999 },
       { startTime: '2024-01-15T23:00:00Z', endTime: '2024-01-16T00:00:00Z', value: 'UnknownStageValue' },
     ];
     const result = aggregateSleepSessions(records);
     const stages = result[0].stage_events.map(e => e.stage_type);
-    expect(stages).toEqual(['unknown', 'unknown']);
+    expect(stages).toEqual(['unknown']);
+    expect(result[0].stage_events[0].start_time).toBe('2024-01-15T22:00:00.000Z');
+    expect(result[0].stage_events[0].end_time).toBe('2024-01-16T00:00:00.000Z');
+    // unknown is excluded from time asleep (matches the server's deep+light+rem definition).
+    expect(result[0].time_asleep_in_seconds).toBe(0);
   });
 
   test('calculates duration for each sleep stage correctly', () => {
@@ -288,6 +293,130 @@ describe('aggregateSleepSessions', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].record_timezone).toBe('Asia/Tokyo');
+  });
+});
+
+describe('aggregateSleepSessions overlapping sources (issue #1379)', () => {
+  // HealthKit returns raw samples from ALL sources mixed together. The reporter's setup:
+  // an Apple Watch writes fine-grained REM/Deep/Core/Awake segments while the AutoSleep
+  // app writes a coarse "in bed" envelope plus a generic "asleep" span over the same
+  // period. Without de-overlapping, every overlapping minute is counted twice.
+
+  // Primary invariant: the emitted stage_events form a non-overlapping timeline.
+  const expectNoOverlap = (events: { start_time: string; end_time: string }[]) => {
+    const sorted = [...events].sort(
+      (a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+    );
+    for (let i = 1; i < sorted.length; i++) {
+      expect(new Date(sorted[i].start_time).getTime()).toBeGreaterThanOrEqual(
+        new Date(sorted[i - 1].end_time).getTime()
+      );
+    }
+  };
+
+  const segmentSeconds = (
+    events: { stage_type: string; duration_in_seconds: number }[],
+    stageType: string
+  ) =>
+    events
+      .filter((e) => e.stage_type === stageType)
+      .reduce((sum, e) => sum + e.duration_in_seconds, 0);
+
+  test('Watch detailed stages under an AutoSleep envelope de-overlap to the union, not the sum', () => {
+    // Apple Watch fine-grained stages, contiguous 23:00–03:00.
+    // AutoSleep generic "asleep" spans exactly the same window (adds no asleep beyond
+    // the Watch), and an in-bed envelope extends wider (22:00–04:00).
+    const records: HKSleepRecord[] = [
+      // AutoSleep envelope (coarse), listed first — order must not matter.
+      { startTime: '2024-01-15T22:00:00Z', endTime: '2024-01-16T04:00:00Z', value: 0 }, // in_bed
+      { startTime: '2024-01-15T23:00:00Z', endTime: '2024-01-16T03:00:00Z', value: 1 }, // generic asleep
+      // Apple Watch detailed stages.
+      { startTime: '2024-01-15T23:00:00Z', endTime: '2024-01-16T00:00:00Z', value: 4 }, // deep 1h
+      { startTime: '2024-01-16T00:00:00Z', endTime: '2024-01-16T01:00:00Z', value: 5 }, // rem 1h
+      { startTime: '2024-01-16T01:00:00Z', endTime: '2024-01-16T01:30:00Z', value: 2 }, // awake 30m
+      { startTime: '2024-01-16T01:30:00Z', endTime: '2024-01-16T03:00:00Z', value: 3 }, // core 1.5h
+    ];
+    const result = aggregateSleepSessions(records);
+    expect(result).toHaveLength(1);
+    const events = result[0].stage_events;
+
+    expectNoOverlap(events);
+
+    // Asleep buckets equal the Watch's union — the generic-asleep overlap is absorbed,
+    // NOT added on top (the buggy "sum of both sources" would double these).
+    expect(result[0].deep_sleep_seconds).toBe(3600);
+    expect(result[0].rem_sleep_seconds).toBe(3600);
+    expect(result[0].light_sleep_seconds).toBe(5400); // core 1.5h
+    expect(result[0].awake_sleep_seconds).toBe(1800);
+    // time asleep = deep + rem + light = 3.5h, not 7.5h (Watch 3.5h + generic 4h).
+    expect(result[0].time_asleep_in_seconds).toBe(3.5 * 3600);
+
+    // The wider in-bed envelope survives only in the margins nothing better covers.
+    expect(segmentSeconds(events, 'in_bed')).toBe(2 * 3600); // 22:00–23:00 + 03:00–04:00
+  });
+
+  test('awake beats generic asleep on the same span', () => {
+    const records: HKSleepRecord[] = [
+      { startTime: '2024-01-16T00:00:00Z', endTime: '2024-01-16T02:00:00Z', value: 1 }, // generic asleep
+      { startTime: '2024-01-16T00:30:00Z', endTime: '2024-01-16T01:00:00Z', value: 2 }, // awake
+    ];
+    const result = aggregateSleepSessions(records);
+    const events = result[0].stage_events;
+    expectNoOverlap(events);
+    // The conflicted 00:30–01:00 span is emitted as awake, not light.
+    const awakeSeg = events.find((e) => e.stage_type === 'awake');
+    expect(awakeSeg).toBeDefined();
+    expect(awakeSeg?.start_time).toBe('2024-01-16T00:30:00.000Z');
+    expect(awakeSeg?.end_time).toBe('2024-01-16T01:00:00.000Z');
+    expect(result[0].awake_sleep_seconds).toBe(1800);
+    // Only the two flanking light slices remain asleep (00:00–00:30 + 01:00–02:00).
+    expect(result[0].time_asleep_in_seconds).toBe(1.5 * 3600);
+  });
+
+  test('deep beats generic asleep on overlap', () => {
+    const records: HKSleepRecord[] = [
+      { startTime: '2024-01-16T00:00:00Z', endTime: '2024-01-16T02:00:00Z', value: 1 }, // generic asleep
+      { startTime: '2024-01-16T00:30:00Z', endTime: '2024-01-16T01:30:00Z', value: 4 }, // deep
+    ];
+    const result = aggregateSleepSessions(records);
+    const events = result[0].stage_events;
+    expectNoOverlap(events);
+    const deepSeg = events.find((e) => e.stage_type === 'deep');
+    expect(deepSeg?.start_time).toBe('2024-01-16T00:30:00.000Z');
+    expect(deepSeg?.end_time).toBe('2024-01-16T01:30:00.000Z');
+    expect(result[0].deep_sleep_seconds).toBe(3600);
+    // deep 1h + surrounding light 1h (00:00–00:30 + 01:30–02:00) = 2h asleep, counted once.
+    expect(result[0].light_sleep_seconds).toBe(3600);
+    expect(result[0].time_asleep_in_seconds).toBe(2 * 3600);
+  });
+
+  test('in-bed margin outside the detailed stages is emitted as in_bed, counted once', () => {
+    // AutoSleep in-bed envelope 22:00–06:00 extends past the Watch's detailed data,
+    // which only covers 23:00–05:00.
+    const records: HKSleepRecord[] = [
+      { startTime: '2024-01-15T22:00:00Z', endTime: '2024-01-16T06:00:00Z', value: 0 }, // in_bed envelope
+      { startTime: '2024-01-15T23:00:00Z', endTime: '2024-01-16T00:00:00Z', value: 4 }, // deep 1h
+      { startTime: '2024-01-16T00:00:00Z', endTime: '2024-01-16T05:00:00Z', value: 3 }, // core 5h
+    ];
+    const result = aggregateSleepSessions(records);
+    const events = result[0].stage_events;
+    expectNoOverlap(events);
+
+    // The two margins (22:00–23:00 and 05:00–06:00) are in_bed, not asleep.
+    const inBed = events.filter((e) => e.stage_type === 'in_bed');
+    const inBedRanges = inBed
+      .map((e) => `${e.start_time}/${e.end_time}`)
+      .sort();
+    expect(inBedRanges).toEqual([
+      '2024-01-15T22:00:00.000Z/2024-01-15T23:00:00.000Z',
+      '2024-01-16T05:00:00.000Z/2024-01-16T06:00:00.000Z',
+    ]);
+    // in_bed total is the 2h of margins, counted once (envelope not double-added).
+    expect(segmentSeconds(events, 'in_bed')).toBe(2 * 3600);
+    // Asleep = deep 1h + core→light 5h = 6h; the in-bed margins are excluded.
+    expect(result[0].time_asleep_in_seconds).toBe(6 * 3600);
+    // The full in-bed envelope still bounds the session duration (22:00–06:00 = 8h).
+    expect(result[0].duration_in_seconds).toBe(8 * 3600);
   });
 });
 

--- a/SparkyFitnessMobile/src/services/healthkit/dataAggregation.ts
+++ b/SparkyFitnessMobile/src/services/healthkit/dataAggregation.ts
@@ -1,6 +1,8 @@
 import { addLog } from '../LogService';
 import {
   HKSleepRecord,
+  InternalSleepStage,
+  SleepRawEvent,
   SleepSessionAccumulator,
   SleepStageType,
   AggregatedSleepSession,
@@ -12,29 +14,132 @@ import { toLocalDateString } from '../../utils/dateUtils';
 // Re-export for backward compatibility
 export { toLocalDateString };
 
-const mapHealthKitSleepStage = (hkStage: string | number): SleepStageType => {
+// Overlap-resolution priority. When multiple HealthKit sources cover the same
+// wall-clock minute (e.g. an Apple Watch's fine-grained stages under an AutoSleep
+// "in bed"/generic-"asleep" envelope), the highest-ranked stage wins that minute.
+// The load-bearing ordering is core(3) > awake(2) > asleep_generic(1): a Watch's
+// 'awake' must override AutoSleep's generic 'asleep' for the same span.
+const SLEEP_STAGE_RANK: Record<InternalSleepStage, number> = {
+  deep: 5,
+  rem: 4,
+  core: 3,
+  awake: 2,
+  asleep_generic: 1,
+  in_bed: 0,
+  unknown: -1,
+};
+
+// Internal stage -> stored output stage. 'core' and 'asleep_generic' both collapse
+// to 'light'; they are only kept distinct internally for the ranking above.
+const SLEEP_STAGE_OUTPUT: Record<InternalSleepStage, SleepStageType> = {
+  deep: 'deep',
+  rem: 'rem',
+  core: 'light',
+  awake: 'awake',
+  asleep_generic: 'light',
+  in_bed: 'in_bed',
+  unknown: 'unknown',
+};
+
+const mapHealthKitSleepStage = (hkStage: string | number): InternalSleepStage => {
   switch (hkStage) {
     case 'HKCategoryValueSleepAnalysisAsleepREM': return 'rem';
     case 'HKCategoryValueSleepAnalysisAsleepDeep': return 'deep';
-    case 'HKCategoryValueSleepAnalysisAsleepCore': return 'light';
+    case 'HKCategoryValueSleepAnalysisAsleepCore': return 'core';
     case 'HKCategoryValueSleepAnalysisAwake': return 'awake';
     case 'HKCategoryValueSleepAnalysisInBed': return 'in_bed';
-    case 'HKCategoryValueSleepAnalysisAsleep': return 'light'; // Fallback for generic asleep
+    case 'HKCategoryValueSleepAnalysisAsleep': return 'asleep_generic'; // Generic (unspecified) asleep
     // Handle numeric enum values often returned by RN HealthKit
-    case 0: return 'in_bed'; // HKCategoryValueSleepAnalysisInBed
-    case 1: return 'light';  // HKCategoryValueSleepAnalysisAsleep (Generic)
-    case 2: return 'awake';  // HKCategoryValueSleepAnalysisAwake
-    case 3: return 'light';  // HKCategoryValueSleepAnalysisAsleepCore
-    case 4: return 'deep';   // HKCategoryValueSleepAnalysisAsleepDeep
-    case 5: return 'rem';    // HKCategoryValueSleepAnalysisAsleepREM
+    // (CategoryValueSleepAnalysis: inBed=0, asleepUnspecified=1, awake=2, core=3, deep=4, REM=5)
+    case 0: return 'in_bed';         // InBed
+    case 1: return 'asleep_generic'; // Asleep (Generic / unspecified)
+    case 2: return 'awake';          // Awake
+    case 3: return 'core';           // AsleepCore
+    case 4: return 'deep';           // AsleepDeep
+    case 5: return 'rem';            // AsleepREM
     default:
       addLog(`[HealthKitService] Unknown sleep stage value: ${hkStage}`, 'WARNING');
       return 'unknown';
   }
 };
 
+/** A resolved, non-overlapping slice of the sleep timeline. */
+interface MergedSleepSegment {
+  startMs: number;
+  endMs: number;
+  stage_type: SleepStageType;
+}
+
+/**
+ * Sweep-line flatten of possibly-overlapping raw samples into one non-overlapping
+ * timeline. For each sub-interval between consecutive boundaries, the highest-ranked
+ * covering sample wins; uncovered sub-intervals (gaps) are dropped; adjacent slices
+ * with the same OUTPUT stage type are coalesced to avoid sliver spam at cross-source
+ * boundaries. N samples/night is small, so O(N^2) boundary scanning is fine.
+ */
+const flattenSleepEvents = (events: SleepRawEvent[]): MergedSleepSegment[] => {
+  if (events.length === 0) return [];
+
+  const boundarySet = new Set<number>();
+  for (const ev of events) {
+    boundarySet.add(ev.startMs);
+    boundarySet.add(ev.endMs);
+  }
+  const boundaries = Array.from(boundarySet).sort((a, b) => a - b);
+
+  const segments: MergedSleepSegment[] = [];
+  for (let i = 0; i < boundaries.length - 1; i++) {
+    const a = boundaries[i];
+    const b = boundaries[i + 1];
+    if (b <= a) continue;
+
+    let best: SleepRawEvent | null = null;
+    for (const ev of events) {
+      if (ev.startMs <= a && ev.endMs >= b && (!best || ev.rank > best.rank)) {
+        best = ev;
+      }
+    }
+    if (!best) continue; // gap: no sample covers this sub-interval
+
+    const stageType = SLEEP_STAGE_OUTPUT[best.internalStage];
+    const last = segments[segments.length - 1];
+    if (last && last.stage_type === stageType && last.endMs === a) {
+      last.endMs = b; // coalesce contiguous same-type slice
+    } else {
+      segments.push({ startMs: a, endMs: b, stage_type: stageType });
+    }
+  }
+
+  return segments;
+};
+
 const finalizeSession = (session: SleepSessionAccumulator): AggregatedSleepSession => {
   const totalDuration = (session.wake_time.getTime() - session.bedtime.getTime()) / 1000;
+
+  const segments = flattenSleepEvents(session.raw_events);
+  let deep = 0;
+  let light = 0;
+  let rem = 0;
+  let awake = 0;
+  const stage_events: SleepStageEvent[] = segments.map((seg) => {
+    const duration = (seg.endMs - seg.startMs) / 1000;
+    if (seg.stage_type === 'deep') deep += duration;
+    else if (seg.stage_type === 'light') light += duration;
+    else if (seg.stage_type === 'rem') rem += duration;
+    else if (seg.stage_type === 'awake') awake += duration;
+    return {
+      stage_type: seg.stage_type,
+      start_time: new Date(seg.startMs).toISOString(),
+      end_time: new Date(seg.endMs).toISOString(),
+      duration_in_seconds: duration,
+    };
+  });
+  // "Time asleep" = deep + light + rem, matching the server's authoritative recompute
+  // (sumAsleepSeconds). Excludes awake, in_bed, and unknown so mobile and server never
+  // carry two definitions of the same field. The server recomputes from stage_events
+  // and discards this value, but keeping them in sync avoids a latent divergence.
+  const timeAsleep = deep + light + rem;
+
   const result: AggregatedSleepSession = {
     type: 'SleepSession',
     source: 'HealthKit',
@@ -43,12 +148,12 @@ const finalizeSession = (session: SleepSessionAccumulator): AggregatedSleepSessi
     bedtime: session.bedtime.toISOString(),
     wake_time: session.wake_time.toISOString(),
     duration_in_seconds: totalDuration,
-    time_asleep_in_seconds: session.total_time_asleep_in_seconds,
-    deep_sleep_seconds: session.deep_sleep_seconds,
-    light_sleep_seconds: session.light_sleep_seconds,
-    rem_sleep_seconds: session.rem_sleep_seconds,
-    awake_sleep_seconds: session.awake_sleep_seconds,
-    stage_events: session.stage_events,
+    time_asleep_in_seconds: timeAsleep,
+    deep_sleep_seconds: deep,
+    light_sleep_seconds: light,
+    rem_sleep_seconds: rem,
+    awake_sleep_seconds: awake,
+    stage_events,
   };
   if (session.record_timezone) {
     result.record_timezone = session.record_timezone;
@@ -71,7 +176,6 @@ export const aggregateSleepSessions = (records: HKSleepRecord[]): AggregatedSlee
   for (const record of sortedRecords) {
     const recordStartTime = new Date(record.startTime);
     const recordEndTime = new Date(record.endTime);
-    const duration = (recordEndTime.getTime() - recordStartTime.getTime()) / 1000;
 
     const stageType = mapHealthKitSleepStage(record.value);
     const recordTz = record.metadata?.HKTimeZone;
@@ -85,13 +189,7 @@ export const aggregateSleepSessions = (records: HKSleepRecord[]): AggregatedSlee
       currentSession = {
         bedtime: recordStartTime,
         wake_time: recordEndTime,
-        stage_events: [],
-        total_duration_in_seconds: 0,
-        total_time_asleep_in_seconds: 0,
-        deep_sleep_seconds: 0,
-        light_sleep_seconds: 0,
-        rem_sleep_seconds: 0,
-        awake_sleep_seconds: 0,
+        raw_events: [],
         record_timezone: recordTz,
       };
     } else {
@@ -109,29 +207,14 @@ export const aggregateSleepSessions = (records: HKSleepRecord[]): AggregatedSlee
       }
     }
 
-    // Add stage event to current session
-    const stageEvent: SleepStageEvent = {
-      stage_type: stageType,
-      start_time: recordStartTime.toISOString(),
-      end_time: recordEndTime.toISOString(),
-      duration_in_seconds: duration,
-    };
-    currentSession.stage_events.push(stageEvent);
-
-    // Sum up sleep stage durations
-    if (stageType === 'deep') {
-      currentSession.deep_sleep_seconds += duration;
-    } else if (stageType === 'light') {
-      currentSession.light_sleep_seconds += duration;
-    } else if (stageType === 'rem') {
-      currentSession.rem_sleep_seconds += duration;
-    } else if (stageType === 'awake') {
-      currentSession.awake_sleep_seconds += duration;
-    }
-
-    if (stageType !== 'awake' && stageType !== 'in_bed') {
-      currentSession.total_time_asleep_in_seconds += duration;
-    }
+    // Collect the raw sample; overlap resolution across sources happens later in
+    // finalizeSession so overlapping wall-clock time is never double-counted.
+    currentSession.raw_events.push({
+      startMs: recordStartTime.getTime(),
+      endMs: recordEndTime.getTime(),
+      internalStage: stageType,
+      rank: SLEEP_STAGE_RANK[stageType],
+    });
   }
 
   // Push the last session if it exists

--- a/SparkyFitnessMobile/src/types/healthRecords.ts
+++ b/SparkyFitnessMobile/src/types/healthRecords.ts
@@ -27,20 +27,43 @@ export interface HKSleepRecord {
 // INTERNAL ACCUMULATOR TYPES
 // ==========================================
 
-/** Sleep stage type including 'in_bed' */
+/** Sleep stage type including 'in_bed' (the output shape stored in stage_events) */
 export type SleepStageType = 'awake' | 'rem' | 'light' | 'deep' | 'in_bed' | 'unknown';
 
-/** Internal session state during sleep aggregation (uses Date objects) */
+/**
+ * Internal sleep stage classification used only during HealthKit overlap resolution.
+ * Splits Apple-Watch 'core' from generic 'asleep' so 'awake' can rank between them
+ * (the common Watch-vs-AutoSleep conflict is Watch=awake vs AutoSleep=generic-asleep,
+ * where the Watch's awake must win). Both 'core' and 'asleep_generic' map to the same
+ * output 'light' stage. See mapHealthKitSleepStage / SLEEP_STAGE_RANK in dataAggregation.ts.
+ */
+export type InternalSleepStage =
+  | 'deep'
+  | 'rem'
+  | 'core'
+  | 'awake'
+  | 'asleep_generic'
+  | 'in_bed'
+  | 'unknown';
+
+/** One raw HealthKit sleep sample collected before overlap resolution (uses epoch ms). */
+export interface SleepRawEvent {
+  startMs: number;
+  endMs: number;
+  internalStage: InternalSleepStage;
+  /** Priority for overlap resolution; higher wins. Derived from SLEEP_STAGE_RANK. */
+  rank: number;
+}
+
+/**
+ * Internal session state during sleep aggregation (uses Date objects).
+ * Collects raw, possibly-overlapping samples from all HealthKit sources; the
+ * non-overlapping timeline and per-stage buckets are derived in finalizeSession.
+ */
 export interface SleepSessionAccumulator {
   bedtime: Date;
   wake_time: Date;
-  stage_events: SleepStageEvent[];
-  total_duration_in_seconds: number;
-  total_time_asleep_in_seconds: number;
-  deep_sleep_seconds: number;
-  light_sleep_seconds: number;
-  rem_sleep_seconds: number;
-  awake_sleep_seconds: number;
+  raw_events: SleepRawEvent[];
   /** IANA timezone from the sample that set wake_time (for server-side day derivation) */
   record_timezone?: string;
 }

--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -1220,6 +1220,25 @@ async function calculateSleepScore(
   // Ensure score is within 0-100 range
   return Math.round(Math.max(0, Math.min(score, maxScore)));
 }
+// "Time asleep" is the sum of the genuinely-asleep stages only: deep + light + rem.
+// It excludes 'awake', and also 'in_bed' and 'unknown' — the in-bed envelope still
+// counts toward `duration` (so efficiency = time_asleep / duration stays meaningful)
+// but must not inflate asleep time. Overlap across sources is resolved on the mobile
+// client before upload, so a plain sum over the stored stages does not double-count.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function sumAsleepSeconds(stages: any[]): number {
+  if (!Array.isArray(stages)) return 0;
+  return stages.reduce((sum, stage) => {
+    if (
+      stage.stage_type === 'deep' ||
+      stage.stage_type === 'light' ||
+      stage.stage_type === 'rem'
+    ) {
+      return sum + (Math.round(Number(stage.duration_in_seconds)) || 0);
+    }
+    return sum;
+  }, 0);
+}
 async function processSleepEntry(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   userId: any,
@@ -1273,15 +1292,9 @@ async function processSleepEntry(
         },
       ];
     }
-    let timeAsleepInSeconds = 0;
-    // This check is now redundant but harmless as stage_events will always have at least one entry
-    if (stage_events && stage_events.length > 0) {
-      timeAsleepInSeconds = stage_events
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .filter((event: any) => event.stage_type !== 'awake')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .reduce((sum: any, event: any) => sum + event.duration_in_seconds, 0);
-    }
+    // Transient time-asleep to seed the first upsert + score; the recompute below
+    // overwrites it from the durable merged stages. Excludes awake/in_bed/unknown.
+    const timeAsleepInSeconds = sumAsleepSeconds(stage_events);
     // User profile (age/gender) + timezone, reusing prefetched values when present.
     const userProfile = prefetched
       ? prefetched.userProfile
@@ -1403,8 +1416,11 @@ async function processSleepEntry(
   }
 }
 
-// Pure aggregate derivation from a stage list. Limitation: overlapping stage segments
-// (rare, but HealthKit can emit them) are SUMmed and would double-count.
+// Pure aggregate derivation from a stage list. The stored stages are already a
+// non-overlapping timeline (mobile resolves cross-source overlap before upload), so the
+// per-stage buckets and `duration` are plain min/max/sum. `time_asleep` counts only the
+// asleep stages (deep/light/rem) via sumAsleepSeconds; `duration` still spans the full
+// in-bed envelope so efficiency = time_asleep / duration stays meaningful.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function recomputeSleepAggregatesFromStages(stages: any[]) {
   if (!stages || stages.length === 0) {
@@ -1445,20 +1461,12 @@ function recomputeSleepAggregatesFromStages(stages: any[]) {
         awake += duration;
         break;
       default:
-        // Unknown stage type — counted in time_asleep below if not 'awake'.
+        // in_bed / unknown: bounds the envelope (min/max above) but is NOT asleep time.
         break;
     }
   }
   const durationInSeconds = Math.max(0, Math.round((maxEnd - minStart) / 1000));
-  const timeAsleep = stages
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    .filter((s: any) => s.stage_type !== 'awake')
-    .reduce(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (sum: number, s: any) =>
-        sum + (Math.round(Number(s.duration_in_seconds)) || 0),
-      0
-    );
+  const timeAsleep = sumAsleepSeconds(stages);
   return {
     bedtime: new Date(minStart),
     wake_time: new Date(maxEnd),
@@ -1489,14 +1497,9 @@ async function updateSleepEntry(
       entry_date,
       ...entryDetails
     } = updateData;
-    let timeAsleepInSeconds = 0;
-    if (stage_events && stage_events.length > 0) {
-      timeAsleepInSeconds = stage_events
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .filter((event: any) => event.stage_type !== 'awake')
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        .reduce((sum: any, event: any) => sum + event.duration_in_seconds, 0);
-    }
+    // Web edit path: derive time asleep the same way as sync (excludes awake/in_bed/
+    // unknown) so editing a synced entry never re-inflates it with the in-bed envelope.
+    const timeAsleepInSeconds = sumAsleepSeconds(stage_events);
     // Fetch user profile to get age and gender
     const userProfile = await userRepository.getUserProfile(userId);
     const tz = await loadUserTimezone(userId);

--- a/SparkyFitnessServer/tests/measurementService.sleepResyncMerge.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.sleepResyncMerge.test.ts
@@ -512,4 +512,182 @@ describe('processHealthData sleep re-sync merge (issue #1180)', () => {
     expect(lastAggregates.light_sleep_seconds).toBe(1800);
     expect(lastAggregates.deep_sleep_seconds).toBe(1800);
   });
+
+  // Regression for issue #1379: the recompute must count only genuinely-asleep stages
+  // (deep + light + rem) as time_asleep. in_bed and unknown stages are stored and bound
+  // the duration envelope, but must NOT be counted as asleep (previously any non-'awake'
+  // stage inflated time_asleep). awake stays excluded as before.
+  it('excludes in_bed and unknown stages from recomputed time_asleep', async () => {
+    await measurementService.processHealthData(
+      [
+        {
+          type: 'SleepSession',
+          source: 'Health Connect',
+          timestamp: '2024-06-01T22:00:00Z',
+          bedtime: '2024-06-01T22:00:00Z',
+          wake_time: '2024-06-02T06:00:00Z',
+          duration_in_seconds: 28800,
+          stage_events: [
+            // Leading in-bed margin (before the detailed stages).
+            {
+              stage_type: 'in_bed',
+              start_time: '2024-06-01T22:00:00Z',
+              end_time: '2024-06-01T22:30:00Z',
+              duration_in_seconds: 1800,
+            },
+            {
+              stage_type: 'light',
+              start_time: '2024-06-01T22:30:00Z',
+              end_time: '2024-06-01T23:30:00Z',
+              duration_in_seconds: 3600,
+            },
+            {
+              stage_type: 'deep',
+              start_time: '2024-06-01T23:30:00Z',
+              end_time: '2024-06-02T01:00:00Z',
+              duration_in_seconds: 5400,
+            },
+            {
+              stage_type: 'rem',
+              start_time: '2024-06-02T01:00:00Z',
+              end_time: '2024-06-02T02:00:00Z',
+              duration_in_seconds: 3600,
+            },
+            {
+              stage_type: 'awake',
+              start_time: '2024-06-02T02:00:00Z',
+              end_time: '2024-06-02T02:15:00Z',
+              duration_in_seconds: 900,
+            },
+            {
+              stage_type: 'unknown',
+              start_time: '2024-06-02T02:15:00Z',
+              end_time: '2024-06-02T02:30:00Z',
+              duration_in_seconds: 900,
+            },
+            // Trailing in-bed margin (after the detailed stages, to 06:00).
+            {
+              stage_type: 'in_bed',
+              start_time: '2024-06-02T02:30:00Z',
+              end_time: '2024-06-02T06:00:00Z',
+              duration_in_seconds: 12600,
+            },
+          ],
+        },
+      ],
+      userId,
+      actingUserId
+    );
+
+    // All stages are stored, including in_bed and unknown.
+    expect(storedStages).toHaveLength(7);
+    const storedTypes = storedStages.map((s) => s.stage_type).sort();
+    expect(storedTypes).toEqual([
+      'awake',
+      'deep',
+      'in_bed',
+      'in_bed',
+      'light',
+      'rem',
+      'unknown',
+    ]);
+
+    const aggCalls = (
+      sleepRepository.updateSleepEntryAggregates as unknown as {
+        mock: { calls: unknown[][] };
+      }
+    ).mock.calls;
+    const lastAggregates = aggCalls[aggCalls.length - 1][3] as {
+      duration_in_seconds: number;
+      time_asleep_in_seconds: number;
+      deep_sleep_seconds: number;
+      light_sleep_seconds: number;
+      rem_sleep_seconds: number;
+      awake_sleep_seconds: number;
+    };
+    // time_asleep = deep (5400) + light (3600) + rem (3600) = 12600.
+    // in_bed (14400) and unknown (900) and awake (900) are all excluded.
+    expect(lastAggregates.time_asleep_in_seconds).toBe(12600);
+    expect(lastAggregates.deep_sleep_seconds).toBe(5400);
+    expect(lastAggregates.light_sleep_seconds).toBe(3600);
+    expect(lastAggregates.rem_sleep_seconds).toBe(3600);
+    expect(lastAggregates.awake_sleep_seconds).toBe(900);
+    // duration still spans the full in-bed envelope (22:00–06:00 = 8h).
+    expect(lastAggregates.duration_in_seconds).toBe(28800);
+  });
+
+  // The web dashboard edit path (PUT /sleep/:id -> updateSleepEntry) round-trips a
+  // synced entry's stored stage_events. It must exclude in_bed/unknown from time_asleep
+  // too, otherwise editing a HealthKit entry would silently re-inflate it.
+  it('updateSleepEntry (web edit) excludes in_bed and unknown from time_asleep', async () => {
+    sleepRepository.updateSleepEntry = vi
+      .fn()
+      .mockResolvedValue({ id: 'entry-web-edit' });
+    sleepRepository.deleteSleepStageEventsByEntryId = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    sleepRepository.upsertSleepStageEvent = vi
+      .fn()
+      .mockResolvedValue(undefined);
+
+    await measurementService.updateSleepEntry(
+      userId,
+      'entry-web-edit',
+      actingUserId,
+      {
+        entry_date: '2024-06-02',
+        bedtime: '2024-06-01T22:00:00Z',
+        wake_time: '2024-06-02T02:30:00Z',
+        duration_in_seconds: 16200,
+        source: 'HealthKit',
+        stage_events: [
+          {
+            stage_type: 'in_bed',
+            start_time: '2024-06-01T22:00:00Z',
+            end_time: '2024-06-01T22:30:00Z',
+            duration_in_seconds: 1800,
+          },
+          {
+            stage_type: 'light',
+            start_time: '2024-06-01T22:30:00Z',
+            end_time: '2024-06-01T23:30:00Z',
+            duration_in_seconds: 3600,
+          },
+          {
+            stage_type: 'deep',
+            start_time: '2024-06-01T23:30:00Z',
+            end_time: '2024-06-02T01:00:00Z',
+            duration_in_seconds: 5400,
+          },
+          {
+            stage_type: 'rem',
+            start_time: '2024-06-02T01:00:00Z',
+            end_time: '2024-06-02T02:00:00Z',
+            duration_in_seconds: 3600,
+          },
+          {
+            stage_type: 'awake',
+            start_time: '2024-06-02T02:00:00Z',
+            end_time: '2024-06-02T02:15:00Z',
+            duration_in_seconds: 900,
+          },
+          {
+            stage_type: 'unknown',
+            start_time: '2024-06-02T02:15:00Z',
+            end_time: '2024-06-02T02:30:00Z',
+            duration_in_seconds: 900,
+          },
+        ],
+      }
+    );
+
+    const updateCall = (
+      sleepRepository.updateSleepEntry as unknown as {
+        mock: { calls: unknown[][] };
+      }
+    ).mock.calls[0];
+    const details = updateCall[3] as { time_asleep_in_seconds: number };
+    // deep (5400) + light (3600) + rem (3600) = 12600; awake/in_bed/unknown excluded.
+    expect(details.time_asleep_in_seconds).toBe(12600);
+  });
 });


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Multiple sources of sleep data were causing duplicate data when syncing through healthkit.

**How did you implement the solution?**
Merge the overlapping samples that were duplicates. When two sources disagree, the more specific stage wins. Existing data will need to be resync'ed.

Linked Issue: Closes #1379

## How to Test

1. Sync sleep data
2. See no overlap

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
