### PR TITLE
fix: anchor Google Health sleep entries to the wake up day

### DIFF
--- a/SparkyFitnessServer/db/migrations/20260705000000_fix_googlehealth_sleep_date_anchor.sql
+++ b/SparkyFitnessServer/db/migrations/20260705000000_fix_googlehealth_sleep_date_anchor.sql
@@ -1,0 +1,33 @@
+-- SparkyFitnessServer/db/migrations/20260705000000_fix_googlehealth_sleep_date_anchor.sql
+-- Re-anchor existing Google Health sleep entries to the wake-up day.
+--
+-- processGoogleSleep previously filed a session under the day it started (the
+-- "night of"): entry_date = start-day, minus one when the session started before
+-- noon local time. That put overnight sleeps one day earlier than Google Health
+-- / Fitbit, which file a sleep under the day it ends. The processor now anchors
+-- to the wake-up day (instantToDay(wake_time, tz)).
+--
+-- The old anchor was NOT uniformly one day early: a same-day daytime nap that
+-- started at or after noon already had the correct (wake-day) date, so a blind
+-- +1 would break those rows. Instead we recompute each row's date from its own
+-- wake_time in the user's timezone, exactly as the processor now does, which is
+-- correct for overnight sleeps, past-midnight sleeps, and naps alike and is
+-- idempotent for rows that were already right.
+--
+-- Timezone resolution mirrors loadUserTimezone: the user's stored timezone when
+-- it is a zone Postgres recognises, otherwise UTC (covers a missing preferences
+-- row, a NULL timezone, or an unrecognised value). wake_time is NOT NULL.
+-- See: https://github.com/CodeWithCJ/SparkyFitness/issues/1723
+
+-- Resolve the timezone once via a join rather than a per-row correlated scan of
+-- pg_timezone_names (a filesystem-backed view). The se/se2 self-join is required:
+-- driving the update straight off user_preferences would inner-join away rows for
+-- users with no preferences row, leaving them un-migrated instead of UTC-anchored.
+UPDATE public.sleep_entries se
+SET entry_date = (se.wake_time AT TIME ZONE COALESCE(tzn.name, 'UTC'))::date,
+    updated_at = CURRENT_TIMESTAMP
+FROM public.sleep_entries se2
+LEFT JOIN public.user_preferences up ON up.user_id = se2.user_id
+LEFT JOIN pg_timezone_names tzn ON tzn.name = up.timezone
+WHERE se.id = se2.id
+  AND se2.source = 'Google Health';

--- a/SparkyFitnessServer/integrations/googlehealth/googleHealthDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/googlehealth/googleHealthDataProcessor.ts
@@ -4,12 +4,7 @@ import exerciseRepository from '../../models/exercise.js';
 import activityDetailsRepository from '../../models/activityDetailsRepository.js';
 import sleepRepository from '../../models/sleepRepository.js';
 import { log } from '../../config/logging.js';
-import {
-  todayInZone,
-  instantToDay,
-  instantHourMinute,
-  addDays,
-} from '@workspace/shared';
+import { todayInZone, instantToDay } from '@workspace/shared';
 import {
   parseDurationToSeconds,
   googleTimeToIso,
@@ -635,10 +630,10 @@ async function processGoogleSleep(
     );
     if (!startIso) continue;
 
-    const startDate = instantToDay(startIso, tz);
-    // Anchor to the "sleep date": if civil start is before noon, attribute to previous day.
-    const startHour = instantHourMinute(startIso, tz).hour;
-    const sleepDate = startHour < 12 ? addDays(startDate, -1) : startDate;
+    // Anchor to the wake-up day, matching how Google Health / Fitbit file a
+    // sleep session (it belongs to the day the session ends, not the day you
+    // fell asleep). Fall back to the start day when there is no end time.
+    const sleepDate = instantToDay(endIso ?? startIso, tz);
 
     const minutesAsleep = parseInt(summary.minutesAsleep as string, 10) || 0;
     const minutesInPeriod =

--- a/SparkyFitnessServer/tests/googleHealthDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/googleHealthDataProcessor.test.ts
@@ -239,10 +239,9 @@ describe('processGoogleActiveZoneMinutes', () => {
 
 // ─── Sleep anchoring ─────────────────────────────────────────────────────────
 
-// The API stores civilStartTime as local time treated as-if-UTC, so
-// getUTCHours() of the ISO string gives the local start hour. Sessions
-// starting before noon local time are attributed to the previous day
-// (they are the tail of the previous night's sleep, not a new day's nap).
+// A sleep session is anchored to the day it ends (the wake-up day), matching
+// how Google Health / Fitbit file it. A session that starts before midnight and
+// one that starts after midnight both belong to the morning they end on.
 
 function sleepPoint(startIso: string, endIso: string, minutesAsleep = 420) {
   return {
@@ -259,8 +258,8 @@ function sleepPoint(startIso: string, endIso: string, minutesAsleep = 420) {
 }
 
 describe('processGoogleSleep — date anchoring', () => {
-  it('attributes a late-evening session (hour >= 12) to its own date', async () => {
-    // 23:30 on May 1 — should land on 2026-05-01
+  it('anchors an overnight session to the day it ends', async () => {
+    // Asleep 23:30 May 1 → awake 07:00 May 2 — files under the wake day, May 2.
     await processGoogleSleep(
       UID,
       CID,
@@ -269,12 +268,13 @@ describe('processGoogleSleep — date anchoring', () => {
     expect(sleepRepository.upsertSleepEntry).toHaveBeenCalledWith(
       UID,
       CID,
-      expect.objectContaining({ entry_date: '2026-05-01' })
+      expect.objectContaining({ entry_date: '2026-05-02' })
     );
   });
 
-  it('attributes a past-midnight session (hour < 12) to the previous date', async () => {
-    // 00:30 on May 2 — civil-time interpretation means it is still May 1 night
+  it('anchors a past-midnight session to its own wake day, not the night before', async () => {
+    // Asleep 00:30 → awake 08:00, both May 2. This is the case that regressed:
+    // it must land on May 2 (wake day), not May 1.
     await processGoogleSleep(
       UID,
       CID,
@@ -283,14 +283,14 @@ describe('processGoogleSleep — date anchoring', () => {
     expect(sleepRepository.upsertSleepEntry).toHaveBeenCalledWith(
       UID,
       CID,
-      expect.objectContaining({ entry_date: '2026-05-01' })
+      expect.objectContaining({ entry_date: '2026-05-02' })
     );
   });
 
   it('keeps the longer session when two sessions share the same anchor date', async () => {
     const shortNap = sleepPoint(
-      '2026-05-01T23:00:00Z',
-      '2026-05-01T23:45:00Z',
+      '2026-05-02T00:00:00Z',
+      '2026-05-02T00:45:00Z',
       40
     );
     const mainSleep = sleepPoint(
@@ -307,9 +307,9 @@ describe('processGoogleSleep — date anchoring', () => {
     );
   });
 
-  it('attributes a past-midnight session (hour < 12 local) to the previous date in a negative offset timezone', async () => {
-    // 2:00 AM local time on May 2 in New York is 2026-05-02T06:00:00Z.
-    // It should be anchored to May 1.
+  it('anchors to the local wake day in a negative offset timezone', async () => {
+    // Awake 2026-05-02T14:00Z is 10:00 AM on May 2 in New York, so the session
+    // files under May 2 in that zone.
     await processGoogleSleep(
       UID,
       CID,
@@ -319,7 +319,7 @@ describe('processGoogleSleep — date anchoring', () => {
     expect(sleepRepository.upsertSleepEntry).toHaveBeenCalledWith(
       UID,
       CID,
-      expect.objectContaining({ entry_date: '2026-05-01' })
+      expect.objectContaining({ entry_date: '2026-05-02' })
     );
   });
 


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Sleep entries synced from google health using the wrong day

**How did you implement the solution?**
Instead of anchoring the sleep data on the day you fall asleep, this correctly attributes them to the day you wake up

Linked Issue: Closes #1723

## How to Test

Could not completely test this with real data as I don't have a google health device.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
