### PR TITLE
fix(mcp): normalize null optional parameters to undefined

### DIFF
--- a/SparkyFitnessServer/routes/mcpRoutes.ts
+++ b/SparkyFitnessServer/routes/mcpRoutes.ts
@@ -16,6 +16,31 @@ const router = express.Router();
 const SERVER_VERSION = versionService.getAppVersion();
 
 /**
+ * Recursively strips keys with null values from an object or array.
+ * This is used to normalize optional parameters sent as null by LLM clients
+ * (e.g. start_date: null) into undefined (omitted) so they satisfy Zod's .optional() validation.
+ */
+function stripNulls(val: any): any {
+  if (val === null) {
+    return undefined;
+  }
+  if (Array.isArray(val)) {
+    return val.map(stripNulls);
+  }
+  if (val && typeof val === 'object') {
+    const clean: Record<string, any> = {};
+    for (const key of Object.keys(val)) {
+      const cleanedVal = stripNulls(val[key]);
+      if (cleanedVal !== undefined) {
+        clean[key] = cleanedVal;
+      }
+    }
+    return clean;
+  }
+  return val;
+}
+
+/**
  * Stateless StreamableHTTP MCP endpoint; auth has already run by here.
  *
  * Scope to authenticatedUserId (the logged-in actor) to match the in-process
@@ -29,6 +54,26 @@ router.post('/', async (req, res) => {
   try {
     const userId = req.authenticatedUserId;
     const tz = await loadUserTimezone(userId);
+
+    // Normalize null arguments to undefined (omitted) for tools/call requests.
+    // This prevents validation errors (MCP -32602) on optional schema fields.
+    if (req.body) {
+      const requests = Array.isArray(req.body) ? req.body : [req.body];
+      for (const r of requests) {
+        if (
+          r &&
+          r.method === 'tools/call' &&
+          r.params &&
+          typeof r.params === 'object' &&
+          'arguments' in r.params &&
+          r.params.arguments &&
+          typeof r.params.arguments === 'object'
+        ) {
+          r.params.arguments = stripNulls(r.params.arguments);
+        }
+      }
+    }
+
     const mcpServer = new McpServer({
       name: 'sparkyfitness-mcp-server',
       version: SERVER_VERSION,

--- a/SparkyFitnessServer/routes/mcpRoutes.ts
+++ b/SparkyFitnessServer/routes/mcpRoutes.ts
@@ -21,18 +21,20 @@ const SERVER_VERSION = versionService.getAppVersion();
  * (e.g. start_date: null) into undefined (omitted) so they satisfy Zod's .optional() validation.
  */
 function stripNulls(val: any): any {
-  if (val === null) {
-    return undefined;
-  }
   if (Array.isArray(val)) {
-    return val.map(stripNulls);
+    return val.map((item) =>
+      item && typeof item === 'object' ? stripNulls(item) : item
+    );
   }
   if (val && typeof val === 'object') {
     const clean: Record<string, any> = {};
     for (const key of Object.keys(val)) {
-      const cleanedVal = stripNulls(val[key]);
-      if (cleanedVal !== undefined) {
-        clean[key] = cleanedVal;
+      const cleanedVal = val[key];
+      if (cleanedVal !== null) {
+        clean[key] =
+          cleanedVal && typeof cleanedVal === 'object'
+            ? stripNulls(cleanedVal)
+            : cleanedVal;
       }
     }
     return clean;

--- a/SparkyFitnessServer/tests/mcpRoutes.test.ts
+++ b/SparkyFitnessServer/tests/mcpRoutes.test.ts
@@ -176,6 +176,58 @@ describe('POST /mcp', () => {
     );
   });
 
+  it('tools/call normalizes null values to undefined in arguments', async () => {
+    vi.mocked(goalService.getUserGoals).mockResolvedValue({ calories: 2000 });
+
+    const res = await request(app)
+      .post('/mcp')
+      .set(MCP_HEADERS)
+      .set('Authorization', 'Bearer valid')
+      .send({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'sparky_get_goal_snapshot',
+          arguments: { target_date: null },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.result.content).toEqual([
+      { type: 'text', text: JSON.stringify({ calories: 2000 }) },
+    ]);
+    expect(goalService.getUserGoals).toHaveBeenCalledWith(
+      TEST_USER,
+      todayInZone('UTC')
+    );
+  });
+
+  it('returns a per-action validation error instead of -32602 when a required field is passed as null', async () => {
+    const res = await request(app)
+      .post('/mcp')
+      .set(MCP_HEADERS)
+      .set('Authorization', 'Bearer valid')
+      .send({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'sparky_manage_goals',
+          arguments: {
+            action: 'set_goals',
+            start_date: null,
+            calories: 2000,
+          },
+        },
+      });
+
+    expect(res.status).toBe(200);
+    const text = res.body.result.content[0].text;
+    expect(text).toContain('Error [VALIDATION]');
+    expect(text).toContain('start_date');
+  });
+
   it('rejects unauthenticated requests with 401', async () => {
     const res = await request(app)
       .post('/mcp')


### PR DESCRIPTION

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)
- Added a recursive `stripNulls` helper in `mcpRoutes.ts` to strip keys with `null` values from tool call arguments.
- This prevents MCP SDK Zod validation failures (error -32602) when LLM clients pass `null` values for optional schema fields (which expect `undefined` or omitted keys).
- If a required field is explicitly passed as `null`, it will be stripped and yield a clear per-action validation error from the tool handler instead of an opaque JSON-RPC error.
- Added unit tests in `mcpRoutes.test.ts` to verify both success and validation failure behavior.

Linked Issue: Closes # https://github.com/CodeWithCJ/SparkyFitness/issues/1540
 
## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
