### PR TITLE
fix: mobile search fixes

### DIFF
--- a/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
@@ -29,6 +29,7 @@ jest.mock('../../src/hooks', () => ({
   useMeals: jest.fn(),
   usePreferences: jest.fn(),
   useServerConnection: jest.fn(),
+  useDebounce: (value: unknown) => value,
 }));
 
 jest.mock('../../src/services/api/externalFoodSearchApi', () => ({

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -90,7 +90,6 @@ type ResultSection = {
     | 'online-top'
     | 'online-provider'
     | 'label'
-    | 'empty-local'
     | 'status';
   data: ResultRow[];
   provider?: ExternalProvider;
@@ -292,6 +291,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   // All Providers fan-out: parallel per-provider searches that stream in.
   const {
     providerResults,
+    anyLoading: anyProviderLoading,
     isSearchActive: isAllProvidersSearchActive,
   } = useAllProvidersSearch(searchText, providers, {
     enabled: isConnected && isAllProviders,
@@ -582,19 +582,12 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
         }
         sections.push({ key: 'meals', kind: 'meal', title: 'Your Meals', data });
       }
-    } else if (localPending) {
+    } else {
       sections.push({
         key: 'local-status',
         kind: 'status',
         title: null,
-        data: [{ type: 'local-loading' }],
-      });
-    } else {
-      sections.push({
-        key: 'empty-local',
-        kind: 'empty-local',
-        title: null,
-        data: [{ type: 'empty-local' }],
+        data: [localPending ? { type: 'local-loading' } : { type: 'empty-local' }],
       });
     }
 
@@ -885,13 +878,14 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
 
     // The External Results / Top Matches header doubles as the source switcher:
     // a single provider, or "All Providers" for the aggregated view. The current
-    // value is shown in the accent colour with a chevron icon so it reads as a
-    // switchable control.
+    // value is shown in the accent colour with a double-arrow selector icon so it
+    // reads as a switchable control; the icon becomes a spinner while loading.
     if (section.kind === 'online' || section.kind === 'online-top') {
       const canSwitch = providerOptions.length > 1;
       const label =
         section.kind === 'online-top' ? 'Top Matches' : 'Online Results';
       const value = isAllProviders ? 'All Sources' : selectedProviderName;
+      const loading = isAllProviders ? anyProviderLoading : isOnlineSearching;
       const header = (
         <View
           ref={onlineHeaderRef}
@@ -908,7 +902,9 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
             >
               {value}
             </Text>
-            {canSwitch ? (
+            {loading ? (
+              <ActivityIndicator size="small" color={accentColor} />
+            ) : canSwitch ? (
               <Icon name="chevron-down" size={16} color={accentColor} />
             ) : null}
           </View>
@@ -1011,24 +1007,9 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   };
 
   const renderResultSectionFooter = ({ section }: { section: ResultSection }) => {
-    if (section.kind === 'food' && isSearching) {
-      return (
-        <View className="py-3 items-center">
-          <ActivityIndicator size="small" color={accentColor} />
-        </View>
-      );
-    }
-    if (section.kind === 'meal' && isMealSearching) {
-      return (
-        <View className="py-3 items-center">
-          <ActivityIndicator size="small" color={accentColor} />
-        </View>
-      );
-    }
-
     if (section.kind !== 'online') return null;
 
-    if (isOnlineSearching) {
+    if (isOnlineSearching && visibleOnlineResults.length === 0) {
       return (
         <View className="py-4 items-center">
           <ActivityIndicator size="small" color={accentColor} />
@@ -1127,7 +1108,14 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
           borderColor: isSearchFocused ? accentColor : 'transparent',
         }}
       >
-        <Icon name="search" size={18} color={textMuted} />
+        <View className="w-[18px] h-[18px] items-center justify-center">
+          {!!searchText.trim() &&
+          (isSearching || isMealSearching || isOnlineSearching) ? (
+            <ActivityIndicator size="small" color={textMuted} />
+          ) : (
+            <Icon name="search" size={18} color={textMuted} />
+          )}
+        </View>
         <View className="flex-1 ml-2">
           <TextInput
             className="text-text-primary"

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -106,13 +106,6 @@ const ALL_PROVIDERS_VALUE = '__all__';
 // online results are also on screen.
 const LOCAL_RESULT_CAP = 6;
 
-// Exact (not min) height for the local-loading/empty-local status row. A hard
-// height, rather than a min-height, avoids a re-measure pass when the row's
-// content swaps between the spinner and the (possibly two-line) empty-state
-// text, which otherwise causes a brief scroll shift in the sections below it
-// (e.g. Online Results) since the list has no getItemLayout.
-const LOCAL_STATUS_ROW_HEIGHT = 72;
-
 const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }) => {
   const date = route.params?.date;
   const pickerMode = route.params?.pickerMode ?? 'log-entry';
@@ -852,23 +845,14 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
         return renderProviderSkeleton();
       case 'local-loading':
         return (
-          <View
-            className="px-4 items-center justify-center"
-            style={{ height: LOCAL_STATUS_ROW_HEIGHT }}
-          >
+          <View className="px-4 py-6 items-center justify-center">
             <ActivityIndicator size="small" color={accentColor} />
           </View>
         );
       case 'empty-local':
         return (
-          <View
-            className="px-4 items-center justify-center"
-            style={{ height: LOCAL_STATUS_ROW_HEIGHT }}
-          >
-            <Text
-              className="text-text-secondary text-base text-center"
-              numberOfLines={2}
-            >
+          <View className="px-4 py-6 items-center justify-center">
+            <Text className="text-text-secondary text-base text-center">
               {isMealBuilderMode
                 ? 'No saved foods found'
                 : 'No saved foods or meals found'}
@@ -1113,7 +1097,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
           borderColor: isSearchFocused ? accentColor : 'transparent',
         }}
       >
-        <View className="w-[18px] h-[18px] items-center justify-center">
+        <View className="w-[20px] h-[20px] items-center justify-center">
           {!!searchText.trim() &&
           (isSearching || isMealSearching || isOnlineSearching) ? (
             <ActivityIndicator size="small" color={textMuted} />

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -107,6 +107,11 @@ const ALL_PROVIDERS_VALUE = '__all__';
 // online results are also on screen.
 const LOCAL_RESULT_CAP = 6;
 
+// Fixed height for the local-loading/empty-local status row so switching
+// between the spinner and the empty-state text never shifts the sections
+// below it (e.g. Online Results).
+const LOCAL_STATUS_ROW_MIN_HEIGHT = 72;
+
 const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }) => {
   const date = route.params?.date;
   const pickerMode = route.params?.pickerMode ?? 'log-entry';
@@ -287,7 +292,6 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   // All Providers fan-out: parallel per-provider searches that stream in.
   const {
     providerResults,
-    anyLoading: anyProviderLoading,
     isSearchActive: isAllProvidersSearchActive,
   } = useAllProvidersSearch(searchText, providers, {
     enabled: isConnected && isAllProviders,
@@ -853,13 +857,19 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
         return renderProviderSkeleton();
       case 'local-loading':
         return (
-          <View className="py-8 items-center">
-            <ActivityIndicator size="large" color={accentColor} />
+          <View
+            className="px-4 py-6 items-center justify-center"
+            style={{ minHeight: LOCAL_STATUS_ROW_MIN_HEIGHT }}
+          >
+            <ActivityIndicator size="small" color={accentColor} />
           </View>
         );
       case 'empty-local':
         return (
-          <View className="px-4 py-6">
+          <View
+            className="px-4 py-6 items-center justify-center"
+            style={{ minHeight: LOCAL_STATUS_ROW_MIN_HEIGHT }}
+          >
             <Text className="text-text-secondary text-base text-center">
               {isMealBuilderMode
                 ? 'No saved foods found'
@@ -875,14 +885,13 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
 
     // The External Results / Top Matches header doubles as the source switcher:
     // a single provider, or "All Providers" for the aggregated view. The current
-    // value is shown in the accent colour with a double-arrow selector icon so it
-    // reads as a switchable control; the icon becomes a spinner while loading.
+    // value is shown in the accent colour with a chevron icon so it reads as a
+    // switchable control.
     if (section.kind === 'online' || section.kind === 'online-top') {
       const canSwitch = providerOptions.length > 1;
       const label =
         section.kind === 'online-top' ? 'Top Matches' : 'Online Results';
       const value = isAllProviders ? 'All Sources' : selectedProviderName;
-      const loading = isAllProviders ? anyProviderLoading : isOnlineSearching;
       const header = (
         <View
           ref={onlineHeaderRef}
@@ -899,9 +908,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
             >
               {value}
             </Text>
-            {loading ? (
-              <ActivityIndicator size="small" color={accentColor} />
-            ) : canSwitch ? (
+            {canSwitch ? (
               <Icon name="chevron-down" size={16} color={accentColor} />
             ) : null}
           </View>
@@ -1004,9 +1011,24 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   };
 
   const renderResultSectionFooter = ({ section }: { section: ResultSection }) => {
+    if (section.kind === 'food' && isSearching) {
+      return (
+        <View className="py-3 items-center">
+          <ActivityIndicator size="small" color={accentColor} />
+        </View>
+      );
+    }
+    if (section.kind === 'meal' && isMealSearching) {
+      return (
+        <View className="py-3 items-center">
+          <ActivityIndicator size="small" color={accentColor} />
+        </View>
+      );
+    }
+
     if (section.kind !== 'online') return null;
 
-    if (isOnlineSearching && visibleOnlineResults.length === 0) {
+    if (isOnlineSearching) {
       return (
         <View className="py-4 items-center">
           <ActivityIndicator size="small" color={accentColor} />
@@ -1105,12 +1127,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
           borderColor: isSearchFocused ? accentColor : 'transparent',
         }}
       >
-        {!!searchText.trim() &&
-        (isSearching || isMealSearching || isOnlineSearching) ? (
-          <ActivityIndicator size="small" color={textMuted} />
-        ) : (
-          <Icon name="search" size={18} color={textMuted} />
-        )}
+        <Icon name="search" size={18} color={textMuted} />
         <View className="flex-1 ml-2">
           <TextInput
             className="text-text-primary"

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -106,10 +106,12 @@ const ALL_PROVIDERS_VALUE = '__all__';
 // online results are also on screen.
 const LOCAL_RESULT_CAP = 6;
 
-// Fixed height for the local-loading/empty-local status row so switching
-// between the spinner and the empty-state text never shifts the sections
-// below it (e.g. Online Results).
-const LOCAL_STATUS_ROW_MIN_HEIGHT = 72;
+// Exact (not min) height for the local-loading/empty-local status row. A hard
+// height, rather than a min-height, avoids a re-measure pass when the row's
+// content swaps between the spinner and the (possibly two-line) empty-state
+// text, which otherwise causes a brief scroll shift in the sections below it
+// (e.g. Online Results) since the list has no getItemLayout.
+const LOCAL_STATUS_ROW_HEIGHT = 72;
 
 const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }) => {
   const date = route.params?.date;
@@ -851,8 +853,8 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
       case 'local-loading':
         return (
           <View
-            className="px-4 py-6 items-center justify-center"
-            style={{ minHeight: LOCAL_STATUS_ROW_MIN_HEIGHT }}
+            className="px-4 items-center justify-center"
+            style={{ height: LOCAL_STATUS_ROW_HEIGHT }}
           >
             <ActivityIndicator size="small" color={accentColor} />
           </View>
@@ -860,10 +862,13 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
       case 'empty-local':
         return (
           <View
-            className="px-4 py-6 items-center justify-center"
-            style={{ minHeight: LOCAL_STATUS_ROW_MIN_HEIGHT }}
+            className="px-4 items-center justify-center"
+            style={{ height: LOCAL_STATUS_ROW_HEIGHT }}
           >
-            <Text className="text-text-secondary text-base text-center">
+            <Text
+              className="text-text-secondary text-base text-center"
+              numberOfLines={2}
+            >
               {isMealBuilderMode
                 ? 'No saved foods found'
                 : 'No saved foods or meals found'}

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -861,13 +861,24 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
             <Text
               className="text-text-secondary text-base text-center"
               style={{ opacity: item.pending ? 0 : 1 }}
+              importantForAccessibility={item.pending ? 'no' : 'yes'}
+              accessibilityElementsHidden={item.pending}
             >
               {isMealBuilderMode
                 ? 'No saved foods found'
                 : 'No saved foods or meals found'}
             </Text>
             {item.pending ? (
-              <View className="absolute inset-0 items-center justify-center">
+              <View
+                className="absolute inset-0 items-center justify-center"
+                accessible
+                accessibilityRole="progressbar"
+                accessibilityLabel={
+                  isMealBuilderMode
+                    ? 'Searching saved foods'
+                    : 'Searching saved foods and meals'
+                }
+              >
                 <ActivityIndicator size="small" color={accentColor} />
               </View>
             ) : null}

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   View,
   Text,
@@ -434,6 +441,19 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   // Local results are still settling while the debounced query has not caught up
   // to the typed term, or while a fetch is in flight.
   const localPending = isSearching || isMealSearching || !isSearchActive;
+  // The foods and meals queries settle independently, so localPending can blip
+  // false->true->false within a keystroke or two. Stick to "pending" for a
+  // short window after it goes false so the status row's spinner/text swap
+  // doesn't flicker mid-typing; becoming pending is still immediate.
+  const [stableLocalPending, setStableLocalPending] = useState(localPending);
+  useEffect(() => {
+    if (localPending) {
+      setStableLocalPending(true);
+      return;
+    }
+    const timer = setTimeout(() => setStableLocalPending(false), 150);
+    return () => clearTimeout(timer);
+  }, [localPending]);
   const hasLocalResults =
     searchResults.length > 0 || (!isMealBuilderMode && mealResults.length > 0);
   // Only show online results from the currently selected provider. On a swap,
@@ -581,7 +601,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
         key: 'local-status',
         kind: 'status',
         title: null,
-        data: [{ type: 'local-status', pending: localPending }],
+        data: [{ type: 'local-status', pending: stableLocalPending }],
       });
     }
 
@@ -654,7 +674,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     return sections;
   }, [
     hasLocalResults,
-    localPending,
+    stableLocalPending,
     searchResults,
     mealResults,
     isMealBuilderMode,

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -1,6 +1,5 @@
 import React, {
   useCallback,
-  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -35,6 +34,7 @@ import {
   useExternalFoodSearch,
   useAllProvidersSearch,
   usePreferences,
+  useDebounce,
 } from '../hooks';
 import { ExternalProvider } from '../types/externalProviders';
 import Toast from 'react-native-toast-message';
@@ -442,18 +442,11 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   // to the typed term, or while a fetch is in flight.
   const localPending = isSearching || isMealSearching || !isSearchActive;
   // The foods and meals queries settle independently, so localPending can blip
-  // false->true->false within a keystroke or two. Stick to "pending" for a
-  // short window after it goes false so the status row's spinner/text swap
-  // doesn't flicker mid-typing; becoming pending is still immediate.
-  const [stableLocalPending, setStableLocalPending] = useState(localPending);
-  useEffect(() => {
-    if (localPending) {
-      setStableLocalPending(true);
-      return;
-    }
-    const timer = setTimeout(() => setStableLocalPending(false), 150);
-    return () => clearTimeout(timer);
-  }, [localPending]);
+  // false->true->false within a keystroke or two. Debounce just the
+  // false-going transition so the status row's spinner/text swap doesn't
+  // flicker mid-typing; becoming pending is still immediate via the ||.
+  const debouncedNotPending = useDebounce(!localPending, 150);
+  const stableLocalPending = localPending || !debouncedNotPending;
   const hasLocalResults =
     searchResults.length > 0 || (!isMealBuilderMode && mealResults.length > 0);
   // Only show online results from the currently selected provider. On a swap,

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -77,8 +77,7 @@ type ResultRow =
   | { type: 'show-all'; provider: ExternalProvider; count: number }
   | { type: 'show-all-local'; section: 'foods' | 'meals'; count: number }
   | { type: 'provider-skeleton' }
-  | { type: 'empty-local' }
-  | { type: 'local-loading' };
+  | { type: 'local-status'; pending: boolean };
 
 type ResultSection = {
   key: string;
@@ -105,13 +104,6 @@ const ALL_PROVIDERS_VALUE = '__all__';
 // How many local rows to show per section before the "Show all" expander, while
 // online results are also on screen.
 const LOCAL_RESULT_CAP = 6;
-
-// Minimum height for the local-loading/empty-local status row, matched to the
-// empty-state text's natural height at standard font scale. A shared minHeight
-// (not a hard height) keeps the spinner and empty-text states the same size in
-// the common case, avoiding a scroll shift, while still letting the text grow
-// past it if accessibility font scaling needs more room.
-const LOCAL_STATUS_ROW_MIN_HEIGHT = 72;
 
 const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }) => {
   const date = route.params?.date;
@@ -589,7 +581,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
         key: 'local-status',
         kind: 'status',
         title: null,
-        data: [localPending ? { type: 'local-loading' } : { type: 'empty-local' }],
+        data: [{ type: 'local-status', pending: localPending }],
       });
     }
 
@@ -850,26 +842,22 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
         return renderLocalShowAllRow(item.section, item.count);
       case 'provider-skeleton':
         return renderProviderSkeleton();
-      case 'local-loading':
+      case 'local-status':
         return (
-          <View
-            className="px-4 py-6 items-center justify-center"
-            style={{ minHeight: LOCAL_STATUS_ROW_MIN_HEIGHT }}
-          >
-            <ActivityIndicator size="small" color={accentColor} />
-          </View>
-        );
-      case 'empty-local':
-        return (
-          <View
-            className="px-4 py-6 items-center justify-center"
-            style={{ minHeight: LOCAL_STATUS_ROW_MIN_HEIGHT }}
-          >
-            <Text className="text-text-secondary text-base text-center">
+          <View className="px-4 py-6 items-center justify-center">
+            <Text
+              className="text-text-secondary text-base text-center"
+              style={{ opacity: item.pending ? 0 : 1 }}
+            >
               {isMealBuilderMode
                 ? 'No saved foods found'
                 : 'No saved foods or meals found'}
             </Text>
+            {item.pending ? (
+              <View className="absolute inset-0 items-center justify-center">
+                <ActivityIndicator size="small" color={accentColor} />
+              </View>
+            ) : null}
           </View>
         );
     }

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -106,6 +106,13 @@ const ALL_PROVIDERS_VALUE = '__all__';
 // online results are also on screen.
 const LOCAL_RESULT_CAP = 6;
 
+// Minimum height for the local-loading/empty-local status row, matched to the
+// empty-state text's natural height at standard font scale. A shared minHeight
+// (not a hard height) keeps the spinner and empty-text states the same size in
+// the common case, avoiding a scroll shift, while still letting the text grow
+// past it if accessibility font scaling needs more room.
+const LOCAL_STATUS_ROW_MIN_HEIGHT = 72;
+
 const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }) => {
   const date = route.params?.date;
   const pickerMode = route.params?.pickerMode ?? 'log-entry';
@@ -845,13 +852,19 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
         return renderProviderSkeleton();
       case 'local-loading':
         return (
-          <View className="px-4 py-6 items-center justify-center">
+          <View
+            className="px-4 py-6 items-center justify-center"
+            style={{ minHeight: LOCAL_STATUS_ROW_MIN_HEIGHT }}
+          >
             <ActivityIndicator size="small" color={accentColor} />
           </View>
         );
       case 'empty-local':
         return (
-          <View className="px-4 py-6 items-center justify-center">
+          <View
+            className="px-4 py-6 items-center justify-center"
+            style={{ minHeight: LOCAL_STATUS_ROW_MIN_HEIGHT }}
+          >
             <Text className="text-text-secondary text-base text-center">
               {isMealBuilderMode
                 ? 'No saved foods found'


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
When no local foods or meals were found the loading indicator for that section was too big causing the online foods section to be pushed down breifly and then brough back up after. 

Also the loading indicator in the search bar was causing the text to move a bit when searching 

**How did you implement the solution?**
The loading spinner and "no results" text used to be treated as two different list items, so swapping between them made everything below jump. Fix: treat them as one item (since the are treated as one item when both aren't found), and lock it to a fixed height. 

The search icon and loading spinner were different sizes, so swapping them pushed the text over. Put both in a fixed-size box.

Linked Issue: Closes #

## How to Test

1. go to food search page
2. search something not in your local db or meals
3. online foods tab no longer jumps up and down

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
