### PR TITLE
fix: allow trailing decimals in serving size input

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/FoodForm.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/FoodForm.test.tsx
@@ -1412,4 +1412,47 @@ describe('FoodForm', () => {
       expect(screen.getByText('Convert with AI')).toBeTruthy();
     });
   });
+
+  it('keeps the trailing decimal while typing an equivalent size', () => {
+    const handleChange = jest.fn();
+    function Harness() {
+      const [items, setItems] = React.useState([
+        { serving_size: 3, serving_unit: 'g', _clientKey: 'eq-test' },
+      ]);
+      return (
+        <FoodForm
+          initialValues={{
+            name: 'Greek Yogurt',
+            servingSize: '100',
+            servingUnit: 'g',
+            calories: '120',
+            protein: '10',
+            carbs: '8',
+            fat: '4',
+          }}
+          equivalents={{
+            items,
+            onChange: (next) => {
+              handleChange(next);
+              setItems(next);
+            },
+          }}
+          onSubmit={jest.fn()}
+        />
+      );
+    }
+
+    const screen = render(<Harness />);
+
+    // Typing the decimal point must not snap the field back to the parsed
+    // integer — that regression made decimals impossible to enter on Android.
+    fireEvent.changeText(screen.getByDisplayValue('3'), '3.');
+    expect(screen.getByDisplayValue('3.')).toBeTruthy();
+
+    fireEvent.changeText(screen.getByDisplayValue('3.'), '3.5');
+    expect(screen.getByDisplayValue('3.5')).toBeTruthy();
+    expect(handleChange).toHaveBeenLastCalledWith([
+      expect.objectContaining({ serving_size: 3.5, _sizeText: '3.5' }),
+    ]);
+  });
 });

--- a/SparkyFitnessMobile/src/components/FoodForm.tsx
+++ b/SparkyFitnessMobile/src/components/FoodForm.tsx
@@ -489,7 +489,8 @@ const EquivalentsSection: React.FC<EquivalentsSectionProps> = ({
         Equivalent sizes
       </Text>
       {items.map((item, index) => {
-        const sizeText = item.serving_size > 0 ? String(item.serving_size) : '';
+        const sizeText =
+          item._sizeText ?? (item.serving_size > 0 ? String(item.serving_size) : '');
         return (
           <View
             key={item.id ?? item._clientKey ?? `idx-${index}`}
@@ -501,7 +502,10 @@ const EquivalentsSection: React.FC<EquivalentsSectionProps> = ({
                 value={sizeText}
                 onChangeText={(text) => {
                   if (!DECIMAL_INPUT_REGEX.test(text)) return;
-                  updateRow(index, { serving_size: parseDecimalInput(text) || 0 });
+                  updateRow(index, {
+                    _sizeText: text,
+                    serving_size: parseDecimalInput(text) || 0,
+                  });
                 }}
                 keyboardType="decimal-pad"
                 returnKeyType="done"

--- a/SparkyFitnessMobile/src/types/foodUnitVariants.ts
+++ b/SparkyFitnessMobile/src/types/foodUnitVariants.ts
@@ -37,6 +37,7 @@ export interface EquivalentUnit {
   serving_size: number;
   serving_unit: string;
   _clientKey?: string;
+  _sizeText?: string;
 }
 
 export type FoodUnitSelectionResult =


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Cannot enter decimal for equivalent ingredient serving input

**How did you implement the solution?**
Allowed it

Linked Issue: Closes #1743

## How to Test

1. Go to equivalent ingredient serving input
2. Enter decimal

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
