### PR TITLE
fix(mobile): health connect time zone and multi integration fix

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/healthConnectService.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthConnectService.test.ts
@@ -24,6 +24,24 @@ const periodBucket = (y: number, m1to12: number, d: number, result: unknown) => 
   endTime: new Date(y, m1to12 - 1, d + 1, 0, 0, 0, 0).toISOString(),
 });
 
+// The cumulative aggregation path probes the range with pageSize:1 reads and
+// derives day attribution from the probed records' zone offsets. This answers
+// those probes with a record that carries no zone offset — keeping tests on
+// the device-zone aggregateGroupByPeriod path with no offset attached — while
+// full reads (raw record types) resolve empty.
+const probeInstant = new Date(2024, 0, 15, 12, 0, 0, 0);
+const offsetlessProbeRecord = {
+  startTime: probeInstant.toISOString(),
+  endTime: probeInstant.toISOString(),
+};
+const mockEmptyReadsWithProbe = () => {
+  mockReadRecords.mockImplementation((_recordType: string, options?: { pageSize?: number }) =>
+    Promise.resolve(
+      options?.pageSize === 1 ? { records: [offsetlessProbeRecord] } : { records: [] },
+    ),
+  );
+};
+
 jest.mock('../../src/services/LogService', () => ({
   addLog: jest.fn(),
 }));
@@ -68,7 +86,7 @@ describe('healthConnectService.ts (Android)', () => {
 
   describe('getAggregatedTotalCaloriesByDate', () => {
     beforeEach(() => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([]);
     });
 
@@ -127,7 +145,7 @@ describe('healthConnectService.ts (Android)', () => {
 
   describe('getAggregatedDistanceByDate', () => {
     beforeEach(() => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([]);
     });
 
@@ -164,7 +182,7 @@ describe('healthConnectService.ts (Android)', () => {
 
   describe('getAggregatedFloorsClimbedByDate', () => {
     beforeEach(() => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([]);
     });
 
@@ -207,7 +225,7 @@ describe('healthConnectService.ts (Android)', () => {
     });
 
     test('sends correctly shaped HealthDataPayload to API', async () => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { COUNT_TOTAL: 5000 }),
       ]);
@@ -230,7 +248,7 @@ describe('healthConnectService.ts (Android)', () => {
     });
 
     test('Steps are aggregated via native aggregateGroupByPeriod (cross-origin dedup)', async () => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       // Native aggregate already handles cross-origin dedup — helper just passes
       // through the value HC returned.
       mockAggregateGroupByPeriod.mockResolvedValue([
@@ -249,7 +267,7 @@ describe('healthConnectService.ts (Android)', () => {
     });
 
     test('ActiveCalories are aggregated via native aggregateGroupByPeriod', async () => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { ACTIVE_CALORIES_TOTAL: { inKilocalories: 350 } }),
       ]);
@@ -318,7 +336,7 @@ describe('healthConnectService.ts (Android)', () => {
     });
 
     test('TotalCalories are aggregated via native aggregateGroupByPeriod', async () => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { ENERGY_TOTAL: { inKilocalories: 1100 } }),
       ]);
@@ -373,7 +391,7 @@ describe('healthConnectService.ts (Android)', () => {
     });
 
     test('returns error when API call fails', async () => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { COUNT_TOTAL: 5000 }),
       ]);
@@ -388,7 +406,7 @@ describe('healthConnectService.ts (Android)', () => {
     });
 
     test('returns apiResponse from successful sync', async () => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { COUNT_TOTAL: 5000 }),
       ]);
@@ -405,7 +423,7 @@ describe('healthConnectService.ts (Android)', () => {
     });
 
     test('passes server record rejections through as uploadErrors without touching syncErrors', async () => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { COUNT_TOTAL: 5000 }),
       ]);
@@ -448,7 +466,7 @@ describe('healthConnectService.ts (Android)', () => {
         // background both do), so meals logged in Health Connect with yesterday's event
         // time were silently missed by a 'today' sync.
         jest.useFakeTimers({ now: new Date(2026, 6, 3, 15, 30, 0) });
-        mockReadRecords.mockResolvedValue({ records: [] });
+        mockEmptyReadsWithProbe();
 
         await androidService.syncHealthData('today', {
           isNutritionSyncEnabled: true,
@@ -470,7 +488,7 @@ describe('healthConnectService.ts (Android)', () => {
     });
 
     test('Distance is aggregated via native aggregateGroupByPeriod', async () => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { DISTANCE: { inMeters: 3000 } }),
       ]);
@@ -487,7 +505,7 @@ describe('healthConnectService.ts (Android)', () => {
     });
 
     test('FloorsClimbed is aggregated via native aggregateGroupByPeriod', async () => {
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockEmptyReadsWithProbe();
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { FLOORS_CLIMBED_TOTAL: 8 }),
       ]);
@@ -505,18 +523,25 @@ describe('healthConnectService.ts (Android)', () => {
   });
 
   describe('per-day UTC offset metadata', () => {
-    // The native aggregate path attributes records to the device-local day
-    // (matching HC UI behavior). One range-wide probe read captures a UTC
-    // offset that is attached to every emitted day — see the basisIsDayOnly
-    // short-circuit in measurementService.resolveHealthEntryDate, which means
-    // per-day offset precision is not load-bearing for server day attribution.
+    // Day attribution follows the zone offsets stored on the records
+    // (matching HC UI behavior, issue #1712); when they match the device
+    // zone, a single probe read captures the offset that is attached to
+    // every emitted day. See the basisIsDayOnly short-circuit in
+    // measurementService.resolveHealthEntryDate — the server trusts the
+    // client's date, and this field records the offset behind it.
+    const deviceOffsetMinutes = -probeInstant.getTimezoneOffset();
 
-    test('TotalCalories: range offset captured from probe read', async () => {
+    test('TotalCalories: offset captured from an end-stamped probe record', async () => {
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { ENERGY_TOTAL: { inKilocalories: 50 } }),
       ]);
       mockReadRecords.mockResolvedValue({
-        records: [{ endZoneOffset: { totalSeconds: 32400 } }], // UTC+9
+        records: [
+          {
+            endTime: probeInstant.toISOString(),
+            endZoneOffset: { totalSeconds: deviceOffsetMinutes * 60 },
+          },
+        ],
       });
 
       const result = await androidService.getAggregatedTotalCaloriesByDate(
@@ -526,15 +551,20 @@ describe('healthConnectService.ts (Android)', () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].date).toBe('2024-01-15');
-      expect(result[0].record_utc_offset_minutes).toBe(540);
+      expect(result[0].record_utc_offset_minutes).toBe(deviceOffsetMinutes);
     });
 
-    test('Distance: range offset captured from probe read', async () => {
+    test('Distance: offset captured from a start-stamped probe record', async () => {
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { DISTANCE: { inMeters: 2000 } }),
       ]);
       mockReadRecords.mockResolvedValue({
-        records: [{ endZoneOffset: { totalSeconds: 32400 } }],
+        records: [
+          {
+            startTime: probeInstant.toISOString(),
+            startZoneOffset: { totalSeconds: deviceOffsetMinutes * 60 },
+          },
+        ],
       });
 
       const result = await androidService.getAggregatedDistanceByDate(
@@ -543,15 +573,20 @@ describe('healthConnectService.ts (Android)', () => {
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].record_utc_offset_minutes).toBe(540);
+      expect(result[0].record_utc_offset_minutes).toBe(deviceOffsetMinutes);
     });
 
-    test('FloorsClimbed: range offset captured from probe read', async () => {
+    test('FloorsClimbed: offset captured from probe read', async () => {
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { FLOORS_CLIMBED_TOTAL: 3 }),
       ]);
       mockReadRecords.mockResolvedValue({
-        records: [{ endZoneOffset: { totalSeconds: 32400 } }],
+        records: [
+          {
+            startTime: probeInstant.toISOString(),
+            startZoneOffset: { totalSeconds: deviceOffsetMinutes * 60 },
+          },
+        ],
       });
 
       const result = await androidService.getAggregatedFloorsClimbedByDate(
@@ -560,14 +595,14 @@ describe('healthConnectService.ts (Android)', () => {
       );
 
       expect(result).toHaveLength(1);
-      expect(result[0].record_utc_offset_minutes).toBe(540);
+      expect(result[0].record_utc_offset_minutes).toBe(deviceOffsetMinutes);
     });
 
-    test('omits offset metadata when probe read returns no records', async () => {
+    test('omits offset metadata when the probe record carries no zone offset', async () => {
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { ENERGY_TOTAL: { inKilocalories: 200 } }),
       ]);
-      mockReadRecords.mockResolvedValue({ records: [] });
+      mockReadRecords.mockResolvedValue({ records: [offsetlessProbeRecord] });
 
       const result = await androidService.getAggregatedTotalCaloriesByDate(
         localMidnight(2024, 1, 15),
@@ -582,9 +617,20 @@ describe('healthConnectService.ts (Android)', () => {
       mockAggregateGroupByPeriod.mockResolvedValue([
         periodBucket(2024, 1, 15, { ENERGY_TOTAL: { inKilocalories: 100 } }),
       ]);
-      mockReadRecords.mockResolvedValue({
-        records: [{ endZoneOffset: { totalSeconds: 32400 } }],
-      });
+      mockReadRecords.mockImplementation((_recordType: string, options?: { pageSize?: number }) =>
+        Promise.resolve(
+          options?.pageSize === 1
+            ? {
+                records: [
+                  {
+                    startTime: probeInstant.toISOString(),
+                    startZoneOffset: { totalSeconds: deviceOffsetMinutes * 60 },
+                  },
+                ],
+              }
+            : { records: [] },
+        ),
+      );
 
       const healthMetricStates: HealthMetricStates = { isTotalCaloriesSyncEnabled: true };
 
@@ -594,7 +640,7 @@ describe('healthConnectService.ts (Android)', () => {
       const calRecords = payload.filter((r: { type: string }) => r.type === 'total_calories');
 
       expect(calRecords.length).toBeGreaterThanOrEqual(1);
-      expect(calRecords[0].record_utc_offset_minutes).toBe(540);
+      expect(calRecords[0].record_utc_offset_minutes).toBe(deviceOffsetMinutes);
     });
   });
 

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
@@ -24,6 +24,7 @@ import {
   requestPermission,
   readRecords,
   aggregateRecord,
+  aggregateGroupByDuration,
   aggregateGroupByPeriod,
 } from 'react-native-health-connect';
 
@@ -48,6 +49,7 @@ const mockInitialize = initialize as jest.Mock;
 const mockRequestPermission = requestPermission as jest.Mock;
 const mockReadRecords = readRecords as jest.Mock;
 const mockAggregateRecord = aggregateRecord as jest.Mock;
+const mockAggregateGroupByDuration = aggregateGroupByDuration as jest.Mock;
 const mockAggregateGroupByPeriod = aggregateGroupByPeriod as jest.Mock;
 
 // Helper to construct an aggregateGroupByPeriod bucket. startTime is the local
@@ -58,6 +60,71 @@ const periodBucket = (y: number, m1to12: number, d: number, result: unknown) => 
   result,
   startTime: new Date(y, m1to12 - 1, d, 0, 0, 0, 0).toISOString(),
   endTime: new Date(y, m1to12 - 1, d + 1, 0, 0, 0, 0).toISOString(),
+});
+
+// The runtime timezone's UTC offset at a given instant, in minutes. Offset
+// fixtures are derived relative to this so the fast/slow path split is the
+// same on every CI machine's zone.
+const deviceOffsetMinutesAt = (instant: Date): number => -instant.getTimezoneOffset();
+
+// A probe record carrying a start-paired zone offset, as the aggregation
+// offset probes read them.
+const probeRecord = (start: Date, offsetMinutes?: number) => ({
+  startTime: start.toISOString(),
+  endTime: start.toISOString(),
+  ...(offsetMinutes != null
+    ? { startZoneOffset: { totalSeconds: offsetMinutes * 60 } }
+    : {}),
+});
+
+// A probe record that carries no zone offset — keeps aggregation tests on
+// the device-zone (aggregateGroupByPeriod) path without attaching an offset,
+// mirroring sources that omit zone metadata.
+const offsetlessProbeResult = () => ({
+  records: [probeRecord(new Date(2024, 0, 15, 12, 0, 0, 0))],
+});
+
+// Serves the offset probes (first/last/binary-search reads) from a fixed
+// record timeline, honoring the requested window, ordering, and pageSize:1.
+const mockProbeTimeline = (records: { start: Date; offsetMinutes: number }[]) => {
+  mockReadRecords.mockImplementation(
+    (
+      _recordType: string,
+      options: {
+        timeRangeFilter: { startTime: string; endTime: string };
+        ascendingOrder?: boolean;
+      },
+    ) => {
+      const startMs = new Date(options.timeRangeFilter.startTime).getTime();
+      const endMs = new Date(options.timeRangeFilter.endTime).getTime();
+      const inRange = records
+        .filter((r) => r.start.getTime() >= startMs && r.start.getTime() <= endMs)
+        .sort((a, b) => a.start.getTime() - b.start.getTime());
+      const ordered = options.ascendingOrder === false ? inRange.reverse() : inRange;
+      return Promise.resolve({
+        records: ordered.slice(0, 1).map((r) => probeRecord(r.start, r.offsetMinutes)),
+      });
+    },
+  );
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// Instant (epoch ms) of the given local calendar date's midnight interpreted
+// at a fixed UTC offset — mirrors the production instantAtOffset arithmetic.
+const midnightAtOffset = (
+  y: number,
+  m1to12: number,
+  d: number,
+  offsetMinutes: number,
+): number => Date.UTC(y, m1to12 - 1, d) - offsetMinutes * 60_000;
+
+// An aggregateGroupByDuration bucket whose startTime is an Instant ISO
+// string, as the bridge serializes them.
+const durationBucket = (startMs: number, result: unknown) => ({
+  result,
+  startTime: new Date(startMs).toISOString(),
+  endTime: new Date(startMs + DAY_MS).toISOString(),
 });
 
 describe('initHealthConnect', () => {
@@ -454,8 +521,9 @@ describe('readHealthRecords', () => {
 describe('getAggregatedStepsByDate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Default: tz-offset lookup finds no records (no offset captured).
-    mockReadRecords.mockResolvedValue({ records: [] });
+    // Default: the offset probe finds a record without zone metadata, so
+    // aggregation stays on the device-zone path with no offset attached.
+    mockReadRecords.mockResolvedValue(offsetlessProbeResult());
     mockAggregateGroupByPeriod.mockResolvedValue([]);
   });
 
@@ -534,15 +602,15 @@ describe('getAggregatedStepsByDate', () => {
     expect(result).toEqual([{ date: '2024-01-16', value: 4200, type: 'step' }]);
   });
 
-  test('captures one range-wide UTC offset and attaches it to every day', async () => {
+  test('attaches the probed offset to every day when it matches the device zone', async () => {
     mockAggregateGroupByPeriod.mockResolvedValue([
       periodBucket(2024, 1, 15, { COUNT_TOTAL: 3000 }),
       periodBucket(2024, 1, 16, { COUNT_TOTAL: 3500 }),
     ]);
+    const probeInstant = new Date(2024, 0, 15, 12, 0, 0, 0);
+    const deviceOffset = deviceOffsetMinutesAt(probeInstant);
     mockReadRecords.mockResolvedValue({
-      records: [
-        { startZoneOffset: { totalSeconds: -28800 } }, // -480 min (UTC-8)
-      ],
+      records: [probeRecord(probeInstant, deviceOffset)],
     });
 
     const result = await getAggregatedStepsByDate(
@@ -550,18 +618,17 @@ describe('getAggregatedStepsByDate', () => {
       localEndOfDay(2024, 1, 16),
     );
 
-    expect(result.every((r) => r.record_utc_offset_minutes === -480)).toBe(true);
-    // Offset lookup must be a single pageSize:1 read for the whole range —
-    // not per-day, which is what blew the quota in the first place.
+    expect(result.every((r) => r.record_utc_offset_minutes === deviceOffset)).toBe(true);
+    // Stationary syncs must stay at a single pageSize:1 probe read for the
+    // whole range — per-day reads are what blew the quota in the first place.
     expect(mockReadRecords).toHaveBeenCalledTimes(1);
     expect(mockReadRecords.mock.calls[0][1]).toMatchObject({ pageSize: 1 });
   });
 
-  test('omits offset when the tz-lookup read returns nothing', async () => {
+  test('omits offset when the probe record carries no zone offset', async () => {
     mockAggregateGroupByPeriod.mockResolvedValue([
       periodBucket(2024, 1, 15, { COUNT_TOTAL: 3000 }),
     ]);
-    mockReadRecords.mockResolvedValue({ records: [] });
 
     const result = await getAggregatedStepsByDate(
       localMidnight(2024, 1, 15),
@@ -569,6 +636,19 @@ describe('getAggregatedStepsByDate', () => {
     );
 
     expect(result[0]).not.toHaveProperty('record_utc_offset_minutes');
+  });
+
+  test('returns empty without calling the native aggregate when the range has no records', async () => {
+    mockReadRecords.mockResolvedValue({ records: [] });
+
+    const result = await getAggregatedStepsByDate(
+      localMidnight(2024, 1, 15),
+      localEndOfDay(2024, 1, 15),
+    );
+
+    expect(result).toEqual([]);
+    expect(mockAggregateGroupByPeriod).not.toHaveBeenCalled();
+    expect(mockAggregateGroupByDuration).not.toHaveBeenCalled();
   });
 
   test('returns the error and empty records when aggregateGroupByPeriod rejects', async () => {
@@ -647,6 +727,203 @@ describe('getAggregatedStepsByDate', () => {
   });
 });
 
+describe('cumulative aggregation timezone-change attribution (#1712)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAggregateGroupByPeriod.mockResolvedValue([]);
+    mockAggregateGroupByDuration.mockResolvedValue([]);
+  });
+
+  test('buckets a post-travel window at the records\' own midnights (regression for #1712)', async () => {
+    // Every record still carries the pre-move zone's offset (device already
+    // moved): day windows must anchor at the old zone's midnights, not the
+    // device zone's — otherwise up to a week of records re-bin across the
+    // new midnights and day totals drift.
+    const off0 = deviceOffsetMinutesAt(new Date(2024, 0, 15, 6, 0, 0, 0)) + 420;
+    mockProbeTimeline([
+      { start: new Date(2024, 0, 15, 6, 0, 0, 0), offsetMinutes: off0 },
+      { start: new Date(2024, 0, 16, 20, 0, 0, 0), offsetMinutes: off0 },
+    ]);
+    const anchor = midnightAtOffset(2024, 1, 15, off0);
+    mockAggregateGroupByDuration.mockResolvedValue([
+      durationBucket(anchor, { COUNT_TOTAL: 5000 }),
+      durationBucket(anchor + DAY_MS, { COUNT_TOTAL: 6000 }),
+      // Partial tail past the window's last label: records the source
+      // stamped into the old zone's next day — dropped, the next sync's
+      // window owns that day.
+      durationBucket(anchor + 2 * DAY_MS, { COUNT_TOTAL: 300 }),
+    ]);
+
+    const endDate = localEndOfDay(2024, 1, 16);
+    const result = await getAggregatedStepsByDate(localMidnight(2024, 1, 15), endDate);
+
+    expect(result).toEqual([
+      { date: '2024-01-15', value: 5000, type: 'step', record_utc_offset_minutes: off0 },
+      { date: '2024-01-16', value: 6000, type: 'step', record_utc_offset_minutes: off0 },
+    ]);
+    expect(mockAggregateGroupByPeriod).not.toHaveBeenCalled();
+    expect(mockAggregateGroupByDuration).toHaveBeenCalledTimes(1);
+    const call = mockAggregateGroupByDuration.mock.calls[0][0];
+    expect(call.timeRangeFilter.startTime).toBe(new Date(anchor).toISOString());
+    expect(call.timeRangeFilter.endTime).toBe(endDate.toISOString());
+    expect(call.timeRangeSlicer).toEqual({ duration: 'DAYS', length: 1 });
+    // No dataOriginFilter — that would defeat HC's native cross-origin dedup.
+    expect(call).not.toHaveProperty('dataOriginFilter');
+    // Two pageSize:1 probes (first + last record), no per-day reads.
+    expect(mockReadRecords).toHaveBeenCalledTimes(2);
+  });
+
+  test('splits a mid-window transition into two contiguous offset segments and folds the westward sliver', async () => {
+    const off1 = deviceOffsetMinutesAt(new Date(2024, 0, 18, 20, 0, 0, 0));
+    const off0 = off1 + 420;
+    mockProbeTimeline([
+      { start: new Date(2024, 0, 15, 6, 0, 0, 0), offsetMinutes: off0 },
+      { start: new Date(2024, 0, 16, 4, 0, 0, 0), offsetMinutes: off0 },
+      { start: new Date(2024, 0, 16, 14, 0, 0, 0), offsetMinutes: off1 },
+      { start: new Date(2024, 0, 17, 10, 0, 0, 0), offsetMinutes: off1 },
+      { start: new Date(2024, 0, 18, 20, 0, 0, 0), offsetMinutes: off1 },
+    ]);
+    const anchor = midnightAtOffset(2024, 1, 15, off0);
+    const boundary = midnightAtOffset(2024, 1, 17, off1);
+    mockAggregateGroupByDuration
+      .mockResolvedValueOnce([
+        durationBucket(anchor, { COUNT_TOTAL: 5000 }),
+        durationBucket(anchor + DAY_MS, { COUNT_TOTAL: 6000 }),
+        // 7h sliver between the old grid's end and the new boundary: the
+        // extended evening of the day before the switch — folds into it.
+        durationBucket(anchor + 2 * DAY_MS, { COUNT_TOTAL: 700 }),
+      ])
+      .mockResolvedValueOnce([
+        durationBucket(boundary, { COUNT_TOTAL: 8000 }),
+        durationBucket(boundary + DAY_MS, { COUNT_TOTAL: 900 }),
+      ]);
+
+    const endDate = localEndOfDay(2024, 1, 18);
+    const result = await getAggregatedStepsByDate(localMidnight(2024, 1, 15), endDate);
+
+    expect(result).toEqual([
+      { date: '2024-01-15', value: 5000, type: 'step', record_utc_offset_minutes: off0 },
+      { date: '2024-01-16', value: 6700, type: 'step', record_utc_offset_minutes: off0 },
+      { date: '2024-01-17', value: 8000, type: 'step', record_utc_offset_minutes: off1 },
+      { date: '2024-01-18', value: 900, type: 'step', record_utc_offset_minutes: off1 },
+    ]);
+    expect(mockAggregateGroupByPeriod).not.toHaveBeenCalled();
+    expect(mockAggregateGroupByDuration).toHaveBeenCalledTimes(2);
+    const [first, second] = mockAggregateGroupByDuration.mock.calls.map((c) => c[0]);
+    // Segments must be contiguous at the switch day's new-zone midnight —
+    // a gap loses records, an overlap double-counts them.
+    expect(first.timeRangeFilter.startTime).toBe(new Date(anchor).toISOString());
+    expect(first.timeRangeFilter.endTime).toBe(new Date(boundary).toISOString());
+    expect(second.timeRangeFilter.startTime).toBe(new Date(boundary).toISOString());
+    expect(second.timeRangeFilter.endTime).toBe(endDate.toISOString());
+    // 2 edge probes + 2 binary-search probes for a 4-day window.
+    expect(mockReadRecords).toHaveBeenCalledTimes(4);
+  });
+
+  test('keeps the whole window on the old anchor when the transition falls after the last midnight', async () => {
+    const off1 = deviceOffsetMinutesAt(new Date(2024, 0, 16, 19, 30, 0, 0));
+    const off0 = off1 + 420;
+    mockProbeTimeline([
+      { start: new Date(2024, 0, 15, 6, 0, 0, 0), offsetMinutes: off0 },
+      { start: new Date(2024, 0, 16, 12, 0, 0, 0), offsetMinutes: off0 },
+      { start: new Date(2024, 0, 16, 19, 30, 0, 0), offsetMinutes: off1 },
+    ]);
+    const anchor = midnightAtOffset(2024, 1, 15, off0);
+    mockAggregateGroupByDuration.mockResolvedValue([
+      durationBucket(anchor, { COUNT_TOTAL: 5000 }),
+      durationBucket(anchor + DAY_MS, { COUNT_TOTAL: 6000 }),
+      durationBucket(anchor + 2 * DAY_MS, { COUNT_TOTAL: 300 }),
+    ]);
+
+    const endDate = new Date(2024, 0, 16, 20, 0, 0, 0);
+    const result = await getAggregatedStepsByDate(localMidnight(2024, 1, 15), endDate);
+
+    expect(result).toEqual([
+      { date: '2024-01-15', value: 5000, type: 'step', record_utc_offset_minutes: off0 },
+      { date: '2024-01-16', value: 6000, type: 'step', record_utc_offset_minutes: off0 },
+    ]);
+    expect(mockAggregateGroupByDuration).toHaveBeenCalledTimes(1);
+    const call = mockAggregateGroupByDuration.mock.calls[0][0];
+    expect(call.timeRangeFilter.startTime).toBe(new Date(anchor).toISOString());
+    expect(call.timeRangeFilter.endTime).toBe(endDate.toISOString());
+  });
+
+  test('falls back to device-zone buckets when offsets diverge without ending in the device zone', async () => {
+    // A UTC-stamping exporter alongside correctly-stamped records looks like
+    // a transition but isn't travel; re-bucketing would scramble a
+    // stationary user's days.
+    const deviceOffset = deviceOffsetMinutesAt(new Date(2024, 0, 16, 12, 0, 0, 0));
+    mockProbeTimeline([
+      { start: new Date(2024, 0, 15, 6, 0, 0, 0), offsetMinutes: deviceOffset + 420 },
+      { start: new Date(2024, 0, 16, 12, 0, 0, 0), offsetMinutes: deviceOffset + 120 },
+    ]);
+    mockAggregateGroupByPeriod.mockResolvedValue([
+      periodBucket(2024, 1, 15, { COUNT_TOTAL: 4000 }),
+    ]);
+
+    const result = await getAggregatedStepsByDate(
+      localMidnight(2024, 1, 15),
+      localEndOfDay(2024, 1, 16),
+    );
+
+    expect(result).toEqual([
+      {
+        date: '2024-01-15',
+        value: 4000,
+        type: 'step',
+        record_utc_offset_minutes: deviceOffset + 420,
+      },
+    ]);
+    expect(mockAggregateGroupByDuration).not.toHaveBeenCalled();
+    expect(mockAggregateGroupByPeriod).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    ['eastward', -1560],
+    ['westward', +1560],
+  ])(
+    'falls back to device-zone buckets when the offset jump exceeds a day (%s)',
+    async (_direction, offsetDelta) => {
+      // A ≥24h offset jump (dateline hop) degenerates the day-window math in
+      // both directions — eastward the segments invert, westward whole
+      // misattributed buckets would fold into the pre-switch day. Bail out.
+      const off1 = deviceOffsetMinutesAt(new Date(2024, 0, 16, 10, 0, 0, 0));
+      const off0 = off1 + offsetDelta;
+      mockProbeTimeline([
+        { start: new Date(2024, 0, 15, 3, 0, 0, 0), offsetMinutes: off0 },
+        { start: new Date(2024, 0, 16, 10, 0, 0, 0), offsetMinutes: off1 },
+      ]);
+      mockAggregateGroupByPeriod.mockResolvedValue([
+        periodBucket(2024, 1, 15, { COUNT_TOTAL: 4000 }),
+      ]);
+
+      const result = await getAggregatedStepsByDate(
+        localMidnight(2024, 1, 15),
+        localEndOfDay(2024, 1, 16),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(mockAggregateGroupByDuration).not.toHaveBeenCalled();
+      expect(mockAggregateGroupByPeriod).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  test('keeps device-zone buckets without an offset when the probe read fails', async () => {
+    mockReadRecords.mockRejectedValue(new Error('probe failed'));
+    mockAggregateGroupByPeriod.mockResolvedValue([
+      periodBucket(2024, 1, 15, { COUNT_TOTAL: 4200 }),
+    ]);
+
+    const result = await getAggregatedStepsByDate(
+      localMidnight(2024, 1, 15),
+      localEndOfDay(2024, 1, 15),
+    );
+
+    expect(result).toEqual([{ date: '2024-01-15', value: 4200, type: 'step' }]);
+    expect(mockAggregateGroupByPeriod).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('alignToLocalDayStart', () => {
   test('returns a new Date rounded down to local midnight', () => {
     const input = new Date(2024, 0, 15, 14, 30, 45, 123);
@@ -668,7 +945,7 @@ describe('alignToLocalDayStart', () => {
 describe('getAggregatedActiveCaloriesByDate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockReadRecords.mockResolvedValue({ records: [] });
+    mockReadRecords.mockResolvedValue(offsetlessProbeResult());
     mockAggregateGroupByPeriod.mockResolvedValue([]);
   });
 

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/provider.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/provider.test.ts
@@ -4,7 +4,11 @@ import {
   readMinMaxAvgByDay,
   postProcessRaw,
 } from '../../../src/services/healthconnect/provider';
-import { aggregateGroupByPeriod, aggregateRecord } from 'react-native-health-connect';
+import {
+  aggregateGroupByPeriod,
+  aggregateRecord,
+  readRecords,
+} from 'react-native-health-connect';
 
 jest.mock('../../../src/services/LogService', () => ({
   addLog: jest.fn(),
@@ -12,6 +16,7 @@ jest.mock('../../../src/services/LogService', () => ({
 
 const mockAggregateGroupByPeriod = aggregateGroupByPeriod as jest.Mock;
 const mockAggregateRecord = aggregateRecord as jest.Mock;
+const mockReadRecords = readRecords as jest.Mock;
 
 const start = new Date(2026, 6, 1, 0, 0, 0, 0);
 const end = new Date(2026, 6, 3, 15, 30, 0);
@@ -21,6 +26,16 @@ describe('healthconnect provider', () => {
     jest.clearAllMocks();
     mockAggregateGroupByPeriod.mockResolvedValue([]);
     mockAggregateRecord.mockReset().mockResolvedValue({});
+    // Answer the cumulative path's offset probes with a record that carries
+    // no zone offset, keeping aggregation on the device-zone path.
+    mockReadRecords.mockResolvedValue({
+      records: [
+        {
+          startTime: new Date(2026, 6, 1, 12, 0, 0, 0).toISOString(),
+          endTime: new Date(2026, 6, 1, 12, 0, 0, 0).toISOString(),
+        },
+      ],
+    });
   });
 
   describe('readCumulativeByDay', () => {

--- a/SparkyFitnessMobile/jest.setup.js
+++ b/SparkyFitnessMobile/jest.setup.js
@@ -89,6 +89,7 @@ jest.mock('react-native-health-connect', () => ({
   requestPermission: jest.fn().mockResolvedValue([]),
   readRecords: jest.fn().mockResolvedValue({ records: [] }),
   aggregateRecord: jest.fn().mockResolvedValue({}),
+  aggregateGroupByDuration: jest.fn().mockResolvedValue([]),
   aggregateGroupByPeriod: jest.fn().mockResolvedValue([]),
   getSdkStatus: jest.fn().mockResolvedValue(3),
   SdkAvailabilityStatus: {

--- a/SparkyFitnessMobile/src/services/healthconnect/index.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/index.ts
@@ -3,6 +3,7 @@ import {
   requestPermission,
   readRecords,
   aggregateRecord,
+  aggregateGroupByDuration,
   aggregateGroupByPeriod,
 } from 'react-native-health-connect';
 import { addLog } from '../LogService';
@@ -68,7 +69,8 @@ export const requestHealthPermissions = async (
 
 const PAGE_SIZE = 5000;
 const MAX_PAGES = 100;
-const FALLBACK_DAY_WINDOW_MS = 24 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const FALLBACK_DAY_WINDOW_MS = DAY_MS;
 const FALLBACK_HOUR_WINDOW_MS = 60 * 60 * 1000;
 
 // Health Connect enforces a foreground API call quota; once exceeded, every
@@ -90,6 +92,7 @@ interface ReadRecordsOptions {
   };
   pageSize: number;
   pageToken?: string;
+  ascendingOrder?: boolean;
 }
 
 // Aliases of the platform-neutral ReadResult shared with iOS.
@@ -297,18 +300,30 @@ export const readHealthRecords = async (
 };
 
 /**
- * Aggregates a cumulative metric by local day for [startDate, endDate] using
- * Health Connect's native aggregateGroupByPeriod (one call per range, not
- * per day). HC's native aggregation handles cross-origin dedup using the
- * user's source priority list — matching what HC's own UI displays — so
- * callers do not need to deduplicate records themselves (issue #1279).
+ * Aggregates a cumulative metric by local day for [startDate, endDate].
+ * HC's native aggregation handles cross-origin dedup using the user's source
+ * priority list — matching what HC's own UI displays — so callers do not
+ * need to deduplicate records themselves (issue #1279). Native call counts
+ * stay bounded regardless of window length (per-day native calls previously
+ * blew HC's API quota).
  *
- * Captures one UTC offset for the whole range via a single pageSize:1 read
- * and attaches it to every day's record. The server treats `date`-only
- * payloads as authoritative for day attribution (see
- * resolveHealthEntryDate's basisIsDayOnly short-circuit in
- * measurementService.ts), so per-day offset precision is not load-bearing —
- * the field exists for observability of timezone-metadata coverage.
+ * Day attribution follows the zone offsets stored on the records, matching
+ * how HC's own UI assigns records to days (issue #1712):
+ *
+ * - When the records' offsets match the device zone (the stationary case,
+ *   including across DST — device zone rules cover it), a single
+ *   aggregateGroupByPeriod call buckets by device-local days.
+ * - When they diverge (the user changed timezone), day windows are rebuilt
+ *   as fixed 24h instant ranges anchored at the *records'* midnights and
+ *   aggregated with aggregateGroupByDuration — one call per offset segment,
+ *   at most two segments. Without this, HC re-bins up to a week of pre-move
+ *   records across the new zone's midnights and day totals drift by
+ *   whatever crossed midnight.
+ *
+ * The server treats `date`-only payloads as authoritative for day
+ * attribution (see resolveHealthEntryDate's basisIsDayOnly short-circuit in
+ * measurementService.ts); `record_utc_offset_minutes` carries the offset
+ * used for each day's attribution.
  */
 export type CumulativeMetricRecordType =
   | 'Steps'
@@ -339,19 +354,26 @@ const formatLocalDay = (date: Date): string => {
 // start, so callers of this module align cumulative query starts with it.
 export { alignToLocalDayStart } from '../../utils/syncUtils';
 
+type EdgeProbeResult =
+  | { outcome: 'record'; instantMs: number; offsetMinutes?: number }
+  | { outcome: 'empty' }
+  | { outcome: 'error' };
+
 /**
- * Reads a single record in the range for the sole purpose of capturing one
- * UTC offset to attach to every aggregated day. Returns undefined if no
- * record / no offset / on any error (offset is observability-only metadata).
+ * Reads the first (ascending) or last (descending) record in the range and
+ * returns its start instant plus the zone offset stored on it, pairing the
+ * offset with the matching timestamp (start with start, end with end) so a
+ * record spanning a DST shift can't mix an end offset with a start instant.
  */
-const readZoneOffsetForRange = async (
+const readEdgeRecord = async (
   recordType: CumulativeMetricRecordType,
   startDate: Date,
   endDate: Date,
-): Promise<number | undefined> => {
+  ascending: boolean,
+): Promise<EdgeProbeResult> => {
   try {
-    if (getWindowError(`offset read for ${recordType}`, startDate, endDate)) {
-      return undefined;
+    if (getWindowError(`offset probe for ${recordType}`, startDate, endDate)) {
+      return { outcome: 'error' };
     }
     const result = await readRecords(
       recordType as Parameters<typeof readRecords>[0],
@@ -362,18 +384,374 @@ const readZoneOffsetForRange = async (
           endTime: endDate.toISOString(),
         },
         pageSize: 1,
+        ascendingOrder: ascending,
       } as unknown as Parameters<typeof readRecords>[1],
     );
-    type OffsetRecord = { startZoneOffset?: HCZoneOffset; endZoneOffset?: HCZoneOffset };
-    const record = (result.records as OffsetRecord[])[0];
-    const offset = record?.endZoneOffset ?? record?.startZoneOffset;
-    if (offset?.totalSeconds != null) {
-      return Math.round(offset.totalSeconds / 60);
+    type EdgeRecord = {
+      startTime?: string;
+      endTime?: string;
+      startZoneOffset?: HCZoneOffset;
+      endZoneOffset?: HCZoneOffset;
+    };
+    const record = (result.records as EdgeRecord[])[0];
+    if (!record) {
+      return { outcome: 'empty' };
     }
-    return undefined;
+    const startMs = record.startTime ? new Date(record.startTime).getTime() : NaN;
+    const endMs = record.endTime ? new Date(record.endTime).getTime() : NaN;
+    if (record.startZoneOffset?.totalSeconds != null && Number.isFinite(startMs)) {
+      return {
+        outcome: 'record',
+        instantMs: startMs,
+        offsetMinutes: Math.round(record.startZoneOffset.totalSeconds / 60),
+      };
+    }
+    if (record.endZoneOffset?.totalSeconds != null && Number.isFinite(endMs)) {
+      return {
+        outcome: 'record',
+        instantMs: endMs,
+        offsetMinutes: Math.round(record.endZoneOffset.totalSeconds / 60),
+      };
+    }
+    const instantMs = Number.isFinite(startMs) ? startMs : endMs;
+    if (!Number.isFinite(instantMs)) {
+      return { outcome: 'error' };
+    }
+    return { outcome: 'record', instantMs };
   } catch {
+    return { outcome: 'error' };
+  }
+};
+
+/** UTC offset minutes the device zone applies at the given instant. */
+const deviceOffsetMinutesAt = (instantMs: number): number =>
+  -new Date(instantMs).getTimezoneOffset();
+
+/** Device-local wall-clock fields, used for fixed-offset instant arithmetic. */
+interface WallClockParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  ms: number;
+}
+
+const wallClockParts = (date: Date): WallClockParts => ({
+  year: date.getFullYear(),
+  month: date.getMonth(),
+  day: date.getDate(),
+  hour: date.getHours(),
+  minute: date.getMinutes(),
+  second: date.getSeconds(),
+  ms: date.getMilliseconds(),
+});
+
+/**
+ * Epoch ms of the wall clock shifted by dayShift days and interpreted at a
+ * fixed UTC offset — "midnight of day k in the records' zone" when the parts
+ * are a midnight.
+ */
+const instantAtOffset = (
+  parts: WallClockParts,
+  dayShift: number,
+  offsetMinutes: number,
+): number =>
+  Date.UTC(
+    parts.year,
+    parts.month,
+    parts.day + dayShift,
+    parts.hour,
+    parts.minute,
+    parts.second,
+    parts.ms,
+  ) -
+  offsetMinutes * 60_000;
+
+/** YYYY-MM-DD label of the wall clock shifted by dayShift days. */
+const dayLabelAt = (parts: WallClockParts, dayShift: number): string => {
+  const shifted = new Date(Date.UTC(parts.year, parts.month, parts.day + dayShift));
+  const y = shifted.getUTCFullYear();
+  const m = String(shifted.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(shifted.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+};
+
+/** Index of endDate's calendar day relative to the parts' day (day 0). */
+const dayIndexSpan = (parts: WallClockParts, endDate: Date): number => {
+  const end = wallClockParts(endDate);
+  return Math.round(
+    (Date.UTC(end.year, end.month, end.day) - Date.UTC(parts.year, parts.month, parts.day)) /
+      DAY_MS,
+  );
+};
+
+/**
+ * One fixed-offset stretch of the window. Buckets are fixed 24h instant
+ * ranges from startMs; a bucket landing past lastDayIndex is either folded
+ * into it (the extended evening of the day before a westward switch) or
+ * dropped (records the source stamped into a local day beyond the window —
+ * the next sync's window covers that day).
+ */
+interface AggregationSegment {
+  startMs: number;
+  endMs: number;
+  firstDayIndex: number;
+  lastDayIndex: number;
+  offsetMinutes: number;
+  overflow: 'fold' | 'drop';
+}
+
+/**
+ * Binary-searches the first day index (1..lastDayIndex + 1) whose midnight
+ * boundary belongs to the post-transition offset. Assumes offsets form a
+ * single step from off0 to off1 over the window; returns undefined as soon
+ * as a probe contradicts that (third offset, probe failure) so the caller
+ * can fall back to device-zone bucketing instead of guessing.
+ */
+const findSwitchDayIndex = async (
+  recordType: CumulativeMetricRecordType,
+  parts: WallClockParts,
+  lastDayIndex: number,
+  off0: number,
+  off1: number,
+  endDate: Date,
+): Promise<number | undefined> => {
+  let lo = 1;
+  let hi = lastDayIndex + 1;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    const probeStart = Math.min(
+      instantAtOffset(parts, mid, off0),
+      instantAtOffset(parts, mid, off1),
+    );
+    const probe = await readEdgeRecord(recordType, new Date(probeStart), endDate, true);
+    if (probe.outcome === 'empty') {
+      // No records at or after this midnight; its boundary offset is moot.
+      hi = mid;
+      continue;
+    }
+    if (probe.outcome === 'error' || probe.offsetMinutes == null) {
+      return undefined;
+    }
+    if (probe.offsetMinutes === off0) {
+      lo = mid + 1;
+    } else if (probe.offsetMinutes === off1) {
+      hi = mid;
+    } else {
+      return undefined;
+    }
+  }
+  return lo;
+};
+
+/**
+ * Plans the offset-anchored segments for a window whose records were stamped
+ * in a zone other than the device's. Returns undefined whenever the data
+ * doesn't look like a clean timezone change — callers then keep device-zone
+ * bucketing, which is the pre-#1712 behavior.
+ */
+const buildOffsetSegments = async (
+  recordType: CumulativeMetricRecordType,
+  startDate: Date,
+  endDate: Date,
+  firstOffsetMinutes: number,
+): Promise<AggregationSegment[] | undefined> => {
+  const lastProbe = await readEdgeRecord(recordType, startDate, endDate, false);
+  if (lastProbe.outcome !== 'record' || lastProbe.offsetMinutes == null) {
     return undefined;
   }
+  const off0 = firstOffsetMinutes;
+  const off1 = lastProbe.offsetMinutes;
+  const parts = wallClockParts(startDate);
+  const lastDayIndex = dayIndexSpan(parts, endDate);
+  const endMs = endDate.getTime();
+  const anchor = instantAtOffset(parts, 0, off0);
+  const wholeWindow: AggregationSegment = {
+    startMs: anchor,
+    endMs,
+    firstDayIndex: 0,
+    lastDayIndex,
+    offsetMinutes: off0,
+    overflow: 'drop',
+  };
+
+  if (off0 === off1) {
+    return [wholeWindow];
+  }
+  // A mid-window offset change is only trustworthy as travel when the window
+  // ends in the device's current zone; otherwise it's likely one source
+  // stamping bogus offsets (e.g. a UTC-stamping exporter) and re-bucketing
+  // would scramble a stationary user's days.
+  if (off1 !== deviceOffsetMinutesAt(lastProbe.instantMs)) {
+    return undefined;
+  }
+  // An offset jump of a day or more (dateline hop) degenerates the day-window
+  // math in both directions — eastward the segments invert, westward whole
+  // misattributed buckets would fold into the pre-switch day.
+  if (Math.abs(off1 - off0) * 60_000 >= DAY_MS) {
+    return undefined;
+  }
+  const switchDay = await findSwitchDayIndex(
+    recordType,
+    parts,
+    lastDayIndex,
+    off0,
+    off1,
+    endDate,
+  );
+  if (switchDay == null) {
+    return undefined;
+  }
+  const boundary = instantAtOffset(parts, switchDay, off1);
+  if (boundary >= endMs) {
+    // Transition after the window's last midnight: every boundary is still
+    // the old zone's.
+    return [wholeWindow];
+  }
+  return [
+    {
+      startMs: anchor,
+      endMs: boundary,
+      firstDayIndex: 0,
+      lastDayIndex: switchDay - 1,
+      offsetMinutes: off0,
+      overflow: 'fold',
+    },
+    {
+      startMs: boundary,
+      endMs,
+      firstDayIndex: switchDay,
+      lastDayIndex,
+      offsetMinutes: off1,
+      overflow: 'drop',
+    },
+  ];
+};
+
+/**
+ * Today's stationary path: one aggregateGroupByPeriod call bucketing by
+ * device-local calendar days.
+ */
+const aggregateByDeviceZone = async (
+  spec: CumulativeMetricSpec,
+  startDate: Date,
+  endDate: Date,
+  rangeOffsetMinutes: number | undefined,
+): Promise<HealthConnectAggregateResult> => {
+  type PeriodBucket = { result: unknown; startTime: string; endTime: string };
+  let buckets: PeriodBucket[];
+  try {
+    buckets = (await aggregateGroupByPeriod({
+      recordType: spec.recordType as Parameters<typeof aggregateGroupByPeriod>[0]['recordType'],
+      timeRangeFilter: {
+        operator: 'between',
+        startTime: startDate.toISOString(),
+        endTime: endDate.toISOString(),
+      },
+      timeRangeSlicer: { period: 'DAYS', length: 1 },
+    })) as unknown as PeriodBucket[];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    addLog(
+      `[HealthConnectService] aggregateGroupByPeriod(${spec.recordType}) failed: ${message}`,
+      'ERROR',
+    );
+    return { records: [], error: message };
+  }
+
+  const results: AggregatedHealthRecord[] = [];
+  for (const bucket of buckets) {
+    const value = spec.extractValue(bucket.result);
+    if (!Number.isFinite(value) || value <= 0) continue;
+
+    const rec: AggregatedHealthRecord = {
+      date: formatLocalDay(new Date(bucket.startTime)),
+      value: spec.round ? Math.round(value) : value,
+      type: spec.outputType,
+    };
+    if (rangeOffsetMinutes != null) {
+      rec.record_utc_offset_minutes = rangeOffsetMinutes;
+    }
+    results.push(rec);
+  }
+
+  addLog(`[HealthConnectService] ${spec.recordType} aggregation: ${results.length} days`, 'DEBUG');
+  return { records: results };
+};
+
+/**
+ * Offset-anchored path: fixed 24h buckets per segment via
+ * aggregateGroupByDuration, so day boundaries sit at the records' own
+ * midnights instead of the device zone's. Native dedup applies within each
+ * call exactly as in the device-zone path.
+ */
+const aggregateByRecordOffsets = async (
+  spec: CumulativeMetricSpec,
+  startDate: Date,
+  segments: AggregationSegment[],
+): Promise<HealthConnectAggregateResult> => {
+  const parts = wallClockParts(startDate);
+  const days = new Map<number, { value: number; offsetMinutes: number }>();
+
+  for (const segment of segments) {
+    type DurationBucket = { result: unknown; startTime: string; endTime: string };
+    let buckets: DurationBucket[];
+    try {
+      buckets = (await aggregateGroupByDuration({
+        recordType: spec.recordType as Parameters<
+          typeof aggregateGroupByDuration
+        >[0]['recordType'],
+        timeRangeFilter: {
+          operator: 'between',
+          startTime: new Date(segment.startMs).toISOString(),
+          endTime: new Date(segment.endMs).toISOString(),
+        },
+        timeRangeSlicer: { duration: 'DAYS', length: 1 },
+      })) as unknown as DurationBucket[];
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      addLog(
+        `[HealthConnectService] aggregateGroupByDuration(${spec.recordType}) failed: ${message}`,
+        'ERROR',
+      );
+      return { records: [], error: message };
+    }
+
+    for (const bucket of buckets) {
+      const value = spec.extractValue(bucket.result);
+      if (!Number.isFinite(value) || value <= 0) continue;
+
+      const bucketIndex = Math.round(
+        (new Date(bucket.startTime).getTime() - segment.startMs) / DAY_MS,
+      );
+      const dayIndex = segment.firstDayIndex + bucketIndex;
+      if (dayIndex > segment.lastDayIndex && segment.overflow === 'drop') continue;
+
+      const boundedIndex = Math.min(dayIndex, segment.lastDayIndex);
+      const existing = days.get(boundedIndex);
+      days.set(boundedIndex, {
+        value: (existing?.value ?? 0) + value,
+        offsetMinutes: existing?.offsetMinutes ?? segment.offsetMinutes,
+      });
+    }
+  }
+
+  const results: AggregatedHealthRecord[] = [...days.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([dayIndex, day]) => ({
+      date: dayLabelAt(parts, dayIndex),
+      value: spec.round ? Math.round(day.value) : day.value,
+      type: spec.outputType,
+      record_utc_offset_minutes: day.offsetMinutes,
+    }));
+
+  addLog(
+    `[HealthConnectService] ${spec.recordType} aggregation: ${results.length} days across ${segments.length} offset segment(s)`,
+    'DEBUG',
+  );
+  return { records: results };
 };
 
 // HC anchors DAYS buckets at the supplied startTime, so callers emitting
@@ -390,48 +768,38 @@ export const aggregateCumulativeMetricByDayDetailed = async (
       return { records: [], error: rangeError };
     }
 
-    type PeriodBucket = { result: unknown; startTime: string; endTime: string };
-    let buckets: PeriodBucket[];
-    try {
-      buckets = (await aggregateGroupByPeriod({
-        recordType: spec.recordType as Parameters<typeof aggregateGroupByPeriod>[0]['recordType'],
-        timeRangeFilter: {
-          operator: 'between',
-          startTime: startDate.toISOString(),
-          endTime: endDate.toISOString(),
-        },
-        timeRangeSlicer: { period: 'DAYS', length: 1 },
-      })) as unknown as PeriodBucket[];
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+    const firstProbe = await readEdgeRecord(spec.recordType, startDate, endDate, true);
+    if (firstProbe.outcome === 'empty') {
       addLog(
-        `[HealthConnectService] aggregateGroupByPeriod(${spec.recordType}) failed: ${message}`,
-        'ERROR',
+        `[HealthConnectService] ${spec.recordType} aggregation: no records in range`,
+        'DEBUG',
       );
-      return { records: [], error: message };
+      return { records: [] };
     }
 
-    const rangeOffset = await readZoneOffsetForRange(spec.recordType, startDate, endDate);
-    const results: AggregatedHealthRecord[] = [];
-
-    for (const bucket of buckets) {
-      const value = spec.extractValue(bucket.result);
-      if (!Number.isFinite(value) || value <= 0) continue;
-
-      const dayString = formatLocalDay(new Date(bucket.startTime));
-      const rec: AggregatedHealthRecord = {
-        date: dayString,
-        value: spec.round ? Math.round(value) : value,
-        type: spec.outputType,
-      };
-      if (rangeOffset != null) {
-        rec.record_utc_offset_minutes = rangeOffset;
+    if (
+      firstProbe.outcome === 'record' &&
+      firstProbe.offsetMinutes != null &&
+      firstProbe.offsetMinutes !== deviceOffsetMinutesAt(firstProbe.instantMs)
+    ) {
+      const segments = await buildOffsetSegments(
+        spec.recordType,
+        startDate,
+        endDate,
+        firstProbe.offsetMinutes,
+      );
+      if (segments) {
+        return await aggregateByRecordOffsets(spec, startDate, segments);
       }
-      results.push(rec);
+      addLog(
+        `[HealthConnectService] ${spec.recordType}: record offsets diverge from the device zone but don't form a clean transition; using device-zone buckets`,
+        'WARNING',
+      );
     }
 
-    addLog(`[HealthConnectService] ${spec.recordType} aggregation: ${results.length} days`, 'DEBUG');
-    return { records: results };
+    const rangeOffsetMinutes =
+      firstProbe.outcome === 'record' ? firstProbe.offsetMinutes : undefined;
+    return await aggregateByDeviceZone(spec, startDate, endDate, rangeOffsetMinutes);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     addLog(`[HealthConnectService] Error aggregating ${spec.recordType}: ${message}`, 'ERROR');

--- a/SparkyFitnessServer/models/measurementRepository.ts
+++ b/SparkyFitnessServer/models/measurementRepository.ts
@@ -44,8 +44,14 @@ async function upsertStepData(
     );
     let result;
     if (existingRecord.rows.length > 0) {
+      // Max-wins per day: an automated sync (device or provider) reports a
+      // day's running step total, and reads can arrive out of order (a partial
+      // early-day read, late-propagating records, cross-source dedup). GREATEST
+      // keeps the largest total seen so a smaller/partial read never clobbers a
+      // complete day. Manual user edits go through upsertCheckInMeasurements,
+      // which overwrites, so a deliberate correction is still possible.
       const updateResult = await client.query(
-        'UPDATE check_in_measurements SET steps = $1, updated_at = now(), updated_by_user_id = $2 WHERE entry_date = $3 AND user_id = $4 RETURNING *',
+        'UPDATE check_in_measurements SET steps = GREATEST($1::integer, steps), updated_at = now(), updated_by_user_id = $2 WHERE entry_date = $3 AND user_id = $4 RETURNING *',
         [value, actingUserId, date, userId]
       );
       result = updateResult.rows[0];
@@ -387,13 +393,21 @@ async function bulkUpsertCheckInMeasurements(
         // Batch UPDATE via unnest: only columns present in the batch are
         // touched; COALESCE keeps a row's other columns intact (measurement
         // values are validated numbers, never null, so COALESCE is exact).
+        // steps is the exception — it is max-wins per day so a smaller/partial
+        // sync read can't clobber a complete day's total (see upsertStepData).
+        // GREATEST ignores a null u.steps (date not carrying steps this batch),
+        // leaving cm.steps intact, exactly as COALESCE would.
         const updateColumns = [
           ...new Set(
             updateDates.flatMap((date) => Object.keys(mergedByDate.get(date)!))
           ),
         ];
         const setClauses = updateColumns
-          .map((column) => `${column} = COALESCE(u.${column}, cm.${column})`)
+          .map((column) =>
+            column === 'steps'
+              ? 'steps = GREATEST(u.steps, cm.steps)'
+              : `${column} = COALESCE(u.${column}, cm.${column})`
+          )
           .join(', ');
         const unnestParams = updateColumns
           .map(

--- a/SparkyFitnessServer/tests/measurementRepository.bulkCheckInMeasurements.test.ts
+++ b/SparkyFitnessServer/tests/measurementRepository.bulkCheckInMeasurements.test.ts
@@ -140,6 +140,39 @@ describe('measurementRepository.bulkUpsertCheckInMeasurements', () => {
     expect(result).toEqual([updatedRow, insertedRow]);
   });
 
+  // Regression: the mobile /api/health-data sync path (bulkUpsert) must not let
+  // a smaller step read clobber a complete day's total. steps is max-wins while
+  // other columns stay COALESCE.
+  it('uses a max-wins GREATEST for steps but COALESCE for other columns on update', async () => {
+    const existingRow = {
+      id: 'ci-existing',
+      entry_date: '2026-07-07',
+      steps: 13441,
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockClient.query.mockImplementation(async (text: string) => {
+      if (text.includes('SELECT * FROM check_in_measurements')) {
+        return { rows: [existingRow] };
+      }
+      if (text.includes('UPDATE check_in_measurements')) {
+        return { rows: [{ ...existingRow, steps: 13441, weight: 70.5 }] };
+      }
+      return { rows: [] };
+    });
+
+    await measurementRepository.bulkUpsertCheckInMeasurements(
+      'user-1',
+      'acting-1',
+      [{ entryDate: '2026-07-07', measurements: { steps: 4252, weight: 70.5 } }]
+    );
+
+    const update = findCall('UPDATE check_in_measurements');
+    expect(update).toBeDefined();
+    expect(update!.text).toContain('steps = GREATEST(u.steps, cm.steps)');
+    expect(update!.text).toContain('weight = COALESCE(u.weight, cm.weight)');
+    expect(update!.text).not.toContain('steps = COALESCE');
+  });
+
   it('filters unauthorized measurement keys and skips entries left empty', async () => {
     const result = await measurementRepository.bulkUpsertCheckInMeasurements(
       'user-1',

--- a/SparkyFitnessServer/tests/measurementRepository.test.ts
+++ b/SparkyFitnessServer/tests/measurementRepository.test.ts
@@ -54,3 +54,75 @@ describe('measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate', () 
     expect(mockClient.release).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('measurementRepository.upsertStepData', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const findQuery = (fragment: string): { text: string; values: any[] } =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockClient.query.mock.calls
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .map((call: any[]) => ({ text: call[0], values: call[1] }))
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .find((call: any) => call.text.includes(fragment));
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Regression: a smaller/partial sync read must not clobber a complete day's
+  // total. The web Daily Steps chart showed 13,441 while the mobile check-in
+  // showed 4,252 because a later, smaller device/provider read overwrote the
+  // full total in check_in_measurements.steps.
+  it('updates existing days with a max-wins GREATEST so a smaller read cannot lower the total', async () => {
+    mockClient.query.mockImplementation(async (text: string) => {
+      if (text.startsWith('SELECT')) {
+        return { rows: [{ id: 'ci-1', steps: 13441 }] };
+      }
+      return { rows: [{ id: 'ci-1', steps: 13441 }] };
+    });
+
+    await measurementRepository.upsertStepData(
+      'user-1',
+      'acting-1',
+      4252,
+      '2026-07-07'
+    );
+
+    const update = findQuery('UPDATE check_in_measurements');
+    expect(update).toBeDefined();
+    expect(update.text).toContain('steps = GREATEST($1::integer, steps)');
+    expect(update.values).toEqual([4252, 'acting-1', '2026-07-07', 'user-1']);
+  });
+
+  it('inserts the incoming value verbatim when no row exists for the day', async () => {
+    mockClient.query.mockImplementation(async (text: string) => {
+      if (text.startsWith('SELECT')) {
+        return { rows: [] };
+      }
+      return { rows: [{ id: 'ci-2', steps: 4252 }] };
+    });
+
+    await measurementRepository.upsertStepData(
+      'user-1',
+      'acting-1',
+      4252,
+      '2026-07-07'
+    );
+
+    expect(findQuery('UPDATE check_in_measurements')).toBeUndefined();
+    const insert = findQuery('INSERT INTO check_in_measurements');
+    expect(insert).toBeDefined();
+    expect(insert.values).toEqual(['user-1', '2026-07-07', 4252, 'acting-1']);
+  });
+});

--- a/patches/react-native-health-connect@3.5.3.patch
+++ b/patches/react-native-health-connect@3.5.3.patch
@@ -219,6 +219,19 @@ index ae107565c6c85e0fd003a658f9b36d6137079977..cc23c78816bac7b977d6dfeba3f9e0e5
        timeRangeSlicer = mapJsPeriodToPeriod(record.getMap("timeRangeSlicer")),
        dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
      )
+diff --git a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+index 7d3364c0d41a24b106c51048eb2a17d01cd98cc6..636a29e0a4b46f3100676f0441b9e0eba10df087 100644
+--- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
++++ b/android/src/main/java/dev/matinzd/healthconnect/records/ReactStepsRecord.kt
+@@ -52,7 +52,7 @@ class ReactStepsRecord : ReactHealthRecordImpl<StepsRecord> {
+   override fun getAggregateGroupByDurationRequest(record: ReadableMap): AggregateGroupByDurationRequest {
+     return AggregateGroupByDurationRequest(
+       metrics = aggregateMetrics,
+-      timeRangeFilter = record.getTimeRangeFilterLocal("timeRangeFilter"),
++      timeRangeFilter = record.getTimeRangeFilter("timeRangeFilter"),
+       timeRangeSlicer = mapJsDurationToDuration(record.getMap("timeRangeSlicer")),
+       dataOriginFilter = convertJsToDataOriginSet(record.getArray("dataOriginFilter"))
+     )
 diff --git a/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt b/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt
 index 73f1fe47f66dd60ceac336833d81da13af6e26fc..89dc296c498869f287465f13c78dd6ffe4f2ed0b 100644
 --- a/android/src/main/java/dev/matinzd/healthconnect/records/ReactTotalCaloriesBurnedRecord.kt

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ packageExtensionsChecksum: sha256-EH/usIOwRpd73KCOjtc0doLNt62F5NOYV32iKiEfIZA=
 
 patchedDependencies:
   react-native-health-connect@3.5.3:
-    hash: be09914bb5fc51030d7373da0d836a76d47518f56f1f7a0e76ce05e7c3b487d0
+    hash: a1aac90a398a3b280f7e5fcfee73f048412da60542d4a9f8120531f370a527c9
     path: patches/react-native-health-connect@3.5.3.patch
 
 importers:
@@ -487,7 +487,7 @@ importers:
         version: 2.31.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-health-connect:
         specifier: ^3.5.3
-        version: 3.5.3(patch_hash=be09914bb5fc51030d7373da0d836a76d47518f56f1f7a0e76ce05e7c3b487d0)(@expo/config-plugins@56.0.10(typescript@6.0.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        version: 3.5.3(patch_hash=a1aac90a398a3b280f7e5fcfee73f048412da60542d4a9f8120531f370a527c9)(@expo/config-plugins@56.0.10(typescript@6.0.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-keyboard-controller:
         specifier: 1.21.6
         version: 1.21.6(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -32196,7 +32196,7 @@ snapshots:
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
 
-  react-native-health-connect@3.5.3(patch_hash=be09914bb5fc51030d7373da0d836a76d47518f56f1f7a0e76ce05e7c3b487d0)(@expo/config-plugins@56.0.10(typescript@6.0.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+  react-native-health-connect@3.5.3(patch_hash=a1aac90a398a3b280f7e5fcfee73f048412da60542d4a9f8120531f370a527c9)(@expo/config-plugins@56.0.10(typescript@6.0.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
       '@expo/config-plugins': 56.0.10(typescript@6.0.3)
       react: 19.2.3


### PR DESCRIPTION
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Daily step totals were disagreeing between web and mobile for the same day because a smaller or partial step read would overwrite a complete total. On android, a timezone change also mis assigned steps to the wrong day and inflated the count

**How did you implement the solution?**
- The automated step writers now use GREATEST on the steps column
- step aggregation detects when a stored zone offset changes from the device's current zone and treats it as a special case. those are bucketed as fixed 24h instant segments on the record's date at midnight instead of the device zone

Linked Issue: Closes #1712

## How to Test

1. Change time zones
2. Sync
3. Enable google health integration and google health sync
4. Sync

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
