### PR TITLE
test: fix long running test waiting for debounce

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/ServerConfigModal.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/ServerConfigModal.test.tsx
@@ -92,8 +92,12 @@ async function flushDebounce(ms = 600) {
   });
 }
 
-/** The URL field renders synchronously on mount; no debounce to wait out. */
-function waitForForm(result: ReturnType<typeof renderModal>) {
+/**
+ * The URL field renders synchronously on mount; no debounce to wait out. Kept
+ * `async` so the 30+ `await waitForForm(...)` call sites read consistently with
+ * the other async helpers.
+ */
+async function waitForForm(result: ReturnType<typeof renderModal>) {
   expect(result.getByPlaceholderText(URL_PLACEHOLDER)).toBeTruthy();
 }
 
@@ -783,7 +787,8 @@ describe('ServerConfigModal', () => {
       result.rerender(<ServerConfigModal {...defaultProps} visible={true} />);
 
       // URL is cleared on reset, so the auth options (email field) collapse away.
-      await flushDebounce();
+      // Clearing the URL schedules no debounce; `rerender` already flushed the
+      // reset via act, so we can assert directly.
       expect(result.getByPlaceholderText(URL_PLACEHOLDER).props.value).toBe('');
       expect(result.queryByPlaceholderText(EMAIL_PLACEHOLDER)).toBeNull();
     });

--- a/SparkyFitnessMobile/__tests__/components/ServerConfigModal.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/ServerConfigModal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import ServerConfigModal from '../../src/components/ServerConfigModal';
 import {
   login,
@@ -79,10 +79,22 @@ function renderModal(props: Partial<React.ComponentProps<typeof ServerConfigModa
   return render(<ServerConfigModal {...defaultProps} {...props} />);
 }
 
-async function waitForForm(result: ReturnType<typeof renderModal>) {
-  await waitFor(() =>
-    expect(result.getByPlaceholderText(URL_PLACEHOLDER)).toBeTruthy(),
-  );
+/**
+ * Fast-forwards the fake clock past the modal's 500ms auth-settings debounce and
+ * flushes the resulting fetch promise. `advanceTimersByTimeAsync` awaits the
+ * microtasks each timer schedules, so the mocked `fetchAuthSettings` resolves
+ * before we assert. We advance timers directly rather than via `waitFor`, which
+ * deadlocks under fake timers in this React Native renderer.
+ */
+async function flushDebounce(ms = 600) {
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(ms);
+  });
+}
+
+/** The URL field renders synchronously on mount; no debounce to wait out. */
+function waitForForm(result: ReturnType<typeof renderModal>) {
+  expect(result.getByPlaceholderText(URL_PLACEHOLDER)).toBeTruthy();
 }
 
 /**
@@ -91,9 +103,8 @@ async function waitForForm(result: ReturnType<typeof renderModal>) {
  * which renders exactly once whenever email auth is enabled.
  */
 async function waitForAuthReady(result: ReturnType<typeof renderModal>) {
-  await waitFor(() => expect(result.getByText('Sign In')).toBeTruthy(), {
-    timeout: 3000,
-  });
+  await flushDebounce();
+  expect(result.getByText('Sign In')).toBeTruthy();
 }
 
 /** Types a URL and waits for the dynamically-fetched auth options to render. */
@@ -111,10 +122,18 @@ function pressConnectButton(result: ReturnType<typeof renderModal>) {
 
 describe('ServerConfigModal', () => {
   beforeEach(() => {
+    // The modal debounces its auth-settings fetch by 500ms. With real timers
+    // every test that enters a URL waits that out in wall-clock time; fake
+    // timers let the helpers fast-forward the debounce instead of sleeping.
+    jest.useFakeTimers();
     jest.clearAllMocks();
     mockClearAuthCookies.mockResolvedValue(undefined);
     mockSaveServerConfig.mockResolvedValue(undefined);
     mockFetchAuthSettings.mockResolvedValue(emailAuthSettings);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   describe('form rendering', () => {
@@ -678,9 +697,10 @@ describe('ServerConfigModal', () => {
         fireEvent.press(result.getByText('Verify'));
       });
 
-      await waitFor(() => {
-        expect(result.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
-      });
+      // Returning to the sign-in form re-fetches auth settings through the
+      // debounce; advance past it before asserting the email field is back.
+      await flushDebounce();
+      expect(result.getByPlaceholderText(EMAIL_PLACEHOLDER)).toBeTruthy();
     });
 
     it('shows generic error for non-LoginError MFA failures', async () => {
@@ -763,9 +783,8 @@ describe('ServerConfigModal', () => {
       result.rerender(<ServerConfigModal {...defaultProps} visible={true} />);
 
       // URL is cleared on reset, so the auth options (email field) collapse away.
-      await waitFor(() => {
-        expect(result.getByPlaceholderText(URL_PLACEHOLDER).props.value).toBe('');
-      });
+      await flushDebounce();
+      expect(result.getByPlaceholderText(URL_PLACEHOLDER).props.value).toBe('');
       expect(result.queryByPlaceholderText(EMAIL_PLACEHOLDER)).toBeNull();
     });
   });


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
A test was taking more than 20 seconds every single run.

**How did you implement the solution?**
Made the timers fake. We don't need to actually wait between each input

Linked Issue: Closes #

## How to Test

1. Run tests

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
