### PR TITLE
feat(food-import): add overwrite option and drop quick-food from CSV import

### DIFF
--- a/SparkyFitnessFrontend/src/api/Foods/foodService.ts
+++ b/SparkyFitnessFrontend/src/api/Foods/foodService.ts
@@ -150,11 +150,12 @@ export const searchDatabaseFoods = async (
 };
 
 export const importFoodsFromCsv = async (
-  foods: FoodDataForBackend[]
+  foods: FoodDataForBackend[],
+  overwrite = false
 ): Promise<void> => {
   await apiCall('/foods/import-from-csv', {
     method: 'POST',
-    body: JSON.stringify({ foods }),
+    body: JSON.stringify({ foods, overwrite }),
   });
 };
 

--- a/SparkyFitnessFrontend/src/components/FoodSearch/CsvImportDialog.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/CsvImportDialog.tsx
@@ -12,7 +12,10 @@ import { FoodDataForBackend } from '@/types/food.ts';
 interface CsvImportDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
-  onSave: (foodDataArray: FoodDataForBackend[]) => Promise<void>;
+  onSave: (
+    foodDataArray: FoodDataForBackend[],
+    overwrite: boolean
+  ) => Promise<void>;
 }
 
 export const CsvImportDialog = ({
@@ -25,7 +28,7 @@ export const CsvImportDialog = ({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
         requireConfirmation
-        className="max-w-6xl max-h-[90vh] overflow-y-auto"
+        className="w-[95vw] max-w-[1600px] max-h-[90vh] overflow-y-auto"
       >
         <DialogHeader>
           <DialogTitle>

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -748,8 +748,11 @@ const EnhancedFoodSearch = ({
     }
   };
 
-  const handleImportFromCSV = async (foodDataArray: FoodDataForBackend[]) => {
-    await importCsvMutation(foodDataArray);
+  const handleImportFromCSV = async (
+    foodDataArray: FoodDataForBackend[],
+    overwrite: boolean
+  ) => {
+    await importCsvMutation({ foods: foodDataArray, overwrite });
     setShowImportFromCsvDialog(false);
   };
 

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoods.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoods.ts
@@ -265,7 +265,13 @@ export const useImportCsvMutation = () => {
   const { t } = useTranslation();
 
   return useMutation({
-    mutationFn: (foods: FoodDataForBackend[]) => importFoodsFromCsv(foods),
+    mutationFn: ({
+      foods,
+      overwrite,
+    }: {
+      foods: FoodDataForBackend[];
+      overwrite: boolean;
+    }) => importFoodsFromCsv(foods, overwrite),
     onSuccess: () => {
       return queryClient.invalidateQueries({
         queryKey: foodKeys.all,

--- a/SparkyFitnessFrontend/src/pages/Foods/FoodImportFromCSV.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/FoodImportFromCSV.tsx
@@ -13,10 +13,12 @@ import { Plus, Download, Upload, Trash2 } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
 import { FoodDataForBackend } from '@/types/food';
 
 interface ImportFromCSVProps {
-  onSave: (foodData: FoodDataForBackend[]) => Promise<void>;
+  onSave: (foodData: FoodDataForBackend[], overwrite: boolean) => Promise<void>;
 }
 
 export interface CSVData {
@@ -25,7 +27,6 @@ export interface CSVData {
   brand: string;
   is_custom: boolean;
   shared_with_public: boolean;
-  is_quick_food: boolean;
   serving_size: number;
   serving_unit: string;
   calories: number;
@@ -86,12 +87,12 @@ const ImportFromCSV = ({ onSave }: ImportFromCSVProps) => {
   const [csvData, setCsvData] = useState<CSVData[]>([]);
   const [headers, setHeaders] = useState<string[]>([]);
   const [csvText, setCsvText] = useState<string>('');
+  const [overwriteExisting, setOverwriteExisting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const textFields = new Set(['name', 'brand']);
   const booleanFields = new Set([
     'shared_with_public',
-    'is_quick_food',
     'is_default',
     'is_custom',
   ]);
@@ -101,7 +102,6 @@ const ImportFromCSV = ({ onSave }: ImportFromCSVProps) => {
     'brand',
     'is_custom',
     'shared_with_public',
-    'is_quick_food',
     'serving_size',
     'serving_unit',
     'calories', // Assumed to be in kcal
@@ -252,7 +252,6 @@ const ImportFromCSV = ({ onSave }: ImportFromCSVProps) => {
         brand: 'Sparky Sample Brand',
         is_custom: 'TRUE',
         shared_with_public: '',
-        is_quick_food: 'FALSE',
         serving_size: 231,
         serving_unit: 'slice',
         calories: 431, // kcal
@@ -318,7 +317,6 @@ const ImportFromCSV = ({ onSave }: ImportFromCSVProps) => {
       brand: '',
       is_custom: true,
       shared_with_public: false,
-      is_quick_food: false,
       serving_size: 100,
       serving_unit: 'g',
       calories: 0, // kcal
@@ -366,10 +364,14 @@ const ImportFromCSV = ({ onSave }: ImportFromCSVProps) => {
       return;
     }
     setLoading(true);
-    const dataForBackend = csvData.map(({ id, ...rest }) => rest);
+    // CSV import never creates quick foods; that is a separate workflow.
+    const dataForBackend = csvData.map(({ id, ...rest }) => ({
+      ...rest,
+      is_quick_food: false,
+    }));
     // console.log(dataForBackend);
     try {
-      await onSave(dataForBackend);
+      await onSave(dataForBackend, overwriteExisting);
     } catch (error) {
       console.error(
         'An error occurred while the parent was handling the save operation:',
@@ -594,6 +596,27 @@ const ImportFromCSV = ({ onSave }: ImportFromCSVProps) => {
               </div>
             </div>
           )}
+
+          <div className="flex items-start gap-2 rounded-md border p-3">
+            <Checkbox
+              id="overwrite-existing"
+              checked={overwriteExisting}
+              onCheckedChange={(checked) =>
+                setOverwriteExisting(checked === true)
+              }
+              className="mt-0.5"
+            />
+            <div className="space-y-1">
+              <Label htmlFor="overwrite-existing" className="cursor-pointer">
+                Override existing food details
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                If a food with the same name and brand already exists, update
+                its nutrition instead of failing the import. Leave unchecked to
+                skip and error on duplicates.
+              </p>
+            </div>
+          </div>
 
           <Button
             type="submit"

--- a/SparkyFitnessServer/models/food.ts
+++ b/SparkyFitnessServer/models/food.ts
@@ -688,50 +688,114 @@ async function deleteFoodAndDependencies(foodId: any, userId: any) {
     client.release();
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function createFoodsInBulk(userId: any, foodDataArray: any) {
+// CSV/bulk import values arrive loosely typed (numbers may still be strings),
+// so nutrient fields accept the raw shapes the sanitize* helpers normalize.
+type NumericInput = number | string | null | undefined;
+type BooleanInput = boolean | string | null | undefined;
+
+interface BulkImportFoodData {
+  name: string;
+  brand?: string | null;
+  is_custom?: BooleanInput;
+  user_id?: string;
+  shared_with_public?: BooleanInput;
+  is_quick_food?: BooleanInput;
+  barcode?: string | null;
+  provider_external_id?: string | null;
+  provider_type?: string | null;
+  serving_size?: NumericInput;
+  serving_unit?: string | null;
+  is_default?: BooleanInput;
+  calories?: NumericInput;
+  protein?: NumericInput;
+  carbs?: NumericInput;
+  fat?: NumericInput;
+  saturated_fat?: NumericInput;
+  polyunsaturated_fat?: NumericInput;
+  monounsaturated_fat?: NumericInput;
+  trans_fat?: NumericInput;
+  cholesterol?: NumericInput;
+  sodium?: NumericInput;
+  potassium?: NumericInput;
+  dietary_fiber?: NumericInput;
+  sugars?: NumericInput;
+  vitamin_a?: NumericInput;
+  vitamin_c?: NumericInput;
+  calcium?: NumericInput;
+  iron?: NumericInput;
+  glycemic_index?: string | null;
+  custom_nutrients?: Record<string, unknown> | null;
+  source?: string | null;
+  ai_confidence?: number | null;
+  allergens?: string[] | null;
+  traces?: string[] | null;
+}
+
+interface GroupedImportFood {
+  name: string;
+  brand?: string | null;
+  is_custom: boolean;
+  user_id: string;
+  shared_with_public: BooleanInput;
+  is_quick_food: BooleanInput;
+  barcode?: string | null;
+  provider_external_id?: string | null;
+  provider_type?: string | null;
+  variants: BulkImportFoodData[];
+}
+
+interface DuplicateFoodRow {
+  id: string;
+  name: string;
+  brand: string;
+}
+
+async function createFoodsInBulk(
+  userId: string,
+  foodDataArray: BulkImportFoodData[],
+  overwrite = false
+) {
   class DuplicateFoodError extends Error {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    duplicates: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    constructor(message: any, duplicates: any) {
+    duplicates: DuplicateFoodRow[];
+    constructor(message: string, duplicates: DuplicateFoodRow[]) {
       super(message);
       this.name = 'DuplicateFoodError';
       this.duplicates = duplicates;
     }
   }
   // 1. --- Grouping incoming Variants by Food (name + brand)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const groupedFoods = foodDataArray.reduce((acc: any, variant: any) => {
-    const key = `${variant.name}|${variant.brand}`;
-    if (!acc[key]) {
-      acc[key] = {
-        name: variant.name,
-        brand: variant.brand,
-        is_custom: true,
-        user_id: userId,
-        shared_with_public: variant.shared_with_public || false,
-        is_quick_food: variant.is_quick_food || false,
-        variants: [],
-      };
-    }
-    acc[key].variants.push(variant);
-    return acc;
-  }, {});
+  const groupedFoods = foodDataArray.reduce(
+    (acc: Record<string, GroupedImportFood>, variant: BulkImportFoodData) => {
+      const key = `${variant.name}|${variant.brand}`;
+      if (!acc[key]) {
+        acc[key] = {
+          name: variant.name,
+          brand: variant.brand,
+          is_custom: true,
+          user_id: userId,
+          shared_with_public: variant.shared_with_public || false,
+          is_quick_food: variant.is_quick_food || false,
+          variants: [],
+        };
+      }
+      acc[key].variants.push(variant);
+      return acc;
+    },
+    {}
+  );
   const foodsToCreate = Object.values(groupedFoods);
   if (foodsToCreate.length === 0) {
     return {
       message: 'No food data provided to import.',
       createdFoods: 0,
+      updatedFoods: 0,
       createdVariants: 0,
     };
   }
   // 2. Pre-flight Duplicate Check before starting the db transaction
   const potentialDuplicates = foodsToCreate.map((food) => [
     userId,
-    // @ts-expect-error TS(2571): Object is of type 'unknown'.
     food.name,
-    // @ts-expect-error TS(2571): Object is of type 'unknown'.
     food.brand,
   ]);
   const flatValues = potentialDuplicates.flat();
@@ -743,23 +807,27 @@ async function createFoodsInBulk(userId: any, foodDataArray: any) {
     )
     .join(', ');
   const duplicateCheckQuery = `
-    SELECT name, brand FROM foods
+    SELECT id, name, brand FROM foods
     WHERE (user_id, name, brand) IN (VALUES ${placeholderString})
   `;
   const clientForDuplicateCheck = await getClient(userId);
-  let existingFoods;
+  let existingFoods: DuplicateFoodRow[];
   try {
     const { rows } = await clientForDuplicateCheck.query(
       // User-specific check for duplicates
       duplicateCheckQuery,
       flatValues
     );
-    existingFoods = rows;
+    existingFoods = rows as DuplicateFoodRow[];
   } finally {
     clientForDuplicateCheck.release();
   }
-  if (existingFoods.length > 0) {
-    // If duplicates are found, throw an error.
+  // Map existing (name|brand) -> food id so we can overwrite in place when requested.
+  const existingFoodIdByKey = new Map<string, string>(
+    existingFoods.map((f) => [`${f.name}|${f.brand}`, f.id])
+  );
+  if (!overwrite && existingFoods.length > 0) {
+    // Duplicates found and the user did not opt into overwriting: abort.
     throw new DuplicateFoodError(
       'The import was terminated because duplicate entries were found in your food list.',
       existingFoods
@@ -770,39 +838,112 @@ async function createFoodsInBulk(userId: any, foodDataArray: any) {
   try {
     await client.query('BEGIN');
     let totalFoodsCreated = 0;
+    let totalFoodsUpdated = 0;
     let totalVariantsCreated = 0;
     for (const food of foodsToCreate) {
-      const foodResult = await client.query(
-        `INSERT INTO foods (name, brand, is_custom, user_id, shared_with_public, is_quick_food,barcode,provider_external_id,provider_type, created_at, updated_at)
+      const existingFoodId = existingFoodIdByKey.get(
+        `${food.name}|${food.brand}`
+      );
+      let foodId: string;
+      if (existingFoodId) {
+        // Overwrite path: update the existing food record in place.
+        await client.query(
+          `UPDATE foods SET
+             is_custom = $2,
+             shared_with_public = $3,
+             is_quick_food = $4,
+             updated_at = now()
+           WHERE id = $1`,
+          [
+            existingFoodId,
+            sanitizeBoolean(food.is_custom) ?? true,
+            sanitizeBoolean(food.shared_with_public) ?? false,
+            sanitizeBoolean(food.is_quick_food) ?? false,
+          ]
+        );
+        foodId = existingFoodId;
+        totalFoodsUpdated++;
+      } else {
+        const foodResult = await client.query(
+          `INSERT INTO foods (name, brand, is_custom, user_id, shared_with_public, is_quick_food,barcode,provider_external_id,provider_type, created_at, updated_at)
            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, now(), now())
            RETURNING id`,
-        [
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          food.name,
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          food.brand,
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          sanitizeBoolean(food.is_custom) ?? true,
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          food.user_id,
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          sanitizeBoolean(food.shared_with_public) ?? false,
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          sanitizeBoolean(food.is_quick_food) ?? false,
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          (food.barcode && normalizeBarcode(food.barcode)) || null,
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          food.provider_external_id || null,
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          food.provider_type || null,
-        ]
-      );
-      const newFoodId = foodResult.rows[0].id;
-      totalFoodsCreated++;
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
+          [
+            food.name,
+            food.brand,
+            sanitizeBoolean(food.is_custom) ?? true,
+            food.user_id,
+            sanitizeBoolean(food.shared_with_public) ?? false,
+            sanitizeBoolean(food.is_quick_food) ?? false,
+            (food.barcode && normalizeBarcode(food.barcode)) || null,
+            food.provider_external_id || null,
+            food.provider_type || null,
+          ]
+        );
+        foodId = foodResult.rows[0].id;
+        totalFoodsCreated++;
+      }
       for (const variant of food.variants) {
-        await client.query(
-          `INSERT INTO food_variants (
+        const variantIsDefault = sanitizeBoolean(variant.is_default) ?? true;
+        // When overwriting, reuse a variant with the same serving so existing
+        // diary entries (which reference the variant id) keep their nutrition.
+        const existingVariant = existingFoodId
+          ? (
+              await client.query(
+                `SELECT id FROM food_variants
+                 WHERE food_id = $1 AND serving_size = $2 AND serving_unit = $3
+                 LIMIT 1`,
+                [
+                  foodId,
+                  sanitizeNumeric(variant.serving_size),
+                  variant.serving_unit,
+                ]
+              )
+            ).rows[0]
+          : null;
+        if (variantIsDefault) {
+          // Keep a single default variant per food.
+          await client.query(
+            'UPDATE food_variants SET is_default = FALSE WHERE food_id = $1',
+            [foodId]
+          );
+        }
+        if (existingVariant) {
+          await client.query(
+            `UPDATE food_variants SET
+                is_default = $2, calories = $3, protein = $4, carbs = $5, fat = $6,
+                saturated_fat = $7, polyunsaturated_fat = $8, monounsaturated_fat = $9, trans_fat = $10,
+                cholesterol = $11, sodium = $12, potassium = $13, dietary_fiber = $14, sugars = $15,
+                vitamin_a = $16, vitamin_c = $17, calcium = $18, iron = $19,
+                glycemic_index = $20, custom_nutrients = $21, updated_at = now()
+              WHERE id = $1`,
+            [
+              existingVariant.id,
+              variantIsDefault,
+              sanitizeNumeric(variant.calories),
+              sanitizeNumeric(variant.protein),
+              sanitizeNumeric(variant.carbs),
+              sanitizeNumeric(variant.fat),
+              sanitizeNumeric(variant.saturated_fat),
+              sanitizeNumeric(variant.polyunsaturated_fat),
+              sanitizeNumeric(variant.monounsaturated_fat),
+              sanitizeNumeric(variant.trans_fat),
+              sanitizeNumeric(variant.cholesterol),
+              sanitizeNumeric(variant.sodium),
+              sanitizeNumeric(variant.potassium),
+              sanitizeNumeric(variant.dietary_fiber),
+              sanitizeNumeric(variant.sugars),
+              sanitizeNumeric(variant.vitamin_a),
+              sanitizeNumeric(variant.vitamin_c),
+              sanitizeNumeric(variant.calcium),
+              sanitizeNumeric(variant.iron),
+              sanitizeGlycemicIndex(variant.glycemic_index),
+              variant.custom_nutrients ?? {},
+            ]
+          );
+        } else {
+          await client.query(
+            `INSERT INTO food_variants (
               food_id, serving_size, serving_unit, is_default, calories, protein, carbs, fat,
               saturated_fat, polyunsaturated_fat, monounsaturated_fat, trans_fat,
               cholesterol, sodium, potassium, dietary_fiber, sugars,
@@ -812,36 +953,37 @@ async function createFoodsInBulk(userId: any, foodDataArray: any) {
               $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
               $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, now(), now()
             )`,
-          [
-            newFoodId,
-            sanitizeNumeric(variant.serving_size),
-            variant.serving_unit,
-            sanitizeBoolean(variant.is_default) ?? true,
-            sanitizeNumeric(variant.calories),
-            sanitizeNumeric(variant.protein),
-            sanitizeNumeric(variant.carbs),
-            sanitizeNumeric(variant.fat),
-            sanitizeNumeric(variant.saturated_fat),
-            sanitizeNumeric(variant.polyunsaturated_fat),
-            sanitizeNumeric(variant.monounsaturated_fat),
-            sanitizeNumeric(variant.trans_fat),
-            sanitizeNumeric(variant.cholesterol),
-            sanitizeNumeric(variant.sodium),
-            sanitizeNumeric(variant.potassium),
-            sanitizeNumeric(variant.dietary_fiber),
-            sanitizeNumeric(variant.sugars),
-            sanitizeNumeric(variant.vitamin_a),
-            sanitizeNumeric(variant.vitamin_c),
-            sanitizeNumeric(variant.calcium),
-            sanitizeNumeric(variant.iron),
-            sanitizeGlycemicIndex(variant.glycemic_index),
-            variant.custom_nutrients ?? {},
-            variant.source ?? 'manual',
-            variant.ai_confidence ?? null,
-            variant.allergens ?? null,
-            variant.traces ?? null,
-          ]
-        );
+            [
+              foodId,
+              sanitizeNumeric(variant.serving_size),
+              variant.serving_unit,
+              variantIsDefault,
+              sanitizeNumeric(variant.calories),
+              sanitizeNumeric(variant.protein),
+              sanitizeNumeric(variant.carbs),
+              sanitizeNumeric(variant.fat),
+              sanitizeNumeric(variant.saturated_fat),
+              sanitizeNumeric(variant.polyunsaturated_fat),
+              sanitizeNumeric(variant.monounsaturated_fat),
+              sanitizeNumeric(variant.trans_fat),
+              sanitizeNumeric(variant.cholesterol),
+              sanitizeNumeric(variant.sodium),
+              sanitizeNumeric(variant.potassium),
+              sanitizeNumeric(variant.dietary_fiber),
+              sanitizeNumeric(variant.sugars),
+              sanitizeNumeric(variant.vitamin_a),
+              sanitizeNumeric(variant.vitamin_c),
+              sanitizeNumeric(variant.calcium),
+              sanitizeNumeric(variant.iron),
+              sanitizeGlycemicIndex(variant.glycemic_index),
+              variant.custom_nutrients ?? {},
+              variant.source ?? 'manual',
+              variant.ai_confidence ?? null,
+              variant.allergens ?? null,
+              variant.traces ?? null,
+            ]
+          );
+        }
         totalVariantsCreated++;
       }
     }
@@ -849,6 +991,7 @@ async function createFoodsInBulk(userId: any, foodDataArray: any) {
     return {
       message: 'Food data imported successfully.',
       createdFoods: totalFoodsCreated,
+      updatedFoods: totalFoodsUpdated,
       createdVariants: totalVariantsCreated,
     };
   } catch (error) {
@@ -1005,6 +1148,7 @@ export { getFoodsWithPagination };
 export { countFoods };
 export { getFoodDeletionImpact };
 export { createFoodsInBulk };
+export type { BulkImportFoodData };
 export { getFoodsNeedingReview };
 export { clearUserIgnoredUpdate };
 export { deleteFoodAndDependencies };

--- a/SparkyFitnessServer/routes/foodCrudRoutes.ts
+++ b/SparkyFitnessServer/routes/foodCrudRoutes.ts
@@ -1107,12 +1107,12 @@ router.delete('/:id', authenticate, async (req, res, next) => {
  *         description: Food data is required.
  */
 router.post('/import-from-csv', authenticate, async (req, res, next) => {
-  const { foods } = req.body;
+  const { foods, overwrite } = req.body;
   if (!foods) {
     return res.status(400).json({ error: 'Food data is required.' });
   }
   try {
-    await foodService.importFoodsInBulk(req.userId, foods);
+    await foodService.importFoodsInBulk(req.userId, foods, overwrite === true);
     res.status(200).json({ message: 'Food data imported successfully.' });
   } catch (error) {
     next(error);

--- a/SparkyFitnessServer/services/foodCoreService.ts
+++ b/SparkyFitnessServer/services/foodCoreService.ts
@@ -19,6 +19,7 @@ import {
   mapFatSecretFood,
 } from '../integrations/fatsecret/fatsecretService.js';
 import { searchYazioByBarcode } from '../integrations/yazio/yazioService.js';
+import type { BulkImportFoodData } from '../models/food.js';
 async function searchFoods(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   authenticatedUserId: any,
@@ -630,8 +631,11 @@ async function getFoodDeletionImpact(authenticatedUserId: any, foodId: any) {
     throw error;
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function importFoodsInBulk(authenticatedUserId: any, foodDataArray: any) {
+async function importFoodsInBulk(
+  authenticatedUserId: string,
+  foodDataArray: BulkImportFoodData[],
+  overwrite = false
+) {
   try {
     if (!foodDataArray) {
       log('error', 'importFoodsInBulk: No food data provided.');
@@ -639,12 +643,12 @@ async function importFoodsInBulk(authenticatedUserId: any, foodDataArray: any) {
     }
     return await foodRepository.createFoodsInBulk(
       authenticatedUserId,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      foodDataArray.map((food: any) => ({
+      foodDataArray.map((food) => ({
         ...food,
         glycemic_index: food.glycemic_index || null,
         custom_nutrients: sanitizeCustomNutrients(food.custom_nutrients),
-      }))
+      })),
+      overwrite
     );
   } catch (error) {
     log(


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

CSV food import previously aborted the whole batch when any food with the same name+brand already existed, and let users flag imported foods as quick foods — which are hidden from the Food tab, so they appeared to vanish after a "successful" import.

**How did you implement the solution?**
(Brief technical approach.)


Changes:
- Add an "Override existing food details" checkbox to the import form. When enabled, duplicates update the existing food record and its matching default variant in place (matched by serving_size + serving_unit) so existing diary entries keep pointing at the same variant id. Non-duplicates in the same batch still insert normally. Threaded an `overwrite` flag through the form → dialog → hook → API → route → service → createFoodsInBulk.
- Remove is_quick_food from the CSV template, header validation, editable columns, and sample row. CSV import now always sends is_quick_food=false; quick foods stay a separate workflow.
- Widen the import dialog (w-[95vw], max-w-[1600px]) to reduce horizontal scrolling over the many-column table.
- Type createFoodsInBulk and importFoodsInBulk with real interfaces (BulkImportFoodData / GroupedImportFood / DuplicateFoodRow) instead of any.


Linked Issue: Closes # https://github.com/CodeWithCJ/SparkyFitness/issues/1748

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
