### PR TITLE
feat: add Intervals.ICU integration

### DIFF
--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -51,6 +51,7 @@ import fitbitRoutes from './routes/fitbitRoutes.js';
 import googleHealthRoutes from './routes/googleHealthRoutes.js';
 import polarRoutes from './routes/polarRoutes.js';
 import stravaRoutes from './routes/stravaRoutes.js';
+import intervalsIcuRoutes from './routes/intervalsicuRoutes.js';
 import hevyRoutes from './routes/hevyRoutes.js';
 import moodRoutes from './routes/moodRoutes.js';
 import fastingRoutes from './routes/fastingRoutes.js';
@@ -82,6 +83,7 @@ import fitbitService from './services/fitbitService.js';
 import googleHealthService from './services/googleHealthService.js';
 import polarService from './services/polarService.js';
 import stravaService from './services/stravaService.js';
+import intervalsIcuService from './services/intervalsicuService.js';
 // @ts-expect-error TS1192
 import dailySummaryRoutes from './routes/dailySummaryRoutes.js';
 import dashboardRoutes from './routes/dashboardRoutes.js';
@@ -494,6 +496,7 @@ app.use('/api/integrations/fitbit', fitbitRoutes);
 app.use('/api/integrations/googlehealth', googleHealthRoutes);
 app.use('/api/integrations/polar', polarRoutes);
 app.use('/api/integrations/strava', stravaRoutes);
+app.use('/api/integrations/intervalsicu', intervalsIcuRoutes);
 app.use('/api/integrations/hevy', hevyRoutes);
 app.use('/api/mood', moodRoutes);
 app.use('/api/fasting', fastingRoutes);
@@ -646,6 +649,29 @@ const scheduleStravaSyncs = async () => {
     }
   });
 };
+// Intervals.ICU sync
+const scheduleIntervalsIcuSyncs = async () => {
+  cron.schedule('0 * * * *', async () => {
+    const intervalsIcuProviders =
+      await externalProviderRepository.getProvidersByType('intervalsicu');
+    for (const provider of intervalsIcuProviders) {
+      if (provider.is_active && provider.sync_frequency !== 'manual') {
+        try {
+          await intervalsIcuService.syncIntervalsIcuData(provider.user_id, 'scheduled');
+          await externalProviderRepository.updateProviderLastSync(
+            provider.id,
+            new Date()
+          );
+        } catch (error) {
+          console.error(
+            `[CRON] Intervals.ICU sync failed for user ${provider.user_id}:`,
+            error
+          );
+        }
+      }
+    }
+  });
+};
 // Polar sync
 const schedulePolarSyncs = async () => {
   cron.schedule('0 * * * *', async () => {
@@ -723,6 +749,7 @@ applyMigrations()
     scheduleFitbitSyncs();
     schedulePolarSyncs();
     scheduleStravaSyncs();
+    scheduleIntervalsIcuSyncs();
     scheduleGoogleHealthSyncs();
     if (process.env.SPARKY_FITNESS_ADMIN_EMAIL) {
       const adminUser = await userRepository.findUserByEmail(

--- a/SparkyFitnessServer/integrations/intervalsicu/intervalsicuDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/intervalsicu/intervalsicuDataProcessor.ts
@@ -1,0 +1,295 @@
+import { log } from '../../config/logging.js';
+import exerciseRepository from '../../models/exercise.js';
+import exerciseEntryRepository from '../../models/exerciseEntry.js';
+import activityDetailsRepository from '../../models/activityDetailsRepository.js';
+import measurementRepository from '../../models/measurementRepository.js';
+import { todayInZone, instantToDay } from '@workspace/shared';
+
+interface IntervalsActivity {
+  id: string;
+  name: string | null;
+  type: string;
+  start_date_local: string;
+  start_date: string;
+  distance: number | null;
+  moving_time: number;
+  elapsed_time: number;
+  total_elevation_gain: number | null;
+  average_heartrate: number | null;
+  max_heartrate: number | null;
+  calories: number | null;
+  average_speed: number | null;
+  max_speed: number | null;
+  average_cadence: number | null;
+  average_temp: number | null;
+  icu_training_load: number | null;
+  icu_atl: number | null;
+  icu_ctl: number | null;
+  source: string | null;
+  kg_lifted: number | null;
+  has_heartrate: boolean;
+}
+
+/**
+ * Map Intervals.ICU activity type to a general exercise category
+ */
+function mapTypeToCategory(type: string): string {
+  const categoryMap: Record<string, string> = {
+    Run: 'Cardio',
+    TrailRun: 'Cardio',
+    VirtualRun: 'Cardio',
+    Walk: 'Cardio',
+    Hike: 'Cardio',
+    Ride: 'Cardio',
+    MountainBikeRide: 'Cardio',
+    GravelRide: 'Cardio',
+    EBikeRide: 'Cardio',
+    VirtualRide: 'Cardio',
+    Handcycle: 'Cardio',
+    Swim: 'Cardio',
+    OpenWaterSwim: 'Cardio',
+    Canoeing: 'Cardio',
+    Kayaking: 'Cardio',
+    Rowing: 'Cardio',
+    StandUpPaddling: 'Cardio',
+    Surfing: 'Cardio',
+    Windsurf: 'Cardio',
+    Kitesurf: 'Cardio',
+    AlpineSki: 'Cardio',
+    BackcountrySki: 'Cardio',
+    NordicSki: 'Cardio',
+    Snowboard: 'Cardio',
+    Snowshoe: 'Cardio',
+    IceSkate: 'Cardio',
+    WeightTraining: 'Strength',
+    StrengthTraining: 'Strength',
+    Crossfit: 'Strength',
+    Yoga: 'Flexibility',
+    Pilates: 'Flexibility',
+    Elliptical: 'Cardio',
+    StairStepper: 'Cardio',
+    RockClimbing: 'Strength',
+    Skateboard: 'Other',
+    InlineSkate: 'Cardio',
+    Golf: 'Other',
+    Soccer: 'Cardio',
+    Wheelchair: 'Cardio',
+    Workout: 'Other',
+    Other: 'Other',
+  };
+  return categoryMap[type] || 'Other';
+}
+
+/**
+ * Process Intervals.ICU activities and create exercise entries
+ */
+async function processIntervalsActivities(
+  userId: number,
+  createdByUserId: number,
+  activities: IntervalsActivity[] = [],
+  startDate: string | null = null,
+  timezone = 'UTC'
+) {
+  if (!activities || activities.length === 0) return;
+
+  for (const activity of activities) {
+    try {
+      // Extract entry date from start_date_local
+      const entryDate = activity.start_date_local
+        ? activity.start_date_local.substring(0, 10)
+        : activity.start_date
+          ? instantToDay(activity.start_date, timezone)
+          : todayInZone(timezone);
+
+      // Safety filter
+      if (startDate && entryDate < startDate) {
+        log(
+          'debug',
+          `[intervalsicuDataProcessor] Skipping activity "${activity.name}" from ${entryDate} (before sync range ${startDate})`
+        );
+        continue;
+      }
+
+      const exerciseName = activity.name || 'Intervals.ICU Activity';
+      const sportType = activity.type || 'Workout';
+      const category = mapTypeToCategory(sportType);
+
+      // Find or create exercise by name
+      let exercise = await exerciseRepository.findExerciseByNameAndUserId(
+        exerciseName,
+        userId
+      );
+      if (!exercise) {
+        exercise = await exerciseRepository.createExercise({
+          user_id: userId,
+          name: exerciseName,
+          category: category,
+          source: 'Intervals.ICU',
+          is_custom: true,
+          shared_with_public: false,
+        });
+      }
+
+      // Unit conversions
+      // distance in meters -> km
+      const distanceKm =
+        activity.distance !== null && activity.distance !== undefined
+          ? parseFloat((activity.distance / 1000).toFixed(2))
+          : null;
+
+      // moving_time in seconds -> minutes
+      const durationMinutes =
+        activity.moving_time !== null && activity.moving_time !== undefined
+          ? Math.round(activity.moving_time / 60)
+          : 0;
+
+      // Intervals.ICU provides calories directly
+      const caloriesAuto = activity.calories || 0;
+
+      // Build notes with rich context from Intervals.ICU
+      const notesParts: string[] = [`Synced from Intervals.ICU. Type: ${sportType}`];
+      if (activity.moving_time) {
+        notesParts.push(`Moving time: ${Math.round(activity.moving_time / 60)}min`);
+      }
+      if (activity.total_elevation_gain) {
+        notesParts.push(`Elevation: ${activity.total_elevation_gain}m`);
+      }
+      if (activity.icu_training_load !== null && activity.icu_training_load !== undefined) {
+        notesParts.push(`Training Load: ${activity.icu_training_load}`);
+      }
+      if (activity.average_speed) {
+        notesParts.push(`Avg Speed: ${(activity.average_speed * 3.6).toFixed(1)}km/h`);
+      }
+
+      const entryData = {
+        exercise_id: exercise.id,
+        entry_date: entryDate,
+        duration_minutes: durationMinutes,
+        calories_burned: caloriesAuto,
+        distance: distanceKm,
+        avg_heart_rate:
+          activity.average_heartrate !== null &&
+          activity.average_heartrate !== undefined
+            ? Math.round(activity.average_heartrate)
+            : null,
+        notes: notesParts.join('. '),
+        entry_source: 'Intervals.ICU',
+        source_id: activity.id ? activity.id.toString() : null,
+        sets: [
+          {
+            set_number: 1,
+            set_type: 'Working Set',
+            duration: durationMinutes,
+            notes: 'Automatically created from Intervals.ICU sync',
+          },
+        ],
+      };
+
+      const newEntry = await exerciseEntryRepository.createExerciseEntry(
+        userId,
+        entryData,
+        createdByUserId,
+        'Intervals.ICU'
+      );
+
+      // Store full activity detail
+      if (newEntry && newEntry.id) {
+        await activityDetailsRepository.createActivityDetail(userId, {
+          exercise_entry_id: newEntry.id,
+          provider_name: 'Intervals.ICU',
+          detail_type: 'full_activity_data',
+          detail_data: activity,
+          created_by_user_id: createdByUserId,
+        });
+      }
+
+      log(
+        'info',
+        `[intervalsicuDataProcessor] Processed activity "${exerciseName}" (${sportType}) for user ${userId} on ${entryDate}`
+      );
+    } catch (error) {
+      log(
+        'error',
+        `[intervalsicuDataProcessor] Error processing activity "${activity.name || activity.id}": ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+}
+
+/**
+ * Process wellness data (weight, steps, sleep, resting HR) from Intervals.ICU
+ */
+async function processWellnessData(
+  userId: number,
+  createdByUserId: number,
+  wellnessEntries: any[] = [],
+  timezone = 'UTC'
+) {
+  if (!wellnessEntries || wellnessEntries.length === 0) return;
+
+  for (const day of wellnessEntries) {
+    try {
+      const entryDate = day.id; // YYYY-MM-DD from Intervals.ICU
+
+      // Map wellness fields to SparkyFitness measurements
+      const measurements: Record<string, number> = {};
+      if (day.weight !== null && day.weight !== undefined) {
+        measurements.weight = day.weight;
+      }
+      if (day.restingHR !== null && day.restingHR !== undefined) {
+        measurements.resting_heart_rate = day.restingHR;
+      }
+      if (day.sleepSecs !== null && day.sleepSecs !== undefined) {
+        measurements.sleep_hours = parseFloat((day.sleepSecs / 3600).toFixed(2));
+      }
+      if (day.hrv !== null && day.hrv !== undefined) {
+        measurements.hrv = day.hrv;
+      }
+      if (day.steps !== null && day.steps !== undefined) {
+        measurements.steps = day.steps;
+      }
+      if (day.spO2 !== null && day.spO2 !== undefined) {
+        measurements.spo2 = day.spO2;
+      }
+      if (day.systolic !== null && day.systolic !== undefined) {
+        measurements.blood_pressure_systolic = day.systolic;
+      }
+      if (day.diastolic !== null && day.diastolic !== undefined) {
+        measurements.blood_pressure_diastolic = day.diastolic;
+      }
+      if (day.vo2max !== null && day.vo2max !== undefined) {
+        measurements.vo2max = day.vo2max;
+      }
+      if (day.bodyFat !== null && day.bodyFat !== undefined) {
+        measurements.body_fat = day.bodyFat;
+      }
+
+      if (Object.keys(measurements).length > 0) {
+        await measurementRepository.upsertCheckInMeasurements(
+          userId,
+          createdByUserId,
+          entryDate,
+          measurements
+        );
+        log(
+          'info',
+          `[intervalsicuDataProcessor] Upserted wellness data for user ${userId} on ${entryDate}: ${Object.keys(measurements).join(', ')}`
+        );
+      }
+    } catch (error) {
+      log(
+        'error',
+        `[intervalsicuDataProcessor] Error processing wellness entry ${day.id}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+}
+
+export { processIntervalsActivities };
+export { processWellnessData };
+export { mapTypeToCategory };
+export default {
+  processIntervalsActivities,
+  processWellnessData,
+  mapTypeToCategory,
+};

--- a/SparkyFitnessServer/integrations/intervalsicu/intervalsicuService.ts
+++ b/SparkyFitnessServer/integrations/intervalsicu/intervalsicuService.ts
@@ -1,0 +1,113 @@
+import axios from 'axios';
+import { getSystemClient } from '../../db/poolManager.js';
+import { decrypt, ENCRYPTION_KEY } from '../../security/encryption.js';
+import { log } from '../../config/logging.js';
+
+const INTERVALS_API_BASE_URL = 'https://intervals.icu/api/v1';
+
+/**
+ * Fetch activities for the authenticated athlete
+ * Uses API_KEY as username, api key as password (Basic auth)
+ */
+export async function fetchActivities(userId: number, oldest: string, limit = 100) {
+  const { apiKey } = await getCredentials(userId);
+  const url = `${INTERVALS_API_BASE_URL}/athlete/0/activities?oldest=${oldest}&limit=${limit}`;
+  const response = await axios.get(url, {
+    auth: { username: 'API_KEY', password: apiKey },
+    headers: { Accept: 'application/json' },
+  });
+  return response.data;
+}
+
+/**
+ * Fetch wellness data (weight, steps, sleep, HR, etc.)
+ */
+export async function fetchWellness(userId: number, oldest: string, newest: string) {
+  const { apiKey } = await getCredentials(userId);
+  const url = `${INTERVALS_API_BASE_URL}/athlete/0/wellness?oldest=${oldest}&newest=${newest}`;
+  const response = await axios.get(url, {
+    auth: { username: 'API_KEY', password: apiKey },
+    headers: { Accept: 'application/json' },
+  });
+  return response.data;
+}
+
+/**
+ * Fetch athlete profile / settings
+ */
+export async function fetchAthlete(userId: number) {
+  const { apiKey } = await getCredentials(userId);
+  const url = `${INTERVALS_API_BASE_URL}/athlete/0`;
+  const response = await axios.get(url, {
+    auth: { username: 'API_KEY', password: apiKey },
+    headers: { Accept: 'application/json' },
+  });
+  return response.data;
+}
+
+/**
+ * Get connection status by checking if valid credentials exist
+ */
+export async function getStatus(userId: number) {
+  try {
+    const credentials = await getCredentials(userId);
+    return {
+      connected: !!credentials.apiKey,
+      provider: 'intervalsicu',
+    };
+  } catch {
+    return { connected: false, provider: 'intervalsicu' };
+  }
+}
+
+/**
+ * Disconnect — just clears the provider row
+ */
+export async function disconnectIntervalsIcu(userId: number) {
+  const client = await getSystemClient();
+  try {
+    await client.query(
+      `DELETE FROM external_data_providers WHERE user_id = $1 AND provider_type = 'intervalsicu'`,
+      [userId]
+    );
+    return { success: true, message: 'Intervals.ICU disconnected.' };
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Extract the encrypted API key from the DB
+ */
+async function getCredentials(userId: number) {
+  const client = await getSystemClient();
+  try {
+    const result = await client.query(
+      `SELECT encrypted_app_id, app_id_iv, app_id_tag
+       FROM external_data_providers
+       WHERE user_id = $1 AND provider_type = 'intervalsicu'`,
+      [userId]
+    );
+    if (result.rows.length === 0) {
+      throw new Error('Intervals.ICU credentials not found for user.');
+    }
+    const { encrypted_app_id, app_id_iv, app_id_tag } = result.rows[0];
+    const apiKey = await decrypt(
+      encrypted_app_id,
+      app_id_iv,
+      app_id_tag,
+      ENCRYPTION_KEY
+    );
+    return { apiKey };
+  } finally {
+    client.release();
+  }
+}
+
+export default {
+  fetchActivities,
+  fetchWellness,
+  fetchAthlete,
+  getStatus,
+  disconnectIntervalsIcu,
+};

--- a/SparkyFitnessServer/routes/intervalsicuRoutes.ts
+++ b/SparkyFitnessServer/routes/intervalsicuRoutes.ts
@@ -1,0 +1,76 @@
+import express from 'express';
+import authMiddleware from '../middleware/authMiddleware.js';
+import intervalsIcuIntegrationService from '../integrations/intervalsicu/intervalsicuService.js';
+import intervalsIcuService from '../services/intervalsicuService.js';
+import { log } from '../config/logging.js';
+
+const router = express.Router();
+
+// All Intervals.ICU routes require authentication
+router.use(authMiddleware.authenticate);
+
+/**
+ * GET /status
+ * Get Intervals.ICU connection status
+ */
+router.get('/status', async (req, res) => {
+  try {
+    const userId = req.userId;
+    const status = await intervalsIcuService.getStatus(userId);
+    res.json(status);
+  } catch (error) {
+    log(
+      'error',
+      `[intervalsicuRoutes] Error getting status: ${error instanceof Error ? error.message : String(error)}`
+    );
+    res.status(500).json({ error: error instanceof Error ? error.message : 'Unknown error' });
+  }
+});
+
+/**
+ * POST /sync
+ * Trigger a manual Intervals.ICU data sync
+ */
+router.post('/sync', async (req, res) => {
+  try {
+    const userId = req.userId;
+    const { startDate, endDate } = req.body;
+    log(
+      'info',
+      `[intervalsicuRoutes] Manual sync triggered for user ${userId}${startDate ? ` from ${startDate}` : ''}${endDate ? ` to ${endDate}` : ''}`
+    );
+    const result = await intervalsIcuService.syncIntervalsIcuData(
+      userId,
+      'manual',
+      startDate,
+      endDate
+    );
+    res.json(result);
+  } catch (error) {
+    log(
+      'error',
+      `[intervalsicuRoutes] Error syncing data: ${error instanceof Error ? error.message : String(error)}`
+    );
+    res.status(500).json({ error: error instanceof Error ? error.message : 'Unknown error' });
+  }
+});
+
+/**
+ * POST /disconnect
+ * Disconnect Intervals.ICU integration
+ */
+router.post('/disconnect', async (req, res) => {
+  try {
+    const userId = req.userId;
+    const result = await intervalsIcuService.disconnectIntervalsIcu(userId);
+    res.json(result);
+  } catch (error) {
+    log(
+      'error',
+      `[intervalsicuRoutes] Error disconnecting: ${error instanceof Error ? error.message : String(error)}`
+    );
+    res.status(500).json({ error: error instanceof Error ? error.message : 'Unknown error' });
+  }
+});
+
+export default router;

--- a/SparkyFitnessServer/services/intervalsicuService.ts
+++ b/SparkyFitnessServer/services/intervalsicuService.ts
@@ -1,0 +1,127 @@
+import { log } from '../config/logging.js';
+import intervalsIcuIntegration from '../integrations/intervalsicu/intervalsicuService.js';
+import intervalsIcuDataProcessor from '../integrations/intervalsicu/intervalsicuDataProcessor.js';
+import { getSystemClient } from '../db/poolManager.js';
+import { loadUserTimezone } from '../utils/timezoneLoader.js';
+import { todayInZone, addDays } from '@workspace/shared';
+
+/**
+ * Orchestrate a full Intervals.ICU data sync for a user
+ */
+async function syncIntervalsIcuData(
+  userId: number,
+  syncType = 'manual',
+  customStartDate: string | null = null,
+  customEndDate: string | null = null
+) {
+  let startDate: string, endDate: string;
+  const tz = await loadUserTimezone(userId);
+  const today = todayInZone(tz);
+
+  if (customStartDate) {
+    startDate = customStartDate;
+    endDate = customEndDate || today;
+  } else if (syncType === 'manual') {
+    endDate = today;
+    startDate = addDays(today, -7);
+  } else {
+    endDate = today;
+    startDate = today;
+  }
+
+  log(
+    'info',
+    `[intervalsicuService] Starting Intervals.ICU sync (${syncType}) for user ${userId} from ${startDate} to ${endDate}`
+  );
+
+  try {
+    // 1. Verify connection
+    await intervalsIcuIntegration.fetchAthlete(userId);
+    log('debug', '[intervalsicuService] Connection verified, fetching data...');
+
+    // 2. Fetch activities
+    const activities = await intervalsIcuIntegration.fetchActivities(
+      userId,
+      startDate
+    );
+
+    // 3. Fetch wellness data (weight, steps, sleep, resting HR, etc.)
+    let wellness: any[] = [];
+    try {
+      wellness = await intervalsIcuIntegration.fetchWellness(
+        userId,
+        startDate,
+        endDate
+      );
+    } catch (err) {
+      log(
+        'warn',
+        `[intervalsicuService] Wellness fetch failed (optional): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    // 4. Process activities
+    if (activities && activities.length > 0) {
+      await intervalsIcuDataProcessor.processIntervalsActivities(
+        userId,
+        userId,
+        activities,
+        startDate,
+        tz
+      );
+    }
+
+    // 5. Process wellness
+    if (wellness && wellness.length > 0) {
+      await intervalsIcuDataProcessor.processWellnessData(
+        userId,
+        userId,
+        wellness,
+        tz
+      );
+    }
+
+    // 6. Update last_sync_at
+    const client = await getSystemClient();
+    try {
+      await client.query(
+        `UPDATE external_data_providers SET last_sync_at = NOW() WHERE user_id = $1 AND provider_type = 'intervalsicu'`,
+        [userId]
+      );
+    } finally {
+      client.release();
+    }
+
+    log(
+      'info',
+      `[intervalsicuService] Full Intervals.ICU sync completed for user ${userId}. ${activities?.length || 0} activities, ${wellness?.length || 0} wellness days processed.`
+    );
+
+    return {
+      success: true,
+      source: 'live_api',
+      activitiesProcessed: activities?.length || 0,
+      wellnessDays: wellness?.length || 0,
+    };
+  } catch (error) {
+    log(
+      'error',
+      `[intervalsicuService] Error during Intervals.ICU sync for user ${userId}: ${error instanceof Error ? error.message : String(error)}`
+    );
+    throw error;
+  }
+}
+
+const getStatus = (userId: number) =>
+  intervalsIcuIntegration.getStatus(userId);
+const disconnectIntervalsIcu = (userId: number) =>
+  intervalsIcuIntegration.disconnectIntervalsIcu(userId);
+
+export { syncIntervalsIcuData };
+export { getStatus };
+export { disconnectIntervalsIcu };
+export default {
+  syncIntervalsIcuData,
+  getStatus,
+  disconnectIntervalsIcu,
+};


### PR DESCRIPTION
## Summary

Adds full **Intervals.ICU** integration to SparkyFitness, following the existing Strava integration pattern. Pulls fitness activities and wellness metrics from Intervals.ICU (which syncs from Amazfit, Garmin, Coros, and 120+ other devices).

## What's Included

### New files (4)
- **`integrations/intervalsicu/intervalsicuService.ts`** — API client using Intervals.ICU's API key auth (Basic auth, `username=API_KEY`)
- **`integrations/intervalsicu/intervalsicuDataProcessor.ts`** — Maps Intervals.ICU activities and wellness data to SparkyFitness models
- **`services/intervalsicuService.ts`** — Sync orchestrator (activities + wellness), handles manual and scheduled syncs
- **`routes/intervalsicuRoutes.ts`** — REST endpoints: `GET /status`, `POST /sync`, `POST /disconnect`

### Modified files (1)
- **`SparkyFitnessServer.ts`** — Mounts routes at `/api/integrations/intervalsicu`, adds hourly CRON sync for active providers

## Intervals.ICU API Usage
| Endpoint | Data |
|----------|------|
| `GET /api/v1/athlete/0/activities?oldest=YYYY-MM-DD&limit=N` | Workouts with HR, training load, weight training volume |
| `GET /api/v1/athlete/0/wellness?oldest=YYYY-MM-DD&newest=YYYY-MM-DD` | Daily weight, steps, sleep, resting HR, HRV, SpO2, BP, body fat, VO2max |

## Data Mapping
- **Activities** → `exercise_entries` (with full activity detail stored via `activity_details`)
- **Wellness metrics** → `measurements` (upserted via `upsertCheckInMeasurements`)

## Auth Model
Intervals.ICU doesn't use OAuth — it uses a static API key with Basic auth (`API_KEY:your-api-key`). The API key is stored encrypted in `external_data_providers` under the `intervalsicu` provider type (using the `app_id` fields).



## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [ ] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.