### PR TITLE
Indicate calendar days that have progress photos (#1759)

### DIFF
--- a/SparkyFitnessFrontend/src/api/CheckIn/checkInPhotoService.ts
+++ b/SparkyFitnessFrontend/src/api/CheckIn/checkInPhotoService.ts
@@ -23,6 +23,15 @@ export const fetchCheckInPhotos = async (
   return response as CheckInPhoto[];
 };
 
+export const fetchCheckInPhotoDates = async (): Promise<string[]> => {
+  const response = await apiCall('/measurements/check-in-photos/dates', {
+    method: 'GET',
+    suppress404Toast: true,
+  });
+  if (!response || !Array.isArray(response)) return [];
+  return response as string[];
+};
+
 export const uploadCheckInPhoto = async (
   date: string,
   type: PhotoType,

--- a/SparkyFitnessFrontend/src/components/DayNavigator.tsx
+++ b/SparkyFitnessFrontend/src/components/DayNavigator.tsx
@@ -11,17 +11,36 @@ import { debug, info, warn } from '@/utils/logging';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import { addDays, localDateToDay, todayInZone } from '@workspace/shared';
+import { useMemo } from 'react';
+
+// Class applied to calendar days that carry a marker (e.g. days with progress
+// photos). It renders a small dot at the bottom of the cell. The dot sits at
+// z-20 so it stays visible above the z-10 day button even when the day is
+// selected, and switches to the foreground color on the selected day for
+// contrast against its filled background.
+const MARKED_DAY_CLASS =
+  "after:content-[''] after:pointer-events-none after:absolute after:bottom-1 " +
+  'after:left-1/2 after:z-20 after:h-1.5 after:w-1.5 after:-translate-x-1/2 ' +
+  'after:rounded-full after:bg-blue-500 ' +
+  'data-[selected=true]:after:bg-primary-foreground';
 
 interface DayNavigatorProps {
   selectedDate: string;
   onDateChange: (date: string) => void;
   className?: string;
+  // Optional YYYY-MM-DD strings to mark with a dot in the calendar (e.g. days
+  // that have progress photos). Omitted by callers that don't need markers.
+  markedDates?: string[];
+  // Legend label shown under the calendar when markedDates is provided.
+  markedDatesLabel?: string;
 }
 
 const DayNavigator = ({
   selectedDate,
   onDateChange,
   className,
+  markedDates,
+  markedDatesLabel,
 }: DayNavigatorProps) => {
   const { t } = useTranslation();
   const {
@@ -34,6 +53,16 @@ const DayNavigator = ({
 
   const selectedPickerDate = parseDateInUserTimezone(selectedDate);
   const selectedDateRelation = getDateRelationToToday(selectedDate);
+
+  // Convert marked day strings to Date objects the same way the selected date
+  // is parsed, so a marker lands on exactly the cell that date would select.
+  const markedDateObjects = useMemo(
+    () =>
+      (markedDates ?? [])
+        .map((d) => parseDateInUserTimezone(d))
+        .filter((d): d is Date => d instanceof Date && !isNaN(d.getTime())),
+    [markedDates, parseDateInUserTimezone]
+  );
 
   const handleDateSelect = (newDate: Date | undefined) => {
     debug(loggingLevel, 'Handling date select from calendar:', newDate);
@@ -133,6 +162,20 @@ const DayNavigator = ({
               selected={selectedPickerDate}
               onSelect={handleDateSelect}
               yearsRange={10}
+              modifiers={
+                markedDateObjects.length > 0
+                  ? { hasMarker: markedDateObjects }
+                  : undefined
+              }
+              modifiersClassNames={{ hasMarker: MARKED_DAY_CLASS }}
+              footer={
+                markedDateObjects.length > 0 && markedDatesLabel ? (
+                  <div className="flex items-center justify-center gap-2 pt-2 text-xs text-muted-foreground">
+                    <span className="h-1.5 w-1.5 rounded-full bg-blue-500" />
+                    {markedDatesLabel}
+                  </div>
+                ) : undefined
+              }
             />
           </PopoverContent>
         </Popover>

--- a/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts
+++ b/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { toast } from '@/hooks/use-toast';
 import {
   fetchCheckInPhotos,
+  fetchCheckInPhotoDates,
   uploadCheckInPhoto,
   deleteCheckInPhoto,
   type PhotoType,
@@ -14,6 +15,22 @@ export type { PhotoType, CheckInPhoto };
 // Mirror the server's multer limit so oversized files are rejected up front
 // with immediate feedback instead of after a round-trip.
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
+
+// Shared key for the "which days have photos" query so the upload/delete
+// mutations can invalidate the calendar indicator alongside the day's photos.
+const PHOTO_DATES_KEY = ['check-in-photo-dates'];
+
+/**
+ * The calendar-day strings (YYYY-MM-DD) on which the user has progress photos.
+ * Used to mark those days on the check-in calendar.
+ */
+export const useCheckInPhotoDates = () => {
+  const { data: photoDates = [] } = useQuery({
+    queryKey: PHOTO_DATES_KEY,
+    queryFn: fetchCheckInPhotoDates,
+  });
+  return photoDates;
+};
 
 export const useCheckInPhotos = (selectedDate: string) => {
   const { t } = useTranslation();
@@ -30,6 +47,7 @@ export const useCheckInPhotos = (selectedDate: string) => {
       uploadCheckInPhoto(selectedDate, type, file),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: PHOTO_DATES_KEY });
       toast({ title: t('checkIn.photos.uploadSuccess', 'Photo saved') });
     },
     onError: (err: Error) => {
@@ -45,6 +63,7 @@ export const useCheckInPhotos = (selectedDate: string) => {
     mutationFn: (id: string) => deleteCheckInPhoto(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey });
+      queryClient.invalidateQueries({ queryKey: PHOTO_DATES_KEY });
       toast({ title: t('checkIn.photos.deleteSuccess', 'Photo removed') });
     },
     onError: () => {

--- a/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts
+++ b/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts
@@ -20,12 +20,17 @@ const MAX_UPLOAD_BYTES = 10 * 1024 * 1024; // 10 MB
 // mutations can invalidate the calendar indicator alongside the day's photos.
 const PHOTO_DATES_KEY = ['check-in-photo-dates'];
 
+// Stable empty-array reference for the loading/undefined state. A fresh `[]`
+// default would change identity every render and defeat the useMemo in
+// DayNavigator that depends on the returned array.
+const EMPTY_DATES: string[] = [];
+
 /**
  * The calendar-day strings (YYYY-MM-DD) on which the user has progress photos.
  * Used to mark those days on the check-in calendar.
  */
 export const useCheckInPhotoDates = () => {
-  const { data: photoDates = [] } = useQuery({
+  const { data: photoDates = EMPTY_DATES } = useQuery({
     queryKey: PHOTO_DATES_KEY,
     queryFn: fetchCheckInPhotoDates,
   });

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx
@@ -9,6 +9,7 @@ import { CheckInTopRow } from './CheckInTopRow';
 import { useCheckInLogic } from '@/hooks/CheckIn/useCheckInLogic';
 import { useSearchParams } from 'react-router-dom';
 import { CheckInPhotos } from './CheckInPhotos';
+import { useCheckInPhotoDates } from '@/hooks/CheckIn/useCheckInPhotos';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
@@ -70,6 +71,7 @@ const CheckIn = () => {
   const [, setSearchParams] = useSearchParams();
   const { t } = useTranslation();
   const [importOpen, setImportOpen] = useState(false);
+  const photoDates = useCheckInPhotoDates();
 
   return (
     <div className="container mx-auto space-y-6">
@@ -80,6 +82,11 @@ const CheckIn = () => {
             setSelectedDate(dateString);
             setSearchParams({ date: dateString });
           }}
+          markedDates={photoDates}
+          markedDatesLabel={t(
+            'checkIn.photos.calendarLegend',
+            'Progress photos'
+          )}
         />
         <Dialog open={importOpen} onOpenChange={setImportOpen}>
           <DialogTrigger asChild>

--- a/SparkyFitnessServer/routes/checkInPhotoRoutes.ts
+++ b/SparkyFitnessServer/routes/checkInPhotoRoutes.ts
@@ -16,6 +16,44 @@ const router = express.Router();
 
 /**
  * @swagger
+ * /measurements/check-in-photos/dates:
+ *   get:
+ *     summary: List the dates on which the user has progress photos
+ *     description: >
+ *       Returns the distinct calendar days (YYYY-MM-DD, newest first) that have
+ *       at least one progress photo. Used to mark those days on the check-in
+ *       calendar. Registered before /:date so it is not shadowed by it.
+ *     tags: [Wellness & Metrics]
+ *     security:
+ *       - cookieAuth: []
+ *     responses:
+ *       200:
+ *         description: Array of YYYY-MM-DD date strings.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: string
+ *                 format: date
+ */
+router.get(
+  '/dates',
+  authenticate,
+  checkPermissionMiddleware('checkin'),
+  async (req, res) => {
+    try {
+      const dates = await checkInPhotoService.getPhotoDates(req.userId);
+      res.json(dates);
+    } catch (err) {
+      log('error', 'Failed to fetch check-in photo dates', err);
+      res.status(500).json({ error: 'Failed to fetch check-in photo dates' });
+    }
+  }
+);
+
+/**
+ * @swagger
  * /measurements/check-in-photos/{date}:
  *   get:
  *     summary: Get progress photos for a check-in date

--- a/SparkyFitnessServer/services/checkInPhotoService.ts
+++ b/SparkyFitnessServer/services/checkInPhotoService.ts
@@ -76,6 +76,33 @@ export const getPhotosByDate = async (
   }
 };
 
+/**
+ * Returns the distinct calendar days (newest first) on which the user has at
+ * least one progress photo. Drives the calendar indicator on the check-in page
+ * so days with photos are easy to find without opening each date. RLS-scoped
+ * through getClient, so a family member only sees dates they may access.
+ */
+export const getPhotoDates = async (userId: string): Promise<string[]> => {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      `SELECT DISTINCT entry_date
+       FROM check_in_photos
+       WHERE user_id = $1
+       ORDER BY entry_date DESC`,
+      [userId]
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return result.rows.map((r: any) =>
+      r.entry_date instanceof Date
+        ? localDateToDay(r.entry_date)
+        : String(r.entry_date)
+    );
+  } finally {
+    client.release();
+  }
+};
+
 export const upsertPhoto = async (
   userId: string,
   entryDate: string,
@@ -254,4 +281,10 @@ export const deletePhoto = async (
   }
 };
 
-export default { getPhotosByDate, upsertPhoto, getPhotoFileById, deletePhoto };
+export default {
+  getPhotosByDate,
+  getPhotoDates,
+  upsertPhoto,
+  getPhotoFileById,
+  deletePhoto,
+};

--- a/SparkyFitnessServer/tests/checkInPhotoRoutes.test.ts
+++ b/SparkyFitnessServer/tests/checkInPhotoRoutes.test.ts
@@ -68,6 +68,39 @@ const MOCK_PHOTO = {
   created_at: '2026-06-14T10:00:00.000Z',
 };
 
+describe('GET /dates', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the list of dates that have photos', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.getPhotoDates.mockResolvedValue([
+      '2026-06-14',
+      '2026-06-10',
+    ]);
+    const res = await request(app).get('/dates');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(['2026-06-14', '2026-06-10']);
+    expect(checkInPhotoService.getPhotoDates).toHaveBeenCalledWith(
+      'test-user-id'
+    );
+  });
+
+  it('is not shadowed by the /:date route (no date-format 400)', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.getPhotoDates.mockResolvedValue([]);
+    const res = await request(app).get('/dates');
+    expect(res.status).toBe(200);
+    expect(checkInPhotoService.getPhotosByDate).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the service throws', async () => {
+    // @ts-expect-error mock
+    checkInPhotoService.getPhotoDates.mockRejectedValue(new Error('DB error'));
+    const res = await request(app).get('/dates');
+    expect(res.status).toBe(500);
+  });
+});
+
 describe('GET /:date', () => {
   beforeEach(() => vi.clearAllMocks());
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Progress photos are hard to find: if you don't shoot every day, you have to open dates one by one to locate the ones with photos. This marks those days directly on the check-in calendar (issue #1759).

**How did you implement the solution?**
A new `GET /measurements/check-in-photos/dates` endpoint returns the distinct days that have at least one progress photo (RLS-scoped, reusing the existing `check_in_photos` table — no migration). `DayNavigator` gains optional `markedDates`/`markedDatesLabel` props that render a blue dot on those days plus a small legend; the check-in page feeds it the dates, and photo upload/delete invalidate the query so the dot updates immediately.

Linked Issue: Closes #1759

> 
**Feature commit files (the only files this change authors):**
- `SparkyFitnessServer/routes/checkInPhotoRoutes.ts`
- `SparkyFitnessServer/services/checkInPhotoService.ts`
- `SparkyFitnessServer/tests/checkInPhotoRoutes.test.ts`
- `SparkyFitnessFrontend/src/api/CheckIn/checkInPhotoService.ts`
- `SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInPhotos.ts`
- `SparkyFitnessFrontend/src/components/DayNavigator.tsx`
- `SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx`

## How to Test

1. Check out this branch, run the server and `pnpm dev` in `SparkyFitnessFrontend/`.
2. Go to **Check-In**, upload a progress photo (front/back/side) for a date.
3. Open the calendar in the day navigator: the day now shows a blue dot, with a "Progress photos" legend underneath.
4. Delete the photo and confirm the dot disappears. Navigate months to confirm dots persist across the calendar.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: Tracked by issue #1759.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: `pnpm run validate` passes (typecheck, lint, Prettier).
- [x] **[MANDATORY for Frontend changes] Translations**: This change modifies no locale files. The only new UI string uses an inline `t()` default, matching the existing progress-photo strings. (Non-`en` locale changes in the diff are from the upstream sync, not this change.)

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: New endpoint is TypeScript, uses the existing permission middleware, and has route tests (`tests/checkInPhotoRoutes.test.ts`, 20 passing). Typecheck/lint pass.
- [x] **[MANDATORY for Backend changes] Database Security**: No new tables — reuses `check_in_photos`; the new read is RLS-scoped through `getClient`, so no `rls_policies.sql` change is required.

## Notes for Reviewers

- The endpoint is registered before `/:date` on purpose so `/dates` isn't shadowed by the date-param route (covered by a test).
- The dot renders above the day button (`z-20`) and switches to the foreground color on the selected day for contrast.
- The calendar overview/gallery mentioned as a secondary "nice to have" in the issue is intentionally left out to keep this PR focused; the new `/dates` endpoint gives a follow-up a natural starting point.