### PR TITLE
feat(food-search): include recent and frequent meals in the search landing

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -699,6 +699,9 @@
     "family": "Family",
     "topFoods": "Top Foods",
     "noRecentOrTopFoods": "No recent or top foods found. Start logging foods to see them here.",
+    "noRecentOrTopItems": "No recent or frequent foods or meals found. Start logging to see them here.",
+    "recent": "Recent",
+    "frequent": "Frequent",
     "noItemsFoundInDatabase": "No items found in your database for \"{{searchTerm}}\".",
     "clickSearchIconOnline": "Click the search icon to search online.",
     "noFoodsFoundOnline": "No foods found from the selected online provider.",
@@ -1635,6 +1638,8 @@
   },
   "mealManagement": {
     "failedToLoadMeals": "Failed to load meals.",
+    "failedToLoadRecentMeals": "Failed to load recent meals.",
+    "failedToLoadTopMeals": "Failed to load top meals.",
     "failedToDeleteMeal": "Failed to delete meal: {{errorMessage}}",
     "couldNotCheckMealUsage": "Could not check meal usage.",
     "mealSavedSuccessfully": "Meal \"{{mealName}}\" saved successfully.",

--- a/SparkyFitnessFrontend/src/api/Foods/meals.ts
+++ b/SparkyFitnessFrontend/src/api/Foods/meals.ts
@@ -35,6 +35,22 @@ export const getMealById = async (mealId: string): Promise<Meal> => {
   return await apiCall(`/meals/${mealId}`, { method: 'GET' });
 };
 
+// Recently logged meal templates, for the food-search landing quick-pick list.
+export const getRecentMeals = async (limit = 3): Promise<Meal[]> => {
+  return await apiCall(`/meals/recent`, {
+    method: 'GET',
+    params: { limit: String(limit) },
+  });
+};
+
+// Most frequently logged meal templates, ranked by usage count.
+export const getTopMeals = async (limit = 3): Promise<Meal[]> => {
+  return await apiCall(`/meals/top`, {
+    method: 'GET',
+    params: { limit: String(limit) },
+  });
+};
+
 export const updateMeal = async (
   mealId: string,
   mealData: Partial<MealPayload>

--- a/SparkyFitnessFrontend/src/api/keys/meals.ts
+++ b/SparkyFitnessFrontend/src/api/keys/meals.ts
@@ -6,6 +6,8 @@ export const mealKeys = {
   filter: (filter: MealFilter, searchTerm?: string) =>
     [...mealKeys.all, 'filter', filter, searchTerm] as const,
   impact: (mealId: string) => [...mealKeys.one(mealId), 'impact'] as const,
+  recent: (limit: number) => [...mealKeys.all, 'recent', limit] as const,
+  top: (limit: number) => [...mealKeys.all, 'top', limit] as const,
 };
 export const foodKeys = {
   all: ['foods'] as const,

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -45,6 +45,11 @@ import {
 import { DEFAULT_NUTRIENTS } from '@/constants/nutrients.ts';
 import { convertNutritionixToFood } from '@/utils/foodSearch.ts';
 import { dedupeAppend } from '@/utils/dedupeAppend.ts';
+import {
+  mergeRecent,
+  mergeFrequent,
+  type LandingEntry,
+} from '@/utils/landingLists.ts';
 import FoodResultCard from './FoodResultCard.tsx';
 import { BarcodeScannerDialog } from './BarcodeScannerDialog.tsx';
 import { CsvImportDialog } from './CsvImportDialog.tsx';
@@ -55,7 +60,10 @@ import {
   searchBarcodeV2Options,
   foodDetailsV2Options,
 } from '@/hooks/Foods/useFoodsV2.ts';
-import { mealSearchOptions } from '@/hooks/Foods/useMeals.ts';
+import {
+  mealSearchOptions,
+  useRecentAndTopMealsQuery,
+} from '@/hooks/Foods/useMeals.ts';
 import {
   useAllProvidersFoodSearch,
   type ExternalResultWrapper,
@@ -184,12 +192,24 @@ const EnhancedFoodSearch = ({
   const { data: customNutrients } = useCustomNutrients();
   const { data: foodDataProviders = EMPTY_PROVIDERS } =
     useExternalProvidersQuery();
-  const { data: recentTopData, isFetching: isFetchingRecent } =
+  // item_display_limit (default 10) is the per-section total cap for the
+  // empty-query landing: each of Recent and Frequent shows up to this many
+  // merged items. It is also the per-source fetch count, so each merged list
+  // can be filled even when one type dominates.
+  const { data: recentTopData, isLoading: isLoadingRecentFoods } =
     useRecentAndTopFoodsQuery(
       itemDisplayLimit,
       mealType,
       showLocalFoods && isSearchEmpty
     );
+  // Recent + frequent meals for the landing quick-pick list, so the landing
+  // (like the typed search) surfaces both foods and meals. Only fetched when
+  // meals are shown and the query is empty.
+  const {
+    recentMeals,
+    topMeals,
+    isLoading: isLoadingRecentMeals,
+  } = useRecentAndTopMealsQuery(itemDisplayLimit, showMeals && isSearchEmpty);
   const { mutateAsync: importCsvMutation } = useImportCsvMutation();
   const { data: searchData, isFetching: isFetchingSearch } =
     useDatabaseFoodSearchQuery(
@@ -202,6 +222,19 @@ const EnhancedFoodSearch = ({
   const recentFoods = recentTopData?.recentFoods || [];
   const topFoods = recentTopData?.topFoods || [];
   const foods = searchData?.searchResults || [];
+
+  // Recent is one merged timeline (meals + foods by last-used date); Frequent is
+  // one merged most-used list (by usage count) with anything already in Recent
+  // removed, so the two sections do not repeat cards. Each capped to
+  // itemDisplayLimit.
+  const recentEntries = mergeRecent(recentMeals, recentFoods, itemDisplayLimit);
+  const recentEntryKeys = new Set(recentEntries.map((e) => e.key));
+  const frequentEntries = mergeFrequent(
+    topMeals,
+    topFoods,
+    recentEntryKeys,
+    itemDisplayLimit
+  );
 
   // Active food-category providers: the only valid options for the provider
   // dropdown, so the resolved default must be drawn from this list (not the raw
@@ -902,6 +935,26 @@ const EnhancedFoodSearch = ({
     />
   );
 
+  // A single Recent/Frequent landing row: a meal card or a food card depending
+  // on the merged entry's kind.
+  const renderLandingEntry = (entry: LandingEntry) =>
+    entry.kind === 'meal' ? (
+      <FoodResultCard
+        key={entry.key}
+        item={entry.meal}
+        isMeal={true}
+        nutrientConfig={nutrientConfig}
+        onCardClick={() => onFoodSelect(entry.meal, 'meal')}
+      />
+    ) : (
+      <FoodResultCard
+        key={entry.key}
+        item={entry.food}
+        nutrientConfig={nutrientConfig}
+        onCardClick={() => onFoodSelect(entry.food, 'food')}
+      />
+    );
+
   return (
     <div className="space-y-4">
       <div className="flex flex-col sm:flex-row flex-wrap gap-2">
@@ -989,39 +1042,46 @@ const EnhancedFoodSearch = ({
       </div>
 
       <div className="space-y-2 max-h-96 overflow-y-auto">
-        {/* Landing: recent + top foods (local mode, empty query) */}
+        {/* Landing: recent + top foods and meals (local mode, empty query) */}
         {showLocalFoods && isSearchEmpty && (
           <>
-            {isFetchingRecent && (
+            {(isLoadingRecentFoods || (showMeals && isLoadingRecentMeals)) && (
               <div className="text-center py-8 text-gray-500">
                 <Loader2 className="w-8 h-8 animate-spin mx-auto mb-2" />
                 {t('enhancedFoodSearch.searchingFoods', 'Searching foods...')}
               </div>
             )}
-            {!isFetchingRecent && (
+            {!isLoadingRecentFoods && !(showMeals && isLoadingRecentMeals) && (
               <>
-                {recentFoods.map((food: Food) => (
-                  <FoodResultCard
-                    key={food.id}
-                    item={food}
-                    nutrientConfig={nutrientConfig}
-                    onCardClick={() => onFoodSelect(food, 'food')}
-                  />
-                ))}
-                {topFoods.map((food: Food) => (
-                  <FoodResultCard
-                    key={food.id}
-                    item={food}
-                    nutrientConfig={nutrientConfig}
-                    onCardClick={() => onFoodSelect(food, 'food')}
-                  />
-                ))}
-                {recentFoods.length === 0 && topFoods.length === 0 && (
+                {/* Recent: one timeline of meals + foods by last-used date */}
+                {recentEntries.length > 0 && (
+                  <>
+                    <SectionHeader>
+                      {t('enhancedFoodSearch.recent', 'Recent')}
+                    </SectionHeader>
+                    {recentEntries.map(renderLandingEntry)}
+                  </>
+                )}
+                {/* Frequent: one list of most-used meals + foods (not in Recent) */}
+                {frequentEntries.length > 0 && (
+                  <>
+                    <SectionHeader>
+                      {t('enhancedFoodSearch.frequent', 'Frequent')}
+                    </SectionHeader>
+                    {frequentEntries.map(renderLandingEntry)}
+                  </>
+                )}
+                {recentEntries.length === 0 && frequentEntries.length === 0 && (
                   <div className="text-center py-8 text-gray-500">
-                    {t(
-                      'enhancedFoodSearch.noRecentOrTopFoods',
-                      'No recent or top foods found. Start logging foods to see them here.'
-                    )}
+                    {showMeals
+                      ? t(
+                          'enhancedFoodSearch.noRecentOrTopItems',
+                          'No recent or frequent foods or meals found. Start logging to see them here.'
+                        )
+                      : t(
+                          'enhancedFoodSearch.noRecentOrTopFoods',
+                          'No recent or top foods found. Start logging foods to see them here.'
+                        )}
                   </div>
                 )}
               </>

--- a/SparkyFitnessFrontend/src/hooks/Foods/useMeals.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useMeals.ts
@@ -5,6 +5,8 @@ import {
   getMealById,
   getMealDeletionImpact,
   getMeals,
+  getRecentMeals,
+  getTopMeals,
   updateMeal,
 } from '@/api/Foods/meals';
 import { MealFilter, MealPayload } from '@/types/meal';
@@ -26,6 +28,44 @@ export const mealSearchOptions = (filter: MealFilter, term?: string) => ({
 
 export const useMeals = (filter: MealFilter, term?: string) => {
   return useQuery(mealSearchOptions(filter, term));
+};
+
+// Recent + frequent meals for the food-search landing quick-pick list. Recent
+// and top come from separate endpoints, so this runs two queries and surfaces
+// their combined loading state alongside the parallel recent/top foods.
+export const useRecentAndTopMealsQuery = (limit: number, enabled = true) => {
+  const { t } = useTranslation();
+  const recent = useQuery({
+    queryKey: mealKeys.recent(limit),
+    queryFn: () => getRecentMeals(limit),
+    enabled,
+    meta: {
+      errorMessage: t(
+        'mealManagement.failedToLoadRecentMeals',
+        'Failed to load recent meals.'
+      ),
+    },
+  });
+  const top = useQuery({
+    queryKey: mealKeys.top(limit),
+    queryFn: () => getTopMeals(limit),
+    enabled,
+    meta: {
+      errorMessage: t(
+        'mealManagement.failedToLoadTopMeals',
+        'Failed to load top meals.'
+      ),
+    },
+  });
+  return {
+    recentMeals: recent.data ?? [],
+    topMeals: top.data ?? [],
+    // isLoading (initial fetch only), not isFetching, so background refetches
+    // do not flash the landing spinner / thrash the layout. Guard with enabled
+    // as a belt-and-suspenders: on v5 a disabled query already reports
+    // isLoading=false, but this stays correct if that ever changes.
+    isLoading: enabled && (recent.isLoading || top.isLoading),
+  };
 };
 
 export const mealDeletionImpactOptions = (mealId: string) => ({

--- a/SparkyFitnessFrontend/src/tests/utils/landingLists.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/landingLists.test.ts
@@ -1,0 +1,103 @@
+import { mergeRecent, mergeFrequent } from '@/utils/landingLists';
+import type { Meal } from '@/types/meal';
+import type { Food } from '@/types/food';
+
+const meal = (id: string, extra: Record<string, unknown> = {}) =>
+  ({ id, name: `meal-${id}`, ...extra }) as unknown as Meal;
+const food = (id: string, extra: Record<string, unknown> = {}) =>
+  ({ id, name: `food-${id}`, ...extra }) as unknown as Food;
+
+describe('mergeRecent', () => {
+  it('interleaves meals and foods by last_used_date, newest first', () => {
+    const meals = [meal('m1', { last_used_date: '2026-07-05' })];
+    const foods = [
+      food('f1', { last_used_date: '2026-07-09' }),
+      food('f2', { last_used_date: '2026-07-01' }),
+    ];
+    const out = mergeRecent(meals, foods, 10);
+    expect(out.map((e) => e.key)).toEqual(['food-f1', 'meal-m1', 'food-f2']);
+  });
+
+  it('keeps meals before foods on a same-day tie (stable)', () => {
+    const meals = [meal('m1', { last_used_date: '2026-07-09' })];
+    const foods = [food('f1', { last_used_date: '2026-07-09' })];
+    expect(mergeRecent(meals, foods, 10).map((e) => e.key)).toEqual([
+      'meal-m1',
+      'food-f1',
+    ]);
+  });
+
+  it('caps the merged timeline at limit', () => {
+    const foods = [
+      food('f1', { last_used_date: '2026-07-09' }),
+      food('f2', { last_used_date: '2026-07-08' }),
+      food('f3', { last_used_date: '2026-07-07' }),
+    ];
+    expect(mergeRecent([], foods, 2).map((e) => e.key)).toEqual([
+      'food-f1',
+      'food-f2',
+    ]);
+  });
+
+  it('tags entries with their kind for rendering', () => {
+    const out = mergeRecent(
+      [meal('m1', { last_used_date: '2026-07-09' })],
+      [food('f1', { last_used_date: '2026-07-08' })],
+      10
+    );
+    expect(out[0]).toMatchObject({ kind: 'meal', key: 'meal-m1' });
+    expect(out[1]).toMatchObject({ kind: 'food', key: 'food-f1' });
+  });
+});
+
+describe('mergeFrequent', () => {
+  it('orders by usage_count desc and coerces numeric-string counts', () => {
+    const meals = [meal('m1', { usage_count: '3' })];
+    const foods = [
+      food('f1', { usage_count: '10' }),
+      food('f2', { usage_count: '1' }),
+    ];
+    expect(
+      mergeFrequent(meals, foods, new Set(), 10).map((e) => e.key)
+    ).toEqual(['food-f1', 'meal-m1', 'food-f2']);
+  });
+
+  it('excludes items already shown in Recent', () => {
+    const meals = [meal('m1', { usage_count: 5 })];
+    const foods = [
+      food('f1', { usage_count: 9 }),
+      food('f2', { usage_count: 2 }),
+    ];
+    const exclude = new Set(['food-f1']);
+    expect(mergeFrequent(meals, foods, exclude, 10).map((e) => e.key)).toEqual([
+      'meal-m1',
+      'food-f2',
+    ]);
+  });
+
+  it('caps at limit after exclusion', () => {
+    const foods = [
+      food('f1', { usage_count: 9 }),
+      food('f2', { usage_count: 8 }),
+      food('f3', { usage_count: 7 }),
+    ];
+    expect(mergeFrequent([], foods, new Set(), 2).map((e) => e.key)).toEqual([
+      'food-f1',
+      'food-f2',
+    ]);
+  });
+
+  it('treats an unparseable usage_count as 0 (NaN-safe comparator)', () => {
+    const foods = [
+      food('f1', { usage_count: 'not-a-number' }),
+      food('f2', { usage_count: 4 }),
+      food('f3', { usage_count: undefined }),
+    ];
+    // f2 (4) ranks above the two that coerce to 0; order stays deterministic.
+    expect(mergeFrequent([], foods, new Set(), 10).map((e) => e.key)).toEqual([
+      'food-f2',
+      'food-f1',
+      'food-f3',
+    ]);
+  });
+});

--- a/SparkyFitnessFrontend/src/utils/landingLists.ts
+++ b/SparkyFitnessFrontend/src/utils/landingLists.ts
@@ -1,0 +1,73 @@
+import type { Meal } from '@/types/meal';
+import type { Food } from '@/types/food';
+
+// A single row in the food-search landing quick-pick lists, tagged so the
+// renderer can dispatch to a meal card or a food card. `key` is unique across
+// both types (id spaces are separate, but the prefix makes React keys safe
+// even if a meal and food ever shared an id).
+export type LandingEntry =
+  | { kind: 'meal'; key: string; meal: Meal }
+  | { kind: 'food'; key: string; food: Food };
+
+// The recent/top endpoints attach these extra columns to their rows. They
+// arrive over JSON as strings (Postgres serializes dates to ISO strings and
+// COUNT(*) to a numeric string), so callers should not assume native types.
+type RecentMeal = Meal & { last_used_date?: string | null };
+type RecentFood = Food & { last_used_date?: string | null };
+type FrequentMeal = Meal & { usage_count?: number | string | null };
+type FrequentFood = Food & { usage_count?: number | string | null };
+
+const mealKey = (m: { id?: string }) => `meal-${m.id ?? ''}`;
+const foodKey = (f: { id?: string }) => `food-${f.id ?? ''}`;
+
+// Recent: merge meals and foods into one timeline ordered by last-used date,
+// newest first. ISO date strings sort lexicographically, so string compare is
+// chronological. Same-day ties keep meals before foods (stable sort over a
+// meals-then-foods concat), matching the sort preference elsewhere.
+export function mergeRecent(
+  meals: RecentMeal[] = [],
+  foods: RecentFood[] = [],
+  limit: number
+): LandingEntry[] {
+  const tagged: { entry: LandingEntry; sort: string }[] = [
+    ...meals.map((m) => ({
+      entry: { kind: 'meal' as const, key: mealKey(m), meal: m },
+      sort: m.last_used_date ?? '',
+    })),
+    ...foods.map((f) => ({
+      entry: { kind: 'food' as const, key: foodKey(f), food: f },
+      sort: f.last_used_date ?? '',
+    })),
+  ];
+  tagged.sort((a, b) => (a.sort < b.sort ? 1 : a.sort > b.sort ? -1 : 0));
+  return tagged.slice(0, Math.max(0, limit)).map((t) => t.entry);
+}
+
+// Frequent: merge meals and foods ordered by usage count, most-used first,
+// dropping anything already shown in Recent (excludeKeys) so the two sections
+// do not repeat cards. usage_count can arrive as a numeric string, so coerce.
+export function mergeFrequent(
+  meals: FrequentMeal[] = [],
+  foods: FrequentFood[] = [],
+  excludeKeys: Set<string> = new Set(),
+  limit: number
+): LandingEntry[] {
+  // Coerce, and never let a bad value become NaN: NaN in a subtraction
+  // comparator breaks sort transitivity and scrambles order.
+  const count = (v: number | string | null | undefined) => {
+    const parsed = Number(v ?? 0);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+  const tagged: { entry: LandingEntry; sort: number }[] = [
+    ...meals.map((m) => ({
+      entry: { kind: 'meal' as const, key: mealKey(m), meal: m },
+      sort: count(m.usage_count),
+    })),
+    ...foods.map((f) => ({
+      entry: { kind: 'food' as const, key: foodKey(f), food: f },
+      sort: count(f.usage_count),
+    })),
+  ].filter((t) => !excludeKeys.has(t.entry.key));
+  tagged.sort((a, b) => b.sort - a.sort);
+  return tagged.slice(0, Math.max(0, limit)).map((t) => t.entry);
+}

--- a/SparkyFitnessServer/models/foodMisc.ts
+++ b/SparkyFitnessServer/models/foodMisc.ts
@@ -89,6 +89,7 @@ async function getRecentFoods(userId: any, limit: any, mealType: any) {
         f.shared_with_public,
         f.provider_external_id,
         f.provider_type,
+        rfe.last_used_date,
         ${DEFAULT_VARIANT_JSON_SQL}
       FROM foods f
       JOIN RecentFoodEntries rfe ON f.id = rfe.food_id

--- a/SparkyFitnessServer/models/mealRepository.ts
+++ b/SparkyFitnessServer/models/mealRepository.ts
@@ -572,39 +572,71 @@ async function getRecentMeals(userId: any, limit = 3) {
         m.serving_unit,
         m.total_servings,
         m.created_at,
-        m.updated_at
+        m.updated_at,
+        lu.last_used_date
       FROM latest_usage lu
       JOIN meals m ON m.id = lu.meal_id
       ORDER BY lu.last_used_date DESC, lu.last_used_at DESC, m.name ASC
       LIMIT $2`,
       [userId, limit]
     );
-    return attachFoodsToMeals(client, result.rows);
+    // await before returning: attachFoodsToMeals runs more queries on `client`,
+    // and the finally below releases it. Returning the un-awaited promise would
+    // release the client back to the pool before those queries finish.
+    return await attachFoodsToMeals(client, result.rows);
   } finally {
     client.release();
   }
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getTopMeals(userId: any, limit = null) {
+async function getTopMeals(userId: any, limit = 3) {
   const client = await getClient(userId); // User-specific operation
   try {
-    // For "top meals", we'll use a simple heuristic: meals with more foods,
-    // or more recently created public meals. This can be refined later.
-    let query = `
-      SELECT m.id, m.user_id, m.name, m.description, m.is_public, m.serving_size, m.serving_unit, m.total_servings, m.created_at, m.updated_at,
-             COUNT(mf.id) AS food_count
-      FROM meals m
-      LEFT JOIN meal_foods mf ON m.id = mf.meal_id
+    // "Top meals" = the meals this user logs most often, ranked by how many
+    // times they have been logged. Usage is counted over the same two sources
+    // as getRecentMeals: meals logged directly (food_entries.meal_id) and meals
+    // logged as a template (food_entry_meals.meal_template_id).
+    //
+    // Join meals first, then GROUP/LIMIT, so the LIMIT is applied to *active*
+    // meals only. A frequently logged meal that was later deleted still leaves
+    // its id in the usage history; limiting before the join would let those
+    // dead ids take top slots and then get dropped by the inner join, returning
+    // fewer than `limit` (or zero) results. (Matches getRecentMeals' ordering.)
+    const result = await client.query(
+      `WITH meal_usage AS (
+        SELECT fe.meal_id AS meal_id
+        FROM food_entries fe
+        WHERE fe.user_id = $1
+          AND fe.meal_id IS NOT NULL
+        UNION ALL
+        SELECT fem.meal_template_id AS meal_id
+        FROM food_entry_meals fem
+        WHERE fem.user_id = $1
+          AND fem.meal_template_id IS NOT NULL
+      )
+      SELECT
+        m.id,
+        m.user_id,
+        m.name,
+        m.description,
+        m.is_public,
+        m.serving_size,
+        m.serving_unit,
+        m.total_servings,
+        m.created_at,
+        m.updated_at,
+        COUNT(*) AS usage_count
+      FROM meal_usage mu
+      JOIN meals m ON m.id = mu.meal_id
       GROUP BY m.id
-      ORDER BY food_count DESC, m.created_at DESC`;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const queryParams: any = [];
-    if (limit !== null) {
-      query += ' LIMIT $2';
-      queryParams.push(limit);
-    }
-    const result = await client.query(query, queryParams);
-    return attachFoodsToMeals(client, result.rows);
+      ORDER BY usage_count DESC, m.name ASC
+      LIMIT $2`,
+      [userId, limit]
+    );
+    // await before the finally releases the client: attachFoodsToMeals runs
+    // more queries on this same client, so returning the promise unawaited would
+    // release the client back to the pool before those queries finish.
+    return await attachFoodsToMeals(client, result.rows);
   } finally {
     client.release();
   }

--- a/SparkyFitnessServer/routes/mealRoutes.ts
+++ b/SparkyFitnessServer/routes/mealRoutes.ts
@@ -391,6 +391,38 @@ router.get('/recent', authenticate, async (req, res, next) => {
 });
 /**
  * @swagger
+ * /meals/top:
+ *   get:
+ *     summary: Get most frequently logged meal templates
+ *     tags: [Nutrition & Meals]
+ *     description: Retrieves the meal templates the authenticated user logs most often, ranked by usage count.
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 3
+ *           minimum: 1
+ *           maximum: 20
+ *         description: The maximum number of top meals to return.
+ *     responses:
+ *       200:
+ *         description: A list of the most frequently logged meal templates.
+ *       403:
+ *         description: User does not have permission to access this resource.
+ */
+router.get('/top', authenticate, async (req, res, next) => {
+  try {
+    const limit = parseRecentMealsLimit(req.query.limit);
+    const meals = await mealService.getTopMeals(req.userId, limit);
+    res.status(200).json(meals);
+  } catch (error) {
+    log('error', 'Error getting top meals:', error);
+    next(error);
+  }
+});
+/**
+ * @swagger
  * /meals/search:
  *   get:
  *     summary: Search for meal templates

--- a/SparkyFitnessServer/services/mealService.ts
+++ b/SparkyFitnessServer/services/mealService.ts
@@ -476,6 +476,16 @@ async function getRecentMeals(userId: string, limit = 3) {
     throw error;
   }
 }
+async function getTopMeals(userId: string, limit = 3) {
+  try {
+    const meals = await mealRepository.getTopMeals(userId, limit);
+    await attachResolvedMealNutrition(userId, meals);
+    return meals;
+  } catch (error) {
+    log('error', `Error in mealService.getTopMeals for user ${userId}:`, error);
+    throw error;
+  }
+}
 async function getMealById(userId: string, mealId: string) {
   try {
     log(
@@ -1041,6 +1051,7 @@ async function createMealFromDiaryEntries(
 export { createMeal };
 export { getMeals };
 export { getRecentMeals };
+export { getTopMeals };
 export { getMealById };
 export { updateMeal };
 export { deleteMeal };
@@ -1059,6 +1070,7 @@ export default {
   createMeal,
   getMeals,
   getRecentMeals,
+  getTopMeals,
   getMealById,
   updateMeal,
   deleteMeal,

--- a/SparkyFitnessServer/tests/mealRoutes.test.ts
+++ b/SparkyFitnessServer/tests/mealRoutes.test.ts
@@ -112,6 +112,29 @@ describe('Meal Routes', () => {
       );
     });
   });
+  describe('GET /meals/top', () => {
+    it('should return the most frequently logged meals for the user', async () => {
+      const meals = [{ id: uuidv4(), name: 'Top Meal' }];
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      mealService.getTopMeals.mockResolvedValue(meals);
+      const res = await request(app).get('/meals/top?limit=5');
+      expect(res.statusCode).toEqual(200);
+      expect(res.body).toEqual(meals);
+      expect(mealService.getTopMeals).toHaveBeenCalledWith('testUserId', 5);
+      expect(mealService.getMealById).not.toHaveBeenCalled();
+    });
+    it('should clamp and default the top meals limit', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      mealService.getTopMeals.mockResolvedValue([]);
+      await request(app).get('/meals/top?limit=200');
+      expect(mealService.getTopMeals).toHaveBeenLastCalledWith(
+        'testUserId',
+        20
+      );
+      await request(app).get('/meals/top?limit=bad');
+      expect(mealService.getTopMeals).toHaveBeenLastCalledWith('testUserId', 3);
+    });
+  });
   describe('GET /meals/:id', () => {
     it('should return a specific meal by ID', async () => {
       const mealId = uuidv4();


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The food-search landing (empty query) showed only recent and frequent foods; meals never appeared for quick re-logging, even though a typed search already returns both foods and meals.

**How did you implement the solution?**
Both recent and frequent meals are derived on-read from the user's existing meal-logging history (`food_entries.meal_id` and `food_entry_meals.meal_template_id`), the same way recent/top foods are derived from food entries. No new tables or tracking. The existing `getRecentMeals` already ranks meals by last-logged date; this rewrites `getTopMeals`, which was an unused stub (it ranked by component-food count, was not user-scoped so it could return other users' meals, and had a bind-parameter mismatch) into a frequency ranking (usage count over the same two sources), scoped to the user, exposed through a new `GET /meals/top` route (mirroring `GET /meals/recent`) with a matching limit parser and route tests. To let the landing merge the two types into one ordered list, the recent endpoints now additionally return the sort key they already compute internally: `last_used_date` is added to the output of `getRecentFoods` and `getRecentMeals` (additive, non-breaking; `usage_count` was already returned by both frequent endpoints). On the web, the landing shows two merged sections built by a small pure helper (`utils/landingLists.ts`, unit-tested): Recent is one timeline of meals and foods ordered by `last_used_date` (newest first; same-day ties keep meals ahead of foods), and Frequent is one list ordered by `usage_count` with anything already shown in Recent removed, so the two sections never repeat a card. Each section is capped at `item_display_limit` (default 10). Entirely aggregation of existing data; no schema changes.

Linked Issue: Closes #1777 

## How to Test

1. Use an account that has logged at least one or two meals (the lists are driven by logging history).
2. Open the food search and leave the query empty.
3. Confirm the landing shows a Recent section and a Frequent section, each mixing meal cards (badged) and food cards.
4. Confirm Recent is a real timeline: a food logged more recently than a meal appears above it, regardless of type.
5. Confirm Frequent does not repeat any card already shown in Recent.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="814" height="562" alt="2026-07-11 13_02_53-Greenshot" src="https://github.com/user-attachments/assets/7c94acb6-026c-4acf-86df-b4e059f226bb" />

### After

<img width="816" height="553" alt="2026-07-11 13_03_48-Greenshot" src="https://github.com/user-attachments/assets/26f08ed1-f63a-482d-9e58-1c6a038326f3" />

</details>

## Notes for Reviewers

No new tables or tracking: recency and frequency are aggregated from existing meal-logging data at query time, mirroring how recent/top foods already work. Web only for now. Extending the same recent/frequent behavior to the mobile app is a planned follow-up: the mobile Library screen already lists recent meals and foods, so the remaining work is the Frequent section plus the merged last-used ordering, and the backend this PR adds (GET /meals/top and the last_used_date fields) is already reusable for it.

Landing layout decisions (all easy to change):
- Section headers use recency labels (Recent / Frequent) rather than type labels (Meals / Foods). The card badge already shows meal vs food, so a Meals/Foods header mostly repeats it, whereas Recent/Frequent surfaces the one thing the card can't otherwise convey. Headers render only when their section is non-empty.
- Each section is one merged list, not grouped by type. Recent is ordered by last-used time (a true timeline); Frequent by usage count. On a same-day recency tie, meals sort just ahead of foods (the only place a type preference applies).
- Frequent excludes anything already shown in Recent, so the two sections never repeat a card (Frequent reads as "your staples you have not logged recently").
- Density: each section is capped at `item_display_limit` (default 10). The preference drives the landing size directly, so it stays a glance while a user who sets a larger value opts into more. Fuller/specific access is covered by search and by pinned favorites (in progress separately).

Backend: `last_used_date` is added to the `getRecentFoods` and `getRecentMeals` outputs so the client can merge the two types by a common key; this is additive (`getRecentFoods` is a pre-existing shared endpoint, so flagging the touch). The new `GET /meals/top` mirrors the existing `GET /meals/recent`: its `limit` query param is parsed and clamped (1–20, default 3) rather than validated by a Zod schema, matching that sibling route; it has route tests. The merge logic lives in a pure, unit-tested helper (`utils/landingLists.ts`). Happy to add a Zod query schema on the new route if you would like it on both.

Backend and Database-Security checklist: this adds a read-only GET endpoint (no Zod body schema, matching its sibling) plus an additive read-only column on two existing recent endpoints, and no new tables/RLS. Typecheck, lint, and tests were run and pass.