### PR TITLE
feat(ai): add Meta as an AI provider

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1039,6 +1039,7 @@
         "ollama": "Ollama",
         "openrouter": "OpenRouter",
         "xai": "xAI (Grok)",
+        "meta": "Meta",
         "custom": "Custom"
       }
     },

--- a/SparkyFitnessFrontend/src/tests/utils/aiServiceUtils.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/aiServiceUtils.test.ts
@@ -26,6 +26,10 @@ describe('getModelOptions', () => {
   it('returns an empty list for an unknown service type', () => {
     expect(getModelOptions('totally-unknown')).toEqual([]);
   });
+
+  it('returns the Muse Spark preset for meta', () => {
+    expect(getModelOptions('meta')).toEqual(['muse-spark-1.1']);
+  });
 });
 
 describe('requiresApiKey', () => {
@@ -48,6 +52,7 @@ describe('requiresApiKey', () => {
     'groq',
     'openrouter',
     'xai',
+    'meta',
   ])('requires a key for cloud provider %s', (serviceType) => {
     expect(requiresApiKey(serviceType)).toBe(true);
   });

--- a/SparkyFitnessFrontend/src/utils/aiServiceUtils.ts
+++ b/SparkyFitnessFrontend/src/utils/aiServiceUtils.ts
@@ -22,6 +22,7 @@ export const getServiceTypes = (t: (key: string) => string): ServiceType[] => [
     label: t('settings.aiService.serviceTypes.openrouter'),
   },
   { value: 'xai', label: t('settings.aiService.serviceTypes.xai') },
+  { value: 'meta', label: t('settings.aiService.serviceTypes.meta') },
   { value: 'custom', label: t('settings.aiService.serviceTypes.custom') },
 ];
 
@@ -92,6 +93,10 @@ export const getModelOptions = (serviceType: string): string[] => {
         'grok-4.20-0309-reasoning',
         'grok-build-0.1',
       ];
+    case 'meta':
+      // Meta Superintelligence Labs' Muse Spark, served over an
+      // OpenAI-compatible Chat Completions API. One published model for now.
+      return ['muse-spark-1.1'];
     // 'openai_compatible' and 'custom' point at arbitrary user-hosted servers,
     // so there is no model name we can suggest — OpenAI's names won't exist on
     // most of them. Returning [] makes the form fall back to the custom-model

--- a/SparkyFitnessServer/ai/config.ts
+++ b/SparkyFitnessServer/ai/config.ts
@@ -50,9 +50,40 @@ function getDefaultVisionModel(serviceType: any) {
       return 'gpt-4o-mini';
   }
 }
+// Resolves the base URL for OpenAI-compatible providers. The AI SDK (chat
+// service) appends `/chat/completions` itself; the raw-request dispatcher
+// appends it explicitly. Providers that expect a user-supplied endpoint
+// ('openai_compatible', 'custom') fall through to `customUrl` unchanged.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getOpenAiCompatibleBaseUrl(
+  serviceType: any,
+  customUrl?: string
+): string | undefined {
+  switch (serviceType) {
+    case 'openai':
+      return 'https://api.openai.com/v1';
+    case 'ollama':
+      return `${customUrl}/v1`;
+    case 'mistral':
+      return 'https://api.mistral.ai/v1';
+    case 'groq':
+      return 'https://api.groq.com/openai/v1';
+    case 'openrouter':
+      return 'https://openrouter.ai/api/v1';
+    case 'xai':
+      return 'https://api.x.ai/v1';
+    case 'meta':
+      // Muse Spark's OpenAI-compatible endpoint (auth is Bearer api_key).
+      return 'https://api.meta.ai/v1';
+    default:
+      return customUrl;
+  }
+}
 export { getDefaultModel };
 export { getDefaultVisionModel };
+export { getOpenAiCompatibleBaseUrl };
 export default {
   getDefaultModel,
   getDefaultVisionModel,
+  getOpenAiCompatibleBaseUrl,
 };

--- a/SparkyFitnessServer/ai/config.ts
+++ b/SparkyFitnessServer/ai/config.ts
@@ -54,16 +54,17 @@ function getDefaultVisionModel(serviceType: any) {
 // service) appends `/chat/completions` itself; the raw-request dispatcher
 // appends it explicitly. Providers that expect a user-supplied endpoint
 // ('openai_compatible', 'custom') fall through to `customUrl` unchanged.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getOpenAiCompatibleBaseUrl(
-  serviceType: any,
+  serviceType: string,
   customUrl?: string
 ): string | undefined {
   switch (serviceType) {
     case 'openai':
       return 'https://api.openai.com/v1';
     case 'ollama':
-      return `${customUrl}/v1`;
+      // Ollama is the one family member whose base is derived from customUrl;
+      // guard so a missing URL yields undefined rather than "undefined/v1".
+      return customUrl ? `${customUrl}/v1` : undefined;
     case 'mistral':
       return 'https://api.mistral.ai/v1';
     case 'groq':

--- a/SparkyFitnessServer/ai/config.ts
+++ b/SparkyFitnessServer/ai/config.ts
@@ -56,7 +56,7 @@ function getDefaultVisionModel(serviceType: any) {
 // ('openai_compatible', 'custom') fall through to `customUrl` unchanged.
 function getOpenAiCompatibleBaseUrl(
   serviceType: string,
-  customUrl?: string
+  customUrl?: string | null
 ): string | undefined {
   switch (serviceType) {
     case 'openai':
@@ -77,7 +77,7 @@ function getOpenAiCompatibleBaseUrl(
       // Muse Spark's OpenAI-compatible endpoint (auth is Bearer api_key).
       return 'https://api.meta.ai/v1';
     default:
-      return customUrl;
+      return customUrl ?? undefined;
   }
 }
 export { getDefaultModel };

--- a/SparkyFitnessServer/ai/config.ts
+++ b/SparkyFitnessServer/ai/config.ts
@@ -16,6 +16,8 @@ function getDefaultModel(serviceType: any) {
       return 'google/gemini-2.5-flash';
     case 'xai':
       return 'grok-4.3';
+    case 'meta':
+      return 'muse-spark-1.1';
     case 'ollama':
       return 'llama3.2';
     default:
@@ -40,6 +42,8 @@ function getDefaultVisionModel(serviceType: any) {
       return 'google/gemini-2.5-flash';
     case 'xai':
       return 'grok-4.3';
+    case 'meta':
+      return 'muse-spark-1.1';
     case 'ollama':
       return 'llava';
     default:

--- a/SparkyFitnessServer/ai/providerDispatch.ts
+++ b/SparkyFitnessServer/ai/providerDispatch.ts
@@ -418,7 +418,11 @@ function openAiFamilyUrl(provider: ProviderConfig): string {
   if (provider.service_type === 'custom') {
     return provider.custom_url as string;
   }
-  return `${getOpenAiCompatibleBaseUrl(provider.service_type, provider.custom_url)}/chat/completions`;
+  const baseUrl = getOpenAiCompatibleBaseUrl(
+    provider.service_type,
+    provider.custom_url
+  );
+  return baseUrl ? `${baseUrl}/chat/completions` : '';
 }
 
 function buildGoogleRequest(

--- a/SparkyFitnessServer/ai/providerDispatch.ts
+++ b/SparkyFitnessServer/ai/providerDispatch.ts
@@ -145,6 +145,7 @@ function providerFamily(serviceType: string): ProviderFamily | null {
     case 'groq':
     case 'openrouter':
     case 'xai':
+    case 'meta': // Muse Spark's OpenAI-compatible endpoint; see openAiFamilyUrl.
     case 'custom':
       return 'openai';
     case 'anthropic':
@@ -421,6 +422,8 @@ function openAiFamilyUrl(provider: ProviderConfig): string {
       return 'https://openrouter.ai/api/v1/chat/completions';
     case 'xai':
       return 'https://api.x.ai/v1/chat/completions';
+    case 'meta':
+      return 'https://api.meta.ai/v1/chat/completions';
     default:
       // 'custom' uses the user-supplied URL as-is.
       return provider.custom_url as string;

--- a/SparkyFitnessServer/ai/providerDispatch.ts
+++ b/SparkyFitnessServer/ai/providerDispatch.ts
@@ -1,7 +1,11 @@
 import undici from 'undici';
 import convert from 'heic-convert';
 import { log } from '../config/logging.js';
-import { getDefaultModel, getDefaultVisionModel } from './config.js';
+import {
+  getDefaultModel,
+  getDefaultVisionModel,
+  getOpenAiCompatibleBaseUrl,
+} from './config.js';
 import {
   createGuardedDispatcher,
   createGuardedFetch,
@@ -409,25 +413,12 @@ interface BuiltRequest {
 }
 
 function openAiFamilyUrl(provider: ProviderConfig): string {
-  switch (provider.service_type) {
-    case 'openai':
-      return 'https://api.openai.com/v1/chat/completions';
-    case 'openai_compatible':
-      return `${provider.custom_url}/chat/completions`;
-    case 'mistral':
-      return 'https://api.mistral.ai/v1/chat/completions';
-    case 'groq':
-      return 'https://api.groq.com/openai/v1/chat/completions';
-    case 'openrouter':
-      return 'https://openrouter.ai/api/v1/chat/completions';
-    case 'xai':
-      return 'https://api.x.ai/v1/chat/completions';
-    case 'meta':
-      return 'https://api.meta.ai/v1/chat/completions';
-    default:
-      // 'custom' uses the user-supplied URL as-is.
-      return provider.custom_url as string;
+  // 'custom' uses the user-supplied URL as-is; every other OpenAI-compatible
+  // provider shares the base-URL map and has `/chat/completions` appended.
+  if (provider.service_type === 'custom') {
+    return provider.custom_url as string;
   }
+  return `${getOpenAiCompatibleBaseUrl(provider.service_type, provider.custom_url)}/chat/completions`;
 }
 
 function buildGoogleRequest(

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -635,7 +635,8 @@ async function processChatMessage(
       aiService.service_type === 'mistral' ||
       aiService.service_type === 'groq' ||
       aiService.service_type === 'openrouter' ||
-      aiService.service_type === 'xai'
+      aiService.service_type === 'xai' ||
+      aiService.service_type === 'meta'
     ) {
       // Connect as OpenAI-compatible
       let baseURL = aiService.custom_url;
@@ -649,6 +650,9 @@ async function processChatMessage(
         baseURL = 'https://api.mistral.ai/v1';
       } else if (aiService.service_type === 'xai') {
         baseURL = 'https://api.x.ai/v1';
+      } else if (aiService.service_type === 'meta') {
+        // Muse Spark's OpenAI-compatible endpoint (auth is Bearer api_key).
+        baseURL = 'https://api.meta.ai/v1';
       }
       const providerOptions: Parameters<typeof createOpenAI>[0] = {
         baseURL,
@@ -1253,7 +1257,8 @@ async function processChatMessageStream(
       aiService.service_type === 'mistral' ||
       aiService.service_type === 'groq' ||
       aiService.service_type === 'openrouter' ||
-      aiService.service_type === 'xai'
+      aiService.service_type === 'xai' ||
+      aiService.service_type === 'meta'
     ) {
       let baseURL = aiService.custom_url;
       if (aiService.service_type === 'ollama') {
@@ -1266,6 +1271,9 @@ async function processChatMessageStream(
         baseURL = 'https://api.mistral.ai/v1';
       } else if (aiService.service_type === 'xai') {
         baseURL = 'https://api.x.ai/v1';
+      } else if (aiService.service_type === 'meta') {
+        // Muse Spark's OpenAI-compatible endpoint (auth is Bearer api_key).
+        baseURL = 'https://api.meta.ai/v1';
       }
       const providerOptions: Parameters<typeof createOpenAI>[0] = {
         baseURL,

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -643,6 +643,16 @@ async function processChatMessage(
         aiService.service_type,
         aiService.custom_url
       );
+      // Providers that need a user-supplied endpoint must have one: an empty
+      // baseURL makes the AI SDK silently fall back to OpenAI's default host.
+      if (
+        requiresUserSuppliedAiUrl(aiService.service_type) &&
+        !baseURL?.trim()
+      ) {
+        throw new Error(
+          `Custom URL is required for service type: ${aiService.service_type}`
+        );
+      }
       const providerOptions: Parameters<typeof createOpenAI>[0] = {
         baseURL,
         apiKey: apiKey || 'no-key',
@@ -1253,6 +1263,16 @@ async function processChatMessageStream(
         aiService.service_type,
         aiService.custom_url
       );
+      // Providers that need a user-supplied endpoint must have one: an empty
+      // baseURL makes the AI SDK silently fall back to OpenAI's default host.
+      if (
+        requiresUserSuppliedAiUrl(aiService.service_type) &&
+        !baseURL?.trim()
+      ) {
+        throw new Error(
+          `Custom URL is required for service type: ${aiService.service_type}`
+        );
+      }
       const providerOptions: Parameters<typeof createOpenAI>[0] = {
         baseURL,
         apiKey: apiKey || 'no-key',

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -2,7 +2,7 @@ import chatRepository from '../models/chatRepository.js';
 import measurementRepository from '../models/measurementRepository.js';
 import preferenceRepository from '../models/preferenceRepository.js';
 import { log } from '../config/logging.js';
-import { getDefaultModel } from '../ai/config.js';
+import { getDefaultModel, getOpenAiCompatibleBaseUrl } from '../ai/config.js';
 import {
   dispatchAiRequest,
   requiresApiKey,
@@ -639,21 +639,10 @@ async function processChatMessage(
       aiService.service_type === 'meta'
     ) {
       // Connect as OpenAI-compatible
-      let baseURL = aiService.custom_url;
-      if (aiService.service_type === 'ollama') {
-        baseURL = `${aiService.custom_url}/v1`;
-      } else if (aiService.service_type === 'groq') {
-        baseURL = 'https://api.groq.com/openai/v1';
-      } else if (aiService.service_type === 'openrouter') {
-        baseURL = 'https://openrouter.ai/api/v1';
-      } else if (aiService.service_type === 'mistral') {
-        baseURL = 'https://api.mistral.ai/v1';
-      } else if (aiService.service_type === 'xai') {
-        baseURL = 'https://api.x.ai/v1';
-      } else if (aiService.service_type === 'meta') {
-        // Muse Spark's OpenAI-compatible endpoint (auth is Bearer api_key).
-        baseURL = 'https://api.meta.ai/v1';
-      }
+      const baseURL = getOpenAiCompatibleBaseUrl(
+        aiService.service_type,
+        aiService.custom_url
+      );
       const providerOptions: Parameters<typeof createOpenAI>[0] = {
         baseURL,
         apiKey: apiKey || 'no-key',
@@ -1260,21 +1249,10 @@ async function processChatMessageStream(
       aiService.service_type === 'xai' ||
       aiService.service_type === 'meta'
     ) {
-      let baseURL = aiService.custom_url;
-      if (aiService.service_type === 'ollama') {
-        baseURL = `${aiService.custom_url}/v1`;
-      } else if (aiService.service_type === 'groq') {
-        baseURL = 'https://api.groq.com/openai/v1';
-      } else if (aiService.service_type === 'openrouter') {
-        baseURL = 'https://openrouter.ai/api/v1';
-      } else if (aiService.service_type === 'mistral') {
-        baseURL = 'https://api.mistral.ai/v1';
-      } else if (aiService.service_type === 'xai') {
-        baseURL = 'https://api.x.ai/v1';
-      } else if (aiService.service_type === 'meta') {
-        // Muse Spark's OpenAI-compatible endpoint (auth is Bearer api_key).
-        baseURL = 'https://api.meta.ai/v1';
-      }
+      const baseURL = getOpenAiCompatibleBaseUrl(
+        aiService.service_type,
+        aiService.custom_url
+      );
       const providerOptions: Parameters<typeof createOpenAI>[0] = {
         baseURL,
         apiKey: apiKey || 'no-key',

--- a/SparkyFitnessServer/tests/chatService.test.ts
+++ b/SparkyFitnessServer/tests/chatService.test.ts
@@ -533,6 +533,7 @@ describe('chatService', () => {
         {
           ...aiServiceSetting,
           service_type: 'ollama',
+          custom_url: 'http://localhost:11434',
           chat_tool_profile: 'core',
         }
       );
@@ -556,6 +557,7 @@ describe('chatService', () => {
         {
           ...aiServiceSetting,
           service_type: 'ollama',
+          custom_url: 'http://localhost:11434',
           chat_tool_profile: 'full',
         }
       );
@@ -579,6 +581,7 @@ describe('chatService', () => {
         {
           ...aiServiceSetting,
           service_type: 'ollama',
+          custom_url: 'http://localhost:11434',
         }
       );
       scriptModel([textStep('Hi there!')]);
@@ -650,6 +653,33 @@ describe('chatService', () => {
         expect(result.content).toBe('Hello from a local server!');
         expect(createOpenAI).toHaveBeenCalledWith(
           expect.objectContaining({ fetch: expect.any(Function) })
+        );
+      }
+    );
+
+    // Guard: a URL-requiring service (ollama/openai_compatible/custom) with no
+    // custom_url resolves to an undefined baseURL, which would make the AI SDK
+    // silently fall back to OpenAI's default host. Reject it instead.
+    it.each(['ollama', 'openai_compatible', 'custom'])(
+      'rejects a %s service that is missing its custom_url',
+      async (serviceType) => {
+        vi.mocked(
+          chatRepository.getAiServiceSettingForBackend
+        ).mockResolvedValue({
+          ...aiServiceSetting,
+          service_type: serviceType,
+          custom_url: null,
+        });
+
+        await expect(
+          chatService.processChatMessage(
+            [{ role: 'user', content: 'hi' }],
+            'svc-1',
+            activeUserId,
+            actorUserId
+          )
+        ).rejects.toThrow(
+          `Custom URL is required for service type: ${serviceType}`
         );
       }
     );

--- a/SparkyFitnessServer/tests/providerDispatch.test.ts
+++ b/SparkyFitnessServer/tests/providerDispatch.test.ts
@@ -565,6 +565,29 @@ describe('dispatchAiRequest — text-only structured request shapes', () => {
     expect(body.provider).toBeUndefined();
   });
 
+  it('meta routes to api.meta.ai and uses json_object fallback (not strict schema)', async () => {
+    const m = mockFetch(openAiBody(JSON.stringify(SAMPLE)));
+    await dispatchAiRequest(
+      baseRequest({
+        provider: makeProvider({
+          service_type: 'meta',
+          api_key: 'meta-key',
+          model_name: 'muse-spark-1.1',
+        }),
+      })
+    );
+    const { url, headers, body } = captured(m);
+    expect(url).toBe('https://api.meta.ai/v1/chat/completions');
+    expect(headers['Authorization']).toBe('Bearer meta-key');
+    expect(body.model).toBe('muse-spark-1.1');
+    // Muse Spark mandates extended thinking, which Anthropic-style forced
+    // tool_choice forbids; kept OUT of STRICT_SCHEMA_PROVIDERS so it uses the
+    // json_object fallback with the schema embedded in the prompt instead.
+    expect((body.response_format as { type: string }).type).toBe('json_object');
+    const messages = body.messages as Array<{ content: string }>;
+    expect(messages[0].content).toContain('JSON Schema');
+  });
+
   it('openrouter sends strict json_schema, provider.require_parameters, and attribution headers', async () => {
     const m = mockFetch(openAiBody(JSON.stringify(SAMPLE)));
     await dispatchAiRequest(


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
SparkyAI had no built-in option for Meta's models, so using Muse Spark meant hand-configuring the generic OpenAI-compatible option. This adds `meta` as a first-class provider.

**How did you implement the solution?**
Registered `meta` through the existing OpenAI-compatible path: a provider entry and `muse-spark-1.1` model preset in the frontend, default model and vision model in `ai/config.ts`, and routing to `https://api.meta.ai/v1/chat/completions` (Bearer api_key) in `ai/providerDispatch.ts` and both chat-service code paths. Meta is intentionally left out of the strict-schema providers because Muse Spark mandates extended thinking, which conflicts with forced tool_choice, so it uses the existing `json_object` structured-output fallback.

Linked Issue: Closes #1789

## How to Test

1. Check out this branch and start the server and frontend as usual.
2. Go to Settings > AI Service and add a new service. "Meta" now appears in the provider dropdown, with `muse-spark-1.1` offered as the model.
3. Enter a Meta API key, save, and set the service active.
4. Send a SparkyAI chat message and confirm you get a normal (non-streamed and streamed) response.
5. Run a food-photo or nutrition-label estimation to confirm the vision default resolves and structured output returns valid JSON.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="1215" height="524" alt="2026-07-11 11_19_18-Greenshot" src="https://github.com/user-attachments/assets/d87e81f7-86a2-4360-8d5f-c30aa44939bc" />

</details>

## Notes for Reviewers

Meta is routed through the same OpenAI-compatible transport as xAI/Groq/OpenRouter, so there is no new dependency and the diff is a set of per-provider `case` additions. The one non-obvious choice: `meta` is kept out of the strict-schema provider set on purpose. Muse Spark requires extended thinking, which is incompatible with Anthropic-style forced tool_choice, so structured output uses the existing `json_object` fallback with the schema in the prompt. The provider-dispatch test documents and locks this behavior. No database or migration changes; no new user-specific tables, so `rls_policies.sql` is untouched.