### PR TITLE
fix(meals): await attachFoodsToMeals in remaining read paths

### DIFF
--- a/SparkyFitnessServer/models/mealRepository.ts
+++ b/SparkyFitnessServer/models/mealRepository.ts
@@ -170,7 +170,8 @@ async function getMeals(userId: any, filter = 'all') {
     // For 'family' and 'public' filters, separate functions will be called in mealService
     query += ' ORDER BY name ASC';
     const result = await client.query(query, queryParams);
-    return attachFoodsToMeals(client, result.rows);
+    // Await so attachFoodsToMeals' queries finish before finally releases the client.
+    return await attachFoodsToMeals(client, result.rows);
   } finally {
     client.release();
   }
@@ -194,7 +195,8 @@ async function searchMeals(
       queryParams.push(limit);
     }
     const result = await client.query(query, queryParams);
-    return attachFoodsToMeals(client, result.rows);
+    // Await so attachFoodsToMeals' queries finish before finally releases the client.
+    return await attachFoodsToMeals(client, result.rows);
   } finally {
     client.release();
   }
@@ -855,7 +857,8 @@ async function getPublicMeals(userId: any) {
        FROM meals
        WHERE is_public = TRUE
        ORDER BY name ASC`);
-    return attachFoodsToMeals(client, result.rows);
+    // Await so attachFoodsToMeals' queries finish before finally releases the client.
+    return await attachFoodsToMeals(client, result.rows);
   } finally {
     client.release();
   }
@@ -876,7 +879,8 @@ async function getFamilyMeals(userId: any) {
        ORDER BY m.name ASC`,
       [userId]
     );
-    return attachFoodsToMeals(client, result.rows);
+    // Await so attachFoodsToMeals' queries finish before finally releases the client.
+    return await attachFoodsToMeals(client, result.rows);
   } finally {
     client.release();
   }


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Four meal read paths released their pooled database client before an in-flight query finished. `getMeals`, `searchMeals`, `getPublicMeals`, and `getFamilyMeals` each ended with `return attachFoodsToMeals(client, result.rows)` without `await`, inside a `try { ... } finally { client.release() }`. Because the call was not awaited, the `finally` released the client back to the pool while `attachFoodsToMeals`' own queries were still running on it, a use-after-release: those queries can land on a connection that has already been handed to another borrower.

**How did you implement the solution?**
Added `await` to the four calls so the client is held until `attachFoodsToMeals` resolves, then released. This matches `getMealById`, which already awaited it, and the same fix applied to `getTopMeals` and `getRecentMeals` in #1790. The change also surfaces any error from `attachFoodsToMeals` inside the `try` rather than as an unhandled rejection. Eight lines total (an `await` plus a one-line explaining comment on each). No schema, route, or API changes.

This is the follow-up offered in the #1790 review thread (https://github.com/CodeWithCJ/SparkyFitness/pull/1790#issuecomment-4949303830), fixing the remaining read paths that PR left untouched to keep its scope tight

## How to Test

This is a race-condition hardening fix with no user-visible behaviour change. The meal list, meal search, public meals, and family meals endpoints continue to return the same results with their attached ingredient lists. Under pool pressure (many concurrent requests) the previous code could intermittently error or read from a reused connection; the awaited version cannot.

## PR Type

- [x] Issue (bug fix). https://github.com/CodeWithCJ/SparkyFitness/issues/1798
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the License terms.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: typecheck, lint, tests. (No new files, endpoints, or schemas. Existing meal-route tests cover these paths. Verified 2026-07-11 on the pushed commit: `typecheck` + `lint` + `format:check` clean, full `vitest run` = 1939 passed / 0 failed.)

## Notes for Reviewers

Scoped deliberately to the four functions #1790 did not touch (`getMeals`, `searchMeals`, `getPublicMeals`, `getFamilyMeals`). `getTopMeals` and `getRecentMeals` are already fixed in #1790, so their lines are intentionally not in this diff and the two PRs do not overlap whichever merges first.
