### PR TITLE
feat(mobile): include recent and frequent meals in the food search landing

### DIFF
--- a/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
@@ -376,4 +376,43 @@ describe('FoodSearchScreen', () => {
       }),
     );
   });
+
+  it('retries the meals queries as well as foods from the landing error state', () => {
+    // An outage fails foods and meals together, so a retry that only refetches
+    // foods would clear the error screen and leave the meals half empty.
+    const refetchFoods = jest.fn();
+    const refetchRecentMeals = jest.fn();
+    const refetchTopMeals = jest.fn();
+    mockUseFoods.mockReturnValue({
+      recentFoods: [],
+      topFoods: [],
+      isLoading: false,
+      isError: true,
+      refetch: refetchFoods,
+    } as any);
+    mockUseRecentMeals.mockReturnValue({
+      recentMeals: [],
+      isLoading: false,
+      isError: true,
+      refetch: refetchRecentMeals,
+    } as any);
+    mockUseTopMeals.mockReturnValue({
+      topMeals: [],
+      isLoading: false,
+      isError: true,
+      refetch: refetchTopMeals,
+    } as any);
+
+    const screen = render(
+      <SafeAreaProvider initialMetrics={{ insets, frame }}>
+        <FoodSearchScreen navigation={navigation} route={route} />
+      </SafeAreaProvider>,
+    );
+
+    fireEvent.press(screen.getByText('Retry'));
+
+    expect(refetchFoods).toHaveBeenCalled();
+    expect(refetchRecentMeals).toHaveBeenCalled();
+    expect(refetchTopMeals).toHaveBeenCalled();
+  });
 });

--- a/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
@@ -14,7 +14,9 @@ import {
   useMealSearch,
   useMeals,
   usePreferences,
+  useRecentMeals,
   useServerConnection,
+  useTopMeals,
 } from '../../src/hooks';
 import type { Meal } from '../../src/types/meals';
 import type { FoodItem } from '../../src/types/foods';
@@ -28,7 +30,9 @@ jest.mock('../../src/hooks', () => ({
   useMealSearch: jest.fn(),
   useMeals: jest.fn(),
   usePreferences: jest.fn(),
+  useRecentMeals: jest.fn(),
   useServerConnection: jest.fn(),
+  useTopMeals: jest.fn(),
   useDebounce: (value: unknown) => value,
 }));
 
@@ -59,7 +63,9 @@ const mockUseFoods = useFoods as jest.MockedFunction<typeof useFoods>;
 const mockUseMealSearch = useMealSearch as jest.MockedFunction<typeof useMealSearch>;
 const mockUseMeals = useMeals as jest.MockedFunction<typeof useMeals>;
 const mockUsePreferences = usePreferences as jest.MockedFunction<typeof usePreferences>;
+const mockUseRecentMeals = useRecentMeals as jest.MockedFunction<typeof useRecentMeals>;
 const mockUseServerConnection = useServerConnection as jest.MockedFunction<typeof useServerConnection>;
+const mockUseTopMeals = useTopMeals as jest.MockedFunction<typeof useTopMeals>;
 
 const insets = { top: 0, bottom: 0, left: 0, right: 0 };
 const frame = { x: 0, y: 0, width: 390, height: 844 };
@@ -184,6 +190,18 @@ describe('FoodSearchScreen', () => {
       isError: false,
       refetch: jest.fn(),
     });
+    mockUseRecentMeals.mockReturnValue({
+      recentMeals: [],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    } as any);
+    mockUseTopMeals.mockReturnValue({
+      topMeals: [],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    } as any);
     mockUseMealSearch.mockReturnValue({
       searchResults: [],
       isSearching: false,

--- a/SparkyFitnessMobile/__tests__/utils/landingLists.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/landingLists.test.ts
@@ -1,0 +1,111 @@
+import { mergeRecent, mergeFrequent } from '../../src/utils/landingLists';
+import type { Meal } from '../../src/types/meals';
+import type { FoodItem } from '../../src/types/foods';
+
+const meal = (id: string, extra: Record<string, unknown> = {}) =>
+  ({ id, name: `meal-${id}`, ...extra }) as unknown as Meal;
+const food = (id: string, extra: Record<string, unknown> = {}) =>
+  ({ id, name: `food-${id}`, ...extra }) as unknown as FoodItem;
+
+describe('mergeRecent', () => {
+  it('interleaves meals and foods by last_used_date, newest first', () => {
+    const meals = [meal('m1', { last_used_date: '2026-07-05' })];
+    const foods = [
+      food('f1', { last_used_date: '2026-07-09' }),
+      food('f2', { last_used_date: '2026-07-01' }),
+    ];
+    const out = mergeRecent(meals, foods, 10);
+    expect(out.map((e) => e.key)).toEqual(['food-f1', 'meal-m1', 'food-f2']);
+  });
+
+  it('keeps meals before foods on a same-day tie (stable)', () => {
+    const meals = [meal('m1', { last_used_date: '2026-07-09' })];
+    const foods = [food('f1', { last_used_date: '2026-07-09' })];
+    expect(mergeRecent(meals, foods, 10).map((e) => e.key)).toEqual([
+      'meal-m1',
+      'food-f1',
+    ]);
+  });
+
+  it('caps the merged timeline at limit', () => {
+    const foods = [
+      food('f1', { last_used_date: '2026-07-09' }),
+      food('f2', { last_used_date: '2026-07-08' }),
+      food('f3', { last_used_date: '2026-07-07' }),
+    ];
+    expect(mergeRecent([], foods, 2).map((e) => e.key)).toEqual([
+      'food-f1',
+      'food-f2',
+    ]);
+  });
+
+  it('tags entries with their kind for rendering', () => {
+    const out = mergeRecent(
+      [meal('m1', { last_used_date: '2026-07-09' })],
+      [food('f1', { last_used_date: '2026-07-08' })],
+      10,
+    );
+    expect(out[0]).toMatchObject({ kind: 'meal', key: 'meal-m1' });
+    expect(out[1]).toMatchObject({ kind: 'food', key: 'food-f1' });
+  });
+
+  it('falls back to a stable order when last_used_date is absent', () => {
+    // Older backend that does not yet return last_used_date: everything sorts
+    // equal, so the meals-then-foods concat order is preserved (no crash, no
+    // scrambling).
+    const out = mergeRecent([meal('m1')], [food('f1'), food('f2')], 10);
+    expect(out.map((e) => e.key)).toEqual(['meal-m1', 'food-f1', 'food-f2']);
+  });
+});
+
+describe('mergeFrequent', () => {
+  it('orders by usage_count desc and coerces numeric-string counts', () => {
+    const meals = [meal('m1', { usage_count: '3' })];
+    const foods = [
+      food('f1', { usage_count: '10' }),
+      food('f2', { usage_count: '1' }),
+    ];
+    expect(mergeFrequent(meals, foods, new Set(), 10).map((e) => e.key)).toEqual(
+      ['food-f1', 'meal-m1', 'food-f2'],
+    );
+  });
+
+  it('excludes items already shown in Recent', () => {
+    const meals = [meal('m1', { usage_count: 5 })];
+    const foods = [
+      food('f1', { usage_count: 9 }),
+      food('f2', { usage_count: 2 }),
+    ];
+    const exclude = new Set(['food-f1']);
+    expect(mergeFrequent(meals, foods, exclude, 10).map((e) => e.key)).toEqual([
+      'meal-m1',
+      'food-f2',
+    ]);
+  });
+
+  it('caps at limit after exclusion', () => {
+    const foods = [
+      food('f1', { usage_count: 9 }),
+      food('f2', { usage_count: 8 }),
+      food('f3', { usage_count: 7 }),
+    ];
+    expect(mergeFrequent([], foods, new Set(), 2).map((e) => e.key)).toEqual([
+      'food-f1',
+      'food-f2',
+    ]);
+  });
+
+  it('treats an unparseable usage_count as 0 (NaN-safe comparator)', () => {
+    const foods = [
+      food('f1', { usage_count: 'not-a-number' }),
+      food('f2', { usage_count: 4 }),
+      food('f3', { usage_count: undefined }),
+    ];
+    // f2 (4) ranks above the two that coerce to 0; order stays deterministic.
+    expect(mergeFrequent([], foods, new Set(), 10).map((e) => e.key)).toEqual([
+      'food-f2',
+      'food-f1',
+      'food-f3',
+    ]);
+  });
+});

--- a/SparkyFitnessMobile/src/components/MealLibraryRow.tsx
+++ b/SparkyFitnessMobile/src/components/MealLibraryRow.tsx
@@ -32,7 +32,7 @@ const MealLibraryRow: React.FC<MealLibraryRowProps> = ({
     >
       <View className="flex-row justify-between items-center">
         <View className="flex-1 mr-3">
-          <View className="flex-row items-center gap-1.5">
+          <View className="flex-row items-baseline gap-1.5">
             <Text
               className="text-text-primary text-base font-medium flex-shrink"
               numberOfLines={1}
@@ -40,8 +40,14 @@ const MealLibraryRow: React.FC<MealLibraryRowProps> = ({
               {meal.name}
             </Text>
             {showBadge ? (
-              <View className="px-1.5 py-0.5 rounded border border-border-subtle flex-shrink-0">
-                <Text className="text-text-secondary text-xs font-semibold uppercase">
+              // Baseline alignment puts the badge's own text on the name's
+              // baseline, which leaves the box hanging under the line; the 2dp
+              // lift pulls the box back onto it.
+              <View
+                className="px-1 py-0.5 rounded border border-border-subtle flex-shrink-0"
+                style={{ transform: [{ translateY: -2 }] }}
+              >
+                <Text className="text-text-secondary text-[9px] font-semibold">
                   Meal
                 </Text>
               </View>

--- a/SparkyFitnessMobile/src/components/MealLibraryRow.tsx
+++ b/SparkyFitnessMobile/src/components/MealLibraryRow.tsx
@@ -40,7 +40,7 @@ const MealLibraryRow: React.FC<MealLibraryRowProps> = ({
               {meal.name}
             </Text>
             {showBadge ? (
-              <View className="px-1.5 py-0.5 rounded border border-border-subtle">
+              <View className="px-1.5 py-0.5 rounded border border-border-subtle flex-shrink-0">
                 <Text className="text-text-secondary text-xs font-semibold uppercase">
                   Meal
                 </Text>

--- a/SparkyFitnessMobile/src/components/MealLibraryRow.tsx
+++ b/SparkyFitnessMobile/src/components/MealLibraryRow.tsx
@@ -7,12 +7,18 @@ interface MealLibraryRowProps {
   meal: Meal;
   onPress?: () => void;
   showDivider?: boolean;
+  // Renders an outline "Meal" badge next to the name. Used where meals are
+  // merged into a list alongside foods (the food-search landing), so a meal is
+  // not mistaken for a food. Off by default for lists that already have a
+  // meals-only header. Mirrors the web food-search meal badge.
+  showBadge?: boolean;
 }
 
 const MealLibraryRow: React.FC<MealLibraryRowProps> = ({
   meal,
   onPress,
   showDivider = false,
+  showBadge = false,
 }) => {
   const foodInfo = useMemo(() => mealToFoodInfo(meal), [meal]);
   const itemCount = meal.foods.length;
@@ -26,9 +32,21 @@ const MealLibraryRow: React.FC<MealLibraryRowProps> = ({
     >
       <View className="flex-row justify-between items-center">
         <View className="flex-1 mr-3">
-          <Text className="text-text-primary text-base font-medium" numberOfLines={1}>
-            {meal.name}
-          </Text>
+          <View className="flex-row items-center gap-1.5">
+            <Text
+              className="text-text-primary text-base font-medium flex-shrink"
+              numberOfLines={1}
+            >
+              {meal.name}
+            </Text>
+            {showBadge ? (
+              <View className="px-1.5 py-0.5 rounded border border-border-subtle">
+                <Text className="text-text-secondary text-xs font-semibold uppercase">
+                  Meal
+                </Text>
+              </View>
+            ) : null}
+          </View>
           {meal.description ? (
             <Text className="text-text-secondary text-sm mt-0.5" numberOfLines={1}>
               {meal.description}

--- a/SparkyFitnessMobile/src/hooks/index.ts
+++ b/SparkyFitnessMobile/src/hooks/index.ts
@@ -51,7 +51,7 @@ export { useFoods } from './useFoods';
 export { useDebounce } from './useDebounce';
 export { useFoodSearch } from './useFoodSearch';
 export { useFoodsLibrary } from './useFoodsLibrary';
-export { useMeals, useRecentMeals, useMeal, useCreateMeal, useUpdateMeal, useDeleteMeal } from './useMeals';
+export { useMeals, useRecentMeals, useTopMeals, useMeal, useCreateMeal, useUpdateMeal, useDeleteMeal } from './useMeals';
 export { useMealSearch } from './useMealSearch';
 export { useExternalProviders } from './useExternalProviders';
 export { useExternalFoodSearch } from './useExternalFoodSearch';

--- a/SparkyFitnessMobile/src/hooks/queryKeys.ts
+++ b/SparkyFitnessMobile/src/hooks/queryKeys.ts
@@ -29,6 +29,10 @@ export const recentMealsQueryKeyRoot = ['recentMeals'] as const;
 
 export const recentMealsQueryKey = (limit: number) => [...recentMealsQueryKeyRoot, limit] as const;
 
+export const topMealsQueryKeyRoot = ['topMeals'] as const;
+
+export const topMealsQueryKey = (limit: number) => [...topMealsQueryKeyRoot, limit] as const;
+
 export const mealSearchQueryKeyRoot = ['mealSearch'] as const;
 
 export const mealSearchQueryKey = (searchTerm: string) => [...mealSearchQueryKeyRoot, searchTerm] as const;

--- a/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
+++ b/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
@@ -8,7 +8,8 @@ import {
   type SaveFoodPayload,
 } from '../services/api/foodsApi';
 import { createFoodEntry, type CreateFoodEntryPayload } from '../services/api/foodEntriesApi';
-import { dailySummaryQueryKey, foodsQueryKey, recentMealsQueryKeyRoot } from './queryKeys';
+import { dailySummaryQueryKey, foodsQueryKey } from './queryKeys';
+import { invalidateMealUsageCaches } from './useMeals';
 import type { FoodEntry } from '../types/foodEntries';
 import type { ExternalFoodVariant } from '../types/externalFoods';
 import { persistExternalVariants } from '../utils/persistExternalVariants';
@@ -114,7 +115,7 @@ export function useAddFoodEntry(options?: UseAddFoodEntryOptions) {
     },
     onSuccess: (entry) => {
       if (entry.meal_id) {
-        queryClient.invalidateQueries({ queryKey: recentMealsQueryKeyRoot, refetchType: 'all' });
+        invalidateMealUsageCaches(queryClient);
       }
       options?.onSuccess?.(entry);
     },

--- a/SparkyFitnessMobile/src/hooks/useAddFoodEntryMeal.ts
+++ b/SparkyFitnessMobile/src/hooks/useAddFoodEntryMeal.ts
@@ -5,7 +5,8 @@ import type {
   FoodEntryMeal,
   FoodEntryMealCreateData,
 } from '../types/foodEntryMeals';
-import { dailySummaryQueryKey, foodsQueryKey, recentMealsQueryKeyRoot } from './queryKeys';
+import { dailySummaryQueryKey, foodsQueryKey } from './queryKeys';
+import { invalidateMealUsageCaches } from './useMeals';
 
 interface UseAddFoodEntryMealOptions {
   onSuccess?: (meal: FoodEntryMeal) => void;
@@ -17,7 +18,7 @@ export function useAddFoodEntryMeal(options?: UseAddFoodEntryMealOptions) {
   const mutation = useMutation({
     mutationFn: (payload: FoodEntryMealCreateData) => createFoodEntryMeal(payload),
     onSuccess: (meal) => {
-      queryClient.invalidateQueries({ queryKey: recentMealsQueryKeyRoot, refetchType: 'all' });
+      invalidateMealUsageCaches(queryClient);
       options?.onSuccess?.(meal);
     },
     onError: () => {

--- a/SparkyFitnessMobile/src/hooks/useDeleteFoodEntryMeal.ts
+++ b/SparkyFitnessMobile/src/hooks/useDeleteFoodEntryMeal.ts
@@ -7,8 +7,8 @@ import {
   dailySummaryQueryKey,
   foodEntryMealDetailQueryKey,
   foodsQueryKey,
-  recentMealsQueryKeyRoot,
 } from './queryKeys';
+import { invalidateMealUsageCaches } from './useMeals';
 
 interface UseDeleteFoodEntryMealOptions {
   mealId: string;
@@ -46,7 +46,7 @@ export function useDeleteFoodEntryMeal({
   const invalidateCache = () => {
     queryClient.invalidateQueries({ queryKey: dailySummaryQueryKey(normalizedDate) });
     queryClient.invalidateQueries({ queryKey: foodEntryMealDetailQueryKey(mealId) });
-    queryClient.invalidateQueries({ queryKey: recentMealsQueryKeyRoot, refetchType: 'all' });
+    invalidateMealUsageCaches(queryClient);
     queryClient.invalidateQueries({ queryKey: [...foodsQueryKey] });
   };
 

--- a/SparkyFitnessMobile/src/hooks/useMeals.ts
+++ b/SparkyFitnessMobile/src/hooks/useMeals.ts
@@ -23,6 +23,11 @@ import {
 import type { QueryClient } from '@tanstack/react-query';
 import type { CreateMealPayload, Meal, UpdateMealPayload } from '../types/meals';
 
+// Stable reference for the "no data yet" case. A fresh `[]` on every render
+// would break memoization for consumers (e.g. the landing-list useMemo in
+// FoodSearchScreen) while a query is still loading.
+const EMPTY_MEALS: Meal[] = [];
+
 function invalidateMealCaches(queryClient: QueryClient, mealId?: string) {
   queryClient.invalidateQueries({ queryKey: mealsQueryKey });
   queryClient.invalidateQueries({ queryKey: recentMealsQueryKeyRoot, refetchType: 'all' });
@@ -45,7 +50,7 @@ export function useMeals(options?: { enabled?: boolean }) {
   });
 
   return {
-    meals: query.data ?? [],
+    meals: query.data ?? EMPTY_MEALS,
     isLoading: query.isLoading,
     isError: query.isError,
     refetch: query.refetch,
@@ -63,7 +68,7 @@ export function useRecentMeals(options?: { enabled?: boolean; limit?: number }) 
   });
 
   return {
-    recentMeals: query.data ?? [],
+    recentMeals: query.data ?? EMPTY_MEALS,
     isLoading: query.isLoading,
     isError: query.isError,
     refetch: query.refetch,
@@ -81,7 +86,7 @@ export function useTopMeals(options?: { enabled?: boolean; limit?: number }) {
   });
 
   return {
-    topMeals: query.data ?? [],
+    topMeals: query.data ?? EMPTY_MEALS,
     isLoading: query.isLoading,
     isError: query.isError,
     refetch: query.refetch,

--- a/SparkyFitnessMobile/src/hooks/useMeals.ts
+++ b/SparkyFitnessMobile/src/hooks/useMeals.ts
@@ -8,6 +8,7 @@ import {
   fetchMealDeletionImpact,
   fetchMeals,
   fetchRecentMeals,
+  fetchTopMeals,
   updateMeal,
 } from '../services/api/mealsApi';
 import {
@@ -16,6 +17,8 @@ import {
   mealsQueryKey,
   recentMealsQueryKey,
   recentMealsQueryKeyRoot,
+  topMealsQueryKey,
+  topMealsQueryKeyRoot,
 } from './queryKeys';
 import type { QueryClient } from '@tanstack/react-query';
 import type { CreateMealPayload, Meal, UpdateMealPayload } from '../types/meals';
@@ -23,6 +26,7 @@ import type { CreateMealPayload, Meal, UpdateMealPayload } from '../types/meals'
 function invalidateMealCaches(queryClient: QueryClient, mealId?: string) {
   queryClient.invalidateQueries({ queryKey: mealsQueryKey });
   queryClient.invalidateQueries({ queryKey: recentMealsQueryKeyRoot, refetchType: 'all' });
+  queryClient.invalidateQueries({ queryKey: topMealsQueryKeyRoot, refetchType: 'all' });
   queryClient.invalidateQueries({ queryKey: mealSearchQueryKeyRoot });
 
   if (mealId) {
@@ -60,6 +64,24 @@ export function useRecentMeals(options?: { enabled?: boolean; limit?: number }) 
 
   return {
     recentMeals: query.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    refetch: query.refetch,
+  };
+}
+
+export function useTopMeals(options?: { enabled?: boolean; limit?: number }) {
+  const { enabled = true, limit = 3 } = options ?? {};
+
+  const query = useQuery({
+    queryKey: topMealsQueryKey(limit),
+    queryFn: () => fetchTopMeals(limit),
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    enabled,
+  });
+
+  return {
+    topMeals: query.data ?? [],
     isLoading: query.isLoading,
     isError: query.isError,
     refetch: query.refetch,

--- a/SparkyFitnessMobile/src/hooks/useMeals.ts
+++ b/SparkyFitnessMobile/src/hooks/useMeals.ts
@@ -28,10 +28,20 @@ import type { CreateMealPayload, Meal, UpdateMealPayload } from '../types/meals'
 // FoodSearchScreen) while a query is still loading.
 const EMPTY_MEALS: Meal[] = [];
 
-function invalidateMealCaches(queryClient: QueryClient, mealId?: string) {
-  queryClient.invalidateQueries({ queryKey: mealsQueryKey });
+/**
+ * Invalidates the caches derived from meal *usage* (recency and frequency).
+ * Call this from any mutation that logs, edits or removes a meal entry: both
+ * lists feed the food-search landing, so refreshing one without the other
+ * leaves the landing internally inconsistent.
+ */
+export function invalidateMealUsageCaches(queryClient: QueryClient) {
   queryClient.invalidateQueries({ queryKey: recentMealsQueryKeyRoot, refetchType: 'all' });
   queryClient.invalidateQueries({ queryKey: topMealsQueryKeyRoot, refetchType: 'all' });
+}
+
+function invalidateMealCaches(queryClient: QueryClient, mealId?: string) {
+  queryClient.invalidateQueries({ queryKey: mealsQueryKey });
+  invalidateMealUsageCaches(queryClient);
   queryClient.invalidateQueries({ queryKey: mealSearchQueryKeyRoot });
 
   if (mealId) {

--- a/SparkyFitnessMobile/src/hooks/useUpdateFoodEntryMeal.ts
+++ b/SparkyFitnessMobile/src/hooks/useUpdateFoodEntryMeal.ts
@@ -10,8 +10,8 @@ import {
   dailySummaryQueryKey,
   foodEntryMealDetailQueryKey,
   foodsQueryKey,
-  recentMealsQueryKeyRoot,
 } from './queryKeys';
+import { invalidateMealUsageCaches } from './useMeals';
 
 interface UseUpdateFoodEntryMealOptions {
   mealId: string;
@@ -46,7 +46,7 @@ export function useUpdateFoodEntryMeal({
       queryClient.invalidateQueries({ queryKey: dailySummaryQueryKey(newDate), refetchType: 'all' });
     }
     queryClient.invalidateQueries({ queryKey: foodEntryMealDetailQueryKey(mealId) });
-    queryClient.invalidateQueries({ queryKey: recentMealsQueryKeyRoot, refetchType: 'all' });
+    invalidateMealUsageCaches(queryClient);
     queryClient.invalidateQueries({ queryKey: [...foodsQueryKey] });
   };
 

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -149,16 +149,21 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   // Recent + frequently-logged meals for the landing merge. Excluded while
   // building a meal (a meal cannot contain a meal), mirroring the typed-search
   // behaviour. Requested at the section cap so the merge with foods is not
-  // starved. Meals stream in and interleave with foods once loaded.
+  // starved.
   const landingMealsEnabled = isConnected && !isMealBuilderMode;
-  const { recentMeals } = useRecentMeals({
+  const { recentMeals, isLoading: isRecentMealsLoading } = useRecentMeals({
     enabled: landingMealsEnabled,
     limit: landingLimit,
   });
-  const { topMeals } = useTopMeals({
+  const { topMeals, isLoading: isTopMealsLoading } = useTopMeals({
     enabled: landingMealsEnabled,
     limit: landingLimit,
   });
+
+  // The landing spinner waits on foods *and* meals. Rendering foods first and
+  // letting meals pop in afterwards shifts rows under the user's thumb mid-tap.
+  const isLandingLoading =
+    isLoading || (landingMealsEnabled && (isRecentMealsLoading || isTopMealsLoading));
 
   const [searchText, setSearchText] = useState('');
   const [isSearchFocused, setIsSearchFocused] = useState(false);
@@ -1274,7 +1279,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     }
 
     // Landing (no/short query): recent + top foods.
-    if (isLoading) {
+    if (isLandingLoading) {
       return (
         <View className="flex-1 justify-center items-center">
           <ActivityIndicator size="large" color={accentColor} />

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -151,11 +151,19 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   // behaviour. Requested at the section cap so the merge with foods is not
   // starved.
   const landingMealsEnabled = isConnected && !isMealBuilderMode;
-  const { recentMeals, isLoading: isRecentMealsLoading } = useRecentMeals({
+  const {
+    recentMeals,
+    isLoading: isRecentMealsLoading,
+    refetch: refetchRecentMeals,
+  } = useRecentMeals({
     enabled: landingMealsEnabled,
     limit: landingLimit,
   });
-  const { topMeals, isLoading: isTopMealsLoading } = useTopMeals({
+  const {
+    topMeals,
+    isLoading: isTopMealsLoading,
+    refetch: refetchTopMeals,
+  } = useTopMeals({
     enabled: landingMealsEnabled,
     limit: landingLimit,
   });
@@ -164,6 +172,19 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   // letting meals pop in afterwards shifts rows under the user's thumb mid-tap.
   const isLandingLoading =
     isLoading || (landingMealsEnabled && (isRecentMealsLoading || isTopMealsLoading));
+
+  // The landing error state is driven by the foods query, but a failure is
+  // usually shared: an outage takes down foods and meals together. Retrying
+  // foods alone would clear the error screen and leave the meals half of the
+  // list silently empty, since nothing else refetches it while the screen
+  // stays mounted.
+  const retryLanding = useCallback(() => {
+    refetch();
+    if (landingMealsEnabled) {
+      refetchRecentMeals();
+      refetchTopMeals();
+    }
+  }, [refetch, refetchRecentMeals, refetchTopMeals, landingMealsEnabled]);
 
   const [searchText, setSearchText] = useState('');
   const [isSearchFocused, setIsSearchFocused] = useState(false);
@@ -1293,7 +1314,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
           <Text className="text-text-secondary text-base mt-4 text-center">
             Failed to load foods
           </Text>
-          <Button variant="secondary" onPress={() => refetch()} className="mt-4 px-6">
+          <Button variant="secondary" onPress={retryLanding} className="mt-4 px-6">
             Retry
           </Button>
         </View>

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -31,6 +31,8 @@ import {
   useFoods,
   useFoodSearch,
   useMealSearch,
+  useRecentMeals,
+  useTopMeals,
   useExternalProviders,
   useExternalFoodSearch,
   useAllProvidersSearch,
@@ -58,16 +60,19 @@ import {
 import { formatServingDescription, formatServingUnit } from '../utils/foodDetails';
 import { useProviderColor } from '../utils/providerColor';
 import { interleaveTopMatches } from '../utils/topMatches';
+import { mergeRecent, mergeFrequent } from '../utils/landingLists';
+import type { LandingEntry } from '../utils/landingLists';
 import { useHeaderActionColors } from '../hooks/useHeaderActionColors';
 import { createNativeHeaderIconButtonItem } from '../utils/nativeHeaderItems';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 
 type FoodSearchScreenProps = RootStackScreenProps<'FoodSearch'>;
 
-// Landing (empty query) sections: recent / top foods.
+// Landing (empty query) sections: recent / top, each a merged timeline of the
+// user's foods and saved meals (a meal is tagged with a "Meal" badge).
 type LandingSection = {
   title: string;
-  data: (FoodItem | TopFoodItem)[];
+  data: LandingEntry[];
 };
 
 // A row in the unified search results. The local foods + meals and the online
@@ -113,6 +118,10 @@ const ALL_PROVIDERS_VALUE = '__all__';
 // online results are also on screen.
 const LOCAL_RESULT_CAP = 6;
 
+// Fallback cap for each landing section (Recently Logged / Top) when the user's
+// item_display_limit preference is unset. Matches the web food-search landing.
+const LANDING_ITEM_LIMIT = 10;
+
 const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }) => {
   const date = route.params?.date;
   const pickerMode = route.params?.pickerMode ?? 'log-entry';
@@ -131,6 +140,24 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   const { preferences } = usePreferences({ enabled: isConnected });
   const { recentFoods, topFoods, isLoading, isError, refetch } = useFoods({
     enabled: isConnected,
+  });
+
+  // Per-section cap for the landing lists (foods + meals merged). Mirrors web,
+  // which caps each landing section at the user's item_display_limit.
+  const landingLimit = preferences?.item_display_limit ?? LANDING_ITEM_LIMIT;
+
+  // Recent + frequently-logged meals for the landing merge. Excluded while
+  // building a meal (a meal cannot contain a meal), mirroring the typed-search
+  // behaviour. Requested at the section cap so the merge with foods is not
+  // starved. Meals stream in and interleave with foods once loaded.
+  const landingMealsEnabled = isConnected && !isMealBuilderMode;
+  const { recentMeals } = useRecentMeals({
+    enabled: landingMealsEnabled,
+    limit: landingLimit,
+  });
+  const { topMeals } = useTopMeals({
+    enabled: landingMealsEnabled,
+    limit: landingLimit,
   });
 
   const [searchText, setSearchText] = useState('');
@@ -543,11 +570,22 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   }, [providerPopoverVisible, onlineHeaderVisible]);
 
   const landingSections = useMemo<LandingSection[]>(() => {
+    // Recently Logged: foods + meals merged into one recency timeline.
+    const recentEntries = mergeRecent(recentMeals, recentFoods, landingLimit);
+    // Top: foods + meals by usage, excluding anything already in Recent so the
+    // two sections never repeat a row.
+    const excludeKeys = new Set(recentEntries.map((entry) => entry.key));
+    const frequentEntries = mergeFrequent(
+      topMeals,
+      topFoods,
+      excludeKeys,
+      landingLimit,
+    );
     return [
-      { title: 'Recently Logged', data: recentFoods.slice(0, 6) },
-      { title: 'Top Foods', data: topFoods },
+      { title: 'Recently Logged', data: recentEntries },
+      { title: 'Top', data: frequentEntries },
     ].filter((section) => section.data.length > 0);
-  }, [recentFoods, topFoods]);
+  }, [recentFoods, topFoods, recentMeals, topMeals, landingLimit]);
 
   const resultSections = useMemo<ResultSection[]>(() => {
     const sections: ResultSection[] = [];
@@ -714,6 +752,22 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
       </View>
     </TouchableOpacity>
   );
+
+  // A landing row is either a food or a saved meal (tagged with a "Meal" badge
+  // so it reads as distinct from a food in the merged list).
+  const renderLandingEntry = (entry: LandingEntry) => {
+    if (entry.kind === 'meal') {
+      return (
+        <MealLibraryRow
+          meal={entry.meal}
+          showBadge
+          showDivider
+          onPress={() => showFoodInfo(mealToFoodInfo(entry.meal))}
+        />
+      );
+    }
+    return renderFoodRow(entry.food);
+  };
 
   const renderOnlineRow = (
     item: ExternalFoodItem,
@@ -1253,8 +1307,8 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
     return (
       <SectionList
         sections={landingSections}
-        keyExtractor={(item, index) => `${index}-${item.id}`}
-        renderItem={({ item }) => renderFoodRow(item)}
+        keyExtractor={(item) => item.key}
+        renderItem={({ item }) => renderLandingEntry(item)}
         renderSectionHeader={({ section }) => renderSectionHeaderTitle(section.title)}
         stickySectionHeadersEnabled
         keyboardShouldPersistTaps="handled"

--- a/SparkyFitnessMobile/src/services/api/mealsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/mealsApi.ts
@@ -36,6 +36,18 @@ export const fetchRecentMeals = async (limit = 3): Promise<Meal[]> => {
 };
 
 /**
+ * Fetches the user's most frequently logged meal templates.
+ */
+export const fetchTopMeals = async (limit = 3): Promise<Meal[]> => {
+  const params = new URLSearchParams({ limit: String(limit) });
+  return apiFetch<Meal[]>({
+    endpoint: `/api/meals/top?${params.toString()}`,
+    serviceName: 'Meals API',
+    operation: 'fetch top meals',
+  });
+};
+
+/**
  * Searches meals by name.
  */
 export const searchMeals = async (searchTerm: string): Promise<Meal[]> => {

--- a/SparkyFitnessMobile/src/utils/landingLists.ts
+++ b/SparkyFitnessMobile/src/utils/landingLists.ts
@@ -1,0 +1,79 @@
+import type { Meal } from '../types/meals';
+import type { FoodItem, TopFoodItem } from '../types/foods';
+
+// A food shown on the search landing is either a recent food or a top
+// (frequency-ranked) food; the two share every field the landing renders.
+export type LandingFood = FoodItem | TopFoodItem;
+
+// A single row in the food-search landing quick-pick lists, tagged so the
+// renderer can dispatch to a meal row or a food row. `key` is unique across
+// both types (id spaces are separate, but the prefix makes React keys safe
+// even if a meal and food ever shared an id).
+export type LandingEntry =
+  | { kind: 'meal'; key: string; meal: Meal }
+  | { kind: 'food'; key: string; food: LandingFood };
+
+// The recent/top endpoints attach these extra columns to their rows. They
+// arrive over JSON as strings (Postgres serializes dates to ISO strings and
+// COUNT(*) to a numeric string), so callers should not assume native types.
+// They are optional so the merge degrades gracefully on a server that has not
+// yet started returning them (older backend without the shared additions).
+type RecentMeal = Meal & { last_used_date?: string | null };
+type RecentFood = LandingFood & { last_used_date?: string | null };
+type FrequentMeal = Meal & { usage_count?: number | string | null };
+type FrequentFood = LandingFood & { usage_count?: number | string | null };
+
+const mealKey = (m: { id?: string }) => `meal-${m.id ?? ''}`;
+const foodKey = (f: { id?: string }) => `food-${f.id ?? ''}`;
+
+// Recent: merge meals and foods into one timeline ordered by last-used date,
+// newest first. ISO date strings sort lexicographically, so string compare is
+// chronological. Same-day ties keep meals before foods (stable sort over a
+// meals-then-foods concat), matching the sort preference elsewhere.
+export function mergeRecent(
+  meals: RecentMeal[] = [],
+  foods: RecentFood[] = [],
+  limit: number,
+): LandingEntry[] {
+  const tagged: { entry: LandingEntry; sort: string }[] = [
+    ...meals.map((m) => ({
+      entry: { kind: 'meal' as const, key: mealKey(m), meal: m },
+      sort: m.last_used_date ?? '',
+    })),
+    ...foods.map((f) => ({
+      entry: { kind: 'food' as const, key: foodKey(f), food: f },
+      sort: f.last_used_date ?? '',
+    })),
+  ];
+  tagged.sort((a, b) => (a.sort < b.sort ? 1 : a.sort > b.sort ? -1 : 0));
+  return tagged.slice(0, Math.max(0, limit)).map((t) => t.entry);
+}
+
+// Frequent: merge meals and foods ordered by usage count, most-used first,
+// dropping anything already shown in Recent (excludeKeys) so the two sections
+// do not repeat rows. usage_count can arrive as a numeric string, so coerce.
+export function mergeFrequent(
+  meals: FrequentMeal[] = [],
+  foods: FrequentFood[] = [],
+  excludeKeys: Set<string> = new Set(),
+  limit: number,
+): LandingEntry[] {
+  // Coerce, and never let a bad value become NaN: NaN in a subtraction
+  // comparator breaks sort transitivity and scrambles order.
+  const count = (v: number | string | null | undefined) => {
+    const parsed = Number(v ?? 0);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  };
+  const tagged: { entry: LandingEntry; sort: number }[] = [
+    ...meals.map((m) => ({
+      entry: { kind: 'meal' as const, key: mealKey(m), meal: m },
+      sort: count(m.usage_count),
+    })),
+    ...foods.map((f) => ({
+      entry: { kind: 'food' as const, key: foodKey(f), food: f },
+      sort: count(f.usage_count),
+    })),
+  ].filter((t) => !excludeKeys.has(t.entry.key));
+  tagged.sort((a, b) => b.sort - a.sort);
+  return tagged.slice(0, Math.max(0, limit)).map((t) => t.entry);
+}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

The web search landing shows recently logged and most frequently logged meals alongside foods, but the mobile landing shows foods only, so saved meals can only be reached by typing a query. This brings mobile to parity.

**How did you implement the solution?**

Mobile now fetches recent meals and top meals and merges them into the existing landing lists, so foods and meals interleave in one list ordered by recency and by usage. The merge logic is factored into `src/utils/landingLists.ts` (`mergeRecent` / `mergeFrequent`, ported from the web implementation) and unit tested. Meal rows are marked with an opt-in "Meal" badge on `MealLibraryRow`. Tapping a meal opens the existing meal flow unchanged. No server changes: this consumes the `GET /api/meals/top` endpoint and `last_used_date` that already landed on `main` with #1790.

Linked Issue: Closes #1805

## How to Test

1. Check out this branch and run `pnpm install`, then run the mobile app against a server on current `main` (the `/api/meals/top` endpoint is required).
2. Log a few meals and a few individual foods so there is usage history for both.
3. Open the food diary and tap to add a food, landing on the search screen with an empty query.
4. Verify that under **Recently Logged**, meals and foods appear interleaved in recency order, and that meal rows carry a "MEAL" badge while food rows do not.
5. Verify the same for the **Top** section, ordered by how often each item is logged.
6. Tap a meal row and verify it opens the existing meal detail/log flow with its ingredients intact.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="480" height="976" alt="sparkyfitness-mobile-meals-in-landing-after" src="https://github.com/user-attachments/assets/8c26aac2-dd88-4a6a-97c1-e16fe0d82fec" />

</details>

## Notes for Reviewers

The merge helpers in `src/utils/landingLists.ts` are a deliberate port of the web logic from #1790 rather than a fresh implementation, so the two clients stay in step. If you would rather they lived in `shared/`, say so and I will move them.

The "Meal" badge on `MealLibraryRow` is behind an opt-in prop so existing callers of that row are unaffected. The mobile app has no i18n layer, so the badge string is a literal.
