### PR TITLE
reset to page 1 on food search change

### DIFF
--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodDatabaseManager.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodDatabaseManager.ts
@@ -87,6 +87,11 @@ export function useFoodDatabaseManager() {
 
   const canEdit = (food: Food) => food.user_id === user?.id;
 
+  const handleSearchChange = (term: string) => {
+    setSearchTerm(term);
+    setCurrentPage(1);
+  };
+
   const handlePageChange = (page: number, pageSize?: number) => {
     if (pageSize !== undefined && pageSize !== itemsPerPage) {
       setItemsPerPage(pageSize);
@@ -255,7 +260,7 @@ export function useFoodDatabaseManager() {
     isMobile,
     visibleNutrients,
     searchTerm,
-    setSearchTerm,
+    setSearchTerm: handleSearchChange,
     itemsPerPage,
     setItemsPerPage,
     currentPage,


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
food search doesn't reset to page 1 on term change

**How did you implement the solution?**
in the state change handler for the search term reset the page to 1

Linked Issue: Closes #1810 

## How to Test

1. go to food library
2. go to page 2
3. search for a food and check it appears in the results

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots


### Before
after searching from page 2 - results blank
<img width="2264" height="648" alt="2026-07-13T13:57:37,093427296+02:00" src="https://github.com/user-attachments/assets/9961b8d1-8e32-40a4-a0db-a89a83807404" />


### After
after change, when searching from page 2 - page reset to page 1 and thus result is shown
<img width="2282" height="620" alt="2026-07-13T14:20:40,567646036+02:00" src="https://github.com/user-attachments/assets/357aba71-f08d-4742-a592-d3de0420b7c1" />


</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
