### PR TITLE
fix: make time control interactive for android

### DIFF
--- a/SparkyFitnessMobile/src/components/EndFastSheet.tsx
+++ b/SparkyFitnessMobile/src/components/EndFastSheet.tsx
@@ -128,6 +128,7 @@ const EndFastSheet = forwardRef<EndFastSheetRef, EndFastSheetProps>(({ onEnded }
       weekday_label: { color: textSecondary },
       month_selector_label: { color: textPrimary, fontWeight: '600' as const },
       year_selector_label: { color: textPrimary, fontWeight: '600' as const },
+      time_selector_label: { color: textPrimary, fontWeight: '600' as const },
       disabled_label: { color: textMuted },
       month_label: { color: textPrimary },
       year_label: { color: textPrimary },
@@ -203,12 +204,22 @@ const EndFastSheet = forwardRef<EndFastSheetRef, EndFastSheetProps>(({ onEnded }
     <BottomSheetModal
       ref={bottomSheetRef}
       enableDynamicSizing
+      // On Android the sheet's content pan gesture steals vertical drags from
+      // the time picker's wheels (plain FlatLists), so content panning stays
+      // off there. Must be static: toggling this prop swaps the sheet's
+      // content wrapper component, remounting the content and dismissing the
+      // modal.
+      enableContentPanningGesture={Platform.OS !== 'android'}
       backdropComponent={renderBackdrop}
       containerComponent={sheetContainer}
       backgroundStyle={{ backgroundColor: surfaceBg }}
       handleIndicatorStyle={{ backgroundColor: textMuted }}
     >
-      <BottomSheetScrollView contentContainerClassName="px-5 pb-safe-or-8">
+      {/* bg-surface is a touch shield, not decoration: with content panning off
+          on Android, gesture-handler lets taps on background-less views fall
+          through to the backdrop's tap-to-close. A background makes this
+          container absorb them. */}
+      <BottomSheetScrollView contentContainerClassName="bg-surface px-5 pb-safe-or-8">
         <Text className="text-lg font-semibold text-text-primary text-center mb-1">
           End fast
         </Text>

--- a/SparkyFitnessMobile/src/components/FastingProtocolSheet.tsx
+++ b/SparkyFitnessMobile/src/components/FastingProtocolSheet.tsx
@@ -178,12 +178,22 @@ const FastingProtocolSheet = forwardRef<FastingProtocolSheetRef>((_props, ref) =
       keyboardBehavior="interactive"
       keyboardBlurBehavior="restore"
       android_keyboardInputMode="adjustPan"
+      // On Android the sheet's content pan gesture steals vertical drags from
+      // the time picker's wheels (plain FlatLists), so content panning stays
+      // off there. Must be static: toggling this prop swaps the sheet's
+      // content wrapper component, remounting the content and dismissing the
+      // modal.
+      enableContentPanningGesture={Platform.OS !== 'android'}
       backdropComponent={renderBackdrop}
       containerComponent={sheetContainer}
       backgroundStyle={{ backgroundColor: surfaceBg }}
       handleIndicatorStyle={{ backgroundColor: textMuted }}
     >
-      <BottomSheetScrollView contentContainerClassName="px-5 pb-safe-or-8">
+      {/* bg-surface is a touch shield, not decoration: with content panning off
+          on Android, gesture-handler lets taps on background-less views fall
+          through to the backdrop's tap-to-close. A background makes this
+          container absorb them. */}
+      <BottomSheetScrollView contentContainerClassName="bg-surface px-5 pb-safe-or-8">
         <Text className="text-lg font-semibold text-text-primary text-center mb-4">
           Start a fast
         </Text>
@@ -266,6 +276,7 @@ const FastingProtocolSheet = forwardRef<FastingProtocolSheetRef>((_props, ref) =
               weekday_label: { color: textSecondary },
               month_selector_label: { color: textPrimary, fontWeight: '600' },
               year_selector_label: { color: textPrimary, fontWeight: '600' },
+              time_selector_label: { color: textPrimary, fontWeight: '600' },
               disabled_label: { color: textMuted },
               month_label: { color: textPrimary },
               year_label: { color: textPrimary },


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Could not select time in the create and end fast menus.

**How did you implement the solution?**
Enabled enableContentPanningGesture for android for the modal

Linked Issue: Closes #1820

## How to Test

1. Open Start fast modal
2. Edit start time
3. End fast
4. edit end time

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
