### PR TITLE
feat: measurement form placeholders and use last button

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1526,6 +1526,7 @@
     "enterHeight": "Enter height in",
     "bodyFatPercentage": "Body Fat %",
     "useRecent": "Use Recent",
+    "useLast": "Use last",
     "useMostRecentForCalculation": "Use most recent Weight, Height, Waist, Neck, and Hips for body fat calculation",
     "enterBodyFatPercentage": "Enter body fat percentage",
     "calculate": "Calculate",

--- a/SparkyFitnessFrontend/src/api/CheckIn/checkInService.ts
+++ b/SparkyFitnessFrontend/src/api/CheckIn/checkInService.ts
@@ -67,7 +67,13 @@ export const updateCheckInMeasurementField = async (payload: {
   });
 };
 
-export const loadExistingCheckInMeasurements = async (
+/**
+ * Loads measurements with carry-forward semantics: each field holds the
+ * latest value recorded on or before the date (steps are same-day only).
+ * For only what was actually recorded on the date itself, use
+ * loadCheckInMeasurementsForDate.
+ */
+export const loadLatestCheckInMeasurements = async (
   selectedDate: string
 ): Promise<CheckInMeasurementsResponse | null> => {
   const response = await apiCall(`/measurements/check-in/${selectedDate}`, {
@@ -79,6 +85,20 @@ export const loadExistingCheckInMeasurements = async (
     return null;
   }
   return checkInMeasurementsResponseSchema.parse(response);
+};
+
+/**
+ * Loads only the measurements recorded on the given date — no carry-forward
+ * from earlier days.
+ */
+export const loadCheckInMeasurementsForDate = async (
+  selectedDate: string
+): Promise<CheckInMeasurementsResponse | null> => {
+  const rows = await fetchRecentStandardMeasurements(
+    selectedDate,
+    selectedDate
+  );
+  return rows[0] ?? null;
 };
 
 export const loadExistingCustomMeasurements = async (

--- a/SparkyFitnessFrontend/src/api/keys/checkin.ts
+++ b/SparkyFitnessFrontend/src/api/keys/checkin.ts
@@ -5,8 +5,10 @@ export const checkInKeys = {
   recentCustom: () => [...checkInKeys.all, 'recentCustom'] as const,
   recentStandard: (startDate: string, endDate: string) =>
     [...checkInKeys.all, 'recentStandard', startDate, endDate] as const,
-  existingCheckIn: (date: string) =>
-    [...checkInKeys.all, 'existingCheckIn', date] as const,
+  latestCheckIn: (date: string) =>
+    [...checkInKeys.all, 'latestCheckIn', date] as const,
+  dayCheckIn: (date: string) =>
+    [...checkInKeys.all, 'dayCheckIn', date] as const,
   existingCustom: (date: string) =>
     [...checkInKeys.all, 'existingCustom', date] as const,
   mostRecent: (type: string) =>

--- a/SparkyFitnessFrontend/src/components/ui/UnitInput.tsx
+++ b/SparkyFitnessFrontend/src/components/ui/UnitInput.tsx
@@ -19,10 +19,39 @@ interface UnitInputProps {
   type: 'weight' | 'height' | 'measurement';
   onChange: (metricValue: number | null) => void;
   placeholder?: string;
+  placeholderValue?: number | null; // Metric base value shown as placeholder when the input is empty
   className?: string;
   inputClassName?: string;
   'aria-label'?: string;
 }
+
+type UnitInputType = UnitInputProps['type'];
+
+const toSingleDisplayString = (
+  metricValue: number,
+  unit: string,
+  type: UnitInputType
+) => {
+  const precision = getPrecision(type, unit);
+  let displayVal = metricValue;
+  if (unit === 'lbs') displayVal = kgToLbs(metricValue);
+  if (unit === 'inches') displayVal = cmToInches(metricValue);
+  return Number(displayVal.toFixed(precision)).toString();
+};
+
+const toSplitDisplayStrings = (
+  metricValue: number,
+  unit: 'st_lbs' | 'ft_in',
+  type: UnitInputType
+): [string, string] => {
+  const precision = getPrecision(type, unit);
+  if (unit === 'st_lbs') {
+    const { stones, lbs } = kgToStonesLbs(metricValue);
+    return [stones.toString(), Number(lbs.toFixed(precision)).toString()];
+  }
+  const { feet, inches } = cmToFeetInches(metricValue);
+  return [feet.toString(), Number(inches.toFixed(precision)).toString()];
+};
 
 export const UnitInput: React.FC<UnitInputProps> = ({
   id,
@@ -31,6 +60,7 @@ export const UnitInput: React.FC<UnitInputProps> = ({
   onChange,
   type,
   placeholder,
+  placeholderValue,
   className,
   inputClassName = '',
   'aria-label': ariaLabel,
@@ -57,37 +87,23 @@ export const UnitInput: React.FC<UnitInputProps> = ({
     if (metricValue === null || Number.isNaN(metricValue)) {
       setVal1('');
       setVal2('');
+    } else if (unit === 'st_lbs' || unit === 'ft_in') {
+      const [display1, display2] = toSplitDisplayStrings(
+        metricValue,
+        unit,
+        type
+      );
+      setVal1(display1);
+      setVal2(display2);
     } else {
-      switch (unit) {
-        case 'st_lbs': {
-          const { stones, lbs } = kgToStonesLbs(metricValue);
-          const precision = getPrecision(type, 'st_lbs');
-          setVal1(stones.toString());
-          setVal2(Number(lbs.toFixed(precision)).toString());
-          break;
-        }
-        case 'ft_in': {
-          const { feet, inches } = cmToFeetInches(metricValue);
-          const precision = getPrecision(type, 'ft_in');
-          setVal1(feet.toString());
-          setVal2(Number(inches.toFixed(precision)).toString());
-          break;
-        }
-        case 'lbs':
-        case 'inches':
-        case 'cm':
-        case 'kg':
-        default: {
-          const precision = getPrecision(type, unit);
-          let displayVal = metricValue;
-          if (unit === 'lbs') displayVal = kgToLbs(metricValue);
-          if (unit === 'inches') displayVal = cmToInches(metricValue);
-          setVal1(Number(displayVal.toFixed(precision)).toString());
-          break;
-        }
-      }
+      setVal1(toSingleDisplayString(metricValue, unit, type));
     }
   }
+
+  const placeholderMetric =
+    placeholderValue == null || Number.isNaN(placeholderValue)
+      ? null
+      : placeholderValue;
 
   const handleSingleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setVal1(e.target.value);
@@ -140,6 +156,10 @@ export const UnitInput: React.FC<UnitInputProps> = ({
   if (unit === 'st_lbs' || unit === 'ft_in') {
     const label1 = unit === 'st_lbs' ? 'st' : 'ft';
     const label2 = unit === 'st_lbs' ? 'lb' : 'in';
+    const [placeholder1, placeholder2] =
+      placeholderMetric !== null
+        ? toSplitDisplayStrings(placeholderMetric, unit, type)
+        : ['0', '0'];
 
     return (
       <div className={`flex items-center gap-2 ${className}`}>
@@ -152,7 +172,7 @@ export const UnitInput: React.FC<UnitInputProps> = ({
             onChange={(e) => handleSplitChange(e.target.value, val2)}
             onBlur={handleSplitBlur}
             className={`pr-8 ${inputClassName}`}
-            placeholder="0"
+            placeholder={placeholder1}
           />
           <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
             {label1}
@@ -171,7 +191,7 @@ export const UnitInput: React.FC<UnitInputProps> = ({
             onChange={(e) => handleSplitChange(val1, e.target.value)}
             onBlur={handleSplitBlur}
             className={`pr-8 ${inputClassName}`}
-            placeholder="0"
+            placeholder={placeholder2}
           />
           <span className="absolute right-2 top-1/2 -translate-y-1/2 text-xs text-muted-foreground">
             {label2}
@@ -184,6 +204,11 @@ export const UnitInput: React.FC<UnitInputProps> = ({
   // Render standard single input
   const precision = getPrecision(type, unit);
   const step = precision > 0 ? (1 / Math.pow(10, precision)).toString() : '1';
+  const singlePlaceholder =
+    placeholder ??
+    (placeholderMetric !== null
+      ? toSingleDisplayString(placeholderMetric, unit, type)
+      : undefined);
 
   return (
     <div className={`relative ${className}`}>
@@ -194,7 +219,7 @@ export const UnitInput: React.FC<UnitInputProps> = ({
         value={val1}
         onChange={handleSingleChange}
         onBlur={handleSingleBlur}
-        placeholder={placeholder}
+        placeholder={singlePlaceholder}
         className={`pr-9 ${inputClassName}`}
         aria-label={ariaLabel}
       />

--- a/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckIn.ts
+++ b/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckIn.ts
@@ -7,7 +7,8 @@ import {
   fetchRecentStandardMeasurements,
   deleteCustomMeasurement,
   updateCheckInMeasurementField,
-  loadExistingCheckInMeasurements,
+  loadLatestCheckInMeasurements,
+  loadCheckInMeasurementsForDate,
   loadExistingCustomMeasurements,
   saveCheckInMeasurements,
   saveCustomMeasurement,
@@ -61,10 +62,23 @@ export const useRecentStandardMeasurements = (
   });
 };
 
-export const useExistingCheckInMeasurements = (date: string) => {
+export const useLatestCheckInMeasurements = (date: string) => {
   return useQuery({
-    queryKey: checkInKeys.existingCheckIn(date),
-    queryFn: () => loadExistingCheckInMeasurements(date),
+    queryKey: checkInKeys.latestCheckIn(date),
+    queryFn: () => loadLatestCheckInMeasurements(date),
+    meta: {
+      errorMessage: i18n.t(
+        'checkIn.failedToLoadExistingCheckIn',
+        'Failed to load existing check-in data.'
+      ),
+    },
+  });
+};
+
+export const useCheckInMeasurementsForDate = (date: string) => {
+  return useQuery({
+    queryKey: checkInKeys.dayCheckIn(date),
+    queryFn: () => loadCheckInMeasurementsForDate(date),
     meta: {
       errorMessage: i18n.t(
         'checkIn.failedToLoadExistingCheckIn',

--- a/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInLogic.ts
+++ b/SparkyFitnessFrontend/src/hooks/CheckIn/useCheckInLogic.ts
@@ -12,13 +12,13 @@ import { userManagementService } from '@/api/Admin/userManagementService';
 import {
   useCustomCategories,
   useDeleteCustomMeasurementMutation,
-  useExistingCheckInMeasurements,
+  useCheckInMeasurementsForDate,
+  useLatestCheckInMeasurements,
   useExistingCustomMeasurements,
   useRecentCustomMeasurements,
   useRecentStandardMeasurements,
   useSaveCheckInMeasurementsMutation,
   useSaveCustomMeasurementMutation,
-  useMostRecentMeasurement,
   useUpdateCheckInMeasurementFieldMutation,
 } from '@/hooks/CheckIn/useCheckIn';
 import {
@@ -26,7 +26,7 @@ import {
   useSaveMoodEntryMutation,
 } from '@/hooks/CheckIn/useMood';
 import { useFastingHistory } from '@/hooks/Fasting/useFasting';
-import { CombinedMeasurement } from '@/types/checkin';
+import { CheckInPlaceholders, CombinedMeasurement } from '@/types/checkin';
 import {
   CheckInMeasurementsResponse,
   CustomMeasurementsResponse,
@@ -37,6 +37,62 @@ import {
 import { useAuth } from '../useAuth';
 import { useSearchParams } from 'react-router-dom';
 import { addDays, todayInZone } from '@workspace/shared';
+
+/**
+ * Builds the check-in upsert payload with per-field edit semantics:
+ * a filled field is set, an emptied field that has a value recorded on this
+ * date is cleared (explicit null), and everything else is omitted so the
+ * server leaves it untouched.
+ */
+export function buildCheckInMeasurementsPayload(
+  entryDate: string,
+  form: {
+    weight: string;
+    neck: string;
+    waist: string;
+    hips: string;
+    steps: string;
+    height: string;
+    bodyFatPercentage: string;
+  },
+  existing: CheckInMeasurementsResponse | null | undefined
+): UpdateCheckInMeasurementsRequest {
+  const payload: UpdateCheckInMeasurementsRequest = { entry_date: entryDate };
+
+  const apply = (
+    key:
+      | 'weight'
+      | 'neck'
+      | 'waist'
+      | 'hips'
+      | 'steps'
+      | 'height'
+      | 'body_fat_percentage',
+    raw: string,
+    parse: (value: string) => number
+  ) => {
+    if (raw.trim() !== '') {
+      const parsed = parse(raw);
+      if (!Number.isNaN(parsed)) {
+        payload[key] = parsed;
+      }
+      return;
+    }
+    if (existing?.[key] != null) {
+      payload[key] = null;
+    }
+  };
+
+  apply('weight', form.weight, parseFloat);
+  apply('neck', form.neck, parseFloat);
+  apply('waist', form.waist, parseFloat);
+  apply('hips', form.hips, parseFloat);
+  apply('steps', form.steps, (value) => parseInt(value, 10));
+  apply('height', form.height, parseFloat);
+  apply('body_fat_percentage', form.bodyFatPercentage, parseFloat);
+
+  return payload;
+}
 
 function useDerivedState<T>(derivedValue: T, selectedDate: string) {
   const [stateMap, setStateMap] = useState<Record<string, T>>({});
@@ -104,8 +160,10 @@ export const useCheckInLogic = (currentUserId: string | undefined) => {
   const { data: customCategories = [] } = useCustomCategories(
     user?.activeUserId
   );
-  const { data: existingCheckIn } =
-    useExistingCheckInMeasurements(selectedDate);
+  // Form values come from what was actually recorded on the selected date;
+  // the latest carried-forward values are only shown as input placeholders.
+  const { data: existingCheckIn } = useCheckInMeasurementsForDate(selectedDate);
+  const { data: latestCheckIn } = useLatestCheckInMeasurements(selectedDate);
   const { data: existingCustom } = useExistingCustomMeasurements(selectedDate);
   const { data: existingMood } = useMoodEntryByDate(selectedDate);
 
@@ -117,7 +175,6 @@ export const useCheckInLogic = (currentUserId: string | undefined) => {
     endDate
   );
   const { data: recentFasting = [] } = useFastingHistory(10, 0);
-  const { data: mostRecentHeightData } = useMostRecentMeasurement('height');
 
   const [useMostRecentForCalculation, setUseMostRecentForCalculation] =
     useState(true);
@@ -156,19 +213,11 @@ export const useCheckInLogic = (currentUserId: string | undefined) => {
   }, [existingCheckIn?.hips]);
 
   const derivedHeight = useMemo(() => {
-    // Height rarely changes day to day. If the selected date's row has a
-    // valid height use it; otherwise fall back to the user's most recent
-    // recorded height so the field isn't empty on a fresh check-in.
     const h = existingCheckIn?.height;
-    if (h != null && h > 0) {
-      return h.toString();
-    }
-    const recent = mostRecentHeightData?.height;
-    if (recent != null && recent > 0) {
-      return recent.toString();
-    }
-    return '';
-  }, [existingCheckIn?.height, mostRecentHeightData?.height]);
+    if (h == null) return '';
+    // State should be Metric (cm).
+    return h.toString();
+  }, [existingCheckIn?.height]);
 
   const derivedBodyFat = useMemo(() => {
     return existingCheckIn?.body_fat_percentage?.toString() || '';
@@ -232,19 +281,9 @@ export const useCheckInLogic = (currentUserId: string | undefined) => {
   const [neck, setNeck] = useDerivedState<string>(derivedNeck, selectedDate);
   const [waist, setWaist] = useDerivedState<string>(derivedWaist, selectedDate);
   const [hips, setHips] = useDerivedState<string>(derivedHips, selectedDate);
-  const [height, setHeightState] = useDerivedState<string>(
+  const [height, setHeight] = useDerivedState<string>(
     derivedHeight,
     selectedDate
-  );
-  const [heightTouchedDates, setHeightTouchedDates] = useState<
-    Record<string, boolean>
-  >({});
-  const setHeight = useCallback(
-    (value: string) => {
-      setHeightTouchedDates((prev) => ({ ...prev, [selectedDate]: true }));
-      setHeightState(value);
-    },
-    [selectedDate, setHeightState]
   );
   const [steps, setSteps] = useDerivedState<string>(derivedSteps, selectedDate);
   const [bodyFatPercentage, setBodyFatPercentage] = useDerivedState<string>(
@@ -266,6 +305,20 @@ export const useCheckInLogic = (currentUserId: string | undefined) => {
   const [customNotes, setCustomNotes] = useDerivedState<Record<string, string>>(
     derivedCustomNotes,
     selectedDate
+  );
+
+  // Latest recorded values (on or before the selected date), shown as input
+  // placeholders so past measurements give context without being resubmitted.
+  const placeholders: CheckInPlaceholders = useMemo(
+    () => ({
+      weight: latestCheckIn?.weight ?? null,
+      neck: latestCheckIn?.neck ?? null,
+      waist: latestCheckIn?.waist ?? null,
+      hips: latestCheckIn?.hips ?? null,
+      height: latestCheckIn?.height ?? null,
+      bodyFatPercentage: latestCheckIn?.body_fat_percentage ?? null,
+    }),
+    [latestCheckIn]
   );
 
   const recentMeasurements = useMemo(() => {
@@ -470,35 +523,11 @@ export const useCheckInLogic = (currentUserId: string | undefined) => {
         moodTags,
       });
 
-      const measurementData: UpdateCheckInMeasurementsRequest = {
-        entry_date: selectedDate,
-      };
-
-      if (weight) {
-        measurementData.weight = parseFloat(weight);
-      }
-      if (neck) {
-        measurementData.neck = parseFloat(neck);
-      }
-      if (waist) {
-        measurementData.waist = parseFloat(waist);
-      }
-      if (hips) {
-        measurementData.hips = parseFloat(hips);
-      }
-      if (steps) {
-        measurementData.steps = parseInt(steps);
-      }
-      const shouldSubmitHeight =
-        height !== '' &&
-        ((existingCheckIn?.height != null && existingCheckIn.height > 0) ||
-          heightTouchedDates[selectedDate] === true);
-      if (shouldSubmitHeight) {
-        measurementData.height = parseFloat(height);
-      }
-      if (bodyFatPercentage) {
-        measurementData.body_fat_percentage = parseFloat(bodyFatPercentage);
-      }
+      const measurementData = buildCheckInMeasurementsPayload(
+        selectedDate,
+        { weight, neck, waist, hips, steps, height, bodyFatPercentage },
+        existingCheckIn
+      );
 
       await saveCheckInMeasurements(measurementData);
 
@@ -683,6 +712,7 @@ export const useCheckInLogic = (currentUserId: string | undefined) => {
     moodNotes,
     moodTags,
     neck,
+    placeholders,
     recentMeasurements,
     selectedDate,
     setBodyFatPercentage,

--- a/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
+++ b/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
@@ -9,7 +9,7 @@ import { calculateFoodEntryNutrition } from '@/utils/nutritionCalculations';
 import { userManagementService } from '@/api/Admin/userManagementService';
 import {
   getMostRecentMeasurement,
-  loadExistingCheckInMeasurements,
+  loadLatestCheckInMeasurements,
 } from '@/api/CheckIn/checkInService';
 import { adaptiveTdeeService } from '@/api/Settings/adaptiveTdeeService';
 import { calculateBmr, BmrAlgorithm } from '@/services/bmrService';
@@ -132,7 +132,7 @@ export const useDailyExerciseStats = (date: string) => {
 export const useDailySteps = (date: string) => {
   return useQuery({
     queryKey: dailyProgressKeys.steps(date),
-    queryFn: () => loadExistingCheckInMeasurements(date),
+    queryFn: () => loadLatestCheckInMeasurements(date),
     enabled: !!date,
     select: (data) => {
       const steps = data?.steps || 0;

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckIn.tsx
@@ -45,6 +45,7 @@ const CheckIn = () => {
     moodNotes,
     moodTags,
     neck,
+    placeholders,
     recentMeasurements,
     selectedDate,
     setBodyFatPercentage,
@@ -128,6 +129,7 @@ const CheckIn = () => {
         hips={hips}
         loading={loading}
         neck={neck}
+        placeholders={placeholders}
         setBodyFatPercentage={setBodyFatPercentage}
         setCustomNotes={setCustomNotes}
         setCustomValues={setCustomValues}

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInForm.tsx
@@ -13,6 +13,37 @@ import { usePreferences } from '@/contexts/PreferencesContext';
 import { useTranslation } from 'react-i18next';
 import { UnitInput } from '@/components/ui/UnitInput';
 import { CustomCategoriesResponse } from '@workspace/shared';
+import { CheckInPlaceholders } from '@/types/checkin';
+import { History } from 'lucide-react';
+
+interface UseLastButtonProps {
+  value: string;
+  lastValue: number | null;
+  onAdopt: (value: string) => void;
+}
+
+// Fills an empty field with the carried-forward value shown in its
+// placeholder, turning it into a real entry for the selected day.
+const UseLastButton: React.FC<UseLastButtonProps> = ({
+  value,
+  lastValue,
+  onAdopt,
+}) => {
+  const { t } = useTranslation();
+  if (value !== '' || lastValue === null) return null;
+  return (
+    <Button
+      type="button"
+      variant="link"
+      size="sm"
+      className="h-7 gap-1.5 p-0 text-xs underline [&_svg]:size-3.5"
+      onClick={() => onAdopt(lastValue.toString())}
+    >
+      <History />
+      {t('checkIn.useLast', 'Use last')}
+    </Button>
+  );
+};
 
 interface CheckInFormProps {
   bodyFatPercentage: string;
@@ -25,6 +56,7 @@ interface CheckInFormProps {
   hips: string;
   loading: boolean;
   neck: string;
+  placeholders: CheckInPlaceholders;
   setBodyFatPercentage: (value: string) => void;
   setCustomNotes: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   setCustomValues: React.Dispatch<React.SetStateAction<Record<string, string>>>;
@@ -53,6 +85,7 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
   hips,
   loading,
   neck,
+  placeholders,
   setBodyFatPercentage,
   setCustomNotes,
   setCustomValues,
@@ -84,12 +117,20 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <Label htmlFor="weight">{t('checkIn.weight', 'Weight')}</Label>
+              <div className="mb-1 flex items-center justify-between">
+                <Label htmlFor="weight">{t('checkIn.weight', 'Weight')}</Label>
+                <UseLastButton
+                  value={weight}
+                  lastValue={placeholders.weight}
+                  onAdopt={setWeight}
+                />
+              </div>
               <UnitInput
                 id="weight"
                 type="weight"
                 unit={defaultWeightUnit}
                 value={weight}
+                placeholderValue={placeholders.weight}
                 onChange={(val) =>
                   setWeight(val !== null ? val.toString() : '')
                 }
@@ -97,12 +138,20 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
             </div>
 
             <div>
-              <Label htmlFor="height">{t('checkIn.height', 'Height')}</Label>
+              <div className="mb-1 flex items-center justify-between">
+                <Label htmlFor="height">{t('checkIn.height', 'Height')}</Label>
+                <UseLastButton
+                  value={height}
+                  lastValue={placeholders.height}
+                  onAdopt={setHeight}
+                />
+              </div>
               <UnitInput
                 id="height"
                 type="height"
                 unit={defaultMeasurementUnit}
                 value={height}
+                placeholderValue={placeholders.height}
                 onChange={(val) =>
                   setHeight(val !== null ? val.toString() : '')
                 }
@@ -123,66 +172,100 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
             </div>
 
             <div>
-              <Label htmlFor="neck">{t('checkIn.neck', 'Neck')}</Label>
+              <div className="mb-1 flex items-center justify-between">
+                <Label htmlFor="neck">{t('checkIn.neck', 'Neck')}</Label>
+                <UseLastButton
+                  value={neck}
+                  lastValue={placeholders.neck}
+                  onAdopt={setNeck}
+                />
+              </div>
               <UnitInput
                 id="neck"
                 type="measurement"
                 unit={defaultMeasurementUnit}
                 value={neck}
+                placeholderValue={placeholders.neck}
                 onChange={(val) => setNeck(val !== null ? val.toString() : '')}
               />
             </div>
 
             <div>
-              <Label htmlFor="waist">{t('checkIn.waist', 'Waist')}</Label>
+              <div className="mb-1 flex items-center justify-between">
+                <Label htmlFor="waist">{t('checkIn.waist', 'Waist')}</Label>
+                <UseLastButton
+                  value={waist}
+                  lastValue={placeholders.waist}
+                  onAdopt={setWaist}
+                />
+              </div>
               <UnitInput
                 id="waist"
                 type="measurement"
                 unit={defaultMeasurementUnit}
                 value={waist}
+                placeholderValue={placeholders.waist}
                 onChange={(val) => setWaist(val !== null ? val.toString() : '')}
               />
             </div>
 
             <div>
-              <Label htmlFor="hips">{t('checkIn.hips', 'Hips')}</Label>
+              <div className="mb-1 flex items-center justify-between">
+                <Label htmlFor="hips">{t('checkIn.hips', 'Hips')}</Label>
+                <UseLastButton
+                  value={hips}
+                  lastValue={placeholders.hips}
+                  onAdopt={setHips}
+                />
+              </div>
               <UnitInput
                 id="hips"
                 type="measurement"
                 unit={defaultMeasurementUnit}
                 value={hips}
+                placeholderValue={placeholders.hips}
                 onChange={(val) => setHips(val !== null ? val.toString() : '')}
               />
             </div>
             <div>
-              <div className="flex items-center justify-between">
-                <Label htmlFor="bodyFat">
+              <div className="mb-1 flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+                <Label htmlFor="bodyFat" className="whitespace-nowrap">
                   {t('checkIn.bodyFatPercentage', 'Body Fat %')}
                 </Label>
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div className="flex items-center space-x-2 mb-2">
-                        <Switch
-                          id="use-most-recent-toggle"
-                          checked={useMostRecentForCalculation}
-                          onCheckedChange={setUseMostRecentForCalculation}
-                        />
-                        <Label htmlFor="use-most-recent-toggle">
-                          {t('checkIn.useRecent', 'Use Recent')}
-                        </Label>
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>
-                        {t(
-                          'checkIn.useMostRecentForCalculation',
-                          'Use most recent Weight, Height, Waist, Neck, and Hips for body fat calculation'
-                        )}
-                      </p>
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
+                <div className="ml-auto flex flex-wrap items-center justify-end gap-x-3 gap-y-1">
+                  <UseLastButton
+                    value={bodyFatPercentage}
+                    lastValue={placeholders.bodyFatPercentage}
+                    onAdopt={setBodyFatPercentage}
+                  />
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div className="flex items-center space-x-2">
+                          <Switch
+                            id="use-most-recent-toggle"
+                            checked={useMostRecentForCalculation}
+                            onCheckedChange={setUseMostRecentForCalculation}
+                          />
+                          <Label
+                            htmlFor="use-most-recent-toggle"
+                            className="whitespace-nowrap"
+                          >
+                            {t('checkIn.useRecent', 'Use Recent')}
+                          </Label>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>
+                          {t(
+                            'checkIn.useMostRecentForCalculation',
+                            'Use most recent Weight, Height, Waist, Neck, and Hips for body fat calculation'
+                          )}
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </div>
               </div>
               <div className="flex items-center">
                 <Input
@@ -191,10 +274,14 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
                   step="0.1"
                   value={bodyFatPercentage}
                   onChange={(e) => setBodyFatPercentage(e.target.value)}
-                  placeholder={t(
-                    'checkIn.enterBodyFatPercentage',
-                    'Enter body fat percentage'
-                  )}
+                  placeholder={
+                    placeholders.bodyFatPercentage !== null
+                      ? placeholders.bodyFatPercentage.toString()
+                      : t(
+                          'checkIn.enterBodyFatPercentage',
+                          'Enter body fat percentage'
+                        )
+                  }
                 />
                 <Button
                   type="button"

--- a/SparkyFitnessFrontend/src/pages/Cycle/DailyLogPanel.tsx
+++ b/SparkyFitnessFrontend/src/pages/Cycle/DailyLogPanel.tsx
@@ -33,7 +33,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import IntercourseLog from './ttc/IntercourseLog';
 import CervicalPositionPicker from './ttc/CervicalPositionPicker';
-import { useExistingCheckInMeasurements } from '@/hooks/CheckIn/useCheckIn';
+import { useLatestCheckInMeasurements } from '@/hooks/CheckIn/useCheckIn';
 import { useSleepEntriesQuery } from '@/hooks/CheckIn/useSleep';
 import { useWaterIntakeQuery } from '@/hooks/Diary/useWaterIntake';
 
@@ -77,7 +77,7 @@ export default function DailyLogPanel(props: DailyLogPanelProps) {
   const { data: settings } = useCycleSettings();
   const isTtc = settings?.mode === 'ttc';
 
-  const checkInQuery = useExistingCheckInMeasurements(date);
+  const checkInQuery = useLatestCheckInMeasurements(date);
   const sleepQuery = useSleepEntriesQuery(date, date);
   const waterQuery = useWaterIntakeQuery(date);
 

--- a/SparkyFitnessFrontend/src/tests/components/CheckInForm.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/CheckInForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { CheckInForm } from '@/pages/CheckIn/CheckInForm';
 
@@ -15,6 +15,15 @@ jest.mock('@/contexts/PreferencesContext', () => ({
   }),
 }));
 
+const emptyPlaceholders = {
+  weight: null,
+  neck: null,
+  waist: null,
+  hips: null,
+  height: null,
+  bodyFatPercentage: null,
+};
+
 const defaultProps = {
   bodyFatPercentage: '',
   customCategories: [],
@@ -26,6 +35,7 @@ const defaultProps = {
   hips: '',
   loading: false,
   neck: '',
+  placeholders: emptyPlaceholders,
   setBodyFatPercentage: jest.fn(),
   setCustomNotes: jest.fn(),
   setCustomValues: jest.fn(),
@@ -51,5 +61,70 @@ describe('CheckInForm', () => {
 
     expect(heightInput).toBeInTheDocument();
     expect(heightInput).toHaveValue(180);
+  });
+
+  it('shows carried-forward values as placeholders, not input values', () => {
+    render(
+      <CheckInForm
+        {...defaultProps}
+        weight=""
+        placeholders={{ ...emptyPlaceholders, weight: 82.5 }}
+      />
+    );
+
+    const weightInput = screen.getByLabelText('Weight');
+
+    expect(weightInput).toHaveValue(null);
+    expect(weightInput).toHaveAttribute('placeholder', '82.5');
+  });
+
+  it('prefers the entered value over the placeholder', () => {
+    render(
+      <CheckInForm
+        {...defaultProps}
+        weight="80"
+        placeholders={{ ...emptyPlaceholders, weight: 82.5 }}
+      />
+    );
+
+    expect(screen.getByLabelText('Weight')).toHaveValue(80);
+  });
+
+  it('adopts the carried-forward value when "Use last" is clicked', () => {
+    const setWeight = jest.fn();
+    render(
+      <CheckInForm
+        {...defaultProps}
+        weight=""
+        placeholders={{ ...emptyPlaceholders, weight: 82.5 }}
+        setWeight={setWeight}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use last' }));
+
+    expect(setWeight).toHaveBeenCalledWith('82.5');
+  });
+
+  it('hides "Use last" when the field already has a value', () => {
+    render(
+      <CheckInForm
+        {...defaultProps}
+        weight="80"
+        placeholders={{ ...emptyPlaceholders, weight: 82.5 }}
+      />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Use last' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides "Use last" when there is no carried-forward value', () => {
+    render(<CheckInForm {...defaultProps} weight="" />);
+
+    expect(
+      screen.queryByRole('button', { name: 'Use last' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/SparkyFitnessFrontend/src/tests/hooks/buildCheckInMeasurementsPayload.test.ts
+++ b/SparkyFitnessFrontend/src/tests/hooks/buildCheckInMeasurementsPayload.test.ts
@@ -1,0 +1,104 @@
+// Break the transitive import of better-auth (ESM-only), which Jest cannot
+// parse; the function under test is pure and never touches these modules.
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+jest.mock('@/contexts/PreferencesContext', () => ({
+  usePreferences: () => ({}),
+}));
+
+import { buildCheckInMeasurementsPayload } from '@/hooks/CheckIn/useCheckInLogic';
+import { CheckInMeasurementsResponse } from '@workspace/shared';
+
+const emptyForm = {
+  weight: '',
+  neck: '',
+  waist: '',
+  hips: '',
+  steps: '',
+  height: '',
+  bodyFatPercentage: '',
+};
+
+const dayRecord = (
+  overrides: Partial<CheckInMeasurementsResponse>
+): CheckInMeasurementsResponse => ({
+  id: 'record-1',
+  user_id: 'user-1',
+  entry_date: '2026-07-14',
+  weight: null,
+  neck: null,
+  waist: null,
+  hips: null,
+  steps: null,
+  height: null,
+  body_fat_percentage: null,
+  created_by_user_id: 'user-1',
+  updated_by_user_id: 'user-1',
+  updated_at: '2026-07-14T00:00:00Z',
+  ...overrides,
+});
+
+describe('buildCheckInMeasurementsPayload', () => {
+  it('omits fields with no input and nothing recorded on the day', () => {
+    const payload = buildCheckInMeasurementsPayload(
+      '2026-07-14',
+      { ...emptyForm, weight: '80.5' },
+      null
+    );
+
+    expect(payload).toEqual({ entry_date: '2026-07-14', weight: 80.5 });
+  });
+
+  it('omits untouched empty fields even when other fields are recorded on the day', () => {
+    const payload = buildCheckInMeasurementsPayload(
+      '2026-07-14',
+      { ...emptyForm, weight: '80.5' },
+      dayRecord({ weight: 81 })
+    );
+
+    expect(payload).toEqual({ entry_date: '2026-07-14', weight: 80.5 });
+    expect(payload).not.toHaveProperty('waist');
+    expect(payload).not.toHaveProperty('height');
+  });
+
+  it('clears a field recorded on the day when the user empties it', () => {
+    const payload = buildCheckInMeasurementsPayload(
+      '2026-07-14',
+      emptyForm,
+      dayRecord({ waist: 90 })
+    );
+
+    expect(payload).toEqual({ entry_date: '2026-07-14', waist: null });
+  });
+
+  it('parses steps as an integer', () => {
+    const payload = buildCheckInMeasurementsPayload(
+      '2026-07-14',
+      { ...emptyForm, steps: '10500' },
+      null
+    );
+
+    expect(payload).toEqual({ entry_date: '2026-07-14', steps: 10500 });
+  });
+
+  it('treats whitespace-only input as empty', () => {
+    const payload = buildCheckInMeasurementsPayload(
+      '2026-07-14',
+      { ...emptyForm, neck: '   ' },
+      null
+    );
+
+    expect(payload).toEqual({ entry_date: '2026-07-14' });
+  });
+
+  it('omits unparseable input instead of clearing the recorded value', () => {
+    const payload = buildCheckInMeasurementsPayload(
+      '2026-07-14',
+      { ...emptyForm, weight: 'abc' },
+      dayRecord({ weight: 81 })
+    );
+
+    expect(payload).toEqual({ entry_date: '2026-07-14' });
+  });
+});

--- a/SparkyFitnessFrontend/src/types/checkin.ts
+++ b/SparkyFitnessFrontend/src/types/checkin.ts
@@ -1,5 +1,16 @@
 import { CustomCategoriesResponse } from '@workspace/shared';
 
+// Latest recorded value per standard measurement (metric), shown as input
+// placeholders on the check-in form.
+export interface CheckInPlaceholders {
+  weight: number | null;
+  neck: number | null;
+  waist: number | null;
+  hips: number | null;
+  height: number | null;
+  bodyFatPercentage: number | null;
+}
+
 export interface CombinedMeasurement {
   id: string;
   entry_date: string;


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
The web check in measurements form prefilled every field with values from previous days and resubmitted all of them, this repeated the measurements on the day. Clearing the field was ignored making values impossible to remove.

**How did you implement the solution?**
It now loads only the measurements from the actual day and shows previous values that are carried forward as placeholders with a per field 'Use last" button to automatically fill out the field with the previous value. The form also now clears fields that weree emptied. This matches the mobile design. Only touched front end.

Linked Issue: Closes #1824 #1823 #1825

## How to Test

1. Go to meaasurements in web front end
2. Click "Use last"

## PR Type

- [x] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots
<img width="640" height="82" alt="image" src="https://github.com/user-attachments/assets/ddabf911-b93f-43e0-9284-7ed6057c0f5b" />

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
