### PR TITLE
fix(yazio): add country/language matching user language

### DIFF
--- a/SparkyFitnessServer/integrations/yazio/yazioService.ts
+++ b/SparkyFitnessServer/integrations/yazio/yazioService.ts
@@ -74,9 +74,6 @@ const YAZIO_LOCALES: Record<
 };
 
 function resolveLanguage(lang: string | null | undefined): string | null {
-  if (lang === undefined || lang === null) {
-    return null;
-  }
   if (typeof lang !== 'string') {
     return null;
   }

--- a/SparkyFitnessServer/integrations/yazio/yazioService.ts
+++ b/SparkyFitnessServer/integrations/yazio/yazioService.ts
@@ -50,6 +50,38 @@ interface YazioCredentials {
   clientId?: string;
   clientSecret?: string;
   baseUrl?: string | null;
+  language?: string;
+}
+
+const SUPPORTED_LANGUAGES = ['en', 'de', 'fr'];
+
+const YAZIO_LOCALES: Record<
+  string,
+  { countries: string[]; locales: string[] }
+> = {
+  de: {
+    countries: ['DE', 'AT', 'CH'],
+    locales: ['de_DE'],
+  },
+  fr: {
+    countries: ['FR', 'BE', 'CH'],
+    locales: ['fr_FR', 'fr_BE'],
+  },
+  en: {
+    countries: ['US', 'GB', 'CA', 'AU'],
+    locales: ['en_US', 'en_GB'],
+  },
+};
+
+function resolveLanguage(lang: string | null | undefined): string | null {
+  if (lang === undefined || lang === null) {
+    return null;
+  }
+  if (typeof lang !== 'string') {
+    return null;
+  }
+  const normalized = lang.trim().toLowerCase().slice(0, 2);
+  return SUPPORTED_LANGUAGES.includes(normalized) ? normalized : null;
 }
 
 interface YazioSearchOptions extends YazioCredentials {
@@ -610,11 +642,21 @@ async function searchRawYazioProducts(
   query: string,
   options: YazioSearchOptions
 ) {
+  const resolvedLang = resolveLanguage(options.language);
+  const resolvedLocales = resolvedLang ? YAZIO_LOCALES[resolvedLang] : null;
+
+  const defaultCountries = ['DE', 'AT', 'CH', 'US', 'FR'];
+  const defaultLocales = ['de_DE', 'en_US', 'fr_FR'];
+
+  const countries =
+    options.countries ?? resolvedLocales?.countries ?? defaultCountries;
+  const locales = options.locales ?? resolvedLocales?.locales ?? defaultLocales;
+
   const params = new URLSearchParams({
     query,
     sex: 'male',
-    countries: (options.countries ?? ['DE', 'AT', 'CH', 'US', 'FR']).join(','),
-    locales: (options.locales ?? ['de_DE', 'en_US', 'fr_FR']).join(','),
+    countries: countries.join(','),
+    locales: locales.join(','),
   });
 
   const data = await yazioFetch<YazioProductSearchResult[]>(

--- a/SparkyFitnessServer/routes/v2/foodRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/foodRoutes.ts
@@ -401,6 +401,7 @@ const detailHandler: RequestHandler<{
           username: credentials.app_id,
           password: credentials.app_key,
           baseUrl: credentials.base_url,
+          language,
         });
         break;
       }

--- a/SparkyFitnessServer/services/externalFoodSearchService.ts
+++ b/SparkyFitnessServer/services/externalFoodSearchService.ts
@@ -406,6 +406,7 @@ export async function searchProviderFoods(
         baseUrl: credentials.base_url,
         page,
         pageSize,
+        language,
       });
       foods = result.foods || [];
       pagination = result.pagination;

--- a/SparkyFitnessServer/services/foodCoreService.ts
+++ b/SparkyFitnessServer/services/foodCoreService.ts
@@ -944,6 +944,7 @@ async function lookupBarcode(barcode: any, userId: any, providerId: any) {
           username: provider.app_id,
           password: provider.app_key,
           baseUrl: provider.base_url,
+          language,
         });
         if (yazioFood) {
           return {

--- a/SparkyFitnessServer/tests/yazioService.test.ts
+++ b/SparkyFitnessServer/tests/yazioService.test.ts
@@ -682,24 +682,15 @@ describe('yazioService', () => {
   });
 
   describe('localization', () => {
-    const product = {
-      product_id: 'localized-product',
-      name: 'Localized Product',
-      serving_quantity: 100,
-      base_unit: 'g',
-      nutrients: { 'energy.energy': 1 },
-    };
-
     beforeEach(() => {
       vi.mocked(global.fetch)
         .mockResolvedValueOnce(
           makeFetchResponse({ access_token: 'local-token', expires_in: 3600 })
         )
-        .mockResolvedValue(makeFetchResponse([product]));
+        .mockResolvedValue(makeFetchResponse([]));
     });
 
-    it('resolves languages or falls back to default/English', async () => {
-      // 1. No language -> defaults to multi-country list
+    it('defaults to multi-country list when no language is specified', async () => {
       await searchYazioFoods('test', { ...yazioClientCredentials });
       expect(global.fetch).toHaveBeenLastCalledWith(
         expect.stringContaining(
@@ -707,8 +698,9 @@ describe('yazioService', () => {
         ),
         expect.any(Object)
       );
+    });
 
-      // 2. Supported language -> de
+    it('resolves supported languages to specific countries and locales', async () => {
       await searchYazioFoods('test', {
         ...yazioClientCredentials,
         language: 'de',
@@ -717,8 +709,9 @@ describe('yazioService', () => {
         expect.stringContaining('countries=DE%2CAT%2CCH&locales=de_DE'),
         expect.any(Object)
       );
+    });
 
-      // 3. Unsupported language -> falls back to multi-country default list
+    it('falls back to default country list when language is unsupported', async () => {
       await searchYazioFoods('test', {
         ...yazioClientCredentials,
         language: 'es',

--- a/SparkyFitnessServer/tests/yazioService.test.ts
+++ b/SparkyFitnessServer/tests/yazioService.test.ts
@@ -680,4 +680,69 @@ describe('yazioService', () => {
 
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  describe('localization', () => {
+    const product = {
+      product_id: 'localized-product',
+      name: 'Localized Product',
+      serving_quantity: 100,
+      base_unit: 'g',
+      nutrients: { 'energy.energy': 1 },
+    };
+
+    beforeEach(() => {
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce(
+          makeFetchResponse({ access_token: 'local-token', expires_in: 3600 })
+        )
+        .mockResolvedValue(makeFetchResponse([product]));
+    });
+
+    it('resolves languages or falls back to default/English', async () => {
+      // 1. No language -> defaults to multi-country list
+      await searchYazioFoods('test', { ...yazioClientCredentials });
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining(
+          'countries=DE%2CAT%2CCH%2CUS%2CFR&locales=de_DE%2Cen_US%2Cfr_FR'
+        ),
+        expect.any(Object)
+      );
+
+      // 2. Supported language -> de
+      await searchYazioFoods('test', {
+        ...yazioClientCredentials,
+        language: 'de',
+      });
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining('countries=DE%2CAT%2CCH&locales=de_DE'),
+        expect.any(Object)
+      );
+
+      // 3. Unsupported language -> falls back to multi-country default list
+      await searchYazioFoods('test', {
+        ...yazioClientCredentials,
+        language: 'es',
+      });
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining(
+          'countries=DE%2CAT%2CCH%2CUS%2CFR&locales=de_DE%2Cen_US%2Cfr_FR'
+        ),
+        expect.any(Object)
+      );
+    });
+
+    it('allows overriding countries and locales', async () => {
+      await searchYazioFoods('test', {
+        ...yazioClientCredentials,
+        language: 'fr',
+        countries: ['JP'],
+        locales: ['ja_JP'],
+      });
+
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining('countries=JP&locales=ja_JP'),
+        expect.any(Object)
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Like the Swiss food database, match the user localisation for YAZIO researchs. 
Yazio seems to support a lot of country/language but i didn't found a exhaustive list so I support only FR/DE/EN.
Fallback to all results if language is not supported.

**How did you implement the solution?**
I did exactly like the Swiss food DB implementation.

## PR Type

- [X] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [X] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [X] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [X] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [X] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.
