### PR TITLE
group synced workouts into preset sessions and map missing fields

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Diary/ExerciseCard.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/ExerciseCard.tsx
@@ -361,10 +361,14 @@ const ExerciseCard = ({
         // Duration & Sets
         if (entry.sets && entry.sets.length > 0) {
           setsCount += entry.sets.length;
-          duration += entry.sets.reduce<number>(
+          const setsDuration = entry.sets.reduce<number>(
             (sum, set) => sum + (set.duration || 0) + (set.rest_time || 0) / 60,
             0
           );
+          // Fall back to the entry-level duration when the sets carry no
+          // per-set timers (e.g. rep-based sets synced from Hevy).
+          duration +=
+            setsDuration > 0 ? setsDuration : entry.duration_minutes || 0;
         } else if (entry.duration_minutes) {
           duration += entry.duration_minutes;
         }

--- a/SparkyFitnessFrontend/src/pages/Diary/ExerciseEntryDisplay.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/ExerciseEntryDisplay.tsx
@@ -90,13 +90,18 @@ const ExerciseEntryDisplay: React.FC<ExerciseEntryDisplayProps> = ({
 
   const isActiveCalories = snapshot?.name === 'Active Calories';
 
-  const durationDisplay = formatMinutesToHHMM(
+  const setsDuration =
     exerciseEntry.sets && exerciseEntry.sets.length > 0
       ? exerciseEntry.sets.reduce(
           (sum, set) => sum + (set.duration || 0) + (set.rest_time || 0) / 60,
           0
         )
-      : exerciseEntry.duration_minutes || 0
+      : 0;
+  // Sets carry their own timers (planks, holds, rest). When those sum to 0
+  // (e.g. pure rep-based sets synced from Hevy), fall back to the entry-level
+  // duration_minutes so the workout's session time still surfaces.
+  const durationDisplay = formatMinutesToHHMM(
+    setsDuration > 0 ? setsDuration : exerciseEntry.duration_minutes || 0
   );
 
   const caloriesDisplay = `${Math.round(convertEnergy(exerciseEntry.calories_burned || 0, 'kcal', energyUnit))} ${getEnergyUnitString(energyUnit)}`;

--- a/SparkyFitnessFrontend/src/pages/Diary/ExercisePresetEntryDisplay.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/ExercisePresetEntryDisplay.tsx
@@ -67,17 +67,18 @@ const ExercisePresetEntryDisplay: React.FC<ExercisePresetEntryDisplayProps> = ({
     ) ?? 0;
 
   const totalMinutes =
-    presetEntry.exercises?.reduce(
-      (sum, ex) =>
-        sum +
-        (ex.sets && ex.sets.length > 0
+    presetEntry.exercises?.reduce((sum, ex) => {
+      const setsDuration =
+        ex.sets && ex.sets.length > 0
           ? ex.sets.reduce(
               (s, set) => s + (set.duration || 0) + (set.rest_time || 0) / 60,
               0
             )
-          : ex.duration_minutes || 0),
-      0
-    ) ?? 0;
+          : 0;
+      // Fall back to the entry-level duration when the sets carry no per-set
+      // timers (e.g. rep-based sets synced from Hevy).
+      return sum + (setsDuration > 0 ? setsDuration : ex.duration_minutes || 0);
+    }, 0) ?? 0;
 
   const avgHR = (() => {
     const withHR =

--- a/SparkyFitnessServer/integrations/hevy/hevyDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/hevy/hevyDataProcessor.ts
@@ -10,19 +10,76 @@ import {
   instantToDay,
   instantHourMinute,
 } from '@workspace/shared';
+
+/** A single set within a Hevy exercise. */
+interface HevySet {
+  index: number;
+  type: string;
+  weight_kg: number | null;
+  reps: number | null;
+  distance_meters: number | null;
+  duration_seconds: number | null;
+  rpe: number | null;
+  custom_metric?: number | null;
+}
+
+/** One exercise within a Hevy workout. */
+interface HevyExercise {
+  index: number;
+  title: string;
+  notes?: string | null;
+  exercise_template_id?: string | null;
+  superset_id?: string | number | null;
+  sets?: HevySet[] | null;
+}
+
+/** A logged Hevy workout (one session). */
+interface HevyWorkout {
+  id: string;
+  title: string;
+  routine_id?: string | null;
+  description?: string | null;
+  start_time: string;
+  end_time: string;
+  updated_at?: string | null;
+  created_at?: string | null;
+  exercises?: HevyExercise[] | null;
+}
+
+/** The Hevy user-info payload we read body metrics from. */
+interface HevyUserInfoResponse {
+  user?: {
+    weight_kg?: number | null;
+    height_cm?: number | null;
+    updated_at?: string | null;
+  } | null;
+}
+
+/** Minimal shapes for the repository rows we consume by id. */
+interface ExerciseRow {
+  id: string;
+}
+interface WorkoutPresetRow {
+  id: number;
+}
+interface PresetEntryRow {
+  id: string;
+}
+interface ExerciseEntryRow {
+  id: string;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Process Hevy user info to sync measurements.
- * @param {string} userId - The Sparky Fitness user ID.
- * @param {string} createdByUserId - The user ID who triggered the sync.
- * @param {Object} data - The Hevy user info response.
  */
 async function processHevyUserInfo(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  createdByUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: any,
+  userId: string,
+  createdByUserId: string,
+  data: HevyUserInfoResponse | null | undefined,
   timezone = 'UTC'
 ) {
   if (!data || !data.user) return;
@@ -31,10 +88,8 @@ async function processHevyUserInfo(
     ? updated_at.split('T')[0]
     : todayInZone(timezone);
   try {
-    const measurements = {};
-    // @ts-expect-error TS(2339): Property 'weight' does not exist on type '{}'.
+    const measurements: { weight?: number; height?: number } = {};
     if (weight_kg) measurements.weight = weight_kg;
-    // @ts-expect-error TS(2339): Property 'height' does not exist on type '{}'.
     if (height_cm) measurements.height = height_cm;
     if (Object.keys(measurements).length > 0) {
       await measurementRepository.upsertCheckInMeasurements(
@@ -51,24 +106,18 @@ async function processHevyUserInfo(
   } catch (error) {
     log(
       'error',
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      `Failed to sync Hevy user measurements for user ${userId}: ${error.message}`
+      `Failed to sync Hevy user measurements for user ${userId}: ${errorMessage(error)}`
     );
   }
 }
+
 /**
  * Process a list of workouts from Hevy.
- * @param {string} userId - The Sparky Fitness user ID.
- * @param {string} createdByUserId - The user ID who triggered the sync.
- * @param {Array} workouts - The list of Hevy workouts.
  */
 async function processHevyWorkouts(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  createdByUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  workouts: any,
+  userId: string,
+  createdByUserId: string,
+  workouts: HevyWorkout[],
   timezone = 'UTC'
 ) {
   log(
@@ -81,9 +130,8 @@ async function processHevyWorkouts(
   // to Hevy-sourced entries. Preset templates (workout_presets) are intentionally
   // left intact and reused across occurrences.
   if (workouts.length > 0) {
-    const entryDates: string[] = workouts.map(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (w: any) => instantToDay(new Date(w.start_time), timezone)
+    const entryDates = workouts.map((w) =>
+      instantToDay(new Date(w.start_time), timezone)
     );
     const startDate = entryDates.reduce((a, b) => (a < b ? a : b));
     const endDate = entryDates.reduce((a, b) => (a > b ? a : b));
@@ -103,8 +151,7 @@ async function processHevyWorkouts(
     } catch (error) {
       log(
         'error',
-        // @ts-expect-error TS(2571): Object is of type 'unknown'.
-        `Failed to clear existing Hevy data before re-sync for user ${userId}: ${error.message}`
+        `Failed to clear existing Hevy data before re-sync for user ${userId}: ${errorMessage(error)}`
       );
     }
   }
@@ -127,25 +174,19 @@ async function processHevyWorkouts(
     } catch (error) {
       log(
         'error',
-        // @ts-expect-error TS(2571): Object is of type 'unknown'.
-        `Failed to process Hevy workout ${workout.id}: ${error.message}`
+        `Failed to process Hevy workout ${workout.id}: ${errorMessage(error)}`
       );
     }
   }
 }
+
 /**
  * Process a single workout from Hevy.
- * @param {string} userId - The Sparky Fitness user ID.
- * @param {string} createdByUserId - The user ID who triggered the sync.
- * @param {Object} workout - The Hevy workout object.
  */
 async function processSingleWorkout(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  createdByUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  workout: any,
+  userId: string,
+  createdByUserId: string,
+  workout: HevyWorkout,
   timezone = 'UTC'
 ) {
   const startTime = new Date(workout.start_time);
@@ -166,10 +207,8 @@ async function processSingleWorkout(
   // name to mirror Garmin. Then create one preset entry — the logged session —
   // that every exercise in this workout attaches to, so the diary shows the
   // whole workout as a single "Vid plan A" group instead of loose exercises.
-  let workoutPreset = await workoutPresetRepository.getWorkoutPresetByName(
-    userId,
-    workout.title
-  );
+  let workoutPreset: WorkoutPresetRow | null =
+    await workoutPresetRepository.getWorkoutPresetByName(userId, workout.title);
   if (!workoutPreset) {
     workoutPreset = await workoutPresetRepository.createWorkoutPreset({
       user_id: userId,
@@ -179,7 +218,12 @@ async function processSingleWorkout(
       is_public: false,
     });
   }
-  const presetEntry =
+  if (!workoutPreset) {
+    throw new Error(
+      `Failed to find or create workout preset for "${workout.title}"`
+    );
+  }
+  const presetEntry: PresetEntryRow =
     await exercisePresetEntryRepository.createExercisePresetEntry(
       userId,
       {
@@ -195,17 +239,24 @@ async function processSingleWorkout(
       },
       createdByUserId
     );
+
+  // Hevy identifies supersets by an opaque id; the DB stores superset_group as a
+  // per-workout integer. Assign each distinct Hevy superset id a stable number
+  // within this workout so grouped exercises share a value.
+  const supersetGroupByHevyId = new Map<string, number>();
+  const exercises = workout.exercises ?? [];
   for (
     let exerciseIndex = 0;
-    exerciseIndex < workout.exercises.length;
+    exerciseIndex < exercises.length;
     exerciseIndex++
   ) {
-    const hevyExercise = workout.exercises[exerciseIndex];
+    const hevyExercise = exercises[exerciseIndex]!;
     // 1. Find or create exercise template
-    let exercise = await exerciseRepository.findExerciseByNameAndUserId(
-      hevyExercise.title,
-      userId
-    );
+    let exercise: ExerciseRow | null =
+      await exerciseRepository.findExerciseByNameAndUserId(
+        hevyExercise.title,
+        userId
+      );
     if (!exercise) {
       exercise = await exerciseRepository.createExercise(
         {
@@ -215,19 +266,25 @@ async function processSingleWorkout(
           is_custom: true,
           shared_with_public: false,
         },
-        // @ts-expect-error TS(2554): Expected 1 arguments, but got 2.
+        // @ts-expect-error TS(2554): repository accepts createdByUserId at runtime
         createdByUserId
       );
     }
+    if (!exercise) {
+      log(
+        'error',
+        `Failed to find or create Hevy exercise "${hevyExercise.title}"`
+      );
+      continue;
+    }
+    const sets = hevyExercise.sets ?? [];
     // Hevy has no per-exercise duration; it only reports whole-workout
     // start/end. When an exercise's sets carry real per-set durations (timed
     // exercises), use their sum. Otherwise attribute the whole-workout
     // duration to the first exercise only (and 0 to the rest) so daily
     // exercise-minute totals aren't multiplied by the number of exercises.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const setDurationSeconds = hevyExercise.sets.reduce(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (sum: number, set: any) => sum + (set.duration_seconds || 0),
+    const setDurationSeconds = sets.reduce(
+      (sum, set) => sum + (set.duration_seconds || 0),
       0
     );
     const durationMinutes =
@@ -237,12 +294,22 @@ async function processSingleWorkout(
           ? workoutDurationMinutes
           : 0;
     // Sum any per-set distances (meters) Hevy reports; null when none.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const distanceMeters = hevyExercise.sets.reduce(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (sum: number, set: any) => sum + (set.distance_meters || 0),
+    const distanceMeters = sets.reduce(
+      (sum, set) => sum + (set.distance_meters || 0),
       0
     );
+    // Map the Hevy superset id to a numeric per-workout group.
+    let supersetGroup: number | null = null;
+    if (
+      hevyExercise.superset_id !== null &&
+      hevyExercise.superset_id !== undefined
+    ) {
+      const key = String(hevyExercise.superset_id);
+      if (!supersetGroupByHevyId.has(key)) {
+        supersetGroupByHevyId.set(key, supersetGroupByHevyId.size + 1);
+      }
+      supersetGroup = supersetGroupByHevyId.get(key)!;
+    }
     // Stable per-exercise identity so re-syncs update in place instead of
     // duplicating. Hevy workout ids are unique; exercise index is unique
     // within a workout.
@@ -255,7 +322,7 @@ async function processSingleWorkout(
       duration_minutes: durationMinutes,
       calories_burned: 0, // Hevy typically doesn't provide per-exercise calories
       distance: distanceMeters > 0 ? distanceMeters : null,
-      superset_group: hevyExercise.superset_id ?? null,
+      superset_group: supersetGroup,
       source_id: sourceId,
       exercise_preset_entry_id: presetEntry.id,
       notes:
@@ -264,8 +331,7 @@ async function processSingleWorkout(
         `Synced from Hevy: ${workout.title}`,
       entry_source: 'Hevy',
       sort_order: hevyExercise.index,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      sets: hevyExercise.sets.map((set: any) => ({
+      sets: sets.map((set) => ({
         set_number: set.index + 1,
         set_type: mapSetType(set.type),
         weight: set.weight_kg,
@@ -278,13 +344,14 @@ async function processSingleWorkout(
     };
     // 3. Create the exercise entry, linked to the session (preset entry) via
     // the 5th argument so it groups under the workout instead of standing alone.
-    const entry = await exerciseEntryRepository.createExerciseEntry(
-      userId,
-      entryData,
-      createdByUserId,
-      'Hevy',
-      presetEntry.id
-    );
+    const entry: ExerciseEntryRow | null =
+      await exerciseEntryRepository.createExerciseEntry(
+        userId,
+        entryData,
+        createdByUserId,
+        'Hevy',
+        presetEntry.id
+      );
     // 4. Populate the reusable preset template with this exercise. Reuses the
     // existing exercise row when present and skips if it already has sets, so
     // repeat occurrences of the same routine don't duplicate template rows.
@@ -300,8 +367,7 @@ async function processSingleWorkout(
     } catch (error) {
       log(
         'error',
-        // @ts-expect-error TS(2571): Object is of type 'unknown'.
-        `Failed to add Hevy exercise to workout preset ${workoutPreset.id}: ${error.message}`
+        `Failed to add Hevy exercise to workout preset ${workoutPreset.id}: ${errorMessage(error)}`
       );
     }
     // 5. Stash the full raw Hevy payload as an activity detail (like Garmin),
@@ -332,27 +398,23 @@ async function processSingleWorkout(
       } catch (error) {
         log(
           'error',
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          `Failed to store Hevy activity detail for entry ${entry.id}: ${error.message}`
+          `Failed to store Hevy activity detail for entry ${entry.id}: ${errorMessage(error)}`
         );
       }
     }
   }
 }
+
 /**
  * Map Hevy set types to Sparky Fitness set types.
- * @param {string} hevyType - Hevy set type (normal, warm_up, drop_set, failure).
- * @returns {string} - Sparky Fitness set type.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mapSetType(hevyType: any) {
-  const mapping = {
+function mapSetType(hevyType: string): string {
+  const mapping: Record<string, string> = {
     normal: 'Working Set',
     warm_up: 'Warm-up',
     drop_set: 'Drop Set',
     failure: 'To Failure',
   };
-  // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
   return mapping[hevyType] || 'Working Set';
 }
 export { processHevyUserInfo };

--- a/SparkyFitnessServer/integrations/hevy/hevyDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/hevy/hevyDataProcessor.ts
@@ -1,8 +1,15 @@
 import exerciseEntryRepository from '../../models/exerciseEntry.js';
 import exerciseRepository from '../../models/exercise.js';
 import measurementRepository from '../../models/measurementRepository.js';
+import activityDetailsRepository from '../../models/activityDetailsRepository.js';
+import workoutPresetRepository from '../../models/workoutPresetRepository.js';
+import exercisePresetEntryRepository from '../../models/exercisePresetEntryRepository.js';
 import { log } from '../../config/logging.js';
-import { todayInZone, instantToDay } from '@workspace/shared';
+import {
+  todayInZone,
+  instantToDay,
+  instantHourMinute,
+} from '@workspace/shared';
 /**
  * Process Hevy user info to sync measurements.
  * @param {string} userId - The Sparky Fitness user ID.
@@ -68,6 +75,39 @@ async function processHevyWorkouts(
     'info',
     `Processing ${workouts.length} Hevy workouts for user ${userId}...`
   );
+  // Mirror the Garmin re-sync model: before rebuilding, clear any existing Hevy
+  // sessions and exercise entries in the synced date range. This keeps re-syncs
+  // idempotent (workouts don't duplicate) at the cost of overwriting local edits
+  // to Hevy-sourced entries. Preset templates (workout_presets) are intentionally
+  // left intact and reused across occurrences.
+  if (workouts.length > 0) {
+    const entryDates: string[] = workouts.map(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (w: any) => instantToDay(new Date(w.start_time), timezone)
+    );
+    const startDate = entryDates.reduce((a, b) => (a < b ? a : b));
+    const endDate = entryDates.reduce((a, b) => (a > b ? a : b));
+    try {
+      await exerciseEntryRepository.deleteExerciseEntriesByEntrySourceAndDate(
+        userId,
+        startDate,
+        endDate,
+        'Hevy'
+      );
+      await exercisePresetEntryRepository.deleteExercisePresetEntriesByEntrySourceAndDate(
+        userId,
+        startDate,
+        endDate,
+        'Hevy'
+      );
+    } catch (error) {
+      log(
+        'error',
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
+        `Failed to clear existing Hevy data before re-sync for user ${userId}: ${error.message}`
+      );
+    }
+  }
   for (const workout of workouts) {
     try {
       await processSingleWorkout(userId, createdByUserId, workout, timezone);
@@ -97,13 +137,57 @@ async function processSingleWorkout(
 ) {
   const startTime = new Date(workout.start_time);
   const endTime = new Date(workout.end_time);
-  // @ts-expect-error TS(2362): The left-hand side of an arithmetic operation must... Remove this comment to see the full error message
-  const durationMinutes = Math.round((endTime - startTime) / (1000 * 60));
+  const workoutDurationMinutes = Math.round(
+    (endTime.getTime() - startTime.getTime()) / (1000 * 60)
+  );
+  // Wall-clock start time of the workout, in the user's timezone, as an
+  // 'HH:MM' string for the exercise_entries.entry_time (TIME) column.
+  const { hour, minute } = instantHourMinute(startTime, timezone);
+  const entryTime = `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
+  const entryDate = instantToDay(startTime, timezone);
   log(
     'debug',
     `Processing Hevy workout: ${workout.title} (${startTime.toISOString()})`
   );
-  for (const hevyExercise of workout.exercises) {
+  // Find or create the reusable workout preset (the Hevy routine), matched by
+  // name to mirror Garmin. Then create one preset entry — the logged session —
+  // that every exercise in this workout attaches to, so the diary shows the
+  // whole workout as a single "Vid plan A" group instead of loose exercises.
+  let workoutPreset = await workoutPresetRepository.getWorkoutPresetByName(
+    userId,
+    workout.title
+  );
+  if (!workoutPreset) {
+    workoutPreset = await workoutPresetRepository.createWorkoutPreset({
+      user_id: userId,
+      name: workout.title,
+      description:
+        workout.description || `Workout session from Hevy: ${workout.title}`,
+      is_public: false,
+    });
+  }
+  const presetEntry =
+    await exercisePresetEntryRepository.createExercisePresetEntry(
+      userId,
+      {
+        user_id: userId,
+        workout_preset_id: workoutPreset.id,
+        name: workout.title,
+        description:
+          workout.description || `Logged session of ${workout.title}`,
+        entry_date: entryDate,
+        created_by_user_id: createdByUserId,
+        notes: `Hevy Workout Session: ${workout.title}`,
+        source: 'Hevy',
+      },
+      createdByUserId
+    );
+  for (
+    let exerciseIndex = 0;
+    exerciseIndex < workout.exercises.length;
+    exerciseIndex++
+  ) {
+    const hevyExercise = workout.exercises[exerciseIndex];
     // 1. Find or create exercise template
     let exercise = await exerciseRepository.findExerciseByNameAndUserId(
       hevyExercise.title,
@@ -122,17 +206,51 @@ async function processSingleWorkout(
         createdByUserId
       );
     }
+    // Hevy has no per-exercise duration; it only reports whole-workout
+    // start/end. When an exercise's sets carry real per-set durations (timed
+    // exercises), use their sum. Otherwise attribute the whole-workout
+    // duration to the first exercise only (and 0 to the rest) so daily
+    // exercise-minute totals aren't multiplied by the number of exercises.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const setDurationSeconds = hevyExercise.sets.reduce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sum: number, set: any) => sum + (set.duration_seconds || 0),
+      0
+    );
+    const durationMinutes =
+      setDurationSeconds > 0
+        ? Math.round(setDurationSeconds / 60)
+        : exerciseIndex === 0
+          ? workoutDurationMinutes
+          : 0;
+    // Sum any per-set distances (meters) Hevy reports; null when none.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const distanceMeters = hevyExercise.sets.reduce(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (sum: number, set: any) => sum + (set.distance_meters || 0),
+      0
+    );
+    // Stable per-exercise identity so re-syncs update in place instead of
+    // duplicating. Hevy workout ids are unique; exercise index is unique
+    // within a workout.
+    const sourceId = `${workout.id}_${hevyExercise.index}`;
     // 2. Prepare entry data
     const entryData = {
       exercise_id: exercise.id,
-      entry_date: instantToDay(startTime, timezone),
-      duration_minutes: durationMinutes, // Note: Hevy provides total workout duration, not per-exercise
+      entry_date: entryDate,
+      entry_time: entryTime,
+      duration_minutes: durationMinutes,
       calories_burned: 0, // Hevy typically doesn't provide per-exercise calories
+      distance: distanceMeters > 0 ? distanceMeters : null,
+      superset_group: hevyExercise.superset_id ?? null,
+      source_id: sourceId,
+      exercise_preset_entry_id: presetEntry.id,
       notes:
         hevyExercise.notes ||
         workout.description ||
         `Synced from Hevy: ${workout.title}`,
       entry_source: 'Hevy',
+      sort_order: hevyExercise.index,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sets: hevyExercise.sets.map((set: any) => ({
         set_number: set.index + 1,
@@ -145,14 +263,67 @@ async function processSingleWorkout(
         rpe: set.rpe,
       })),
     };
-    // 3. Create/update exercise entry using repository
-    // This handles snapshotting and duplicates
-    await exerciseEntryRepository.createExerciseEntry(
+    // 3. Create the exercise entry, linked to the session (preset entry) via
+    // the 5th argument so it groups under the workout instead of standing alone.
+    const entry = await exerciseEntryRepository.createExerciseEntry(
       userId,
       entryData,
       createdByUserId,
-      'Hevy'
+      'Hevy',
+      presetEntry.id
     );
+    // 4. Populate the reusable preset template with this exercise. Reuses the
+    // existing exercise row when present and skips if it already has sets, so
+    // repeat occurrences of the same routine don't duplicate template rows.
+    try {
+      await workoutPresetRepository.addExerciseToWorkoutPreset(
+        userId,
+        workoutPreset.id,
+        exercise.id,
+        null,
+        entryData.sets,
+        hevyExercise.index
+      );
+    } catch (error) {
+      log(
+        'error',
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
+        `Failed to add Hevy exercise to workout preset ${workoutPreset.id}: ${error.message}`
+      );
+    }
+    // 5. Stash the full raw Hevy payload as an activity detail (like Garmin),
+    // so nothing Hevy sends is lost and it stays visible/editable in the
+    // Advanced section of the exercise entry. The bulk cleanup above already
+    // removed any prior details (ON DELETE CASCADE from the entry), so this is
+    // a fresh insert.
+    if (entry?.id) {
+      try {
+        await activityDetailsRepository.createActivityDetail(userId, {
+          exercise_entry_id: entry.id,
+          provider_name: 'Hevy',
+          detail_type: 'full_activity_data',
+          detail_data: {
+            workout: {
+              id: workout.id,
+              title: workout.title,
+              description: workout.description,
+              routine_id: workout.routine_id,
+              start_time: workout.start_time,
+              end_time: workout.end_time,
+            },
+            exercise: hevyExercise,
+          },
+          created_by_user_id: createdByUserId,
+          updated_by_user_id: createdByUserId,
+        });
+      } catch (error) {
+        log(
+          'error',
+          // @ts-expect-error TS(2571): Object is of type 'unknown'.
+          `Failed to store Hevy activity detail for entry ${entry.id}: ${error.message}`
+        );
+      }
+    }
   }
 }
 /**

--- a/SparkyFitnessServer/integrations/hevy/hevyDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/hevy/hevyDataProcessor.ts
@@ -108,7 +108,20 @@ async function processHevyWorkouts(
       );
     }
   }
+  // The raw bundle can hold the same workout under overlapping page keys
+  // (e.g. `raw_workouts_page` and `raw_workouts_page_1`), and paginated API
+  // fetches can overlap too. Process each workout id only once — otherwise a
+  // second pass creates a duplicate preset-entry session whose exercises stay
+  // deduped on the first one, leaving an empty orphan session.
+  const seenWorkoutIds = new Set<string>();
   for (const workout of workouts) {
+    if (workout.id) {
+      if (seenWorkoutIds.has(workout.id)) {
+        log('debug', `Skipping duplicate Hevy workout ${workout.id}`);
+        continue;
+      }
+      seenWorkoutIds.add(workout.id);
+    }
     try {
       await processSingleWorkout(userId, createdByUserId, workout, timezone);
     } catch (error) {

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -454,7 +454,7 @@ async function _createExerciseEntryWithClient(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createdByUserId: any,
   entrySource = 'Manual',
-  exercisePresetEntryId = null,
+  exercisePresetEntryId: string | null = null,
   options: { skipDuplicateCheck?: boolean } = {}
 ) {
   try {
@@ -631,7 +631,7 @@ async function createExerciseEntry(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createdByUserId: any,
   entrySource = 'Manual',
-  exercisePresetEntryId = null,
+  exercisePresetEntryId: string | null = null,
   options: { skipDuplicateCheck?: boolean } = {}
 ) {
   const client = await getClient(userId);

--- a/SparkyFitnessServer/tests/hevyDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/hevyDataProcessor.test.ts
@@ -271,6 +271,25 @@ describe('processHevyWorkouts — workout-preset grouping', () => {
   });
 });
 
+describe('processHevyWorkouts — duplicate workout guard', () => {
+  it('processes a repeated workout id once (no orphan/empty preset entry)', async () => {
+    // Same workout twice (mirrors the mock bundle holding page 1 under two keys).
+    await processHevyWorkouts(
+      UID,
+      CID,
+      [sampleWorkout(), sampleWorkout()],
+      'UTC'
+    );
+    expect(
+      exercisePresetEntryRepository.createExercisePresetEntry
+    ).toHaveBeenCalledTimes(1);
+    // 3 exercises, not 6.
+    expect(
+      workoutPresetRepository.addExerciseToWorkoutPreset
+    ).toHaveBeenCalledTimes(3);
+  });
+});
+
 describe('processHevyWorkouts — re-sync cleanup', () => {
   it('clears existing Hevy entries and preset entries over the batch date range', async () => {
     const older = sampleWorkout();

--- a/SparkyFitnessServer/tests/hevyDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/hevyDataProcessor.test.ts
@@ -1,0 +1,312 @@
+import { vi, beforeEach, describe, it, expect } from 'vitest';
+
+vi.mock('../models/exerciseEntry.js', () => ({
+  default: {
+    createExerciseEntry: vi.fn().mockResolvedValue({ id: 'entry-1' }),
+    deleteExerciseEntriesByEntrySourceAndDate: vi
+      .fn()
+      .mockResolvedValue(undefined),
+  },
+}));
+vi.mock('../models/exercise.js', () => ({
+  default: {
+    findExerciseByNameAndUserId: vi
+      .fn()
+      .mockImplementation((name: string) =>
+        Promise.resolve({ id: `exercise-${name}` })
+      ),
+    createExercise: vi.fn().mockResolvedValue({ id: 'exercise-new' }),
+  },
+}));
+vi.mock('../models/measurementRepository.js', () => ({
+  default: { upsertCheckInMeasurements: vi.fn().mockResolvedValue(undefined) },
+}));
+vi.mock('../models/activityDetailsRepository.js', () => ({
+  default: {
+    createActivityDetail: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+vi.mock('../models/workoutPresetRepository.js', () => ({
+  default: {
+    getWorkoutPresetByName: vi.fn().mockResolvedValue(null),
+    createWorkoutPreset: vi.fn().mockResolvedValue({ id: 42 }),
+    addExerciseToWorkoutPreset: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+vi.mock('../models/exercisePresetEntryRepository.js', () => ({
+  default: {
+    createExercisePresetEntry: vi
+      .fn()
+      .mockResolvedValue({ id: 'preset-entry-1' }),
+    deleteExercisePresetEntriesByEntrySourceAndDate: vi
+      .fn()
+      .mockResolvedValue(undefined),
+  },
+}));
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+import { processHevyWorkouts } from '../integrations/hevy/hevyDataProcessor.js';
+import exerciseEntryRepository from '../models/exerciseEntry.js';
+import activityDetailsRepository from '../models/activityDetailsRepository.js';
+import workoutPresetRepository from '../models/workoutPresetRepository.js';
+import exercisePresetEntryRepository from '../models/exercisePresetEntryRepository.js';
+
+const UID = 'user-1';
+const CID = 'user-1';
+
+// A workout with three exercises: two untimed, one with per-set durations.
+function sampleWorkout() {
+  return {
+    id: 'workout-abc',
+    title: 'Vid plan A',
+    routine_id: 'routine-1',
+    description: '',
+    start_time: '2026-07-13T05:52:14+00:00',
+    end_time: '2026-07-13T06:52:14+00:00', // 60 minutes
+    exercises: [
+      {
+        index: 0,
+        title: 'Bulgarian Split Squat',
+        notes: '',
+        exercise_template_id: 'B5D3A742',
+        superset_id: null,
+        sets: [
+          {
+            index: 0,
+            type: 'normal',
+            weight_kg: 20,
+            reps: 6,
+            duration_seconds: null,
+            distance_meters: null,
+            rpe: null,
+          },
+          {
+            index: 1,
+            type: 'normal',
+            weight_kg: 20,
+            reps: 8,
+            duration_seconds: null,
+            distance_meters: null,
+            rpe: null,
+          },
+        ],
+      },
+      {
+        index: 1,
+        title: 'Pull Up',
+        notes: '',
+        exercise_template_id: '1B2B1E7C',
+        superset_id: 'ss-1',
+        sets: [
+          {
+            index: 0,
+            type: 'normal',
+            weight_kg: null,
+            reps: 6,
+            duration_seconds: null,
+            distance_meters: null,
+            rpe: null,
+          },
+        ],
+      },
+      {
+        index: 2,
+        title: 'Plank',
+        notes: '',
+        exercise_template_id: 'PLANK01',
+        superset_id: null,
+        sets: [
+          {
+            index: 0,
+            type: 'normal',
+            weight_kg: null,
+            reps: null,
+            duration_seconds: 90,
+            distance_meters: null,
+            rpe: null,
+          },
+          {
+            index: 1,
+            type: 'normal',
+            weight_kg: null,
+            reps: null,
+            duration_seconds: 90,
+            distance_meters: null,
+            rpe: null,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function callForExercise(name: string): any[] | undefined {
+  return (
+    exerciseEntryRepository.createExerciseEntry as unknown as {
+      mock: { calls: unknown[][] };
+    }
+  ).mock.calls.find(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (c) => (c[1] as any).exercise_id === `exercise-${name}`
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function entryArgForExercise(name: string): any {
+  return callForExercise(name)?.[1];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('processHevyWorkouts — field mapping', () => {
+  it('maps entry_time from the workout start time in the user timezone', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
+    expect(entryArgForExercise('Bulgarian Split Squat').entry_time).toBe(
+      '05:52'
+    );
+  });
+
+  it('shifts entry_time into a negative-offset timezone', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'America/New_York');
+    // 05:52 UTC is 01:52 in New York (EDT, -04:00)
+    expect(entryArgForExercise('Bulgarian Split Squat').entry_time).toBe(
+      '01:52'
+    );
+  });
+
+  it('sets a stable per-exercise source_id (workout id + exercise index)', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
+    expect(entryArgForExercise('Bulgarian Split Squat').source_id).toBe(
+      'workout-abc_0'
+    );
+    expect(entryArgForExercise('Pull Up').source_id).toBe('workout-abc_1');
+  });
+
+  it('maps superset_id to superset_group', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
+    expect(
+      entryArgForExercise('Bulgarian Split Squat').superset_group
+    ).toBeNull();
+    expect(entryArgForExercise('Pull Up').superset_group).toBe('ss-1');
+  });
+
+  it('attributes whole-workout duration to the first untimed exercise only', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
+    expect(entryArgForExercise('Bulgarian Split Squat').duration_minutes).toBe(
+      60
+    );
+    expect(entryArgForExercise('Pull Up').duration_minutes).toBe(0);
+  });
+
+  it('uses summed per-set duration for timed exercises', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
+    // 90 + 90 = 180s → 3 min
+    expect(entryArgForExercise('Plank').duration_minutes).toBe(3);
+  });
+});
+
+describe('processHevyWorkouts — workout-preset grouping', () => {
+  it('creates the workout preset by name when missing', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
+    expect(workoutPresetRepository.getWorkoutPresetByName).toHaveBeenCalledWith(
+      UID,
+      'Vid plan A'
+    );
+    expect(workoutPresetRepository.createWorkoutPreset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: UID,
+        name: 'Vid plan A',
+        is_public: false,
+      })
+    );
+  });
+
+  it('creates one preset entry (session) for the workout, sourced Hevy', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
+    expect(
+      exercisePresetEntryRepository.createExercisePresetEntry
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      exercisePresetEntryRepository.createExercisePresetEntry
+    ).toHaveBeenCalledWith(
+      UID,
+      expect.objectContaining({
+        workout_preset_id: 42,
+        name: 'Vid plan A',
+        entry_date: '2026-07-13',
+        source: 'Hevy',
+      }),
+      CID
+    );
+  });
+
+  it('links every exercise entry to the preset entry (5th arg + field)', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
+    for (const name of ['Bulgarian Split Squat', 'Pull Up', 'Plank']) {
+      const call = callForExercise(name)!;
+      expect(call[3]).toBe('Hevy'); // entrySource
+      expect(call[4]).toBe('preset-entry-1'); // exercisePresetEntryId (5th arg)
+      expect(call[1].exercise_preset_entry_id).toBe('preset-entry-1');
+    }
+  });
+
+  it('adds each exercise to the workout preset template', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
+    expect(
+      workoutPresetRepository.addExerciseToWorkoutPreset
+    ).toHaveBeenCalledTimes(3);
+    expect(
+      workoutPresetRepository.addExerciseToWorkoutPreset
+    ).toHaveBeenCalledWith(
+      UID,
+      42,
+      'exercise-Bulgarian Split Squat',
+      null,
+      expect.any(Array),
+      0
+    );
+  });
+});
+
+describe('processHevyWorkouts — re-sync cleanup', () => {
+  it('clears existing Hevy entries and preset entries over the batch date range', async () => {
+    const older = sampleWorkout();
+    older.id = 'workout-old';
+    older.start_time = '2026-07-08T05:00:00+00:00';
+    older.end_time = '2026-07-08T06:00:00+00:00';
+    await processHevyWorkouts(UID, CID, [sampleWorkout(), older], 'UTC');
+
+    expect(
+      exerciseEntryRepository.deleteExerciseEntriesByEntrySourceAndDate
+    ).toHaveBeenCalledWith(UID, '2026-07-08', '2026-07-13', 'Hevy');
+    expect(
+      exercisePresetEntryRepository.deleteExercisePresetEntriesByEntrySourceAndDate
+    ).toHaveBeenCalledWith(UID, '2026-07-08', '2026-07-13', 'Hevy');
+  });
+});
+
+describe('processHevyWorkouts — raw JSON activity detail', () => {
+  it('stores full_activity_data per entry', async () => {
+    await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
+
+    expect(activityDetailsRepository.createActivityDetail).toHaveBeenCalledWith(
+      UID,
+      expect.objectContaining({
+        exercise_entry_id: 'entry-1',
+        provider_name: 'Hevy',
+        detail_type: 'full_activity_data',
+        detail_data: expect.objectContaining({
+          workout: expect.objectContaining({ id: 'workout-abc' }),
+          exercise: expect.objectContaining({ title: 'Bulgarian Split Squat' }),
+        }),
+      })
+    );
+    // One detail row per exercise
+    expect(
+      activityDetailsRepository.createActivityDetail
+    ).toHaveBeenCalledTimes(3);
+  });
+});

--- a/SparkyFitnessServer/tests/hevyDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/hevyDataProcessor.test.ts
@@ -185,12 +185,13 @@ describe('processHevyWorkouts — field mapping', () => {
     expect(entryArgForExercise('Pull Up').source_id).toBe('workout-abc_1');
   });
 
-  it('maps superset_id to superset_group', async () => {
+  it('maps the Hevy superset id to a numeric per-workout group', async () => {
     await processHevyWorkouts(UID, CID, [sampleWorkout()], 'UTC');
     expect(
       entryArgForExercise('Bulgarian Split Squat').superset_group
     ).toBeNull();
-    expect(entryArgForExercise('Pull Up').superset_group).toBe('ss-1');
+    // First distinct superset id in the workout → group 1 (numeric, not the raw id).
+    expect(entryArgForExercise('Pull Up').superset_group).toBe(1);
   });
 
   it('attributes whole-workout duration to the first untimed exercise only', async () => {


### PR DESCRIPTION
Hevy sync previously created each exercise as a loose, standalone entry and dropped several fields Hevy does provide, so a single workout showed as unrelated diary cards with a blank start time and 0m duration.

Server (integrations/hevy/hevyDataProcessor.ts):
- Mirror the Garmin flow: find/create a workout_preset (by name) per routine, create one exercise_preset_entry (the logged session), and link every exercise entry to it so the workout renders as a single group. Also fill the reusable preset template via addExerciseToWorkoutPreset.
- Re-sync is idempotent: bulk-delete existing 'Hevy' entries and preset entries in the batch's date range before rebuilding.
- Map fields that were being discarded: entry_time (tz-aware workout start), superset_group, distance, and a stable per-exercise source_id (workout.id + index). Attribute whole-workout duration to the first exercise only (or summed per-set durations for timed exercises) to avoid inflating daily totals.
- Store the full raw Hevy payload as a 'full_activity_data' activity detail so nothing is lost and it stays visible in the entry's Advanced section.

Frontend (Diary): when an entry's per-set timers sum to 0 (rep-based sets from Hevy), fall back to entry-level duration_minutes so the session time surfaces instead of showing 0m (ExerciseCard, ExerciseEntryDisplay, ExercisePresetEntryDisplay).

Note: RPE, per-set duration, rest, and heart rate stay blank because Hevy's export does not include them. Preset dedup is name-based (no migration).

Tests: new tests/hevyDataProcessor.test.ts (12 cases) covering field mapping, preset grouping, session linking, and re-sync cleanup.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
