### PR TITLE
hevy integrations fixes: rep types and sync

### DIFF
--- a/SparkyFitnessServer/integrations/hevy/hevyDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/hevy/hevyDataProcessor.ts
@@ -411,8 +411,8 @@ async function processSingleWorkout(
 function mapSetType(hevyType: string): string {
   const mapping: Record<string, string> = {
     normal: 'Working Set',
-    warm_up: 'Warm-up',
-    drop_set: 'Drop Set',
+    warmup: 'Warm-up',
+    dropset: 'Drop Set',
     failure: 'To Failure',
   };
   return mapping[hevyType] || 'Working Set';

--- a/SparkyFitnessServer/integrations/hevy/hevyService.ts
+++ b/SparkyFitnessServer/integrations/hevy/hevyService.ts
@@ -318,14 +318,14 @@ async function syncHevyData(
         hasMore = currentPage < pageCount;
         currentPage++;
       } else {
-        const oldestWorkout = workouts[workouts.length - 1];
-        const oldestTime = new Date(oldestWorkout.start_time);
-        if (oldestTime < sevenDaysAgo) {
-          hasMore = false;
+        const newestWorkout = workouts[0];
+        if (newestWorkout) {
+          const newestTime = new Date(newestWorkout.start_time);
+          hasMore = newestTime >= sevenDaysAgo && currentPage < pageCount;
         } else {
-          hasMore = currentPage < pageCount;
-          currentPage++;
+          hasMore = false;
         }
+        currentPage++;
       }
     }
     // 2. Process EVERYTHING second (The Action Phase)


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Two bugs in the Hevy integration:

1. Warmup and dropset sets showing as "Working Set" 

2. Missing workouts from page 2+

**How did you implement the solution?**

1. Changed the mapping keys in mapSetType() from warm_up/drop_set to warmup/dropset.

2. Changed the pagination check to look at the newest workout on the page instead of the oldest. If the newest is still within 7 days, pagination continues. Otherwise, all remaining pages will be older too.

**Linked Issue**

#170 

## How to Test

1. Sync Hevy data
2. Check that warmup sets show as "Warm-up" and dropsets as "Drop Set" (not "Working Set")
3. Verify that workouts beyond the first 10 (page 2+) appear in Sparky after the sync

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

All PRs:

- [x] **[MANDATORY - ALL] Integrity & License** : I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

New features only:

- [ ] [MANDATORY for new feature] Alignment: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

Frontend changes (`SparkyFitnessFrontend/`):

- [ ] [MANDATORY for Frontend changes] Quality: I have run pnpm run validate and it passes.
- [ ] [MANDATORY for Frontend changes] Translations: I have only updated the English (en) translation file.

Backend changes (`SparkyFitnessServer/`):

- [x] **[MANDATORY for Backend changes] Code Quality** : I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] [MANDATORY for Backend changes] Database Security: I have updated rls_policies.sql for any new user-specific tables.

UI changes (components, screens, pages):

- [ ] [MANDATORY for UI changes] Screenshots: I have attached Before/After screenshots below.

Mobile changes (`SparkyFitnessMobile/`):

- [ ] [MANDATORY for Mobile changes] Tested on device or emulator: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.