### PR TITLE
fix: allow logging the same exercise twice per day in diary

### DIFF
--- a/SparkyFitnessServer/routes/exerciseEntryRoutes.ts
+++ b/SparkyFitnessServer/routes/exerciseEntryRoutes.ts
@@ -376,7 +376,13 @@ router.post(
           distance,
           avg_heart_rate,
           activity_details,
-        }
+        },
+        // Manual diary adds should always create a new entry, even when the
+        // same exercise/date already has one (e.g. two workouts in a day).
+        // Skip the "same exercise + date" merge-into-existing check unless
+        // this entry is tied to a workout plan assignment, which has its own
+        // assignment+date dedup that must still apply.
+        { skipDuplicateCheck: !workout_plan_assignment_id }
       );
       res.status(201).json(newEntry);
     } catch (error) {

--- a/SparkyFitnessServer/tests/exerciseEntryRoutes.duplicateCheck.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntryRoutes.duplicateCheck.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'
+import request from 'supertest';
+import express from 'express';
+import exerciseEntryRoutes from '../routes/exerciseEntryRoutes.js';
+import exerciseService from '../services/exerciseService.js';
+
+vi.mock('../middleware/authMiddleware.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authenticate: vi.fn((req: any, _res: any, next: any) => {
+    req.userId = 'user-123';
+    req.originalUserId = 'actor-123';
+    next();
+  }),
+}));
+vi.mock('../middleware/checkPermissionMiddleware.js', () => ({
+  default: vi.fn(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    () => (_req: any, _res: any, next: any) => next()
+  ),
+}));
+vi.mock('../middleware/uploadMiddleware.js', () => ({
+  createUploadMiddleware: vi.fn(() => ({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    single: vi.fn(() => (_req: any, _res: any, next: any) => next()),
+  })),
+}));
+vi.mock('../services/exerciseService.js', () => ({
+  default: { createExerciseEntry: vi.fn() },
+}));
+vi.mock('../services/exerciseEntryService.js', () => ({ default: {} }));
+vi.mock('../services/fitImportService.js', () => ({ default: {} }));
+vi.mock('../utils/permissionUtils.js', () => ({
+  canAccessUserData: vi.fn(),
+}));
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+const app = express();
+app.use(express.json());
+app.use('/exercise-entries', exerciseEntryRoutes);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+app.use((err: any, _req: any, res: any, _next: any) => {
+  res.status(500).json({ error: err.message });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(exerciseService.createExerciseEntry).mockResolvedValue({
+    id: 'entry-1',
+  });
+});
+
+describe('POST /exercise-entries duplicate-check wiring', () => {
+  it('skips the manual same-exercise/same-date dedup for a plain diary add', async () => {
+    await request(app)
+      .post('/exercise-entries')
+      .send({
+        exercise_id: '11111111-1111-1111-1111-111111111111',
+        duration_minutes: 30,
+        calories_burned: 200,
+        entry_date: '2026-07-18',
+      })
+      .expect(201);
+
+    expect(exerciseService.createExerciseEntry).toHaveBeenCalledTimes(1);
+    const [, , , options] = vi.mocked(exerciseService.createExerciseEntry).mock
+      .calls[0];
+    expect(options).toEqual({ skipDuplicateCheck: true });
+  });
+
+  it('keeps the assignment+date dedup when the entry is tied to a workout plan assignment', async () => {
+    await request(app)
+      .post('/exercise-entries')
+      .send({
+        exercise_id: '11111111-1111-1111-1111-111111111111',
+        duration_minutes: 30,
+        calories_burned: 200,
+        entry_date: '2026-07-18',
+        workout_plan_assignment_id: 'assignment-1',
+      })
+      .expect(201);
+
+    expect(exerciseService.createExerciseEntry).toHaveBeenCalledTimes(1);
+    const [, , , options] = vi.mocked(exerciseService.createExerciseEntry).mock
+      .calls[0];
+    expect(options).toEqual({ skipDuplicateCheck: false });
+  });
+});


### PR DESCRIPTION
Fixed: the diary "add exercise" POST route now passes { skipDuplicateCheck: !workout_plan_assignment_id } to exerciseService.createExerciseEntry in exerciseEntryRoutes.ts, reusing the option flag the chatbot already relies on. This bypasses the server's manual "same exercise + same date" merge-into-existing check for plain diary adds, so logging the same exercise twice now creates two entries instead of silently overwriting the first — while still preserving the assignment+date dedup when an entry is tied to a workout plan.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes # https://github.com/CodeWithCJ/SparkyFitness/issues/1734

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
