### PR TITLE
feat(mobile): add daily nutrition details and nutrient trends screens

### DIFF
--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -1027,6 +1027,7 @@ function AppContent() {
             component={SafeDailyNutritionDetails}
             options={createStackScreenOptions('Nutrition Details', {
               presentation: 'modal',
+              headerBackButtonDisplayMode: 'minimal',
               ...(Platform.OS === 'android' ? androidModalAnimation : {}),
             })}
           />

--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -69,6 +69,8 @@ import WhatsNewScreen from './src/screens/WhatsNewScreen';
 import MeasurementsAddScreen from './src/screens/MeasurementsAddScreen';
 import ChatScreen from './src/screens/ChatScreen';
 import OnboardingScreen from './src/screens/OnboardingScreen';
+import DailyNutritionDetailsScreen from './src/screens/DailyNutritionDetailsScreen';
+import NutrientTrendsScreen from './src/screens/NutrientTrendsScreen';
 import ReauthModal from './src/components/ReauthModal';
 import ServerConfigModal from './src/components/ServerConfigModal';
 import { useAuth } from './src/hooks/useAuth';
@@ -223,6 +225,8 @@ const SafePasskeySettings = withErrorBoundary(PasskeySettingsScreen, 'PasskeySet
 const SafeAppSettings = withErrorBoundary(AppSettingsScreen, 'AppSettings', { canGoBack: true });
 const SafeAbout = withErrorBoundary(AboutScreen, 'About', { canGoBack: true });
 const SafeWhatsNew = withErrorBoundary(WhatsNewScreen, 'WhatsNew', { canGoBack: true });
+const SafeDailyNutritionDetails = withErrorBoundary(DailyNutritionDetailsScreen, 'DailyNutritionDetails', { canGoBack: true });
+const SafeNutrientTrends = withErrorBoundary(NutrientTrendsScreen, 'NutrientTrends', { canGoBack: true });
 
 function AppContent() {
   const { theme } = useUniwind();
@@ -1017,6 +1021,19 @@ function AppContent() {
             name="MealTypeDetail"
             component={SafeMealTypeDetail}
             options={({ route }) => createStackScreenOptions(route.params.mealLabel ?? 'Meal', { headerBackTitle: 'Diary' })}
+          />
+          <Stack.Screen
+            name="DailyNutritionDetails"
+            component={SafeDailyNutritionDetails}
+            options={createStackScreenOptions('Nutrition Details', {
+              presentation: 'modal',
+              ...(Platform.OS === 'android' ? androidModalAnimation : {}),
+            })}
+          />
+          <Stack.Screen
+            name="NutrientTrends"
+            component={SafeNutrientTrends}
+            options={createStackScreenOptions('Trends', { headerBackTitle: 'Details' })}
           />
           <Stack.Screen
             name="ExerciseSearch"

--- a/SparkyFitnessMobile/__tests__/components/NutritionMacroCard.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/NutritionMacroCard.test.tsx
@@ -10,6 +10,11 @@ jest.mock('../../src/components/MacroCompositionRing', () => {
   };
 });
 
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useIsFocused: () => true,
+}));
+
 describe('NutritionMacroCard', () => {
   const baseProps = {
     calories: 600,

--- a/SparkyFitnessMobile/__tests__/screens/FoodPhotoLogEntryScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodPhotoLogEntryScreen.test.tsx
@@ -28,7 +28,14 @@ jest.mock('../../src/services/api/goalsApi', () => ({
 }));
 jest.mock('../../src/services/haptics', () => ({
   fireSuccessHaptic: jest.fn(),
+  fireImpactHaptic: jest.fn(),
 }));
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useIsFocused: () => true,
+}));
+
 jest.mock('react-native-toast-message', () => ({
   __esModule: true,
   default: { show: jest.fn() },

--- a/SparkyFitnessMobile/jest.setup.js
+++ b/SparkyFitnessMobile/jest.setup.js
@@ -441,6 +441,15 @@ jest.mock('@shopify/react-native-skia', () => {
           close: jest.fn().mockReturnThis(),
         }),
       },
+      PathBuilder: {
+        Make: () => ({
+          addArc: jest.fn().mockReturnThis(),
+          moveTo: jest.fn().mockReturnThis(),
+          lineTo: jest.fn().mockReturnThis(),
+          close: jest.fn().mockReturnThis(),
+          build: jest.fn().mockReturnValue(null),
+        }),
+      },
     },
     rect: jest.fn((x, y, width, height) => ({ x, y, width, height })),
     rrect: jest.fn((r, rx, ry) => ({ rect: r, rx, ry })),

--- a/SparkyFitnessMobile/src/components/MacroCard.tsx
+++ b/SparkyFitnessMobile/src/components/MacroCard.tsx
@@ -93,35 +93,45 @@ const MacroCard: React.FC<MacroCardProps> = ({
         </Text>
       </View>
       {hasGoal && (
-        <View
-          className="h-2"
-          onLayout={(e) => setBarWidth(e.nativeEvent.layout.width)}
-        >
+        <>
+          <View
+            className="h-2"
+            onLayout={(e) => setBarWidth(e.nativeEvent.layout.width)}
+          >
+            {barWidth > 0 && (
+              <View
+                style={{
+                  width: barWidth,
+                  height: barHeight,
+                  borderRadius,
+                  overflow: 'hidden',
+                  backgroundColor: trackColor,
+                }}
+              >
+                <Animated.View
+                  style={[
+                    { position: 'absolute', left: 0, top: 0, height: barHeight, backgroundColor: color },
+                    fillStyle,
+                  ]}
+                />
+                <Animated.View
+                  style={[
+                    { position: 'absolute', top: 0, height: barHeight, backgroundColor: color, opacity: 0.65 },
+                    overflowStyle,
+                  ]}
+                />
+              </View>
+            )}
+          </View>
           {barWidth > 0 && (
-            <View
-              style={{
-                width: barWidth,
-                height: barHeight,
-                borderRadius,
-                overflow: 'hidden',
-                backgroundColor: trackColor,
-              }}
-            >
-              <Animated.View
-                style={[
-                  { position: 'absolute', left: 0, top: 0, height: barHeight, backgroundColor: color },
-                  fillStyle,
-                ]}
-              />
-              <Animated.View
-                style={[
-                  { position: 'absolute', top: 0, height: barHeight, backgroundColor: color, opacity: 0.65 },
-                  overflowStyle,
-                ]}
-              />
-            </View>
+            <Text className="text-[10px] text-text-muted mt-1">
+              {Math.round(progress * 100)}% · {(() => {
+                const diff = goal - consumed;
+                return diff > 0 ? `${Math.round(diff)}${unit} left` : diff < 0 ? `${Math.round(Math.abs(diff))}${unit} over` : 'met';
+              })()}
+            </Text>
           )}
-        </View>
+        </>
       )}
     </View>
   );

--- a/SparkyFitnessMobile/src/components/NutrientBarChart.tsx
+++ b/SparkyFitnessMobile/src/components/NutrientBarChart.tsx
@@ -1,0 +1,253 @@
+import React, { useMemo, useState, useCallback } from 'react';
+import { View, Text, Platform } from 'react-native';
+import { CartesianChart, Bar } from 'victory-native';
+import { matchFont, Line as SkiaLine } from '@shopify/react-native-skia';
+import { useCSSVariable } from 'uniwind';
+import type { TrendRange } from '../hooks/useNutritionTrends';
+import ChartTouchOverlay, {
+  ChartLayoutReporter,
+  EMPTY_CHART_TOUCH_LAYOUT,
+  createChartTouchLayoutSignature,
+  type ChartTouchLayout,
+} from './ChartTouchOverlay';
+
+export type NutrientChartDataPoint = {
+  day: string;
+  value: number;
+};
+
+type NutrientBarChartProps = {
+  data: NutrientChartDataPoint[];
+  isLoading: boolean;
+  isError: boolean;
+  range: TrendRange;
+  nutrientLabel: string;
+  unit: string;
+  goal?: number;
+};
+
+const INNER_PADDING: Record<TrendRange, number> = {
+  '7d': 0.3,
+  '30d': 0.2,
+  '90d': 0.1,
+};
+
+const X_TICK_COUNT: Record<TrendRange, number> = {
+  '7d': 7,
+  '30d': 6,
+  '90d': 5,
+};
+
+const fontFamily = Platform.select({ ios: 'Helvetica', default: 'sans-serif' });
+const font = matchFont({ fontFamily, fontSize: 11 });
+
+const formatYLabel = (value: number) => {
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  if (value % 1 !== 0) return value.toFixed(1);
+  return String(value);
+};
+
+const formatXLabel7d = (day: string): string => {
+  if (typeof day !== 'string') return '';
+  const [year, month, d] = day.split('-').map(Number);
+  const date = new Date(year, month - 1, d);
+  return date.toLocaleDateString('en-US', { weekday: 'short' });
+};
+
+const formatXLabel30d90d = (day: string): string => {
+  if (typeof day !== 'string') return '';
+  const [year, month, d] = day.split('-').map(Number);
+  const date = new Date(year, month - 1, d);
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+};
+
+const formatTooltipDate = (day: string): string => {
+  const [year, month, d] = day.split('-').map(Number);
+  const date = new Date(year, month - 1, d);
+  return date.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+const DEFAULT_TOOLTIP = 'Press a bar for details';
+
+const NutrientTooltip: React.FC<{ text: string }> = ({ text }) => (
+  <View className="h-6 justify-center mt-3 mb-1">
+    <Text className="text-text-secondary text-sm text-center">{text}</Text>
+  </View>
+);
+
+const NutrientBarChart: React.FC<NutrientBarChartProps> = ({
+  data,
+  isLoading,
+  isError,
+  range,
+  nutrientLabel,
+  unit,
+  goal,
+}) => {
+  const [accentColor, textMuted] = useCSSVariable([
+    '--color-accent-primary',
+    '--color-text-muted',
+  ]) as [string, string];
+  const [tooltipText, setTooltipText] = useState(DEFAULT_TOOLTIP);
+  const [touchLayout, setTouchLayout] = useState<ChartTouchLayout>(
+    EMPTY_CHART_TOUCH_LAYOUT,
+  );
+
+  const hasData = useMemo(() => data.some(d => d.value > 0), [data]);
+
+  const maxVal = useMemo(() => {
+    const dataMax = Math.max(...data.map((d) => d.value), 0);
+    if (goal && goal > 0) {
+      return Math.max(dataMax, goal) * 1.1;
+    }
+    return undefined;
+  }, [data, goal]);
+
+  const formatXLabel = range === '7d' ? formatXLabel7d : formatXLabel30d90d;
+
+  const [tooltipResetKey, setTooltipResetKey] = useState({ data, range });
+  if (tooltipResetKey.data !== data || tooltipResetKey.range !== range) {
+    setTooltipResetKey({ data, range });
+    setTooltipText(DEFAULT_TOOLTIP);
+  }
+
+  const handleTouchLayoutChange = useCallback(
+    (nextLayout: ChartTouchLayout) => {
+      setTouchLayout(currentLayout => {
+        const currentSignature = createChartTouchLayoutSignature(currentLayout);
+        const nextSignature = createChartTouchLayoutSignature(nextLayout);
+
+        if (currentSignature === nextSignature) {
+          return currentLayout;
+        }
+
+        return nextLayout;
+      });
+    },
+    [],
+  );
+
+  const handleSelectBar = useCallback(
+    (index: number) => {
+      const point = data[index];
+
+      if (!point) {
+        return;
+      }
+
+      const formattedVal = point.value % 1 !== 0 ? point.value.toFixed(1) : point.value;
+      setTooltipText(
+        `${formattedVal}${unit} consumed · ${formatTooltipDate(
+          point.day,
+        )}`,
+      );
+    },
+    [data, unit],
+  );
+
+  const handleClearSelection = useCallback(() => {
+    setTooltipText(DEFAULT_TOOLTIP);
+  }, []);
+
+  return (
+    <View className="bg-surface rounded-xl p-4 my-2 shadow-sm">
+      <Text className="text-text-primary text-lg font-semibold mb-2">
+        {nutrientLabel} ({unit})
+      </Text>
+
+      <NutrientTooltip text={tooltipText} />
+
+      {isLoading ? (
+        <View className="h-50 justify-center items-center">
+          <Text className="text-text-muted text-sm">Loading...</Text>
+        </View>
+      ) : isError ? (
+        <View className="h-50 justify-center items-center">
+          <Text className="text-text-muted text-sm">
+            Failed to load trend data
+          </Text>
+        </View>
+      ) : !hasData ? (
+        <View className="h-50 justify-center items-center">
+          <Text className="text-text-muted text-sm">
+            No logged intake for this period
+          </Text>
+        </View>
+      ) : (
+        <View style={{ height: 175 }}>
+          <CartesianChart
+            data={data}
+            xKey="day"
+            yKeys={['value']}
+            domain={maxVal ? { y: [0, maxVal] } : { y: [0] }}
+            domainPadding={{ left: 25, right: 25 }}
+            xAxis={{
+              font,
+              tickCount: X_TICK_COUNT[range],
+              labelColor: textMuted,
+              formatXLabel,
+            }}
+            yAxis={[
+              {
+                font,
+                tickCount: 5,
+                labelColor: textMuted,
+                formatYLabel,
+              },
+            ]}
+          >
+            {({ points, chartBounds }) => {
+              let goalY: number | null = null;
+              if (goal && goal > 0 && maxVal && maxVal > 0) {
+                const height = chartBounds.bottom - chartBounds.top;
+                const calculatedY = chartBounds.bottom - (goal / maxVal) * height;
+                // Only render if it lies within the chart's visible drawing area
+                if (calculatedY >= chartBounds.top && calculatedY <= chartBounds.bottom) {
+                  goalY = calculatedY;
+                }
+              }
+
+              return (
+                <>
+                  <ChartLayoutReporter
+                    chartBounds={chartBounds}
+                    points={points.value}
+                    onChange={handleTouchLayoutChange}
+                  />
+                  <Bar
+                    points={points.value}
+                    chartBounds={chartBounds}
+                    color={accentColor}
+                    innerPadding={INNER_PADDING[range]}
+                    animate={{ type: 'timing', duration: 300 }}
+                    roundedCorners={{ topLeft: 6, topRight: 6 }}
+                  />
+                  {goalY !== null && (
+                    <SkiaLine
+                      p1={{ x: chartBounds.left, y: goalY }}
+                      p2={{ x: chartBounds.right, y: goalY }}
+                      color="#10B981"
+                      strokeWidth={1.5}
+                    />
+                  )}
+                </>
+              );
+            }}
+          </CartesianChart>
+          <ChartTouchOverlay
+            layout={touchLayout}
+            onSelect={handleSelectBar}
+            onClear={handleClearSelection}
+            testIDPrefix="nutrient-touch-overlay"
+          />
+        </View>
+      )}
+    </View>
+  );
+};
+
+export default NutrientBarChart;

--- a/SparkyFitnessMobile/src/components/NutritionMacroCard.tsx
+++ b/SparkyFitnessMobile/src/components/NutritionMacroCard.tsx
@@ -26,6 +26,10 @@ interface NutritionMacroCardProps {
   // share are computed against this net value too, mirroring the web behavior.
   showNetCarbs?: boolean;
   fiber?: number;
+  calorieGoal?: number;
+  proteinGoal?: number;
+  carbsGoal?: number;
+  fatGoal?: number;
 }
 
 const RING_SIZE = 130;
@@ -41,6 +45,10 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
   goalsLoading,
   showNetCarbs = false,
   fiber,
+  calorieGoal,
+  proteinGoal,
+  carbsGoal,
+  fatGoal,
 }) => {
   const [proteinColor, carbsColor, fatColor, trackColor] = useCSSVariable([
     '--color-macro-protein',
@@ -74,6 +82,7 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
       value: protein,
       color: proteinColor,
       goalPercent: goalPercentages?.protein,
+      goal: proteinGoal,
     },
     {
       key: 'Carbs',
@@ -81,6 +90,7 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
       value: displayCarbs,
       color: carbsColor,
       goalPercent: goalPercentages?.carbs,
+      goal: carbsGoal,
     },
     {
       key: 'Fat',
@@ -88,8 +98,9 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
       value: fat,
       color: fatColor,
       goalPercent: goalPercentages?.fat,
+      goal: fatGoal,
     },
-  ] as const;
+  ];
 
   const showGoalProgress =
     goalsLoading === true ||
@@ -107,14 +118,14 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
 
       {showGoalProgress ? (
         <View className="flex-row items-center">
-          <View className="flex-1 items-center pr-10">
+          <View className="flex-1 items-center pr-2">
             <Text className="text-text-primary text-3xl font-medium">
               {Math.round(calories)}
             </Text>
             <Text className="text-text-secondary text-base mt-2">calories</Text>
             {goalPercentages?.calories != null ? (
-              <Text className="text-text-muted text-sm mt-1">
-                {goalPercentages.calories}% of goal
+              <Text className="text-text-muted text-sm mt-1 text-center">
+                {goalPercentages.calories}% of {calorieGoal && calorieGoal > 0 ? `${Math.round(calorieGoal).toLocaleString()} kcal` : 'goal'}
               </Text>
             ) : null}
           </View>
@@ -129,6 +140,7 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
                     <Text className="text-text-secondary text-sm">{macro.label}</Text>
                     <Text className="text-text-primary text-sm font-medium">
                       {Math.round(macro.value)}g
+                      {macro.goal && macro.goal > 0 ? ` / ${Math.round(macro.goal)}g` : ''}
                     </Text>
                   </View>
                   <View className="h-2 rounded-full bg-progress-track overflow-hidden">
@@ -144,7 +156,7 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
                   </View>
                   {goalPct != null ? (
                     <Text className="text-text-muted text-xs mt-1">
-                      {goalPct}% of goal
+                      {goalPct}%
                     </Text>
                   ) : null}
                 </View>

--- a/SparkyFitnessMobile/src/components/NutritionMacroCard.tsx
+++ b/SparkyFitnessMobile/src/components/NutritionMacroCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import { useCSSVariable } from 'uniwind';
 import MacroCompositionRing from './MacroCompositionRing';
+import ProgressRing from './ProgressRing';
 import { getNetCarbsValue } from '../utils/nutrientUtils';
 
 export interface NutritionGoalPercentages {
@@ -50,12 +51,13 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
   carbsGoal,
   fatGoal,
 }) => {
-  const [proteinColor, carbsColor, fatColor, trackColor] = useCSSVariable([
+  const [proteinColor, carbsColor, fatColor, trackColor, accentColor] = useCSSVariable([
     '--color-macro-protein',
     '--color-macro-carbs',
     '--color-macro-fat',
     '--color-progress-track',
-  ]) as [string, string, string, string];
+    '--color-accent-primary',
+  ]) as [string, string, string, string, string];
 
   const useNetCarbs = showNetCarbs && fiber !== undefined;
   const displayCarbs = useNetCarbs ? getNetCarbsValue(carbs, fiber) : carbs;
@@ -118,16 +120,33 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
 
       {showGoalProgress ? (
         <View className="flex-row items-center">
-          <View className="flex-1 items-center pr-2">
-            <Text className="text-text-primary text-3xl font-medium">
-              {Math.round(calories)}
-            </Text>
-            <Text className="text-text-secondary text-base mt-2">calories</Text>
-            {goalPercentages?.calories != null ? (
-              <Text className="text-text-muted text-sm mt-1 text-center">
-                {goalPercentages.calories}% of {calorieGoal && calorieGoal > 0 ? `${Math.round(calorieGoal).toLocaleString()} kcal` : 'goal'}
+          <View className="flex-1 items-center pr-2 justify-center">
+            <View className="items-center justify-center relative" style={{ width: 110, height: 110 }}>
+              <ProgressRing
+                progress={calories / (calorieGoal || 1)}
+                size={100}
+                strokeWidth={8}
+                color={accentColor}
+                backgroundColor={trackColor}
+              />
+              <View className="absolute items-center justify-center">
+                <Text className="text-text-primary text-xl font-bold">
+                  {calorieGoal && calorieGoal > 0 ? Math.max(0, Math.round(calorieGoal - calories)).toLocaleString() : Math.round(calories).toLocaleString()}
+                </Text>
+                <Text className="text-text-muted text-[10px] uppercase font-semibold mt-0.5">
+                  {calorieGoal && calorieGoal > 0 ? 'left' : 'kcal'}
+                </Text>
+              </View>
+            </View>
+            {calorieGoal && calorieGoal > 0 ? (
+              <Text className="text-text-muted text-xs mt-2 text-center">
+                {Math.round(calories).toLocaleString()} / {Math.round(calorieGoal).toLocaleString()} kcal ({goalPercentages?.calories}%)
               </Text>
-            ) : null}
+            ) : (
+              <Text className="text-text-muted text-xs mt-2 text-center">
+                {Math.round(calories).toLocaleString()} kcal
+              </Text>
+            )}
           </View>
 
           <View className="flex-2 gap-3">
@@ -154,11 +173,15 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
                       />
                     ) : null}
                   </View>
-                  {goalPct != null ? (
-                    <Text className="text-text-muted text-xs mt-1">
-                      {goalPct}%
-                    </Text>
-                  ) : null}
+                  {goalPct != null ? (() => {
+                    const diff = macro.goal ? macro.goal - macro.value : 0;
+                    const remainingText = diff > 0 ? `${Math.round(diff)}g left` : diff < 0 ? `${Math.round(Math.abs(diff))}g over` : 'met';
+                    return (
+                      <Text className="text-text-muted text-xs mt-1">
+                        {goalPct}%{macro.goal && macro.goal > 0 ? ` · ${remainingText}` : ''}
+                      </Text>
+                    );
+                  })() : null}
                 </View>
               );
             })}

--- a/SparkyFitnessMobile/src/hooks/index.ts
+++ b/SparkyFitnessMobile/src/hooks/index.ts
@@ -112,3 +112,5 @@ export { useCustomNutrients } from './useCustomNutrients';
 export type { UserCustomNutrient } from './useCustomNutrients';
 export { useNutrientDisplayPreferences } from './useNutrientDisplayPreferences';
 export { useChatHistory } from './useChatHistory';
+export { useNutritionTrends } from './useNutritionTrends';
+export type { TrendRange } from './useNutritionTrends';

--- a/SparkyFitnessMobile/src/hooks/queryKeys.ts
+++ b/SparkyFitnessMobile/src/hooks/queryKeys.ts
@@ -105,3 +105,6 @@ export const customNutrientsQueryKey = ['customNutrients'] as const;
 export const nutrientDisplayPreferencesQueryKey = ['nutrientDisplayPreferences'] as const;
 
 export const chatHistoryQueryKey = ['chatHistory'] as const;
+
+export const nutritionTrendsQueryKey = (startDate: string, endDate: string) =>
+  ['nutritionTrends', startDate, endDate] as const;

--- a/SparkyFitnessMobile/src/hooks/useDailySummary.ts
+++ b/SparkyFitnessMobile/src/hooks/useDailySummary.ts
@@ -112,6 +112,7 @@ export function useDailySummary({ date, enabled = true }: UseDailySummaryOptions
         foodEntries,
         exerciseEntries,
         calorieBalance: resolvedCalorieBalance,
+        goals,
         customNutrientTotals: calculateCustomNutrientTotals(foodEntries),
         // Per-custom-nutrient goals (keyed by name, matching customNutrientTotals).
         // Normalized to numbers; absent/zero goals are simply not tracked.

--- a/SparkyFitnessMobile/src/hooks/useNutritionTrends.ts
+++ b/SparkyFitnessMobile/src/hooks/useNutritionTrends.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchNutritionTrends } from '../services/api/reportsApi';
+import { useRefetchOnFocus } from './useRefetchOnFocus';
+import { nutritionTrendsQueryKey } from './queryKeys';
+import { getTodayDate, addDays } from '../utils/dateUtils';
+
+export type TrendRange = '7d' | '30d' | '90d';
+
+const RANGE_DAYS: Record<TrendRange, number> = {
+  '7d': 7,
+  '30d': 30,
+  '90d': 90,
+};
+
+interface UseNutritionTrendsOptions {
+  range: TrendRange;
+  enabled?: boolean;
+}
+
+export function useNutritionTrends({ range, enabled = true }: UseNutritionTrendsOptions) {
+  const today = getTodayDate();
+  const days = RANGE_DAYS[range];
+  const startDate = addDays(today, -(days - 1));
+
+  const query = useQuery({
+    queryKey: nutritionTrendsQueryKey(startDate, today),
+    queryFn: () => fetchNutritionTrends(startDate, today),
+    enabled,
+  });
+
+  useRefetchOnFocus(query.refetch, enabled);
+
+  return {
+    data: query.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    refetch: query.refetch,
+  };
+}

--- a/SparkyFitnessMobile/src/screens/DailyNutritionDetailsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DailyNutritionDetailsScreen.tsx
@@ -1,0 +1,313 @@
+import React, { useMemo } from 'react';
+import { View, Text, ScrollView, ActivityIndicator, TouchableOpacity } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useCSSVariable } from 'uniwind';
+
+import { useScreenHeader } from '../hooks/useScreenHeader';
+import { useDailySummary } from '../hooks/useDailySummary';
+import { useNutrientDisplayPreferences } from '../hooks/useNutrientDisplayPreferences';
+import { useCustomNutrients } from '../hooks/useCustomNutrients';
+import { useServerConnection } from '../hooks/useServerConnection';
+import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
+import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
+import { NUTRIENT_META } from '../constants/nutrients';
+import NutritionMacroCard from '../components/NutritionMacroCard';
+import Icon from '../components/Icon';
+import type { RootStackScreenProps } from '../types/navigation';
+import type { FoodEntry } from '../types/foodEntries';
+
+type DailyNutritionDetailsScreenProps = RootStackScreenProps<'DailyNutritionDetails'>;
+
+const DailyNutritionDetailsScreen: React.FC<DailyNutritionDetailsScreenProps> = ({ route, navigation }) => {
+  const { date } = route.params;
+  const insets = useSafeAreaInsets();
+  const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
+  const usesNativeHeader = useNativeIOSHeadersActive();
+  const { isConnected } = useServerConnection();
+
+  const { summary, isLoading, isError } = useDailySummary({ date });
+  const { preferences } = useNutrientDisplayPreferences({ enabled: isConnected });
+  const { customNutrients: customDefs } = useCustomNutrients({ enabled: isConnected });
+
+  const [accentColor, progressTrackColor] = useCSSVariable([
+    '--color-accent-primary',
+    '--color-progress-track',
+  ]) as [string, string];
+
+  // Configure screen header
+  const header = useScreenHeader({
+    title: 'Nutrition Details',
+    left: { kind: 'back' },
+  });
+
+  // Calculate standard nutrient totals from food entries
+  const calculateNutrientTotal = (entries: FoodEntry[], key: keyof FoodEntry): number => {
+    return entries.reduce((total, entry) => {
+      if (!entry.serving_size) return total;
+      const value = entry[key];
+      if (typeof value !== 'number') return total;
+      return total + (value * entry.quantity) / entry.serving_size;
+    }, 0);
+  };
+
+  // Determine standard and custom display items ordered and filtered by report_tabular preference
+  const displayGroups = useMemo(() => {
+    if (!summary) return null;
+
+    const reportPref = preferences.find(
+      (p) => p.view_group === 'report_tabular' && p.platform === 'mobile',
+    ) || preferences.find(
+      (p) => p.view_group === 'report_tabular' && p.platform === 'web',
+    );
+
+    // Default visible keys in a logical fallback order if no report preferences are found
+    const visibleKeys = reportPref
+      ? (reportPref.visible_nutrients as string[])
+      : [
+          'dietary_fiber',
+          'sugars',
+          'saturated_fat',
+          'trans_fat',
+          'cholesterol',
+          'sodium',
+          'potassium',
+          'vitamin_a',
+          'vitamin_c',
+          'calcium',
+          'iron',
+        ];
+
+    // Build lists of nutrients grouped into categories for a clean dashboard view
+    const standardItems: {
+      key: string;
+      label: string;
+      unit: string;
+      consumed: number;
+      goal?: number;
+    }[] = [];
+
+    const customItems: {
+      key: string;
+      label: string;
+      unit: string;
+      consumed: number;
+      goal?: number;
+    }[] = [];
+
+    // Filter and compute standard nutrients in order of visibleKeys
+    for (const key of visibleKeys) {
+      // Exclude base macros from the detailed breakdown if they are already visible in top card
+      if (['calories', 'protein', 'carbs', 'fat'].includes(key)) {
+        continue;
+      }
+
+      if (key === 'glycemic_index') {
+        standardItems.push({
+          key,
+          label: NUTRIENT_META[key]?.label ?? 'Glycemic Index',
+          unit: '',
+          consumed: 0, // categorical, handled specifically in render
+          goal: undefined,
+        });
+        continue;
+      }
+
+      const meta = NUTRIENT_META[key];
+      if (meta) {
+        const consumed = calculateNutrientTotal(summary.foodEntries, key as keyof FoodEntry);
+        const goal = summary.goals[key as keyof typeof summary.goals] as number | undefined;
+
+        standardItems.push({
+          key,
+          label: meta.label,
+          unit: meta.unit,
+          consumed,
+          goal: goal && goal > 0 ? goal : undefined,
+        });
+      }
+    }
+
+    // Process custom user-defined nutrients
+    const seenCustom = new Set<string>();
+    for (const def of customDefs) {
+      const isVisible = !reportPref || visibleKeys.includes(def.name);
+      if (isVisible) {
+        const consumed = summary.customNutrientTotals[def.name] ?? 0;
+        const goal = summary.customNutrientGoals[def.name] ?? undefined;
+        customItems.push({
+          key: def.name,
+          label: def.name,
+          unit: def.unit || 'g',
+          consumed,
+          goal: goal && goal > 0 ? goal : undefined,
+        });
+        seenCustom.add(def.name);
+      }
+    }
+
+    // Add any logged custom nutrients not in current custom definitions
+    for (const [name, consumed] of Object.entries(summary.customNutrientTotals)) {
+      if (seenCustom.has(name)) continue;
+      const isVisible = !reportPref || visibleKeys.includes(name);
+      if (isVisible) {
+        const goal = summary.customNutrientGoals[name] ?? undefined;
+        customItems.push({
+          key: name,
+          label: name,
+          unit: 'g',
+          consumed,
+          goal: goal && goal > 0 ? goal : undefined,
+        });
+      }
+    }
+
+    return { standardItems, customItems };
+  }, [summary, preferences, customDefs]);
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 bg-background justify-center items-center">
+        <ActivityIndicator size="large" color={accentColor} />
+      </View>
+    );
+  }
+
+  if (isError || !summary) {
+    return (
+      <View className="flex-1 bg-background justify-center items-center p-4">
+        <Text className="text-text-primary text-base font-semibold mb-2">
+          Failed to load nutrition details
+        </Text>
+        <Text className="text-text-secondary text-sm text-center">
+          Please check your connection and try again.
+        </Text>
+      </View>
+    );
+  }
+
+  const goalPercentages = {
+    calories: summary.calorieGoal > 0 ? Math.round((summary.caloriesConsumed / summary.calorieGoal) * 100) : null,
+    protein: summary.protein.goal > 0 ? Math.round((summary.protein.consumed / summary.protein.goal) * 100) : null,
+    carbs: summary.carbs.goal > 0 ? Math.round((summary.carbs.consumed / summary.carbs.goal) * 100) : null,
+    fat: summary.fat.goal > 0 ? Math.round((summary.fat.consumed / summary.fat.goal) * 100) : null,
+  };
+
+  const renderNutrientRow = (item: {
+    key: string;
+    label: string;
+    unit: string;
+    consumed: number;
+    goal?: number;
+  }) => {
+    if (item.key === 'glycemic_index') {
+      const giValues = summary.foodEntries
+        .map((e) => e.glycemic_index)
+        .filter((gi) => gi && gi !== 'None');
+      const giValue = giValues.length > 0 ? giValues[0] : 'None';
+
+      return (
+        <View key={item.key} className="py-3 border-b border-border-subtle">
+          <View className="flex-row justify-between items-center">
+            <Text className="text-text-secondary text-sm font-medium">{item.label}</Text>
+            <Text className="text-text-primary text-sm font-semibold">{giValue}</Text>
+          </View>
+        </View>
+      );
+    }
+
+    const hasGoal = item.goal !== undefined && item.goal > 0;
+    const progressPercent = hasGoal ? Math.min(Math.round((item.consumed / (item.goal || 1)) * 100), 100) : 0;
+
+    return (
+      <TouchableOpacity
+        key={item.key}
+        activeOpacity={0.7}
+        onPress={() =>
+          navigation.navigate('NutrientTrends', {
+            nutrientKey: item.key,
+            nutrientLabel: item.label,
+            unit: item.unit,
+            goal: item.goal,
+          })
+        }
+        className="py-3 border-b border-border-subtle"
+      >
+        <View className="flex-row justify-between items-baseline mb-1">
+          <Text className="text-text-secondary text-sm font-medium">{item.label}</Text>
+          <View className="flex-row items-center gap-1.5">
+            <Text className="text-text-primary text-sm font-semibold">
+              {Math.round(item.consumed).toLocaleString()}
+              <Text className="text-text-muted text-xs font-normal"> {item.unit}</Text>
+              {hasGoal && (
+                <Text className="text-text-muted text-xs font-normal">
+                  {` / ${Math.round(item.goal!).toLocaleString()} ${item.unit}`}
+                </Text>
+              )}
+            </Text>
+            <Icon name="chevron-forward" size={14} color={progressTrackColor} />
+          </View>
+        </View>
+        {hasGoal && (
+          <View className="h-1.5 bg-progress-track rounded-full overflow-hidden mt-1" style={{ backgroundColor: progressTrackColor }}>
+            <View
+              className="h-full rounded-full"
+              style={{
+                backgroundColor: accentColor,
+                width: `${progressPercent}%`,
+              }}
+            />
+          </View>
+        )}
+      </TouchableOpacity>
+    );
+  };
+
+  return (
+    <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
+      {header}
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{
+          padding: 16,
+          paddingBottom: insets.bottom + 80 + activeWorkoutBarPadding,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Macronutrients Card */}
+        <NutritionMacroCard
+          calories={summary.caloriesConsumed}
+          protein={summary.protein.consumed}
+          carbs={summary.carbs.consumed}
+          fat={summary.fat.consumed}
+          fiber={summary.fiber.consumed}
+          goalPercentages={goalPercentages}
+          showNetCarbs={false}
+          calorieGoal={summary.calorieGoal}
+          proteinGoal={summary.protein.goal}
+          carbsGoal={summary.carbs.goal}
+          fatGoal={summary.fat.goal}
+        />
+
+
+
+        {/* Predefined Nutrients Section */}
+        {displayGroups && displayGroups.standardItems.length > 0 && (
+          <View className="bg-surface rounded-xl p-4 mt-4 shadow-sm">
+            <Text className="text-text-primary text-base font-bold mb-2">Nutrient Breakdown</Text>
+            {displayGroups.standardItems.map(renderNutrientRow)}
+          </View>
+        )}
+
+        {/* Custom Nutrients Section */}
+        {displayGroups && displayGroups.customItems.length > 0 && (
+          <View className="bg-surface rounded-xl p-4 mt-4 shadow-sm">
+            <Text className="text-text-primary text-base font-bold mb-2">Custom Tracked Nutrients</Text>
+            {displayGroups.customItems.map(renderNutrientRow)}
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+};
+
+export default DailyNutritionDetailsScreen;

--- a/SparkyFitnessMobile/src/screens/DailyNutritionDetailsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DailyNutritionDetailsScreen.tsx
@@ -218,6 +218,14 @@ const DailyNutritionDetailsScreen: React.FC<DailyNutritionDetailsScreenProps> = 
     const hasGoal = item.goal !== undefined && item.goal > 0;
     const progressPercent = hasGoal ? Math.min(Math.round((item.consumed / (item.goal || 1)) * 100), 100) : 0;
 
+    let subText = '';
+    if (hasGoal) {
+      const diff = item.goal! - item.consumed;
+      const remainingLabel = diff > 0 ? `${Math.round(diff).toLocaleString()}${item.unit} left` : diff < 0 ? `${Math.round(Math.abs(diff)).toLocaleString()}${item.unit} over` : 'met';
+      const pct = Math.round((item.consumed / item.goal!) * 100);
+      subText = `${pct}% · ${remainingLabel}`;
+    }
+
     return (
       <TouchableOpacity
         key={item.key}
@@ -232,31 +240,31 @@ const DailyNutritionDetailsScreen: React.FC<DailyNutritionDetailsScreenProps> = 
         }
         className="py-3 border-b border-border-subtle"
       >
-        <View className="flex-row justify-between items-baseline mb-1">
+        <View className="flex-row justify-between items-center mb-1">
           <Text className="text-text-secondary text-sm font-medium">{item.label}</Text>
-          <View className="flex-row items-center gap-1.5">
+          <View className="flex-row items-center gap-1">
             <Text className="text-text-primary text-sm font-semibold">
-              {Math.round(item.consumed).toLocaleString()}
-              <Text className="text-text-muted text-xs font-normal"> {item.unit}</Text>
-              {hasGoal && (
-                <Text className="text-text-muted text-xs font-normal">
-                  {` / ${Math.round(item.goal!).toLocaleString()} ${item.unit}`}
-                </Text>
-              )}
+              {Math.round(item.consumed).toLocaleString()}{item.unit}
+              {hasGoal && ` / ${Math.round(item.goal!).toLocaleString()}${item.unit}`}
             </Text>
             <Icon name="chevron-forward" size={14} color={progressTrackColor} />
           </View>
         </View>
         {hasGoal && (
-          <View className="h-1.5 bg-progress-track rounded-full overflow-hidden mt-1" style={{ backgroundColor: progressTrackColor }}>
-            <View
-              className="h-full rounded-full"
-              style={{
-                backgroundColor: accentColor,
-                width: `${progressPercent}%`,
-              }}
-            />
-          </View>
+          <>
+            <View className="h-1.5 bg-progress-track rounded-full overflow-hidden mt-1" style={{ backgroundColor: progressTrackColor }}>
+              <View
+                className="h-full rounded-full"
+                style={{
+                  backgroundColor: accentColor,
+                  width: `${progressPercent}%`,
+                }}
+              />
+            </View>
+            <Text className="text-[10px] text-text-muted mt-1">
+              {subText}
+            </Text>
+          </>
         )}
       </TouchableOpacity>
     );

--- a/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
@@ -314,7 +314,16 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
           if (dashboardNutrients.length === 0) return null;
           return (
             <View className="bg-surface rounded-xl p-3 mb-3 shadow-sm">
-              <Text className="text-md font-bold text-text-secondary mb-2 px-1">Macronutrients</Text>
+              <Pressable
+                onPress={() => navigation.navigate('DailyNutritionDetails', { date: summary.date })}
+                className="flex-row justify-between items-center mb-2 px-1"
+              >
+                <Text className="text-md font-bold text-text-secondary">Nutrients</Text>
+                <View className="flex-row items-center">
+                  <Text className="text-xs font-semibold text-accent-primary mr-1">Details</Text>
+                  <Icon name="chevron-forward" size={14} color={accentColor} />
+                </View>
+              </Pressable>
               <View className="flex-row flex-wrap justify-between">
                 {dashboardNutrients.map((nutrientKey) => {
                   // Resolve display label and unit.

--- a/SparkyFitnessMobile/src/screens/NutrientTrendsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/NutrientTrendsScreen.tsx
@@ -1,0 +1,178 @@
+import React, { useMemo, useState } from 'react';
+import { View, Text, ScrollView, ActivityIndicator } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useCSSVariable } from 'uniwind';
+
+import { useScreenHeader } from '../hooks/useScreenHeader';
+import { useNutritionTrends, type TrendRange } from '../hooks/useNutritionTrends';
+import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
+import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
+import SegmentedControl, { type Segment } from '../components/SegmentedControl';
+import NutrientBarChart from '../components/NutrientBarChart';
+import type { RootStackScreenProps } from '../types/navigation';
+
+type NutrientTrendsScreenProps = RootStackScreenProps<'NutrientTrends'>;
+
+const RANGE_SEGMENTS: Segment<TrendRange>[] = [
+  { key: '7d', label: '7d' },
+  { key: '30d', label: '30d' },
+  { key: '90d', label: '90d' },
+];
+
+const NutrientTrendsScreen: React.FC<NutrientTrendsScreenProps> = ({ route }) => {
+  const { nutrientKey, nutrientLabel, unit, goal } = route.params;
+  const insets = useSafeAreaInsets();
+  const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
+  const usesNativeHeader = useNativeIOSHeadersActive();
+  const [range, setRange] = useState<TrendRange>('7d');
+
+  const [accentColor] = useCSSVariable(['--color-accent-primary']) as [string];
+
+  const header = useScreenHeader({
+    title: `${nutrientLabel} Trends`,
+    left: { kind: 'back' },
+  });
+
+  const { data, isLoading, isError } = useNutritionTrends({ range });
+
+  // Map historical trend data to extract values for this specific nutrient
+  const chartData = useMemo(() => {
+    return data.map((item) => {
+      const rawVal = item[nutrientKey];
+      const val = typeof rawVal === 'number' ? rawVal : parseFloat(String(rawVal)) || 0;
+      return {
+        day: item.date,
+        value: val,
+      };
+    });
+  }, [data, nutrientKey]);
+
+  // Compute stats
+  const stats = useMemo(() => {
+    if (chartData.length === 0) {
+      return { average: 0, peak: 0, peakDay: '' };
+    }
+
+    const sum = chartData.reduce((acc, point) => acc + point.value, 0);
+    const average = sum / chartData.length;
+
+    let peak = 0;
+    let peakDay = '';
+    chartData.forEach((point) => {
+      if (point.value > peak) {
+        peak = point.value;
+        peakDay = point.day;
+      }
+    });
+
+    return { average, peak, peakDay };
+  }, [chartData]);
+
+  const formattedPeakDay = useMemo(() => {
+    if (!stats.peakDay) return '';
+    const [year, month, d] = stats.peakDay.split('-').map(Number);
+    const date = new Date(year, month - 1, d);
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  }, [stats.peakDay]);
+
+  if (isLoading) {
+    return (
+      <View className="flex-1 bg-background justify-center items-center">
+        <ActivityIndicator size="large" color={accentColor} />
+      </View>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View className="flex-1 bg-background justify-center items-center p-4">
+        <Text className="text-text-primary text-base font-semibold mb-2">
+          Failed to load trend data
+        </Text>
+        <Text className="text-text-secondary text-sm text-center">
+          Please check your connection and try again.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
+      {header}
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{
+          padding: 16,
+          paddingBottom: insets.bottom + 80 + activeWorkoutBarPadding,
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Segmented Range Control */}
+        <View className="mb-4">
+          <SegmentedControl
+            segments={RANGE_SEGMENTS}
+            activeKey={range}
+            onSelect={setRange}
+          />
+        </View>
+
+        {/* Nutrient Intake Chart */}
+        <NutrientBarChart
+          data={chartData}
+          isLoading={isLoading}
+          isError={isError}
+          range={range}
+          nutrientLabel={nutrientLabel}
+          unit={unit}
+          goal={goal}
+        />
+
+        {/* Statistics Summary Card */}
+        <View className="bg-surface rounded-xl p-4 mt-4 shadow-sm">
+          <Text className="text-text-primary text-base font-bold mb-3">
+            Summary Statistics
+          </Text>
+
+          <View className="flex-row justify-between py-2 border-b border-border-subtle">
+            <Text className="text-text-secondary text-sm">Daily Average</Text>
+            <Text className="text-text-primary text-sm font-semibold">
+              {stats.average % 1 !== 0 ? stats.average.toFixed(1) : stats.average} {unit}
+            </Text>
+          </View>
+
+          <View className="flex-row justify-between py-2 border-b border-border-subtle">
+            <Text className="text-text-secondary text-sm">Highest Intake Day</Text>
+            <View className="items-end">
+              <Text className="text-text-primary text-sm font-semibold">
+                {stats.peak % 1 !== 0 ? stats.peak.toFixed(1) : stats.peak} {unit}
+              </Text>
+              {formattedPeakDay ? (
+                <Text className="text-text-muted text-xs mt-0.5">{formattedPeakDay}</Text>
+              ) : null}
+            </View>
+          </View>
+
+          {goal && goal > 0 ? (
+            <>
+              <View className="flex-row justify-between py-2 border-b border-border-subtle">
+                <Text className="text-text-secondary text-sm">Target Daily Goal</Text>
+                <Text className="text-text-primary text-sm font-semibold">
+                  {Math.round(goal).toLocaleString()} {unit}
+                </Text>
+              </View>
+
+              <View className="flex-row justify-between py-2">
+                <Text className="text-text-secondary text-sm">Average vs. Target</Text>
+                <Text className="text-text-primary text-sm font-semibold">
+                  {Math.round((stats.average / goal) * 100)}% of goal
+                </Text>
+              </View>
+            </>
+          ) : null}
+        </View>
+      </ScrollView>
+    </View>
+  );
+};
+
+export default NutrientTrendsScreen;

--- a/SparkyFitnessMobile/src/services/api/reportsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/reportsApi.ts
@@ -1,0 +1,35 @@
+import { apiFetch } from './apiClient';
+
+export interface NutritionTrendPoint {
+  date: string;
+  calories: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+  saturated_fat: number;
+  polyunsaturated_fat: number;
+  monounsaturated_fat: number;
+  trans_fat: number;
+  cholesterol: number;
+  sodium: number;
+  potassium: number;
+  dietary_fiber: number;
+  sugars: number;
+  vitamin_a: number;
+  vitamin_c: number;
+  calcium: number;
+  iron: number;
+  [customNutrient: string]: string | number;
+}
+
+export const fetchNutritionTrends = (
+  startDate: string,
+  endDate: string
+): Promise<NutritionTrendPoint[]> =>
+  apiFetch<NutritionTrendPoint[]>({
+    endpoint: `/api/reports/mini-nutrition-trends?startDate=${encodeURIComponent(
+      startDate
+    )}&endDate=${encodeURIComponent(endDate)}`,
+    serviceName: 'Reports API',
+    operation: 'fetch nutrition trends',
+  });

--- a/SparkyFitnessMobile/src/types/dailySummary.ts
+++ b/SparkyFitnessMobile/src/types/dailySummary.ts
@@ -1,5 +1,6 @@
 import type { ExerciseSessionResponse, CalorieBalance } from '@workspace/shared';
 import type { FoodEntry } from './foodEntries';
+import type { DailyGoals } from './goals';
 
 export interface MacroSummary {
   consumed: number;
@@ -28,6 +29,7 @@ export interface DailySummary {
   foodEntries: FoodEntry[];
   exerciseEntries: ExerciseSessionResponse[];
   calorieBalance: CalorieBalance;
+  goals: DailyGoals;
   /** Pre-aggregated custom nutrient totals for the day (name → consumed value). */
   customNutrientTotals: Record<string, number>;
   /** Per-custom-nutrient goals (name → goal value); empty when none are set. */

--- a/SparkyFitnessMobile/src/types/navigation.ts
+++ b/SparkyFitnessMobile/src/types/navigation.ts
@@ -91,6 +91,13 @@ export type RootStackParamList = {
     adjustedCustomNutrients?: Record<string, string | number> | null;
   };
   MealTypeDetail: { date: string; mealType: MealTypeKey; mealLabel?: string };
+  DailyNutritionDetails: { date: string };
+  NutrientTrends: {
+    nutrientKey: string;
+    nutrientLabel: string;
+    unit: string;
+    goal?: number;
+  };
   FoodForm:
     | {
         mode: 'create-food';

--- a/SparkyFitnessMobile/targets/widget/Info.plist
+++ b/SparkyFitnessMobile/targets/widget/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>APP_GROUP_IDENTIFIER</key>
-    <string>group.org.SparkyApps.SparkyFitnessMobile.dev</string>
+    <string>group.org.SparkyApps.SparkyFitnessMobile1.dev</string>
     <key>NSExtension</key>
     <dict>
       <key>NSExtensionPointIdentifier</key>

--- a/SparkyFitnessMobile/targets/widget/Info.plist
+++ b/SparkyFitnessMobile/targets/widget/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>APP_GROUP_IDENTIFIER</key>
-    <string>group.org.SparkyApps.SparkyFitnessMobile1.dev</string>
+    <string>group.org.SparkyApps.SparkyFitnessMobile.dev</string>
     <key>NSExtension</key>
     <dict>
       <key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)
- Implement DailyNutritionDetailsScreen to display a preference-aware tabular breakdown of standard and custom nutrients.
- Link the entry point to the Dashboard's "Nutrients" section, adding chevron indicators and tap-to-navigate action.
- Add reportsApi and useNutritionTrends hook to query daily historical records from `/reports/mini-nutrition-trends`.
- Implement NutrientBarChart utilizing victory-native (Skia-backed CartesianChart) to plot daily nutrient consumption.
- Add a mathematically scaled target goal guideline (drawn with Skia Line) that dynamically fits the chart domain.
- Clean up and revert temporary details layout changes from the Diary summary card.
- Run typecheck and lint checks successfully with 0 errors and warnings.

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes # https://github.com/CodeWithCJ/SparkyFitness/issues/1338

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>


**Nutrient section dashboard udpated to include % and actual remaining.**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/a78c646a-0887-45e4-a7d0-08b5da847b56" />

**Added new details screen.**

<img width="1206
" height="2622" alt="image" src="https://github.com/user-attachments/assets/fea3dbc1-1bdb-48b2-b8bd-e4290a1c9893" />


**trend chart for the selected nutrient**

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/980c33cc-cd58-4d48-892e-c943419d3af2" />

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
