### PR TITLE
feat(mobile): add editable entry time to food and meal logging

### DIFF
--- a/SparkyFitnessMobile/__tests__/screens/EditLoggedMealScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/EditLoggedMealScreen.test.tsx
@@ -165,6 +165,18 @@ jest.mock('../../src/components/CalendarSheet', () => {
   };
 });
 
+jest.mock('../../src/components/TimeSheet', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: React.forwardRef((_p: any, ref: any) => {
+      React.useImperativeHandle(ref, () => ({ present: jest.fn() }));
+      return <View />;
+    }),
+  };
+});
+
 const mockUseFoodEntryMealDetails = useFoodEntryMealDetails as jest.MockedFunction<typeof useFoodEntryMealDetails>;
 const mockUseUpdateFoodEntryMeal = useUpdateFoodEntryMeal as jest.MockedFunction<typeof useUpdateFoodEntryMeal>;
 const mockUseDeleteFoodEntryMeal = useDeleteFoodEntryMeal as jest.MockedFunction<typeof useDeleteFoodEntryMeal>;

--- a/SparkyFitnessMobile/__tests__/screens/FoodEntryAddScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodEntryAddScreen.test.tsx
@@ -195,6 +195,20 @@ jest.mock('../../src/components/CalendarSheet', () => {
   };
 });
 
+jest.mock('../../src/components/TimeSheet', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const MockTimeSheet = React.forwardRef((_props: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({ present: jest.fn() }));
+    return <View testID="time-sheet" />;
+  });
+  MockTimeSheet.displayName = 'MockTimeSheet';
+  return {
+    __esModule: true,
+    default: MockTimeSheet,
+  };
+});
+
 jest.mock('../../src/utils/mealBuilderDraft', () => {
   const actual = jest.requireActual('../../src/utils/mealBuilderDraft');
   return {
@@ -713,6 +727,7 @@ describe('FoodEntryAddScreen', () => {
         quantity: 1,
         unit: 'cup',
         entry_date: '2026-04-23',
+        entry_time: null,
         food_id: 'food-1',
         variant_id: 'variant-1',
       },
@@ -1005,6 +1020,7 @@ describe('FoodEntryAddScreen', () => {
           quantity: 1,
           unit: 'oz',
           entry_date: '2026-04-23',
+          entry_time: null,
           food_id: 'saved-food-1',
           variant_id: 'saved-variant-oz',
         },
@@ -1086,6 +1102,7 @@ describe('FoodEntryAddScreen', () => {
           quantity: 1,
           unit: 'oz',
           entry_date: '2026-04-23',
+          entry_time: null,
         },
       });
     });

--- a/SparkyFitnessMobile/__tests__/screens/FoodEntryViewScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodEntryViewScreen.test.tsx
@@ -155,6 +155,20 @@ jest.mock('../../src/components/CalendarSheet', () => {
   };
 });
 
+jest.mock('../../src/components/TimeSheet', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const MockTimeSheet = React.forwardRef((_props: any, ref: any) => {
+    React.useImperativeHandle(ref, () => ({ present: jest.fn() }));
+    return <View testID="time-sheet" />;
+  });
+  MockTimeSheet.displayName = 'MockTimeSheet';
+  return {
+    __esModule: true,
+    default: MockTimeSheet,
+  };
+});
+
 const mockUseMealTypes = useMealTypes as jest.MockedFunction<typeof useMealTypes>;
 const mockUseFoodVariants = useFoodVariants as jest.MockedFunction<typeof useFoodVariants>;
 const mockUseCreateFoodVariant =

--- a/SparkyFitnessMobile/src/components/SwipeableFoodRow.tsx
+++ b/SparkyFitnessMobile/src/components/SwipeableFoodRow.tsx
@@ -13,6 +13,7 @@ import { useDeleteFoodEntry } from '../hooks/useDeleteFoodEntry';
 import { useDeleteFoodEntryMeal } from '../hooks/useDeleteFoodEntryMeal';
 import type { FoodEntry } from '../types/foodEntries';
 import type { EntryNutrition } from '../utils/mealNutrition';
+import { formatTimeLabel } from '../utils/entryTimeDisplay';
 
 interface SwipeableFoodRowProps {
   entry: FoodEntry;
@@ -100,6 +101,7 @@ const SwipeableFoodRow: React.FC<SwipeableFoodRowProps> = ({ entry, nutrition, o
 
   const canQuickAdjust = !isMealComponent && !!onAdjustServing && Number(entry.serving_size) > 0;
   const name = entry.food_name || 'Unknown food';
+  const timeLabel = formatTimeLabel(entry.entry_time);
 
   const handlePress = () => {
     if (isMealComponent && entry.food_entry_meal_id) {
@@ -145,6 +147,11 @@ const SwipeableFoodRow: React.FC<SwipeableFoodRowProps> = ({ entry, nutrition, o
               <Text className="text-sm text-text-secondary" numberOfLines={1}>
                 {' · '}{entry.quantity} {entry.unit}
               </Text>
+              {timeLabel && (
+                <Text className="text-xs text-text-link ml-1.5" numberOfLines={1}>
+                  {timeLabel}
+                </Text>
+              )}
             </View>
           </TouchableOpacity>
           {canQuickAdjust ? (

--- a/SparkyFitnessMobile/src/components/TimeSheet.tsx
+++ b/SparkyFitnessMobile/src/components/TimeSheet.tsx
@@ -1,0 +1,127 @@
+import React, { forwardRef, useCallback, useImperativeHandle, useMemo, useRef } from 'react';
+import { Platform } from 'react-native';
+import {
+  BottomSheetBackdrop,
+  BottomSheetModal,
+  BottomSheetView,
+  type BottomSheetBackdropProps,
+} from '@gorhom/bottom-sheet';
+import { FullWindowOverlay } from 'react-native-screens';
+import { useCSSVariable, useUniwind } from 'uniwind';
+import DateTimePicker, { type DateType } from 'react-native-ui-datepicker';
+
+// Render the sheet inside an iOS UIWindow so it sits above any native modal
+// presentation. No-op on Android.
+const sheetContainer =
+  Platform.OS === 'ios'
+    ? ({ children }: React.PropsWithChildren) => <FullWindowOverlay>{children}</FullWindowOverlay>
+    : undefined;
+
+/** Normalizes the picker's 6-way `DateType` into a JS `Date`. */
+function dateTypeToDate(date: DateType): Date | null {
+  if (!date) return null;
+  if (date instanceof Date) return date;
+  if (typeof date === 'object' && 'toDate' in date) return date.toDate();
+  if (typeof date === 'string') return new Date(date);
+  return new Date(date);
+}
+
+/** Builds a `Date` seeded with today's date and the given 'HH:MM' (or now if empty/invalid). */
+function timeStringToDate(value: string): Date {
+  const now = new Date();
+  if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(value)) return now;
+  const [hours, minutes] = value.split(':').map(Number);
+  const date = new Date(now);
+  date.setHours(hours, minutes, 0, 0);
+  return date;
+}
+
+function dateToTimeString(date: Date): string {
+  return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+}
+
+export interface TimeSheetRef {
+  present: () => void;
+  dismiss: () => void;
+}
+
+interface TimeSheetProps {
+  value: string; // '' or 'HH:MM'
+  onSelectTime: (time: string) => void;
+}
+
+const TimeSheet = forwardRef<TimeSheetRef, TimeSheetProps>(({ value, onSelectTime }, ref) => {
+  const bottomSheetRef = useRef<BottomSheetModal>(null);
+  const { theme } = useUniwind();
+  const isDarkMode = theme === 'dark' || theme === 'amoled';
+
+  const [surfaceBg, textMuted, accentPrimary, textPrimary] = useCSSVariable([
+    '--color-surface',
+    '--color-text-muted',
+    '--color-accent-primary',
+    '--color-text-primary',
+  ]) as [string, string, string, string];
+
+  useImperativeHandle(ref, () => ({
+    present: () => bottomSheetRef.current?.present(),
+    dismiss: () => bottomSheetRef.current?.dismiss(),
+  }));
+
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        opacity={isDarkMode ? 0.7 : 0.5}
+        disappearsOnIndex={-1}
+        appearsOnIndex={0}
+      />
+    ),
+    [isDarkMode],
+  );
+
+  const handleChange = useCallback(
+    ({ date }: { date: DateType }) => {
+      const js = dateTypeToDate(date);
+      if (js && !Number.isNaN(js.getTime())) onSelectTime(dateToTimeString(js));
+    },
+    [onSelectTime],
+  );
+
+  const pickerStyles = useMemo(
+    () => ({
+      time_selector_label: { color: textPrimary, fontWeight: '600' as const },
+      time_label: { color: textPrimary },
+      selected_month: { backgroundColor: accentPrimary },
+      selected_month_label: { color: '#FFFFFF' },
+    }),
+    [accentPrimary, textPrimary],
+  );
+
+  return (
+    <BottomSheetModal
+      ref={bottomSheetRef}
+      enableDynamicSizing
+      backdropComponent={renderBackdrop}
+      containerComponent={sheetContainer}
+      backgroundStyle={{ backgroundColor: surfaceBg }}
+      handleIndicatorStyle={{ backgroundColor: textMuted }}
+    >
+      <BottomSheetView className="pb-safe-or-5 px-2">
+        <DateTimePicker
+          mode="single"
+          date={timeStringToDate(value)}
+          timePicker
+          initialView="time"
+          hideHeader
+          use12Hours
+          onChange={handleChange}
+          styles={pickerStyles}
+        />
+      </BottomSheetView>
+    </BottomSheetModal>
+  );
+});
+
+TimeSheet.displayName = 'TimeSheet';
+
+export default TimeSheet;

--- a/SparkyFitnessMobile/src/screens/EditLoggedMealScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/EditLoggedMealScreen.tsx
@@ -11,6 +11,9 @@ import { useScreenHeader, SAVE_LABEL, SAVING_LABEL } from '../hooks/useScreenHea
 import StepperInput from '../components/StepperInput';
 import BottomSheetPicker from '../components/BottomSheetPicker';
 import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarSheet';
+import TimeSheet, { type TimeSheetRef } from '../components/TimeSheet';
+import { toHourMinute } from '@workspace/shared';
+import { formatTimeLabel } from '../utils/entryTimeDisplay';
 import NutritionMacroCard from '../components/NutritionMacroCard';
 import SwipeableIngredientRow from '../components/SwipeableIngredientRow';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
@@ -71,6 +74,7 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
   const usesNativeHeader = useNativeIOSHeadersActive();
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
   const calendarRef = useRef<CalendarSheetRef>(null);
+  const timeSheetRef = useRef<TimeSheetRef>(null);
 
   const { meal, isLoading, isError, error } = useFoodEntryMealDetails(foodEntryMealId, { initialMeal });
   const { mealTypes } = useMealTypes();
@@ -79,6 +83,7 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
 
   const [name, setName] = useState<string | null>(null);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [entryTime, setEntryTime] = useState<string | null>(null);
   const [selectedMealId, setSelectedMealId] = useState<string | undefined>(undefined);
   const [quantityText, setQuantityText] = useState<string | null>(null);
   const [ingredients, setIngredients] = useState<MealIngredientDraft[]>([]);
@@ -135,6 +140,7 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
 
   const effectiveName = name ?? meal?.name ?? '';
   const effectiveDate = selectedDate ?? (meal ? normalizeDate(meal.entry_date) : null);
+  const effectiveEntryTime = entryTime ?? (meal ? toHourMinute(meal.entry_time) ?? '' : '');
   const effectiveMealId = selectedMealId ?? meal?.meal_type_id ?? undefined;
   const effectiveQuantityText = quantityText ?? (meal ? String(meal.quantity) : '');
   const quantity = parseDecimalInput(effectiveQuantityText) || 0;
@@ -159,6 +165,7 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
     (
       (name !== null && name !== meal.name) ||
       (selectedDate !== null && selectedDate !== initialDate) ||
+      (entryTime !== null && entryTime !== (toHourMinute(meal.entry_time) ?? '')) ||
       (selectedMealId !== undefined && selectedMealId !== meal.meal_type_id) ||
       (quantityText !== null && quantity !== meal.quantity) ||
       foodsTouched
@@ -281,6 +288,7 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
       meal_type: selectedMealType?.name ?? meal.meal_type,
       meal_type_id: effectiveMealId,
       entry_date: effectiveDate,
+      entry_time: effectiveEntryTime || null,
       quantity,
       unit: meal.unit,
       meal_template_id: meal.meal_template_id,
@@ -429,6 +437,30 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
           </View>
         </Animated.View>
 
+        {/* Time row */}
+        <Animated.View layout={LinearTransition.duration(300)} className="flex-row items-center">
+          <Text className="text-text-secondary text-base mr-2">Time</Text>
+          <TouchableOpacity
+            onPress={() => timeSheetRef.current?.present()}
+            activeOpacity={0.7}
+            className="flex-row items-center"
+          >
+            <Text className="text-text-primary text-base font-medium">
+              {formatTimeLabel(effectiveEntryTime) ?? 'None'}
+            </Text>
+            <Icon name="chevron-down" size={12} color={textPrimary} style={{ marginLeft: 6 }} weight="medium" />
+          </TouchableOpacity>
+          {effectiveEntryTime !== '' && (
+            <TouchableOpacity
+              activeOpacity={0.7}
+              className="flex-row items-center ml-4"
+              onPress={() => setEntryTime('')}
+            >
+              <Text className="text-text-link text-sm font-medium">Clear</Text>
+            </TouchableOpacity>
+          )}
+        </Animated.View>
+
         {/* Component foods: tap a row to edit, swipe to remove, button to add. */}
         <View className="mt-2">
           <Text className="text-text-secondary text-sm mb-2">Foods in this meal</Text>
@@ -489,6 +521,11 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
         ref={calendarRef}
         selectedDate={effectiveDate ?? ''}
         onSelectDate={(date) => setSelectedDate(date)}
+      />
+      <TimeSheet
+        ref={timeSheetRef}
+        value={effectiveEntryTime}
+        onSelectTime={(time) => setEntryTime(time)}
       />
     </View>
   );

--- a/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
@@ -20,7 +20,10 @@ import FoodNutritionSummary from '../components/FoodNutritionSummary';
 import { fetchDailyGoals } from '../services/api/goalsApi';
 import { setPendingMealIngredientSelection } from '../services/mealBuilderSelection';
 import { CreateFoodEntryPayload } from '../services/api/foodEntriesApi';
-import { getTodayDate, formatDateLabel } from '../utils/dateUtils';
+import { getTodayDate, getDeviceTimezone, formatDateLabel } from '../utils/dateUtils';
+import { prefillEntryTime, userHourMinute } from '@workspace/shared';
+import TimeSheet, { type TimeSheetRef } from '../components/TimeSheet';
+import { formatTimeLabel } from '../utils/entryTimeDisplay';
 import { getMealTypeLabel } from '../constants/meals';
 import { goalsQueryKey } from '../hooks/queryKeys';
 import {
@@ -184,6 +187,7 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
     initialDate ?? getTodayDate(),
   );
   const calendarRef = useRef<CalendarSheetRef>(null);
+  const timeSheetRef = useRef<TimeSheetRef>(null);
   const { mealTypes, defaultMealTypeId } = useMealTypes();
   const { isConnected } = useServerConnection();
   const { preferences } = usePreferences({ enabled: isConnected });
@@ -228,6 +232,27 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
   const activeItem = savedFoodOverride ?? item;
   const effectiveMealId = selectedMealId ?? defaultMealTypeId;
   const selectedMealType = mealTypes.find((mt) => mt.id === effectiveMealId);
+
+  const [entryTime, setEntryTime] = useState('');
+  const entryTimeTouched = useRef(false);
+  useEffect(() => {
+    if (entryTimeTouched.current) return;
+    setEntryTime(
+      prefillEntryTime({
+        defaultTime: selectedMealType?.default_time,
+        isToday: selectedDate === getTodayDate(),
+        tz: getDeviceTimezone(),
+      }),
+    );
+  }, [selectedDate, selectedMealType?.default_time]);
+  const handleSelectEntryTime = (time: string) => {
+    entryTimeTouched.current = true;
+    setEntryTime(time);
+  };
+  const handleSetEntryTimeNow = () => {
+    const { hour, minute } = userHourMinute(getDeviceTimezone());
+    handleSelectEntryTime(`${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`);
+  };
 
   const isLocalFood = activeItem.source === 'local';
   const hasExternalVariants = !!(
@@ -766,6 +791,7 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
       quantity,
       unit: displayValues.servingUnit,
       entry_date: selectedDate,
+      entry_time: entryTime || null,
     };
 
     switch (activeItem.source) {
@@ -819,6 +845,7 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
       meal_type: mealTypeName,
       meal_type_id: effectiveMealId ?? undefined,
       entry_date: selectedDate,
+      entry_time: entryTime || null,
       name: item.name,
       quantity,
       unit: displayValues.servingUnit,
@@ -1418,6 +1445,43 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
               )}
             </View>
 
+            <View className="flex-row items-center mt-2">
+              <TouchableOpacity
+                onPress={() => timeSheetRef.current?.present()}
+                activeOpacity={0.7}
+                className="flex-row items-center"
+              >
+                <Text className="text-text-secondary text-base">Time</Text>
+                <Text className="text-text-primary text-base font-medium mx-1.5">
+                  {formatTimeLabel(entryTime) ?? 'None'}
+                </Text>
+                <Icon
+                  name="chevron-down"
+                  size={12}
+                  color={textPrimary}
+                  weight="medium"
+                />
+              </TouchableOpacity>
+
+              <TouchableOpacity
+                activeOpacity={0.7}
+                className="flex-row items-center mx-4"
+                onPress={handleSetEntryTimeNow}
+              >
+                <Text className="text-text-link text-sm font-medium mx-1.5">Now</Text>
+              </TouchableOpacity>
+
+              {entryTime !== '' && (
+                <TouchableOpacity
+                  activeOpacity={0.7}
+                  className="flex-row items-center"
+                  onPress={() => handleSelectEntryTime('')}
+                >
+                  <Text className="text-text-link text-sm font-medium mx-1.5">Clear</Text>
+                </TouchableOpacity>
+              )}
+            </View>
+
             {selectedMealType ? (
               <View className="flex-row items-center mt-2">
                 <Text className="text-text-secondary text-base">Meal</Text>
@@ -1518,6 +1582,11 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
         ref={calendarRef}
         selectedDate={selectedDate}
         onSelectDate={setSelectedDate}
+      />
+      <TimeSheet
+        ref={timeSheetRef}
+        value={entryTime}
+        onSelectTime={handleSelectEntryTime}
       />
     </View>
   );

--- a/SparkyFitnessMobile/src/screens/FoodEntryViewScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryViewScreen.tsx
@@ -20,6 +20,9 @@ import StepperInput from '../components/StepperInput';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import BottomSheetPicker from '../components/BottomSheetPicker';
 import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarSheet';
+import TimeSheet, { type TimeSheetRef } from '../components/TimeSheet';
+import { toHourMinute } from '@workspace/shared';
+import { formatTimeLabel } from '../utils/entryTimeDisplay';
 import { normalizeDate, formatDateLabel } from '../utils/dateUtils';
 import { getMealTypeLabel } from '../constants/meals';
 import { useMealTypes, usePreferences, useServerConnection, useCustomNutrients } from '../hooks';
@@ -118,6 +121,7 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
   const { profile } = useProfile();
   const calendarRef = useRef<CalendarSheetRef>(null);
+  const timeSheetRef = useRef<TimeSheetRef>(null);
 
   useEffect(() => {
     if (entry.food_entry_meal_id) {
@@ -134,6 +138,7 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
   interface EditState {
     isEditing: boolean;
     selectedDate: string;
+    entryTime: string;
     selectedMealId: string | undefined;
     selectedVariantId: string | undefined;
     quantityText: string;
@@ -144,9 +149,11 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
   }
 
   const initialDate = normalizeDate(entry.entry_date);
+  const initialEntryTime = toHourMinute(entry.entry_time) || '';
   const [editState, setEditState] = useState<EditState>({
     isEditing: false,
     selectedDate: initialDate,
+    entryTime: initialEntryTime,
     selectedMealId: entry.meal_type_id,
     selectedVariantId: entry.variant_id,
     quantityText: String(entry.quantity),
@@ -157,6 +164,7 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
   const {
     isEditing,
     selectedDate,
+    entryTime,
     selectedMealId,
     selectedVariantId,
     quantityText,
@@ -599,6 +607,7 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
         setEditState({
           isEditing: false,
           selectedDate: normalizeDate(mergedEntry.entry_date),
+          entryTime: toHourMinute(mergedEntry.entry_time) || '',
           selectedMealId: mergedEntry.meal_type_id,
           selectedVariantId: mergedEntry.variant_id,
           quantityText: String(mergedEntry.quantity),
@@ -612,6 +621,9 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
     const payload: UpdateFoodEntryPayload = {};
     if (quantity !== entry.quantity) payload.quantity = quantity;
     if (displayValues.servingUnit !== entry.unit) payload.unit = displayValues.servingUnit;
+    if ((entryTime || null) !== (toHourMinute(entry.entry_time) || null)) {
+      payload.entry_time = entryTime || null;
+    }
     if (selectedVariantId !== entry.variant_id) {
       payload.variant_id = selectedVariantId;
       payload.unit = displayValues.servingUnit;
@@ -1134,6 +1146,46 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
           </View>
         </Animated.View>
 
+        <Animated.View
+          layout={LinearTransition.duration(300)}
+          className="mt-2 flex-row items-center"
+        >
+          <Text className="text-text-secondary text-base mr-2">Time</Text>
+          {isEditing ? (
+            <>
+              <TouchableOpacity
+                onPress={() => timeSheetRef.current?.present()}
+                activeOpacity={0.7}
+                className="flex-row items-center"
+              >
+                <Text className="text-text-primary text-base font-medium">
+                  {formatTimeLabel(entryTime) ?? 'None'}
+                </Text>
+                <Icon
+                  name="chevron-down"
+                  size={12}
+                  color={textPrimary}
+                  style={{ marginLeft: 6 }}
+                  weight="medium"
+                />
+              </TouchableOpacity>
+              {entryTime !== '' && (
+                <TouchableOpacity
+                  activeOpacity={0.7}
+                  className="flex-row items-center ml-4"
+                  onPress={() => updateEdit({ entryTime: '' })}
+                >
+                  <Text className="text-text-link text-sm font-medium">Clear</Text>
+                </TouchableOpacity>
+              )}
+            </>
+          ) : (
+            <Text className="text-text-primary text-base font-medium">
+              {formatTimeLabel(entry.entry_time) ?? 'None'}
+            </Text>
+          )}
+        </Animated.View>
+
         <Animated.View layout={LinearTransition.duration(300)}>
           <Button
             variant="ghost"
@@ -1152,6 +1204,13 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
           ref={calendarRef}
           selectedDate={selectedDate}
           onSelectDate={(date) => updateEdit({ selectedDate: date })}
+        />
+      )}
+      {isEditing && (
+        <TimeSheet
+          ref={timeSheetRef}
+          value={entryTime}
+          onSelectTime={(time) => updateEdit({ entryTime: time })}
         />
       )}
     </View>

--- a/SparkyFitnessMobile/src/services/api/foodEntriesApi.ts
+++ b/SparkyFitnessMobile/src/services/api/foodEntriesApi.ts
@@ -6,6 +6,7 @@ export interface CreateFoodEntryPayload {
   quantity: number;
   unit: string;
   entry_date: string;
+  entry_time?: string | null;
   // Linked food entry
   food_id?: string;
   variant_id?: string;
@@ -53,6 +54,7 @@ export interface UpdateFoodEntryPayload {
   meal_type_id?: string;
   variant_id?: string;
   entry_date?: string;
+  entry_time?: string | null;
   // Nutrition snapshot overrides (server applies to entry snapshot)
   food_name?: string;
   brand_name?: string;

--- a/SparkyFitnessMobile/src/types/foodEntries.ts
+++ b/SparkyFitnessMobile/src/types/foodEntries.ts
@@ -18,6 +18,7 @@ export interface FoodEntry {
   food_name?: string;
   brand_name?: string;
   entry_date: string;
+  entry_time?: string | null;
   meal_plan_template_id?: string;
   serving_size: number;
   serving_unit?: string;

--- a/SparkyFitnessMobile/src/types/foodEntryMeals.ts
+++ b/SparkyFitnessMobile/src/types/foodEntryMeals.ts
@@ -36,6 +36,7 @@ export interface FoodEntryMeal {
   meal_type: string;
   meal_type_id: string | null;
   entry_date: string;
+  entry_time?: string | null;
   name: string;
   description: string | null;
   quantity: number;
@@ -71,6 +72,7 @@ export interface FoodEntryMealCreateData {
   meal_type: string;
   meal_type_id?: string;
   entry_date: string;
+  entry_time?: string | null;
   name: string;
   description?: string;
   quantity: number;
@@ -84,6 +86,7 @@ export interface FoodEntryMealUpdateData {
   meal_type?: string;
   meal_type_id?: string;
   entry_date?: string;
+  entry_time?: string | null;
   quantity?: number;
   unit?: string;
   meal_template_id?: string | null;

--- a/SparkyFitnessMobile/src/types/mealTypes.ts
+++ b/SparkyFitnessMobile/src/types/mealTypes.ts
@@ -6,4 +6,5 @@ export interface MealType {
   created_at: string;
   is_visible: boolean;
   show_in_quick_log: boolean;
+  default_time?: string | null;
 }

--- a/SparkyFitnessMobile/src/utils/entryTimeDisplay.ts
+++ b/SparkyFitnessMobile/src/utils/entryTimeDisplay.ts
@@ -1,0 +1,14 @@
+import { toHourMinute } from '@workspace/shared';
+
+/**
+ * Formats a stored entry_time ('HH:MM' or 'HH:MM:SS') as a localized 12h
+ * label (e.g. '1:45 PM'). Returns null when there is no time set.
+ */
+export function formatTimeLabel(time: string | null | undefined): string | null {
+  const hourMinute = toHourMinute(time);
+  if (!hourMinute) return null;
+  const [hours, minutes] = hourMinute.split(':').map(Number);
+  const date = new Date();
+  date.setHours(hours, minutes, 0, 0);
+  return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}


### PR DESCRIPTION
Mobile logging only sent entry_date, leaving diary entries without a time of day and no way to set or edit one, unlike web. Add a bottom-sheet time picker (TimeSheet) plus a Time row on the add/edit food and edit meal screens, prefilled via the shared entryTime helpers, and surface the saved time on diary rows.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/01646fd9-29f4-4f8d-aeaa-da7c92344824" />

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/fd960e27-8e72-47fd-a627-ea0f4a861b12" />

Past date entries default to meal default time

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/1cc2ba2d-54ff-4163-abb5-d2f9155e5c06" />


## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
