### PR TITLE
feat(mobile): show meal calorie targets in diary and meal detail views

### DIFF
--- a/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
+++ b/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
@@ -26,6 +26,7 @@ interface FoodNutritionSummaryProps {
   provider_verified?: boolean;
   /** Raw custom nutrient values for this food/variant (key = nutrient name, value = amount per serving). */
   customNutrients?: Record<string, string | number> | null;
+  calorieGoal?: number;
 }
 
 const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
@@ -38,6 +39,7 @@ const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
   showNetCarbs = false,
   provider_verified = false,
   customNutrients,
+  calorieGoal,
 }) => {
   const accentColor = useCSSVariable('--color-accent-primary') as string;
   const { isConnected } = useServerConnection();
@@ -126,6 +128,7 @@ const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
         goalPercentages={goalPercentages}
         goalsLoading={goalsLoading}
         showNetCarbs={showNetCarbs}
+        calorieGoal={calorieGoal}
       />
 
       {primaryNutrients.length > 0 ? (

--- a/SparkyFitnessMobile/src/components/FoodSummary.tsx
+++ b/SparkyFitnessMobile/src/components/FoodSummary.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View, Text, Pressable } from 'react-native';
 import { useCSSVariable } from 'uniwind';
 import type { FoodEntry } from '../types/foodEntries';
+import type { DailyGoals } from '../types/goals';
 import Icon, { type IconName } from './Icon';
 import { MEAL_TYPES, MEAL_CONFIG } from '../constants/meals';
 import SwipeableFoodRow from './SwipeableFoodRow';
@@ -9,11 +10,14 @@ import {
   calculateEntryNutrition,
   calculateMealNutrition,
   groupFoodEntriesByMealType,
+  getMealPercentage,
   type MealTypeKey,
 } from '../utils/mealNutrition';
 
 interface FoodSummaryProps {
   foodEntries: FoodEntry[];
+  goals?: DailyGoals;
+  calorieGoal?: number;
   onAddFood?: () => void;
   onAdjustServing?: (entry: FoodEntry) => void;
   onPressMealType?: (mealType: MealTypeKey, entries: FoodEntry[]) => void;
@@ -22,22 +26,40 @@ interface FoodSummaryProps {
 interface MealSectionProps {
   mealType: MealTypeKey;
   entries: FoodEntry[];
+  goals?: DailyGoals;
+  calorieGoal?: number;
   onAdjustServing?: (entry: FoodEntry) => void;
   onPressMealType?: (mealType: MealTypeKey, entries: FoodEntry[]) => void;
 }
 
-const MealSection: React.FC<MealSectionProps> = ({ mealType, entries, onAdjustServing, onPressMealType }) => {
+const MealSection: React.FC<MealSectionProps> = ({
+  mealType,
+  entries,
+  goals,
+  calorieGoal,
+  onAdjustServing,
+  onPressMealType,
+}) => {
   const config = MEAL_CONFIG[mealType] || { label: mealType, icon: 'meal-snack' as IconName };
   const accentPrimary = useCSSVariable('--color-accent-primary') as string;
 
   const totalCalories = calculateMealNutrition(entries).values.calories;
+  const targetCalories = React.useMemo(() => {
+    if (!goals || !calorieGoal || mealType === 'other') return 0;
+    const percentage = getMealPercentage(mealType, goals);
+    return Math.round((calorieGoal * percentage) / 100);
+  }, [goals, calorieGoal, mealType]);
+
   const headerContent = (
     <>
       <Icon name={config.icon} size={18} color={accentPrimary} />
       <Text className="text-base font-bold text-text-secondary flex-1">{config.label}</Text>
-      {totalCalories > 0 && (
+      {(totalCalories > 0 || targetCalories > 0) && (
         <View className="bg-accent-primary/5 rounded-full px-2.5 py-0.5">
-          <Text className="text-xs text-accent-primary font-semibold">{totalCalories} Cal</Text>
+          <Text className="text-xs text-accent-primary font-semibold">
+            {totalCalories}
+            {targetCalories > 0 ? ` / ${targetCalories}` : ''} Cal
+          </Text>
         </View>
       )}
       {onPressMealType && (
@@ -77,7 +99,14 @@ const MealSection: React.FC<MealSectionProps> = ({ mealType, entries, onAdjustSe
   );
 };
 
-const FoodSummary: React.FC<FoodSummaryProps> = ({ foodEntries, onAddFood, onAdjustServing, onPressMealType }) => {
+const FoodSummary: React.FC<FoodSummaryProps> = ({
+  foodEntries,
+  goals,
+  calorieGoal,
+  onAddFood,
+  onAdjustServing,
+  onPressMealType,
+}) => {
   if (foodEntries.length === 0) {
     return (
       <Pressable onPress={onAddFood} className="bg-surface rounded-xl p-4 mb-2 shadow-sm items-center py-6">
@@ -105,6 +134,8 @@ const FoodSummary: React.FC<FoodSummaryProps> = ({ foodEntries, onAddFood, onAdj
           key={mealType}
           mealType={mealType}
           entries={grouped[mealType]}
+          goals={goals}
+          calorieGoal={calorieGoal}
           onAdjustServing={onAdjustServing}
           onPressMealType={onPressMealType}
         />
@@ -113,6 +144,8 @@ const FoodSummary: React.FC<FoodSummaryProps> = ({ foodEntries, onAddFood, onAdj
         <MealSection
           mealType="other"
           entries={grouped.other}
+          goals={goals}
+          calorieGoal={calorieGoal}
           onAdjustServing={onAdjustServing}
           onPressMealType={onPressMealType}
         />

--- a/SparkyFitnessMobile/src/components/NutritionMacroCard.tsx
+++ b/SparkyFitnessMobile/src/components/NutritionMacroCard.tsx
@@ -189,23 +189,34 @@ const NutritionMacroCard: React.FC<NutritionMacroCardProps> = ({
         </View>
       ) : (
         <View className="flex-row items-center gap-x-5">
-          <View
-            className="items-center justify-center"
-            style={{ width: RING_SIZE, height: RING_SIZE }}
-          >
-            <MacroCompositionRing
-              size={RING_SIZE}
-              strokeWidth={RING_STROKE}
-              shares={shares}
-              colors={{ protein: proteinColor, carbs: carbsColor, fat: fatColor }}
-              trackColor={trackColor}
-            />
-            <View className="absolute items-center justify-center">
-              <Text className="text-text-primary text-3xl font-medium">
-                {Math.round(calories)}
-              </Text>
-              <Text className="text-text-secondary text-xs mt-0.5">calories</Text>
+          <View className="items-center">
+            <View
+              className="items-center justify-center"
+              style={{ width: RING_SIZE, height: RING_SIZE }}
+            >
+              <MacroCompositionRing
+                size={RING_SIZE}
+                strokeWidth={RING_STROKE}
+                shares={shares}
+                colors={{ protein: proteinColor, carbs: carbsColor, fat: fatColor }}
+                trackColor={trackColor}
+              />
+              <View className="absolute items-center justify-center">
+                <Text className="text-text-primary text-3xl font-medium">
+                  {calorieGoal && calorieGoal > 0
+                    ? Math.max(0, Math.round(calorieGoal - calories)).toLocaleString()
+                    : Math.round(calories)}
+                </Text>
+                <Text className="text-text-secondary text-xs mt-0.5">
+                  {calorieGoal && calorieGoal > 0 ? 'left' : 'calories'}
+                </Text>
+              </View>
             </View>
+            {calorieGoal && calorieGoal > 0 ? (
+              <Text className="text-text-secondary text-xs font-medium mt-2 text-center">
+                {Math.round(calories).toLocaleString()} / {Math.round(calorieGoal).toLocaleString()} Cal
+              </Text>
+            ) : null}
           </View>
 
           <View className="flex-1 gap-3 pl-5">

--- a/SparkyFitnessMobile/src/screens/DiaryScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DiaryScreen.tsx
@@ -259,6 +259,8 @@ const DiaryScreen: React.FC<DiaryScreenProps> = ({ navigation }) => {
           <>
             <FoodSummary
               foodEntries={summary.foodEntries}
+              goals={summary.goals}
+              calorieGoal={summary.calorieGoal}
               onAddFood={() => navigation.navigate('FoodSearch', { date: selectedDate })}
               onAdjustServing={(entry) => servingSheetRef.current?.present(entry)}
               onPressMealType={openMealTypeDetail}

--- a/SparkyFitnessMobile/src/screens/MealTypeDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MealTypeDetailScreen.tsx
@@ -20,6 +20,7 @@ import {
   calculateEntryNutrition,
   calculateMealNutrition,
   filterFoodEntriesByMealType,
+  getMealPercentage,
 } from '../utils/mealNutrition';
 import { getMealTypeLabel } from '../constants/meals';
 import type { RootStackScreenProps } from '../types/navigation';
@@ -51,6 +52,11 @@ const MealTypeDetailScreen: React.FC<MealTypeDetailScreenProps> = ({ navigation,
     [summary?.foodEntries, mealType],
   );
   const nutrition = useMemo(() => calculateMealNutrition(entries), [entries]);
+  const targetCalories = useMemo(() => {
+    if (!summary?.goals || !summary?.calorieGoal || mealType === 'other') return 0;
+    const percentage = getMealPercentage(mealType, summary.goals);
+    return Math.round((summary.calorieGoal * percentage) / 100);
+  }, [summary, mealType]);
 
   const { copyMeal, isPending: isCopying } = useCopyFoodEntries({
     onSuccess: () => copySheetRef.current?.dismiss(),
@@ -134,10 +140,11 @@ const MealTypeDetailScreen: React.FC<MealTypeDetailScreenProps> = ({ navigation,
       >
         <FoodNutritionSummary
           name={label}
-          brand={formatDateLabel(date)}
+          brand={targetCalories > 0 ? `${formatDateLabel(date)} · Target: ${targetCalories} Cal` : formatDateLabel(date)}
           values={nutrition.values}
           showNetCarbs={showNetCarbs}
           customNutrients={Object.keys(nutrition.customNutrients).length > 0 ? nutrition.customNutrients : null}
+          calorieGoal={targetCalories > 0 ? targetCalories : undefined}
         />
 
         <View className="bg-surface rounded-xl p-4 shadow-sm">

--- a/SparkyFitnessMobile/src/types/goals.ts
+++ b/SparkyFitnessMobile/src/types/goals.ts
@@ -27,4 +27,5 @@ export interface DailyGoals {
   dinner_percentage?: number;
   snacks_percentage?: number;
   custom_nutrients?: Record<string, string | number>;
+  custom_meal_percentages?: Record<string, number>;
 }

--- a/SparkyFitnessMobile/src/utils/mealNutrition.ts
+++ b/SparkyFitnessMobile/src/utils/mealNutrition.ts
@@ -1,6 +1,7 @@
 import { MEAL_TYPES } from '../constants/meals';
 import type { FoodEntry } from '../types/foodEntries';
 import type { FoodDisplayValues } from './foodDetails';
+import type { DailyGoals } from '../types/goals';
 import { calculateCustomNutrientTotals } from '../services/api/foodEntriesApi';
 
 export type MealTypeKey = (typeof MEAL_TYPES)[number] | 'other';
@@ -104,4 +105,17 @@ export function calculateMealNutrition(entries: FoodEntry[]): MealNutrition {
     },
     customNutrients: calculateCustomNutrientTotals(entries),
   };
+}
+
+export function getMealPercentage(mealName: string, goals?: DailyGoals): number {
+  if (!goals) return 0;
+
+  const key = mealName.toLowerCase();
+
+  if (goals.custom_meal_percentages && key in goals.custom_meal_percentages) {
+    return goals.custom_meal_percentages[key] ?? 0;
+  }
+
+  const legacyKey = `${key}_percentage` as keyof DailyGoals;
+  return (goals[legacyKey] as number) ?? 0;
 }

--- a/shared/src/schemas/api/DailyGoals.api.zod.ts
+++ b/shared/src/schemas/api/DailyGoals.api.zod.ts
@@ -29,6 +29,7 @@ export const dailyGoalsResponseSchema = z.object({
   dinner_percentage: z.number(),
   snacks_percentage: z.number(),
   custom_nutrients: z.record(z.string(), z.union([z.string(), z.number()])).optional(),
+  custom_meal_percentages: z.record(z.string(), z.number()).optional(),
 });
 
 export type DailyGoalsResponse = z.infer<typeof dailyGoalsResponseSchema>;

--- a/shared/src/schemas/database/UserGoals.zod.ts
+++ b/shared/src/schemas/database/UserGoals.zod.ts
@@ -35,6 +35,7 @@ export const userGoalsSchema = z.object({
   snacks_percentage: z.number().nullable(),
   water_goal_ml: z.number().nullable(),
   custom_nutrients: z.unknown().nullable(),
+  custom_meal_percentages: z.unknown().nullable(),
 });
 
 export const userGoalsInitializerSchema = z.object({
@@ -71,6 +72,7 @@ export const userGoalsInitializerSchema = z.object({
   snacks_percentage: z.number().optional().nullable(),
   water_goal_ml: z.number().optional().nullable(),
   custom_nutrients: z.unknown().optional().nullable(),
+  custom_meal_percentages: z.unknown().optional().nullable(),
 });
 
 export const userGoalsMutatorSchema = z.object({
@@ -107,6 +109,7 @@ export const userGoalsMutatorSchema = z.object({
   snacks_percentage: z.number().optional().nullable(),
   water_goal_ml: z.number().optional().nullable(),
   custom_nutrients: z.unknown().optional().nullable(),
+  custom_meal_percentages: z.unknown().optional().nullable(),
 });
 
 export type UserGoals = z.infer<typeof userGoalsSchema>;


### PR DESCRIPTION
Mirror the web's per-meal calorie allocation on mobile: the diary meal pills and the meal-type detail screen now show actual vs. target calories (e.g. "326 / 440 Cal"), computed from custom_meal_percentages or legacy per-meal percentage goals.

- Add custom_meal_percentages to shared/db Zod schemas and mobile DailyGoals type.
- Add getMealPercentage() util to resolve a meal's percentage from custom or legacy goal fields.
- FoodSummary/DiaryScreen: show target calories in meal pills.
- MealTypeDetailScreen: show target in subtitle and pass calorieGoal into the nutrition card.
- NutritionMacroCard: ring shows calories remaining with an actual/target caption when a per-meal goal is available.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes # https://github.com/CodeWithCJ/SparkyFitness/issues/1686

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/d05e9550-28c6-498b-93c6-bb08c82cf94c" />

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/1c5ef7e3-c4fe-4ad9-b965-9d15147c1cb5" />

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
