### PR TITLE
feat(mobile): sync diary date across Dashboard, Diary, and logging screens

### DIFF
--- a/SparkyFitnessMobile/__tests__/screens/FoodEntryAddScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodEntryAddScreen.test.tsx
@@ -178,6 +178,8 @@ jest.mock('../../src/components/FoodNutritionSummary', () => {
   return {
     __esModule: true,
     default: ({ name }: any) => <Text>{name}</Text>,
+    FoodNutritionHeader: ({ name }: any) => <Text>{name}</Text>,
+    FoodNutrientBreakdown: () => null,
   };
 });
 

--- a/SparkyFitnessMobile/__tests__/screens/WorkoutPresetDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/WorkoutPresetDetailScreen.test.tsx
@@ -147,6 +147,7 @@ describe('WorkoutPresetDetailScreen', () => {
       expect(navigation.navigate).toHaveBeenCalledWith('WorkoutAdd', {
         preset,
         popCount: 2,
+        date: expect.any(String),
       });
     });
     expect(startLiveWorkout).not.toHaveBeenCalled();

--- a/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
+++ b/SparkyFitnessMobile/src/components/FoodNutritionSummary.tsx
@@ -9,7 +9,7 @@ import type { FoodDisplayValues } from '../utils/foodDetails';
 import NutritionMacroCard, { type NutritionGoalPercentages } from './NutritionMacroCard';
 import { useCustomNutrients, useServerConnection } from '../hooks';
 
-interface FoodNutritionSummaryProps {
+interface FoodNutritionHeaderProps {
   name: string;
   brand?: string | null;
   values: FoodDisplayValues;
@@ -24,12 +24,11 @@ interface FoodNutritionSummaryProps {
   // enabled.
   showNetCarbs?: boolean;
   provider_verified?: boolean;
-  /** Raw custom nutrient values for this food/variant (key = nutrient name, value = amount per serving). */
-  customNutrients?: Record<string, string | number> | null;
   calorieGoal?: number;
 }
 
-const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
+/** Food name, brand, and the calorie ring / macro bars. */
+export const FoodNutritionHeader: React.FC<FoodNutritionHeaderProps> = ({
   name,
   brand,
   values,
@@ -38,8 +37,51 @@ const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
   goalsLoading,
   showNetCarbs = false,
   provider_verified = false,
-  customNutrients,
   calorieGoal,
+}) => {
+  const scale = (value: number) => value * servings;
+
+  return (
+    <View className="gap-4">
+      <View>
+        <View className="flex-row items-start gap-1.5">
+          <Text className="text-text-primary text-3xl font-bold flex-shrink">{name}</Text>
+          {provider_verified ? <VerifiedBadge size="md" style={{ marginTop: 5 }} /> : null}
+        </View>
+        {brand ? (
+          <Text className="text-text-secondary text-base mt-1">{brand}</Text>
+        ) : null}
+      </View>
+
+      <NutritionMacroCard
+        calories={scale(values.calories)}
+        protein={scale(values.protein)}
+        carbs={scale(values.carbs)}
+        fat={scale(values.fat)}
+        fiber={values.fiber !== undefined ? scale(values.fiber) : undefined}
+        goalPercentages={goalPercentages}
+        goalsLoading={goalsLoading}
+        showNetCarbs={showNetCarbs}
+        calorieGoal={calorieGoal}
+      />
+    </View>
+  );
+};
+
+interface FoodNutrientBreakdownProps {
+  values: FoodDisplayValues;
+  servings?: number;
+  showNetCarbs?: boolean;
+  /** Raw custom nutrient values for this food/variant (key = nutrient name, value = amount per serving). */
+  customNutrients?: Record<string, string | number> | null;
+}
+
+/** Full nutrient list (fiber, sugars, sodium, etc.) with the "show more" toggle. */
+export const FoodNutrientBreakdown: React.FC<FoodNutrientBreakdownProps> = ({
+  values,
+  servings = 1,
+  showNetCarbs = false,
+  customNutrients,
 }) => {
   const accentColor = useCSSVariable('--color-accent-primary') as string;
   const { isConnected } = useServerConnection();
@@ -109,28 +151,6 @@ const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
 
   return (
     <Animated.View className="gap-4" layout={layoutTransition}>
-      <View>
-        <View className="flex-row items-start gap-1.5">
-          <Text className="text-text-primary text-3xl font-bold flex-shrink">{name}</Text>
-          {provider_verified ? <VerifiedBadge size="md" style={{ marginTop: 5 }} /> : null}
-        </View>
-        {brand ? (
-          <Text className="text-text-secondary text-base mt-1">{brand}</Text>
-        ) : null}
-      </View>
-
-      <NutritionMacroCard
-        calories={scale(values.calories)}
-        protein={scale(values.protein)}
-        carbs={scale(values.carbs)}
-        fat={scale(values.fat)}
-        fiber={values.fiber !== undefined ? scale(values.fiber) : undefined}
-        goalPercentages={goalPercentages}
-        goalsLoading={goalsLoading}
-        showNetCarbs={showNetCarbs}
-        calorieGoal={calorieGoal}
-      />
-
       {primaryNutrients.length > 0 ? (
         <Animated.View className="rounded-xl" layout={layoutTransition}>
           {primaryNutrients.map((nutrient, index) => {
@@ -169,6 +189,19 @@ const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = ({
           </Button>
         </Animated.View>
       ) : null}
+    </Animated.View>
+  );
+};
+
+interface FoodNutritionSummaryProps extends FoodNutritionHeaderProps, FoodNutrientBreakdownProps {}
+
+/** Combined header + nutrient breakdown, preserved for existing single-block callers. */
+const FoodNutritionSummary: React.FC<FoodNutritionSummaryProps> = (props) => {
+  const layoutTransition = LinearTransition.duration(250);
+  return (
+    <Animated.View className="gap-4" layout={layoutTransition}>
+      <FoodNutritionHeader {...props} />
+      <FoodNutrientBreakdown {...props} />
     </Animated.View>
   );
 };

--- a/SparkyFitnessMobile/src/screens/ActivityAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ActivityAddScreen.tsx
@@ -25,7 +25,8 @@ import { useCreateExerciseEntry, useUpdateExerciseEntry } from '../hooks/useExer
 import { usePreferences } from '../hooks/usePreferences';
 import Toast from 'react-native-toast-message';
 import { addLog } from '../services/LogService';
-import { formatDateLabel } from '../utils/dateUtils';
+import { addDays, formatDateLabel, getTodayDate } from '../utils/dateUtils';
+import { useDiaryDateStore } from '../stores/diaryDateStore';
 import type { RootStackScreenProps } from '../types/navigation';
 
 type Props = RootStackScreenProps<'ActivityAdd'>;
@@ -56,7 +57,7 @@ const ActivityAddScreen: React.FC<Props> = ({ navigation, route }) => {
     setDistance,
     setCalories,
     setAvgHeartRate,
-    setDate,
+    setDate: setFormDate,
     setNotes,
     populate,
     hasDraftData,
@@ -66,6 +67,12 @@ const ActivityAddScreen: React.FC<Props> = ({ navigation, route }) => {
     initialDate,
     skipDraftLoad: (!!route.params?.selectedExercise || !!route.params?.skipDraftLoad) && !isEditMode,
   });
+  // Logging always targets the Dashboard/Diary date; changing it here should
+  // carry back so the other views stay on the same day, not just inherit it.
+  const setDate = useCallback((date: string) => {
+    setFormDate(date);
+    useDiaryDateStore.getState().setSelectedDate(date);
+  }, [setFormDate]);
 
   const { createEntry, isPending: isCreating, invalidateCache: invalidateCreateCache } = useCreateExerciseEntry();
   const { updateEntry, isPending: isUpdating, invalidateCache: invalidateUpdateCache } = useUpdateExerciseEntry();
@@ -191,17 +198,35 @@ const ActivityAddScreen: React.FC<Props> = ({ navigation, route }) => {
             </View>
 
             {/* Date row */}
-            <TouchableOpacity
-              onPress={() => calendarSheetRef.current?.present()}
-              activeOpacity={0.7}
-              className="flex-row items-center mb-4"
-            >
-              <Text className="text-text-secondary text-base">Date</Text>
-              <Text className="text-text-primary text-base font-medium mx-1.5">
-                {formatDateLabel(state.entryDate)}
-              </Text>
-              <Icon name="chevron-down" size={12} color={textPrimary} weight="medium" />
-            </TouchableOpacity>
+            <View className="flex-row items-center mb-4">
+              <TouchableOpacity
+                onPress={() => calendarSheetRef.current?.present()}
+                activeOpacity={0.7}
+                className="flex-row items-center"
+              >
+                <Text className="text-text-secondary text-base">Date</Text>
+                <Text className="text-text-primary text-base font-medium mx-1.5">
+                  {formatDateLabel(state.entryDate)}
+                </Text>
+                <Icon name="chevron-down" size={12} color={textPrimary} weight="medium" />
+              </TouchableOpacity>
+
+              {state.entryDate === getTodayDate() ? (
+                <TouchableOpacity activeOpacity={0.7}
+                  className="flex-row items-center mx-4"
+                  onPress={() => setDate(addDays(getTodayDate(), -1))}
+                >
+                  <Text className="text-text-link text-sm font-medium mx-1.5">Use Yesterday</Text>
+                </TouchableOpacity>
+              ) : (
+                <TouchableOpacity activeOpacity={0.7}
+                  className="flex-row items-center mx-4"
+                  onPress={() => setDate(getTodayDate())}
+                >
+                  <Text className="text-text-link text-sm font-medium mx-1.5">Use Today</Text>
+                </TouchableOpacity>
+              )}
+            </View>
 
             {/* Exercise picker row */}
             <TouchableOpacity

--- a/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
@@ -22,7 +22,7 @@ import CalorieRingCard from '../components/CalorieRingCard';
 import MacroCard from '../components/MacroCard';
 import DateNavigator from '../components/DateNavigator';
 import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarSheet';
-import { addDays, getTodayDate } from '../utils/dateUtils';
+import { useDiaryDateStore } from '../stores/diaryDateStore';
 import {
   setNativeHeaderDatePickerOptions,
   type NativeHeaderDatePickerNavigation,
@@ -59,39 +59,35 @@ type DashboardScreenProps = CompositeScreenProps<
 
 const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
   const queryClient = useQueryClient();
-  const [selectedDate, setSelectedDate] = useState(getTodayDate);
+  const selectedDate = useDiaryDateStore((s) => s.selectedDate);
+  const setSelectedDate = useDiaryDateStore((s) => s.setSelectedDate);
+  const goToPreviousDay = useDiaryDateStore((s) => s.goToPreviousDay);
+  const goToNextDay = useDiaryDateStore((s) => s.goToNextDay);
+  const goToToday = useDiaryDateStore((s) => s.goToToday);
+  const syncTodayRollover = useDiaryDateStore((s) => s.syncTodayRollover);
   const [stepsRange, setStepsRange] = useState<StepsRange>('7d');
-  const lastKnownToday = useRef(getTodayDate());
   const scrollViewRef = useRef<ScrollView>(null);
   const calendarRef = useRef<CalendarSheetRef>(null);
 
   // Only reset to today when the calendar day has actually changed (midnight rollover)
   useFocusEffect(
     useCallback(() => {
-      const today = getTodayDate();
-      if (today !== lastKnownToday.current) {
-        lastKnownToday.current = today;
-        setSelectedDate(today);
-      }
-    }, [])
+      syncTodayRollover();
+    }, [syncTodayRollover])
   );
-
-  const goToPreviousDay = useCallback(() => setSelectedDate(prev => addDays(prev, -1)), []);
-  const goToNextDay = useCallback(() => setSelectedDate(prev => addDays(prev, 1)), []);
-  const goToToday = useCallback(() => setSelectedDate(getTodayDate()), []);
 
   // Re-tapping the active Dashboard tab acts as a quick return to
   // today's summary and the top of the screen.
   useEffect(() => {
     return navigation.addListener('tabPress', () => {
       if (navigation.isFocused()) {
-        setSelectedDate(getTodayDate());
+        goToToday();
         scrollViewRef.current?.scrollTo({ y: 0, animated: true });
       }
     });
-  }, [navigation]);
+  }, [navigation, goToToday]);
   const openCalendar = useCallback(() => calendarRef.current?.present(), []);
-  const handleCalendarSelect = useCallback((date: string) => setSelectedDate(date), []);
+  const handleCalendarSelect = useCallback((date: string) => setSelectedDate(date), [setSelectedDate]);
   const usesNativeTabs = useNativeIOSTabsActive();
   const { defaultColor: nativeHeaderActionColor } = useHeaderActionColors();
   const syncNativeHeaderDatePicker = useCallback(() => {

--- a/SparkyFitnessMobile/src/screens/DiaryScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DiaryScreen.tsx
@@ -21,13 +21,13 @@ import { useServerConnection, useDailySummary, useCustomNutrients, useNutrientDi
 import { useMeasurements } from '../hooks/useMeasurements';
 import { usePreferences } from '../hooks/usePreferences';
 import { useExerciseImageSource } from '../hooks/useExerciseImageSource';
-import { addDays, getTodayDate } from '../utils/dateUtils';
 import {
   setNativeHeaderDatePickerOptions,
   type NativeHeaderDatePickerNavigation,
 } from '../utils/nativeHeaderDatePicker';
 import { useNativeIOSTabsActive } from '../services/nativeTabBarPreference';
 import { useActiveWorkoutStore } from '../stores/activeWorkoutStore';
+import { useDiaryDateStore } from '../stores/diaryDateStore';
 import type { MealTypeKey } from '../utils/mealNutrition';
 import type { CompositeScreenProps } from '@react-navigation/native';
 import type { BottomTabScreenProps } from '@react-navigation/bottom-tabs';
@@ -42,20 +42,20 @@ type DiaryScreenProps = CompositeScreenProps<
 
 const DiaryScreen: React.FC<DiaryScreenProps> = ({ navigation }) => {
   const insets = useSafeAreaInsets();
-  const [selectedDate, setSelectedDate] = useState(getTodayDate);
-  const lastKnownToday = useRef(getTodayDate());
+  const selectedDate = useDiaryDateStore((s) => s.selectedDate);
+  const setSelectedDate = useDiaryDateStore((s) => s.setSelectedDate);
+  const goToPreviousDay = useDiaryDateStore((s) => s.goToPreviousDay);
+  const goToNextDay = useDiaryDateStore((s) => s.goToNextDay);
+  const goToToday = useDiaryDateStore((s) => s.goToToday);
+  const syncTodayRollover = useDiaryDateStore((s) => s.syncTodayRollover);
   const scrollViewRef = useRef<ScrollView>(null);
   const calendarRef = useRef<CalendarSheetRef>(null);
   const servingSheetRef = useRef<ServingAdjustSheetRef>(null);
 
   useFocusEffect(
     useCallback(() => {
-      const today = getTodayDate();
-      if (today !== lastKnownToday.current) {
-        lastKnownToday.current = today;
-        setSelectedDate(today);
-      }
-    }, [])
+      syncTodayRollover();
+    }, [syncTodayRollover])
   );
 
   // Re-tapping the active Diary tab acts as a quick return to today's
@@ -63,19 +63,16 @@ const DiaryScreen: React.FC<DiaryScreenProps> = ({ navigation }) => {
   useEffect(() => {
     return navigation.addListener('tabPress', () => {
       if (navigation.isFocused()) {
-        setSelectedDate(getTodayDate());
+        goToToday();
         scrollViewRef.current?.scrollTo({ y: 0, animated: true });
       }
     });
-  }, [navigation]);
+  }, [navigation, goToToday]);
 
   useEffect(() => {
     navigation.setParams({ selectedDate });
   }, [navigation, selectedDate]);
 
-  const goToPreviousDay = useCallback(() => setSelectedDate(prev => addDays(prev, -1)), []);
-  const goToNextDay = useCallback(() => setSelectedDate(prev => addDays(prev, 1)), []);
-  const goToToday = useCallback(() => setSelectedDate(getTodayDate()), []);
   const openCalendar = useCallback(() => calendarRef.current?.present(), []);
   const accentColor = useCSSVariable('--color-accent-primary') as string;
   const usesNativeTabs = useNativeIOSTabsActive();
@@ -120,7 +117,7 @@ const DiaryScreen: React.FC<DiaryScreenProps> = ({ navigation }) => {
     Gesture.Fling().direction(Directions.LEFT).onEnd(goToNextDay).runOnJS(true),
   ), [goToPreviousDay, goToNextDay]);
 
-  const handleCalendarSelect = useCallback((date: string) => setSelectedDate(date), []);
+  const handleCalendarSelect = useCallback((date: string) => setSelectedDate(date), [setSelectedDate]);
   const openMealTypeDetail = useCallback((mealType: MealTypeKey) => {
     navigation.navigate('MealTypeDetail', { date: selectedDate, mealType });
   }, [navigation, selectedDate]);

--- a/SparkyFitnessMobile/src/screens/ExerciseDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ExerciseDetailScreen.tsx
@@ -23,6 +23,7 @@ import {
 } from '../hooks';
 import { useExerciseStats } from '../hooks/useExerciseStats';
 import { useStartLiveWorkout } from '../hooks/useStartLiveWorkout';
+import { useDiaryDateStore } from '../stores/diaryDateStore';
 import {
   buildSingleExerciseStartPayload,
   formatRecentSessionSet,
@@ -294,6 +295,7 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
     navigation.navigate('ActivityAdd', {
       selectedExercise: exercise,
       selectionNonce: Date.now(),
+      date: useDiaryDateStore.getState().selectedDate,
     });
   };
 

--- a/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
@@ -16,11 +16,12 @@ import { useQuery } from '@tanstack/react-query';
 import Icon from '../components/Icon';
 import StepperInput from '../components/StepperInput';
 import BottomSheetPicker from '../components/BottomSheetPicker';
-import FoodNutritionSummary from '../components/FoodNutritionSummary';
+import { FoodNutritionHeader, FoodNutrientBreakdown } from '../components/FoodNutritionSummary';
 import { fetchDailyGoals } from '../services/api/goalsApi';
 import { setPendingMealIngredientSelection } from '../services/mealBuilderSelection';
 import { CreateFoodEntryPayload } from '../services/api/foodEntriesApi';
-import { getTodayDate, getDeviceTimezone, formatDateLabel } from '../utils/dateUtils';
+import { addDays, getTodayDate, getDeviceTimezone, formatDateLabel } from '../utils/dateUtils';
+import { useDiaryDateStore } from '../stores/diaryDateStore';
 import { prefillEntryTime, userHourMinute } from '@workspace/shared';
 import TimeSheet, { type TimeSheetRef } from '../components/TimeSheet';
 import { formatTimeLabel } from '../utils/entryTimeDisplay';
@@ -183,9 +184,15 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
   const returnDepth = route.params?.returnDepth ?? 1;
   const ingredientIndex = route.params?.ingredientIndex;
   const isMealBuilderMode = pickerMode === 'meal-builder';
-  const [selectedDate, setSelectedDate] = useState(
-    initialDate ?? getTodayDate(),
+  const [selectedDate, setSelectedDateState] = useState(
+    initialDate ?? useDiaryDateStore.getState().selectedDate,
   );
+  // Logging always targets the Dashboard/Diary date; changing it here should
+  // carry back so the other views stay on the same day, not just inherit it.
+  const setSelectedDate = useCallback((date: string) => {
+    setSelectedDateState(date);
+    useDiaryDateStore.getState().setSelectedDate(date);
+  }, []);
   const calendarRef = useRef<CalendarSheetRef>(null);
   const timeSheetRef = useRef<TimeSheetRef>(null);
   const { mealTypes, defaultMealTypeId } = useMealTypes();
@@ -1314,7 +1321,7 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
       {header}
 
       <ScrollView className="flex-1" contentContainerClassName="px-4 pt-4 pb-4 gap-4">
-        <FoodNutritionSummary
+        <FoodNutritionHeader
           name={adjustedValues?.name || activeItem.name}
           brand={adjustedValues?.brand ?? activeItem.brand}
           values={displayValues}
@@ -1328,7 +1335,6 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
           goalsLoading={isGoalsLoading}
           showNetCarbs={showNetCarbs}
           provider_verified={activeItem.provider_verified}
-          customNutrients={selectedCustomNutrients}
         />
 
         <View className="mt-2">
@@ -1435,7 +1441,14 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
                 />
               </TouchableOpacity>
 
-              {selectedDate !== getTodayDate() && (
+              {selectedDate === getTodayDate() ? (
+                <TouchableOpacity activeOpacity={0.7}
+                  className="flex-row items-center mx-4"
+                  onPress={() => setSelectedDate(addDays(getTodayDate(), -1))}
+                >
+                  <Text className="text-text-link text-sm font-medium mx-1.5">Use Yesterday</Text>
+                </TouchableOpacity>
+              ) : (
                 <TouchableOpacity activeOpacity={0.7}
                   className="flex-row items-center mx-4"
                   onPress={() => setSelectedDate(getTodayDate())}
@@ -1512,6 +1525,13 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
             ) : null}
           </>
         ) : null}
+
+        <FoodNutrientBreakdown
+          values={displayValues}
+          servings={servings}
+          showNetCarbs={showNetCarbs}
+          customNutrients={selectedCustomNutrients}
+        />
 
       </ScrollView>
 

--- a/SparkyFitnessMobile/src/screens/WorkoutAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutAddScreen.tsx
@@ -23,7 +23,8 @@ import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarShee
 import { useWorkoutForm, getWorkoutDraftSubmission } from '../hooks/useWorkoutForm';
 import { useSelectedExercise } from '../hooks/useSelectedExercise';
 import { useExerciseSetEditing } from '../hooks/useExerciseSetEditing';
-import { formatDateLabel } from '../utils/dateUtils';
+import { addDays, formatDateLabel, getTodayDate } from '../utils/dateUtils';
+import { useDiaryDateStore } from '../stores/diaryDateStore';
 import { useCreateWorkout, useUpdateWorkout } from '../hooks/useExerciseMutations';
 import { usePreferences } from '../hooks/usePreferences';
 import { useExerciseImageSource } from '../hooks/useExerciseImageSource';
@@ -77,13 +78,19 @@ const WorkoutAddScreen: React.FC<Props> = ({ navigation, route }) => {
     ungroupExercise,
     reorderExercises,
     setName,
-    setDate,
+    setDate: setFormDate,
     populate,
     populateFromPreset,
     hasDraftData,
     discardDraft,
     exercisesModifiedRef,
   } = useWorkoutForm({ isEditMode, skipDraftLoad, initialDate });
+  // Logging always targets the Dashboard/Diary date; changing it here should
+  // carry back so the other views stay on the same day, not just inherit it.
+  const setDate = useCallback((date: string) => {
+    setFormDate(date);
+    useDiaryDateStore.getState().setSelectedDate(date);
+  }, [setFormDate]);
 
   const [eligibleIds, setEligibleIds] = useState<Set<string>>(() => new Set());
 
@@ -321,17 +328,35 @@ const WorkoutAddScreen: React.FC<Props> = ({ navigation, route }) => {
                 </View>
 
                 {/* Date row */}
-                <TouchableOpacity
-                  onPress={() => calendarSheetRef.current?.present()}
-                  activeOpacity={0.7}
-                  className="flex-row items-center mb-4"
-                >
-                  <Text className="text-text-secondary text-base">Date</Text>
-                  <Text className="text-text-primary text-base font-medium mx-1.5">
-                    {formatDateLabel(state.entryDate)}
-                  </Text>
-                  <Icon name="chevron-down" size={12} color={textPrimary} weight="medium" />
-                </TouchableOpacity>
+                <View className="flex-row items-center mb-4">
+                  <TouchableOpacity
+                    onPress={() => calendarSheetRef.current?.present()}
+                    activeOpacity={0.7}
+                    className="flex-row items-center"
+                  >
+                    <Text className="text-text-secondary text-base">Date</Text>
+                    <Text className="text-text-primary text-base font-medium mx-1.5">
+                      {formatDateLabel(state.entryDate)}
+                    </Text>
+                    <Icon name="chevron-down" size={12} color={textPrimary} weight="medium" />
+                  </TouchableOpacity>
+
+                  {state.entryDate === getTodayDate() ? (
+                    <TouchableOpacity activeOpacity={0.7}
+                      className="flex-row items-center mx-4"
+                      onPress={() => setDate(addDays(getTodayDate(), -1))}
+                    >
+                      <Text className="text-text-link text-sm font-medium mx-1.5">Use Yesterday</Text>
+                    </TouchableOpacity>
+                  ) : (
+                    <TouchableOpacity activeOpacity={0.7}
+                      className="flex-row items-center mx-4"
+                      onPress={() => setDate(getTodayDate())}
+                    >
+                      <Text className="text-text-link text-sm font-medium mx-1.5">Use Today</Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
 
                 {/* Full-bleed: cancel the scroll container's px-4 so the card
                     separators reach the screen edges. */}

--- a/SparkyFitnessMobile/src/screens/WorkoutPresetDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutPresetDetailScreen.tsx
@@ -20,6 +20,7 @@ import { useScreenHeader, type HeaderItem } from '../hooks/useScreenHeader';
 import { useStartLiveWorkout } from '../hooks/useStartLiveWorkout';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
+import { useDiaryDateStore } from '../stores/diaryDateStore';
 import {
   buildPresetStartExercisesPayload,
   makeSparseExercise,
@@ -151,7 +152,11 @@ const WorkoutPresetDetailScreen: React.FC<WorkoutPresetDetailScreenProps> = ({
   }, [startLiveWorkout, preset]);
 
   const navigateToPresetWorkout = useCallback(() => {
-    navigation.navigate('WorkoutAdd', { preset, popCount: 2 });
+    navigation.navigate('WorkoutAdd', {
+      preset,
+      popCount: 2,
+      date: useDiaryDateStore.getState().selectedDate,
+    });
   }, [navigation, preset]);
 
   // The form path (retroactive logging) is the one that owns workout drafts,

--- a/SparkyFitnessMobile/src/stores/diaryDateStore.ts
+++ b/SparkyFitnessMobile/src/stores/diaryDateStore.ts
@@ -1,0 +1,41 @@
+import { create } from 'zustand';
+import { addDays, getTodayDate } from '../utils/dateUtils';
+
+/**
+ * Shared date for Dashboard, Diary, and the logging flows launched from them
+ * (Log Food/Exercise/Workout/Activity, Add Measurements). Intentionally not
+ * persisted: every fresh app launch starts on today, and a date picked mid
+ * session is shared across those views until changed.
+ */
+export interface DiaryDateState {
+  selectedDate: string;
+  lastKnownToday: string;
+  setSelectedDate: (date: string) => void;
+  goToPreviousDay: () => void;
+  goToNextDay: () => void;
+  goToToday: () => void;
+  /**
+   * Re-anchors to today on day rollover, but only if the stored date was
+   * still pointing at the previous "today" — a date the user deliberately
+   * navigated to (past or future) is left alone.
+   */
+  syncTodayRollover: () => void;
+}
+
+export const useDiaryDateStore = create<DiaryDateState>((set, get) => ({
+  selectedDate: getTodayDate(),
+  lastKnownToday: getTodayDate(),
+  setSelectedDate: (date) => set({ selectedDate: date }),
+  goToPreviousDay: () => set((state) => ({ selectedDate: addDays(state.selectedDate, -1) })),
+  goToNextDay: () => set((state) => ({ selectedDate: addDays(state.selectedDate, 1) })),
+  goToToday: () => set({ selectedDate: getTodayDate() }),
+  syncTodayRollover: () => {
+    const today = getTodayDate();
+    const { lastKnownToday, selectedDate } = get();
+    if (today === lastKnownToday) return;
+    set({
+      lastKnownToday: today,
+      selectedDate: selectedDate === lastKnownToday ? today : selectedDate,
+    });
+  },
+}));


### PR DESCRIPTION

Dashboard and Diary used to track the selected date independently, so switching tabs could silently land on a different day and cause entries to be logged against the wrong date. Food/meal, exercise, and workout-preset logging inherited "today" instead of whatever day the user had open, with no way to carry a date change back out.

- Add a shared, in-memory diaryDateStore (Zustand, not persisted) that Dashboard and Diary now read/write instead of separate local state.
- FoodEntryAddScreen, ActivityAddScreen, and WorkoutAddScreen fall back to the shared date when opened without an explicit date param (e.g. via Library), and now write date changes back to the shared store so Dashboard/Diary stay in sync in both directions.
- ExerciseDetailScreen and WorkoutPresetDetailScreen pass the shared date explicitly when opening the log screen.
- Add a symmetric "Use Yesterday" quick action (alongside the existing "Use Today") on food, meal, exercise, and workout logging screens.
- Split FoodNutritionSummary into FoodNutritionHeader and FoodNutrientBreakdown so FoodEntryAddScreen can show serving/meal/ date/time controls above the nutrient list instead of below it; other callers keep the combined default export unchanged.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes # https://github.com/CodeWithCJ/SparkyFitness/issues/1749

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>
<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/9bbcf61e-e730-4f2a-8ded-bf191b4b5430" />


<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/457d8b71-ba92-4778-b6b7-5f761b9e2e5a" />

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/87bd2c6c-4927-4da4-afde-4da195a4abe2" />

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
