### PR TITLE
feat(helm): key in existingSecret and valueFrom in extraEnv 

### DIFF
--- a/helm/chart/Chart.yaml
+++ b/helm/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sparkyfitness
 description: Sparkyfitness fitness tracking application
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: "v0.16.6.1"
 kubeVersion: ">= 1.28.0-0"
 home: https://github.com/CodeWithCJ/SparkyFitness

--- a/helm/chart/templates/frontend/deployment.yaml
+++ b/helm/chart/templates/frontend/deployment.yaml
@@ -56,9 +56,17 @@ spec:
               value: {{ .Values.frontend.port | quote }}
             - name: NGINX_RATE_LIMIT
               value: {{ .Values.frontend.rateLimit | default "5r/s" | quote }}
+            {{- if kindIs "slice" .Values.frontend.extraEnv }}
+            {{- toYaml .Values.frontend.extraEnv | nindent 12 }}
+            {{- else }}
             {{- range $k, $v := .Values.frontend.extraEnv }}
             - name: {{ $k }}
+              {{- if kindIs "map" $v }}
+              {{- toYaml $v | nindent 14 }}
+              {{- else }}
               value: {{ $v | quote }}
+              {{- end }}
+            {{- end }}
             {{- end }}
           {{- with .Values.frontend.containerSecurityContext }}
           securityContext:

--- a/helm/chart/templates/garmin/deployment.yaml
+++ b/helm/chart/templates/garmin/deployment.yaml
@@ -53,9 +53,17 @@ spec:
               value: {{ .Values.garmin.port | quote }}
             - name: GARMIN_SERVICE_IS_CN
               value: {{ .Values.config.garmin.isChinaRegion | quote }}
+            {{- if kindIs "slice" .Values.garmin.extraEnv }}
+            {{- toYaml .Values.garmin.extraEnv | nindent 12 }}
+            {{- else }}
             {{- range $k, $v := .Values.garmin.extraEnv }}
             - name: {{ $k }}
+              {{- if kindIs "map" $v }}
+              {{- toYaml $v | nindent 14 }}
+              {{- else }}
               value: {{ $v | quote }}
+              {{- end }}
+            {{- end }}
             {{- end }}
           {{- with .Values.garmin.containerSecurityContext }}
           securityContext:

--- a/helm/chart/templates/server/deployment.yaml
+++ b/helm/chart/templates/server/deployment.yaml
@@ -85,23 +85,23 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "sparkyfitness.appSecretName" . }}
-                  key: api_encryption_key
+                  key: {{ .Values.server.secrets.existingSecretKeys.apiEncryptionKey | default "api_encryption_key" }}
             - name: BETTER_AUTH_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "sparkyfitness.appSecretName" . }}
-                  key: better_auth_secret
+                  key: {{ .Values.server.secrets.existingSecretKeys.betterAuthSecret | default "better_auth_secret" }}
             # --- App database credentials (limited-privilege user) ---
             - name: SPARKY_FITNESS_APP_DB_USER
               valueFrom:
                 secretKeyRef:
                   name: {{ include "sparkyfitness.appDbSecretName" . }}
-                  key: username
+                  key: {{ .Values.server.appDatabase.existingSecretKeys.username | default "username" }}
             - name: SPARKY_FITNESS_APP_DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "sparkyfitness.appDbSecretName" . }}
-                  key: password
+                  key: {{ .Values.server.appDatabase.existingSecretKeys.password | default "password" }}
             # --- Database credentials (owner) ---
             - name: SPARKY_FITNESS_DB_USER
               {{- if .Values.postgresql.enabled }}
@@ -110,7 +110,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "sparkyfitness.databaseSecretName" . }}
-                  key: username
+                  key: {{ .Values.externalDatabase.auth.existingSecretKeys.username | default "username" }}
               {{- end }}
             - name: SPARKY_FITNESS_DB_PASSWORD
               valueFrom:
@@ -119,7 +119,7 @@ spec:
                   {{- if .Values.postgresql.enabled }}
                   key: user-password
                   {{- else }}
-                  key: password
+                  key: {{ .Values.externalDatabase.auth.existingSecretKeys.password | default "password" }}
                   {{- end }}
             {{- if .Values.config.oidc.enabled }}
             # --- OIDC credentials ---
@@ -127,12 +127,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "sparkyfitness.oidcSecretName" . }}
-                  key: client_id
+                  key: {{ .Values.config.oidc.secrets.existingSecretKeys.clientId | default "client_id" }}
             - name: SPARKY_FITNESS_OIDC_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ include "sparkyfitness.oidcSecretName" . }}
-                  key: client_secret
+                  key: {{ .Values.config.oidc.secrets.existingSecretKeys.clientSecret | default "client_secret" }}
             {{- end }}
             {{- if .Values.config.email.enabled }}
             # --- SMTP credentials ---
@@ -140,16 +140,24 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "sparkyfitness.smtpSecretName" . }}
-                  key: username
+                  key: {{ .Values.config.email.secrets.existingSecretKeys.username | default "username" }}
             - name: SPARKY_FITNESS_EMAIL_PASS
               valueFrom:
                 secretKeyRef:
                   name: {{ include "sparkyfitness.smtpSecretName" . }}
-                  key: password
+                  key: {{ .Values.config.email.secrets.existingSecretKeys.password | default "password" }}
             {{- end }}
+            {{- if kindIs "slice" .Values.server.extraEnv }}
+            {{- toYaml .Values.server.extraEnv | nindent 12 }}
+            {{- else }}
             {{- range $k, $v := .Values.server.extraEnv }}
             - name: {{ $k }}
+              {{- if kindIs "map" $v }}
+              {{- toYaml $v | nindent 14 }}
+              {{- else }}
               value: {{ $v | quote }}
+              {{- end }}
+            {{- end }}
             {{- end }}
           {{- with .Values.server.containerSecurityContext }}
           securityContext:

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -95,6 +95,10 @@ config:
       clientSecret: ""
       # -- Use an existing K8s Secret (keys: client_id, client_secret)
       existingSecret: ""
+      # -- Override the default keys used when existingSecret is set
+      existingSecretKeys:
+        clientId: client_id
+        clientSecret: client_secret
 
   # -- Email / SMTP notifications
   email:
@@ -116,6 +120,10 @@ config:
       password: ""
       # -- Use an existing K8s Secret (keys: username, password)
       existingSecret: ""
+      # -- Override the default keys used when existingSecret is set
+      existingSecretKeys:
+        username: username
+        password: password
 
   # -- Garmin Connect integration
   garmin:
@@ -260,6 +268,10 @@ server:
     betterAuthSecret: ""
     # -- Use an existing K8s Secret (keys: api_encryption_key, better_auth_secret)
     existingSecret: ""
+    # -- Override the default keys used when existingSecret is set
+    existingSecretKeys:
+      apiEncryptionKey: api_encryption_key
+      betterAuthSecret: better_auth_secret
   # -- Application database credentials (limited-privilege user for runtime queries)
   appDatabase:
     # -- Username for the limited-privilege app DB user
@@ -268,6 +280,10 @@ server:
     password: ""
     # -- Use an existing K8s Secret (keys: username, password)
     existingSecret: ""
+    # -- Override the default keys used when existingSecret is set
+    existingSecretKeys:
+      username: username
+      password: password
   persistence:
     backup:
       size: 5Gi
@@ -286,8 +302,8 @@ server:
     tempUploads:
       # -- Mount path inside the container for temporary uploads
       mountPath: /app/SparkyFitnessServer/temp_uploads
-  # -- Extra environment variables injected into the server container (key: value)
-  extraEnv: {}
+  # -- Extra environment variables injected into the server container (key: value or standard Kubernetes env array)
+  # extraEnv: {}
   # -- Extra envFrom sources (configMapRef, secretRef) for the server container
   extraEnvFrom: []
   # -- Extra volumes to add to the server pod
@@ -390,8 +406,8 @@ frontend:
   #             kubernetes.io/metadata.name: ingress-nginx
   networkPolicy:
     from: []
-  # -- Extra environment variables injected into the frontend container (key: value)
-  extraEnv: {}
+  # -- Extra environment variables injected into the frontend container (key: value or standard Kubernetes env array)
+  # extraEnv: {}
   # -- Extra envFrom sources (configMapRef, secretRef) for the frontend container
   extraEnvFrom: []
   # -- Extra volumes added to the frontend pod
@@ -461,8 +477,8 @@ garmin:
     readOnlyRootFilesystem: true
     capabilities:
       drop: [ALL]
-  # -- Extra environment variables injected into the garmin container (key: value)
-  extraEnv: {}
+  # -- Extra environment variables injected into the garmin container (key: value or standard Kubernetes env array)
+  # extraEnv: {}
   # -- Extra envFrom sources (configMapRef, secretRef) for the garmin container
   extraEnvFrom: []
   # -- Extra volumes added to the garmin pod
@@ -625,6 +641,10 @@ externalDatabase:
     username: ""
     password: ""
     existingSecret: ""
+    # -- Override the default keys used when existingSecret is set
+    existingSecretKeys:
+      username: username
+      password: password
   # -- NetworkPolicy egress restriction for the external database.
   # Only relevant when networkPolicy.enabled=true and postgresql.enabled=false.
   # Set at least one of cidrs / namespaceSelector / podSelector to restrict the


### PR DESCRIPTION
# feat(helm): key in existingSecret and valueFrom in extraEnv 

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
The Helm chart forced strict hardcoded key names for `existingSecret` resources, and the `extraEnv` injections only natively supported basic key-value strings, preventing users from safely pulling config map or secret mapping references natively via `valueFrom`.

**How did you implement the solution?**
I introduced a customizable `existingSecretKeys` config block falling back cleanly to defaults when omitted. For `extraEnv`, I implemented Go template `kindIs` routing in the `deployment.yaml` files, allowing maps and native Kubernetes slices to correctly render. Finally, I removed the strict `extraEnv: {}` mapping from the root `values.yaml` so Helm's strict value merger lets array types pass cleanly.

Linked Issue: Closes #

## How to Test

1. Check out this branch and pass an array natively to `extraEnv` locally using `helm template sparkyfitness helm/chart -s templates/server/deployment.yaml`.
2. Navigate to the rendered output and confirm the slice is fully translated.
3. Verify that the chart generates default key values safely even when `existingSecretKeys` is deliberately excluded.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

Closes #1879

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> These changes are 100% backwards compatible! Existing users leveraging the standard `MY_VAR: "value"` mapping in `extraEnv` will experience no downtime or parsing errors, and any omission of `existingSecretKeys` will cleanly render the legacy hardcoded key names to prevent breaking previous deployments.
