### PR TITLE
fix(ai): log external foods in the variant's own unit, not bare servings

### DIFF
--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -37,7 +37,10 @@ import {
 } from './schemas/food.js';
 import { optionalDateSchema, uuidSchema } from './schemas/common.js';
 import { normalizeActionArgs, normalizeDayKeywords } from './dates.js';
-import { normalizeServingUnit } from '../../utils/foodUtils.js';
+import {
+  normalizeServingUnit,
+  reconcileEntryUnitToVariant,
+} from '../../utils/foodUtils.js';
 
 const VALID_ACTIONS = [
   'search_food',
@@ -1170,13 +1173,10 @@ Actions:
                   match.id,
                   userId
                 );
-                let variantId =
-                  match.default_variant?.id || match.variants?.[0]?.id;
-                let unit =
-                  args.unit ||
-                  match.default_variant?.serving_unit ||
-                  match.variants?.[0]?.serving_unit ||
-                  'serving';
+                let chosenVariant: any =
+                  match.default_variant ||
+                  match.variants?.[0] ||
+                  (Array.isArray(variants) ? variants[0] : undefined);
                 if (args.unit && Array.isArray(variants)) {
                   const normalizedReqUnit = normalizeServingUnit(args.unit);
                   const matchedVariant = variants.find(
@@ -1184,26 +1184,33 @@ Actions:
                       normalizeServingUnit(v.serving_unit) === normalizedReqUnit
                   );
                   if (matchedVariant) {
-                    variantId = matchedVariant.id;
-                    unit = matchedVariant.serving_unit;
+                    chosenVariant = matchedVariant;
                   }
                 }
+                // Keep the stored entry's unit aligned with the variant's own
+                // serving_unit so the diary math does not read a whole-serving
+                // count as a gram/ml amount.
+                const logged = reconcileEntryUnitToVariant(
+                  quantity,
+                  args.unit,
+                  chosenVariant
+                );
                 const entry = await foodEntryService.createFoodEntry(
                   userId,
                   userId,
                   {
                     user_id: userId,
                     food_id: match.id,
-                    variant_id: variantId,
+                    variant_id: chosenVariant?.id,
                     entry_date: entryDate,
-                    quantity,
-                    unit,
+                    quantity: logged.quantity,
+                    unit: logged.unit,
                     meal_type: args.meal_type,
                     entry_time: args.entry_time,
                   }
                 );
                 return formatConfirmation(
-                  `"${entry.food_name}" was already in the food database — logged ${quantity} ${unit} for ${args.meal_type} on ${entryDate}.`
+                  `"${entry.food_name}" was already in the food database — logged ${logged.quantity} ${logged.unit} for ${args.meal_type} on ${entryDate}.`
                 );
               }
 
@@ -1310,7 +1317,7 @@ Actions:
 
               const dv = food.default_variant;
               let variantId = dv?.id;
-              let unit = args.unit || 'serving';
+              let chosenVariant: any = dv;
 
               if (args.unit) {
                 const normalizedReqUnit = normalizeServingUnit(args.unit);
@@ -1320,28 +1327,38 @@ Actions:
                 );
                 if (matchedAlt) {
                   variantId = matchedAlt.id;
-                  unit = matchedAlt.serving_unit;
+                  chosenVariant = matchedAlt;
                 } else if (
                   dv &&
                   normalizeServingUnit(dv.serving_unit) === normalizedReqUnit
                 ) {
                   variantId = dv.id;
-                  unit = dv.serving_unit;
+                  chosenVariant = dv;
                 }
               }
+
+              // Align the stored entry's unit with the chosen variant's own
+              // serving_unit. Newly imported foods are usually gram/ml denominated,
+              // so logging a bare "serving" count here made the diary math treat
+              // "1 serving" as "1 gram".
+              const logged = reconcileEntryUnitToVariant(
+                quantity,
+                args.unit,
+                chosenVariant
+              );
 
               await foodEntryService.createFoodEntry(userId, userId, {
                 user_id: userId,
                 food_id: food.id,
                 variant_id: variantId,
                 entry_date: entryDate,
-                quantity,
-                unit,
+                quantity: logged.quantity,
+                unit: logged.unit,
                 meal_type: args.meal_type,
                 entry_time: args.entry_time,
               });
               return formatConfirmation(
-                `Saved "${food.name}" from ${result.source} (${dv?.calories || 0} kcal per ${dv?.serving_size || 100}${dv?.serving_unit || 'g'}) and logged ${quantity} ${unit} to ${args.meal_type} on ${entryDate}.`
+                `Saved "${food.name}" from ${result.source} (${dv?.calories || 0} kcal per ${dv?.serving_size || 100}${dv?.serving_unit || 'g'}) and logged ${logged.quantity} ${logged.unit} to ${args.meal_type} on ${entryDate}.`
               );
             }
 

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -1149,7 +1149,7 @@ describe('log_external_food', () => {
     );
 
     expect(result).toBe(
-      '✅ Saved "Apple" from usda (52 kcal per 100g) and logged 2 serving to breakfast on 2026-06-10.'
+      '✅ Saved "Apple" from usda (52 kcal per 100g) and logged 200 g to breakfast on 2026-06-10.'
     );
     expect(foodCoreService.createFood).toHaveBeenCalledWith('user-1', {
       user_id: 'user-1',
@@ -1190,8 +1190,8 @@ describe('log_external_food', () => {
         food_id: FOOD_ID,
         variant_id: VARIANT_ID,
         entry_date: '2026-06-10',
-        quantity: 2,
-        unit: 'serving',
+        quantity: 200,
+        unit: 'g',
         meal_type: 'breakfast',
       }
     );
@@ -1289,7 +1289,7 @@ describe('log_external_food', () => {
     );
 
     expect(result).toBe(
-      '✅ Saved "Apple pie" from usda (296 kcal per 125g) and logged 1 serving to snacks on 2026-06-10.'
+      '✅ Saved "Apple pie" from usda (296 kcal per 125g) and logged 125 g to snacks on 2026-06-10.'
     );
     expect(foodCoreService.createFood).toHaveBeenCalledWith(
       'user-1',
@@ -1318,7 +1318,7 @@ describe('log_external_food', () => {
     );
 
     expect(result).toBe(
-      '✅ "Eggs" was already in the food database — logged 2 g for breakfast on 2026-06-10.'
+      '✅ "Eggs" was already in the food database — logged 200 g for breakfast on 2026-06-10.'
     );
     expect(foodCoreService.createFood).not.toHaveBeenCalled();
     expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
@@ -1377,7 +1377,7 @@ describe('log_external_food', () => {
     );
 
     expect(result).toBe(
-      '✅ Saved "Apple" from usda (52 kcal per 100g) and logged 1 serving to breakfast on 2026-06-10.'
+      '✅ Saved "Apple" from usda (52 kcal per 100g) and logged 100 g to breakfast on 2026-06-10.'
     );
   });
 });

--- a/SparkyFitnessServer/tests/foodEntryUnitReconcile.test.ts
+++ b/SparkyFitnessServer/tests/foodEntryUnitReconcile.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { reconcileEntryUnitToVariant } from '../utils/foodUtils.js';
+
+describe('reconcileEntryUnitToVariant', () => {
+  it('converts an implicit serving count against a gram variant into grams', () => {
+    // "1 serving" of a 174 g wrap -> 174 g, so the diary math yields the full portion
+    // instead of treating "1 serving" as "1 gram".
+    expect(
+      reconcileEntryUnitToVariant(1, undefined, {
+        serving_size: 174,
+        serving_unit: 'g',
+      })
+    ).toEqual({ quantity: 174, unit: 'g' });
+  });
+
+  it('converts an explicit "serving" unit against a gram variant', () => {
+    // 3 pieces of a 40 g baklava -> 120 g.
+    expect(
+      reconcileEntryUnitToVariant(3, 'serving', {
+        serving_size: 40,
+        serving_unit: 'g',
+      })
+    ).toEqual({ quantity: 120, unit: 'g' });
+  });
+
+  it('treats plural/alias serving units as servings', () => {
+    expect(
+      reconcileEntryUnitToVariant(2, 'servings', {
+        serving_size: 50,
+        serving_unit: 'g',
+      })
+    ).toEqual({ quantity: 100, unit: 'g' });
+  });
+
+  it('leaves a matching concrete unit untouched', () => {
+    expect(
+      reconcileEntryUnitToVariant(174, 'g', {
+        serving_size: 174,
+        serving_unit: 'g',
+      })
+    ).toEqual({ quantity: 174, unit: 'g' });
+  });
+
+  it('leaves a serving count against a serving-denominated variant untouched', () => {
+    expect(
+      reconcileEntryUnitToVariant(2, 'serving', {
+        serving_size: 1,
+        serving_unit: 'serving',
+      })
+    ).toEqual({ quantity: 2, unit: 'serving' });
+  });
+
+  it('falls back to a factor of 1 when serving_size is missing or invalid', () => {
+    expect(
+      reconcileEntryUnitToVariant(2, 'serving', {
+        serving_size: 0,
+        serving_unit: 'ml',
+      })
+    ).toEqual({ quantity: 2, unit: 'ml' });
+  });
+
+  it('passes a non-matching explicit unit through unchanged', () => {
+    expect(
+      reconcileEntryUnitToVariant(2, 'piece', {
+        serving_size: 30,
+        serving_unit: 'g',
+      })
+    ).toEqual({ quantity: 2, unit: 'piece' });
+  });
+});

--- a/SparkyFitnessServer/utils/foodUtils.ts
+++ b/SparkyFitnessServer/utils/foodUtils.ts
@@ -213,6 +213,47 @@ function normalizeServingUnit(unit: any) {
   if (SERVING_UNIT_ALIASES[firstWord]) return SERVING_UNIT_ALIASES[firstWord];
   return clean;
 }
+// Reconcile a caller-supplied (quantity, unit) with the variant an entry will be
+// logged against, so the stored entry's unit always matches the variant's own
+// serving_unit.
+//
+// The diary math (frontend calculateFoodEntryNutrition) scales a variant's nutrients
+// by quantity / serving_size and assumes the entry unit is the same unit as
+// serving_size. When a food's variant is measured in a concrete unit (g, ml, ...) but
+// the amount was expressed in whole "servings" (the default when the AI omits a unit),
+// storing unit:"serving" makes that math read "1 serving" as "1 gram". Because
+// 1 serving == the variant's serving_size, convert the serving count into the variant's
+// own unit. Mirrors the convention already used for meal components in foodEntryService
+// (unit === 'serving' => quantity * serving_size).
+function reconcileEntryUnitToVariant(
+  quantity: number,
+  requestedUnit: string | null | undefined,
+  variant:
+    | { serving_size?: number | null; serving_unit?: string | null }
+    | null
+    | undefined
+): { quantity: number; unit: string } {
+  const variantUnit = variant?.serving_unit || 'serving';
+  const requested = requestedUnit || 'serving';
+
+  if (normalizeServingUnit(requested) === normalizeServingUnit(variantUnit)) {
+    // Already dimensionally consistent (e.g. "g" against a gram variant).
+    return { quantity, unit: variantUnit };
+  }
+
+  if (normalizeServingUnit(requested) === 'serving') {
+    // A whole-serving count against a concrete-unit variant: 1 serving is one
+    // serving_size of that unit.
+    const servingSize = Number(variant?.serving_size);
+    const factor =
+      Number.isFinite(servingSize) && servingSize > 0 ? servingSize : 1;
+    return { quantity: quantity * factor, unit: variantUnit };
+  }
+
+  // Some other explicit unit that does not match the variant; leave the caller's
+  // values untouched rather than guessing a conversion.
+  return { quantity, unit: requested };
+}
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function normalizeBarcode(barcode: any) {
   if (typeof barcode === 'string' && barcode.length === 12) {
@@ -222,12 +263,14 @@ function normalizeBarcode(barcode: any) {
 }
 export { sanitizeCustomNutrients };
 export { normalizeServingUnit };
+export { reconcileEntryUnitToVariant };
 export { normalizeBarcode };
 export { buildAliasIndex };
 export { applyCustomNutrientMatches };
 export default {
   sanitizeCustomNutrients,
   normalizeServingUnit,
+  reconcileEntryUnitToVariant,
   normalizeBarcode,
   buildAliasIndex,
   applyCustomNutrientMatches,


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
When the AI assistant logs a food via `log_external_food`, the entry was written with `unit: "serving"` even though the food's variant is measured in a concrete unit (g, ml, ...). The diary math (`calculateFoodEntryNutrition`) scales nutrients by `quantity / serving_size` assuming the entry unit matches `serving_size`, so "1 serving" of a 174 g item was treated as "1 gram" and rendered ~1 kcal.

**How did you implement the solution?**
Before persisting the entry, reconcile the requested unit with the chosen variant's `serving_unit`. A whole-serving count against a concrete-unit variant becomes `quantity * serving_size` of that unit (1 serving == serving_size), mirroring the convention already used for meal components in `foodEntryService`. This keeps the existing invariant that `entry.unit` matches the variant's `serving_unit`, so the unchanged diary math renders correctly. Applied to both `log_external_food` branches (newly imported food and an already-internal match).

Linked Issue: N/A - bug fix (a prior issue is only required for new features per CONTRIBUTING).

## How to Test

1. Check out this branch, `pnpm install`, and from `SparkyFitnessServer/` run `pnpm run typecheck && pnpm run lint && pnpm run test`.
2. New unit test: `SparkyFitnessServer/tests/foodEntryUnitReconcile.test.ts` covers the reconcile helper (serving -> grams conversion, matching units left untouched, alias handling, invalid `serving_size` fallback).
3. End to end: ask the assistant to log a food it fetches from a provider (e.g. "log a chicken shawarma wrap") whose variant is gram denominated, then open the diary. Before: the entry shows ~1 kcal ("1 serving"). After: it logs the full portion in grams (e.g. "174 g") and shows the correct calories.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. (No new tables in this PR.)

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

N/A - backend-only change (AI food-logging tool). No UI code was modified.

</details>

## Notes for Reviewers

- The root cause is a broken invariant, not the display math: everywhere else an entry's `unit` equals its variant's `serving_unit` (the `log_food` path enforces this in `resolveQuantityForVariantUnit`). Only `log_external_food` wrote `unit: "serving"` against a gram/ml variant. The fix restores the invariant at the write site.
- A display-layer guard was considered but rejected: the `FoodEntry` snapshot carries `serving_size` but not `serving_unit`, so the frontend cannot reliably detect the mismatch for existing rows. The write site has both, so the fix belongs there.
- The reconcile logic intentionally mirrors the existing meal-component convention in `foodEntryService` (`unit === 'serving' ? quantity * serving_size`).
- Four assertions in `tests/chatbotToolsFood.test.ts` were updated because they encoded the old serving-as-gram output (e.g. "logged 1 serving" of a 100 g apple is now "logged 100 g").
- Scope note: an explicit non-serving unit that matches no variant (e.g. asking for `piece` when only a gram variant exists) is passed through unchanged, same as before, rather than guessing a conversion.
