### PR TITLE
feat(helm): add extraObjects support

### DIFF
--- a/helm/chart/templates/extra-objects.yaml
+++ b/helm/chart/templates/extra-objects.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.extraObjects }}
+{{- range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/helm/chart/values.yaml
+++ b/helm/chart/values.yaml
@@ -736,3 +736,14 @@ externalSecrets:
         property: username
       - secretKey: password
         property: password
+
+# ========================== 6. EXTRA OBJECTS =================================
+# -- Array of extra K8s manifests to deploy
+# extraObjects:
+#   - apiVersion: v1
+#     kind: ConfigMap
+#     metadata:
+#       name: extra-config
+#     data:
+#       key: value
+extraObjects: []


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The Helm chart currently lacks a way to inject arbitrary Kubernetes manifests alongside the deployment. This PR adds an `extraObjects` field to support custom resources.

**How did you implement the solution?**
- Appended an `extraObjects: []` array to `helm/chart/values.yaml` with commented-out examples.
- Created `helm/chart/templates/extra-objects.yaml` which iterates over `.Values.extraObjects` and uses `tpl` and `toYaml` to render them into the final manifest output, allowing users to leverage Helm variables within their custom objects.

Linked Issue: Closes #1885

## How to Test

1. Check out this branch and navigate to `helm/chart`
2. Add a test object to `values.yaml` under `extraObjects` that uses a template variable (e.g. `{{ .Release.Name }}`).
3. Run `helm template .` and verify that the custom object is correctly rendered in the output with the variables evaluated.

## PR Type

- [x] New Feature

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the License terms.

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

## Notes for Reviewers

> The `extraObjects` field is added to the very bottom of `values.yaml` to prevent cluttering the main application configuration. It expects a list of valid Kubernetes manifest dictionaries, and supports Helm templating inside the objects.
