### PR TITLE
feat(nutrition): allow multiple active meal plans and add template duplication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,8 @@ Cheap ways to learn things:
 - Frontend local dev proxies `/api`, `/health-data`, and `/uploads` to the server on `3010`. The `/health-data` proxy is rewritten to `/api/health-data`, while server APIs remain rooted at `/api`.
 - Server runtime secrets are usually sourced from repo-root `.env`, commonly created from `docker/.env.example`. The server can also load secret files via `SparkyFitnessServer/utils/secretLoader.ts`.
 - Extract shared logic on the **second** duplication ("rule of two"), not the third - duplicated logic drifts as different sessions edit each copy. Extract *behavior*, not coincidental shape. See `agent-docs/anti-patterns.md`.
+- **Strict TypeScript Typing:** Never use `any` or `// eslint-disable-next-line @typescript-eslint/no-explicit-any` when creating new functions or editing existing code. Always define explicit TypeScript interfaces, types, or import schemas from `@workspace/shared`. Do NOT copy legacy `any` parameter signatures when refactoring or extending legacy service/repository files.
+
 
 ## Architecture Docs (Reduce Scanning, Prevent Bugs)
 

--- a/SparkyFitnessFrontend/src/api/Foods/mealPlanTemplate.ts
+++ b/SparkyFitnessFrontend/src/api/Foods/mealPlanTemplate.ts
@@ -48,3 +48,13 @@ export const deleteMealPlanTemplate = async (
   }
   await api.delete(url);
 };
+
+export const duplicateMealPlanTemplate = async (
+  userId: string,
+  templateId: string,
+  currentClientDate?: string
+): Promise<MealPlanTemplate> => {
+  return await api.post(`/meal-plan-templates/${templateId}/duplicate`, {
+    body: { userId, currentClientDate },
+  });
+};

--- a/SparkyFitnessFrontend/src/hooks/Foods/useMealplanTemplate.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useMealplanTemplate.ts
@@ -2,6 +2,7 @@ import { mealPlanKeys } from '@/api/keys/meals';
 import {
   createMealPlanTemplate,
   deleteMealPlanTemplate,
+  duplicateMealPlanTemplate,
   getMealPlanTemplates,
   updateMealPlanTemplate,
 } from '@/api/Foods/mealPlanTemplate';
@@ -111,6 +112,37 @@ export const useDeleteMealPlanMutation = () => {
       successMessage: t(
         'mealManagement.mealPlanDeletedSuccessfully',
         'Meal plan deleted successfully.'
+      ),
+    },
+  });
+};
+
+export const useDuplicateMealPlanMutation = () => {
+  const queryClient = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: ({
+      userId,
+      templateId,
+      currentClientDate,
+    }: {
+      userId: string;
+      templateId: string;
+      currentClientDate?: string;
+    }) => duplicateMealPlanTemplate(userId, templateId, currentClientDate),
+    onSuccess: (_data, variables) => {
+      return queryClient.invalidateQueries({
+        queryKey: mealPlanKeys.byUser(variables.userId),
+      });
+    },
+    meta: {
+      errorMessage: t(
+        'mealManagement.failedToDuplicateMealPlan',
+        'Failed to duplicate meal plan.'
+      ),
+      successMessage: t(
+        'mealManagement.mealPlanDuplicatedSuccessfully',
+        'Meal plan duplicated successfully.'
       ),
     },
   });

--- a/SparkyFitnessFrontend/src/pages/Foods/MealPlanCalendar.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/MealPlanCalendar.tsx
@@ -17,6 +17,7 @@ import {
   X,
   CalendarDays,
   MoreHorizontal,
+  Copy,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -30,6 +31,7 @@ import { useIsMobile } from '@/hooks/use-mobile';
 import {
   useCreateMealPlanMutation,
   useDeleteMealPlanMutation,
+  useDuplicateMealPlanMutation,
   useMealPlanTemplates,
   useUpdateMealPlanMutation,
 } from '@/hooks/Foods/useMealplanTemplate';
@@ -57,6 +59,8 @@ const MealPlanCalendar: React.FC = () => {
   const { mutateAsync: createMealPlanTemplate } = useCreateMealPlanMutation();
   const { mutateAsync: updateMealPlanTemplate } = useUpdateMealPlanMutation();
   const { mutateAsync: deleteMealPlanTemplate } = useDeleteMealPlanMutation();
+  const { mutateAsync: duplicateMealPlanTemplate } =
+    useDuplicateMealPlanMutation();
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
@@ -144,6 +148,26 @@ const MealPlanCalendar: React.FC = () => {
       }
     },
     [activeUserId, deleteMealPlanTemplate, invalidate]
+  );
+
+  const handleDuplicate = useCallback(
+    async (templateId: string) => {
+      if (!activeUserId) return;
+      try {
+        const now = new Date();
+        const currentClientDate = formatDateToYYYYMMDD(now);
+
+        await duplicateMealPlanTemplate({
+          userId: activeUserId,
+          templateId,
+          currentClientDate,
+        });
+        invalidate();
+      } catch (error) {
+        // Handled by mutation cache
+      }
+    },
+    [activeUserId, duplicateMealPlanTemplate, invalidate]
   );
 
   const handleTogglePlanActive = useCallback(
@@ -311,6 +335,10 @@ const MealPlanCalendar: React.FC = () => {
                 <DropdownMenuItem onClick={() => handleEdit(template)}>
                   <Edit className="mr-2 h-4 w-4" />
                   {t('common.edit', 'Edit')}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleDuplicate(template.id!)}>
+                  <Copy className="mr-2 h-4 w-4" />
+                  {t('common.duplicate', 'Duplicate')}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() =>

--- a/SparkyFitnessFrontend/src/pages/Foods/MealPlanCalendar.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/MealPlanCalendar.tsx
@@ -379,7 +379,7 @@ const MealPlanCalendar: React.FC = () => {
         },
       },
     ],
-    [t, handleTogglePlanActive, handleEdit, handleDelete]
+    [t, handleTogglePlanActive, handleEdit, handleDelete, handleDuplicate]
   );
 
   return (

--- a/SparkyFitnessFrontend/src/pages/Foods/MealPlanTemplateForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/Foods/MealPlanTemplateForm.tsx
@@ -516,16 +516,24 @@ const MealPlanTemplateForm: React.FC<MealPlanTemplateFormProps> = ({
                 />
               </div>
             </div>
-            <div className="flex items-center space-x-2">
-              <input
-                type="checkbox"
-                id="isActive"
-                checked={isActive}
-                onChange={(e) => setIsActive(e.target.checked)}
-              />
-              <Label htmlFor="isActive">
-                {t('mealPlanTemplateForm.setActiveLabel')}
-              </Label>
+            <div className="flex flex-col space-y-1">
+              <div className="flex items-center space-x-2">
+                <input
+                  type="checkbox"
+                  id="isActive"
+                  checked={isActive}
+                  onChange={(e) => setIsActive(e.target.checked)}
+                />
+                <Label htmlFor="isActive">
+                  {t('mealPlanTemplateForm.setActiveLabel')}
+                </Label>
+              </div>
+              <p className="text-xs text-muted-foreground ml-6">
+                {t(
+                  'mealPlanTemplateForm.multipleActiveHint',
+                  'Multiple meal plans can be active at the same time. Active plans automatically populate diary entries.'
+                )}
+              </p>
             </div>
             <div className="space-y-4">
               {daysOfWeek.map((day, dayIndex) => {

--- a/SparkyFitnessServer/db/migrations/20260725173500_allow_multiple_active_meal_plans.sql
+++ b/SparkyFitnessServer/db/migrations/20260725173500_allow_multiple_active_meal_plans.sql
@@ -1,0 +1,4 @@
+-- Migration: Allow multiple active meal plan templates per user
+-- Drops the unique constraint index restricting users to only 1 active meal plan at a time.
+
+DROP INDEX IF EXISTS public.one_active_meal_plan_per_user;

--- a/SparkyFitnessServer/models/mealPlanTemplateRepository.ts
+++ b/SparkyFitnessServer/models/mealPlanTemplateRepository.ts
@@ -347,8 +347,7 @@ async function getMealPlanTemplateOwnerId(templateId: any) {
     client.release();
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getActiveMealPlanForDate(userId: any, date: any) {
+async function getActiveMealPlansForDate(userId: string, date: Date | string) {
   const client = await getClient(userId); // User-specific operation
   try {
     const query = `
@@ -381,17 +380,22 @@ async function getActiveMealPlanForDate(userId: any, date: any) {
                     '[]'::json
                 ) as assignments
             FROM meal_plan_templates t
-            WHERE t.is_active = TRUE
-              AND t.start_date <= $1
-              AND (t.end_date IS NULL OR t.end_date >= $1)
+            WHERE t.user_id = $1
+              AND t.is_active = TRUE
+              AND t.start_date <= $2
+              AND (t.end_date IS NULL OR t.end_date >= $2)
             ORDER BY t.start_date DESC
-            LIMIT 1
         `;
-    const result = await client.query(query, [date]);
-    return result.rows[0];
+    const result = await client.query(query, [userId, date]);
+    return result.rows;
   } finally {
     client.release();
   }
+}
+
+async function getActiveMealPlanForDate(userId: string, date: Date | string) {
+  const plans = await getActiveMealPlansForDate(userId, date);
+  return plans[0] || null;
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getMealPlanTemplatesByMealId(mealId: any) {
@@ -444,6 +448,7 @@ export { deleteMealPlanTemplate };
 export { deactivateAllMealPlanTemplates };
 export { getMealPlanTemplateOwnerId };
 export { getActiveMealPlanForDate };
+export { getActiveMealPlansForDate };
 export { getMealPlanTemplatesByMealId };
 export { getMealPlanTemplateAssignments };
 export default {
@@ -454,6 +459,7 @@ export default {
   deactivateAllMealPlanTemplates,
   getMealPlanTemplateOwnerId,
   getActiveMealPlanForDate,
+  getActiveMealPlansForDate,
   getMealPlanTemplatesByMealId,
   getMealPlanTemplateAssignments,
 };

--- a/SparkyFitnessServer/routes/mealPlanTemplateRoutes.ts
+++ b/SparkyFitnessServer/routes/mealPlanTemplateRoutes.ts
@@ -137,7 +137,10 @@ router.put('/:id', authenticate, async (req, res, next) => {
  */
 router.delete('/:id', authenticate, async (req, res, next) => {
   try {
-    const { currentClientDate } = req.query;
+    const currentClientDate =
+      typeof req.query.currentClientDate === 'string'
+        ? req.query.currentClientDate
+        : undefined;
     await mealPlanTemplateService.deleteMealPlanTemplate(
       req.params.id,
 
@@ -149,4 +152,42 @@ router.delete('/:id', authenticate, async (req, res, next) => {
     next(error);
   }
 });
+
+/**
+ * @swagger
+ * /meal-plan-templates/{id}/duplicate:
+ *   post:
+ *     summary: Duplicate a meal plan template
+ *     tags: [Nutrition & Meals]
+ *     description: Clones an existing meal plan template and its assignments.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: The ID of the meal plan template to duplicate.
+ *     responses:
+ *       201:
+ *         description: The meal plan template was duplicated successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MealPlanTemplate'
+ */
+router.post('/:id/duplicate', authenticate, async (req, res, next) => {
+  try {
+    const { currentClientDate } = req.body || {};
+    const newPlan = await mealPlanTemplateService.duplicateMealPlanTemplate(
+      req.params.id,
+      req.userId,
+      currentClientDate
+    );
+    res.status(201).json(newPlan);
+  } catch (error) {
+    next(error);
+  }
+});
+
 export default router;

--- a/SparkyFitnessServer/services/mealPlanTemplateService.ts
+++ b/SparkyFitnessServer/services/mealPlanTemplateService.ts
@@ -2,17 +2,39 @@ import mealPlanTemplateRepository from '../models/mealPlanTemplateRepository.js'
 import foodRepository from '../models/foodRepository.js';
 import { log } from '../config/logging.js';
 import { resolveTemplateStartDay } from '../utils/timezoneLoader.js';
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function createMealPlanTemplate(userId: any, planData: any) {
+
+export interface MealPlanAssignmentData {
+  id?: string;
+  day_of_week: number;
+  meal_type_id?: string;
+  meal_type?: string;
+  item_type: 'meal' | 'food';
+  meal_id?: string | null;
+  food_id?: string | null;
+  variant_id?: string | null;
+  quantity?: number;
+  unit?: string;
+}
+
+export interface MealPlanTemplateData {
+  id?: string;
+  user_id?: string;
+  plan_name: string;
+  description?: string;
+  start_date?: Date | string;
+  end_date?: Date | string | null;
+  is_active?: boolean;
+  assignments?: MealPlanAssignmentData[];
+  day_presets?: MealPlanAssignmentData[];
+  currentClientDate?: string;
+}
+
+async function createMealPlanTemplate(
+  userId: string,
+  planData: MealPlanTemplateData
+) {
   log('info', 'createMealPlanTemplate service - received planData:', planData);
   try {
-    if (planData.is_active) {
-      log(
-        'info',
-        `createMealPlanTemplate service - Deactivating all other meal plan templates for user ${userId}`
-      );
-      await mealPlanTemplateRepository.deactivateAllMealPlanTemplates(userId);
-    }
     const newPlan = await mealPlanTemplateRepository.createMealPlanTemplate({
       ...planData,
       user_id: userId,
@@ -40,26 +62,25 @@ async function createMealPlanTemplate(userId: any, planData: any) {
     }
     return newPlan;
   } catch (error) {
+    const err = error as Error;
     log(
       'error',
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      `Error creating meal plan template for user ${userId}: ${error.message}`,
+      `Error creating meal plan template for user ${userId}: ${err.message}`,
       error
     );
     throw new Error('Failed to create meal plan template.', { cause: error });
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getMealPlanTemplates(userId: any) {
+
+async function getMealPlanTemplates(userId: string) {
   try {
     const templates =
       await mealPlanTemplateRepository.getMealPlanTemplatesByUserId(userId);
     const templatesWithAssignments = await Promise.all(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      templates.map(async (template: any) => {
+      templates.map(async (template: MealPlanTemplateData) => {
         const assignments =
           await mealPlanTemplateRepository.getMealPlanTemplateAssignments(
-            template.id,
+            template.id!,
             userId
           );
         return { ...template, assignments };
@@ -75,8 +96,12 @@ async function getMealPlanTemplates(userId: any) {
     throw new Error('Failed to fetch meal plan templates.', { cause: error });
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function updateMealPlanTemplate(planId: any, userId: any, planData: any) {
+
+async function updateMealPlanTemplate(
+  planId: string,
+  userId: string,
+  planData: MealPlanTemplateData
+) {
   log(
     'info',
     `updateMealPlanTemplate service - received planData for plan ${planId}:`,
@@ -94,13 +119,6 @@ async function updateMealPlanTemplate(planId: any, userId: any, planData: any) {
       `updateMealPlanTemplate service - Deleting old food entries for template ${planId}`
     );
     await foodRepository.deleteFoodEntriesByTemplateId(planId, userId, today);
-    if (planData.is_active) {
-      log(
-        'info',
-        `updateMealPlanTemplate service - Deactivating all other meal plan templates for user ${userId}`
-      );
-      await mealPlanTemplateRepository.deactivateAllMealPlanTemplates(userId);
-    }
     const updatedPlan = await mealPlanTemplateRepository.updateMealPlanTemplate(
       planId,
       { ...planData, user_id: userId }
@@ -124,10 +142,10 @@ async function updateMealPlanTemplate(planId: any, userId: any, planData: any) {
     }
     return updatedPlan;
   } catch (error) {
+    const err = error as Error;
     log(
       'error',
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      `Error updating meal plan template ${planId} for user ${userId}: ${error.message}`,
+      `Error updating meal plan template ${planId} for user ${userId}: ${err.message}`,
       error
     );
     throw new Error('Failed to update meal plan template.', { cause: error });
@@ -135,12 +153,9 @@ async function updateMealPlanTemplate(planId: any, userId: any, planData: any) {
 }
 
 async function deleteMealPlanTemplate(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  planId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  currentClientDate: any
+  planId: string,
+  userId: string,
+  currentClientDate?: string
 ) {
   try {
     const today = await resolveTemplateStartDay(userId, currentClientDate);
@@ -154,22 +169,67 @@ async function deleteMealPlanTemplate(
       userId
     );
   } catch (error) {
+    const err = error as Error;
     log(
       'error',
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      `Error deleting meal plan template ${planId} for user ${userId}: ${error.message}`,
+      `Error deleting meal plan template ${planId} for user ${userId}: ${err.message}`,
       error
     );
     throw new Error('Failed to delete meal plan template.', { cause: error });
   }
 }
+
+async function duplicateMealPlanTemplate(
+  planId: string,
+  userId: string,
+  currentClientDate?: string
+) {
+  try {
+    log(
+      'info',
+      `duplicateMealPlanTemplate service - duplicating template ${planId} for user ${userId}`
+    );
+    const templates = await getMealPlanTemplates(userId);
+    const sourceTemplate = templates.find(
+      (t: MealPlanTemplateData) => t.id === planId
+    );
+    if (!sourceTemplate) {
+      throw new Error(`Meal plan template ${planId} not found.`);
+    }
+
+    const clonedPlanData: MealPlanTemplateData = {
+      plan_name: `${sourceTemplate.plan_name} (Copy)`,
+      description: sourceTemplate.description || '',
+      start_date: new Date(),
+      end_date: sourceTemplate.end_date || null,
+      is_active: false,
+      assignments: sourceTemplate.assignments || [],
+      currentClientDate,
+    };
+
+    return await createMealPlanTemplate(userId, clonedPlanData);
+  } catch (error) {
+    const err = error as Error;
+    log(
+      'error',
+      `Error duplicating meal plan template ${planId} for user ${userId}: ${err.message}`,
+      error
+    );
+    throw new Error('Failed to duplicate meal plan template.', {
+      cause: error,
+    });
+  }
+}
+
 export { createMealPlanTemplate };
 export { getMealPlanTemplates };
 export { updateMealPlanTemplate };
 export { deleteMealPlanTemplate };
+export { duplicateMealPlanTemplate };
 export default {
   createMealPlanTemplate,
   getMealPlanTemplates,
   updateMealPlanTemplate,
   deleteMealPlanTemplate,
+  duplicateMealPlanTemplate,
 };

--- a/SparkyFitnessServer/tests/mealPlanTemplateService.test.ts
+++ b/SparkyFitnessServer/tests/mealPlanTemplateService.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import mealPlanTemplateService from '../services/mealPlanTemplateService.js';
+import mealPlanTemplateRepository from '../models/mealPlanTemplateRepository.js';
+import foodRepository from '../models/foodRepository.js';
+
+vi.mock('../models/mealPlanTemplateRepository.js', () => ({
+  default: {
+    createMealPlanTemplate: vi.fn(),
+    getMealPlanTemplatesByUserId: vi.fn(),
+    getMealPlanTemplateAssignments: vi.fn(),
+    updateMealPlanTemplate: vi.fn(),
+    deleteMealPlanTemplate: vi.fn(),
+    deactivateAllMealPlanTemplates: vi.fn(),
+  },
+}));
+
+vi.mock('../models/foodRepository.js', () => ({
+  default: {
+    createFoodEntriesFromTemplate: vi.fn().mockResolvedValue(true),
+    deleteFoodEntriesByTemplateId: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+vi.mock('../utils/timezoneLoader.js', () => ({
+  resolveTemplateStartDay: vi.fn().mockResolvedValue('2026-07-25'),
+}));
+
+describe('mealPlanTemplateService', () => {
+  const userId = 'user-123';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('createMealPlanTemplate should create active template without deactivating other plans', async () => {
+    const mockPlan = {
+      id: 'plan-1',
+      plan_name: 'Base Plan',
+      is_active: true,
+    };
+    vi.mocked(
+      mealPlanTemplateRepository.createMealPlanTemplate
+    ).mockResolvedValue(mockPlan);
+
+    const result = await mealPlanTemplateService.createMealPlanTemplate(
+      userId,
+      {
+        plan_name: 'Base Plan',
+        is_active: true,
+      }
+    );
+
+    expect(result).toEqual(mockPlan);
+    expect(
+      mealPlanTemplateRepository.deactivateAllMealPlanTemplates
+    ).not.toHaveBeenCalled();
+    expect(foodRepository.createFoodEntriesFromTemplate).toHaveBeenCalledWith(
+      'plan-1',
+      userId,
+      '2026-07-25'
+    );
+  });
+
+  it('updateMealPlanTemplate should update template without deactivating other plans', async () => {
+    const mockPlan = {
+      id: 'plan-2',
+      plan_name: 'Cutting Plan',
+      is_active: true,
+    };
+    vi.mocked(
+      mealPlanTemplateRepository.updateMealPlanTemplate
+    ).mockResolvedValue(mockPlan);
+
+    const result = await mealPlanTemplateService.updateMealPlanTemplate(
+      'plan-2',
+      userId,
+      {
+        plan_name: 'Cutting Plan',
+        is_active: true,
+      }
+    );
+
+    expect(result).toEqual(mockPlan);
+    expect(
+      mealPlanTemplateRepository.deactivateAllMealPlanTemplates
+    ).not.toHaveBeenCalled();
+    expect(foodRepository.deleteFoodEntriesByTemplateId).toHaveBeenCalledWith(
+      'plan-2',
+      userId,
+      '2026-07-25'
+    );
+    expect(foodRepository.createFoodEntriesFromTemplate).toHaveBeenCalledWith(
+      'plan-2',
+      userId,
+      '2026-07-25'
+    );
+  });
+
+  it('duplicateMealPlanTemplate should clone original plan with (Copy) name and inactive state', async () => {
+    const originalTemplate = {
+      id: 'plan-orig',
+      plan_name: 'Keto Plan',
+      description: 'Low carb plan',
+      start_date: new Date('2026-01-01'),
+      end_date: null,
+      is_active: true,
+      assignments: [
+        {
+          day_of_week: 1,
+          meal_type_id: 'mt-1',
+          item_type: 'food',
+          food_id: 'f-1',
+          quantity: 2,
+        },
+      ],
+    };
+
+    vi.mocked(
+      mealPlanTemplateRepository.getMealPlanTemplatesByUserId
+    ).mockResolvedValue([originalTemplate]);
+    vi.mocked(
+      mealPlanTemplateRepository.getMealPlanTemplateAssignments
+    ).mockResolvedValue(originalTemplate.assignments);
+
+    const clonedPlan = {
+      id: 'plan-copy',
+      plan_name: 'Keto Plan (Copy)',
+      is_active: false,
+    };
+    vi.mocked(
+      mealPlanTemplateRepository.createMealPlanTemplate
+    ).mockResolvedValue(clonedPlan);
+
+    const result = await mealPlanTemplateService.duplicateMealPlanTemplate(
+      'plan-orig',
+      userId
+    );
+
+    expect(result).toEqual(clonedPlan);
+    expect(
+      mealPlanTemplateRepository.createMealPlanTemplate
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: userId,
+        plan_name: 'Keto Plan (Copy)',
+        description: 'Low carb plan',
+        is_active: false,
+        assignments: originalTemplate.assignments,
+      })
+    );
+  });
+});

--- a/docs/content/8.developer/4.database.md
+++ b/docs/content/8.developer/4.database.md
@@ -83,7 +83,7 @@ Quick reference of all tables by domain and purpose. For detailed security tier,
 | `meal_foods` | Ingredients assigned to meals |
 | `meal_types` | Custom meal type definitions (breakfast, lunch, etc.) |
 | `meal_plans` | Weekly meal planning schedules |
-| `meal_plan_templates` | Reusable meal plan templates |
+| `meal_plan_templates` | Reusable meal plan templates (supports multiple active plans per user) |
 | `meal_plan_template_assignments` | Scheduled meal templates to calendar |
 | `meal_plan_assignment_sets` | Sets within assigned meal plans |
 


### PR DESCRIPTION


> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)
- Database: Added migration 20260725173500_allow_multiple_active_meal_plans.sql to drop the single-active unique index `one_active_meal_plan_per_user`.
- Server: Removed automatic plan deactivation on create/update to support multiple active meal plans concurrently.
- Server: Added `POST /api/meal-plan-templates/:id/duplicate` endpoint and `duplicateMealPlanTemplate` service function to clone templates and assignments with a `(Copy)` suffix.
- Server: Added `getActiveMealPlansForDate` repository method to query all active plans for a date range.
- Frontend: Added 1-click `Duplicate` row action in `MealPlanCalendar` table and added helper text in `MealPlanTemplateForm`.
- Refactor: Strictly typed all server meal template service/repository parameters with explicit interfaces (0 `any` types).
- Docs & Rules: Updated `docs/content/8.developer/4.database.md` and added strict TypeScript typing rule to `AGENTS.md`.
- Tests: Added unit test suite in `mealPlanTemplateService.test.ts` covering multiple active plans and template duplication.
- 
**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #1478

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
