### PR TITLE
feat: medications in mobile app

### DIFF
--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -1242,10 +1242,7 @@ function AppContent() {
           <Stack.Screen
             name="MedicationDetail"
             component={SafeMedicationDetail}
-            options={({ route }) => createStackScreenOptions(
-              route.params.medicationId ? 'Medication' : 'Medication',
-              { headerBackTitle: 'Medications' },
-            )}
+            options={createStackScreenOptions('Medication', { headerBackTitle: 'Medications' })}
           />
           <Stack.Screen
             name="MedicationForm"

--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -126,6 +126,7 @@ import ActiveWorkoutBar, {
   notifyActiveWorkoutBarSwipeProgress,
 } from './src/components/ActiveWorkoutBar';
 import { ActiveWorkoutTransitionScreenLayout } from './src/components/ActiveWorkoutTransitionProbe';
+import MedicationReminderReconciler from './src/components/MedicationReminderReconciler';
 import { withErrorBoundary } from './src/components/ScreenErrorBoundary';
 import { useNativeIOSTabsActive, useNativeIOSHeadersActive } from './src/services/nativeTabBarPreference';
 
@@ -1289,6 +1290,7 @@ function AppContent() {
           }}
         />
         <ActiveWorkoutBar />
+        <MedicationReminderReconciler />
         <SafeAreaToast />
       </SafeAreaProvider>
     </NavigationContainer>

--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -74,6 +74,9 @@ import CycleOnboardingScreen from './src/screens/CycleOnboardingScreen';
 import CycleHubScreen from './src/screens/CycleHubScreen';
 import CycleLogModalScreen from './src/screens/CycleLogModalScreen';
 import PregnancySetupScreen from './src/screens/PregnancySetupScreen';
+import MedicationsListScreen from './src/screens/MedicationsListScreen';
+import MedicationDetailScreen from './src/screens/MedicationDetailScreen';
+import MedicationFormScreen from './src/screens/MedicationFormScreen';
 import DailyNutritionDetailsScreen from './src/screens/DailyNutritionDetailsScreen';
 import NutrientTrendsScreen from './src/screens/NutrientTrendsScreen';
 import ReauthModal from './src/components/ReauthModal';
@@ -105,6 +108,7 @@ import { initializeTheme } from './src/services/themeService';
 import { loadActiveDraft, clearDraft } from './src/services/workoutDraftService';
 import { addLog, initLogService } from './src/services/LogService';
 import { initNotifications } from './src/services/notifications';
+import { initMedicationNotificationActions } from './src/services/medicationNotificationHandler';
 import { initWorkoutLiveActivity } from './src/services/workoutLiveActivity';
 import { ensureTimezoneBootstrapped } from './src/services/api/preferencesApi';
 import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -239,6 +243,9 @@ const SafeCycleOnboarding = withErrorBoundary(CycleOnboardingScreen, 'CycleOnboa
 const SafeCycleHub = withErrorBoundary(CycleHubScreen, 'CycleHub', { canGoBack: true });
 const SafeCycleLogModal = withErrorBoundary(CycleLogModalScreen, 'CycleLogModal', { canGoBack: true });
 const SafePregnancySetup = withErrorBoundary(PregnancySetupScreen, 'PregnancySetup', { canGoBack: true });
+const SafeMedicationsList = withErrorBoundary(MedicationsListScreen, 'MedicationsList', { canGoBack: true });
+const SafeMedicationDetail = withErrorBoundary(MedicationDetailScreen, 'MedicationDetail', { canGoBack: true });
+const SafeMedicationForm = withErrorBoundary(MedicationFormScreen, 'MedicationForm', { canGoBack: true });
 
 function AppContent() {
   const { theme } = useUniwind();
@@ -618,6 +625,7 @@ function AppContent() {
     initializeApp();
 
     initWorkoutNotificationActions();
+    initMedicationNotificationActions();
 
     // iOS-only (no-op on Android): keeps the workout Live Activity in sync
     // with the active-workout store.
@@ -1220,6 +1228,28 @@ function AppContent() {
             name="PregnancySetup"
             component={SafePregnancySetup}
             options={createStackScreenOptions('Pregnancy Setup', {
+              presentation: 'modal',
+              headerBackButtonDisplayMode: 'minimal',
+              ...(Platform.OS === 'android' ? androidModalAnimation : {}),
+            })}
+          />
+          <Stack.Screen
+            name="MedicationsList"
+            component={SafeMedicationsList}
+            options={createStackScreenOptions('Medications', { headerBackButtonDisplayMode: 'minimal' })}
+          />
+          <Stack.Screen
+            name="MedicationDetail"
+            component={SafeMedicationDetail}
+            options={({ route }) => createStackScreenOptions(
+              route.params.medicationId ? 'Medication' : 'Medication',
+              { headerBackTitle: 'Medications' },
+            )}
+          />
+          <Stack.Screen
+            name="MedicationForm"
+            component={SafeMedicationForm}
+            options={createStackScreenOptions('Medication', {
               presentation: 'modal',
               headerBackButtonDisplayMode: 'minimal',
               ...(Platform.OS === 'android' ? androidModalAnimation : {}),

--- a/SparkyFitnessMobile/src/components/MedicationReminderReconciler.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationReminderReconciler.tsx
@@ -7,10 +7,6 @@ import { getTodayDate } from '../utils/dateUtils';
 import { reconcileMedicationReminders } from '../services/medicationReminderService';
 import { addLog } from '../services/LogService';
 
-const schedulingLock = new Set<string>();
-
-const LOCK_KEY = 'medication-reminders';
-
 const MedicationReminderReconciler: React.FC = () => {
   const medicationRemindersEnabled = useAppPreferencesStore((s) => s.medicationRemindersEnabled);
   const notificationsEnabled = useAppPreferencesStore((s) => s.notificationsEnabled);
@@ -24,15 +20,10 @@ const MedicationReminderReconciler: React.FC = () => {
   useEffect(() => {
     if (isLoadingMeds || isLoadingEntries) return;
     if (!medications || medications.length === 0) return;
-    if (schedulingLock.has(LOCK_KEY)) return;
 
-    schedulingLock.add(LOCK_KEY);
     reconcileMedicationReminders(medications, todayEntries ?? [])
       .catch((error) => {
         addLog(`Medication reminder reconciliation failed: ${(error as Error).message}`, 'ERROR');
-      })
-      .finally(() => {
-        schedulingLock.delete(LOCK_KEY);
       });
   }, [medications, todayEntries, isLoadingMeds, isLoadingEntries, medicationRemindersEnabled, notificationsEnabled, medicationReminderRepeats, today]);
 

--- a/SparkyFitnessMobile/src/components/MedicationReminderReconciler.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationReminderReconciler.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { AppState } from 'react-native';
 
 import { useMedications, useMedicationEntries } from '../hooks/useMedications';
@@ -7,41 +7,43 @@ import { getTodayDate } from '../utils/dateUtils';
 import { reconcileMedicationReminders } from '../services/medicationReminderService';
 import { addLog } from '../services/LogService';
 
+const schedulingLock = new Set<string>();
+
+const LOCK_KEY = 'medication-reminders';
+
 const MedicationReminderReconciler: React.FC = () => {
   const medicationRemindersEnabled = useAppPreferencesStore((s) => s.medicationRemindersEnabled);
   const notificationsEnabled = useAppPreferencesStore((s) => s.notificationsEnabled);
   const medicationReminderRepeats = useAppPreferencesStore((s) => s.medicationReminderRepeats);
 
-  const { data: medications, isLoading: isLoadingMeds } = useMedications({ activeOnly: true });
+  const { data: medications, isLoading: isLoadingMeds, refetch: refetchMeds } = useMedications({ activeOnly: true });
 
   const today = getTodayDate();
-  const { data: todayEntries, isLoading: isLoadingEntries } = useMedicationEntries({ fromDate: today, toDate: today });
-
-  const reconcilingRef = useRef(false);
+  const { data: todayEntries, isLoading: isLoadingEntries, refetch: refetchEntries } = useMedicationEntries({ fromDate: today, toDate: today });
 
   useEffect(() => {
     if (isLoadingMeds || isLoadingEntries) return;
     if (!medications || medications.length === 0) return;
-    if (reconcilingRef.current) return;
+    if (schedulingLock.has(LOCK_KEY)) return;
 
-    reconcilingRef.current = true;
+    schedulingLock.add(LOCK_KEY);
     reconcileMedicationReminders(medications, todayEntries ?? [])
       .catch((error) => {
         addLog(`Medication reminder reconciliation failed: ${(error as Error).message}`, 'ERROR');
       })
       .finally(() => {
-        reconcilingRef.current = false;
+        schedulingLock.delete(LOCK_KEY);
       });
   }, [medications, todayEntries, isLoadingMeds, isLoadingEntries, medicationRemindersEnabled, notificationsEnabled, medicationReminderRepeats, today]);
 
-  // Re-reconcile on app resume
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (state) => {
       if (state !== 'active') return;
-      reconcilingRef.current = false;
+      void refetchMeds();
+      void refetchEntries();
     });
     return () => subscription.remove();
-  }, []);
+  }, [refetchMeds, refetchEntries]);
 
   return null;
 };

--- a/SparkyFitnessMobile/src/components/MedicationReminderReconciler.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationReminderReconciler.tsx
@@ -11,29 +11,35 @@ const MedicationReminderReconciler: React.FC = () => {
   const medicationRemindersEnabled = useAppPreferencesStore((s) => s.medicationRemindersEnabled);
   const notificationsEnabled = useAppPreferencesStore((s) => s.notificationsEnabled);
   const medicationReminderRepeats = useAppPreferencesStore((s) => s.medicationReminderRepeats);
+  const remindersActive = medicationRemindersEnabled && notificationsEnabled;
 
-  const { data: medications, isLoading: isLoadingMeds, refetch: refetchMeds } = useMedications({ activeOnly: true });
+  const { data: medications, isLoading: isLoadingMeds, refetch: refetchMeds } = useMedications({ activeOnly: true, enabled: remindersActive });
 
   const today = getTodayDate();
-  const { data: todayEntries, isLoading: isLoadingEntries, refetch: refetchEntries } = useMedicationEntries({ fromDate: today, toDate: today });
+  const { data: todayEntries, isLoading: isLoadingEntries, refetch: refetchEntries } = useMedicationEntries({ fromDate: today, toDate: today, enabled: remindersActive });
 
   useEffect(() => {
-    if (isLoadingMeds || isLoadingEntries) return;
+    if (remindersActive && (isLoadingMeds || isLoadingEntries)) return;
 
-    reconcileMedicationReminders(medications ?? [], todayEntries ?? [])
-      .catch((error) => {
-        addLog(`Medication reminder reconciliation failed: ${(error as Error).message}`, 'ERROR');
-      });
-  }, [medications, todayEntries, isLoadingMeds, isLoadingEntries, medicationRemindersEnabled, notificationsEnabled, medicationReminderRepeats, today]);
+    // With reminders off the queries stay disabled; the reconcile still runs
+    // (with empty data) so any pending reminders get cancelled.
+    reconcileMedicationReminders(
+      remindersActive ? medications ?? [] : [],
+      remindersActive ? todayEntries ?? [] : [],
+    ).catch((error) => {
+      addLog(`Medication reminder reconciliation failed: ${(error as Error).message}`, 'ERROR');
+    });
+  }, [medications, todayEntries, isLoadingMeds, isLoadingEntries, remindersActive, medicationReminderRepeats, today]);
 
   useEffect(() => {
+    if (!remindersActive) return;
     const subscription = AppState.addEventListener('change', (state) => {
       if (state !== 'active') return;
       void refetchMeds();
       void refetchEntries();
     });
     return () => subscription.remove();
-  }, [refetchMeds, refetchEntries]);
+  }, [refetchMeds, refetchEntries, remindersActive]);
 
   return null;
 };

--- a/SparkyFitnessMobile/src/components/MedicationReminderReconciler.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationReminderReconciler.tsx
@@ -19,9 +19,8 @@ const MedicationReminderReconciler: React.FC = () => {
 
   useEffect(() => {
     if (isLoadingMeds || isLoadingEntries) return;
-    if (!medications || medications.length === 0) return;
 
-    reconcileMedicationReminders(medications, todayEntries ?? [])
+    reconcileMedicationReminders(medications ?? [], todayEntries ?? [])
       .catch((error) => {
         addLog(`Medication reminder reconciliation failed: ${(error as Error).message}`, 'ERROR');
       });

--- a/SparkyFitnessMobile/src/components/MedicationReminderReconciler.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationReminderReconciler.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
+
+import { useMedications, useMedicationEntries } from '../hooks/useMedications';
+import { useAppPreferencesStore } from '../stores/appPreferencesStore';
+import { getTodayDate } from '../utils/dateUtils';
+import { reconcileMedicationReminders } from '../services/medicationReminderService';
+import { addLog } from '../services/LogService';
+
+const MedicationReminderReconciler: React.FC = () => {
+  const medicationRemindersEnabled = useAppPreferencesStore((s) => s.medicationRemindersEnabled);
+  const notificationsEnabled = useAppPreferencesStore((s) => s.notificationsEnabled);
+  const medicationReminderRepeats = useAppPreferencesStore((s) => s.medicationReminderRepeats);
+
+  const { data: medications, isLoading: isLoadingMeds } = useMedications({ activeOnly: true });
+
+  const today = getTodayDate();
+  const { data: todayEntries, isLoading: isLoadingEntries } = useMedicationEntries({ fromDate: today, toDate: today });
+
+  const reconcilingRef = useRef(false);
+
+  useEffect(() => {
+    if (isLoadingMeds || isLoadingEntries) return;
+    if (!medications || medications.length === 0) return;
+    if (reconcilingRef.current) return;
+
+    reconcilingRef.current = true;
+    reconcileMedicationReminders(medications, todayEntries ?? [])
+      .catch((error) => {
+        addLog(`Medication reminder reconciliation failed: ${(error as Error).message}`, 'ERROR');
+      })
+      .finally(() => {
+        reconcilingRef.current = false;
+      });
+  }, [medications, todayEntries, isLoadingMeds, isLoadingEntries, medicationRemindersEnabled, notificationsEnabled, medicationReminderRepeats, today]);
+
+  // Re-reconcile on app resume
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state !== 'active') return;
+      reconcilingRef.current = false;
+    });
+    return () => subscription.remove();
+  }, []);
+
+  return null;
+};
+
+export default MedicationReminderReconciler;

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -56,6 +56,14 @@ const SwipeableMedRow: React.FC<{
   const skipped = entry?.status === 'skipped';
   const completed = taken || skipped;
 
+  const [successBg, iconSuccess, iconDecorative, iconWarning, bgWarning] = useCSSVariable([
+    '--color-bg-success',
+    '--color-icon-success',
+    '--color-icon-decorative',
+    '--color-icon-warning',
+    '--color-bg-warning',
+  ]) as [string, string, string, string, string];
+
   const handleTake = () => {
     swipeableRef.current?.close();
     onTake(due);
@@ -84,7 +92,7 @@ const SwipeableMedRow: React.FC<{
     <View style={{ flexDirection: 'row' }}>
       <TouchableOpacity
         className="justify-center items-center"
-        style={{ width: ACTION_WIDTH, backgroundColor: '#22C55E' }}
+        style={{ width: ACTION_WIDTH, backgroundColor: successBg }}
         onPress={handleTake}
         activeOpacity={0.7}
       >
@@ -93,7 +101,7 @@ const SwipeableMedRow: React.FC<{
       </TouchableOpacity>
       <TouchableOpacity
         className="justify-center items-center"
-        style={{ width: ACTION_WIDTH, backgroundColor: '#F59E0B' }}
+        style={{ width: ACTION_WIDTH, backgroundColor: bgWarning }}
         onPress={handleSkip}
         activeOpacity={0.7}
       >
@@ -130,13 +138,13 @@ const SwipeableMedRow: React.FC<{
             className="w-6 h-6 rounded-full items-center justify-center mr-3"
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
             style={{
-              backgroundColor: taken ? '#22C55E' : skipped ? '#F59E0B' : 'transparent',
-              borderWidth: completed ? 0 : 1.5,
-              borderColor: '#6B7280',
+              backgroundColor: 'transparent',
+              borderWidth: 1.5,
+              borderColor: taken ? iconSuccess : skipped ? iconWarning : '#6B7280',
             }}
           >
-            {taken && <Icon name="checkmark" size={14} color="#FFFFFF" />}
-            {skipped && <Icon name="close" size={14} color="#FFFFFF" />}
+            {taken && <Icon name="checkmark" size={14} color={iconSuccess} />}
+            {skipped && <Icon name="close" size={14} color={iconWarning} />}
           </Pressable>
           <View className="flex-1">
             <Text className={`text-base ${completed ? 'text-text-muted' : 'text-text-primary'}`} numberOfLines={1}>
@@ -154,7 +162,7 @@ const SwipeableMedRow: React.FC<{
               ) : null}
             </View>
           </View>
-          <Icon name="chevron-forward" size={16} color="#9CA3AF" />
+          <Icon name="chevron-forward" size={16} color={iconDecorative} />
         </Pressable>
       </ReanimatedSwipeable>
     </Animated.View>
@@ -170,7 +178,7 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
   const createEntryMutation = useCreateMedicationEntry();
   const deleteEntryMutation = useDeleteMedicationEntry();
 
-  const [accentPrimary] = useCSSVariable(['--color-accent-primary']) as [string];
+  const [accentPrimary, iconSuccess, iconDecorative] = useCSSVariable(['--color-accent-primary', '--color-icon-success', '--color-icon-decorative']) as [string, string, string];
 
   const dueDoses = useMemo(() => {
     if (!medications) return [];
@@ -189,14 +197,6 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
   const entryForDue = useCallback(
     (due: DueDose) => entries?.find((e) => entryMatchesDue(e, due)),
     [entries],
-  );
-
-  const completedCount = useMemo(
-    () => dueDoses.filter((d) => {
-      const e = entryForDue(d);
-      return e && (e.status === 'taken' || e.status === 'skipped');
-    }).length,
-    [dueDoses, entryForDue],
   );
 
   const handleTake = useCallback(
@@ -308,29 +308,18 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
   return (
     <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
       <View className="flex-row items-center justify-between mb-2">
-        <Text className="text-md font-bold text-text-secondary">Medications</Text>
-        <View className="flex-row items-center">
-          {dueDoses.length > 0 && (
-            <Text className="text-sm text-text-muted mr-3">
-              {completedCount}/{dueDoses.length}
-            </Text>
-          )}
-          <TouchableOpacity
-            onPress={() => navigation.navigate('MedicationsList')}
-            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-            accessibilityRole="button"
-            accessibilityLabel="Manage medications"
-            className="flex-row items-center"
-          >
-            <Text className="text-sm text-accent-primary font-medium">Manage</Text>
-            <Icon name="chevron-forward" size={14} color={accentPrimary} style={{ marginLeft: 2 }} />
-          </TouchableOpacity>
-        </View>
+        <TouchableOpacity
+          onPress={() => navigation.navigate('MedicationsList')}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="Go to medications list"
+        >
+          <Text className="text-md font-bold text-text-secondary">Medications</Text>
+        </TouchableOpacity>
       </View>
 
       {dueDoses.length > 0 && (
-        <View className="mb-3">
-          <Text className="text-xs font-semibold text-text-muted uppercase tracking-wide mb-1">Scheduled</Text>
+        <View>
           {dueDoses.map((due, index) => (
             <SwipeableMedRow
               key={`${due.medication.id}-${due.schedule.id}-${index}`}
@@ -347,7 +336,6 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
 
       {prnMeds.length > 0 && (
         <View>
-          <Text className="text-xs font-semibold text-text-muted uppercase tracking-wide mb-1">As Needed</Text>
           {prnMeds.map((med) => {
             const prnCount = entries?.filter(
               (e) => e.medication_id === med.id && e.status === 'prn_taken' && e.entry_date === selectedDate,
@@ -358,8 +346,10 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
                 className="py-2.5 px-1 flex-row items-center"
                 onPress={() => navigation.navigate('MedicationDetail', { medicationId: med.id })}
               >
-                <View className="w-6 h-6 rounded-full items-center justify-center mr-3" style={{ backgroundColor: 'transparent', borderWidth: 1.5, borderColor: prnCount > 0 ? '#22C55E' : '#6B7280' }}>
-                  {prnCount > 0 && <Text className="text-xs font-bold" style={{ color: '#22C55E' }}>{prnCount}</Text>}
+                <View className="w-6 h-6 rounded-full items-center justify-center mr-3" style={{ backgroundColor: 'transparent', borderWidth: 1.5, borderColor: prnCount > 0 ? iconSuccess : '#6B7280' }}>
+                  {prnCount > 0 ? (
+                    <Text className="text-xs font-bold" style={{ color: iconSuccess }}>{prnCount}</Text>
+                  ) : null}
                 </View>
                 <View className="flex-1">
                   <Text className={`text-base ${prnCount > 0 ? 'text-text-muted' : 'text-text-primary'}`} numberOfLines={1}>
@@ -383,7 +373,7 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
                 >
                   <Text className="text-sm font-semibold" style={{ color: accentPrimary }}>Log</Text>
                 </TouchableOpacity>
-                <Icon name="chevron-forward" size={16} color="#9CA3AF" style={{ marginLeft: 6 }} />
+                <Icon name="chevron-forward" size={16} color={iconDecorative} style={{ marginLeft: 6 }} />
               </Pressable>
             );
           })}

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -208,23 +208,45 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
         return;
       }
       if (existing) {
-        deleteEntryMutation.mutate(existing.id);
-      }
-      createEntryMutation.mutate(
-        {
-          medication_id: due.medication.id,
-          schedule_id: due.schedule.id,
-          status: 'taken' as MedicationEntryStatus,
-          entry_date: selectedDate,
-          taken_at: new Date().toISOString(),
-        },
-        {
-          onSuccess: () => Toast.show({ type: 'success', text1: `${due.medication.name} taken` }),
-          onError: (error) => {
-            addLog(`Failed to log medication: ${error.message}`, 'ERROR');
+        deleteEntryMutation.mutateAsync(existing.id).then(
+          () => {
+            createEntryMutation.mutate(
+              {
+                medication_id: due.medication.id,
+                schedule_id: due.schedule.id,
+                status: 'taken' as MedicationEntryStatus,
+                entry_date: selectedDate,
+                taken_at: new Date().toISOString(),
+              },
+              {
+                onSuccess: () => Toast.show({ type: 'success', text1: `${due.medication.name} taken` }),
+                onError: (error) => {
+                  addLog(`Failed to log medication: ${error.message}`, 'ERROR');
+                },
+              },
+            );
           },
-        },
-      );
+          (error) => {
+            addLog(`Failed to delete existing medication entry: ${error.message}`, 'ERROR');
+          },
+        );
+      } else {
+        createEntryMutation.mutate(
+          {
+            medication_id: due.medication.id,
+            schedule_id: due.schedule.id,
+            status: 'taken' as MedicationEntryStatus,
+            entry_date: selectedDate,
+            taken_at: new Date().toISOString(),
+          },
+          {
+            onSuccess: () => Toast.show({ type: 'success', text1: `${due.medication.name} taken` }),
+            onError: (error) => {
+              addLog(`Failed to log medication: ${error.message}`, 'ERROR');
+            },
+          },
+        );
+      }
     },
     [entryForDue, createEntryMutation, deleteEntryMutation, selectedDate],
   );
@@ -238,22 +260,43 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
         return;
       }
       if (existing) {
-        deleteEntryMutation.mutate(existing.id);
-      }
-      createEntryMutation.mutate(
-        {
-          medication_id: due.medication.id,
-          schedule_id: due.schedule.id,
-          status: 'skipped' as MedicationEntryStatus,
-          entry_date: selectedDate,
-        },
-        {
-          onSuccess: () => Toast.show({ type: 'info', text1: `${due.medication.name} skipped` }),
-          onError: (error) => {
-            addLog(`Failed to skip medication: ${error.message}`, 'ERROR');
+        deleteEntryMutation.mutateAsync(existing.id).then(
+          () => {
+            createEntryMutation.mutate(
+              {
+                medication_id: due.medication.id,
+                schedule_id: due.schedule.id,
+                status: 'skipped' as MedicationEntryStatus,
+                entry_date: selectedDate,
+              },
+              {
+                onSuccess: () => Toast.show({ type: 'info', text1: `${due.medication.name} skipped` }),
+                onError: (error) => {
+                  addLog(`Failed to skip medication: ${error.message}`, 'ERROR');
+                },
+              },
+            );
           },
-        },
-      );
+          (error) => {
+            addLog(`Failed to delete existing medication entry: ${error.message}`, 'ERROR');
+          },
+        );
+      } else {
+        createEntryMutation.mutate(
+          {
+            medication_id: due.medication.id,
+            schedule_id: due.schedule.id,
+            status: 'skipped' as MedicationEntryStatus,
+            entry_date: selectedDate,
+          },
+          {
+            onSuccess: () => Toast.show({ type: 'info', text1: `${due.medication.name} skipped` }),
+            onError: (error) => {
+              addLog(`Failed to skip medication: ${error.message}`, 'ERROR');
+            },
+          },
+        );
+      }
     },
     [entryForDue, createEntryMutation, deleteEntryMutation, selectedDate],
   );

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -4,7 +4,6 @@ import { useCSSVariable } from 'uniwind';
 import Toast from 'react-native-toast-message';
 import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
 import type { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
-import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
 import type { CompositeNavigationProp } from '@react-navigation/native';
 import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -12,7 +11,6 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import Icon from './Icon';
 import { useMedications, useMedicationEntries, useCreateMedicationEntry, useDeleteMedicationEntry } from '../hooks/useMedications';
 import { useDiaryDateStore } from '../stores/diaryDateStore';
-import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import { getDueDosesForDate, type SharedScheduleRule } from '@workspace/shared';
 import type { RootStackParamList, TabParamList } from '../types/navigation';
 import type { Medication, MedicationDetail, MedicationEntry, MedicationEntryStatus } from '../types/medications';
@@ -50,8 +48,6 @@ const SwipeableMedRow: React.FC<{
   onNavigate: (medicationId: string) => void;
 }> = ({ due, entry, onTake, onSkip, onToggleTaken, onNavigate }) => {
   const swipeableRef = useRef<SwipeableMethods | null>(null);
-  const rowHeight = useSharedValue<number | null>(null);
-  const isRemoving = useSharedValue(false);
   const taken = entry?.status === 'taken' || entry?.status === 'prn_taken';
   const skipped = entry?.status === 'skipped';
   const completed = taken || skipped;
@@ -73,20 +69,6 @@ const SwipeableMedRow: React.FC<{
     swipeableRef.current?.close();
     onSkip(due);
   };
-
-  const handleLayout = (event: { nativeEvent: { layout: { height: number } } }) => {
-    if (rowHeight.value === null) {
-      rowHeight.value = event.nativeEvent.layout.height;
-    }
-  };
-
-  const animatedStyle = useAnimatedStyle(() => {
-    if (!isRemoving.value || rowHeight.value === null) return {};
-    return {
-      height: rowHeight.value,
-      overflow: 'hidden' as const,
-    };
-  });
 
   const renderRightActions = () => (
     <View style={{ flexDirection: 'row' }}>
@@ -122,7 +104,6 @@ const SwipeableMedRow: React.FC<{
   const doseLabel = med.dose_amount != null ? `${med.dose_amount} ${med.dose_unit ?? ''}`.trim() : '';
 
   return (
-    <Animated.View style={animatedStyle} onLayout={handleLayout}>
       <ReanimatedSwipeable
         ref={swipeableRef}
         renderRightActions={renderRightActions}
@@ -140,7 +121,7 @@ const SwipeableMedRow: React.FC<{
             style={{
               backgroundColor: 'transparent',
               borderWidth: 1.5,
-              borderColor: taken ? iconSuccess : skipped ? iconWarning : '#6B7280',
+              borderColor: taken ? iconSuccess : skipped ? iconWarning : iconDecorative,
             }}
           >
             {taken && <Icon name="checkmark" size={14} color={iconSuccess} />}
@@ -165,13 +146,11 @@ const SwipeableMedRow: React.FC<{
           <Icon name="chevron-forward" size={16} color={iconDecorative} />
         </Pressable>
       </ReanimatedSwipeable>
-    </Animated.View>
   );
 };
 
 const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
   const selectedDate = useDiaryDateStore((s) => s.selectedDate);
-  const medicationsCardVisible = useAppPreferencesStore((s) => s.medicationsCardVisible);
 
   const { data: medications, isLoading: isLoadingMeds } = useMedications({ activeOnly: true });
   const { data: entries, isLoading: isLoadingEntries } = useMedicationEntries({ fromDate: selectedDate, toDate: selectedDate });
@@ -333,8 +312,6 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
     [createEntryMutation, selectedDate],
   );
 
-  if (!medicationsCardVisible) return null;
-
   if (isLoadingMeds || isLoadingEntries) {
     return (
       <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
@@ -383,13 +360,14 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
             const prnCount = entries?.filter(
               (e) => e.medication_id === med.id && e.status === 'prn_taken' && e.entry_date === selectedDate,
             ).length ?? 0;
+            const typeMeta = MEDICATION_TYPES.find((t) => t.id === med.type_id);
             return (
               <Pressable
                 key={med.id}
                 className="py-2.5 px-1 flex-row items-center"
                 onPress={() => navigation.navigate('MedicationDetail', { medicationId: med.id })}
               >
-                <View className="w-6 h-6 rounded-full items-center justify-center mr-3" style={{ backgroundColor: 'transparent', borderWidth: 1.5, borderColor: prnCount > 0 ? iconSuccess : '#6B7280' }}>
+                <View className="w-6 h-6 rounded-full items-center justify-center mr-3" style={{ backgroundColor: 'transparent', borderWidth: 1.5, borderColor: prnCount > 0 ? iconSuccess : iconDecorative }}>
                   {prnCount > 0 ? (
                     <Text className="text-xs font-bold" style={{ color: iconSuccess }}>{prnCount}</Text>
                   ) : null}
@@ -399,8 +377,8 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
                     {med.name}
                   </Text>
                   <View className="flex-row items-center mt-0.5">
-                    {MEDICATION_TYPES.find((t) => t.id === med.type_id)?.label ? (
-                      <Text className="text-xs text-text-secondary" numberOfLines={1}>{MEDICATION_TYPES.find((t) => t.id === med.type_id)!.label}</Text>
+                    {typeMeta ? (
+                      <Text className="text-xs text-text-secondary" numberOfLines={1}>{typeMeta.label}</Text>
                     ) : null}
                     {med.dose_amount != null && med.dose_unit ? (
                       <Text className="text-xs text-text-secondary ml-2">{med.dose_amount} {med.dose_unit}</Text>

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -182,12 +182,12 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
 
   const dueDoses = useMemo(() => {
     if (!medications) return [];
-    return getDueDosesForDate(medications as any, selectedDate) as DueDose[];
+    return getDueDosesForDate(medications, selectedDate) as DueDose[];
   }, [medications, selectedDate]);
 
   const prnMeds = useMemo(() => {
     if (!medications) return [];
-    return (medications as MedicationDetail[]).filter((med) => {
+    return medications.filter((med) => {
       if (!med.is_active) return false;
       if (!med.schedules || med.schedules.length === 0) return true;
       return med.schedules.some((s) => s.schedule_type_id === 'prn');

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -37,7 +37,7 @@ const ACTION_WIDTH = 80;
 
 function entryMatchesDue(entry: MedicationEntry, due: DueDose): boolean {
   if (entry.schedule_id && entry.schedule_id === due.schedule.id) return true;
-  if (entry.medication_id === due.medication.id && !entry.schedule_id) return true;
+  if (entry.medication_id === due.medication.id && !entry.schedule_id && entry.status !== 'prn_taken') return true;
   return false;
 }
 

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -411,6 +411,8 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
                   onPress={() => handleLogPrn(med)}
                   hitSlop={{ top: 8, bottom: 8, left: 12, right: 12 }}
                   activeOpacity={0.6}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Log ${med.name}`}
                   className="rounded-full px-3 py-1"
                   style={{ backgroundColor: accentPrimary + '18' }}
                 >

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -1,0 +1,396 @@
+import React, { useCallback, useMemo, useRef } from 'react';
+import { View, Text, Pressable, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { useCSSVariable } from 'uniwind';
+import Toast from 'react-native-toast-message';
+import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
+import type { SwipeableMethods } from 'react-native-gesture-handler/ReanimatedSwipeable';
+import Animated, { useSharedValue, useAnimatedStyle } from 'react-native-reanimated';
+import type { CompositeNavigationProp } from '@react-navigation/native';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+
+import Icon from './Icon';
+import { useMedications, useMedicationEntries, useCreateMedicationEntry, useDeleteMedicationEntry } from '../hooks/useMedications';
+import { useDiaryDateStore } from '../stores/diaryDateStore';
+import { useAppPreferencesStore } from '../stores/appPreferencesStore';
+import { getDueDosesForDate, type SharedScheduleRule } from '@workspace/shared';
+import type { RootStackParamList, TabParamList } from '../types/navigation';
+import type { Medication, MedicationDetail, MedicationEntry, MedicationEntryStatus } from '../types/medications';
+import { MEDICATION_TYPES } from '../types/medications';
+import { addLog } from '../services/LogService';
+
+type MedicationsCardNavigation = CompositeNavigationProp<
+  BottomTabNavigationProp<TabParamList, 'Dashboard'>,
+  NativeStackNavigationProp<RootStackParamList>
+>;
+
+interface MedicationsCardProps {
+  navigation: MedicationsCardNavigation;
+}
+
+interface DueDose {
+  medication: MedicationDetail;
+  schedule: SharedScheduleRule & { id: string };
+}
+
+const ACTION_WIDTH = 80;
+
+function entryMatchesDue(entry: MedicationEntry, due: DueDose): boolean {
+  if (entry.schedule_id && entry.schedule_id === due.schedule.id) return true;
+  if (entry.medication_id === due.medication.id && !entry.schedule_id) return true;
+  return false;
+}
+
+const SwipeableMedRow: React.FC<{
+  due: DueDose;
+  entry: MedicationEntry | undefined;
+  onTake: (due: DueDose) => void;
+  onSkip: (due: DueDose) => void;
+  onToggleTaken: (due: DueDose) => void;
+  onNavigate: (medicationId: string) => void;
+}> = ({ due, entry, onTake, onSkip, onToggleTaken, onNavigate }) => {
+  const swipeableRef = useRef<SwipeableMethods | null>(null);
+  const rowHeight = useSharedValue<number | null>(null);
+  const isRemoving = useSharedValue(false);
+  const taken = entry?.status === 'taken' || entry?.status === 'prn_taken';
+  const skipped = entry?.status === 'skipped';
+  const completed = taken || skipped;
+
+  const handleTake = () => {
+    swipeableRef.current?.close();
+    onTake(due);
+  };
+
+  const handleSkip = () => {
+    swipeableRef.current?.close();
+    onSkip(due);
+  };
+
+  const handleLayout = (event: { nativeEvent: { layout: { height: number } } }) => {
+    if (rowHeight.value === null) {
+      rowHeight.value = event.nativeEvent.layout.height;
+    }
+  };
+
+  const animatedStyle = useAnimatedStyle(() => {
+    if (!isRemoving.value || rowHeight.value === null) return {};
+    return {
+      height: rowHeight.value,
+      overflow: 'hidden' as const,
+    };
+  });
+
+  const renderRightActions = () => (
+    <View style={{ flexDirection: 'row' }}>
+      <TouchableOpacity
+        className="justify-center items-center"
+        style={{ width: ACTION_WIDTH, backgroundColor: '#22C55E' }}
+        onPress={handleTake}
+        activeOpacity={0.7}
+      >
+        <Icon name="checkmark" size={20} color="#FFFFFF" />
+        <Text className="text-white font-semibold text-xs mt-0.5">Take</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        className="justify-center items-center"
+        style={{ width: ACTION_WIDTH, backgroundColor: '#F59E0B' }}
+        onPress={handleSkip}
+        activeOpacity={0.7}
+      >
+        <Icon name="close" size={20} color="#FFFFFF" />
+        <Text className="text-white font-semibold text-xs mt-0.5">Skip</Text>
+      </TouchableOpacity>
+    </View>
+  );
+
+  const timeLabel = due.schedule.time_of_day
+    ? (() => {
+        const [h, m] = due.schedule.time_of_day.split(':').map(Number);
+        return new Date(2000, 0, 1, h, m).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+      })()
+    : '';
+  const med = due.medication;
+  const typeLabel = MEDICATION_TYPES.find((t) => t.id === med.type_id)?.label ?? '';
+  const doseLabel = med.dose_amount != null ? `${med.dose_amount} ${med.dose_unit ?? ''}`.trim() : '';
+
+  return (
+    <Animated.View style={animatedStyle} onLayout={handleLayout}>
+      <ReanimatedSwipeable
+        ref={swipeableRef}
+        renderRightActions={renderRightActions}
+        overshootRight={false}
+        rightThreshold={40}
+      >
+        <Pressable
+          className="py-2.5 px-1 flex-row items-center bg-surface"
+          onPress={() => onNavigate(med.id)}
+        >
+          <Pressable
+            onPress={() => onToggleTaken(due)}
+            className="w-6 h-6 rounded-full items-center justify-center mr-3"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            style={{
+              backgroundColor: taken ? '#22C55E' : skipped ? '#F59E0B' : 'transparent',
+              borderWidth: completed ? 0 : 1.5,
+              borderColor: '#6B7280',
+            }}
+          >
+            {taken && <Icon name="checkmark" size={14} color="#FFFFFF" />}
+            {skipped && <Icon name="close" size={14} color="#FFFFFF" />}
+          </Pressable>
+          <View className="flex-1">
+            <Text className={`text-base ${completed ? 'text-text-muted' : 'text-text-primary'}`} numberOfLines={1}>
+              {med.name}
+            </Text>
+            <View className="flex-row items-center mt-0.5">
+              {typeLabel ? (
+                <Text className="text-xs text-text-secondary" numberOfLines={1}>{typeLabel}</Text>
+              ) : null}
+              {doseLabel ? (
+                <Text className="text-xs text-text-secondary ml-2" numberOfLines={1}>{doseLabel}</Text>
+              ) : null}
+              {timeLabel ? (
+                <Text className="text-xs text-text-muted ml-2">{timeLabel}</Text>
+              ) : null}
+            </View>
+          </View>
+          <Icon name="chevron-forward" size={16} color="#9CA3AF" />
+        </Pressable>
+      </ReanimatedSwipeable>
+    </Animated.View>
+  );
+};
+
+const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
+  const selectedDate = useDiaryDateStore((s) => s.selectedDate);
+  const medicationsCardVisible = useAppPreferencesStore((s) => s.medicationsCardVisible);
+
+  const { data: medications, isLoading: isLoadingMeds } = useMedications({ activeOnly: true });
+  const { data: entries, isLoading: isLoadingEntries } = useMedicationEntries({ fromDate: selectedDate, toDate: selectedDate });
+  const createEntryMutation = useCreateMedicationEntry();
+  const deleteEntryMutation = useDeleteMedicationEntry();
+
+  const [accentPrimary] = useCSSVariable(['--color-accent-primary']) as [string];
+
+  const dueDoses = useMemo(() => {
+    if (!medications) return [];
+    return getDueDosesForDate(medications as any, selectedDate) as DueDose[];
+  }, [medications, selectedDate]);
+
+  const prnMeds = useMemo(() => {
+    if (!medications) return [];
+    return (medications as MedicationDetail[]).filter((med) => {
+      if (!med.is_active) return false;
+      if (!med.schedules || med.schedules.length === 0) return true;
+      return med.schedules.some((s) => s.schedule_type_id === 'prn');
+    });
+  }, [medications]);
+
+  const entryForDue = useCallback(
+    (due: DueDose) => entries?.find((e) => entryMatchesDue(e, due)),
+    [entries],
+  );
+
+  const completedCount = useMemo(
+    () => dueDoses.filter((d) => {
+      const e = entryForDue(d);
+      return e && (e.status === 'taken' || e.status === 'skipped');
+    }).length,
+    [dueDoses, entryForDue],
+  );
+
+  const handleTake = useCallback(
+    (due: DueDose) => {
+      const existing = entryForDue(due);
+      if (existing && (existing.status === 'taken' || existing.status === 'prn_taken')) {
+        deleteEntryMutation.mutate(existing.id);
+        Toast.show({ type: 'info', text1: `${due.medication.name} unmarked` });
+        return;
+      }
+      if (existing) {
+        deleteEntryMutation.mutate(existing.id);
+      }
+      createEntryMutation.mutate(
+        {
+          medication_id: due.medication.id,
+          schedule_id: due.schedule.id,
+          status: 'taken' as MedicationEntryStatus,
+          entry_date: selectedDate,
+          taken_at: new Date().toISOString(),
+        },
+        {
+          onSuccess: () => Toast.show({ type: 'success', text1: `${due.medication.name} taken` }),
+          onError: (error) => {
+            addLog(`Failed to log medication: ${error.message}`, 'ERROR');
+          },
+        },
+      );
+    },
+    [entryForDue, createEntryMutation, deleteEntryMutation, selectedDate],
+  );
+
+  const handleSkip = useCallback(
+    (due: DueDose) => {
+      const existing = entryForDue(due);
+      if (existing && existing.status === 'skipped') {
+        deleteEntryMutation.mutate(existing.id);
+        Toast.show({ type: 'info', text1: `${due.medication.name} unskipped` });
+        return;
+      }
+      if (existing) {
+        deleteEntryMutation.mutate(existing.id);
+      }
+      createEntryMutation.mutate(
+        {
+          medication_id: due.medication.id,
+          schedule_id: due.schedule.id,
+          status: 'skipped' as MedicationEntryStatus,
+          entry_date: selectedDate,
+        },
+        {
+          onSuccess: () => Toast.show({ type: 'info', text1: `${due.medication.name} skipped` }),
+          onError: (error) => {
+            addLog(`Failed to skip medication: ${error.message}`, 'ERROR');
+          },
+        },
+      );
+    },
+    [entryForDue, createEntryMutation, deleteEntryMutation, selectedDate],
+  );
+
+  const handleToggleTaken = useCallback(
+    (due: DueDose) => {
+      const existing = entryForDue(due);
+      if (existing) {
+        deleteEntryMutation.mutate(existing.id);
+        return;
+      }
+      handleTake(due);
+    },
+    [entryForDue, deleteEntryMutation, handleTake],
+  );
+
+  const handleLogPrn = useCallback(
+    (med: Medication) => {
+      createEntryMutation.mutate(
+        {
+          medication_id: med.id,
+          status: 'prn_taken' as MedicationEntryStatus,
+          entry_date: selectedDate,
+          taken_at: new Date().toISOString(),
+        },
+        {
+          onSuccess: () => Toast.show({ type: 'success', text1: `${med.name} logged` }),
+          onError: (error) => {
+            addLog(`Failed to log PRN medication: ${error.message}`, 'ERROR');
+          },
+        },
+      );
+    },
+    [createEntryMutation, selectedDate],
+  );
+
+  if (!medicationsCardVisible) return null;
+
+  if (isLoadingMeds || isLoadingEntries) {
+    return (
+      <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
+        <View className="flex-row items-center justify-between">
+          <Text className="text-md font-bold text-text-secondary">Medications</Text>
+          <ActivityIndicator size="small" color={accentPrimary} />
+        </View>
+      </View>
+    );
+  }
+
+  if (dueDoses.length === 0 && prnMeds.length === 0) return null;
+
+  return (
+    <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
+      <View className="flex-row items-center justify-between mb-2">
+        <Text className="text-md font-bold text-text-secondary">Medications</Text>
+        <View className="flex-row items-center">
+          {dueDoses.length > 0 && (
+            <Text className="text-sm text-text-muted mr-3">
+              {completedCount}/{dueDoses.length}
+            </Text>
+          )}
+          <TouchableOpacity
+            onPress={() => navigation.navigate('MedicationsList')}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel="Manage medications"
+            className="flex-row items-center"
+          >
+            <Text className="text-sm text-accent-primary font-medium">Manage</Text>
+            <Icon name="chevron-forward" size={14} color={accentPrimary} style={{ marginLeft: 2 }} />
+          </TouchableOpacity>
+        </View>
+      </View>
+
+      {dueDoses.length > 0 && (
+        <View className="mb-3">
+          <Text className="text-xs font-semibold text-text-muted uppercase tracking-wide mb-1">Scheduled</Text>
+          {dueDoses.map((due, index) => (
+            <SwipeableMedRow
+              key={`${due.medication.id}-${due.schedule.id}-${index}`}
+              due={due}
+              entry={entryForDue(due)}
+              onTake={handleTake}
+              onSkip={handleSkip}
+              onToggleTaken={handleToggleTaken}
+              onNavigate={(medId) => navigation.navigate('MedicationDetail', { medicationId: medId })}
+            />
+          ))}
+        </View>
+      )}
+
+      {prnMeds.length > 0 && (
+        <View>
+          <Text className="text-xs font-semibold text-text-muted uppercase tracking-wide mb-1">As Needed</Text>
+          {prnMeds.map((med) => {
+            const prnCount = entries?.filter(
+              (e) => e.medication_id === med.id && e.status === 'prn_taken' && e.entry_date === selectedDate,
+            ).length ?? 0;
+            return (
+              <Pressable
+                key={med.id}
+                className="py-2.5 px-1 flex-row items-center"
+                onPress={() => navigation.navigate('MedicationDetail', { medicationId: med.id })}
+              >
+                <View className="w-6 h-6 rounded-full items-center justify-center mr-3" style={{ backgroundColor: 'transparent', borderWidth: 1.5, borderColor: prnCount > 0 ? '#22C55E' : '#6B7280' }}>
+                  {prnCount > 0 && <Text className="text-xs font-bold" style={{ color: '#22C55E' }}>{prnCount}</Text>}
+                </View>
+                <View className="flex-1">
+                  <Text className={`text-base ${prnCount > 0 ? 'text-text-muted' : 'text-text-primary'}`} numberOfLines={1}>
+                    {med.name}
+                  </Text>
+                  <View className="flex-row items-center mt-0.5">
+                    {MEDICATION_TYPES.find((t) => t.id === med.type_id)?.label ? (
+                      <Text className="text-xs text-text-secondary" numberOfLines={1}>{MEDICATION_TYPES.find((t) => t.id === med.type_id)!.label}</Text>
+                    ) : null}
+                    {med.dose_amount != null && med.dose_unit ? (
+                      <Text className="text-xs text-text-secondary ml-2">{med.dose_amount} {med.dose_unit}</Text>
+                    ) : null}
+                  </View>
+                </View>
+                <TouchableOpacity
+                  onPress={() => handleLogPrn(med)}
+                  hitSlop={{ top: 8, bottom: 8, left: 12, right: 12 }}
+                  activeOpacity={0.6}
+                  className="rounded-full px-3 py-1"
+                  style={{ backgroundColor: accentPrimary + '18' }}
+                >
+                  <Text className="text-sm font-semibold" style={{ color: accentPrimary }}>Log</Text>
+                </TouchableOpacity>
+                <Icon name="chevron-forward" size={16} color="#9CA3AF" style={{ marginLeft: 6 }} />
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
+    </View>
+  );
+};
+
+export default MedicationsCard;

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -178,124 +178,75 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
     [entries],
   );
 
-  const handleTake = useCallback(
-    (due: DueDose) => {
+  const showEntryError = useCallback((message: string, error: Error) => {
+    addLog(`${message}: ${error.message}`, 'ERROR');
+    Toast.show({ type: 'error', text1: message });
+  }, []);
+
+  const logDose = useCallback(
+    (due: DueDose, status: 'taken' | 'skipped') => {
+      const isTaken = status === 'taken';
       const existing = entryForDue(due);
-      if (existing && (existing.status === 'taken' || existing.status === 'prn_taken')) {
+
+      // Repeating the same action undoes the log instead of re-creating it.
+      const undone = isTaken
+        ? existing?.status === 'taken' || existing?.status === 'prn_taken'
+        : existing?.status === 'skipped';
+      if (existing && undone) {
         deleteEntryMutation.mutate(existing.id, {
-          onSuccess: () => Toast.show({ type: 'info', text1: `${due.medication.name} unmarked` }),
-          onError: (error) => addLog(`Failed to unmark medication: ${error.message}`, 'ERROR'),
+          onSuccess: () =>
+            Toast.show({ type: 'info', text1: `${due.medication.name} ${isTaken ? 'unmarked' : 'unskipped'}` }),
+          onError: (error) => showEntryError(`Failed to unmark ${due.medication.name}`, error),
         });
         return;
       }
-      if (existing) {
-        deleteEntryMutation.mutateAsync(existing.id).then(
-          () => {
-            createEntryMutation.mutate(
-              {
-                medication_id: due.medication.id,
-                schedule_id: due.schedule.id,
-                status: 'taken' as MedicationEntryStatus,
-                entry_date: selectedDate,
-                taken_at: new Date().toISOString(),
-              },
-              {
-                onSuccess: () => Toast.show({ type: 'success', text1: `${due.medication.name} taken` }),
-                onError: (error) => {
-                  addLog(`Failed to log medication: ${error.message}`, 'ERROR');
-                },
-              },
-            );
-          },
-          (error) => {
-            addLog(`Failed to delete existing medication entry: ${error.message}`, 'ERROR');
-          },
-        );
-      } else {
+
+      const create = () => {
         createEntryMutation.mutate(
           {
             medication_id: due.medication.id,
             schedule_id: due.schedule.id,
-            status: 'taken' as MedicationEntryStatus,
+            status,
             entry_date: selectedDate,
-            taken_at: new Date().toISOString(),
+            taken_at: isTaken ? new Date().toISOString() : undefined,
           },
           {
-            onSuccess: () => Toast.show({ type: 'success', text1: `${due.medication.name} taken` }),
-            onError: (error) => {
-              addLog(`Failed to log medication: ${error.message}`, 'ERROR');
-            },
+            onSuccess: () =>
+              Toast.show({
+                type: isTaken ? 'success' : 'info',
+                text1: `${due.medication.name} ${isTaken ? 'taken' : 'skipped'}`,
+              }),
+            onError: (error) => showEntryError(`Failed to log ${due.medication.name}`, error),
           },
         );
+      };
+
+      if (existing) {
+        deleteEntryMutation.mutateAsync(existing.id).then(create, (error: Error) => {
+          showEntryError(`Failed to update ${due.medication.name}`, error);
+        });
+      } else {
+        create();
       }
     },
-    [entryForDue, createEntryMutation, deleteEntryMutation, selectedDate],
+    [entryForDue, createEntryMutation, deleteEntryMutation, selectedDate, showEntryError],
   );
 
-  const handleSkip = useCallback(
-    (due: DueDose) => {
-      const existing = entryForDue(due);
-      if (existing && existing.status === 'skipped') {
-        deleteEntryMutation.mutate(existing.id, {
-          onSuccess: () => Toast.show({ type: 'info', text1: `${due.medication.name} unskipped` }),
-          onError: (error) => addLog(`Failed to unskip medication: ${error.message}`, 'ERROR'),
-        });
-        return;
-      }
-      if (existing) {
-        deleteEntryMutation.mutateAsync(existing.id).then(
-          () => {
-            createEntryMutation.mutate(
-              {
-                medication_id: due.medication.id,
-                schedule_id: due.schedule.id,
-                status: 'skipped' as MedicationEntryStatus,
-                entry_date: selectedDate,
-              },
-              {
-                onSuccess: () => Toast.show({ type: 'info', text1: `${due.medication.name} skipped` }),
-                onError: (error) => {
-                  addLog(`Failed to skip medication: ${error.message}`, 'ERROR');
-                },
-              },
-            );
-          },
-          (error) => {
-            addLog(`Failed to delete existing medication entry: ${error.message}`, 'ERROR');
-          },
-        );
-      } else {
-        createEntryMutation.mutate(
-          {
-            medication_id: due.medication.id,
-            schedule_id: due.schedule.id,
-            status: 'skipped' as MedicationEntryStatus,
-            entry_date: selectedDate,
-          },
-          {
-            onSuccess: () => Toast.show({ type: 'info', text1: `${due.medication.name} skipped` }),
-            onError: (error) => {
-              addLog(`Failed to skip medication: ${error.message}`, 'ERROR');
-            },
-          },
-        );
-      }
-    },
-    [entryForDue, createEntryMutation, deleteEntryMutation, selectedDate],
-  );
+  const handleTake = useCallback((due: DueDose) => logDose(due, 'taken'), [logDose]);
+  const handleSkip = useCallback((due: DueDose) => logDose(due, 'skipped'), [logDose]);
 
   const handleToggleTaken = useCallback(
     (due: DueDose) => {
       const existing = entryForDue(due);
       if (existing) {
         deleteEntryMutation.mutate(existing.id, {
-          onError: (error) => addLog(`Failed to toggle medication: ${error.message}`, 'ERROR'),
+          onError: (error) => showEntryError(`Failed to update ${due.medication.name}`, error),
         });
         return;
       }
       handleTake(due);
     },
-    [entryForDue, deleteEntryMutation, handleTake],
+    [entryForDue, deleteEntryMutation, handleTake, showEntryError],
   );
 
   const handleLogPrn = useCallback(
@@ -309,13 +260,11 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
         },
         {
           onSuccess: () => Toast.show({ type: 'success', text1: `${med.name} logged` }),
-          onError: (error) => {
-            addLog(`Failed to log PRN medication: ${error.message}`, 'ERROR');
-          },
+          onError: (error) => showEntryError(`Failed to log ${med.name}`, error),
         },
       );
     },
-    [createEntryMutation, selectedDate],
+    [createEntryMutation, selectedDate, showEntryError],
   );
 
   if (isLoadingMeds || isLoadingEntries) {

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -182,8 +182,10 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
     (due: DueDose) => {
       const existing = entryForDue(due);
       if (existing && (existing.status === 'taken' || existing.status === 'prn_taken')) {
-        deleteEntryMutation.mutate(existing.id);
-        Toast.show({ type: 'info', text1: `${due.medication.name} unmarked` });
+        deleteEntryMutation.mutate(existing.id, {
+          onSuccess: () => Toast.show({ type: 'info', text1: `${due.medication.name} unmarked` }),
+          onError: (error) => addLog(`Failed to unmark medication: ${error.message}`, 'ERROR'),
+        });
         return;
       }
       if (existing) {
@@ -234,8 +236,10 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
     (due: DueDose) => {
       const existing = entryForDue(due);
       if (existing && existing.status === 'skipped') {
-        deleteEntryMutation.mutate(existing.id);
-        Toast.show({ type: 'info', text1: `${due.medication.name} unskipped` });
+        deleteEntryMutation.mutate(existing.id, {
+          onSuccess: () => Toast.show({ type: 'info', text1: `${due.medication.name} unskipped` }),
+          onError: (error) => addLog(`Failed to unskip medication: ${error.message}`, 'ERROR'),
+        });
         return;
       }
       if (existing) {
@@ -284,7 +288,9 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
     (due: DueDose) => {
       const existing = entryForDue(due);
       if (existing) {
-        deleteEntryMutation.mutate(existing.id);
+        deleteEntryMutation.mutate(existing.id, {
+          onError: (error) => addLog(`Failed to toggle medication: ${error.message}`, 'ERROR'),
+        });
         return;
       }
       handleTake(due);

--- a/SparkyFitnessMobile/src/components/NotificationPermissionBanner.tsx
+++ b/SparkyFitnessMobile/src/components/NotificationPermissionBanner.tsx
@@ -1,0 +1,90 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useState,
+} from 'react';
+import { AppState } from 'react-native';
+import { useFocusEffect } from '@react-navigation/native';
+
+import OSDeniedWarningCard from './OSDeniedWarningCard';
+import {
+  getNotificationPermissionStatus,
+  requestNotificationPermissionWithGuidance,
+  type AppNotificationPermission,
+} from '../services/notifications';
+import { useAppPreferencesStore } from '../stores/appPreferencesStore';
+import { addLog } from '../services/LogService';
+
+export interface NotificationPermissionBannerHandle {
+  refresh: () => void;
+}
+
+const NotificationPermissionBanner = forwardRef<
+  NotificationPermissionBannerHandle
+>((_, ref) => {
+  const notificationsEnabled = useAppPreferencesStore((s) => s.notificationsEnabled);
+
+  const [osStatus, setOsStatus] = useState<AppNotificationPermission | null>(null);
+
+  const refreshStatus = useCallback(async () => {
+    try {
+      const status = await getNotificationPermissionStatus();
+      setOsStatus(status);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      addLog(
+        `[NotificationPermissionBanner] refresh failed: ${message}`,
+        'WARNING',
+      );
+    }
+  }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      refresh: () => {
+        refreshStatus();
+      },
+    }),
+    [refreshStatus],
+  );
+
+  useFocusEffect(
+    useCallback(() => {
+      refreshStatus();
+    }, [refreshStatus]),
+  );
+
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        refreshStatus();
+      }
+    });
+    return () => sub.remove();
+  }, [refreshStatus]);
+
+  const handleOpenSettings = useCallback(async () => {
+    await requestNotificationPermissionWithGuidance();
+    refreshStatus();
+  }, [refreshStatus]);
+
+  const visible =
+    notificationsEnabled && osStatus === 'denied';
+
+  if (!visible) return null;
+
+  return (
+    <OSDeniedWarningCard
+      onPress={() => {
+        void handleOpenSettings();
+      }}
+    />
+  );
+});
+
+NotificationPermissionBanner.displayName = 'NotificationPermissionBanner';
+
+export default NotificationPermissionBanner;

--- a/SparkyFitnessMobile/src/components/NotificationPermissionBanner.tsx
+++ b/SparkyFitnessMobile/src/components/NotificationPermissionBanner.tsx
@@ -11,7 +11,8 @@ import { useFocusEffect } from '@react-navigation/native';
 import OSDeniedWarningCard from './OSDeniedWarningCard';
 import {
   getNotificationPermissionStatus,
-  requestNotificationPermissionWithGuidance,
+  openSystemNotificationSettings,
+  requestNotificationPermission,
   type AppNotificationPermission,
 } from '../services/notifications';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
@@ -66,20 +67,27 @@ const NotificationPermissionBanner = forwardRef<
     return () => sub.remove();
   }, [refreshStatus]);
 
-  const handleOpenSettings = useCallback(async () => {
-    await requestNotificationPermissionWithGuidance();
+  // Undetermined can still trigger the OS prompt directly (tapping the card is
+  // the user action); after a denial only system settings can change it.
+  const handlePress = useCallback(async () => {
+    if (osStatus === 'undetermined') {
+      await requestNotificationPermission();
+    } else {
+      await openSystemNotificationSettings();
+    }
     refreshStatus();
-  }, [refreshStatus]);
+  }, [osStatus, refreshStatus]);
 
   const visible =
-    notificationsEnabled && osStatus === 'denied';
+    notificationsEnabled && (osStatus === 'denied' || osStatus === 'undetermined');
 
   if (!visible) return null;
 
   return (
     <OSDeniedWarningCard
+      actionLabel={osStatus === 'undetermined' ? 'Enable Notifications' : 'Open Settings'}
       onPress={() => {
-        void handleOpenSettings();
+        void handlePress();
       }}
     />
   );

--- a/SparkyFitnessMobile/src/components/OSDeniedWarningCard.tsx
+++ b/SparkyFitnessMobile/src/components/OSDeniedWarningCard.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { useCSSVariable } from 'uniwind';
+
+import Icon from './Icon';
+
+interface Props {
+  onPress: () => void;
+  body?: string;
+}
+
+const TITLE = 'Grant permissions';
+const DEFAULT_BODY =
+  "SparkyFitness alerts (rest timers, fasting goals, medication reminders) won't fire. Tap to fix.";
+
+const OSDeniedWarningCard: React.FC<Props> = ({ onPress }) => {
+  const [iconWarning, iconDecorative] = useCSSVariable([
+    '--color-icon-warning',
+    '--color-icon-decorative',
+  ]) as [string, string];
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${TITLE}. Tap to open Settings.`}
+      className="bg-surface rounded-xl p-4 mb-4 shadow-sm border flex-row items-start"
+      style={{ borderColor: iconWarning }}
+    >
+      <Icon name="warning" size={20} color={iconWarning} style={{ marginTop: 2 }} />
+      <View className="flex-1 ml-3">
+        <Text className="text-base font-semibold text-text-primary">{TITLE}</Text>
+        <Text className="text-text-primary text-sm mt-1 opacity-80">{DEFAULT_BODY}</Text>
+      </View>
+      <Icon name="chevron-forward" size={16} color={iconDecorative} />
+    </Pressable>
+  );
+};
+
+export default OSDeniedWarningCard;

--- a/SparkyFitnessMobile/src/components/OSDeniedWarningCard.tsx
+++ b/SparkyFitnessMobile/src/components/OSDeniedWarningCard.tsx
@@ -6,33 +6,29 @@ import Icon from './Icon';
 
 interface Props {
   onPress: () => void;
-  body?: string;
+  actionLabel: string;
 }
 
 const TITLE = 'Grant permissions';
 const DEFAULT_BODY =
-  "SparkyFitness alerts (rest timers, fasting goals, medication reminders) won't fire. Tap to fix.";
+  "SparkyFitness alerts (rest timers, fasting goals, medication reminders) won't fire.";
 
-const OSDeniedWarningCard: React.FC<Props> = ({ onPress }) => {
-  const [iconWarning, iconDecorative] = useCSSVariable([
-    '--color-icon-warning',
-    '--color-icon-decorative',
-  ]) as [string, string];
+const OSDeniedWarningCard: React.FC<Props> = ({ onPress, actionLabel }) => {
+  const [iconWarning] = useCSSVariable(['--color-icon-warning']) as [string];
 
   return (
     <Pressable
       onPress={onPress}
       accessibilityRole="button"
-      accessibilityLabel={`${TITLE}. Tap to open Settings.`}
-      className="bg-surface rounded-xl p-4 mb-4 shadow-sm border flex-row items-start"
-      style={{ borderColor: iconWarning }}
+      accessibilityLabel={`${TITLE}. ${DEFAULT_BODY} ${actionLabel}.`}
+      className="bg-surface rounded-xl p-4 mb-4 shadow-sm flex-row items-start"
     >
       <Icon name="warning" size={20} color={iconWarning} style={{ marginTop: 2 }} />
       <View className="flex-1 ml-3">
         <Text className="text-base font-semibold text-text-primary">{TITLE}</Text>
         <Text className="text-text-primary text-sm mt-1 opacity-80">{DEFAULT_BODY}</Text>
+        <Text className="text-sm font-semibold text-accent-primary self-end mt-2">{actionLabel}</Text>
       </View>
-      <Icon name="chevron-forward" size={16} color={iconDecorative} />
     </Pressable>
   );
 };

--- a/SparkyFitnessMobile/src/hooks/index.ts
+++ b/SparkyFitnessMobile/src/hooks/index.ts
@@ -157,9 +157,6 @@ export {
   useUpdateMedication,
   useDeleteMedication,
   useCreateMedicationEntry,
-  useUpdateMedicationEntry,
   useDeleteMedicationEntry,
-  useAddMedicationSchedule,
-  useDeleteMedicationSchedule,
 } from './useMedications';
 

--- a/SparkyFitnessMobile/src/hooks/index.ts
+++ b/SparkyFitnessMobile/src/hooks/index.ts
@@ -54,6 +54,10 @@ export {
   pregnancyChecklistQueryKey,
   pregnancyAppointmentsQueryKey,
   pregnancyPhotosQueryKey,
+  medicationsRootQueryKey,
+  medicationsListQueryKey,
+  medicationDetailQueryKey,
+  medicationEntriesQueryKey,
 } from './queryKeys';
 export { useServerConnection } from './useServerConnection';
 export { useServerConfigs } from './useServerConfigs';
@@ -143,4 +147,19 @@ export { useSymptomEntries, useSymptomMutations } from './useSymptoms';
 export { useCycleHistory } from './useCycleHistory';
 export { useCycleOverview, useCycleInsights, useCycleCorrelations } from './useCycleInsights';
 export { useCycleTests, useCycleTestMutations } from './useCycleTests';
+
+// --- Medications ---
+export {
+  useMedications,
+  useMedicationDetail,
+  useMedicationEntries,
+  useCreateMedication,
+  useUpdateMedication,
+  useDeleteMedication,
+  useCreateMedicationEntry,
+  useUpdateMedicationEntry,
+  useDeleteMedicationEntry,
+  useAddMedicationSchedule,
+  useDeleteMedicationSchedule,
+} from './useMedications';
 

--- a/SparkyFitnessMobile/src/hooks/queryKeys.ts
+++ b/SparkyFitnessMobile/src/hooks/queryKeys.ts
@@ -135,3 +135,12 @@ export const pregnancyAppointmentsQueryKey = ['healthAppointments'] as const;
 export const pregnancyPhotosQueryKey = ['pregnancyPhotos'] as const;
 
 export const symptomEntriesQueryKey = (fromDate: string, toDate: string) => ['symptomEntries', fromDate, toDate] as const;
+
+// --- Medications ---
+export const medicationsRootQueryKey = ['medications'] as const;
+export const medicationsListQueryKey = (opts?: { activeOnly?: boolean }) =>
+  ['medications', 'list', opts ?? {}] as const;
+export const medicationDetailQueryKey = (id: string) =>
+  ['medications', 'detail', id] as const;
+export const medicationEntriesQueryKey = (opts?: { fromDate?: string; toDate?: string; medicationId?: string }) =>
+  ['medications', 'entries', opts ?? {}] as const;

--- a/SparkyFitnessMobile/src/hooks/useMedications.ts
+++ b/SparkyFitnessMobile/src/hooks/useMedications.ts
@@ -1,0 +1,154 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  listMedications,
+  getMedication,
+  listEntries,
+  createMedication,
+  updateMedication,
+  deleteMedication,
+  createEntry,
+  updateEntry,
+  deleteEntry,
+  addSchedule,
+  deleteSchedule,
+} from '../services/api/medicationsApi';
+import {
+  medicationsRootQueryKey,
+  medicationsListQueryKey,
+  medicationDetailQueryKey,
+  medicationEntriesQueryKey,
+} from './queryKeys';
+import { useRefetchOnFocus } from './useRefetchOnFocus';
+import type {
+  CreateMedicationInput,
+  UpdateMedicationInput,
+  CreateMedicationEntryInput,
+  UpdateMedicationEntryInput,
+  CreateScheduleInput,
+} from '../types/medications';
+
+interface QueryOptions {
+  enabled?: boolean;
+}
+
+export function useMedications(opts?: { activeOnly?: boolean } & QueryOptions) {
+  const { enabled, ...filters } = opts ?? {};
+  const query = useQuery({
+    queryKey: medicationsListQueryKey(filters),
+    queryFn: () => listMedications(filters),
+    enabled: enabled ?? true,
+  });
+  useRefetchOnFocus(query.refetch, enabled ?? true);
+  return query;
+}
+
+export function useMedicationDetail(id: string, options?: QueryOptions) {
+  const query = useQuery({
+    queryKey: medicationDetailQueryKey(id),
+    queryFn: () => getMedication(id),
+    enabled: options?.enabled ?? true,
+  });
+  useRefetchOnFocus(query.refetch, options?.enabled ?? true);
+  return query;
+}
+
+export function useMedicationEntries(
+  opts?: { fromDate?: string; toDate?: string; medicationId?: string } & QueryOptions,
+) {
+  const { enabled, ...filters } = opts ?? {};
+  const query = useQuery({
+    queryKey: medicationEntriesQueryKey(filters),
+    queryFn: () => listEntries(filters),
+    enabled: enabled ?? true,
+  });
+  useRefetchOnFocus(query.refetch, enabled ?? true);
+  return query;
+}
+
+export function useCreateMedication() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateMedicationInput) => createMedication(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
+    },
+  });
+}
+
+export function useUpdateMedication() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: string; body: UpdateMedicationInput }) =>
+      updateMedication(id, body),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
+      queryClient.invalidateQueries({ queryKey: medicationDetailQueryKey(variables.id) });
+    },
+  });
+}
+
+export function useDeleteMedication() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteMedication(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
+    },
+  });
+}
+
+export function useCreateMedicationEntry() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateMedicationEntryInput) => createEntry(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: medicationEntriesQueryKey() });
+      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
+    },
+  });
+}
+
+export function useUpdateMedicationEntry() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, body }: { id: string; body: UpdateMedicationEntryInput }) =>
+      updateEntry(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: medicationEntriesQueryKey() });
+      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
+    },
+  });
+}
+
+export function useDeleteMedicationEntry() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteEntry(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: medicationEntriesQueryKey() });
+      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
+    },
+  });
+}
+
+export function useAddMedicationSchedule(medicationId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateScheduleInput) => addSchedule(medicationId, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
+      queryClient.invalidateQueries({ queryKey: medicationDetailQueryKey(medicationId) });
+    },
+  });
+}
+
+export function useDeleteMedicationSchedule() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteSchedule(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
+    },
+  });
+}

--- a/SparkyFitnessMobile/src/hooks/useMedications.ts
+++ b/SparkyFitnessMobile/src/hooks/useMedications.ts
@@ -8,10 +8,7 @@ import {
   updateMedication,
   deleteMedication,
   createEntry,
-  updateEntry,
   deleteEntry,
-  addSchedule,
-  deleteSchedule,
 } from '../services/api/medicationsApi';
 import {
   medicationsRootQueryKey,
@@ -24,8 +21,6 @@ import type {
   CreateMedicationInput,
   UpdateMedicationInput,
   CreateMedicationEntryInput,
-  UpdateMedicationEntryInput,
-  CreateScheduleInput,
 } from '../types/medications';
 
 interface QueryOptions {
@@ -109,18 +104,6 @@ export function useCreateMedicationEntry() {
   });
 }
 
-export function useUpdateMedicationEntry() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ id, body }: { id: string; body: UpdateMedicationEntryInput }) =>
-      updateEntry(id, body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: medicationEntriesQueryKey() });
-      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
-    },
-  });
-}
-
 export function useDeleteMedicationEntry() {
   const queryClient = useQueryClient();
   return useMutation({
@@ -132,23 +115,4 @@ export function useDeleteMedicationEntry() {
   });
 }
 
-export function useAddMedicationSchedule(medicationId: string) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (body: CreateScheduleInput) => addSchedule(medicationId, body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
-      queryClient.invalidateQueries({ queryKey: medicationDetailQueryKey(medicationId) });
-    },
-  });
-}
 
-export function useDeleteMedicationSchedule() {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (id: string) => deleteSchedule(id),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey });
-    },
-  });
-}

--- a/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
@@ -4,6 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
 
 import BottomSheetPicker from '../components/BottomSheetPicker';
+import SettingsRow, { SettingsRowGroup } from '../components/SettingsRow';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import NotificationPermissionBanner, {
   type NotificationPermissionBannerHandle,
@@ -14,7 +15,7 @@ import {
   type ThemePreference,
 } from '../services/themeService';
 import {
-  requestNotificationPermissionWithGuidance,
+  requestNotificationPermission,
   setNotificationsEnabled,
 } from '../services/notifications';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
@@ -64,7 +65,7 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
       return;
     }
     await setNotificationsEnabled(true);
-    await requestNotificationPermissionWithGuidance();
+    await requestNotificationPermission();
     bannerRef.current?.refresh();
   }, []);
 
@@ -74,9 +75,14 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
         setMedicationRemindersEnabled(false);
         return;
       }
-      await requestNotificationPermissionWithGuidance();
+      const status = await requestNotificationPermission();
       bannerRef.current?.refresh();
-      setMedicationRemindersEnabled(true);
+      // Without OS permission the toggle would show "on" while reminders
+      // silently never fire; leave it off until permission is granted. The
+      // permission banner above explains and links to system settings.
+      if (status === 'granted') {
+        setMedicationRemindersEnabled(true);
+      }
     },
     [setMedicationRemindersEnabled],
   );
@@ -93,8 +99,6 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
         }}
         contentInsetAdjustmentBehavior={usesNativeHeader ? 'automatic' : 'never'}
       >
-        <NotificationPermissionBanner ref={bannerRef} />
-
         <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
           <View className="flex-row justify-between items-center">
             <Text className="text-base text-text-primary">Theme</Text>
@@ -124,54 +128,62 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
             </Text>
           </View>
         )}
-        <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
-          <View className="flex-row justify-between items-center">
-            <Text className="text-base text-text-primary">Notifications</Text>
-            <Switch
-              value={notificationsEnabled}
-              onValueChange={handleNotificationsToggle}
-              trackColor={{ false: formDisabled, true: formEnabled }}
-              thumbColor="#FFFFFF"
+        <SettingsRowGroup>
+          <SettingsRow
+            title="Notifications"
+            subtitle={
+              <Text className="text-sm text-text-secondary">
+                Alerts for workout rest timers and fasting goals.
+              </Text>
+            }
+            rightAccessory={
+              <Switch
+                value={notificationsEnabled}
+                onValueChange={handleNotificationsToggle}
+                trackColor={{ false: formDisabled, true: formEnabled }}
+                thumbColor="#FFFFFF"
+              />
+            }
+          />
+          {notificationsEnabled && (
+            <SettingsRow
+              title="Medication Reminders"
+              subtitle={
+                <Text className="text-sm text-text-secondary">
+                  Reminders for scheduled medications.
+                </Text>
+              }
+              rightAccessory={
+                <Switch
+                  value={medicationRemindersEnabled}
+                  onValueChange={handleMedicationRemindersToggle}
+                  trackColor={{ false: formDisabled, true: formEnabled }}
+                  thumbColor="#FFFFFF"
+                />
+              }
             />
-          </View>
-          <Text className="text-text-secondary text-sm mt-2">
-            Alerts for workout rest timers and fasting goals.
-          </Text>
-        </View>
+          )}
+          {notificationsEnabled && medicationRemindersEnabled && (
+            <SettingsRow
+              title="Repeat Reminders"
+              subtitle={
+                <Text className="text-sm text-text-secondary">
+                  Repeat each reminder every 10 minutes, up to 3 times, until the dose is logged.
+                </Text>
+              }
+              rightAccessory={
+                <Switch
+                  value={medicationReminderRepeats}
+                  onValueChange={setMedicationReminderRepeats}
+                  trackColor={{ false: formDisabled, true: formEnabled }}
+                  thumbColor="#FFFFFF"
+                />
+              }
+            />
+          )}
+        </SettingsRowGroup>
 
-        {notificationsEnabled && (
-          <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
-            <View className="flex-row justify-between items-center">
-              <Text className="text-base text-text-primary">Medication Reminders</Text>
-              <Switch
-                value={medicationRemindersEnabled}
-                onValueChange={handleMedicationRemindersToggle}
-                trackColor={{ false: formDisabled, true: formEnabled }}
-                thumbColor="#FFFFFF"
-              />
-            </View>
-            <Text className="text-text-secondary text-sm mt-2">
-              Reminders for scheduled medications.
-            </Text>
-          </View>
-        )}
-
-        {medicationRemindersEnabled && (
-          <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
-            <View className="flex-row justify-between items-center">
-              <Text className="text-base text-text-primary">Repeat Reminders</Text>
-              <Switch
-                value={medicationReminderRepeats}
-                onValueChange={setMedicationReminderRepeats}
-                trackColor={{ false: formDisabled, true: formEnabled }}
-                thumbColor="#FFFFFF"
-              />
-            </View>
-            <Text className="text-text-secondary text-sm mt-2">
-              Repeat each reminder every 10 minutes, up to 3 times, until the dose is logged.
-            </Text>
-          </View>
-        )}
+        <NotificationPermissionBanner ref={bannerRef} />
 
         <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
           <View className="flex-row justify-between items-center">

--- a/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
@@ -40,6 +40,10 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
   const soundsEnabled = useAppPreferencesStore((s) => s.soundsEnabled);
   const setSoundsEnabled = useAppPreferencesStore((s) => s.setSoundsEnabled);
   const notificationsEnabled = useAppPreferencesStore((s) => s.notificationsEnabled);
+  const medicationRemindersEnabled = useAppPreferencesStore((s) => s.medicationRemindersEnabled);
+  const setMedicationRemindersEnabled = useAppPreferencesStore((s) => s.setMedicationRemindersEnabled);
+  const medicationReminderRepeats = useAppPreferencesStore((s) => s.medicationReminderRepeats);
+  const setMedicationReminderRepeats = useAppPreferencesStore((s) => s.setMedicationReminderRepeats);
   const liquidGlassEnabled = useAppPreferencesStore((s) => s.liquidGlassTabBarEnabled);
   const setLiquidGlassTabBarEnabled = useAppPreferencesStore(
     (s) => s.setLiquidGlassTabBarEnabled,
@@ -100,6 +104,37 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
           </View>
           <Text className="text-text-secondary text-sm mt-2">
             Alerts for workout rest timers and fasting goals.
+          </Text>
+        </View>
+
+        <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
+          <View className="flex-row justify-between items-center">
+            <Text className="text-base text-text-primary">Medication Reminders</Text>
+            <Switch
+              value={medicationRemindersEnabled}
+              onValueChange={setMedicationRemindersEnabled}
+              trackColor={{ false: formDisabled, true: formEnabled }}
+              thumbColor="#FFFFFF"
+            />
+          </View>
+          <Text className="text-text-secondary text-sm mt-2">
+            Reminders for scheduled medications.
+          </Text>
+        </View>
+
+        <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
+          <View className="flex-row justify-between items-center">
+            <Text className="text-base text-text-primary">Repeat Reminders</Text>
+            <Switch
+              value={medicationReminderRepeats}
+              onValueChange={setMedicationReminderRepeats}
+              trackColor={{ false: formDisabled, true: formEnabled }}
+              thumbColor="#FFFFFF"
+              disabled={!medicationRemindersEnabled}
+            />
+          </View>
+          <Text className="text-text-secondary text-sm mt-2">
+            If not marked, repeat reminders every 10 minutes up to 3 times.
           </Text>
         </View>
 

--- a/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
@@ -1,16 +1,22 @@
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import { View, Text, ScrollView, Switch } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
 
 import BottomSheetPicker from '../components/BottomSheetPicker';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
+import NotificationPermissionBanner, {
+  type NotificationPermissionBannerHandle,
+} from '../components/NotificationPermissionBanner';
 import {
   useThemePreference,
   setThemePreference,
   type ThemePreference,
 } from '../services/themeService';
-import { setNotificationsEnabled } from '../services/notifications';
+import {
+  requestNotificationPermissionWithGuidance,
+  setNotificationsEnabled,
+} from '../services/notifications';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 import { useScreenHeader } from '../hooks/useScreenHeader';
@@ -50,6 +56,30 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
   );
   const supportsLiquidGlassTabBar = canUseLiquidGlass();
   const usesNativeHeader = useNativeIOSHeadersActive();
+  const bannerRef = useRef<NotificationPermissionBannerHandle>(null);
+
+  const handleNotificationsToggle = useCallback(async (value: boolean) => {
+    if (!value) {
+      await setNotificationsEnabled(false);
+      return;
+    }
+    await setNotificationsEnabled(true);
+    await requestNotificationPermissionWithGuidance();
+    bannerRef.current?.refresh();
+  }, []);
+
+  const handleMedicationRemindersToggle = useCallback(
+    async (value: boolean) => {
+      if (!value) {
+        setMedicationRemindersEnabled(false);
+        return;
+      }
+      await requestNotificationPermissionWithGuidance();
+      bannerRef.current?.refresh();
+      setMedicationRemindersEnabled(true);
+    },
+    [setMedicationRemindersEnabled],
+  );
 
   const header = useScreenHeader({ title: 'App Settings', left: { kind: 'back' } });
 
@@ -63,6 +93,7 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
         }}
         contentInsetAdjustmentBehavior={usesNativeHeader ? 'automatic' : 'never'}
       >
+        <NotificationPermissionBanner ref={bannerRef} />
 
         <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
           <View className="flex-row justify-between items-center">
@@ -76,6 +107,7 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
             />
           </View>
         </View>
+
         {supportsLiquidGlassTabBar && (
           <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
             <View className="flex-row justify-between items-center">
@@ -97,7 +129,7 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
             <Text className="text-base text-text-primary">Notifications</Text>
             <Switch
               value={notificationsEnabled}
-              onValueChange={setNotificationsEnabled}
+              onValueChange={handleNotificationsToggle}
               trackColor={{ false: formDisabled, true: formEnabled }}
               thumbColor="#FFFFFF"
             />
@@ -107,37 +139,39 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
           </Text>
         </View>
 
-        <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
-          <View className="flex-row justify-between items-center">
-            <Text className="text-base text-text-primary">Medication Reminders</Text>
-            <Switch
-              value={medicationRemindersEnabled}
-              onValueChange={setMedicationRemindersEnabled}
-              trackColor={{ false: formDisabled, true: formEnabled }}
-              thumbColor="#FFFFFF"
-              disabled={!notificationsEnabled}
-            />
+        {notificationsEnabled && (
+          <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
+            <View className="flex-row justify-between items-center">
+              <Text className="text-base text-text-primary">Medication Reminders</Text>
+              <Switch
+                value={medicationRemindersEnabled}
+                onValueChange={handleMedicationRemindersToggle}
+                trackColor={{ false: formDisabled, true: formEnabled }}
+                thumbColor="#FFFFFF"
+              />
+            </View>
+            <Text className="text-text-secondary text-sm mt-2">
+              Reminders for scheduled medications.
+            </Text>
           </View>
-          <Text className="text-text-secondary text-sm mt-2">
-            Reminders for scheduled medications.
-          </Text>
-        </View>
+        )}
 
-        <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
-          <View className="flex-row justify-between items-center">
-            <Text className="text-base text-text-primary">Repeat Reminders</Text>
-            <Switch
-              value={medicationReminderRepeats}
-              onValueChange={setMedicationReminderRepeats}
-              trackColor={{ false: formDisabled, true: formEnabled }}
-              thumbColor="#FFFFFF"
-              disabled={!medicationRemindersEnabled}
-            />
+        {medicationRemindersEnabled && (
+          <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
+            <View className="flex-row justify-between items-center">
+              <Text className="text-base text-text-primary">Repeat Reminders</Text>
+              <Switch
+                value={medicationReminderRepeats}
+                onValueChange={setMedicationReminderRepeats}
+                trackColor={{ false: formDisabled, true: formEnabled }}
+                thumbColor="#FFFFFF"
+              />
+            </View>
+            <Text className="text-text-secondary text-sm mt-2">
+              Repeat each reminder every 10 minutes, up to 3 times, until the dose is logged.
+            </Text>
           </View>
-          <Text className="text-text-secondary text-sm mt-2">
-            Repeat each reminder every 10 minutes, up to 3 times, until the dose is logged.
-          </Text>
-        </View>
+        )}
 
         <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
           <View className="flex-row justify-between items-center">

--- a/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
@@ -134,7 +134,7 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
             />
           </View>
           <Text className="text-text-secondary text-sm mt-2">
-            If not marked, repeat reminders every 10 minutes up to 3 times.
+            Repeat each reminder every 10 minutes, up to 3 times, until the dose is logged.
           </Text>
         </View>
 

--- a/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/AppSettingsScreen.tsx
@@ -115,6 +115,7 @@ const AppSettingsScreen: React.FC<AppSettingsScreenProps> = () => {
               onValueChange={setMedicationRemindersEnabled}
               trackColor={{ false: formDisabled, true: formEnabled }}
               thumbColor="#FFFFFF"
+              disabled={!notificationsEnabled}
             />
           </View>
           <Text className="text-text-secondary text-sm mt-2">

--- a/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
@@ -40,7 +40,6 @@ import FastingCard from '../components/FastingCard';
 import CycleCard from '../components/CycleCard';
 import FastingGoalReconciler from '../components/FastingGoalReconciler';
 import MedicationsCard from '../components/MedicationsCard';
-import NotificationPermissionBanner from '../components/NotificationPermissionBanner';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import type { CompositeScreenProps } from '@react-navigation/native';
@@ -280,8 +279,6 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={accentColor || '#3B82F6'} />
         }
       >
-        <NotificationPermissionBanner />
-
         {(summary.foodEntries.length > 0 || summary.exerciseEntries.length > 0 || goal > 0) && (
           <CalorieRingCard
             caloriesConsumed={eaten}

--- a/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
@@ -40,7 +40,6 @@ import FastingCard from '../components/FastingCard';
 import CycleCard from '../components/CycleCard';
 import FastingGoalReconciler from '../components/FastingGoalReconciler';
 import MedicationsCard from '../components/MedicationsCard';
-import MedicationReminderReconciler from '../components/MedicationReminderReconciler';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import type { CompositeScreenProps } from '@react-navigation/native';
@@ -437,7 +436,6 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
             to `selectedDate`. Visibility is a local app setting toggled from
             Dashboard Settings. */}
         <FastingGoalReconciler />
-        <MedicationReminderReconciler />
         {fastingCardVisible && <FastingCard navigation={navigation} />}
         {cycleCardVisible && <CycleCard navigation={navigation} />}
 

--- a/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
@@ -40,6 +40,7 @@ import FastingCard from '../components/FastingCard';
 import CycleCard from '../components/CycleCard';
 import FastingGoalReconciler from '../components/FastingGoalReconciler';
 import MedicationsCard from '../components/MedicationsCard';
+import NotificationPermissionBanner from '../components/NotificationPermissionBanner';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import type { CompositeScreenProps } from '@react-navigation/native';
@@ -279,6 +280,8 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={accentColor || '#3B82F6'} />
         }
       >
+        <NotificationPermissionBanner />
+
         {(summary.foodEntries.length > 0 || summary.exerciseEntries.length > 0 || goal > 0) && (
           <CalorieRingCard
             caloriesConsumed={eaten}

--- a/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
@@ -16,6 +16,7 @@ import {
   useCustomNutrients,
   useNutrientDisplayPreferences,
   fastingRootQueryKey,
+  medicationsRootQueryKey,
 } from '../hooks';
 import type { StepsRange } from '../hooks';
 import CalorieRingCard from '../components/CalorieRingCard';
@@ -38,6 +39,8 @@ import StatusView from '../components/StatusView';
 import FastingCard from '../components/FastingCard';
 import CycleCard from '../components/CycleCard';
 import FastingGoalReconciler from '../components/FastingGoalReconciler';
+import MedicationsCard from '../components/MedicationsCard';
+import MedicationReminderReconciler from '../components/MedicationReminderReconciler';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import type { CompositeScreenProps } from '@react-navigation/native';
@@ -168,6 +171,7 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
   const cycleCardVisible = useAppPreferencesStore((s) => s.cycleCardVisible);
   const hydrationCardVisible = useAppPreferencesStore((s) => s.hydrationCardVisible);
   const askSparkyVisible = useAppPreferencesStore((s) => s.askSparkyVisible);
+  const medicationsCardVisible = useAppPreferencesStore((s) => s.medicationsCardVisible);
 
   useLayoutEffect(() => {
     syncNativeHeaderDatePicker();
@@ -190,6 +194,8 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
       refetchNutrientPrefs(),
       // FastingCard owns its own queries; nudge them on pull-to-refresh.
       queryClient.invalidateQueries({ queryKey: fastingRootQueryKey }),
+      // MedicationsCard owns its own queries.
+      queryClient.invalidateQueries({ queryKey: medicationsRootQueryKey }),
     ]);
     setRefreshing(false);
   }, [refetch, refetchPreferences, refetchMeasurements, refetchSteps, refetchCustomNutrients, refetchNutrientPrefs, queryClient]);
@@ -431,8 +437,11 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
             to `selectedDate`. Visibility is a local app setting toggled from
             Dashboard Settings. */}
         <FastingGoalReconciler />
+        <MedicationReminderReconciler />
         {fastingCardVisible && <FastingCard navigation={navigation} />}
         {cycleCardVisible && <CycleCard navigation={navigation} />}
+
+        {medicationsCardVisible && <MedicationsCard navigation={navigation} />}
 
         <Text className="text-text-primary text-xl font-bold mb-2">Health Trends</Text>
         <SegmentedControl segments={RANGE_SEGMENTS} activeKey={stepsRange} onSelect={setStepsRange} />

--- a/SparkyFitnessMobile/src/screens/DashboardSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardSettingsScreen.tsx
@@ -53,6 +53,8 @@ const DashboardSettingsScreen: React.FC<DashboardSettingsScreenProps> = () => {
   const setHydrationCardVisible = useAppPreferencesStore((s) => s.setHydrationCardVisible);
   const askSparkyVisible = useAppPreferencesStore((s) => s.askSparkyVisible);
   const setAskSparkyVisible = useAppPreferencesStore((s) => s.setAskSparkyVisible);
+  const medicationsCardVisible = useAppPreferencesStore((s) => s.medicationsCardVisible);
+  const setMedicationsCardVisible = useAppPreferencesStore((s) => s.setMedicationsCardVisible);
 
   const queryClient = useQueryClient();
   const { isConnected } = useServerConnection();
@@ -223,6 +225,18 @@ const DashboardSettingsScreen: React.FC<DashboardSettingsScreenProps> = () => {
               <Switch
                 value={cycleCardVisible}
                 onValueChange={setCycleCardVisible}
+                trackColor={{ false: formDisabled, true: formEnabled }}
+                thumbColor="#FFFFFF"
+              />
+            }
+          />
+          <SettingsRow
+            title="Medications"
+            subtitle="Show the medications card on the Dashboard"
+            rightAccessory={
+              <Switch
+                value={medicationsCardVisible}
+                onValueChange={setMedicationsCardVisible}
                 trackColor={{ false: formDisabled, true: formEnabled }}
                 thumbColor="#FFFFFF"
               />

--- a/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
@@ -9,6 +9,7 @@ import { useDiaryDateStore } from '../stores/diaryDateStore';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 import { useScreenHeader } from '../hooks/useScreenHeader';
 import Icon from '../components/Icon';
+import { getDueDosesForDate } from '@workspace/shared';
 import type { RootStackScreenProps } from '../types/navigation';
 import { MEDICATION_TYPES, DAY_LABELS } from '../types/medications';
 import type { MedicationEntry, MedicationEntryStatus } from '../types/medications';
@@ -43,14 +44,16 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
   );
 
   const unloggedSchedules = useMemo(() => {
-    if (!med?.schedules) return [];
-    return med.schedules.filter((sched) => {
-      if (sched.schedule_type_id === 'prn') return false;
-      return !todayEntries.some(
-        (e) => e.schedule_id === sched.id && (e.status === 'taken' || e.status === 'skipped'),
-      );
-    });
-  }, [med, todayEntries]);
+    if (!med) return [];
+    const dueDoses = getDueDosesForDate([med], selectedDate);
+    return dueDoses
+      .filter((due) =>
+        !todayEntries.some(
+          (e) => e.schedule_id === due.schedule.id && (e.status === 'taken' || e.status === 'skipped'),
+        ),
+      )
+      .map((due) => due.schedule);
+  }, [med, todayEntries, selectedDate]);
 
   const handleDelete = useCallback(() => {
     if (!med) return;

--- a/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
@@ -1,15 +1,18 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { View, Text, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import Toast from 'react-native-toast-message';
+import { useCSSVariable } from 'uniwind';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
-import { useMedicationDetail, useDeleteMedication, useMedicationEntries, useDeleteMedicationEntry } from '../hooks/useMedications';
+import { useMedicationDetail, useDeleteMedication, useMedicationEntries, useDeleteMedicationEntry, useCreateMedicationEntry } from '../hooks/useMedications';
 import { useDiaryDateStore } from '../stores/diaryDateStore';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 import { useScreenHeader } from '../hooks/useScreenHeader';
 import Icon from '../components/Icon';
 import type { RootStackScreenProps } from '../types/navigation';
 import { MEDICATION_TYPES, DAY_LABELS } from '../types/medications';
-import type { MedicationEntry } from '../types/medications';
+import type { MedicationEntry, MedicationEntryStatus } from '../types/medications';
+import { addLog } from '../services/LogService';
 
 type MedicationDetailScreenProps = RootStackScreenProps<'MedicationDetail'>;
 
@@ -24,12 +27,30 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
   const { data: entries } = useMedicationEntries({ fromDate: selectedDate, toDate: selectedDate, medicationId });
   const deleteMedicationMutation = useDeleteMedication();
   const deleteEntryMutation = useDeleteMedicationEntry();
+  const createEntryMutation = useCreateMedicationEntry();
+
+  const [iconDanger] = useCSSVariable(['--color-icon-danger']) as [string];
 
   const isPrn = !med?.schedules || med.schedules.length === 0 || med.schedules.some((s) => s.schedule_type_id === 'prn');
 
-  const todayPrnDoses = (entries ?? []).filter(
-    (e) => e.medication_id === medicationId && e.status === 'prn_taken' && e.entry_date === selectedDate,
+  const todayEntries = useMemo(() => entries ?? [], [entries]);
+
+  const todayPrnDoses = useMemo(
+    () => todayEntries.filter(
+      (e) => e.medication_id === medicationId && e.status === 'prn_taken' && e.entry_date === selectedDate,
+    ),
+    [todayEntries, medicationId, selectedDate],
   );
+
+  const unloggedSchedules = useMemo(() => {
+    if (!med?.schedules) return [];
+    return med.schedules.filter((sched) => {
+      if (sched.schedule_type_id === 'prn') return false;
+      return !todayEntries.some(
+        (e) => e.schedule_id === sched.id && (e.status === 'taken' || e.status === 'skipped'),
+      );
+    });
+  }, [med, todayEntries]);
 
   const handleDelete = useCallback(() => {
     if (!med) return;
@@ -69,6 +90,46 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
     [deleteEntryMutation],
   );
 
+  const handleLogSchedule = useCallback(
+    (scheduleId: string) => {
+      if (!med) return;
+      createEntryMutation.mutate(
+        {
+          medication_id: med.id,
+          schedule_id: scheduleId,
+          status: 'taken' as MedicationEntryStatus,
+          entry_date: selectedDate,
+          taken_at: new Date().toISOString(),
+        },
+        {
+          onSuccess: () => Toast.show({ type: 'success', text1: `${med.name} taken` }),
+          onError: (error) => {
+            addLog(`Failed to log medication: ${error.message}`, 'ERROR');
+          },
+        },
+      );
+    },
+    [med, createEntryMutation, selectedDate],
+  );
+
+  const handleLogPrn = useCallback(() => {
+    if (!med) return;
+    createEntryMutation.mutate(
+      {
+        medication_id: med.id,
+        status: 'prn_taken' as MedicationEntryStatus,
+        entry_date: selectedDate,
+        taken_at: new Date().toISOString(),
+      },
+      {
+        onSuccess: () => Toast.show({ type: 'success', text1: `${med.name} logged` }),
+        onError: (error) => {
+          addLog(`Failed to log PRN medication: ${error.message}`, 'ERROR');
+        },
+      },
+    );
+  }, [med, createEntryMutation, selectedDate]);
+
   const header = useScreenHeader({
     title: med?.name ?? 'Medication',
     left: { kind: 'back' },
@@ -79,20 +140,16 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
     },
   });
 
-  if (isLoading || !med) {
-    return (
-      <View className="flex-1 bg-background items-center justify-center" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
-        {header}
-        <Text className="text-text-muted text-base mt-4">Loading...</Text>
-      </View>
-    );
-  }
-
-  const typeLabel = MEDICATION_TYPES.find((t) => t.id === med.type_id)?.label ?? med.type_id;
+  const typeLabel = med ? (MEDICATION_TYPES.find((t) => t.id === med.type_id)?.label ?? med.type_id) : '';
 
   return (
     <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
       {header}
+      {isLoading || !med ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-text-muted text-base">Loading...</Text>
+        </View>
+      ) : (
       <ScrollView
         contentContainerStyle={{ padding: 16, paddingBottom: insets.bottom + 80 + activeWorkoutBarPadding }}
         contentInsetAdjustmentBehavior={usesNativeHeader ? 'automatic' : 'never'}
@@ -112,47 +169,21 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
           <InfoRow label="Status" value={med.is_active ? 'Active' : 'Inactive'} />
         </View>
 
-        {med.schedules && med.schedules.length > 0 && (
-          <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
-            <Text className="text-sm font-semibold text-text-secondary mb-2">Schedules</Text>
-            {med.schedules.map((sched, index) => (
-              <View key={sched.id} className="mb-2 last:mb-0">
-                <Text className="text-base text-text-primary capitalize">{sched.schedule_type_id.replace('_', ' ')}</Text>
-                {sched.time_of_day && (
-                  <Text className="text-sm text-text-secondary mt-0.5">
-                      {(() => {
-                        const [h, m] = sched.time_of_day.split(':').map(Number);
-                        return new Date(2000, 0, 1, h, m).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-                      })()}
-                  </Text>
-                )}
-                {sched.schedule_type_id === 'specific_days' && sched.days_of_week && (
-                  <Text className="text-xs text-text-muted mt-0.5">
-                    {sched.days_of_week.map((d) => DAY_LABELS[d]).join(', ')}
-                  </Text>
-                )}
-                {sched.schedule_type_id === 'every_n_days' && sched.interval_days && (
-                  <Text className="text-xs text-text-muted mt-0.5">Every {sched.interval_days} days</Text>
-                )}
-                {sched.dose_amount && (
-                  <Text className="text-xs text-text-muted mt-0.5">Dose: {sched.dose_amount}</Text>
-                )}
-                {sched.with_meal && (
-                  <Text className="text-xs text-text-muted mt-0.5">With: {sched.with_meal}</Text>
-                )}
-                {index < (med.schedules?.length ?? 0) - 1 && (
-                  <View className="h-px bg-chrome-border mt-2" />
-                )}
-              </View>
-            ))}
-          </View>
-        )}
-
         {isPrn && (
           <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
-            <Text className="text-sm font-semibold text-text-secondary mb-2">
-              {`Today's Doses${todayPrnDoses.length > 0 ? ` (${todayPrnDoses.length})` : ''}`}
-            </Text>
+            <View className="flex-row items-center justify-between mb-2">
+              <Text className="text-sm font-semibold text-text-secondary">
+                {`Today's Doses${todayPrnDoses.length > 0 ? ` (${todayPrnDoses.length})` : ''}`}
+              </Text>
+              <TouchableOpacity
+                onPress={handleLogPrn}
+                hitSlop={{ top: 8, bottom: 8, left: 12, right: 12 }}
+                activeOpacity={0.6}
+                className="rounded-full px-3 py-1"
+              >
+                <Text className="text-sm font-semibold text-accent-primary">Log</Text>
+              </TouchableOpacity>
+            </View>
             {todayPrnDoses.length === 0 ? (
               <Text className="text-sm text-text-muted py-2">No doses logged today.</Text>
             ) : (
@@ -174,7 +205,7 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
                     activeOpacity={0.6}
                     className="ml-3"
                   >
-                    <Icon name="trash" size={18} color="#EF4444" />
+                    <Icon name="trash" size={18} color={iconDanger} />
                   </TouchableOpacity>
                 </View>
               ))
@@ -182,19 +213,69 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
           </View>
         )}
 
+        {med.schedules && med.schedules.length > 0 && (
+          <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
+            <Text className="text-sm font-semibold text-text-secondary mb-2">Schedules</Text>
+            {med.schedules.map((sched, index) => {
+              const isUnlogged = unloggedSchedules.some((s) => s.id === sched.id);
+              return (
+                <View key={sched.id} className="mb-2 last:mb-0">
+                  <View className="flex-row items-center justify-between">
+                    <View className="flex-1">
+                      <Text className="text-base text-text-primary capitalize">{sched.schedule_type_id.replace('_', ' ')}</Text>
+                      {sched.time_of_day && (
+                        <Text className="text-sm text-text-secondary mt-0.5">
+                            {(() => {
+                              const [h, m] = sched.time_of_day.split(':').map(Number);
+                              return new Date(2000, 0, 1, h, m).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+                            })()}
+                        </Text>
+                      )}
+                      {sched.schedule_type_id === 'specific_days' && sched.days_of_week && (
+                        <Text className="text-xs text-text-muted mt-0.5">
+                          {sched.days_of_week.map((d) => DAY_LABELS[d]).join(', ')}
+                        </Text>
+                      )}
+                      {sched.schedule_type_id === 'every_n_days' && sched.interval_days && (
+                        <Text className="text-xs text-text-muted mt-0.5">Every {sched.interval_days} days</Text>
+                      )}
+                      {sched.dose_amount && (
+                        <Text className="text-xs text-text-muted mt-0.5">Dose: {sched.dose_amount}</Text>
+                      )}
+                      {sched.with_meal && (
+                        <Text className="text-xs text-text-muted mt-0.5">With: {sched.with_meal}</Text>
+                      )}
+                    </View>
+                    {isUnlogged && sched.time_of_day && (
+                      <TouchableOpacity
+                        onPress={() => handleLogSchedule(sched.id)}
+                        hitSlop={{ top: 8, bottom: 8, left: 12, right: 12 }}
+                        activeOpacity={0.6}
+                        className="rounded-full px-3 py-1 ml-2"
+                      >
+                        <Text className="text-sm font-semibold text-accent-primary">Log</Text>
+                      </TouchableOpacity>
+                    )}
+                  </View>
+                  {index < (med.schedules?.length ?? 0) - 1 && (
+                    <View className="h-px bg-chrome-border mt-2" />
+                  )}
+                </View>
+              );
+            })}
+          </View>
+        )}
+
         <TouchableOpacity
           className="bg-surface rounded-xl p-4 shadow-sm mb-3"
           onPress={handleDelete}
         >
-          <Text className="text-base font-medium text-center" style={{ color: '#EF4444' }}>
+          <Text className="text-base font-medium text-center text-text-danger-subtle">
             Delete Medication
           </Text>
         </TouchableOpacity>
-
-        <Text className="text-xs text-text-muted text-center px-4">
-          Full medication history and schedule can be managed in the web app.
-        </Text>
       </ScrollView>
+      )}
     </View>
   );
 };

--- a/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
@@ -1,0 +1,209 @@
+import React, { useCallback } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, Alert } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
+import { useMedicationDetail, useDeleteMedication, useMedicationEntries, useDeleteMedicationEntry } from '../hooks/useMedications';
+import { useDiaryDateStore } from '../stores/diaryDateStore';
+import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
+import { useScreenHeader } from '../hooks/useScreenHeader';
+import Icon from '../components/Icon';
+import type { RootStackScreenProps } from '../types/navigation';
+import { MEDICATION_TYPES, DAY_LABELS } from '../types/medications';
+import type { MedicationEntry } from '../types/medications';
+
+type MedicationDetailScreenProps = RootStackScreenProps<'MedicationDetail'>;
+
+const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, navigation }) => {
+  const { medicationId } = route.params;
+  const insets = useSafeAreaInsets();
+  const usesNativeHeader = useNativeIOSHeadersActive();
+  const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
+  const selectedDate = useDiaryDateStore((s) => s.selectedDate);
+
+  const { data: med, isLoading } = useMedicationDetail(medicationId);
+  const { data: entries } = useMedicationEntries({ fromDate: selectedDate, toDate: selectedDate, medicationId });
+  const deleteMedicationMutation = useDeleteMedication();
+  const deleteEntryMutation = useDeleteMedicationEntry();
+
+  const isPrn = !med?.schedules || med.schedules.length === 0 || med.schedules.some((s) => s.schedule_type_id === 'prn');
+
+  const todayPrnDoses = (entries ?? []).filter(
+    (e) => e.medication_id === medicationId && e.status === 'prn_taken' && e.entry_date === selectedDate,
+  );
+
+  const handleDelete = useCallback(() => {
+    if (!med) return;
+    Alert.alert(
+      'Delete Medication',
+      `Are you sure you want to delete '${med.name}'? This will also remove all schedules and logged entries.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: () => {
+            deleteMedicationMutation.mutate(med.id, {
+              onSuccess: () => navigation.goBack(),
+            });
+          },
+        },
+      ],
+    );
+  }, [med, deleteMedicationMutation, navigation]);
+
+  const handleRemoveDose = useCallback(
+    (entry: MedicationEntry) => {
+      Alert.alert(
+        'Remove Dose',
+        `Remove this logged dose from ${entry.taken_at ? new Date(entry.taken_at).toLocaleTimeString() : 'today'}?`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Remove',
+            style: 'destructive',
+            onPress: () => deleteEntryMutation.mutate(entry.id),
+          },
+        ],
+      );
+    },
+    [deleteEntryMutation],
+  );
+
+  const header = useScreenHeader({
+    title: med?.name ?? 'Medication',
+    left: { kind: 'back' },
+    right: {
+      kind: 'text',
+      label: 'Edit',
+      onPress: () => navigation.navigate('MedicationForm', { medicationId }),
+    },
+  });
+
+  if (isLoading || !med) {
+    return (
+      <View className="flex-1 bg-background items-center justify-center" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
+        {header}
+        <Text className="text-text-muted text-base mt-4">Loading...</Text>
+      </View>
+    );
+  }
+
+  const typeLabel = MEDICATION_TYPES.find((t) => t.id === med.type_id)?.label ?? med.type_id;
+
+  return (
+    <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
+      {header}
+      <ScrollView
+        contentContainerStyle={{ padding: 16, paddingBottom: insets.bottom + 80 + activeWorkoutBarPadding }}
+        contentInsetAdjustmentBehavior={usesNativeHeader ? 'automatic' : 'never'}
+      >
+        <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
+          <InfoRow label="Type" value={typeLabel} />
+          {med.strength_value != null && (
+            <InfoRow label="Strength" value={`${med.strength_value} ${med.strength_unit ?? ''}`} />
+          )}
+          {med.dose_amount != null && (
+            <InfoRow label="Dose" value={`${med.dose_amount} ${med.dose_unit ?? ''}`} />
+          )}
+          {med.reason && <InfoRow label="Reason" value={med.reason} />}
+          {med.prescriber && <InfoRow label="Prescriber" value={med.prescriber} />}
+          {med.pharmacy && <InfoRow label="Pharmacy" value={med.pharmacy} />}
+          {med.notes && <InfoRow label="Notes" value={med.notes} />}
+          <InfoRow label="Status" value={med.is_active ? 'Active' : 'Inactive'} />
+        </View>
+
+        {med.schedules && med.schedules.length > 0 && (
+          <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
+            <Text className="text-sm font-semibold text-text-secondary mb-2">Schedules</Text>
+            {med.schedules.map((sched, index) => (
+              <View key={sched.id} className="mb-2 last:mb-0">
+                <Text className="text-base text-text-primary capitalize">{sched.schedule_type_id.replace('_', ' ')}</Text>
+                {sched.time_of_day && (
+                  <Text className="text-sm text-text-secondary mt-0.5">
+                      {(() => {
+                        const [h, m] = sched.time_of_day.split(':').map(Number);
+                        return new Date(2000, 0, 1, h, m).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+                      })()}
+                  </Text>
+                )}
+                {sched.schedule_type_id === 'specific_days' && sched.days_of_week && (
+                  <Text className="text-xs text-text-muted mt-0.5">
+                    {sched.days_of_week.map((d) => DAY_LABELS[d]).join(', ')}
+                  </Text>
+                )}
+                {sched.schedule_type_id === 'every_n_days' && sched.interval_days && (
+                  <Text className="text-xs text-text-muted mt-0.5">Every {sched.interval_days} days</Text>
+                )}
+                {sched.dose_amount && (
+                  <Text className="text-xs text-text-muted mt-0.5">Dose: {sched.dose_amount}</Text>
+                )}
+                {sched.with_meal && (
+                  <Text className="text-xs text-text-muted mt-0.5">With: {sched.with_meal}</Text>
+                )}
+                {index < (med.schedules?.length ?? 0) - 1 && (
+                  <View className="h-px bg-chrome-border mt-2" />
+                )}
+              </View>
+            ))}
+          </View>
+        )}
+
+        {isPrn && (
+          <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
+            <Text className="text-sm font-semibold text-text-secondary mb-2">
+              {`Today's Doses${todayPrnDoses.length > 0 ? ` (${todayPrnDoses.length})` : ''}`}
+            </Text>
+            {todayPrnDoses.length === 0 ? (
+              <Text className="text-sm text-text-muted py-2">No doses logged today.</Text>
+            ) : (
+              todayPrnDoses.map((dose) => (
+                <View key={dose.id} className="flex-row items-center justify-between py-2 border-b border-chrome-border last:border-b-0">
+                  <View className="flex-1">
+                    <Text className="text-base text-text-primary">
+                      {dose.taken_at
+                        ? new Date(dose.taken_at).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' })
+                        : 'Logged'}
+                    </Text>
+                    {dose.notes && (
+                      <Text className="text-xs text-text-muted mt-0.5">{dose.notes}</Text>
+                    )}
+                  </View>
+                  <TouchableOpacity
+                    onPress={() => handleRemoveDose(dose)}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    activeOpacity={0.6}
+                    className="ml-3"
+                  >
+                    <Icon name="trash" size={18} color="#EF4444" />
+                  </TouchableOpacity>
+                </View>
+              ))
+            )}
+          </View>
+        )}
+
+        <TouchableOpacity
+          className="bg-surface rounded-xl p-4 shadow-sm mb-3"
+          onPress={handleDelete}
+        >
+          <Text className="text-base font-medium text-center" style={{ color: '#EF4444' }}>
+            Delete Medication
+          </Text>
+        </TouchableOpacity>
+
+        <Text className="text-xs text-text-muted text-center px-4">
+          Full medication history and schedule can be managed in the web app.
+        </Text>
+      </ScrollView>
+    </View>
+  );
+};
+
+const InfoRow: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <View className="flex-row py-1.5">
+    <Text className="text-sm text-text-muted w-28">{label}</Text>
+    <Text className="text-sm text-text-primary flex-1">{value}</Text>
+  </View>
+);
+
+export default MedicationDetailScreen;

--- a/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
@@ -190,8 +190,8 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
             {todayPrnDoses.length === 0 ? (
               <Text className="text-sm text-text-muted py-2">No doses logged today.</Text>
             ) : (
-              todayPrnDoses.map((dose) => (
-                <View key={dose.id} className="flex-row items-center justify-between py-2 border-b border-chrome-border last:border-b-0">
+              todayPrnDoses.map((dose, index) => (
+                <View key={dose.id} className={`flex-row items-center justify-between py-2${index < todayPrnDoses.length - 1 ? ' border-b border-chrome-border' : ''}`}>
                   <View className="flex-1">
                     <Text className="text-base text-text-primary">
                       {dose.taken_at

--- a/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
@@ -68,6 +68,10 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
           onPress: () => {
             deleteMedicationMutation.mutate(med.id, {
               onSuccess: () => navigation.goBack(),
+              onError: (error) => {
+                addLog(`Failed to delete medication: ${error.message}`, 'ERROR');
+                Toast.show({ type: 'error', text1: 'Failed to delete medication' });
+              },
             });
           },
         },
@@ -85,7 +89,13 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
           {
             text: 'Remove',
             style: 'destructive',
-            onPress: () => deleteEntryMutation.mutate(entry.id),
+            onPress: () =>
+              deleteEntryMutation.mutate(entry.id, {
+                onError: (error) => {
+                  addLog(`Failed to remove dose: ${error.message}`, 'ERROR');
+                  Toast.show({ type: 'error', text1: 'Failed to remove dose' });
+                },
+              }),
           },
         ],
       );
@@ -108,6 +118,7 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
           onSuccess: () => Toast.show({ type: 'success', text1: `${med.name} taken` }),
           onError: (error) => {
             addLog(`Failed to log medication: ${error.message}`, 'ERROR');
+            Toast.show({ type: 'error', text1: `Failed to log ${med.name}` });
           },
         },
       );
@@ -128,6 +139,7 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
         onSuccess: () => Toast.show({ type: 'success', text1: `${med.name} logged` }),
         onError: (error) => {
           addLog(`Failed to log PRN medication: ${error.message}`, 'ERROR');
+          Toast.show({ type: 'error', text1: `Failed to log ${med.name}` });
         },
       },
     );

--- a/SparkyFitnessMobile/src/screens/MedicationFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationFormScreen.tsx
@@ -87,6 +87,8 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
   }, []);
 
   const handleSave = useCallback(() => {
+    if (createMedication.isPending || updateMedication.isPending) return;
+
     if (!form.name.trim()) {
       Alert.alert('Required', 'Please enter a medication name.');
       return;
@@ -116,7 +118,10 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
     if (isEditing && medicationId) {
       updateMedication.mutate(
         { id: medicationId, body: { ...base, is_active: form.isActive } },
-        { onSuccess: () => navigation.goBack() },
+        {
+          onSuccess: () => navigation.goBack(),
+          onError: (error) => Alert.alert('Error', `Failed to update medication: ${error.message}`),
+        },
       );
     } else {
       createMedication.mutate(
@@ -125,6 +130,7 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
           onSuccess: (med) => {
             navigation.replace('MedicationDetail', { medicationId: med.id });
           },
+          onError: (error) => Alert.alert('Error', `Failed to create medication: ${error.message}`),
         },
       );
     }
@@ -136,6 +142,8 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
     right: {
       kind: 'primary',
       label: 'Save',
+      busy: createMedication.isPending || updateMedication.isPending,
+      busyLabel: 'Saving…',
       onPress: handleSave,
     },
   });

--- a/SparkyFitnessMobile/src/screens/MedicationFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationFormScreen.tsx
@@ -6,7 +6,7 @@ import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import BottomSheetPicker from '../components/BottomSheetPicker';
 import { useMedicationDetail, useCreateMedication, useUpdateMedication } from '../hooks/useMedications';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
-import { useScreenHeader } from '../hooks/useScreenHeader';
+import { useScreenHeader, SAVE_LABEL, SAVING_LABEL } from '../hooks/useScreenHeader';
 import FormInput from '../components/FormInput';
 import type { RootStackScreenProps } from '../types/navigation';
 import { MEDICATION_TYPES } from '../types/medications';
@@ -141,9 +141,9 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
     left: { kind: 'dismiss', onPress: () => navigation.goBack() },
     right: {
       kind: 'primary',
-      label: 'Save',
+      label: SAVE_LABEL,
       busy: createMedication.isPending || updateMedication.isPending,
-      busyLabel: 'Saving…',
+      busyLabel: SAVING_LABEL,
       onPress: handleSave,
     },
   });

--- a/SparkyFitnessMobile/src/screens/MedicationFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationFormScreen.tsx
@@ -1,0 +1,344 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { View, Text, ScrollView, TextInput, Switch, Alert, Modal, TouchableOpacity, FlatList } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useCSSVariable } from 'uniwind';
+import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
+import { useMedicationDetail, useCreateMedication, useUpdateMedication } from '../hooks/useMedications';
+import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
+import { useScreenHeader } from '../hooks/useScreenHeader';
+import Icon from '../components/Icon';
+import type { RootStackScreenProps } from '../types/navigation';
+import { MEDICATION_TYPES } from '../types/medications';
+
+type MedicationFormScreenProps = RootStackScreenProps<'MedicationForm'>;
+
+interface FormState {
+  name: string;
+  typeId: string;
+  strengthValue: string;
+  strengthUnit: string;
+  doseAmount: string;
+  doseUnit: string;
+  reason: string;
+  prescriber: string;
+  pharmacy: string;
+  notes: string;
+  isActive: boolean;
+}
+
+const EMPTY_FORM: FormState = {
+  name: '',
+  typeId: 'pill',
+  strengthValue: '',
+  strengthUnit: 'mg',
+  doseAmount: '',
+  doseUnit: 'tablet',
+  reason: '',
+  prescriber: '',
+  pharmacy: '',
+  notes: '',
+  isActive: true,
+};
+
+function baseFromMed(
+  existingMed?: NonNullable<ReturnType<typeof useMedicationDetail>['data']>,
+): FormState {
+  if (!existingMed) return EMPTY_FORM;
+  return {
+    name: existingMed.name,
+    typeId: existingMed.type_id,
+    strengthValue: existingMed.strength_value != null ? String(existingMed.strength_value) : '',
+    strengthUnit: existingMed.strength_unit ?? 'mg',
+    doseAmount: existingMed.dose_amount != null ? String(existingMed.dose_amount) : '',
+    doseUnit: existingMed.dose_unit ?? 'tablet',
+    reason: existingMed.reason ?? '',
+    prescriber: existingMed.prescriber ?? '',
+    pharmacy: existingMed.pharmacy ?? '',
+    notes: existingMed.notes ?? '',
+    isActive: existingMed.is_active,
+  };
+}
+
+function SimplePicker({
+  visible,
+  title,
+  options,
+  onSelect,
+  onClose,
+}: {
+  visible: boolean;
+  title: string;
+  options: { label: string; value: string }[];
+  onSelect: (value: string) => void;
+  onClose: () => void;
+}) {
+  const [surfaceBg] = useCSSVariable(['--color-surface']) as [string];
+  const [textPrimary] = useCSSVariable(['--color-text-primary']) as [string];
+  const [accent] = useCSSVariable(['--color-accent-primary']) as [string];
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <TouchableOpacity
+        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'center', alignItems: 'center' }}
+        activeOpacity={1}
+        onPress={onClose}
+      >
+        <View
+          style={{ backgroundColor: surfaceBg, borderRadius: 16, padding: 8, width: '80%', maxHeight: '70%' }}
+        >
+          <Text style={{ color: textPrimary, fontSize: 17, fontWeight: '600', textAlign: 'center', paddingVertical: 12 }}>
+            {title}
+          </Text>
+          <FlatList
+            data={options}
+            keyExtractor={(item) => item.value}
+            renderItem={({ item }) => (
+              <TouchableOpacity
+                onPress={() => { onSelect(item.value); onClose(); }}
+                style={{ paddingVertical: 12, paddingHorizontal: 16, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}
+                activeOpacity={0.6}
+              >
+                <Text style={{ color: textPrimary, fontSize: 16 }}>{item.label}</Text>
+                <Icon name="checkmark" size={18} color={accent} style={{ opacity: 0 }} />
+              </TouchableOpacity>
+            )}
+          />
+        </View>
+      </TouchableOpacity>
+    </Modal>
+  );
+}
+
+const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navigation }) => {
+  const medicationId = route.params?.medicationId;
+  const isEditing = !!medicationId;
+  const insets = useSafeAreaInsets();
+  const usesNativeHeader = useNativeIOSHeadersActive();
+  const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
+  const [formEnabled, formDisabled] = useCSSVariable([
+    '--color-form-enabled',
+    '--color-form-disabled',
+  ]) as [string, string];
+
+  const { data: existingMed } = useMedicationDetail(medicationId ?? '', { enabled: isEditing });
+  const createMedication = useCreateMedication();
+  const updateMedication = useUpdateMedication();
+
+  const [edits, setEdits] = useState<Partial<FormState>>({});
+
+  const form: FormState = useMemo(
+    () => ({ ...baseFromMed(existingMed), ...edits }),
+    [existingMed, edits],
+  );
+
+  const updateField = useCallback(<K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setEdits((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  const [typePickerVisible, setTypePickerVisible] = useState(false);
+
+  const handleSave = useCallback(() => {
+    if (!form.name.trim()) {
+      Alert.alert('Required', 'Please enter a medication name.');
+      return;
+    }
+
+    const strengthNum = form.strengthValue ? parseFloat(form.strengthValue) : null;
+    const doseNum = form.doseAmount ? parseFloat(form.doseAmount) : null;
+
+    const base = {
+      name: form.name.trim(),
+      type_id: form.typeId,
+      strength_value: strengthNum,
+      strength_unit: form.strengthUnit || null,
+      dose_amount: doseNum,
+      dose_unit: form.doseUnit || null,
+      reason: form.reason || undefined,
+      prescriber: form.prescriber || undefined,
+      pharmacy: form.pharmacy || undefined,
+      notes: form.notes || undefined,
+    };
+
+    if (isEditing && medicationId) {
+      updateMedication.mutate(
+        { id: medicationId, body: { ...base, is_active: form.isActive } },
+        { onSuccess: () => navigation.goBack() },
+      );
+    } else {
+      createMedication.mutate(
+        { ...base, is_active: form.isActive },
+        {
+          onSuccess: (med) => {
+            navigation.replace('MedicationDetail', { medicationId: med.id });
+          },
+        },
+      );
+    }
+  }, [form, isEditing, medicationId, createMedication, updateMedication, navigation]);
+
+  const header = useScreenHeader({
+    title: isEditing ? 'Edit Medication' : 'New Medication',
+    left: { kind: 'back' },
+    right: {
+      kind: 'primary',
+      label: 'Save',
+      onPress: handleSave,
+    },
+  });
+
+  const typeOptions = useMemo(() => MEDICATION_TYPES.map((t) => ({ label: t.label, value: t.id })), []);
+  const selectedTypeLabel = useMemo(() => MEDICATION_TYPES.find((t) => t.id === form.typeId)?.label ?? form.typeId, [form.typeId]);
+
+  return (
+    <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
+      {header}
+      <ScrollView
+        contentContainerStyle={{ padding: 16, paddingBottom: insets.bottom + 80 + activeWorkoutBarPadding }}
+        contentInsetAdjustmentBehavior={usesNativeHeader ? 'automatic' : 'never'}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
+          <FormField label="Name *">
+            <TextInput
+              className="text-base text-text-primary"
+              placeholder="e.g., Lisinopril"
+              placeholderTextColor="#9CA3AF"
+              value={form.name}
+              onChangeText={(v) => updateField('name', v)}
+              autoCapitalize="words"
+            />
+          </FormField>
+
+          <FormField label="Type">
+            <TouchableOpacity
+              className="flex-row items-center justify-between px-3 py-2.5 rounded-lg border border-border-subtle bg-raised min-h-11"
+              onPress={() => setTypePickerVisible(true)}
+              activeOpacity={0.7}
+            >
+              <Text className="text-base flex-1 text-text-primary">{selectedTypeLabel}</Text>
+              <Icon name="chevron-down" size={16} color="#9CA3AF" />
+            </TouchableOpacity>
+          </FormField>
+
+          <View className="flex-row">
+            <FormField label="Strength" style={{ flex: 1, marginRight: 8 }}>
+              <TextInput
+                className="text-base text-text-primary"
+                placeholder="e.g., 10"
+                placeholderTextColor="#9CA3AF"
+                value={form.strengthValue}
+                onChangeText={(v) => updateField('strengthValue', v)}
+                keyboardType="decimal-pad"
+              />
+            </FormField>
+            <FormField label="Unit" style={{ flex: 1, marginLeft: 8 }}>
+              <TextInput
+                className="text-base text-text-primary"
+                placeholder="mg"
+                placeholderTextColor="#9CA3AF"
+                value={form.strengthUnit}
+                onChangeText={(v) => updateField('strengthUnit', v)}
+              />
+            </FormField>
+          </View>
+
+          <View className="flex-row">
+            <FormField label="Dose" style={{ flex: 1, marginRight: 8 }}>
+              <TextInput
+                className="text-base text-text-primary"
+                placeholder="e.g., 1"
+                placeholderTextColor="#9CA3AF"
+                value={form.doseAmount}
+                onChangeText={(v) => updateField('doseAmount', v)}
+                keyboardType="decimal-pad"
+              />
+            </FormField>
+            <FormField label="Unit" style={{ flex: 1, marginLeft: 8 }}>
+              <TextInput
+                className="text-base text-text-primary"
+                placeholder="tablet"
+                placeholderTextColor="#9CA3AF"
+                value={form.doseUnit}
+                onChangeText={(v) => updateField('doseUnit', v)}
+              />
+            </FormField>
+          </View>
+
+          <FormField label="Reason">
+            <TextInput
+              className="text-base text-text-primary"
+              placeholder="e.g., Blood pressure"
+              placeholderTextColor="#9CA3AF"
+              value={form.reason}
+              onChangeText={(v) => updateField('reason', v)}
+            />
+          </FormField>
+
+          <FormField label="Prescriber">
+            <TextInput
+              className="text-base text-text-primary"
+              placeholder="Doctor name"
+              placeholderTextColor="#9CA3AF"
+              value={form.prescriber}
+              onChangeText={(v) => updateField('prescriber', v)}
+            />
+          </FormField>
+
+          <FormField label="Pharmacy">
+            <TextInput
+              className="text-base text-text-primary"
+              placeholder="Pharmacy name"
+              placeholderTextColor="#9CA3AF"
+              value={form.pharmacy}
+              onChangeText={(v) => updateField('pharmacy', v)}
+            />
+          </FormField>
+
+          <FormField label="Notes">
+            <TextInput
+              className="text-base text-text-primary"
+              placeholder="Additional notes"
+              placeholderTextColor="#9CA3AF"
+              value={form.notes}
+              onChangeText={(v) => updateField('notes', v)}
+              multiline
+              numberOfLines={3}
+              textAlignVertical="top"
+            />
+          </FormField>
+
+          <View className="flex-row justify-between items-center py-3 border-t border-chrome-border">
+            <Text className="text-base text-text-primary">Active</Text>
+            <Switch
+              value={form.isActive}
+              onValueChange={(v) => updateField('isActive', v)}
+              trackColor={{ false: formDisabled, true: formEnabled }}
+              thumbColor="#FFFFFF"
+            />
+          </View>
+        </View>
+      </ScrollView>
+
+      <SimplePicker
+        visible={typePickerVisible}
+        title="Medication Type"
+        options={typeOptions}
+        onSelect={(val) => updateField('typeId', val)}
+        onClose={() => setTypePickerVisible(false)}
+      />
+    </View>
+  );
+};
+
+const FormField: React.FC<{
+  label: string;
+  children: React.ReactNode;
+  style?: object;
+}> = ({ label, children, style }) => (
+  <View className="py-3 border-b border-chrome-border" style={style}>
+    <Text className="text-xs font-semibold text-text-muted uppercase tracking-wide mb-1">{label}</Text>
+    {children}
+  </View>
+);
+
+export default MedicationFormScreen;

--- a/SparkyFitnessMobile/src/screens/MedicationFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationFormScreen.tsx
@@ -95,6 +95,11 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
     const strengthNum = form.strengthValue ? parseFloat(form.strengthValue) : null;
     const doseNum = form.doseAmount ? parseFloat(form.doseAmount) : null;
 
+    if ((form.strengthValue && !Number.isFinite(strengthNum)) || (form.doseAmount && !Number.isFinite(doseNum))) {
+      Alert.alert('Invalid number', 'Please enter valid numeric values for strength and dose.');
+      return;
+    }
+
     const base = {
       name: form.name.trim(),
       type_id: form.typeId,

--- a/SparkyFitnessMobile/src/screens/MedicationFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationFormScreen.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { View, Text, ScrollView, TextInput, Switch, Alert, Modal, TouchableOpacity, FlatList } from 'react-native';
+import { View, Text, ScrollView, Switch, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
+import BottomSheetPicker from '../components/BottomSheetPicker';
 import { useMedicationDetail, useCreateMedication, useUpdateMedication } from '../hooks/useMedications';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 import { useScreenHeader } from '../hooks/useScreenHeader';
-import Icon from '../components/Icon';
+import FormInput from '../components/FormInput';
 import type { RootStackScreenProps } from '../types/navigation';
 import { MEDICATION_TYPES } from '../types/medications';
 
@@ -59,56 +60,6 @@ function baseFromMed(
   };
 }
 
-function SimplePicker({
-  visible,
-  title,
-  options,
-  onSelect,
-  onClose,
-}: {
-  visible: boolean;
-  title: string;
-  options: { label: string; value: string }[];
-  onSelect: (value: string) => void;
-  onClose: () => void;
-}) {
-  const [surfaceBg] = useCSSVariable(['--color-surface']) as [string];
-  const [textPrimary] = useCSSVariable(['--color-text-primary']) as [string];
-  const [accent] = useCSSVariable(['--color-accent-primary']) as [string];
-
-  return (
-    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
-      <TouchableOpacity
-        style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.4)', justifyContent: 'center', alignItems: 'center' }}
-        activeOpacity={1}
-        onPress={onClose}
-      >
-        <View
-          style={{ backgroundColor: surfaceBg, borderRadius: 16, padding: 8, width: '80%', maxHeight: '70%' }}
-        >
-          <Text style={{ color: textPrimary, fontSize: 17, fontWeight: '600', textAlign: 'center', paddingVertical: 12 }}>
-            {title}
-          </Text>
-          <FlatList
-            data={options}
-            keyExtractor={(item) => item.value}
-            renderItem={({ item }) => (
-              <TouchableOpacity
-                onPress={() => { onSelect(item.value); onClose(); }}
-                style={{ paddingVertical: 12, paddingHorizontal: 16, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}
-                activeOpacity={0.6}
-              >
-                <Text style={{ color: textPrimary, fontSize: 16 }}>{item.label}</Text>
-                <Icon name="checkmark" size={18} color={accent} style={{ opacity: 0 }} />
-              </TouchableOpacity>
-            )}
-          />
-        </View>
-      </TouchableOpacity>
-    </Modal>
-  );
-}
-
 const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navigation }) => {
   const medicationId = route.params?.medicationId;
   const isEditing = !!medicationId;
@@ -134,8 +85,6 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
   const updateField = useCallback(<K extends keyof FormState>(key: K, value: FormState[K]) => {
     setEdits((prev) => ({ ...prev, [key]: value }));
   }, []);
-
-  const [typePickerVisible, setTypePickerVisible] = useState(false);
 
   const handleSave = useCallback(() => {
     if (!form.name.trim()) {
@@ -178,7 +127,7 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
 
   const header = useScreenHeader({
     title: isEditing ? 'Edit Medication' : 'New Medication',
-    left: { kind: 'back' },
+    left: { kind: 'dismiss', onPress: () => navigation.goBack() },
     right: {
       kind: 'primary',
       label: 'Save',
@@ -187,7 +136,6 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
   });
 
   const typeOptions = useMemo(() => MEDICATION_TYPES.map((t) => ({ label: t.label, value: t.id })), []);
-  const selectedTypeLabel = useMemo(() => MEDICATION_TYPES.find((t) => t.id === form.typeId)?.label ?? form.typeId, [form.typeId]);
 
   return (
     <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
@@ -197,115 +145,105 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
         contentInsetAdjustmentBehavior={usesNativeHeader ? 'automatic' : 'never'}
         keyboardShouldPersistTaps="handled"
       >
-        <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm">
-          <FormField label="Name *">
-            <TextInput
-              className="text-base text-text-primary"
-              placeholder="e.g., Lisinopril"
-              placeholderTextColor="#9CA3AF"
+        <View className="bg-surface rounded-xl p-4 mb-3 shadow-sm gap-4">
+          <View className="gap-1.5">
+            <Text className="text-text-secondary text-sm font-medium">Name *</Text>
+            <FormInput
+              placeholder="Lisinopril"
               value={form.name}
               onChangeText={(v) => updateField('name', v)}
               autoCapitalize="words"
             />
-          </FormField>
+          </View>
 
-          <FormField label="Type">
-            <TouchableOpacity
-              className="flex-row items-center justify-between px-3 py-2.5 rounded-lg border border-border-subtle bg-raised min-h-11"
-              onPress={() => setTypePickerVisible(true)}
-              activeOpacity={0.7}
-            >
-              <Text className="text-base flex-1 text-text-primary">{selectedTypeLabel}</Text>
-              <Icon name="chevron-down" size={16} color="#9CA3AF" />
-            </TouchableOpacity>
-          </FormField>
+          <View className="gap-1.5">
+            <Text className="text-text-secondary text-sm font-medium">Type</Text>
+            <BottomSheetPicker
+              value={form.typeId}
+              options={typeOptions}
+              onSelect={(val) => updateField('typeId', val)}
+              title="Medication Type"
+            />
+          </View>
 
-          <View className="flex-row">
-            <FormField label="Strength" style={{ flex: 1, marginRight: 8 }}>
-              <TextInput
-                className="text-base text-text-primary"
-                placeholder="e.g., 10"
-                placeholderTextColor="#9CA3AF"
+          <View className="flex-row gap-4">
+            <View className="flex-1 gap-1.5">
+              <Text className="text-text-secondary text-sm font-medium">Strength</Text>
+              <FormInput
+                placeholder="10"
                 value={form.strengthValue}
                 onChangeText={(v) => updateField('strengthValue', v)}
                 keyboardType="decimal-pad"
               />
-            </FormField>
-            <FormField label="Unit" style={{ flex: 1, marginLeft: 8 }}>
-              <TextInput
-                className="text-base text-text-primary"
+            </View>
+            <View className="flex-1 gap-1.5">
+              <Text className="text-text-secondary text-sm font-medium">Unit</Text>
+              <FormInput
                 placeholder="mg"
-                placeholderTextColor="#9CA3AF"
                 value={form.strengthUnit}
                 onChangeText={(v) => updateField('strengthUnit', v)}
               />
-            </FormField>
+            </View>
           </View>
 
-          <View className="flex-row">
-            <FormField label="Dose" style={{ flex: 1, marginRight: 8 }}>
-              <TextInput
-                className="text-base text-text-primary"
-                placeholder="e.g., 1"
-                placeholderTextColor="#9CA3AF"
+          <View className="flex-row gap-4">
+            <View className="flex-1 gap-1.5">
+              <Text className="text-text-secondary text-sm font-medium">Dose</Text>
+              <FormInput
+                placeholder="1"
                 value={form.doseAmount}
                 onChangeText={(v) => updateField('doseAmount', v)}
                 keyboardType="decimal-pad"
               />
-            </FormField>
-            <FormField label="Unit" style={{ flex: 1, marginLeft: 8 }}>
-              <TextInput
-                className="text-base text-text-primary"
+            </View>
+            <View className="flex-1 gap-1.5">
+              <Text className="text-text-secondary text-sm font-medium">Unit</Text>
+              <FormInput
                 placeholder="tablet"
-                placeholderTextColor="#9CA3AF"
                 value={form.doseUnit}
                 onChangeText={(v) => updateField('doseUnit', v)}
               />
-            </FormField>
+            </View>
           </View>
 
-          <FormField label="Reason">
-            <TextInput
-              className="text-base text-text-primary"
-              placeholder="e.g., Blood pressure"
-              placeholderTextColor="#9CA3AF"
+          <View className="gap-1.5">
+            <Text className="text-text-secondary text-sm font-medium">Reason</Text>
+            <FormInput
+              placeholder="Blood pressure"
               value={form.reason}
               onChangeText={(v) => updateField('reason', v)}
             />
-          </FormField>
+          </View>
 
-          <FormField label="Prescriber">
-            <TextInput
-              className="text-base text-text-primary"
-              placeholder="Doctor name"
-              placeholderTextColor="#9CA3AF"
+          <View className="gap-1.5">
+            <Text className="text-text-secondary text-sm font-medium">Prescriber</Text>
+            <FormInput
+              placeholder="Dr. Ipsum"
               value={form.prescriber}
               onChangeText={(v) => updateField('prescriber', v)}
             />
-          </FormField>
+          </View>
 
-          <FormField label="Pharmacy">
-            <TextInput
-              className="text-base text-text-primary"
-              placeholder="Pharmacy name"
-              placeholderTextColor="#9CA3AF"
+          <View className="gap-1.5">
+            <Text className="text-text-secondary text-sm font-medium">Pharmacy</Text>
+            <FormInput
+              placeholder="Sunny Pharmacy"
               value={form.pharmacy}
               onChangeText={(v) => updateField('pharmacy', v)}
             />
-          </FormField>
+          </View>
 
-          <FormField label="Notes">
-            <TextInput
-              className="text-base text-text-primary"
-              placeholder="Additional notes"
-              placeholderTextColor="#9CA3AF"
+          <View className="gap-1.5">
+            <Text className="text-text-secondary text-sm font-medium">Notes</Text>
+            <FormInput
               value={form.notes}
               onChangeText={(v) => updateField('notes', v)}
               multiline
               numberOfLines={3}
               textAlignVertical="top"
+              style={{ minHeight: 72 }}
             />
-          </FormField>
+          </View>
 
           <View className="flex-row justify-between items-center py-3 border-t border-chrome-border">
             <Text className="text-base text-text-primary">Active</Text>
@@ -318,27 +256,8 @@ const MedicationFormScreen: React.FC<MedicationFormScreenProps> = ({ route, navi
           </View>
         </View>
       </ScrollView>
-
-      <SimplePicker
-        visible={typePickerVisible}
-        title="Medication Type"
-        options={typeOptions}
-        onSelect={(val) => updateField('typeId', val)}
-        onClose={() => setTypePickerVisible(false)}
-      />
     </View>
   );
 };
-
-const FormField: React.FC<{
-  label: string;
-  children: React.ReactNode;
-  style?: object;
-}> = ({ label, children, style }) => (
-  <View className="py-3 border-b border-chrome-border" style={style}>
-    <Text className="text-xs font-semibold text-text-muted uppercase tracking-wide mb-1">{label}</Text>
-    {children}
-  </View>
-);
 
 export default MedicationFormScreen;

--- a/SparkyFitnessMobile/src/screens/MedicationsListScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationsListScreen.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { View, Text, FlatList, RefreshControl, TouchableOpacity, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import Toast from 'react-native-toast-message';
 import { useCSSVariable } from 'uniwind';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { useMedications, useDeleteMedication } from '../hooks/useMedications';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 import { useScreenHeader } from '../hooks/useScreenHeader';
 import Icon from '../components/Icon';
+import { addLog } from '../services/LogService';
 import type { RootStackScreenProps } from '../types/navigation';
 import type { Medication } from '../types/medications';
 import { MEDICATION_TYPES } from '../types/medications';
@@ -41,7 +43,16 @@ const MedicationsListScreen: React.FC<MedicationsListScreenProps> = ({ navigatio
           {
             text: 'Delete',
             style: 'destructive',
-            onPress: () => deleteMedicationMutation.mutate(med.id),
+            onPress: () =>
+              deleteMedicationMutation.mutate(med.id, {
+                onSuccess: () => {
+                  Toast.show({ type: 'success', text1: `'${med.name}' deleted` });
+                },
+                onError: (error) => {
+                  addLog(`Failed to delete medication: ${error.message}`, 'ERROR');
+                  Toast.show({ type: 'error', text1: 'Failed to delete medication' });
+                },
+              }),
           },
         ],
       );

--- a/SparkyFitnessMobile/src/screens/MedicationsListScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationsListScreen.tsx
@@ -17,7 +17,7 @@ const MedicationsListScreen: React.FC<MedicationsListScreenProps> = ({ navigatio
   const insets = useSafeAreaInsets();
   const usesNativeHeader = useNativeIOSHeadersActive();
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
-  const accentColor = useCSSVariable('--color-accent-primary') as string;
+  const [accentColor, iconDecorative] = useCSSVariable(['--color-accent-primary', '--color-icon-decorative']) as [string, string];
   const [refreshing, setRefreshing] = useState(false);
 
   const { data: medications, isLoading, isError, refetch } = useMedications();
@@ -55,7 +55,19 @@ const MedicationsListScreen: React.FC<MedicationsListScreenProps> = ({ navigatio
     setRefreshing(false);
   }, [refetch]);
 
-  const header = useScreenHeader({ title: 'Medications', left: { kind: 'back' } });
+  const header = useScreenHeader({
+    title: 'Medications',
+    left: { kind: 'back' },
+    right: {
+      kind: 'icon',
+      sfSymbol: 'plus',
+      ionicon: 'add-outline',
+      role: 'primary',
+      onPress: () => navigation.navigate('MedicationForm', {}),
+      accessibilityLabel: 'Add medication',
+      identifier: 'medications-list-add',
+    },
+  });
 
   const renderMedItem = ({ item }: { item: Medication }) => {
     const typeLabel = MEDICATION_TYPES.find((t) => t.id === item.type_id)?.label ?? item.type_id;
@@ -82,7 +94,7 @@ const MedicationsListScreen: React.FC<MedicationsListScreenProps> = ({ navigatio
             ) : null}
           </View>
         </View>
-        <Icon name="chevron-forward" size={16} color="#9CA3AF" />
+        <Icon name="chevron-forward" size={16} color={iconDecorative} />
       </TouchableOpacity>
     );
   };
@@ -107,7 +119,7 @@ const MedicationsListScreen: React.FC<MedicationsListScreenProps> = ({ navigatio
         </View>
       ) : sections.length === 0 ? (
         <View className="flex-1 items-center justify-center p-8">
-          <Icon name="wellness" size={48} color="#9CA3AF" />
+          <Icon name="wellness" size={48} color={iconDecorative} />
           <Text className="text-text-muted text-lg mt-4 text-center">No medications yet</Text>
           <Text className="text-text-muted text-sm mt-2 text-center">
             Add your first medication to start tracking.
@@ -142,16 +154,6 @@ const MedicationsListScreen: React.FC<MedicationsListScreenProps> = ({ navigatio
           contentInsetAdjustmentBehavior={usesNativeHeader ? 'automatic' : 'never'}
           refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={accentColor} />}
         />
-      )}
-      {sections.length > 0 && (
-        <TouchableOpacity
-          className="absolute bottom-6 right-6 w-14 h-14 bg-accent-primary rounded-full items-center justify-center shadow-lg"
-          style={{ bottom: insets.bottom + 80 + activeWorkoutBarPadding }}
-          onPress={() => navigation.navigate('MedicationForm', {})}
-          activeOpacity={0.8}
-        >
-          <Icon name="add" size={28} color="#FFFFFF" />
-        </TouchableOpacity>
       )}
     </View>
   );

--- a/SparkyFitnessMobile/src/screens/MedicationsListScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationsListScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useMemo } from 'react';
-import { View, Text, FlatList, RefreshControl, TouchableOpacity, Alert } from 'react-native';
+import { View, Text, SectionList, RefreshControl, TouchableOpacity, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
 import { useCSSVariable } from 'uniwind';
@@ -143,21 +143,14 @@ const MedicationsListScreen: React.FC<MedicationsListScreenProps> = ({ navigatio
           </TouchableOpacity>
         </View>
       ) : (
-        <FlatList
-          data={sections}
-          keyExtractor={(section) => section.title}
-          renderItem={({ item: section }) => (
-            <View>
-              <Text className="text-xs font-semibold text-text-muted uppercase tracking-wide px-4 pt-4 pb-1">
-                {section.title}
-              </Text>
-              {section.data.map((med) => (
-                <View key={med.id}>
-                  {renderMedItem({ item: med })}
-                  <View className="h-px bg-chrome-border ml-4" />
-                </View>
-              ))}
-            </View>
+        <SectionList
+          sections={sections}
+          keyExtractor={(item) => item.id}
+          renderItem={renderMedItem}
+          renderSectionHeader={({ section }) => (
+            <Text className="text-xs font-semibold text-text-muted uppercase tracking-wide px-4 pt-4 pb-1">
+              {section.title}
+            </Text>
           )}
           contentContainerStyle={{
             paddingBottom: insets.bottom + 80 + activeWorkoutBarPadding,

--- a/SparkyFitnessMobile/src/screens/MedicationsListScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationsListScreen.tsx
@@ -1,0 +1,160 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { View, Text, FlatList, RefreshControl, TouchableOpacity, Alert } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useCSSVariable } from 'uniwind';
+import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
+import { useMedications, useDeleteMedication } from '../hooks/useMedications';
+import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
+import { useScreenHeader } from '../hooks/useScreenHeader';
+import Icon from '../components/Icon';
+import type { RootStackScreenProps } from '../types/navigation';
+import type { Medication } from '../types/medications';
+import { MEDICATION_TYPES } from '../types/medications';
+
+type MedicationsListScreenProps = RootStackScreenProps<'MedicationsList'>;
+
+const MedicationsListScreen: React.FC<MedicationsListScreenProps> = ({ navigation }) => {
+  const insets = useSafeAreaInsets();
+  const usesNativeHeader = useNativeIOSHeadersActive();
+  const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
+  const accentColor = useCSSVariable('--color-accent-primary') as string;
+  const [refreshing, setRefreshing] = useState(false);
+
+  const { data: medications, isLoading, isError, refetch } = useMedications();
+  const deleteMedicationMutation = useDeleteMedication();
+
+  const { active, inactive } = useMemo(() => {
+    const meds = medications ?? [];
+    return {
+      active: meds.filter((m) => m.is_active),
+      inactive: meds.filter((m) => !m.is_active),
+    };
+  }, [medications]);
+
+  const handleDelete = useCallback(
+    (med: Medication) => {
+      Alert.alert(
+        'Delete Medication',
+        `Are you sure you want to delete '${med.name}'? This will also remove all schedules and logged entries.`,
+        [
+          { text: 'Cancel', style: 'cancel' },
+          {
+            text: 'Delete',
+            style: 'destructive',
+            onPress: () => deleteMedicationMutation.mutate(med.id),
+          },
+        ],
+      );
+    },
+    [deleteMedicationMutation],
+  );
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true);
+    await refetch();
+    setRefreshing(false);
+  }, [refetch]);
+
+  const header = useScreenHeader({ title: 'Medications', left: { kind: 'back' } });
+
+  const renderMedItem = ({ item }: { item: Medication }) => {
+    const typeLabel = MEDICATION_TYPES.find((t) => t.id === item.type_id)?.label ?? item.type_id;
+    const doseLabel = item.dose_amount != null ? `${item.dose_amount} ${item.dose_unit ?? ''}`.trim() : '';
+
+    return (
+      <TouchableOpacity
+        className="py-3 px-4 bg-surface flex-row items-center"
+        onPress={() => navigation.navigate('MedicationDetail', { medicationId: item.id })}
+        onLongPress={() => handleDelete(item)}
+        activeOpacity={0.7}
+      >
+        <View className="flex-1">
+          <Text className={`text-base ${item.is_active ? 'text-text-primary' : 'text-text-muted'}`} numberOfLines={1}>
+            {item.name}
+          </Text>
+          <View className="flex-row items-center mt-1">
+            <Text className="text-xs text-text-secondary">{typeLabel}</Text>
+            {doseLabel ? (
+              <Text className="text-xs text-text-muted ml-2">· {doseLabel}</Text>
+            ) : null}
+            {item.reason ? (
+              <Text className="text-xs text-text-muted ml-2" numberOfLines={1}>· {item.reason}</Text>
+            ) : null}
+          </View>
+        </View>
+        <Icon name="chevron-forward" size={16} color="#9CA3AF" />
+      </TouchableOpacity>
+    );
+  };
+
+  const sections: { title: string; data: Medication[] }[] = [];
+  if (active.length > 0) sections.push({ title: 'Active', data: active });
+  if (inactive.length > 0) sections.push({ title: 'Inactive', data: inactive });
+
+  return (
+    <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
+      {header}
+      {isLoading ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-text-muted text-base">Loading medications...</Text>
+        </View>
+      ) : isError ? (
+        <View className="flex-1 items-center justify-center p-8">
+          <Text className="text-text-muted text-base text-center">Failed to load medications.</Text>
+          <TouchableOpacity onPress={() => void refetch()} className="mt-4">
+            <Text className="text-accent-primary text-base font-medium">Retry</Text>
+          </TouchableOpacity>
+        </View>
+      ) : sections.length === 0 ? (
+        <View className="flex-1 items-center justify-center p-8">
+          <Icon name="wellness" size={48} color="#9CA3AF" />
+          <Text className="text-text-muted text-lg mt-4 text-center">No medications yet</Text>
+          <Text className="text-text-muted text-sm mt-2 text-center">
+            Add your first medication to start tracking.
+          </Text>
+          <TouchableOpacity
+            className="mt-4 bg-accent-primary px-6 py-3 rounded-xl"
+            onPress={() => navigation.navigate('MedicationForm', {})}
+          >
+            <Text className="text-white font-semibold">Add Medication</Text>
+          </TouchableOpacity>
+        </View>
+      ) : (
+        <FlatList
+          data={sections}
+          keyExtractor={(section) => section.title}
+          renderItem={({ item: section }) => (
+            <View>
+              <Text className="text-xs font-semibold text-text-muted uppercase tracking-wide px-4 pt-4 pb-1">
+                {section.title}
+              </Text>
+              {section.data.map((med) => (
+                <View key={med.id}>
+                  {renderMedItem({ item: med })}
+                  <View className="h-px bg-chrome-border ml-4" />
+                </View>
+              ))}
+            </View>
+          )}
+          contentContainerStyle={{
+            paddingBottom: insets.bottom + 80 + activeWorkoutBarPadding,
+          }}
+          contentInsetAdjustmentBehavior={usesNativeHeader ? 'automatic' : 'never'}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={accentColor} />}
+        />
+      )}
+      {sections.length > 0 && (
+        <TouchableOpacity
+          className="absolute bottom-6 right-6 w-14 h-14 bg-accent-primary rounded-full items-center justify-center shadow-lg"
+          style={{ bottom: insets.bottom + 80 + activeWorkoutBarPadding }}
+          onPress={() => navigation.navigate('MedicationForm', {})}
+          activeOpacity={0.8}
+        >
+          <Icon name="add" size={28} color="#FFFFFF" />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+};
+
+export default MedicationsListScreen;

--- a/SparkyFitnessMobile/src/services/api/medicationsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/medicationsApi.ts
@@ -12,11 +12,11 @@ const SERVICE_NAME = 'Medications API';
 
 export const listMedications = async (opts?: {
   activeOnly?: boolean;
-}): Promise<Medication[]> => {
+}): Promise<MedicationDetail[]> => {
   const params = new URLSearchParams();
   if (opts?.activeOnly) params.set('activeOnly', 'true');
   const qs = params.toString();
-  const result = await apiFetch<Medication[] | null>({
+  const result = await apiFetch<MedicationDetail[] | null>({
     endpoint: `/api/v2/medications${qs ? `?${qs}` : ''}`,
     serviceName: SERVICE_NAME,
     operation: 'list medications',

--- a/SparkyFitnessMobile/src/services/api/medicationsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/medicationsApi.ts
@@ -6,8 +6,6 @@ import type {
   CreateMedicationInput,
   UpdateMedicationInput,
   CreateMedicationEntryInput,
-  UpdateMedicationEntryInput,
-  CreateScheduleInput,
 } from '../../types/medications';
 
 const SERVICE_NAME = 'Medications API';
@@ -59,26 +57,6 @@ export const deleteMedication = (id: string): Promise<void> =>
     method: 'DELETE',
   });
 
-export const addSchedule = (
-  medicationId: string,
-  body: CreateScheduleInput,
-): Promise<MedicationDetail['schedules'][number]> =>
-  apiFetch<MedicationDetail['schedules'][number]>({
-    endpoint: `/api/v2/medications/${medicationId}/schedules`,
-    serviceName: SERVICE_NAME,
-    operation: 'add schedule',
-    method: 'POST',
-    body,
-  });
-
-export const deleteSchedule = (id: string): Promise<void> =>
-  apiFetch<void>({
-    endpoint: `/api/v2/medications/schedules/${id}`,
-    serviceName: SERVICE_NAME,
-    operation: 'delete schedule',
-    method: 'DELETE',
-  });
-
 export const listEntries = async (opts?: {
   fromDate?: string;
   toDate?: string;
@@ -103,18 +81,6 @@ export const createEntry = (body: CreateMedicationEntryInput): Promise<Medicatio
     serviceName: SERVICE_NAME,
     operation: 'create entry',
     method: 'POST',
-    body,
-  });
-
-export const updateEntry = (
-  id: string,
-  body: UpdateMedicationEntryInput,
-): Promise<MedicationEntry> =>
-  apiFetch<MedicationEntry>({
-    endpoint: `/api/v2/medications/entries/${id}`,
-    serviceName: SERVICE_NAME,
-    operation: 'update entry',
-    method: 'PUT',
     body,
   });
 

--- a/SparkyFitnessMobile/src/services/api/medicationsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/medicationsApi.ts
@@ -1,0 +1,127 @@
+import { apiFetch } from './apiClient';
+import type {
+  Medication,
+  MedicationDetail,
+  MedicationEntry,
+  CreateMedicationInput,
+  UpdateMedicationInput,
+  CreateMedicationEntryInput,
+  UpdateMedicationEntryInput,
+  CreateScheduleInput,
+} from '../../types/medications';
+
+const SERVICE_NAME = 'Medications API';
+
+export const listMedications = async (opts?: {
+  activeOnly?: boolean;
+}): Promise<Medication[]> => {
+  const params = new URLSearchParams();
+  if (opts?.activeOnly) params.set('activeOnly', 'true');
+  const qs = params.toString();
+  const result = await apiFetch<Medication[] | null>({
+    endpoint: `/api/v2/medications${qs ? `?${qs}` : ''}`,
+    serviceName: SERVICE_NAME,
+    operation: 'list medications',
+  });
+  return result ?? [];
+};
+
+export const getMedication = (id: string): Promise<MedicationDetail> =>
+  apiFetch<MedicationDetail>({
+    endpoint: `/api/v2/medications/${id}`,
+    serviceName: SERVICE_NAME,
+    operation: 'get medication',
+  });
+
+export const createMedication = (body: CreateMedicationInput): Promise<Medication> =>
+  apiFetch<Medication>({
+    endpoint: '/api/v2/medications',
+    serviceName: SERVICE_NAME,
+    operation: 'create medication',
+    method: 'POST',
+    body,
+  });
+
+export const updateMedication = (id: string, body: UpdateMedicationInput): Promise<Medication> =>
+  apiFetch<Medication>({
+    endpoint: `/api/v2/medications/${id}`,
+    serviceName: SERVICE_NAME,
+    operation: 'update medication',
+    method: 'PUT',
+    body,
+  });
+
+export const deleteMedication = (id: string): Promise<void> =>
+  apiFetch<void>({
+    endpoint: `/api/v2/medications/${id}`,
+    serviceName: SERVICE_NAME,
+    operation: 'delete medication',
+    method: 'DELETE',
+  });
+
+export const addSchedule = (
+  medicationId: string,
+  body: CreateScheduleInput,
+): Promise<MedicationDetail['schedules'][number]> =>
+  apiFetch<MedicationDetail['schedules'][number]>({
+    endpoint: `/api/v2/medications/${medicationId}/schedules`,
+    serviceName: SERVICE_NAME,
+    operation: 'add schedule',
+    method: 'POST',
+    body,
+  });
+
+export const deleteSchedule = (id: string): Promise<void> =>
+  apiFetch<void>({
+    endpoint: `/api/v2/medications/schedules/${id}`,
+    serviceName: SERVICE_NAME,
+    operation: 'delete schedule',
+    method: 'DELETE',
+  });
+
+export const listEntries = async (opts?: {
+  fromDate?: string;
+  toDate?: string;
+  medicationId?: string;
+}): Promise<MedicationEntry[]> => {
+  const params = new URLSearchParams();
+  if (opts?.fromDate) params.set('fromDate', opts.fromDate);
+  if (opts?.toDate) params.set('toDate', opts.toDate);
+  if (opts?.medicationId) params.set('medicationId', opts.medicationId);
+  const qs = params.toString();
+  const result = await apiFetch<MedicationEntry[] | null>({
+    endpoint: `/api/v2/medications/entries${qs ? `?${qs}` : ''}`,
+    serviceName: SERVICE_NAME,
+    operation: 'list entries',
+  });
+  return result ?? [];
+};
+
+export const createEntry = (body: CreateMedicationEntryInput): Promise<MedicationEntry> =>
+  apiFetch<MedicationEntry>({
+    endpoint: '/api/v2/medications/entries',
+    serviceName: SERVICE_NAME,
+    operation: 'create entry',
+    method: 'POST',
+    body,
+  });
+
+export const updateEntry = (
+  id: string,
+  body: UpdateMedicationEntryInput,
+): Promise<MedicationEntry> =>
+  apiFetch<MedicationEntry>({
+    endpoint: `/api/v2/medications/entries/${id}`,
+    serviceName: SERVICE_NAME,
+    operation: 'update entry',
+    method: 'PUT',
+    body,
+  });
+
+export const deleteEntry = (id: string): Promise<void> =>
+  apiFetch<void>({
+    endpoint: `/api/v2/medications/entries/${id}`,
+    serviceName: SERVICE_NAME,
+    operation: 'delete entry',
+    method: 'DELETE',
+  });

--- a/SparkyFitnessMobile/src/services/backgroundSyncService.ts
+++ b/SparkyFitnessMobile/src/services/backgroundSyncService.ts
@@ -22,6 +22,9 @@ import {
 } from './storage';
 import { queryClient } from '../hooks/queryClient';
 import { refreshHealthSyncCache } from '../hooks/refreshHealthSyncCache';
+import { listMedications, listEntries } from './api/medicationsApi';
+import { reconcileMedicationReminders } from './medicationReminderService';
+import { getTodayDate } from '../utils/dateUtils';
 
 const isAppActive = (): boolean => AppState.currentState === 'active';
 
@@ -184,6 +187,20 @@ const performBackgroundSyncInternal = async (taskId: string): Promise<void> => {
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     await addLog(`[Background Sync] Writeback phase failed: ${message}`, 'ERROR');
+  }
+
+  // Fetch fresh schedules from the server and updates
+  // scheduled local notifications
+  try {
+    const today = getTodayDate();
+    const [medications, entries] = await Promise.all([
+      listMedications({ activeOnly: true }),
+      listEntries({ fromDate: today, toDate: today }),
+    ]);
+    await reconcileMedicationReminders(medications, entries);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await addLog(`[Background Sync] Medication reminder reconciliation failed: ${message}`, 'ERROR');
   }
 };
 

--- a/SparkyFitnessMobile/src/services/backgroundSyncService.ts
+++ b/SparkyFitnessMobile/src/services/backgroundSyncService.ts
@@ -25,6 +25,7 @@ import { refreshHealthSyncCache } from '../hooks/refreshHealthSyncCache';
 import { listMedications, listEntries } from './api/medicationsApi';
 import { reconcileMedicationReminders } from './medicationReminderService';
 import { getTodayDate } from '../utils/dateUtils';
+import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 
 const isAppActive = (): boolean => AppState.currentState === 'active';
 
@@ -189,14 +190,19 @@ const performBackgroundSyncInternal = async (taskId: string): Promise<void> => {
     await addLog(`[Background Sync] Writeback phase failed: ${message}`, 'ERROR');
   }
 
-  // Fetch fresh schedules from the server and updates
-  // scheduled local notifications
+  // Reconcile medication reminders against fresh server schedules. With
+  // reminders disabled the fetches are skipped but the reconcile still runs
+  // so any pending reminders get cancelled.
   try {
+    const prefs = useAppPreferencesStore.getState();
+    const remindersActive = prefs.medicationRemindersEnabled && prefs.notificationsEnabled;
     const today = getTodayDate();
-    const [medications, entries] = await Promise.all([
-      listMedications({ activeOnly: true }),
-      listEntries({ fromDate: today, toDate: today }),
-    ]);
+    const [medications, entries] = remindersActive
+      ? await Promise.all([
+          listMedications({ activeOnly: true }),
+          listEntries({ fromDate: today, toDate: today }),
+        ])
+      : [[], []];
     await reconcileMedicationReminders(medications, entries);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/SparkyFitnessMobile/src/services/medicationNotificationHandler.ts
+++ b/SparkyFitnessMobile/src/services/medicationNotificationHandler.ts
@@ -33,7 +33,7 @@ export function initMedicationNotificationActions(): void {
       return;
     }
 
-    void handleNotificationAction(status, medicationId, scheduleId ?? null, entryDate, response.notification.request.identifier, data?.key ?? null);
+    void handleNotificationAction(status, medicationId, scheduleId ?? null, entryDate, response.notification.request.identifier, data?.baseKey ?? data?.key ?? null);
   });
 }
 
@@ -69,8 +69,8 @@ async function handleNotificationAction(
 
     if (key) {
       const allPending = await Notifications.getAllScheduledNotificationsAsync();
-      const repeats = allPending.filter((n) => n.content.data?.key === key);
-      await Promise.all(repeats.map((n) =>
+      const toCancel = allPending.filter((n) => n.content.data?.baseKey === key);
+      await Promise.all(toCancel.map((n) =>
         Notifications.cancelScheduledNotificationAsync(n.identifier).catch(() => {}),
       ));
     }

--- a/SparkyFitnessMobile/src/services/medicationNotificationHandler.ts
+++ b/SparkyFitnessMobile/src/services/medicationNotificationHandler.ts
@@ -1,0 +1,78 @@
+import { addNotificationResponseListener, dismissDeliveredNotification, MEDICATION_TAKEN_ACTION, MEDICATION_SKIP_ACTION } from './notifications';
+import { createEntry, listEntries } from './api/medicationsApi';
+import { addLog } from '../services/LogService';
+import type { MedicationEntryStatus } from '../types/medications';
+
+let initialized = false;
+
+export function initMedicationNotificationActions(): void {
+  if (initialized) return;
+  initialized = true;
+
+  addNotificationResponseListener((response) => {
+    const actionId = response.actionIdentifier;
+
+    let status: MedicationEntryStatus | null = null;
+    if (actionId === MEDICATION_TAKEN_ACTION) {
+      status = 'taken';
+    } else if (actionId === MEDICATION_SKIP_ACTION) {
+      status = 'skipped';
+    }
+
+    if (!status) return;
+
+    const content = response.notification.request.content;
+    const data = content.data as Record<string, string | undefined>;
+    const medicationId = data?.medicationId;
+    const scheduleId = data?.scheduleId;
+    const entryDate = data?.entryDate;
+
+    if (!medicationId || !entryDate) {
+      addLog('[MedicationNotificationAction] Missing required data in notification', 'WARNING');
+      return;
+    }
+
+    void handleNotificationAction(status, medicationId, scheduleId ?? null, entryDate, response.notification.request.identifier);
+  });
+}
+
+async function handleNotificationAction(
+  status: MedicationEntryStatus,
+  medicationId: string,
+  scheduleId: string | null,
+  entryDate: string,
+  notificationId: string,
+): Promise<void> {
+  try {
+    const existing = await listEntries({ fromDate: entryDate, toDate: entryDate, medicationId });
+    const duplicate = existing.find(
+      (e) =>
+        e.medication_id === medicationId &&
+        ((scheduleId && e.schedule_id === scheduleId) || (!scheduleId && !e.schedule_id)) &&
+        (e.status === 'taken' || e.status === 'skipped'),
+    );
+
+    if (duplicate) {
+      await dismissDeliveredNotification(notificationId);
+      return;
+    }
+
+    await createEntry({
+      medication_id: medicationId,
+      schedule_id: scheduleId,
+      status,
+      entry_date: entryDate,
+      taken_at: status === 'taken' ? new Date().toISOString() : undefined,
+    });
+
+    await dismissDeliveredNotification(notificationId);
+    addLog(`[MedicationNotificationAction] Logged medication ${medicationId} as ${status}`, 'DEBUG');
+  } catch (error) {
+    addLog(`[MedicationNotificationAction] Failed to log medication: ${(error as Error).message}`, 'ERROR');
+  }
+}
+
+/** Test-only helper — resets module-level state. */
+export function __resetMedicationNotificationStateForTests(): void {
+  initialized = false;
+}

--- a/SparkyFitnessMobile/src/services/medicationNotificationHandler.ts
+++ b/SparkyFitnessMobile/src/services/medicationNotificationHandler.ts
@@ -1,3 +1,4 @@
+import * as Notifications from 'expo-notifications';
 import { addNotificationResponseListener, dismissDeliveredNotification, MEDICATION_TAKEN_ACTION, MEDICATION_SKIP_ACTION } from './notifications';
 import { createEntry, listEntries } from './api/medicationsApi';
 import { addLog } from '../services/LogService';
@@ -32,7 +33,7 @@ export function initMedicationNotificationActions(): void {
       return;
     }
 
-    void handleNotificationAction(status, medicationId, scheduleId ?? null, entryDate, response.notification.request.identifier);
+    void handleNotificationAction(status, medicationId, scheduleId ?? null, entryDate, response.notification.request.identifier, data?.key ?? null);
   });
 }
 
@@ -42,6 +43,7 @@ async function handleNotificationAction(
   scheduleId: string | null,
   entryDate: string,
   notificationId: string,
+  key: string | null,
 ): Promise<void> {
   try {
     const existing = await listEntries({ fromDate: entryDate, toDate: entryDate, medicationId });
@@ -64,6 +66,14 @@ async function handleNotificationAction(
       entry_date: entryDate,
       taken_at: status === 'taken' ? new Date().toISOString() : undefined,
     });
+
+    if (key) {
+      const allPending = await Notifications.getAllScheduledNotificationsAsync();
+      const repeats = allPending.filter((n) => n.content.data?.key === key);
+      await Promise.all(repeats.map((n) =>
+        Notifications.cancelScheduledNotificationAsync(n.identifier).catch(() => {}),
+      ));
+    }
 
     await dismissDeliveredNotification(notificationId);
     addLog(`[MedicationNotificationAction] Logged medication ${medicationId} as ${status}`, 'DEBUG');

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -6,8 +6,9 @@ import { getDueDosesForDate } from '@workspace/shared';
 import { ensureNotificationPermission, MEDICATION_REMINDER_CATEGORY } from './notifications';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import type { MedicationDetail, MedicationEntry } from '../types/medications';
+import { addLog } from './LogService';
 
-const CHANNEL_ID = 'medication-reminders';
+export const CHANNEL_ID = 'medication-reminders';
 const REPEAT_MINUTES = [10, 20, 30];
 const schedulingLock = new Set<string>();
 
@@ -45,7 +46,8 @@ async function scheduleReminder(
         channelId: CHANNEL_ID,
       },
     });
-  } catch {
+  } catch (err) {
+    addLog(`scheduleReminder failed: ${(err as Error).message}`, 'ERROR');
     return null;
   }
 }

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native';
 import * as Notifications from 'expo-notifications';
 
-import { getTodayDate, addDays } from '../utils/dateUtils';
+import { getTodayDate } from '../utils/dateUtils';
 import { getDueDosesForDate } from '@workspace/shared';
 import { ensureNotificationPermission, MEDICATION_REMINDER_CATEGORY } from './notifications';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
@@ -10,7 +10,6 @@ import { addLog } from './LogService';
 
 export const CHANNEL_ID = 'medication-reminders';
 const REPEAT_MINUTES = [10, 20, 30];
-const LOOKAHEAD_DAYS = 7;
 const schedulingLock = new Set<string>();
 
 function medReminderKey(medicationId: string, scheduleId: string, date: string, timeOfDay: string) {
@@ -58,7 +57,7 @@ async function scheduleReminder(
 }
 
 /**
- * Reconcile medication reminder notifications for today and the next 7 days.
+ * Reconcile medication reminder notifications for today.
  * Can be called from the foreground or background.
  *
  * Uses Notifications.getAllScheduledNotificationsAsync() instead of an
@@ -97,35 +96,30 @@ export async function reconcileMedicationReminders(
     }
 
     const today = getTodayDate();
+    const dueDoses = getDueDosesForDate(medications, today);
 
     const unloggedKeys = new Set<string>();
-    const allDueByDay: { date: string; due: ReturnType<typeof getDueDosesForDate>[number] }[] = [];
+    const unloggedDoses: { due: ReturnType<typeof getDueDosesForDate>[number]; timeOfDay: string }[] = [];
 
-    for (let i = 0; i <= LOOKAHEAD_DAYS; i++) {
-      const date = addDays(today, i);
-      const dueDoses = getDueDosesForDate(medications, date);
+    for (const due of dueDoses) {
+      const timeOfDay = due.schedule.time_of_day;
+      if (!timeOfDay) continue;
 
-      for (const due of dueDoses) {
-        allDueByDay.push({ date, due });
+      const isLogged = entries.some(
+        (e) =>
+          e.medication_id === due.medication.id &&
+          e.schedule_id === due.schedule.id &&
+          (e.status === 'taken' || e.status === 'skipped'),
+      );
 
-        const isLogged = i === 0 && entries.some(
-          (e) =>
-            e.medication_id === due.medication.id &&
-            e.schedule_id === due.schedule.id &&
-            e.entry_date === today &&
-            (e.status === 'taken' || e.status === 'skipped'),
-        );
+      if (!isLogged) {
+        const baseKey = medReminderKey(due.medication.id, due.schedule.id, today, timeOfDay);
+        unloggedKeys.add(baseKey);
+        unloggedDoses.push({ due, timeOfDay });
 
-        if (!isLogged) {
-          const timeOfDay = due.schedule.time_of_day;
-          if (timeOfDay) {
-            const baseKey = medReminderKey(due.medication.id, due.schedule.id, date, timeOfDay);
-            unloggedKeys.add(baseKey);
-            if (prefs.medicationReminderRepeats) {
-              for (const offset of REPEAT_MINUTES) {
-                unloggedKeys.add(repeatMedReminderKey(baseKey, offset));
-              }
-            }
+        if (prefs.medicationReminderRepeats) {
+          for (const offset of REPEAT_MINUTES) {
+            unloggedKeys.add(repeatMedReminderKey(baseKey, offset));
           }
         }
       }
@@ -147,35 +141,30 @@ export async function reconcileMedicationReminders(
         .map((n) => n.content.data?.key as string),
     );
 
-    for (const { date, due } of allDueByDay) {
-      const timeOfDay = due.schedule.time_of_day;
-      if (!timeOfDay) continue;
-
-      const baseKey = medReminderKey(due.medication.id, due.schedule.id, date, timeOfDay);
-      if (!unloggedKeys.has(baseKey)) continue;
+    for (const { due, timeOfDay } of unloggedDoses) {
+      const baseKey = medReminderKey(due.medication.id, due.schedule.id, today, timeOfDay);
+      if (pendingKeys.has(baseKey)) continue;
 
       const [hours, minutes] = timeOfDay.split(':').map(Number);
       const body = `Time to take ${due.medication.name}${due.medication.dose_amount != null ? ` (${due.medication.dose_amount} ${due.medication.dose_unit ?? ''})` : ''}`;
       const data = {
         medicationId: due.medication.id,
         scheduleId: due.schedule.id,
-        entryDate: date,
+        entryDate: today,
         key: baseKey,
         baseKey,
       };
 
-      // Build trigger date for this specific day
-      const [year, month, day] = date.split('-').map(Number);
+      const [year, month, day] = today.split('-').map(Number);
       const triggerDate = new Date(year, month - 1, day, hours, minutes, 0, 0);
-      if (triggerDate.getTime() > Date.now() && !pendingKeys.has(baseKey)) {
+      if (triggerDate.getTime() > Date.now()) {
         await scheduleReminder(body, triggerDate, data);
       }
 
-      // Repeat reminders (+10, +20, +30 min)
       if (prefs.medicationReminderRepeats) {
         for (const offset of REPEAT_MINUTES) {
           const repeatKey = repeatMedReminderKey(baseKey, offset);
-          if (!unloggedKeys.has(repeatKey) || pendingKeys.has(repeatKey)) continue;
+          if (pendingKeys.has(repeatKey)) continue;
           const repeatDate = new Date(triggerDate.getTime() + offset * 60000);
           if (repeatDate.getTime() > Date.now()) {
             await scheduleReminder(body, repeatDate, { ...data, key: repeatKey });

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -91,51 +91,39 @@ export async function reconcileMedicationReminders(
 
     const today = getTodayDate();
     const dueDoses = getDueDosesForDate(medications as any, today);
-    const allPending = await Notifications.getAllScheduledNotificationsAsync();
 
-    // Only consider notifications that are medication reminders (have medicationId in data)
-    const medReminders = allPending.filter((n) => n.content.data?.medicationId);
-    const todayPrefix = `med_${today}`;
-
-    // Cancel reminders for past dates
-    const staleReminders = medReminders.filter((n) => {
-      const key = n.content.data?.key as string | undefined;
-      return key && !key.startsWith(todayPrefix);
-    });
-    await cancelReminders(staleReminders.map((n) => n.identifier));
-
-    // Find which due doses don't have a logged entry
-    const unloggedDoses = dueDoses.filter((due) => {
-      return !entries.some(
-        (e) =>
-          e.medication_id === due.medication.id &&
-          e.schedule_id === due.schedule.id &&
-          (e.status === 'taken' || e.status === 'skipped'),
-      );
-    });
-
-    // Cancel reminders for doses that have been logged
-    const loggedKeys = new Set(
+    const unloggedKeys = new Set(
       dueDoses
-        .filter((due) => !unloggedDoses.includes(due))
+        .filter((due) =>
+          !entries.some(
+            (e) =>
+              e.medication_id === due.medication.id &&
+              e.schedule_id === due.schedule.id &&
+              (e.status === 'taken' || e.status === 'skipped'),
+          ),
+        )
         .map((due) => medReminderKey(due.medication.id, due.schedule.id, today)),
     );
-    const toCancel = medReminders.filter((n) => {
-      const key = n.content.data?.key as string | undefined;
-      return key && loggedKeys.has(key);
-    });
-    await cancelReminders(toCancel.map((n) => n.identifier));
 
-    // Schedule reminders for unlogged doses that don't already have one
-    const remainingKeys = new Set(
-      medReminders
-        .filter((n) => !toCancel.includes(n) && !staleReminders.includes(n))
+    const allPending = await Notifications.getAllScheduledNotificationsAsync();
+    const toCancel = allPending
+      .filter((n) => {
+        if (!n.content.data?.medicationId) return false;
+        const key = n.content.data.key as string | undefined;
+        return !key || !unloggedKeys.has(key);
+      })
+      .map((n) => n.identifier);
+    if (toCancel.length > 0) await cancelReminders(toCancel);
+
+    const pendingKeys = new Set(
+      allPending
+        .filter((n) => n.content.data?.medicationId && toCancel.indexOf(n.identifier) === -1)
         .map((n) => n.content.data?.key as string),
     );
 
-    for (const due of unloggedDoses) {
+    for (const due of dueDoses) {
       const key = medReminderKey(due.medication.id, due.schedule.id, today);
-      if (remainingKeys.has(key)) continue;
+      if (!unloggedKeys.has(key) || pendingKeys.has(key)) continue;
 
       const timeOfDay = due.schedule.time_of_day;
       if (!timeOfDay) continue;

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -3,12 +3,11 @@ import * as Notifications from 'expo-notifications';
 
 import { getTodayDate } from '../utils/dateUtils';
 import { getDueDosesForDate } from '@workspace/shared';
-import { ensureNotificationPermission, MEDICATION_REMINDER_CATEGORY } from './notifications';
+import { ensureNotificationPermission, MEDICATION_REMINDER_CATEGORY, MEDICATION_REMINDER_CHANNEL_ID } from './notifications';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import type { MedicationDetail, MedicationEntry } from '../types/medications';
 import { addLog } from './LogService';
 
-export const CHANNEL_ID = 'medication-reminders';
 const REPEAT_MINUTES = [10, 20, 30];
 const schedulingLock = new Set<string>();
 
@@ -47,7 +46,7 @@ async function scheduleReminder(
       trigger: {
         type: Notifications.SchedulableTriggerInputTypes.DATE,
         date: triggerDate,
-        channelId: CHANNEL_ID,
+        channelId: MEDICATION_REMINDER_CHANNEL_ID,
       },
     });
   } catch (err) {
@@ -88,7 +87,7 @@ export async function reconcileMedicationReminders(
     if (!granted) return;
 
     if (Platform.OS === 'android') {
-      await Notifications.setNotificationChannelAsync(CHANNEL_ID, {
+      await Notifications.setNotificationChannelAsync(MEDICATION_REMINDER_CHANNEL_ID, {
         name: 'Medication reminders',
         importance: Notifications.AndroidImportance.HIGH,
         enableVibrate: true,

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -3,7 +3,7 @@ import * as Notifications from 'expo-notifications';
 
 import { getTodayDate } from '../utils/dateUtils';
 import { getDueDosesForDate } from '@workspace/shared';
-import { ensureNotificationPermission, MEDICATION_REMINDER_CATEGORY, MEDICATION_REMINDER_CHANNEL_ID } from './notifications';
+import { hasNotificationPermission, MEDICATION_REMINDER_CATEGORY, MEDICATION_REMINDER_CHANNEL_ID } from './notifications';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import type { MedicationDetail, MedicationEntry } from '../types/medications';
 import { addLog } from './LogService';
@@ -83,8 +83,15 @@ export async function reconcileMedicationReminders(
       return;
     }
 
-    const granted = await ensureNotificationPermission();
-    if (!granted) return;
+    const granted = await hasNotificationPermission();
+    if (!granted) {
+      const all = await Notifications.getAllScheduledNotificationsAsync();
+      const medIds = all
+        .filter((n) => n.content.data?.medicationId)
+        .map((n) => n.identifier);
+      if (medIds.length > 0) await cancelReminders(medIds);
+      return;
+    }
 
     if (Platform.OS === 'android') {
       await Notifications.setNotificationChannelAsync(MEDICATION_REMINDER_CHANNEL_ID, {

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -13,8 +13,12 @@ const REPEAT_MINUTES = [10, 20, 30];
 const LOOKAHEAD_DAYS = 7;
 const schedulingLock = new Set<string>();
 
-function medReminderKey(medicationId: string, scheduleId: string, date: string) {
-  return `med_${date}_${medicationId}_${scheduleId}`;
+function medReminderKey(medicationId: string, scheduleId: string, date: string, timeOfDay: string) {
+  return `med_${date}_${medicationId}_${scheduleId}_${timeOfDay}`;
+}
+
+function repeatMedReminderKey(baseKey: string, offset: number) {
+  return `${baseKey}_${offset}`;
 }
 
 async function cancelReminders(ids: string[]): Promise<void> {
@@ -113,7 +117,16 @@ export async function reconcileMedicationReminders(
         );
 
         if (!isLogged) {
-          unloggedKeys.add(medReminderKey(due.medication.id, due.schedule.id, date));
+          const timeOfDay = due.schedule.time_of_day;
+          if (timeOfDay) {
+            const baseKey = medReminderKey(due.medication.id, due.schedule.id, date, timeOfDay);
+            unloggedKeys.add(baseKey);
+            if (prefs.medicationReminderRepeats) {
+              for (const offset of REPEAT_MINUTES) {
+                unloggedKeys.add(repeatMedReminderKey(baseKey, offset));
+              }
+            }
+          }
         }
       }
     }
@@ -135,11 +148,11 @@ export async function reconcileMedicationReminders(
     );
 
     for (const { date, due } of allDueByDay) {
-      const key = medReminderKey(due.medication.id, due.schedule.id, date);
-      if (!unloggedKeys.has(key) || pendingKeys.has(key)) continue;
-
       const timeOfDay = due.schedule.time_of_day;
       if (!timeOfDay) continue;
+
+      const baseKey = medReminderKey(due.medication.id, due.schedule.id, date, timeOfDay);
+      if (!unloggedKeys.has(baseKey)) continue;
 
       const [hours, minutes] = timeOfDay.split(':').map(Number);
       const body = `Time to take ${due.medication.name}${due.medication.dose_amount != null ? ` (${due.medication.dose_amount} ${due.medication.dose_unit ?? ''})` : ''}`;
@@ -147,22 +160,25 @@ export async function reconcileMedicationReminders(
         medicationId: due.medication.id,
         scheduleId: due.schedule.id,
         entryDate: date,
-        key,
+        key: baseKey,
+        baseKey,
       };
 
       // Build trigger date for this specific day
       const [year, month, day] = date.split('-').map(Number);
       const triggerDate = new Date(year, month - 1, day, hours, minutes, 0, 0);
-      if (triggerDate.getTime() > Date.now()) {
+      if (triggerDate.getTime() > Date.now() && !pendingKeys.has(baseKey)) {
         await scheduleReminder(body, triggerDate, data);
       }
 
       // Repeat reminders (+10, +20, +30 min)
       if (prefs.medicationReminderRepeats) {
         for (const offset of REPEAT_MINUTES) {
+          const repeatKey = repeatMedReminderKey(baseKey, offset);
+          if (!unloggedKeys.has(repeatKey) || pendingKeys.has(repeatKey)) continue;
           const repeatDate = new Date(triggerDate.getTime() + offset * 60000);
           if (repeatDate.getTime() > Date.now()) {
-            await scheduleReminder(body, repeatDate, data);
+            await scheduleReminder(body, repeatDate, { ...data, key: repeatKey });
           }
         }
       }

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -1,9 +1,13 @@
-import { Platform } from 'react-native';
 import * as Notifications from 'expo-notifications';
 
 import { getTodayDate } from '../utils/dateUtils';
 import { getDueDosesForDate } from '@workspace/shared';
-import { hasNotificationPermission, MEDICATION_REMINDER_CATEGORY, MEDICATION_REMINDER_CHANNEL_ID } from './notifications';
+import {
+  ensureMedicationReminderChannel,
+  hasNotificationPermission,
+  MEDICATION_REMINDER_CATEGORY,
+  MEDICATION_REMINDER_CHANNEL_ID,
+} from './notifications';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import type { MedicationDetail, MedicationEntry } from '../types/medications';
 import { addLog } from './LogService';
@@ -93,13 +97,7 @@ export async function reconcileMedicationReminders(
       return;
     }
 
-    if (Platform.OS === 'android') {
-      await Notifications.setNotificationChannelAsync(MEDICATION_REMINDER_CHANNEL_ID, {
-        name: 'Medication reminders',
-        importance: Notifications.AndroidImportance.HIGH,
-        enableVibrate: true,
-      });
-    }
+    await ensureMedicationReminderChannel();
 
     const today = getTodayDate();
     const dueDoses = getDueDosesForDate(medications, today);

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -1,0 +1,185 @@
+import { Platform } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Notifications from 'expo-notifications';
+
+import { getTodayDate } from '../utils/dateUtils';
+import { getDueDosesForDate } from '@workspace/shared';
+import { ensureNotificationPermission, MEDICATION_REMINDER_CATEGORY } from './notifications';
+import { useAppPreferencesStore } from '../stores/appPreferencesStore';
+import type { Medication, MedicationEntry } from '../types/medications';
+
+const STORAGE_KEY = '@Medications:reminderNotifications';
+const CHANNEL_ID = 'medication-reminders';
+const REPEAT_MINUTES = [10, 20, 30];
+
+interface StoredReminder {
+  key: string;
+  notificationIds: string[];
+}
+
+async function readStoredReminders(): Promise<StoredReminder[]> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeStoredReminders(reminders: StoredReminder[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(reminders));
+  } catch {
+    // best-effort
+  }
+}
+
+async function cancelReminders(ids: string[]): Promise<void> {
+  await Promise.all(ids.map(async (id) => {
+    try {
+      await Notifications.cancelScheduledNotificationAsync(id);
+    } catch {
+      // already cancelled or invalid
+    }
+  }));
+}
+
+async function scheduleReminder(
+  body: string,
+  triggerDate: Date,
+  data: Record<string, string>,
+): Promise<string | null> {
+  try {
+    return await Notifications.scheduleNotificationAsync({
+      content: {
+        title: 'Medication reminder',
+        body,
+        sound: true,
+        categoryIdentifier: MEDICATION_REMINDER_CATEGORY,
+        data,
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.DATE,
+        date: triggerDate,
+        channelId: CHANNEL_ID,
+      },
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reconcile medication reminder notifications for today.
+ * Can be called from the foreground or background
+ *
+ * @param medications - Active medications from the API
+ * @param entries - Today's medication entries from the API
+ */
+export async function reconcileMedicationReminders(
+  medications: Medication[],
+  entries: MedicationEntry[],
+): Promise<void> {
+  const prefs = useAppPreferencesStore.getState();
+  if (!prefs.medicationRemindersEnabled || !prefs.notificationsEnabled) {
+    const stored = await readStoredReminders();
+    if (stored.length > 0) {
+      await Promise.all(stored.map((r) => cancelReminders(r.notificationIds)));
+      await writeStoredReminders([]);
+    }
+    return;
+  }
+
+  const granted = await ensureNotificationPermission();
+  if (!granted) return;
+
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync(CHANNEL_ID, {
+      name: 'Medication reminders',
+      importance: Notifications.AndroidImportance.HIGH,
+      enableVibrate: true,
+    });
+  }
+
+  const today = getTodayDate();
+  const dueDoses = getDueDosesForDate(medications as any, today);
+  const stored = await readStoredReminders();
+  const todayPrefix = `med_${today}`;
+
+  // Cancel reminders for past dates
+  const staleReminders = stored.filter((r) => !r.key.startsWith(todayPrefix));
+  await Promise.all(staleReminders.map((r) => cancelReminders(r.notificationIds)));
+  const freshStored = stored.filter((r) => r.key.startsWith(todayPrefix));
+
+  // Find which due doses don't have a logged entry
+  const unloggedDoses = dueDoses.filter((due) => {
+    return !entries.some(
+      (e) =>
+        e.medication_id === due.medication.id &&
+        e.schedule_id === due.schedule.id &&
+        (e.status === 'taken' || e.status === 'skipped'),
+    );
+  });
+
+  // Cancel reminders for doses that have been logged
+  const loggedKeys = new Set(
+    dueDoses
+      .filter((due) => !unloggedDoses.includes(due))
+      .map((due) => `med_${today}_${due.medication.id}_${due.schedule.id}`),
+  );
+  const toCancel = freshStored.filter((r) => loggedKeys.has(r.key));
+  await Promise.all(toCancel.map((r) => cancelReminders(r.notificationIds)));
+  const afterCancel = freshStored.filter((r) => !loggedKeys.has(r.key));
+
+  // Schedule reminders for unlogged doses that don't already have one
+  const existingKeys = new Set(afterCancel.map((r) => r.key));
+  const newReminders: StoredReminder[] = [];
+
+  for (const due of unloggedDoses) {
+    const key = `med_${today}_${due.medication.id}_${due.schedule.id}`;
+    if (existingKeys.has(key)) continue;
+
+    const timeOfDay = due.schedule.time_of_day;
+    if (!timeOfDay) continue;
+
+    const [hours, minutes] = timeOfDay.split(':').map(Number);
+    const body = `Time to take ${due.medication.name}${due.medication.dose_amount != null ? ` (${due.medication.dose_amount} ${due.medication.dose_unit ?? ''})` : ''}`;
+    const data = {
+      medicationId: due.medication.id,
+      scheduleId: due.schedule.id,
+      entryDate: today,
+    };
+
+    const notificationIds: string[] = [];
+
+    // Initial reminder
+    const triggerDate = new Date();
+    triggerDate.setHours(hours, minutes, 0, 0);
+    if (triggerDate.getTime() > Date.now()) {
+      const id = await scheduleReminder(body, triggerDate, data);
+      if (id) notificationIds.push(id);
+    }
+
+    // Repeat reminders (+10, +20, +30 min)
+    if (prefs.medicationReminderRepeats) {
+      for (const offset of REPEAT_MINUTES) {
+        const repeatDate = new Date(triggerDate.getTime() + offset * 60000);
+        if (repeatDate.getTime() > Date.now()) {
+          const id = await scheduleReminder(body, repeatDate, data);
+          if (id) notificationIds.push(id);
+        }
+      }
+    }
+
+    if (notificationIds.length > 0) {
+      newReminders.push({ key, notificationIds });
+    }
+  }
+
+  if (newReminders.length > 0 || toCancel.length > 0) {
+    const updated = [...afterCancel, ...newReminders];
+    await writeStoredReminders(updated);
+  }
+}

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -108,6 +108,7 @@ export async function reconcileMedicationReminders(
           (e) =>
             e.medication_id === due.medication.id &&
             e.schedule_id === due.schedule.id &&
+            e.entry_date === today &&
             (e.status === 'taken' || e.status === 'skipped'),
         );
 

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -9,6 +9,7 @@ import type { Medication, MedicationEntry } from '../types/medications';
 
 const CHANNEL_ID = 'medication-reminders';
 const REPEAT_MINUTES = [10, 20, 30];
+const schedulingLock = new Set<string>();
 
 function medReminderKey(medicationId: string, scheduleId: string, date: string) {
   return `med_${date}_${medicationId}_${scheduleId}`;
@@ -63,102 +64,109 @@ export async function reconcileMedicationReminders(
   medications: Medication[],
   entries: MedicationEntry[],
 ): Promise<void> {
-  const prefs = useAppPreferencesStore.getState();
-  if (!prefs.medicationRemindersEnabled || !prefs.notificationsEnabled) {
-    const all = await Notifications.getAllScheduledNotificationsAsync();
-    const medIds = all
-      .filter((n) => n.content.data?.medicationId)
-      .map((n) => n.identifier);
-    if (medIds.length > 0) await cancelReminders(medIds);
-    return;
-  }
+  if (schedulingLock.has('medication-reminders')) return;
+  schedulingLock.add('medication-reminders');
 
-  const granted = await ensureNotificationPermission();
-  if (!granted) return;
-
-  if (Platform.OS === 'android') {
-    await Notifications.setNotificationChannelAsync(CHANNEL_ID, {
-      name: 'Medication reminders',
-      importance: Notifications.AndroidImportance.HIGH,
-      enableVibrate: true,
-    });
-  }
-
-  const today = getTodayDate();
-  const dueDoses = getDueDosesForDate(medications as any, today);
-  const allPending = await Notifications.getAllScheduledNotificationsAsync();
-
-  // Only consider notifications that are medication reminders (have medicationId in data)
-  const medReminders = allPending.filter((n) => n.content.data?.medicationId);
-  const todayPrefix = `med_${today}`;
-
-  // Cancel reminders for past dates
-  const staleReminders = medReminders.filter((n) => {
-    const key = n.content.data?.key as string | undefined;
-    return key && !key.startsWith(todayPrefix);
-  });
-  await cancelReminders(staleReminders.map((n) => n.identifier));
-
-  // Find which due doses don't have a logged entry
-  const unloggedDoses = dueDoses.filter((due) => {
-    return !entries.some(
-      (e) =>
-        e.medication_id === due.medication.id &&
-        e.schedule_id === due.schedule.id &&
-        (e.status === 'taken' || e.status === 'skipped'),
-    );
-  });
-
-  // Cancel reminders for doses that have been logged
-  const loggedKeys = new Set(
-    dueDoses
-      .filter((due) => !unloggedDoses.includes(due))
-      .map((due) => medReminderKey(due.medication.id, due.schedule.id, today)),
-  );
-  const toCancel = medReminders.filter((n) => {
-    const key = n.content.data?.key as string | undefined;
-    return key && loggedKeys.has(key);
-  });
-  await cancelReminders(toCancel.map((n) => n.identifier));
-
-  // Schedule reminders for unlogged doses that don't already have one
-  const remainingKeys = new Set(
-    medReminders
-      .filter((n) => !toCancel.includes(n) && !staleReminders.includes(n))
-      .map((n) => n.content.data?.key as string),
-  );
-
-  for (const due of unloggedDoses) {
-    const key = medReminderKey(due.medication.id, due.schedule.id, today);
-    if (remainingKeys.has(key)) continue;
-
-    const timeOfDay = due.schedule.time_of_day;
-    if (!timeOfDay) continue;
-
-    const [hours, minutes] = timeOfDay.split(':').map(Number);
-    const body = `Time to take ${due.medication.name}${due.medication.dose_amount != null ? ` (${due.medication.dose_amount} ${due.medication.dose_unit ?? ''})` : ''}`;
-    const data = {
-      medicationId: due.medication.id,
-      scheduleId: due.schedule.id,
-      entryDate: today,
-      key,
-    };
-
-    // Initial reminder
-    const triggerDate = new Date();
-    triggerDate.setHours(hours, minutes, 0, 0);
-    if (triggerDate.getTime() > Date.now()) {
-      await scheduleReminder(body, triggerDate, data);
+  try {
+    const prefs = useAppPreferencesStore.getState();
+    if (!prefs.medicationRemindersEnabled || !prefs.notificationsEnabled) {
+      const all = await Notifications.getAllScheduledNotificationsAsync();
+      const medIds = all
+        .filter((n) => n.content.data?.medicationId)
+        .map((n) => n.identifier);
+      if (medIds.length > 0) await cancelReminders(medIds);
+      return;
     }
 
-    // Repeat reminders (+10, +20, +30 min)
-    if (prefs.medicationReminderRepeats) {
-      for (const offset of REPEAT_MINUTES) {
-        const repeatDate = new Date(triggerDate.getTime() + offset * 60000);
-        if (repeatDate.getTime() > Date.now()) {
-          await scheduleReminder(body, repeatDate, data);
+    const granted = await ensureNotificationPermission();
+    if (!granted) return;
+
+    if (Platform.OS === 'android') {
+      await Notifications.setNotificationChannelAsync(CHANNEL_ID, {
+        name: 'Medication reminders',
+        importance: Notifications.AndroidImportance.HIGH,
+        enableVibrate: true,
+      });
+    }
+
+    const today = getTodayDate();
+    const dueDoses = getDueDosesForDate(medications as any, today);
+    const allPending = await Notifications.getAllScheduledNotificationsAsync();
+
+    // Only consider notifications that are medication reminders (have medicationId in data)
+    const medReminders = allPending.filter((n) => n.content.data?.medicationId);
+    const todayPrefix = `med_${today}`;
+
+    // Cancel reminders for past dates
+    const staleReminders = medReminders.filter((n) => {
+      const key = n.content.data?.key as string | undefined;
+      return key && !key.startsWith(todayPrefix);
+    });
+    await cancelReminders(staleReminders.map((n) => n.identifier));
+
+    // Find which due doses don't have a logged entry
+    const unloggedDoses = dueDoses.filter((due) => {
+      return !entries.some(
+        (e) =>
+          e.medication_id === due.medication.id &&
+          e.schedule_id === due.schedule.id &&
+          (e.status === 'taken' || e.status === 'skipped'),
+      );
+    });
+
+    // Cancel reminders for doses that have been logged
+    const loggedKeys = new Set(
+      dueDoses
+        .filter((due) => !unloggedDoses.includes(due))
+        .map((due) => medReminderKey(due.medication.id, due.schedule.id, today)),
+    );
+    const toCancel = medReminders.filter((n) => {
+      const key = n.content.data?.key as string | undefined;
+      return key && loggedKeys.has(key);
+    });
+    await cancelReminders(toCancel.map((n) => n.identifier));
+
+    // Schedule reminders for unlogged doses that don't already have one
+    const remainingKeys = new Set(
+      medReminders
+        .filter((n) => !toCancel.includes(n) && !staleReminders.includes(n))
+        .map((n) => n.content.data?.key as string),
+    );
+
+    for (const due of unloggedDoses) {
+      const key = medReminderKey(due.medication.id, due.schedule.id, today);
+      if (remainingKeys.has(key)) continue;
+
+      const timeOfDay = due.schedule.time_of_day;
+      if (!timeOfDay) continue;
+
+      const [hours, minutes] = timeOfDay.split(':').map(Number);
+      const body = `Time to take ${due.medication.name}${due.medication.dose_amount != null ? ` (${due.medication.dose_amount} ${due.medication.dose_unit ?? ''})` : ''}`;
+      const data = {
+        medicationId: due.medication.id,
+        scheduleId: due.schedule.id,
+        entryDate: today,
+        key,
+      };
+
+      // Initial reminder
+      const triggerDate = new Date();
+      triggerDate.setHours(hours, minutes, 0, 0);
+      if (triggerDate.getTime() > Date.now()) {
+        await scheduleReminder(body, triggerDate, data);
+      }
+
+      // Repeat reminders (+10, +20, +30 min)
+      if (prefs.medicationReminderRepeats) {
+        for (const offset of REPEAT_MINUTES) {
+          const repeatDate = new Date(triggerDate.getTime() + offset * 60000);
+          if (repeatDate.getTime() > Date.now()) {
+            await scheduleReminder(body, repeatDate, data);
+          }
         }
       }
     }
+  } finally {
+    schedulingLock.delete('medication-reminders');
   }
 }

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native';
 import * as Notifications from 'expo-notifications';
 
-import { getTodayDate } from '../utils/dateUtils';
+import { getTodayDate, addDays } from '../utils/dateUtils';
 import { getDueDosesForDate } from '@workspace/shared';
 import { ensureNotificationPermission, MEDICATION_REMINDER_CATEGORY } from './notifications';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
@@ -10,6 +10,7 @@ import { addLog } from './LogService';
 
 export const CHANNEL_ID = 'medication-reminders';
 const REPEAT_MINUTES = [10, 20, 30];
+const LOOKAHEAD_DAYS = 7;
 const schedulingLock = new Set<string>();
 
 function medReminderKey(medicationId: string, scheduleId: string, date: string) {
@@ -53,7 +54,7 @@ async function scheduleReminder(
 }
 
 /**
- * Reconcile medication reminder notifications for today.
+ * Reconcile medication reminder notifications for today and the next 7 days.
  * Can be called from the foreground or background.
  *
  * Uses Notifications.getAllScheduledNotificationsAsync() instead of an
@@ -92,20 +93,29 @@ export async function reconcileMedicationReminders(
     }
 
     const today = getTodayDate();
-    const dueDoses = getDueDosesForDate(medications, today);
 
-    const unloggedKeys = new Set(
-      dueDoses
-        .filter((due) =>
-          !entries.some(
-            (e) =>
-              e.medication_id === due.medication.id &&
-              e.schedule_id === due.schedule.id &&
-              (e.status === 'taken' || e.status === 'skipped'),
-          ),
-        )
-        .map((due) => medReminderKey(due.medication.id, due.schedule.id, today)),
-    );
+    const unloggedKeys = new Set<string>();
+    const allDueByDay: { date: string; due: ReturnType<typeof getDueDosesForDate>[number] }[] = [];
+
+    for (let i = 0; i <= LOOKAHEAD_DAYS; i++) {
+      const date = addDays(today, i);
+      const dueDoses = getDueDosesForDate(medications, date);
+
+      for (const due of dueDoses) {
+        allDueByDay.push({ date, due });
+
+        const isLogged = i === 0 && entries.some(
+          (e) =>
+            e.medication_id === due.medication.id &&
+            e.schedule_id === due.schedule.id &&
+            (e.status === 'taken' || e.status === 'skipped'),
+        );
+
+        if (!isLogged) {
+          unloggedKeys.add(medReminderKey(due.medication.id, due.schedule.id, date));
+        }
+      }
+    }
 
     const allPending = await Notifications.getAllScheduledNotificationsAsync();
     const toCancel = allPending
@@ -123,8 +133,8 @@ export async function reconcileMedicationReminders(
         .map((n) => n.content.data?.key as string),
     );
 
-    for (const due of dueDoses) {
-      const key = medReminderKey(due.medication.id, due.schedule.id, today);
+    for (const { date, due } of allDueByDay) {
+      const key = medReminderKey(due.medication.id, due.schedule.id, date);
       if (!unloggedKeys.has(key) || pendingKeys.has(key)) continue;
 
       const timeOfDay = due.schedule.time_of_day;
@@ -135,13 +145,13 @@ export async function reconcileMedicationReminders(
       const data = {
         medicationId: due.medication.id,
         scheduleId: due.schedule.id,
-        entryDate: today,
+        entryDate: date,
         key,
       };
 
-      // Initial reminder
-      const triggerDate = new Date();
-      triggerDate.setHours(hours, minutes, 0, 0);
+      // Build trigger date for this specific day
+      const [year, month, day] = date.split('-').map(Number);
+      const triggerDate = new Date(year, month - 1, day, hours, minutes, 0, 0);
       if (triggerDate.getTime() > Date.now()) {
         await scheduleReminder(body, triggerDate, data);
       }

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -1,5 +1,4 @@
 import { Platform } from 'react-native';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Notifications from 'expo-notifications';
 
 import { getTodayDate } from '../utils/dateUtils';
@@ -8,32 +7,11 @@ import { ensureNotificationPermission, MEDICATION_REMINDER_CATEGORY } from './no
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
 import type { Medication, MedicationEntry } from '../types/medications';
 
-const STORAGE_KEY = '@Medications:reminderNotifications';
 const CHANNEL_ID = 'medication-reminders';
 const REPEAT_MINUTES = [10, 20, 30];
 
-interface StoredReminder {
-  key: string;
-  notificationIds: string[];
-}
-
-async function readStoredReminders(): Promise<StoredReminder[]> {
-  try {
-    const raw = await AsyncStorage.getItem(STORAGE_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-async function writeStoredReminders(reminders: StoredReminder[]): Promise<void> {
-  try {
-    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(reminders));
-  } catch {
-    // best-effort
-  }
+function medReminderKey(medicationId: string, scheduleId: string, date: string) {
+  return `med_${date}_${medicationId}_${scheduleId}`;
 }
 
 async function cancelReminders(ids: string[]): Promise<void> {
@@ -73,7 +51,10 @@ async function scheduleReminder(
 
 /**
  * Reconcile medication reminder notifications for today.
- * Can be called from the foreground or background
+ * Can be called from the foreground or background.
+ *
+ * Uses Notifications.getAllScheduledNotificationsAsync() instead of an
+ * AsyncStorage ledger — every pending request already carries its content.data.
  *
  * @param medications - Active medications from the API
  * @param entries - Today's medication entries from the API
@@ -84,11 +65,11 @@ export async function reconcileMedicationReminders(
 ): Promise<void> {
   const prefs = useAppPreferencesStore.getState();
   if (!prefs.medicationRemindersEnabled || !prefs.notificationsEnabled) {
-    const stored = await readStoredReminders();
-    if (stored.length > 0) {
-      await Promise.all(stored.map((r) => cancelReminders(r.notificationIds)));
-      await writeStoredReminders([]);
-    }
+    const all = await Notifications.getAllScheduledNotificationsAsync();
+    const medIds = all
+      .filter((n) => n.content.data?.medicationId)
+      .map((n) => n.identifier);
+    if (medIds.length > 0) await cancelReminders(medIds);
     return;
   }
 
@@ -105,13 +86,18 @@ export async function reconcileMedicationReminders(
 
   const today = getTodayDate();
   const dueDoses = getDueDosesForDate(medications as any, today);
-  const stored = await readStoredReminders();
+  const allPending = await Notifications.getAllScheduledNotificationsAsync();
+
+  // Only consider notifications that are medication reminders (have medicationId in data)
+  const medReminders = allPending.filter((n) => n.content.data?.medicationId);
   const todayPrefix = `med_${today}`;
 
   // Cancel reminders for past dates
-  const staleReminders = stored.filter((r) => !r.key.startsWith(todayPrefix));
-  await Promise.all(staleReminders.map((r) => cancelReminders(r.notificationIds)));
-  const freshStored = stored.filter((r) => r.key.startsWith(todayPrefix));
+  const staleReminders = medReminders.filter((n) => {
+    const key = n.content.data?.key as string | undefined;
+    return key && !key.startsWith(todayPrefix);
+  });
+  await cancelReminders(staleReminders.map((n) => n.identifier));
 
   // Find which due doses don't have a logged entry
   const unloggedDoses = dueDoses.filter((due) => {
@@ -127,19 +113,24 @@ export async function reconcileMedicationReminders(
   const loggedKeys = new Set(
     dueDoses
       .filter((due) => !unloggedDoses.includes(due))
-      .map((due) => `med_${today}_${due.medication.id}_${due.schedule.id}`),
+      .map((due) => medReminderKey(due.medication.id, due.schedule.id, today)),
   );
-  const toCancel = freshStored.filter((r) => loggedKeys.has(r.key));
-  await Promise.all(toCancel.map((r) => cancelReminders(r.notificationIds)));
-  const afterCancel = freshStored.filter((r) => !loggedKeys.has(r.key));
+  const toCancel = medReminders.filter((n) => {
+    const key = n.content.data?.key as string | undefined;
+    return key && loggedKeys.has(key);
+  });
+  await cancelReminders(toCancel.map((n) => n.identifier));
 
   // Schedule reminders for unlogged doses that don't already have one
-  const existingKeys = new Set(afterCancel.map((r) => r.key));
-  const newReminders: StoredReminder[] = [];
+  const remainingKeys = new Set(
+    medReminders
+      .filter((n) => !toCancel.includes(n) && !staleReminders.includes(n))
+      .map((n) => n.content.data?.key as string),
+  );
 
   for (const due of unloggedDoses) {
-    const key = `med_${today}_${due.medication.id}_${due.schedule.id}`;
-    if (existingKeys.has(key)) continue;
+    const key = medReminderKey(due.medication.id, due.schedule.id, today);
+    if (remainingKeys.has(key)) continue;
 
     const timeOfDay = due.schedule.time_of_day;
     if (!timeOfDay) continue;
@@ -150,16 +141,14 @@ export async function reconcileMedicationReminders(
       medicationId: due.medication.id,
       scheduleId: due.schedule.id,
       entryDate: today,
+      key,
     };
-
-    const notificationIds: string[] = [];
 
     // Initial reminder
     const triggerDate = new Date();
     triggerDate.setHours(hours, minutes, 0, 0);
     if (triggerDate.getTime() > Date.now()) {
-      const id = await scheduleReminder(body, triggerDate, data);
-      if (id) notificationIds.push(id);
+      await scheduleReminder(body, triggerDate, data);
     }
 
     // Repeat reminders (+10, +20, +30 min)
@@ -167,19 +156,9 @@ export async function reconcileMedicationReminders(
       for (const offset of REPEAT_MINUTES) {
         const repeatDate = new Date(triggerDate.getTime() + offset * 60000);
         if (repeatDate.getTime() > Date.now()) {
-          const id = await scheduleReminder(body, repeatDate, data);
-          if (id) notificationIds.push(id);
+          await scheduleReminder(body, repeatDate, data);
         }
       }
     }
-
-    if (notificationIds.length > 0) {
-      newReminders.push({ key, notificationIds });
-    }
-  }
-
-  if (newReminders.length > 0 || toCancel.length > 0) {
-    const updated = [...afterCancel, ...newReminders];
-    await writeStoredReminders(updated);
   }
 }

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -5,7 +5,7 @@ import { getTodayDate } from '../utils/dateUtils';
 import { getDueDosesForDate } from '@workspace/shared';
 import { ensureNotificationPermission, MEDICATION_REMINDER_CATEGORY } from './notifications';
 import { useAppPreferencesStore } from '../stores/appPreferencesStore';
-import type { Medication, MedicationEntry } from '../types/medications';
+import type { MedicationDetail, MedicationEntry } from '../types/medications';
 
 const CHANNEL_ID = 'medication-reminders';
 const REPEAT_MINUTES = [10, 20, 30];
@@ -61,7 +61,7 @@ async function scheduleReminder(
  * @param entries - Today's medication entries from the API
  */
 export async function reconcileMedicationReminders(
-  medications: Medication[],
+  medications: MedicationDetail[],
   entries: MedicationEntry[],
 ): Promise<void> {
   if (schedulingLock.has('medication-reminders')) return;
@@ -90,7 +90,7 @@ export async function reconcileMedicationReminders(
     }
 
     const today = getTodayDate();
-    const dueDoses = getDueDosesForDate(medications as any, today);
+    const dueDoses = getDueDosesForDate(medications, today);
 
     const unloggedKeys = new Set(
       dueDoses

--- a/SparkyFitnessMobile/src/services/notifications.ts
+++ b/SparkyFitnessMobile/src/services/notifications.ts
@@ -22,6 +22,10 @@ const REST_COMPLETE_CATEGORY = 'rest-complete';
  */
 export const COMPLETE_SET_ACTION = 'complete-set';
 
+export const MEDICATION_REMINDER_CATEGORY = 'medication-reminder';
+export const MEDICATION_TAKEN_ACTION = 'medication-taken';
+export const MEDICATION_SKIP_ACTION = 'medication-skip';
+
 let initialized = false;
 let hasShownDeniedToast = false;
 
@@ -44,12 +48,15 @@ export async function initNotifications(): Promise<void> {
 
   try {
     Notifications.setNotificationHandler({
-      handleNotification: async () => ({
-        shouldShowBanner: false,
-        shouldShowList: false,
-        shouldPlaySound: true,
-        shouldSetBadge: false,
-      }),
+      handleNotification: async (notification) => {
+        const isMedReminder = notification.request.content.categoryIdentifier === MEDICATION_REMINDER_CATEGORY;
+        return {
+          shouldShowBanner: isMedReminder,
+          shouldShowList: isMedReminder,
+          shouldPlaySound: true,
+          shouldSetBadge: false,
+        };
+      },
     });
 
     if (Platform.OS === 'android') {
@@ -63,6 +70,11 @@ export async function initNotifications(): Promise<void> {
         importance: Notifications.AndroidImportance.HIGH,
         enableVibrate: true,
       });
+      await Notifications.setNotificationChannelAsync('medication-reminders', {
+        name: 'Medication reminders',
+        importance: Notifications.AndroidImportance.HIGH,
+        enableVibrate: true,
+      });
     }
 
     // "Complete Set" button on the rest-complete ping. The press is handled
@@ -72,6 +84,19 @@ export async function initNotifications(): Promise<void> {
       {
         identifier: COMPLETE_SET_ACTION,
         buttonTitle: 'Complete Set',
+        options: { opensAppToForeground: false },
+      },
+    ]);
+
+    await Notifications.setNotificationCategoryAsync(MEDICATION_REMINDER_CATEGORY, [
+      {
+        identifier: MEDICATION_TAKEN_ACTION,
+        buttonTitle: 'Take',
+        options: { opensAppToForeground: false },
+      },
+      {
+        identifier: MEDICATION_SKIP_ACTION,
+        buttonTitle: 'Skip',
         options: { opensAppToForeground: false },
       },
     ]);

--- a/SparkyFitnessMobile/src/services/notifications.ts
+++ b/SparkyFitnessMobile/src/services/notifications.ts
@@ -30,6 +30,20 @@ let initialized = false;
 let hasShownDeniedToast = false;
 
 /**
+ * Idempotent Android channel setup. Exposed separately because reminder
+ * scheduling can run from a background task, where `initNotifications`
+ * (invoked from App startup) may not have run in the current JS context.
+ */
+export async function ensureMedicationReminderChannel(): Promise<void> {
+  if (Platform.OS !== 'android') return;
+  await Notifications.setNotificationChannelAsync(MEDICATION_REMINDER_CHANNEL_ID, {
+    name: 'Medication reminders',
+    importance: Notifications.AndroidImportance.HIGH,
+    enableVibrate: true,
+  });
+}
+
+/**
  * Updates the app-local notifications toggle (backed by appPreferencesStore,
  * independent of the OS notification permission). Turning notifications off also
  * cancels any alerts already scheduled (rest-timer + fasting-goal) so they don't
@@ -70,11 +84,7 @@ export async function initNotifications(): Promise<void> {
         importance: Notifications.AndroidImportance.HIGH,
         enableVibrate: true,
       });
-      await Notifications.setNotificationChannelAsync(MEDICATION_REMINDER_CHANNEL_ID, {
-        name: 'Medication reminders',
-        importance: Notifications.AndroidImportance.HIGH,
-        enableVibrate: true,
-      });
+      await ensureMedicationReminderChannel();
     }
 
     // "Complete Set" button on the rest-complete ping. The press is handled
@@ -147,76 +157,25 @@ export async function getNotificationPermissionStatus(): Promise<AppNotification
 
 export async function openSystemNotificationSettings(): Promise<void> {
   try {
-    if (Platform.OS === 'ios') {
-      try {
-        await Linking.openURL('app-settings:root=NOTIFICATIONS_ID');
-        return;
-      } catch (err) {
-        addLog(
-          `Direct notification-settings deep-link failed, falling back to app-settings:: ${(err as Error).message}`,
-          'WARNING',
-        );
-        await Linking.openURL('app-settings:');
-      }
-      return;
-    }
     await Linking.openSettings();
   } catch (err) {
     addLog(`openSystemNotificationSettings failed: ${(err as Error).message}`, 'ERROR');
   }
 }
 
-function showNotificationsDisabledAlert(): Promise<void> {
-  return new Promise<void>((resolve) => {
-    Alert.alert(
-      'Notification permission needed',
-      "SparkyFitness can't deliver alerts without notification permission. Tap Open Settings to grant it, or disable notifications to continue without alerts.",
-      [
-        { text: 'Not Now', style: 'cancel', onPress: () => resolve() },
-        {
-          text: 'Disable notifications',
-          style: 'destructive',
-          onPress: () => {
-            void setNotificationsEnabled(false).finally(() => resolve());
-          },
-        },
-        {
-          text: 'Open Settings',
-          onPress: () => {
-            void openSystemNotificationSettings().finally(() => resolve());
-          },
-        },
-      ],
-    );
-  });
-}
-
-export async function requestNotificationPermissionWithGuidance(): Promise<AppNotificationPermission> {
-  let currentStatus: AppNotificationPermission;
-  try {
-    const current = await Notifications.getPermissionsAsync();
-    if (current.status === 'granted') return 'granted';
-    currentStatus = current.status === 'denied' ? 'denied' : 'undetermined';
-  } catch (err) {
-    addLog(`requestNotificationPermissionWithGuidance probe failed: ${(err as Error).message}`, 'ERROR');
-    return 'undetermined';
-  }
-
-  if (currentStatus === 'denied') {
-    await showNotificationsDisabledAlert();
-    return 'denied';
-  }
-
+/**
+ * Request notification permission without any interstitial UI. The OS shows
+ * its prompt only while the status is undetermined; once denied or granted
+ * this resolves with the current status silently — after a denial only system
+ * settings can change it.
+ */
+export async function requestNotificationPermission(): Promise<AppNotificationPermission> {
   try {
     const requested = await Notifications.requestPermissionsAsync();
     if (requested.status === 'granted') return 'granted';
-    await showNotificationsDisabledAlert();
     return requested.status === 'denied' ? 'denied' : 'undetermined';
   } catch (err) {
-    addLog(
-      `Notifications.requestPermissionsAsync failed: ${(err as Error).message}`,
-      'ERROR',
-    );
+    addLog(`requestNotificationPermission failed: ${(err as Error).message}`, 'ERROR');
     return 'undetermined';
   }
 }

--- a/SparkyFitnessMobile/src/services/notifications.ts
+++ b/SparkyFitnessMobile/src/services/notifications.ts
@@ -1,4 +1,4 @@
-import { Alert, Platform } from 'react-native';
+import { Alert, Linking, Platform } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Notifications from 'expo-notifications';
 import Toast from 'react-native-toast-message';
@@ -23,6 +23,8 @@ export const COMPLETE_SET_ACTION = 'complete-set';
 export const MEDICATION_REMINDER_CATEGORY = 'medication-reminder';
 export const MEDICATION_TAKEN_ACTION = 'medication-taken';
 export const MEDICATION_SKIP_ACTION = 'medication-skip';
+
+export type AppNotificationPermission = 'granted' | 'denied' | 'undetermined';
 
 let initialized = false;
 let hasShownDeniedToast = false;
@@ -127,6 +129,98 @@ export async function ensureNotificationPermission(): Promise<boolean> {
   }
 }
 
+export async function hasNotificationPermission(): Promise<boolean> {
+  return (await getNotificationPermissionStatus()) === 'granted';
+}
+
+export async function getNotificationPermissionStatus(): Promise<AppNotificationPermission> {
+  try {
+    const current = await Notifications.getPermissionsAsync();
+    if (current.status === 'granted') return 'granted';
+    if (current.status === 'denied') return 'denied';
+    return 'undetermined';
+  } catch (err) {
+    addLog(`getNotificationPermissionStatus failed: ${(err as Error).message}`, 'ERROR');
+    return 'undetermined';
+  }
+}
+
+export async function openSystemNotificationSettings(): Promise<void> {
+  try {
+    if (Platform.OS === 'ios') {
+      try {
+        await Linking.openURL('app-settings:root=NOTIFICATIONS_ID');
+        return;
+      } catch (err) {
+        addLog(
+          `Direct notification-settings deep-link failed, falling back to app-settings:: ${(err as Error).message}`,
+          'WARNING',
+        );
+        await Linking.openURL('app-settings:');
+      }
+      return;
+    }
+    await Linking.openSettings();
+  } catch (err) {
+    addLog(`openSystemNotificationSettings failed: ${(err as Error).message}`, 'ERROR');
+  }
+}
+
+function showNotificationsDisabledAlert(): Promise<void> {
+  return new Promise<void>((resolve) => {
+    Alert.alert(
+      'Notification permission needed',
+      "SparkyFitness can't deliver alerts without notification permission. Tap Open Settings to grant it, or disable notifications to continue without alerts.",
+      [
+        { text: 'Not Now', style: 'cancel', onPress: () => resolve() },
+        {
+          text: 'Disable notifications',
+          style: 'destructive',
+          onPress: () => {
+            void setNotificationsEnabled(false).finally(() => resolve());
+          },
+        },
+        {
+          text: 'Open Settings',
+          onPress: () => {
+            void openSystemNotificationSettings().finally(() => resolve());
+          },
+        },
+      ],
+    );
+  });
+}
+
+export async function requestNotificationPermissionWithGuidance(): Promise<AppNotificationPermission> {
+  let currentStatus: AppNotificationPermission;
+  try {
+    const current = await Notifications.getPermissionsAsync();
+    if (current.status === 'granted') return 'granted';
+    currentStatus = current.status === 'denied' ? 'denied' : 'undetermined';
+  } catch (err) {
+    addLog(`requestNotificationPermissionWithGuidance probe failed: ${(err as Error).message}`, 'ERROR');
+    return 'undetermined';
+  }
+
+  if (currentStatus === 'denied') {
+    await showNotificationsDisabledAlert();
+    return 'denied';
+  }
+
+  try {
+    const requested = await Notifications.requestPermissionsAsync();
+    if (requested.status === 'granted') return 'granted';
+    await showNotificationsDisabledAlert();
+    return requested.status === 'denied' ? 'denied' : 'undetermined';
+  } catch (err) {
+    addLog(
+      `Notifications.requestPermissionsAsync failed: ${(err as Error).message}`,
+      'ERROR',
+    );
+    return 'undetermined';
+  }
+}
+
 /**
  * One-time Android prompt for the "Alarms & reminders" special access.
  * Without it, expo-notifications schedules inexact alarms that the OS batches
@@ -137,8 +231,7 @@ export async function maybePromptForExactAlarmPermission(): Promise<void> {
   if (!ExactAlarmBridge.isAvailable) return;
   if (!useAppPreferencesStore.getState().notificationsEnabled) return;
   try {
-    const current = await Notifications.getPermissionsAsync();
-    if (current.status !== 'granted') return;
+    if (!(await hasNotificationPermission())) return;
     if (await ExactAlarmBridge.canScheduleExactAlarms()) return;
     if ((await AsyncStorage.getItem(EXACT_ALARM_PROMPT_KEY)) === 'true') return;
     await AsyncStorage.setItem(EXACT_ALARM_PROMPT_KEY, 'true');

--- a/SparkyFitnessMobile/src/services/notifications.ts
+++ b/SparkyFitnessMobile/src/services/notifications.ts
@@ -5,10 +5,8 @@ import Toast from 'react-native-toast-message';
 import { addLog } from './LogService';
 import { fireSuccessHaptic } from './haptics';
 import { ExactAlarmBridge } from './ExactAlarmBridge';
-import {
-  useAppPreferencesStore,
-  __resetAppPreferencesStoreForTests,
-} from '../stores/appPreferencesStore';
+import { useAppPreferencesStore, __resetAppPreferencesStoreForTests } from '../stores/appPreferencesStore';
+import { CHANNEL_ID as MEDICATION_CHANNEL_ID } from './medicationReminderService';
 
 const CHANNEL_ID = 'workout-timer';
 const FASTING_CHANNEL_ID = 'fasting';
@@ -70,7 +68,7 @@ export async function initNotifications(): Promise<void> {
         importance: Notifications.AndroidImportance.HIGH,
         enableVibrate: true,
       });
-      await Notifications.setNotificationChannelAsync('medication-reminders', {
+      await Notifications.setNotificationChannelAsync(MEDICATION_CHANNEL_ID, {
         name: 'Medication reminders',
         importance: Notifications.AndroidImportance.HIGH,
         enableVibrate: true,

--- a/SparkyFitnessMobile/src/services/notifications.ts
+++ b/SparkyFitnessMobile/src/services/notifications.ts
@@ -6,10 +6,10 @@ import { addLog } from './LogService';
 import { fireSuccessHaptic } from './haptics';
 import { ExactAlarmBridge } from './ExactAlarmBridge';
 import { useAppPreferencesStore, __resetAppPreferencesStoreForTests } from '../stores/appPreferencesStore';
-import { CHANNEL_ID as MEDICATION_CHANNEL_ID } from './medicationReminderService';
 
 const CHANNEL_ID = 'workout-timer';
 const FASTING_CHANNEL_ID = 'fasting';
+export const MEDICATION_REMINDER_CHANNEL_ID = 'medication-reminders';
 const EXACT_ALARM_PROMPT_KEY = '@SparkyFitness/exactAlarmPromptShown';
 
 const REST_COMPLETE_CATEGORY = 'rest-complete';
@@ -68,7 +68,7 @@ export async function initNotifications(): Promise<void> {
         importance: Notifications.AndroidImportance.HIGH,
         enableVibrate: true,
       });
-      await Notifications.setNotificationChannelAsync(MEDICATION_CHANNEL_ID, {
+      await Notifications.setNotificationChannelAsync(MEDICATION_REMINDER_CHANNEL_ID, {
         name: 'Medication reminders',
         importance: Notifications.AndroidImportance.HIGH,
         enableVibrate: true,

--- a/SparkyFitnessMobile/src/stores/appPreferencesStore.ts
+++ b/SparkyFitnessMobile/src/stores/appPreferencesStore.ts
@@ -36,6 +36,9 @@ export const PREFERENCE_DEFAULTS = {
   fastingCardVisible: true,
   cycleCardVisible: true,
   askSparkyVisible: true,
+  medicationsCardVisible: true,
+  medicationRemindersEnabled: true,
+  medicationReminderRepeats: true,
   liquidGlassTabBarEnabled: false,
   activeWorkoutMetricColumn: 'rpe' as ActiveWorkoutMetricColumn,
   diarySummaryVisible: false,
@@ -51,6 +54,9 @@ export type AppPreferencesData = {
   fastingCardVisible: boolean;
   cycleCardVisible: boolean;
   askSparkyVisible: boolean;
+  medicationsCardVisible: boolean;
+  medicationRemindersEnabled: boolean;
+  medicationReminderRepeats: boolean;
   liquidGlassTabBarEnabled: boolean;
   activeWorkoutMetricColumn: ActiveWorkoutMetricColumn;
   diarySummaryVisible: boolean;
@@ -66,6 +72,9 @@ export interface AppPreferencesState extends AppPreferencesData {
   setFastingCardVisible: (value: boolean) => void;
   setCycleCardVisible: (value: boolean) => void;
   setAskSparkyVisible: (value: boolean) => void;
+  setMedicationsCardVisible: (value: boolean) => void;
+  setMedicationRemindersEnabled: (value: boolean) => void;
+  setMedicationReminderRepeats: (value: boolean) => void;
   setLiquidGlassTabBarEnabled: (value: boolean) => void;
   setActiveWorkoutMetricColumn: (value: ActiveWorkoutMetricColumn) => void;
   setDiarySummaryVisible: (value: boolean) => void;
@@ -121,6 +130,9 @@ export const useAppPreferencesStore = create<AppPreferencesState>()(
       setFastingCardVisible: (value) => set({ fastingCardVisible: value }),
       setCycleCardVisible: (value) => set({ cycleCardVisible: value }),
       setAskSparkyVisible: (value) => set({ askSparkyVisible: value }),
+      setMedicationsCardVisible: (value) => set({ medicationsCardVisible: value }),
+      setMedicationRemindersEnabled: (value) => set({ medicationRemindersEnabled: value }),
+      setMedicationReminderRepeats: (value) => set({ medicationReminderRepeats: value }),
       setLiquidGlassTabBarEnabled: (value) => set({ liquidGlassTabBarEnabled: value }),
       setActiveWorkoutMetricColumn: (value) => set({ activeWorkoutMetricColumn: value }),
       setDiarySummaryVisible: (value) => set({ diarySummaryVisible: value }),
@@ -139,6 +151,9 @@ export const useAppPreferencesStore = create<AppPreferencesState>()(
         fastingCardVisible: state.fastingCardVisible,
         cycleCardVisible: state.cycleCardVisible,
         askSparkyVisible: state.askSparkyVisible,
+        medicationsCardVisible: state.medicationsCardVisible,
+        medicationRemindersEnabled: state.medicationRemindersEnabled,
+        medicationReminderRepeats: state.medicationReminderRepeats,
         liquidGlassTabBarEnabled: state.liquidGlassTabBarEnabled,
         // Older persisted blobs without these keys backfill via the default
         // shallow merge — no version bump needed.

--- a/SparkyFitnessMobile/src/types/medications.ts
+++ b/SparkyFitnessMobile/src/types/medications.ts
@@ -70,14 +70,6 @@ export interface CreateMedicationEntryInput {
   notes?: string | null;
 }
 
-export interface UpdateMedicationEntryInput {
-  status?: MedicationEntryStatus;
-  taken_at?: string | null;
-  dose_amount?: number | null;
-  unit?: string | null;
-  notes?: string | null;
-}
-
 export interface CreateMedicationInput {
   name: string;
   type_id: string;
@@ -112,20 +104,6 @@ export interface UpdateMedicationInput {
   is_active?: boolean;
 }
 
-export interface CreateScheduleInput {
-  schedule_type_id: string;
-  time_of_day?: string | null;
-  days_of_week?: number[] | null;
-  interval_days?: number | null;
-  day_of_month?: number | null;
-  cycle_on_days?: number | null;
-  cycle_off_days?: number | null;
-  start_date?: string | null;
-  end_date?: string | null;
-  dose_amount?: number | null;
-  with_meal?: string | null;
-}
-
 export const MEDICATION_TYPES = [
   { id: 'pill', label: 'Pill' },
   { id: 'tablet', label: 'Tablet' },
@@ -141,26 +119,6 @@ export const MEDICATION_TYPES = [
   { id: 'other', label: 'Other' },
 ] as const;
 
-export const SCHEDULE_TYPES = [
-  { id: 'daily', label: 'Daily' },
-  { id: 'specific_days', label: 'Specific Days' },
-  { id: 'every_n_days', label: 'Every N Days' },
-  { id: 'weekly', label: 'Weekly' },
-  { id: 'monthly', label: 'Monthly' },
-  { id: 'cyclic', label: 'Cyclic' },
-  { id: 'prn', label: 'As Needed (PRN)' },
-  { id: 'taper', label: 'Taper' },
-] as const;
 
-// not used yet..
-export const ROUTE_TYPES = [
-  { id: 'oral', label: 'Oral' },
-  { id: 'subcutaneous', label: 'Subcutaneous' },
-  { id: 'intramuscular', label: 'Intramuscular' },
-  { id: 'topical', label: 'Topical' },
-  { id: 'inhaled', label: 'Inhaled' },
-  { id: 'nasal', label: 'Nasal' },
-  { id: 'other', label: 'Other' },
-] as const;
 
 export const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;

--- a/SparkyFitnessMobile/src/types/medications.ts
+++ b/SparkyFitnessMobile/src/types/medications.ts
@@ -1,0 +1,166 @@
+export interface MedicationSchedule {
+  id: string;
+  medication_id: string;
+  schedule_type_id: string;
+  time_of_day?: string | null;
+  days_of_week?: number[] | null;
+  interval_days?: number | null;
+  day_of_month?: number | null;
+  cycle_on_days?: number | null;
+  cycle_off_days?: number | null;
+  start_date?: string | null;
+  end_date?: string | null;
+  active: boolean;
+  dose_amount?: number | null;
+  with_meal?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface Medication {
+  id: string;
+  user_id: string;
+  name: string;
+  type_id: string;
+  route_type_id?: string | null;
+  strength_value?: number | null;
+  strength_unit?: string | null;
+  dose_amount?: number | null;
+  dose_unit?: string | null;
+  reason?: string | null;
+  prescriber?: string | null;
+  pharmacy?: string | null;
+  rx_number?: string | null;
+  notes?: string | null;
+  is_glp1: boolean;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MedicationDetail extends Medication {
+  schedules: MedicationSchedule[];
+}
+
+export type MedicationEntryStatus = 'taken' | 'skipped' | 'snoozed' | 'prn_taken';
+
+export interface MedicationEntry {
+  id: string;
+  user_id: string;
+  medication_id: string;
+  schedule_id?: string | null;
+  status: MedicationEntryStatus;
+  entry_date: string;
+  taken_at?: string | null;
+  dose_amount?: number | null;
+  unit?: string | null;
+  notes?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateMedicationEntryInput {
+  medication_id: string;
+  schedule_id?: string | null;
+  status: MedicationEntryStatus;
+  entry_date: string;
+  taken_at?: string | null;
+  dose_amount?: number | null;
+  unit?: string | null;
+  notes?: string | null;
+}
+
+export interface UpdateMedicationEntryInput {
+  status?: MedicationEntryStatus;
+  taken_at?: string | null;
+  dose_amount?: number | null;
+  unit?: string | null;
+  notes?: string | null;
+}
+
+export interface CreateMedicationInput {
+  name: string;
+  type_id: string;
+  route_type_id?: string | null;
+  strength_value?: number | null;
+  strength_unit?: string | null;
+  dose_amount?: number | null;
+  dose_unit?: string | null;
+  reason?: string | null;
+  prescriber?: string | null;
+  pharmacy?: string | null;
+  rx_number?: string | null;
+  notes?: string | null;
+  is_glp1?: boolean;
+  is_active?: boolean;
+}
+
+export interface UpdateMedicationInput {
+  name?: string;
+  type_id?: string;
+  route_type_id?: string | null;
+  strength_value?: number | null;
+  strength_unit?: string | null;
+  dose_amount?: number | null;
+  dose_unit?: string | null;
+  reason?: string | null;
+  prescriber?: string | null;
+  pharmacy?: string | null;
+  rx_number?: string | null;
+  notes?: string | null;
+  is_glp1?: boolean;
+  is_active?: boolean;
+}
+
+export interface CreateScheduleInput {
+  schedule_type_id: string;
+  time_of_day?: string | null;
+  days_of_week?: number[] | null;
+  interval_days?: number | null;
+  day_of_month?: number | null;
+  cycle_on_days?: number | null;
+  cycle_off_days?: number | null;
+  start_date?: string | null;
+  end_date?: string | null;
+  dose_amount?: number | null;
+  with_meal?: string | null;
+}
+
+export const MEDICATION_TYPES = [
+  { id: 'pill', label: 'Pill' },
+  { id: 'tablet', label: 'Tablet' },
+  { id: 'capsule', label: 'Capsule' },
+  { id: 'liquid', label: 'Liquid' },
+  { id: 'injection', label: 'Injection' },
+  { id: 'patch', label: 'Patch' },
+  { id: 'inhaler', label: 'Inhaler' },
+  { id: 'drops', label: 'Drops' },
+  { id: 'nasal_spray', label: 'Nasal Spray' },
+  { id: 'cream', label: 'Cream' },
+  { id: 'suppository', label: 'Suppository' },
+  { id: 'other', label: 'Other' },
+] as const;
+
+export const SCHEDULE_TYPES = [
+  { id: 'daily', label: 'Daily' },
+  { id: 'specific_days', label: 'Specific Days' },
+  { id: 'every_n_days', label: 'Every N Days' },
+  { id: 'weekly', label: 'Weekly' },
+  { id: 'monthly', label: 'Monthly' },
+  { id: 'cyclic', label: 'Cyclic' },
+  { id: 'prn', label: 'As Needed (PRN)' },
+  { id: 'taper', label: 'Taper' },
+] as const;
+
+// not used yet..
+export const ROUTE_TYPES = [
+  { id: 'oral', label: 'Oral' },
+  { id: 'subcutaneous', label: 'Subcutaneous' },
+  { id: 'intramuscular', label: 'Intramuscular' },
+  { id: 'topical', label: 'Topical' },
+  { id: 'inhaled', label: 'Inhaled' },
+  { id: 'nasal', label: 'Nasal' },
+  { id: 'other', label: 'Other' },
+] as const;
+
+export const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;

--- a/SparkyFitnessMobile/src/types/navigation.ts
+++ b/SparkyFitnessMobile/src/types/navigation.ts
@@ -205,6 +205,9 @@ export type RootStackParamList = {
   AppSettings: undefined;
   About: undefined;
   WhatsNew: undefined;
+  MedicationsList: undefined;
+  MedicationDetail: { medicationId: string };
+  MedicationForm: { medicationId?: string };
 };
 
 declare global {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Adds full medication tracking to the mobile app. Includes dashboard quick-actions and reminder notifications with repeat follow-ups.

**How did you implement the solution?**
Updated types, API client, TanStack Query hooks, added screens, notification service, and background sync integration. The reminder reconciler runs both in the foreground (react component on teh dashboard page) and during background sync (fetches fresh schedules from server). Notification scheduling uses expo-notifications with DATE triggers and a take/skip action category.

Linked Issue: Closes #1906 

## How to Test

1. Check out this branch and run Android app
2. Add medications either on the app or web
3. Verify that they show in dashboard card
4. Mark doses as taken, tap to view medication into
5. Swipe left on medication in dashboard to skip or take

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="512" alt="medications on dashboard" src="https://github.com/user-attachments/assets/e78c8488-c95f-4b22-bc3b-48b4033bfce4" />
<img width="512" alt="medications list" src="https://github.com/user-attachments/assets/1c0b5b06-05a6-4eb6-8807-de71b8e30100" />
<img width="512" alt="medication history" src="https://github.com/user-attachments/assets/6c86f1ed-f9bd-4748-a49d-7e01695e8809" />
<img width="512" alt="edit medication" src="https://github.com/user-attachments/assets/41bac877-cc6f-4d8b-8b5f-4aedc263f9e6" />

</details>

## Notes for Reviewers

- GLP-1 specific UI is intentionally excluded from mobile; generic medications only (for now?)
- Background sync now also fetches fresh medication schedules and re-reconciles reminders
- Not positive I'm using the dose amount and unit correctly, let me know if not

### Future changes

- UI for editing/adding medication schedules
- Settings for reminder repeating specifics
- GLP-1 specifics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full medications experience: active/inactive lists, medication detail, and create/edit form (including scheduled dose logging with Take/Skip and today PRN logging).
  * Integrated a day-based medications card on the dashboard with swipe actions and quick “mark taken” status toggles.
  * Added medication reminders via actionable notifications (Take/Skip) with optional repeat reminders.
  * Added settings for enabling medication reminders, repeat behavior, and showing/hiding the dashboard medications card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->