### PR TITLE
fix: mcp respond to get and delete requests

### DIFF
--- a/SparkyFitnessServer/routes/mcpRoutes.ts
+++ b/SparkyFitnessServer/routes/mcpRoutes.ts
@@ -147,4 +147,12 @@ router.post('/', async (req, res) => {
   }
 });
 
+router.get('/', (_req, res) => {
+  res.set('Allow', 'POST').status(405).end();
+});
+
+router.delete('/', (_req, res) => {
+  res.set('Allow', 'POST').status(405).end();
+});
+
 export default router;

--- a/SparkyFitnessServer/tests/mcpRoutes.test.ts
+++ b/SparkyFitnessServer/tests/mcpRoutes.test.ts
@@ -360,6 +360,48 @@ describe('POST /mcp', () => {
 // The route never registers dev tools for a non-admin, so a non-admin tools/call
 // returns MCP "tool not found" — the call-time guard can't be reached that way.
 // Exercise the guard directly on the built tool's execute() instead.
+describe('GET /mcp and DELETE /mcp', () => {
+  it('GET returns 405 with Allow: POST when authenticated', async () => {
+    const res = await request(app)
+      .get('/mcp')
+      .set('Authorization', 'Bearer valid');
+
+    expect(res.status).toBe(405);
+    expect(res.headers.allow).toBe('POST');
+    expect(res.text).toBe('');
+  });
+
+  it('DELETE returns 405 with Allow: POST when authenticated', async () => {
+    const res = await request(app)
+      .delete('/mcp')
+      .set('Authorization', 'Bearer valid');
+
+    expect(res.status).toBe(405);
+    expect(res.headers.allow).toBe('POST');
+    expect(res.text).toBe('');
+  });
+
+  it('GET still 405s when the client sends Accept: text/event-stream (the SSE Accept negotiation that triggered the bug)', async () => {
+    const res = await request(app)
+      .get('/mcp')
+      .set('Authorization', 'Bearer valid')
+      .set('Accept', 'text/event-stream');
+
+    expect(res.status).toBe(405);
+    expect(res.headers.allow).toBe('POST');
+  });
+
+  it('rejects unauthenticated GET with 401 (same gate as POST)', async () => {
+    const res = await request(app).get('/mcp');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects unauthenticated DELETE with 401', async () => {
+    const res = await request(app).delete('/mcp');
+    expect(res.status).toBe(401);
+  });
+});
+
 describe('buildDevTools call-time guard', () => {
   // Registry handlers read only rawArgs; a stub satisfies the execute() signature.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Many MCP clients do not handle these not being available

**How did you implement the solution?**
Added responses for both request types, just responding with 405

Linked Issue: Closes #

## How to Test

1. Run the server
2. Test with official `@modelcontextprotocol/inspector`
3. No more errors

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Notes for Reviewers

This is just a small issue I noticed when testing the MCP with my Pebble Index 01, this issue made it unusable.
I also added some other MCP tests, they can be removed from this pr if it's wanted but I figured they fit since there weren't really tests I could see
