### PR TITLE
fix(yazio): show correct servings in search and barcode scans

### DIFF
--- a/SparkyFitnessMobile/AGENTS.md
+++ b/SparkyFitnessMobile/AGENTS.md
@@ -33,7 +33,7 @@ pnpm run android
 pnpm run lint
 pnpm run typecheck
 pnpm run validate
-pnpm run test:run -- --watchman=false --runInBand
+pnpm exec jest --watchman=false --runInBand
 pnpm exec jest --watchman=false --runInBand <test-path>
 pnpm run test:coverage -- --watchman=false --runInBand
 npx expo prebuild --clean

--- a/SparkyFitnessMobile/__tests__/hooks/useAddFoodEntry.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useAddFoodEntry.test.ts
@@ -511,4 +511,105 @@ describe('useAddFoodEntry', () => {
       variant_id: 'one-portion-variant',
     });
   });
+
+  test('uses one unambiguous legacy variant for a described provider serving', async () => {
+    mockSaveFood.mockResolvedValue({
+      id: 'food-1',
+      name: 'Legacy Food',
+      default_variant: {
+        id: 'default-variant',
+        serving_size: 100,
+        serving_unit: 'g',
+      },
+    } as unknown as Awaited<ReturnType<typeof saveFood>>);
+
+    const storedVariants = [
+      {
+        id: 'default-variant',
+        food_id: 'food-1',
+        serving_size: 100,
+        serving_unit: 'g',
+        calories: 100,
+        protein: 1,
+        carbs: 10,
+        fat: 1,
+      },
+      {
+        id: 'legacy-serving',
+        food_id: 'food-1',
+        serving_size: 1,
+        serving_unit: 'serving',
+        calories: 80,
+        protein: 1,
+        carbs: 8,
+        fat: 1,
+      },
+    ] as Awaited<ReturnType<typeof fetchFoodVariants>>;
+    mockFetchFoodVariants
+      .mockResolvedValueOnce(storedVariants)
+      .mockResolvedValueOnce(storedVariants);
+    mockCreateFoodEntry.mockResolvedValue({
+      id: 'entry-1',
+      food_id: 'food-1',
+      variant_id: 'legacy-serving',
+      meal_type: 'breakfast',
+      meal_type_id: 'meal-type-1',
+      quantity: 1,
+      unit: 'serving',
+      entry_date: '2026-04-25',
+      food_name: 'Legacy Food',
+      brand_name: null,
+      serving_size: 1,
+      serving_unit: 'serving',
+      calories: 80,
+      protein: 1,
+      carbs: 8,
+      fat: 1,
+    });
+
+    const { result } = renderHook(() => useAddFoodEntry(), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.addEntryAsync({
+        saveFoodPayload: {
+          name: 'Legacy Food',
+          serving_size: 1,
+          serving_unit: 'serving (80 g)',
+          calories: 80,
+          protein: 1,
+          carbs: 8,
+          fat: 1,
+        },
+        externalVariants: [
+          {
+            serving_size: 1,
+            serving_unit: 'serving',
+            serving_description: '1 serving (80 g)',
+            calories: 80,
+            protein: 1,
+            carbs: 8,
+            fat: 1,
+          },
+        ],
+        createEntryPayload: {
+          meal_type_id: 'meal-type-1',
+          quantity: 1,
+          unit: 'serving',
+          entry_date: '2026-04-25',
+        },
+      });
+    });
+
+    expect(mockCreateFoodVariant).not.toHaveBeenCalled();
+    expect(mockCreateFoodEntry).toHaveBeenCalledWith({
+      meal_type_id: 'meal-type-1',
+      quantity: 1,
+      unit: 'serving',
+      entry_date: '2026-04-25',
+      food_id: 'food-1',
+      variant_id: 'legacy-serving',
+    });
+  });
 });

--- a/SparkyFitnessMobile/__tests__/hooks/useAddFoodEntry.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useAddFoodEntry.test.ts
@@ -701,6 +701,56 @@ describe('useAddFoodEntry', () => {
     },
   );
 
+  test('uses an exact saved default to resolve multiple exact stored variants', async () => {
+    mockSaveFood.mockResolvedValue({
+      id: 'food-1',
+      name: 'Duplicate Packages',
+      default_variant: {
+        id: 'package-400-default',
+        serving_size: 1,
+        serving_unit: 'package (400 g)',
+      },
+    } as unknown as Awaited<ReturnType<typeof saveFood>>);
+    mockFetchFoodVariants.mockResolvedValue([
+      makeStoredVariant('package-400-a', 'package (400 g)', 200),
+      makeStoredVariant('package-400-b', 'package (400 g)', 210),
+    ]);
+
+    const { result } = renderHook(() => useAddFoodEntry(), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.addEntryAsync({
+        saveFoodPayload: {
+          name: 'Duplicate Packages',
+          brand: null,
+          serving_size: 1,
+          serving_unit: 'package (400 g)',
+          calories: 200,
+          protein: 2,
+          carbs: 20,
+          fat: 2,
+        },
+        createEntryPayload: {
+          meal_type_id: 'meal-type-1',
+          quantity: 1,
+          unit: 'package (400 g)',
+          entry_date: '2026-04-25',
+        },
+      });
+    });
+
+    expect(mockCreateFoodEntry).toHaveBeenCalledWith({
+      meal_type_id: 'meal-type-1',
+      quantity: 1,
+      unit: 'package (400 g)',
+      entry_date: '2026-04-25',
+      food_id: 'food-1',
+      variant_id: 'package-400-default',
+    });
+  });
+
   test('uses an exact saved default when the variant refresh fails', async () => {
     mockSaveFood.mockResolvedValue({
       id: 'food-1',

--- a/SparkyFitnessMobile/__tests__/hooks/useAddFoodEntry.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useAddFoodEntry.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, waitFor, act } from '@testing-library/react-native';
+import Toast from 'react-native-toast-message';
 import { useAddFoodEntry } from '../../src/hooks/useAddFoodEntry';
 import { createFoodEntry } from '../../src/services/api/foodEntriesApi';
 import { createFoodVariant, fetchFoodVariants, saveFood } from '../../src/services/api/foodsApi';
@@ -698,6 +699,13 @@ describe('useAddFoodEntry', () => {
       });
 
       expect(mockCreateFoodEntry).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(Toast.show).toHaveBeenCalledWith({
+          type: 'error',
+          text1: 'Failed to add food',
+          text2: 'Choose a different serving.',
+        });
+      });
     },
   );
 

--- a/SparkyFitnessMobile/__tests__/hooks/useAddFoodEntry.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useAddFoodEntry.test.ts
@@ -3,6 +3,7 @@ import { useAddFoodEntry } from '../../src/hooks/useAddFoodEntry';
 import { createFoodEntry } from '../../src/services/api/foodEntriesApi';
 import { createFoodVariant, fetchFoodVariants, saveFood } from '../../src/services/api/foodsApi';
 import { createTestQueryClient, createQueryWrapper, type QueryClient } from './queryTestUtils';
+import type { FoodVariantDetail } from '../../src/types/foods';
 
 jest.mock('../../src/services/api/foodEntriesApi', () => ({
   createFoodEntry: jest.fn(),
@@ -24,6 +25,23 @@ const mockCreateFoodVariant =
 const mockFetchFoodVariants =
   fetchFoodVariants as jest.MockedFunction<typeof fetchFoodVariants>;
 const mockSaveFood = saveFood as jest.MockedFunction<typeof saveFood>;
+
+function makeStoredVariant(
+  id: string,
+  servingUnit: string,
+  calories: number,
+): FoodVariantDetail {
+  return {
+    id,
+    food_id: 'food-1',
+    serving_size: 1,
+    serving_unit: servingUnit,
+    calories,
+    protein: 1,
+    carbs: 10,
+    fat: 1,
+  } as FoodVariantDetail;
+}
 
 describe('useAddFoodEntry', () => {
   let queryClient: QueryClient;
@@ -610,6 +628,123 @@ describe('useAddFoodEntry', () => {
       entry_date: '2026-04-25',
       food_id: 'food-1',
       variant_id: 'legacy-serving',
+    });
+  });
+
+  test.each([
+    {
+      failureKind: 'ambiguous legacy matches',
+      variants: [
+        makeStoredVariant('legacy-200', 'package', 100),
+        makeStoredVariant('legacy-400', 'package', 200),
+      ],
+    },
+    {
+      failureKind: 'ambiguous exact matches',
+      variants: [
+        makeStoredVariant('package-400-a', 'package (400 g)', 200),
+        makeStoredVariant('package-400-b', 'package (400 g)', 210),
+      ],
+    },
+    {
+      failureKind: 'a failed variant refresh',
+      variants: null,
+    },
+  ])(
+    'does not log after $failureKind with a mismatched default',
+    async ({ variants }: { variants: FoodVariantDetail[] | null }) => {
+      mockSaveFood.mockResolvedValue({
+        id: 'food-1',
+        name: 'Ambiguous Packages',
+        default_variant: {
+          id: 'default-variant',
+          serving_size: 100,
+          serving_unit: 'g',
+        },
+      } as unknown as Awaited<ReturnType<typeof saveFood>>);
+      if (variants) {
+        mockFetchFoodVariants.mockResolvedValue(variants);
+      } else {
+        mockFetchFoodVariants.mockRejectedValue(new Error('refresh failed'));
+      }
+
+      const { result } = renderHook(() => useAddFoodEntry(), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+
+      await act(async () => {
+        await expect(
+          result.current.addEntryAsync({
+            saveFoodPayload: {
+              name: 'Ambiguous Packages',
+              brand: null,
+              serving_size: 1,
+              serving_unit: 'package (400 g)',
+              calories: 200,
+              protein: 2,
+              carbs: 20,
+              fat: 2,
+            },
+            createEntryPayload: {
+              meal_type_id: 'meal-type-1',
+              quantity: 1,
+              unit: 'package (400 g)',
+              entry_date: '2026-04-25',
+            },
+          }),
+        ).rejects.toThrow(
+          'Could not uniquely resolve the selected serving variant',
+        );
+      });
+
+      expect(mockCreateFoodEntry).not.toHaveBeenCalled();
+    },
+  );
+
+  test('uses an exact saved default when the variant refresh fails', async () => {
+    mockSaveFood.mockResolvedValue({
+      id: 'food-1',
+      name: 'Exact Package',
+      default_variant: {
+        id: 'package-400',
+        serving_size: 1,
+        serving_unit: 'package (400 g)',
+      },
+    } as unknown as Awaited<ReturnType<typeof saveFood>>);
+    mockFetchFoodVariants.mockRejectedValue(new Error('refresh failed'));
+
+    const { result } = renderHook(() => useAddFoodEntry(), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.addEntryAsync({
+        saveFoodPayload: {
+          name: 'Exact Package',
+          brand: null,
+          serving_size: 1,
+          serving_unit: 'package (400 g)',
+          calories: 200,
+          protein: 2,
+          carbs: 20,
+          fat: 2,
+        },
+        createEntryPayload: {
+          meal_type_id: 'meal-type-1',
+          quantity: 1,
+          unit: 'package (400 g)',
+          entry_date: '2026-04-25',
+        },
+      });
+    });
+
+    expect(mockCreateFoodEntry).toHaveBeenCalledWith({
+      meal_type_id: 'meal-type-1',
+      quantity: 1,
+      unit: 'package (400 g)',
+      entry_date: '2026-04-25',
+      food_id: 'food-1',
+      variant_id: 'package-400',
     });
   });
 });

--- a/SparkyFitnessMobile/__tests__/screens/FoodScanScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodScanScreen.test.tsx
@@ -149,7 +149,7 @@ describe('FoodScanScreen', () => {
     expect(mockNavigation.replace).not.toHaveBeenCalled();
   });
 
-  it('passes verified Yazio barcode results with serving descriptions to FoodEntryAdd', async () => {
+  it('passes all verified Yazio barcode portions with gram descriptions to FoodEntryAdd', async () => {
     mockLookupBarcodeV2.mockResolvedValue({
       source: 'yazio',
       food: {
@@ -181,6 +181,26 @@ describe('FoodScanScreen', () => {
             carbs: 10,
             fat: 1,
           },
+          {
+            id: 'remote-variant-2',
+            serving_size: 200,
+            serving_unit: 'g',
+            serving_description: '200 g',
+            calories: 50,
+            protein: 1,
+            carbs: 10,
+            fat: 1,
+          },
+          {
+            id: 'remote-variant-3',
+            serving_size: 1,
+            serving_unit: 'package',
+            serving_description: '1 package (400 g)',
+            calories: 100,
+            protein: 2,
+            carbs: 20,
+            fat: 2,
+          },
         ],
       },
     } as any);
@@ -198,13 +218,23 @@ describe('FoodScanScreen', () => {
             source: 'external',
             provider_verified: true,
             servingDescription: '1 piece (200 g)',
-            externalVariants: [
+            externalVariants: expect.arrayContaining([
               expect.objectContaining({
                 serving_size: 1,
                 serving_unit: 'piece',
                 serving_description: '1 piece (200 g)',
               }),
-            ],
+              expect.objectContaining({
+                serving_size: 200,
+                serving_unit: 'g',
+                serving_description: '200 g',
+              }),
+              expect.objectContaining({
+                serving_size: 1,
+                serving_unit: 'package',
+                serving_description: '1 package (400 g)',
+              }),
+            ]),
           }),
         }),
       );

--- a/SparkyFitnessMobile/__tests__/services/externalFoodSearchApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/externalFoodSearchApi.test.ts
@@ -1535,6 +1535,26 @@ describe('externalFoodSearchApi', () => {
               fat: 4,
               is_default: false,
             },
+            {
+              serving_size: 1,
+              serving_unit: 'serving',
+              serving_description: '1 serving (400 g)',
+              calories: 324,
+              protein: 20,
+              carbs: 40,
+              fat: 8,
+              is_default: false,
+            },
+            {
+              serving_size: 400,
+              serving_unit: 'g',
+              serving_description: '400 g',
+              calories: 324,
+              protein: 20,
+              carbs: 40,
+              fat: 8,
+              is_default: false,
+            },
           ],
         };
 
@@ -1544,6 +1564,8 @@ describe('externalFoodSearchApi', () => {
           '1 serving (200 g)',
           '100 g',
           '200 g',
+          '1 serving (400 g)',
+          '400 g',
         ]);
       });
 

--- a/SparkyFitnessMobile/__tests__/services/externalFoodSearchApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/externalFoodSearchApi.test.ts
@@ -1487,6 +1487,66 @@ describe('externalFoodSearchApi', () => {
         expect(result.variants![1].trans_fat).toBe(0);
       });
 
+      test('preserves every Yazio serving description with its gram weight', () => {
+        const food = {
+          name: 'Protein Pudding',
+          brand: 'Yazio Brand',
+          provider_external_id: 'yazio-pudding',
+          provider_type: 'yazio',
+          is_custom: false,
+          default_variant: {
+            serving_size: 100,
+            serving_unit: 'g',
+            serving_description: '100 g',
+            calories: 81,
+            protein: 5,
+            carbs: 10,
+            fat: 2,
+            is_default: true,
+          },
+          variants: [
+            {
+              serving_size: 100,
+              serving_unit: 'g',
+              serving_description: '100 g',
+              calories: 81,
+              protein: 5,
+              carbs: 10,
+              fat: 2,
+              is_default: true,
+            },
+            {
+              serving_size: 1,
+              serving_unit: 'serving',
+              serving_description: '1 serving (200 g)',
+              calories: 162,
+              protein: 10,
+              carbs: 20,
+              fat: 4,
+              is_default: false,
+            },
+            {
+              serving_size: 200,
+              serving_unit: 'g',
+              serving_description: '200 g',
+              calories: 162,
+              protein: 10,
+              carbs: 20,
+              fat: 4,
+              is_default: false,
+            },
+          ],
+        };
+
+        const result = transformNormalizedFood(food, 'yazio');
+
+        expect(result.variants?.map(variant => variant.serving_description)).toEqual([
+          '1 serving (200 g)',
+          '100 g',
+          '200 g',
+        ]);
+      });
+
       test('puts default_variant first in variants array', () => {
         const defaultVariant = {
           serving_size: 140, serving_unit: 'g', calories: 220,

--- a/SparkyFitnessMobile/__tests__/utils/foodDetails.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/foodDetails.test.ts
@@ -657,6 +657,43 @@ describe('groupEquivalentVariants', () => {
     expect(groupEquivalentVariants([package200, package400])).toHaveLength(2);
   });
 
+  test.each([
+    ['matches the 200 g variant', 100],
+    ['matches neither metric variant', 50],
+  ])(
+    'keeps persisted metric packages visible when legacy nutrition %s',
+    (_scenario, legacyCalories) => {
+      const legacy = makeLocalVariant({
+        id: 'legacy-package',
+        serving_size: 1,
+        serving_unit: 'package',
+        calories: legacyCalories,
+      });
+      const package200 = makeLocalVariant({
+        id: 'package-200',
+        serving_size: 1,
+        serving_unit: 'package (200 g)',
+        calories: 100,
+      });
+      const package400 = makeLocalVariant({
+        id: 'package-400',
+        serving_size: 1,
+        serving_unit: 'package (400 g)',
+        calories: 200,
+      });
+
+      const groups = groupEquivalentVariants([legacy, package200, package400]);
+
+      expect(groups.map(group => group.base.id)).toEqual([
+        'package-200',
+        'package-400',
+      ]);
+      expect(groups[0].equivalents.map(equivalent => equivalent.id)).toEqual([
+        'legacy-package',
+      ]);
+    },
+  );
+
   test('promotes non-reference variant to base when 100g matches first', () => {
     const reference = makeLocalVariant({
       id: 'a',

--- a/SparkyFitnessMobile/__tests__/utils/foodDetails.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/foodDetails.test.ts
@@ -15,6 +15,7 @@ import {
   resolveLocalPickerVariantId,
   formatServingDescription,
   selectDisplayVariant,
+  toPersistedServingUnit,
 } from '../../src/utils/foodDetails';
 
 function makeItem(overrides: Partial<FoodInfoItem> = {}): FoodInfoItem {
@@ -109,6 +110,65 @@ describe('formatServingDescription', () => {
   });
 });
 
+describe('toPersistedServingUnit', () => {
+  it('keeps metric units compact', () => {
+    expect(
+      toPersistedServingUnit({
+        serving_size: 200,
+        serving_unit: 'g',
+        serving_description: '200 g',
+      }),
+    ).toBe('g');
+    expect(
+      toPersistedServingUnit({
+        serving_size: 250,
+        serving_unit: 'g',
+        serving_description: '1 cup (250 g)',
+      }),
+    ).toBe('g');
+  });
+
+  it('embeds metric context for otherwise ambiguous named servings', () => {
+    expect(
+      toPersistedServingUnit({
+        serving_size: 1,
+        serving_unit: 'package',
+        serving_description: '1 package (200 g)',
+      }),
+    ).toBe('package (200 g)');
+    expect(
+      toPersistedServingUnit({
+        serving_size: 1,
+        serving_unit: 'package',
+        serving_description: '1 package (400 g)',
+      }),
+    ).toBe('package (400 g)');
+  });
+
+  it('preserves a plain unit when no metric context is available', () => {
+    expect(
+      toPersistedServingUnit({ serving_size: 1, serving_unit: 'serving' }),
+    ).toBe('serving');
+    expect(
+      toPersistedServingUnit({
+        serving_size: 200,
+        serving_unit: 'glass.small',
+        serving_description: 'Small glass',
+      }),
+    ).toBe('glass.small');
+  });
+
+  it('does not append the same metric context twice', () => {
+    expect(
+      toPersistedServingUnit({
+        serving_size: 1,
+        serving_unit: 'package (200 g)',
+        serving_description: '1 package (200 g)',
+      }),
+    ).toBe('package (200 g)');
+  });
+});
+
 describe('selectDisplayVariant', () => {
   it('returns the default variant when no variants are provided', () => {
     const dv = makeDisplayVariant(100, 'g');
@@ -174,6 +234,17 @@ describe('selectDisplayVariant', () => {
     const result = selectDisplayVariant(dv, variants);
     expect(result.displayVariant).toBe(dv);
     expect(result.orderedVariants).toEqual([dv, another]);
+  });
+
+  it('keeps named servings with different metric weights distinct', () => {
+    const reference = makeDisplayVariant(100, 'g', '100 g');
+    const package200 = makeDisplayVariant(1, 'package', '1 package (200 g)');
+    const package400 = makeDisplayVariant(1, 'package', '1 package (400 g)');
+
+    expect(
+      selectDisplayVariant(reference, [reference, package200, package400])
+        .orderedVariants,
+    ).toEqual([package200, reference, package400]);
   });
 
   it('ignores variants without meaningful descriptions', () => {
@@ -336,6 +407,26 @@ describe('convertEquivalentVariantQuantity', () => {
 describe('buildExternalVariantOptions', () => {
   test('returns an empty list when variants is undefined', () => {
     expect(buildExternalVariantOptions(undefined)).toEqual([]);
+  });
+
+  test('shows named servings with different metric weights separately', () => {
+    const options = buildExternalVariantOptions([
+      makeExternalVariant({
+        serving_unit: 'package',
+        serving_description: '1 package (200 g)',
+        calories: 100,
+      }),
+      makeExternalVariant({
+        serving_unit: 'package',
+        serving_description: '1 package (400 g)',
+        calories: 200,
+      }),
+    ]);
+
+    expect(options.map(option => option.label)).toEqual([
+      '1 package (200 g) (100 cal)',
+      '1 package (400 g) (200 cal)',
+    ]);
   });
 
   test('uses serving_description and assigns ext-{index} ids', () => {
@@ -541,6 +632,29 @@ describe('nutritionMatches', () => {
 describe('groupEquivalentVariants', () => {
   test('returns empty array for undefined input', () => {
     expect(groupEquivalentVariants(undefined)).toEqual([]);
+  });
+
+  test('does not group named servings with different metric weights', () => {
+    const package200 = {
+      ...makeLocalVariant({
+        id: 'package-200',
+        serving_size: 1,
+        serving_unit: 'package',
+        calories: 100,
+      }),
+      serving_description: '1 package (200 g)',
+    };
+    const package400 = {
+      ...makeLocalVariant({
+        id: 'package-400',
+        serving_size: 1,
+        serving_unit: 'package',
+        calories: 200,
+      }),
+      serving_description: '1 package (400 g)',
+    };
+
+    expect(groupEquivalentVariants([package200, package400])).toHaveLength(2);
   });
 
   test('promotes non-reference variant to base when 100g matches first', () => {

--- a/SparkyFitnessMobile/__tests__/utils/persistExternalVariants.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/persistExternalVariants.test.ts
@@ -71,6 +71,75 @@ describe('persistExternalVariants', () => {
     );
   });
 
+  it('persists both a named YAZIO serving and its metric equivalent', async () => {
+    mockedFetchFoodVariants.mockResolvedValue([
+      {
+        id: 'default-variant',
+        food_id: 'food-1',
+        serving_size: 100,
+        serving_unit: 'g',
+        calories: 50,
+        protein: 5,
+        carbs: 6,
+        fat: 1,
+      },
+    ]);
+
+    await persistExternalVariants(
+      {
+        id: 'food-1',
+        default_variant: { serving_size: 100, serving_unit: 'g' },
+      },
+      [
+        {
+          serving_size: 100,
+          serving_unit: 'g',
+          serving_description: '100 g',
+          calories: 50,
+          protein: 5,
+          carbs: 6,
+          fat: 1,
+        },
+        {
+          serving_size: 1,
+          serving_unit: 'package',
+          serving_description: '1 package (200 g)',
+          calories: 100,
+          protein: 10,
+          carbs: 12,
+          fat: 2,
+        },
+        {
+          serving_size: 200,
+          serving_unit: 'g',
+          serving_description: '200 g',
+          calories: 100,
+          protein: 10,
+          carbs: 12,
+          fat: 2,
+        },
+      ],
+    );
+
+    expect(mockedCreateFoodVariant).toHaveBeenCalledTimes(2);
+    expect(mockedCreateFoodVariant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        food_id: 'food-1',
+        serving_size: 1,
+        serving_unit: 'package',
+        calories: 100,
+      }),
+    );
+    expect(mockedCreateFoodVariant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        food_id: 'food-1',
+        serving_size: 200,
+        serving_unit: 'g',
+        calories: 100,
+      }),
+    );
+  });
+
   it('does not update an existing provider variant with provider display metadata', async () => {
     mockedFetchFoodVariants.mockResolvedValue([
       {

--- a/SparkyFitnessMobile/__tests__/utils/persistExternalVariants.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/persistExternalVariants.test.ts
@@ -71,7 +71,7 @@ describe('persistExternalVariants', () => {
     );
   });
 
-  it('persists both a named YAZIO serving and its metric equivalent', async () => {
+  it('persists named YAZIO servings with their distinct metric descriptions', async () => {
     mockedFetchFoodVariants.mockResolvedValue([
       {
         id: 'default-variant',
@@ -88,7 +88,10 @@ describe('persistExternalVariants', () => {
     await persistExternalVariants(
       {
         id: 'food-1',
-        default_variant: { serving_size: 100, serving_unit: 'g' },
+        default_variant: {
+          serving_size: 100,
+          serving_unit: 'g',
+        },
       },
       [
         {
@@ -118,16 +121,42 @@ describe('persistExternalVariants', () => {
           carbs: 12,
           fat: 2,
         },
+        {
+          serving_size: 1,
+          serving_unit: 'package',
+          serving_description: '1 package (400 g)',
+          calories: 200,
+          protein: 20,
+          carbs: 24,
+          fat: 4,
+        },
+        {
+          serving_size: 400,
+          serving_unit: 'g',
+          serving_description: '400 g',
+          calories: 200,
+          protein: 20,
+          carbs: 24,
+          fat: 4,
+        },
       ],
     );
 
-    expect(mockedCreateFoodVariant).toHaveBeenCalledTimes(2);
+    expect(mockedCreateFoodVariant).toHaveBeenCalledTimes(4);
     expect(mockedCreateFoodVariant).toHaveBeenCalledWith(
       expect.objectContaining({
         food_id: 'food-1',
         serving_size: 1,
-        serving_unit: 'package',
+        serving_unit: 'package (200 g)',
         calories: 100,
+      }),
+    );
+    expect(mockedCreateFoodVariant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        food_id: 'food-1',
+        serving_size: 1,
+        serving_unit: 'package (400 g)',
+        calories: 200,
       }),
     );
     expect(mockedCreateFoodVariant).toHaveBeenCalledWith(
@@ -138,6 +167,14 @@ describe('persistExternalVariants', () => {
         calories: 100,
       }),
     );
+    expect(mockedCreateFoodVariant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        food_id: 'food-1',
+        serving_size: 400,
+        serving_unit: 'g',
+        calories: 200,
+      }),
+    );
   });
 
   it('does not update an existing provider variant with provider display metadata', async () => {
@@ -146,13 +183,12 @@ describe('persistExternalVariants', () => {
         id: 'existing-piece',
         food_id: 'food-1',
         serving_size: 1,
-        serving_unit: 'piece',
-        serving_description: '1 piece',
+        serving_unit: 'piece (200g)',
         calories: 50,
         protein: 1,
         carbs: 10,
         fat: 1,
-      } as any,
+      },
     ]);
 
     await persistExternalVariants(
@@ -174,6 +210,56 @@ describe('persistExternalVariants', () => {
     );
 
     expect(mockedCreateFoodVariant).not.toHaveBeenCalled();
+  });
+
+  it('creates an encoded variant when multiple legacy rows are ambiguous', async () => {
+    mockedFetchFoodVariants.mockResolvedValue([
+      {
+        id: 'legacy-a',
+        food_id: 'food-1',
+        serving_size: 1,
+        serving_unit: 'package',
+        calories: 100,
+        protein: 1,
+        carbs: 10,
+        fat: 1,
+      },
+      {
+        id: 'legacy-b',
+        food_id: 'food-1',
+        serving_size: 1,
+        serving_unit: 'package',
+        calories: 200,
+        protein: 2,
+        carbs: 20,
+        fat: 2,
+      },
+    ]);
+
+    await persistExternalVariants(
+      {
+        id: 'food-1',
+        default_variant: { serving_size: 100, serving_unit: 'g' },
+      },
+      [
+        {
+          serving_size: 1,
+          serving_unit: 'package',
+          serving_description: '1 package (300 g)',
+          calories: 300,
+          protein: 3,
+          carbs: 30,
+          fat: 3,
+        },
+      ],
+    );
+
+    expect(mockedCreateFoodVariant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serving_size: 1,
+        serving_unit: 'package (300 g)',
+      }),
+    );
   });
 
   it('falls back to skipping the saved default when existing variants cannot be fetched', async () => {
@@ -208,7 +294,10 @@ describe('persistExternalVariants', () => {
 
     expect(mockedCreateFoodVariant).toHaveBeenCalledTimes(1);
     expect(mockedCreateFoodVariant).toHaveBeenCalledWith(
-      expect.objectContaining({ serving_size: 1, serving_unit: 'serving' }),
+      expect.objectContaining({
+        serving_size: 1,
+        serving_unit: 'serving (80 g)',
+      }),
     );
   });
 });

--- a/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
+++ b/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
@@ -15,6 +15,7 @@ import type { ExternalFoodVariant } from '../types/externalFoods';
 import type { FoodVariantDetail } from '../types/foods';
 import {
   baseServingVariantKey,
+  hasDistinctMetricServingContext,
   servingVariantKey,
 } from '../utils/foodDetails';
 import { persistExternalVariants } from '../utils/persistExternalVariants';
@@ -36,35 +37,72 @@ interface UseAddFoodEntryOptions {
   onSuccess?: (entry: FoodEntry) => void;
 }
 
+type StoredServingReference = Pick<
+  FoodVariantDetail,
+  'id' | 'serving_size' | 'serving_unit'
+>;
+
+const SELECTED_VARIANT_RESOLUTION_ERROR =
+  'Could not uniquely resolve the selected serving variant';
+
 /**
- * Resolve the stored variant for the user's selected serving. Prefer an exact
- * encoded unit; only fall back to a legacy unencoded unit when it is unique.
+ * Resolve the stored variant for the user's selected serving. Prefer one exact
+ * encoded unit; only fall back to one legacy unencoded unit. The server-returned
+ * default is safe only when its normalized identity exactly matches selection.
  */
 async function resolveSelectedVariant(
   foodId: string,
   selectedServingSize: number,
   selectedServingUnit: string,
-): Promise<FoodVariantDetail | undefined> {
-  try {
-    const allVariants = await fetchFoodVariants(foodId);
-    const selectedIdentity = {
-      serving_size: selectedServingSize,
-      serving_unit: selectedServingUnit,
-    };
-    const exactKey = servingVariantKey(selectedIdentity);
-    const exactMatch = allVariants.find(
-      variant => servingVariantKey(variant) === exactKey,
-    );
-    if (exactMatch) return exactMatch;
+  defaultVariant:
+    | {
+        id?: string;
+        serving_size: number;
+        serving_unit: string;
+      }
+    | null
+    | undefined,
+): Promise<StoredServingReference> {
+  const selectedIdentity = {
+    serving_size: selectedServingSize,
+    serving_unit: selectedServingUnit,
+  };
+  const exactKey = servingVariantKey(selectedIdentity);
+  const exactDefault =
+    defaultVariant?.id && servingVariantKey(defaultVariant) === exactKey
+      ? {
+          id: defaultVariant.id,
+          serving_size: defaultVariant.serving_size,
+          serving_unit: defaultVariant.serving_unit,
+        }
+      : undefined;
 
-    const baseKey = baseServingVariantKey(selectedIdentity);
-    const legacyMatches = allVariants.filter(
-      variant => baseServingVariantKey(variant) === baseKey,
-    );
-    return legacyMatches.length === 1 ? legacyMatches[0] : undefined;
+  let allVariants: FoodVariantDetail[];
+  try {
+    allVariants = await fetchFoodVariants(foodId);
   } catch {
-    return undefined;
+    if (exactDefault) return exactDefault;
+    throw new Error(SELECTED_VARIANT_RESOLUTION_ERROR);
   }
+
+  const exactMatches = allVariants.filter(
+    variant => servingVariantKey(variant) === exactKey,
+  );
+  if (exactMatches.length === 1) return exactMatches[0];
+  if (exactMatches.length > 1) {
+    throw new Error(SELECTED_VARIANT_RESOLUTION_ERROR);
+  }
+  if (exactDefault) return exactDefault;
+
+  const baseKey = baseServingVariantKey(selectedIdentity);
+  const legacyMatches = allVariants.filter(
+    variant =>
+      !hasDistinctMetricServingContext(variant) &&
+      baseServingVariantKey(variant) === baseKey,
+  );
+  if (legacyMatches.length === 1) return legacyMatches[0];
+
+  throw new Error(SELECTED_VARIANT_RESOLUTION_ERROR);
 }
 
 export function useAddFoodEntry(options?: UseAddFoodEntryOptions) {
@@ -100,11 +138,10 @@ export function useAddFoodEntry(options?: UseAddFoodEntryOptions) {
             saved.id,
             selectedServingSize,
             selectedServingUnit,
+            saved.default_variant,
           );
-          if (resolvedVariant) {
-            variantId = resolvedVariant.id;
-            unit = resolvedVariant.serving_unit;
-          }
+          variantId = resolvedVariant.id;
+          unit = resolvedVariant.serving_unit;
         }
 
         if (!variantId) {

--- a/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
+++ b/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
@@ -12,6 +12,11 @@ import { dailySummaryQueryKey, foodsQueryKey } from './queryKeys';
 import { invalidateMealUsageCaches } from './useMeals';
 import type { FoodEntry } from '../types/foodEntries';
 import type { ExternalFoodVariant } from '../types/externalFoods';
+import type { FoodVariantDetail } from '../types/foods';
+import {
+  baseServingVariantKey,
+  servingVariantKey,
+} from '../utils/foodDetails';
 import { persistExternalVariants } from '../utils/persistExternalVariants';
 
 export interface AddFoodEntryInput {
@@ -32,20 +37,31 @@ interface UseAddFoodEntryOptions {
 }
 
 /**
- * Resolve the DB variant_id that matches the user's selected serving,
- * after persistExternalVariants has ensured all provider variants exist.
+ * Resolve the stored variant for the user's selected serving. Prefer an exact
+ * encoded unit; only fall back to a legacy unencoded unit when it is unique.
  */
-async function resolveSelectedVariantId(
+async function resolveSelectedVariant(
   foodId: string,
   selectedServingSize: number,
   selectedServingUnit: string,
-): Promise<string | undefined> {
+): Promise<FoodVariantDetail | undefined> {
   try {
     const allVariants = await fetchFoodVariants(foodId);
-    const match = allVariants.find(
-      (v) => v.serving_size === selectedServingSize && v.serving_unit === selectedServingUnit
+    const selectedIdentity = {
+      serving_size: selectedServingSize,
+      serving_unit: selectedServingUnit,
+    };
+    const exactKey = servingVariantKey(selectedIdentity);
+    const exactMatch = allVariants.find(
+      variant => servingVariantKey(variant) === exactKey,
     );
-    return match?.id;
+    if (exactMatch) return exactMatch;
+
+    const baseKey = baseServingVariantKey(selectedIdentity);
+    const legacyMatches = allVariants.filter(
+      variant => baseServingVariantKey(variant) === baseKey,
+    );
+    return legacyMatches.length === 1 ? legacyMatches[0] : undefined;
   } catch {
     return undefined;
   }
@@ -74,29 +90,20 @@ export function useAddFoodEntry(options?: UseAddFoodEntryOptions) {
         // Persist any missing external provider variants.
         await persistExternalVariants(saved, input.externalVariants);
 
-        // If we used the default variant but the user actually selected a
-        // different external serving (e.g. "1 Portion" instead of "100 g"),
-        // look up the correct persisted variant id.
+        // If the user selected a non-default external serving, resolve the
+        // persisted row and use both its id and actual stored unit. This also
+        // handles one unambiguous legacy row without metric context.
         if (!input.saveThenCreateVariantPayload) {
           const selectedServingSize = input.saveFoodPayload.serving_size;
           const selectedServingUnit = input.saveFoodPayload.serving_unit;
-          const resolvedId = await resolveSelectedVariantId(
+          const resolvedVariant = await resolveSelectedVariant(
             saved.id,
             selectedServingSize,
             selectedServingUnit,
           );
-          if (resolvedId) {
-            variantId = resolvedId;
-          }
-          // If the user's selected variant differs from the default, also
-          // update the entry unit to match the selected variant's unit.
-          if (input.externalVariants) {
-            const selected = input.externalVariants.find(
-              (v) => v.serving_size === selectedServingSize && v.serving_unit === selectedServingUnit,
-            );
-            if (selected) {
-              unit = selected.serving_unit;
-            }
+          if (resolvedVariant) {
+            variantId = resolvedVariant.id;
+            unit = resolvedVariant.serving_unit;
           }
         }
 

--- a/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
+++ b/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
@@ -89,10 +89,10 @@ async function resolveSelectedVariant(
     variant => servingVariantKey(variant) === exactKey,
   );
   if (exactMatches.length === 1) return exactMatches[0];
+  if (exactDefault) return exactDefault;
   if (exactMatches.length > 1) {
     throw new Error(SELECTED_VARIANT_RESOLUTION_ERROR);
   }
-  if (exactDefault) return exactDefault;
 
   const baseKey = baseServingVariantKey(selectedIdentity);
   const legacyMatches = allVariants.filter(

--- a/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
+++ b/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
@@ -163,8 +163,12 @@ export function useAddFoodEntry(options?: UseAddFoodEntryOptions) {
       }
       options?.onSuccess?.(entry);
     },
-    onError: () => {
-      Toast.show({ type: 'error', text1: 'Failed to add food', text2: 'Please try again.' });
+    onError: (error) => {
+      const text2 =
+        error instanceof Error && error.message === SELECTED_VARIANT_RESOLUTION_ERROR
+          ? 'Choose a different serving.'
+          : 'Please try again.';
+      Toast.show({ type: 'error', text1: 'Failed to add food', text2 });
     },
   });
 

--- a/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
@@ -79,6 +79,7 @@ import {
   formatVariantServingLabel,
   resolveFoodDisplayValues,
   resolveLocalPickerVariantId,
+  toPersistedServingUnit,
   unitVariantToDisplayValues,
   type FoodDisplayValues,
 } from '../utils/foodDetails';
@@ -766,7 +767,11 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
         provider_verified: activeItem.provider_verified === true,
         is_custom: activeItem.is_custom ?? true,
         serving_size: saveFoodSourceValues.servingSize,
-        serving_unit: saveFoodSourceValues.servingUnit,
+        serving_unit: toPersistedServingUnit({
+          serving_size: saveFoodSourceValues.servingSize,
+          serving_unit: saveFoodSourceValues.servingUnit,
+          serving_description: saveFoodSourceValues.servingDescription,
+        }),
         calories: saveFoodSourceValues.calories,
         protein: saveFoodSourceValues.protein,
         carbs: saveFoodSourceValues.carbs,

--- a/SparkyFitnessMobile/src/utils/foodDetails.ts
+++ b/SparkyFitnessMobile/src/utils/foodDetails.ts
@@ -138,15 +138,15 @@ export function hasMeaningfulDescription(
 }
 
 /**
- * Compare two variants by value using serving_size + serving_unit.
- * The API may return the same variant in both default_variant and variants[]
- * as separate object references — reference equality (===) fails.
+ * Compare two variants by their persisted serving identity. Provider variants
+ * can share size/unit while differing by an explicit metric package weight.
  */
-export function isSameVariant(
-  a: { serving_size: number; serving_unit: string },
-  b: { serving_size: number; serving_unit: string },
-): boolean {
-  return a.serving_size === b.serving_size && a.serving_unit === b.serving_unit;
+export function isSameVariant(a: ServingIdentity, b: ServingIdentity): boolean {
+  if (servingVariantKey(a) === servingVariantKey(b)) return true;
+  if (baseServingVariantKey(a) !== baseServingVariantKey(b)) return false;
+  return !(
+    hasDistinctMetricServingContext(a) && hasDistinctMetricServingContext(b)
+  );
 }
 
 export function foodInfoToDisplayValues(item: FoodInfoItem): FoodDisplayValues {
@@ -523,12 +523,64 @@ export function buildExternalUnitVariants(
   );
 }
 
+export interface ServingIdentity {
+  serving_size?: number;
+  serving_unit?: string;
+  serving_description?: string | null;
+}
+
+const METRIC_SERVING_UNIT_PATTERN = /^(?:g|kg|ml|l)$/i;
+const METRIC_CONTEXT_PATTERN =
+  /\(\s*(\d+(?:[.,]\d+)?)\s*(g|kg|ml|l)\s*\)\s*$/i;
+
+export function toPersistedServingUnit(variant: ServingIdentity): string {
+  const servingUnit = variant.serving_unit?.trim() || 'serving';
+  if (
+    METRIC_SERVING_UNIT_PATTERN.test(servingUnit) ||
+    METRIC_CONTEXT_PATTERN.test(servingUnit)
+  ) {
+    return servingUnit;
+  }
+
+  const metricContext = variant.serving_description
+    ?.trim()
+    .match(METRIC_CONTEXT_PATTERN);
+  if (!metricContext) return servingUnit;
+
+  const [, amount, unit] = metricContext;
+  return `${servingUnit} (${amount} ${unit.toLowerCase()})`;
+}
+
+function normalizeServingUnitKey(servingUnit: string): string {
+  return servingUnit.replace(/\s+/g, '').toLowerCase();
+}
+
+export function servingVariantKey(variant: ServingIdentity): string {
+  return `${variant.serving_size}:${normalizeServingUnitKey(
+    toPersistedServingUnit(variant),
+  )}`;
+}
+
+export function baseServingVariantKey(variant: ServingIdentity): string {
+  const servingUnit = toPersistedServingUnit(variant).replace(
+    /\s+\(\s*\d+(?:[.,]\d+)?\s*(?:g|kg|ml|l)\s*\)\s*$/i,
+    '',
+  );
+  return `${variant.serving_size}:${normalizeServingUnitKey(servingUnit)}`;
+}
+
+export function hasDistinctMetricServingContext(
+  variant: ServingIdentity,
+): boolean {
+  return servingVariantKey(variant) !== baseServingVariantKey(variant);
+}
+
 export function buildCreateFoodVariantInput(
   variant: FoodUnitVariant,
 ): Omit<CreateFoodVariantPayload, 'food_id'> {
   return {
     serving_size: variant.serving_size,
-    serving_unit: variant.serving_unit,
+    serving_unit: toPersistedServingUnit(variant),
     calories: variant.calories,
     protein: variant.protein,
     carbs: variant.carbs,
@@ -629,12 +681,28 @@ export interface VariantGroup<T extends FoodVariantDetail = FoodVariantDetail> {
   equivalents: EquivalentUnit[];
 }
 
-export function groupEquivalentVariants<T extends FoodVariantDetail>(
-  variants: T[] | undefined,
-): VariantGroup<T>[] {
+function hasConflictingMetricServingContext(
+  a: ServingIdentity,
+  b: ServingIdentity,
+): boolean {
+  return (
+    hasDistinctMetricServingContext(a) &&
+    hasDistinctMetricServingContext(b) &&
+    baseServingVariantKey(a) === baseServingVariantKey(b) &&
+    servingVariantKey(a) !== servingVariantKey(b)
+  );
+}
+
+export function groupEquivalentVariants<
+  T extends FoodVariantDetail & ServingIdentity = FoodVariantDetail,
+>(variants: T[] | undefined): VariantGroup<T>[] {
   const groups: VariantGroup<T>[] = [];
   for (const variant of variants ?? []) {
-    const match = groups.find(g => nutritionMatches(g.base, variant));
+    const match = groups.find(
+      g =>
+        nutritionMatches(g.base, variant) &&
+        !hasConflictingMetricServingContext(g.base, variant),
+    );
     if (match) {
       // Promote the non-reference variant to base when a reference serving
       // (100g/100ml) was matched first — the picker option should carry the
@@ -653,15 +721,9 @@ export function groupEquivalentVariants<T extends FoodVariantDetail>(
         match.equivalents.push(toEquivalentUnit(variant));
       }
     } else {
-      // Fallback: same serving size/unit but different nutrition (e.g. rounding)
-      // — still treat as equivalents so they don't appear as duplicate picker
-      // entries. This handles Yazio data where \"portion (150 g)\" and \"150 g\"
-      // have identical portion size but slightly different stored nutrient values.
-      const sizeMatch = groups.find(
-        g =>
-          g.base.serving_size === variant.serving_size &&
-          g.base.serving_unit === variant.serving_unit,
-      );
+      // Fallback: the same persisted serving identity with different nutrition
+      // (for example provider rounding) is still one picker option.
+      const sizeMatch = groups.find(g => isSameVariant(g.base, variant));
       if (sizeMatch) {
         sizeMatch.equivalents.push(toEquivalentUnit(variant));
       } else {

--- a/SparkyFitnessMobile/src/utils/foodDetails.ts
+++ b/SparkyFitnessMobile/src/utils/foodDetails.ts
@@ -704,16 +704,28 @@ export function groupEquivalentVariants<
         !hasConflictingMetricServingContext(g.base, variant),
     );
     if (match) {
-      // Promote the non-reference variant to base when a reference serving
+      // Prefer a context-rich persisted serving over its matching legacy row so
+      // variants such as package (200 g) and package (400 g) remain separate
+      // visible options even when the undecorated package row was loaded first.
+      const shouldPromoteMetricContext =
+        !hasDistinctMetricServingContext(match.base) &&
+        hasDistinctMetricServingContext(variant) &&
+        baseServingVariantKey(match.base) === baseServingVariantKey(variant);
+
+      // Also promote a non-reference variant when a reference serving
       // (100g/100ml) was matched first — the picker option should carry the
-      // user-friendly name (e.g. \"piece\") with the metric equivalent inline,
+      // user-friendly name (e.g. "piece") with the metric equivalent inline,
       // not the other way around. Without this swap, the reference variant
       // becomes the lone base option and the selected non-reference variant
-      // is pushed into a fallback, producing a duplicate \"gram entry\" in the
+      // is pushed into a fallback, producing a duplicate "gram entry" in the
       // picker alongside the correct serving.
       if (
-        isReferenceServing(match.base.serving_size, match.base.serving_unit) &&
-        !isReferenceServing(variant.serving_size, variant.serving_unit)
+        shouldPromoteMetricContext ||
+        (isReferenceServing(
+          match.base.serving_size,
+          match.base.serving_unit,
+        ) &&
+          !isReferenceServing(variant.serving_size, variant.serving_unit))
       ) {
         match.equivalents.push(toEquivalentUnit(match.base));
         match.base = variant;
@@ -725,7 +737,17 @@ export function groupEquivalentVariants<
       // (for example provider rounding) is still one picker option.
       const sizeMatch = groups.find(g => isSameVariant(g.base, variant));
       if (sizeMatch) {
-        sizeMatch.equivalents.push(toEquivalentUnit(variant));
+        const shouldPromoteMetricContext =
+          !hasDistinctMetricServingContext(sizeMatch.base) &&
+          hasDistinctMetricServingContext(variant) &&
+          baseServingVariantKey(sizeMatch.base) ===
+            baseServingVariantKey(variant);
+        if (shouldPromoteMetricContext) {
+          sizeMatch.equivalents.push(toEquivalentUnit(sizeMatch.base));
+          sizeMatch.base = variant;
+        } else {
+          sizeMatch.equivalents.push(toEquivalentUnit(variant));
+        }
       } else {
         groups.push({ base: variant, equivalents: [] });
       }

--- a/SparkyFitnessMobile/src/utils/persistExternalVariants.ts
+++ b/SparkyFitnessMobile/src/utils/persistExternalVariants.ts
@@ -4,7 +4,12 @@ import {
   type CreateFoodVariantPayload,
 } from '../services/api/foodsApi';
 import type { ExternalFoodVariant } from '../types/externalFoods';
-import type { FoodVariantDetail } from '../types/foods';
+import {
+  baseServingVariantKey,
+  hasDistinctMetricServingContext,
+  servingVariantKey,
+  toPersistedServingUnit,
+} from './foodDetails';
 
 type SavedFoodWithDefaultVariant = {
   id: string;
@@ -13,12 +18,6 @@ type SavedFoodWithDefaultVariant = {
     serving_unit?: string;
   } | null;
 };
-
-function variantKey(
-  variant: { serving_size?: number; serving_unit?: string } | null | undefined,
-) {
-  return `${variant?.serving_size}:${variant?.serving_unit}`;
-}
 
 /**
  * Persist all external provider variants as local food_variants for a saved food.
@@ -33,35 +32,56 @@ export async function persistExternalVariants(
 ) {
   if (!externalVariants || externalVariants.length === 0) return;
 
-  let existingByKey = new Map<string, FoodVariantDetail>();
+  const existingKeys = new Set<string>();
+  const legacyExistingBaseKeyCounts = new Map<string, number>();
   let fetchedExistingVariants = false;
   try {
     const existing = await fetchFoodVariants(savedFood.id);
-    existingByKey = new Map(
-      existing.map(variant => [variantKey(variant), variant]),
-    );
+    existing.forEach(variant => {
+      existingKeys.add(servingVariantKey(variant));
+      if (!hasDistinctMetricServingContext(variant)) {
+        const baseKey = baseServingVariantKey(variant);
+        legacyExistingBaseKeyCounts.set(
+          baseKey,
+          (legacyExistingBaseKeyCounts.get(baseKey) ?? 0) + 1,
+        );
+      }
+    });
     fetchedExistingVariants = true;
   } catch {
     // If we can't check existing variants, fall back to the saved default only.
     // A possible duplicate is less harmful than missing all alternate servings.
   }
 
-  const defaultKey = variantKey(savedFood.default_variant);
+  const defaultKey = servingVariantKey(savedFood.default_variant ?? {});
+  const externalBaseKeyCounts = externalVariants.reduce((counts, variant) => {
+    const key = baseServingVariantKey(variant);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    return counts;
+  }, new Map<string, number>());
+
+  const variantsToCreate = externalVariants.filter(variant => {
+    const key = servingVariantKey(variant);
+    if (existingKeys.has(key)) return false;
+    const baseKey = baseServingVariantKey(variant);
+    if (
+      externalBaseKeyCounts.get(baseKey) === 1 &&
+      legacyExistingBaseKeyCounts.get(baseKey) === 1
+    ) {
+      return false;
+    }
+    if (!fetchedExistingVariants && key === defaultKey) return false;
+    existingKeys.add(key);
+    return true;
+  });
 
   await Promise.all(
-    externalVariants.map(async variant => {
-      const key = variantKey(variant);
-      const existingVariant = existingByKey.get(key);
-      if (existingVariant) {
-        return;
-      }
-      if (!fetchedExistingVariants && key === defaultKey) return;
-
+    variantsToCreate.map(async variant => {
       try {
         await createFoodVariant({
           food_id: savedFood.id,
           serving_size: variant.serving_size,
-          serving_unit: variant.serving_unit,
+          serving_unit: toPersistedServingUnit(variant),
           calories: variant.calories,
           protein: variant.protein,
           carbs: variant.carbs,
@@ -77,7 +97,7 @@ export async function persistExternalVariants(
           cholesterol: variant.cholesterol,
           vitamin_a: variant.vitamin_a,
           vitamin_c: variant.vitamin_c,
-        } as CreateFoodVariantPayload);
+        } satisfies CreateFoodVariantPayload);
       } catch {
         // Non-blocking: one provider variant failing should not prevent logging.
       }

--- a/SparkyFitnessServer/integrations/yazio/yazioService.ts
+++ b/SparkyFitnessServer/integrations/yazio/yazioService.ts
@@ -111,15 +111,17 @@ interface YazioProductSearchResult {
   eans?: string[];
 }
 
+interface YazioServing {
+  serving?: string;
+  amount?: number;
+  serving_quantity?: number;
+  unit?: string;
+  base_unit?: string;
+}
+
 interface YazioProduct extends YazioProductSearchResult {
   is_deleted?: boolean;
-  servings?: Array<{
-    serving?: string;
-    amount?: number;
-    serving_quantity?: number;
-    unit?: string;
-    base_unit?: string;
-  }>;
+  servings?: YazioServing[];
 }
 
 const tokenCache = new Map<string, YazioToken>();
@@ -294,6 +296,98 @@ function mergeYazioSearchCandidateVerification(
   };
 }
 
+function getYazioProductId(
+  product: YazioProductSearchResult
+): string | undefined {
+  return product.id ?? product.product_id;
+}
+
+function topLevelYazioServing(
+  candidate: YazioProductSearchResult
+): YazioServing | null {
+  if (typeof candidate.serving !== 'string' || !candidate.serving.trim()) {
+    return null;
+  }
+
+  const amount = numberValue(candidate.amount);
+  if (amount <= 0) {
+    return null;
+  }
+
+  const servingQuantity = numberValue(candidate.serving_quantity, 1);
+  return {
+    serving: candidate.serving,
+    amount,
+    serving_quantity: servingQuantity > 0 ? servingQuantity : 1,
+    base_unit: candidate.base_unit,
+  };
+}
+
+function yazioServingKey(serving: YazioServing): string {
+  return [
+    normalizeYazioServingName(serving.serving)?.toLowerCase() ?? '',
+    numberValue(serving.amount),
+    numberValue(serving.serving_quantity, 1),
+    normalizeServingUnit(serving.unit ?? serving.base_unit),
+  ].join(':');
+}
+
+function mergeYazioCandidateServings(
+  product: YazioProduct,
+  candidates: YazioProductSearchResult[]
+): YazioProduct {
+  const servings = [...(product.servings ?? [])];
+  const seen = new Set(servings.map(yazioServingKey));
+
+  for (const candidate of candidates) {
+    const serving = topLevelYazioServing(candidate);
+    if (!serving) {
+      continue;
+    }
+
+    const key = yazioServingKey(serving);
+    if (!seen.has(key)) {
+      seen.add(key);
+      servings.push(serving);
+    }
+  }
+
+  return servings.length === (product.servings?.length ?? 0)
+    ? product
+    : { ...product, servings };
+}
+
+interface YazioSearchCandidateGroup {
+  product: YazioProductSearchResult;
+  candidates: YazioProductSearchResult[];
+}
+
+function groupYazioSearchCandidates(
+  products: YazioProductSearchResult[]
+): YazioSearchCandidateGroup[] {
+  const groups: YazioSearchCandidateGroup[] = [];
+  const groupIndexByProductId = new Map<string, number>();
+
+  for (const product of products) {
+    const productId = getYazioProductId(product);
+    if (!productId) {
+      continue;
+    }
+
+    const existingIndex = groupIndexByProductId.get(productId);
+
+    if (existingIndex !== undefined) {
+      groups[existingIndex]?.candidates.push(product);
+      continue;
+    }
+
+    groupIndexByProductId.set(productId, groups.length);
+    groups.push({ product, candidates: [product] });
+  }
+
+  return groups;
+}
+
 function normalizeServingUnit(unit: unknown): string {
   if (typeof unit !== 'string' || unit.trim().length === 0) {
     return 'g';
@@ -394,6 +488,7 @@ function isMetricServingName(value: string, metricUnit: string): boolean {
 
 function buildYazioServingDescription(
   servingName: string,
+  servingQuantity: unknown,
   amount: number,
   metricUnit: string
 ): string {
@@ -401,7 +496,13 @@ function buildYazioServingDescription(
     return metricServingDescription(amount, metricUnit);
   }
 
-  return `${servingName} (${metricServingDescription(amount, metricUnit)})`;
+  const parsedQuantity = numberValue(servingQuantity, 1);
+  const quantity = parsedQuantity > 0 ? parsedQuantity : 1;
+  const servingLabel = /^\d/.test(servingName)
+    ? servingName
+    : `${formatAmount(quantity)} ${servingName}`;
+
+  return `${servingLabel} (${metricServingDescription(amount, metricUnit)})`;
 }
 
 function isYazioDensityPayload(nutrients: Record<string, unknown>): boolean {
@@ -542,13 +643,20 @@ function mapYazioServingVariants(
     }
 
     const isMetric = isMetricServingName(servingName, metricUnit);
-    const servingSize = isMetric ? amount : 1;
+    const parsedServingQuantity = numberValue(serving.serving_quantity, 1);
+    const servingQuantity =
+      parsedServingQuantity > 0 ? parsedServingQuantity : 1;
+    const servingSize = isMetric ? amount : servingQuantity;
     const servingUnitLabel = isMetric ? metricUnit : servingName;
-    const key = `${servingSize}:${servingUnitLabel}`;
-    if (seen.has(key)) {
+    const metricKey = `${amount}:${metricUnit}`;
+    const key = isMetric
+      ? metricKey
+      : `${servingSize}:${servingUnitLabel}:${metricKey}`;
+    const shouldAddNamedVariant = !seen.has(key);
+    const shouldAddMetricVariant = !isMetric && !seen.has(metricKey);
+    if (!shouldAddNamedVariant && !shouldAddMetricVariant) {
       continue;
     }
-    seen.add(key);
 
     const nutrition = mapYazioVariantNutrition(
       nutrients,
@@ -559,30 +667,31 @@ function mapYazioServingVariants(
           : 0
     );
 
-    variants.push({
-      serving_size: servingSize,
-      serving_unit: servingUnitLabel,
-      serving_description: buildYazioServingDescription(
-        servingName,
-        amount,
-        metricUnit
-      ),
-      ...nutrition,
-      is_default: false,
-    });
+    if (shouldAddNamedVariant) {
+      seen.add(key);
+      variants.push({
+        serving_size: servingSize,
+        serving_unit: servingUnitLabel,
+        serving_description: buildYazioServingDescription(
+          servingName,
+          servingQuantity,
+          amount,
+          metricUnit
+        ),
+        ...nutrition,
+        is_default: false,
+      });
+    }
 
-    if (!isMetric) {
-      const metricKey = `${amount}:${metricUnit}`;
-      if (!seen.has(metricKey)) {
-        seen.add(metricKey);
-        variants.push({
-          serving_size: amount,
-          serving_unit: metricUnit,
-          serving_description: metricServingDescription(amount, metricUnit),
-          ...nutrition,
-          is_default: false,
-        });
-      }
+    if (shouldAddMetricVariant) {
+      seen.add(metricKey);
+      variants.push({
+        serving_size: amount,
+        serving_unit: metricUnit,
+        serving_description: metricServingDescription(amount, metricUnit),
+        ...nutrition,
+        is_default: false,
+      });
     }
   }
 
@@ -596,6 +705,8 @@ function mapYazioProduct(
   if (!product) {
     return null;
   }
+
+  product = mergeYazioCandidateServings(product, [product]);
 
   const externalId = product.id ?? product.product_id ?? options?.productId;
   const name = product.name?.trim();
@@ -676,30 +787,40 @@ async function searchYazioFoods(query: string, options: YazioSearchOptions) {
   const page = options.page ?? 1;
   const pageSize = options.pageSize ?? 20;
   const products = await searchRawYazioProducts(query, options);
+  const productGroups = groupYazioSearchCandidates(products);
   const offset = Math.max(page - 1, 0) * pageSize;
-  const pageItems = products.slice(offset, offset + pageSize);
+  const pageGroups = productGroups.slice(offset, offset + pageSize);
 
   const foods = await Promise.all(
-    pageItems.map(async (product) => {
-      const productId = product.id ?? product.product_id;
+    pageGroups.map(async ({ product, candidates: siblingCandidates }) => {
+      const productId = getYazioProductId(product);
       if (!productId) {
-        return mapYazioProduct(product);
+        return mapYazioProduct(
+          mergeYazioCandidateServings(product, siblingCandidates)
+        );
       }
       try {
         const detailed = await getRawYazioFoodDetails(productId, options);
         return detailed
           ? mapYazioProduct(
-              mergeYazioSearchCandidateVerification(detailed, product),
+              mergeYazioCandidateServings(
+                mergeYazioSearchCandidateVerification(detailed, product),
+                siblingCandidates
+              ),
               { productId }
             )
-          : mapYazioProduct(product);
+          : mapYazioProduct(
+              mergeYazioCandidateServings(product, siblingCandidates)
+            );
       } catch (error) {
         log(
           'debug',
           `YAZIO search detail enrichment failed for candidate ${productId}:`,
           error
         );
-        return mapYazioProduct(product);
+        return mapYazioProduct(
+          mergeYazioCandidateServings(product, siblingCandidates)
+        );
       }
     })
   );
@@ -709,8 +830,8 @@ async function searchYazioFoods(query: string, options: YazioSearchOptions) {
     pagination: {
       page,
       pageSize,
-      totalCount: products.length,
-      hasMore: offset + pageSize < products.length,
+      totalCount: productGroups.length,
+      hasMore: offset + pageSize < productGroups.length,
     },
   };
 }
@@ -770,10 +891,14 @@ async function searchYazioByBarcode(
   ).slice(0, 20);
 
   for (const candidate of candidates) {
-    const productId = candidate.id ?? candidate.product_id;
+    const productId = getYazioProductId(candidate);
     if (!productId) {
       continue;
     }
+
+    const siblingCandidates = candidates.filter(
+      (sibling) => getYazioProductId(sibling) === productId
+    );
 
     let detailedProduct: YazioProduct | null;
     try {
@@ -799,7 +924,10 @@ async function searchYazioByBarcode(
     }
 
     const food = mapYazioProduct(
-      mergeYazioSearchCandidateVerification(detailedProduct, candidate),
+      mergeYazioCandidateServings(
+        mergeYazioSearchCandidateVerification(detailedProduct, candidate),
+        siblingCandidates
+      ),
       { productId }
     );
     if (food) {

--- a/SparkyFitnessServer/integrations/yazio/yazioService.ts
+++ b/SparkyFitnessServer/integrations/yazio/yazioService.ts
@@ -359,6 +359,7 @@ function mergeYazioCandidateServings(
 
 interface YazioSearchCandidateGroup {
   product: YazioProductSearchResult;
+  productId: string;
   candidates: YazioProductSearchResult[];
 }
 
@@ -382,7 +383,7 @@ function groupYazioSearchCandidates(
     }
 
     groupIndexByProductId.set(productId, groups.length);
-    groups.push({ product, candidates: [product] });
+    groups.push({ product, productId, candidates: [product] });
   }
 
   return groups;
@@ -792,37 +793,33 @@ async function searchYazioFoods(query: string, options: YazioSearchOptions) {
   const pageGroups = productGroups.slice(offset, offset + pageSize);
 
   const foods = await Promise.all(
-    pageGroups.map(async ({ product, candidates: siblingCandidates }) => {
-      const productId = getYazioProductId(product);
-      if (!productId) {
-        return mapYazioProduct(
-          mergeYazioCandidateServings(product, siblingCandidates)
-        );
+    pageGroups.map(
+      async ({ product, productId, candidates: siblingCandidates }) => {
+        try {
+          const detailed = await getRawYazioFoodDetails(productId, options);
+          return detailed
+            ? mapYazioProduct(
+                mergeYazioCandidateServings(
+                  mergeYazioSearchCandidateVerification(detailed, product),
+                  siblingCandidates
+                ),
+                { productId }
+              )
+            : mapYazioProduct(
+                mergeYazioCandidateServings(product, siblingCandidates)
+              );
+        } catch (error) {
+          log(
+            'debug',
+            `YAZIO search detail enrichment failed for candidate ${productId}:`,
+            error
+          );
+          return mapYazioProduct(
+            mergeYazioCandidateServings(product, siblingCandidates)
+          );
+        }
       }
-      try {
-        const detailed = await getRawYazioFoodDetails(productId, options);
-        return detailed
-          ? mapYazioProduct(
-              mergeYazioCandidateServings(
-                mergeYazioSearchCandidateVerification(detailed, product),
-                siblingCandidates
-              ),
-              { productId }
-            )
-          : mapYazioProduct(
-              mergeYazioCandidateServings(product, siblingCandidates)
-            );
-      } catch (error) {
-        log(
-          'debug',
-          `YAZIO search detail enrichment failed for candidate ${productId}:`,
-          error
-        );
-        return mapYazioProduct(
-          mergeYazioCandidateServings(product, siblingCandidates)
-        );
-      }
-    })
+    )
   );
 
   return {

--- a/SparkyFitnessServer/schemas/foodSchemas.ts
+++ b/SparkyFitnessServer/schemas/foodSchemas.ts
@@ -5,6 +5,10 @@ export const FoodVariantSchema = z.object({
   user_id: z.string().optional(),
   serving_size: z.number(),
   serving_unit: z.string(),
+  serving_description: z.preprocess(
+    (value) => (value === null ? undefined : value),
+    z.string().optional()
+  ),
   calories: z.number(),
   protein: z.number(),
   carbs: z.number(),

--- a/SparkyFitnessServer/tests/foodSchemas.test.ts
+++ b/SparkyFitnessServer/tests/foodSchemas.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
+  BarcodeResponseSchema,
+  FoodVariantSchema,
   PaginationSchema,
   SearchResponseSchema,
 } from '../schemas/foodSchemas.js';
@@ -7,6 +9,7 @@ import {
 const validVariant = {
   serving_size: 100,
   serving_unit: 'g',
+  serving_description: '100 g',
   calories: 50,
   protein: 1,
   carbs: 10,
@@ -14,12 +17,43 @@ const validVariant = {
   is_default: true,
 };
 
+const packageVariant = {
+  ...validVariant,
+  serving_size: 1,
+  serving_unit: 'package',
+  serving_description: '1 package (200 g)',
+  calories: 100,
+  is_default: false,
+};
+
+const metricPackageVariant = {
+  ...packageVariant,
+  serving_size: 200,
+  serving_unit: 'g',
+  serving_description: '200 g',
+};
+
 const validFood = {
   name: 'Yam',
   brand: null,
   is_custom: false,
   default_variant: validVariant,
+  variants: [validVariant, packageVariant, metricPackageVariant],
 };
+
+describe('FoodVariantSchema', () => {
+  it('accepts an explicitly null provider serving description', () => {
+    const result = FoodVariantSchema.safeParse({
+      ...validVariant,
+      serving_description: null,
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.serving_description).toBeUndefined();
+    }
+  });
+});
 
 describe('PaginationSchema', () => {
   it('accepts numeric pagination fields and keeps them as numbers', () => {
@@ -94,6 +128,25 @@ describe('SearchResponseSchema', () => {
     if (result.success) {
       expect(result.data.pagination.page).toBe(1);
       expect(result.data.pagination.totalCount).toBe(1);
+      expect(
+        result.data.foods[0]?.variants?.map(
+          (variant) => variant.serving_description
+        )
+      ).toEqual(['100 g', '1 package (200 g)', '200 g']);
     }
+  });
+});
+
+describe('BarcodeResponseSchema', () => {
+  it('preserves all serving variants and their gram descriptions', () => {
+    const result = BarcodeResponseSchema.parse({
+      source: 'yazio',
+      food: validFood,
+    });
+
+    expect(result.food?.variants).toHaveLength(3);
+    expect(
+      result.food?.variants?.map((variant) => variant.serving_description)
+    ).toEqual(['100 g', '1 package (200 g)', '200 g']);
   });
 });

--- a/SparkyFitnessServer/tests/yazioService.test.ts
+++ b/SparkyFitnessServer/tests/yazioService.test.ts
@@ -215,7 +215,7 @@ describe('yazioService', () => {
     expect(smallKiwi).toMatchObject({
       serving_size: 1,
       serving_unit: 'Frucht, klein',
-      serving_description: 'Frucht, klein (70 g)',
+      serving_description: '1 Frucht, klein (70 g)',
       calories: 43,
       carbs: 6.4,
       protein: 0.7,
@@ -241,13 +241,13 @@ describe('yazioService', () => {
       result?.variants?.map((variant) => variant.serving_description)
     ).toEqual([
       '100 g',
-      'Frucht, halb (45 g)',
+      '1 Frucht, halb (45 g)',
       '45 g',
-      'Frucht, klein (70 g)',
+      '1 Frucht, klein (70 g)',
       '70 g',
-      'Frucht, mittel (90 g)',
+      '1 Frucht, mittel (90 g)',
       '90 g',
-      'Frucht, groß (115 g)',
+      '1 Frucht, groß (115 g)',
       '115 g',
       '1 g',
     ]);
@@ -288,6 +288,101 @@ describe('yazioService', () => {
     expect(Number.isFinite(pieceVariant?.calories ?? Number.NaN)).toBe(true);
   });
 
+  it('maps a search candidate top-level portion with its metric equivalent', () => {
+    const result = mapYazioProduct({
+      product_id: 'package-search-result',
+      name: 'Protein Dessert',
+      serving: 'package',
+      serving_quantity: 1,
+      amount: 200,
+      base_unit: 'g',
+      nutrients: {
+        'energy.energy': 0.81,
+        'nutrient.protein': 0.05,
+        'nutrient.carb': 0.1,
+        'nutrient.fat': 0.02,
+      },
+    });
+
+    expect(
+      result?.variants.map((variant) => variant.serving_description)
+    ).toEqual(['100 g', '1 package (200 g)', '200 g']);
+    expect(result?.variants[1]).toMatchObject({
+      serving_size: 1,
+      serving_unit: 'package',
+      calories: 162,
+    });
+  });
+
+  it('keeps a non-unit serving quantity in the structured variant and description', () => {
+    const result = mapYazioProduct({
+      product_id: 'multi-package-search-result',
+      name: 'Protein Dessert Multipack',
+      serving: 'package',
+      serving_quantity: 2,
+      amount: 200,
+      base_unit: 'g',
+      nutrients: {
+        'energy.energy': 0.81,
+        'nutrient.protein': 0.05,
+        'nutrient.carb': 0.1,
+        'nutrient.fat': 0.02,
+      },
+    });
+
+    expect(result?.variants[1]).toMatchObject({
+      serving_size: 2,
+      serving_unit: 'package',
+      serving_description: '2 package (200 g)',
+      calories: 162,
+    });
+    expect(result?.variants[2]).toMatchObject({
+      serving_size: 200,
+      serving_unit: 'g',
+      serving_description: '200 g',
+      calories: 162,
+    });
+  });
+
+  it('keeps every metric equivalent when YAZIO repeats a serving name at different weights', () => {
+    const result = mapYazioProduct({
+      id: 'repeated-package-weights',
+      name: 'Twin Pack Product',
+      producer: 'YAZIO',
+      base_unit: 'g',
+      nutrients: {
+        'energy.energy': 1,
+        'nutrient.protein': 0.05,
+        'nutrient.carb': 0.1,
+        'nutrient.fat': 0.02,
+      },
+      servings: [
+        {
+          serving: 'package',
+          serving_quantity: 1,
+          amount: 200,
+          base_unit: 'g',
+        },
+        {
+          serving: 'package',
+          serving_quantity: 1,
+          amount: 400,
+          base_unit: 'g',
+        },
+      ],
+    });
+
+    expect(
+      result?.variants.map((variant) => variant.serving_description)
+    ).toEqual([
+      '100 g',
+      '1 package (200 g)',
+      '200 g',
+      '1 package (400 g)',
+      '400 g',
+    ]);
+  });
+
   it('authenticates and searches products with pagination', async () => {
     const product = {
       product_id: '7c91b431-a2b5-4f11-8f52-f346dc941f2a',
@@ -308,7 +403,24 @@ describe('yazioService', () => {
       .mockResolvedValueOnce(
         makeFetchResponse({ access_token: 'token-1', expires_in: 3600 })
       )
-      .mockResolvedValueOnce(makeFetchResponse([product, product]))
+      .mockResolvedValueOnce(
+        makeFetchResponse([
+          product,
+          {
+            ...product,
+            serving: 'package',
+            serving_quantity: 1,
+            amount: 200,
+          },
+          {
+            name: 'Unmappable result without product id',
+            serving: 'package',
+            serving_quantity: 1,
+            amount: 500,
+            base_unit: 'g',
+          },
+        ])
+      )
       .mockResolvedValueOnce(
         makeFetchResponse({
           ...product,
@@ -347,11 +459,14 @@ describe('yazioService', () => {
     );
     expect(result.foods).toHaveLength(1);
     expect(result.foods[0]?.provider_verified).toBe(true);
+    expect(
+      result.foods[0]?.variants.map((variant) => variant.serving_description)
+    ).toEqual(['100 g', '1 package (200 g)', '200 g']);
     expect(result.pagination).toEqual({
       page: 1,
       pageSize: 1,
-      totalCount: 2,
-      hasMore: true,
+      totalCount: 1,
+      hasMore: false,
     });
   });
 
@@ -520,6 +635,67 @@ describe('yazioService', () => {
     );
     expect(result?.provider_verified).toBe(true);
     expect(result?.barcode).toBe('0094395000172');
+  });
+
+  it('merges every barcode candidate portion for the matching YAZIO product', async () => {
+    const productId = 'multi-serving-barcode-product';
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce(
+        makeFetchResponse({ access_token: 'token-multi', expires_in: 3600 })
+      )
+      .mockResolvedValueOnce(
+        makeFetchResponse([
+          {
+            product_id: productId,
+            name: 'Multi Portion Pudding',
+            serving: 'serving',
+            serving_quantity: 1,
+            amount: 200,
+            base_unit: 'g',
+            is_verified: true,
+          },
+          {
+            product_id: productId,
+            name: 'Multi Portion Pudding',
+            serving: 'package',
+            serving_quantity: 1,
+            amount: 400,
+            base_unit: 'g',
+            is_verified: true,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(
+        makeFetchResponse({
+          id: productId,
+          name: 'Multi Portion Pudding',
+          base_unit: 'g',
+          servings: [],
+          eans: ['4008400401621'],
+          nutrients: {
+            'energy.energy': 0.81,
+            'nutrient.protein': 0.05,
+            'nutrient.carb': 0.1,
+            'nutrient.fat': 0.02,
+          },
+        })
+      );
+
+    const result = await searchYazioByBarcode('4008400401621', {
+      username: 'barcode-portions@example.com',
+      password: 'secret',
+      ...yazioClientCredentials,
+    });
+
+    expect(
+      result?.variants.map((variant) => variant.serving_description)
+    ).toEqual([
+      '100 g',
+      '1 serving (200 g)',
+      '200 g',
+      '1 package (400 g)',
+      '400 g',
+    ]);
   });
 
   it('skips non-matching detail EANs and returns null when no candidate matches', async () => {


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

This fixes YAZIO servings being displayed incorrectly or incompletely in both the **online food search** and the **barcode scan** flow. It also prevents a selected weighted named serving (for example, `package (400 g)`) from being collapsed after storage or logged under an unrelated default variant when a saved food is deduplicated.

**How did you implement the solution?**

- Group YAZIO search candidates by product ID and merge their top-level servings into the detailed product response.
- Preserve `serving_quantity` for named units while also exposing equivalent `g`/`ml` variants from `amount`.
- Build quantity-aware descriptions and preserve same-name portions with different metric weights.
- Encode metric serving context in persisted named units so `package (200 g)` and `package (400 g)` remain distinct after reload.
- Promote context-rich persisted variants over matching legacy rows when building local picker groups.
- Resolve the selected saved variant only through one exact identity, one genuinely unencoded legacy match, or an exactly matching server default. Ambiguous matches and unrelated defaults now fail closed instead of creating a wrong diary entry.
- Normalize `serving_description: null` to `undefined` at the server schema boundary.
- Add server and mobile regression coverage for search grouping, barcode lookup, persistence, legacy rows, ambiguous matches, and refresh failures.

Linked Issue: #1364

## How to Test

1. From `SparkyFitnessServer/`, run `pnpm run validate` and `SKIP_RLS_MATRIX=1 NODE_ENV=test pnpm run test:ci`.
2. From `SparkyFitnessMobile/`, run `pnpm run validate` and `pnpm exec jest --watchman=false --runInBand`.
3. Search or scan a YAZIO product that reports two same-name weighted servings, such as `package (200 g)` and `package (400 g)`.
4. Verify both options remain visible after saving/reloading and selecting one logs that exact persisted variant.
5. Verify ambiguous legacy/exact matches do not create a diary entry under the default variant.

Local results on the current PR head:

- Server focused schema/YAZIO tests: **30 passed**.
- Server full CI-equivalent suite: **194 files; 2,361 passed, 210 expected RLS skips, 0 failed**.
- Mobile focused serving/persistence tests: **67 passed**.
- Mobile validation: **TypeScript strict + ESLint, 0 warnings**.
- Mobile full suite: **233 suites; 3,837 passed, 0 failed**.
- Independent final review: **no P0/P1/P2 findings**.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: Not applicable; this is a bug fix related to #1364.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: Not applicable; no frontend files changed.
- [ ] **[MANDATORY for Frontend changes] Translations**: Not applicable; no translations changed.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: Typecheck, lint, formatting, focused tests, and the full CI-equivalent suite pass.
- [x] **[MANDATORY for Backend changes] Database Security**: No tables, migrations, SQL, or RLS policies changed.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: Not applicable; serving identity and save resolution changed without visual layout changes.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: Tested on Device via Development Build on iPhone 16 pro Max.

## Screenshots

Not applicable; no visual layout changed.

## Notes for Reviewers

- Production behavior changes span the YAZIO server mapping and the mobile serving persistence/selection path.
- No database migration, lockfile update, new endpoint, frontend change, or shared-schema change is included.
- Distinct metric contexts remain separate even when an older undecorated serving row loads first.
- Entry creation intentionally aborts when the selected persisted variant cannot be resolved uniquely.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added richer YAZIO serving handling (named servings and gram-weight equivalents), with serving descriptions preserved during searches and barcode scans.
  - Improved merging of related YAZIO results into complete variant sets for food entries.
- **Bug Fixes**
  - Fixed persisted serving/variant resolution with clearer behavior for ambiguous or refresh-failing scenarios.
  - Prevented distinct serving weights from being incorrectly merged.
  - Normalized `null` serving descriptions consistently in API payloads and validation.
- **Tests**
  - Expanded automated coverage for YAZIO serving mapping, persistence, and variant resolution edge cases.
- **Documentation**
  - Updated Jest run guidance for watchman-disabled testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->