### PR TITLE
fix(ai): preserve system instructions for OpenAI-compatible reasoning models

### DIFF
--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -755,16 +755,19 @@ const RETENTION_24H_MODEL_PREFIXES = [
   'gpt-5.5',
 ];
 
-// Only the canonical 'openai' service type needs request-level providerOptions.
-// The OpenAI-compatible types share the `openai` namespace via createOpenAI(), so
-// gate strictly to 'openai' to avoid injecting prompt_cache_* into backends that
-// may reject it. (Anthropic caches on the tools — see ai/tools/index.ts; Gemini
-// auto-caches with no flag.)
+// Only the canonical 'openai' service type receives prompt-cache options.
+// OpenAI-compatible services still need the SDK-only systemMessageMode override:
+// reasoning-model IDs otherwise convert Sparky's system prompt to `developer`,
+// which older compatible gateways may not recognize as system instructions.
+// (Anthropic caches on the tools — see ai/tools/index.ts; Gemini auto-caches.)
 export function buildChatProviderOptions(
   serviceType: string,
   userId: string,
   modelName: string
 ): Record<string, Record<string, JSONValue>> | undefined {
+  if (serviceType === 'openai_compatible') {
+    return { openai: { systemMessageMode: 'system' } };
+  }
   if (serviceType !== 'openai') return undefined;
   const openai: Record<string, JSONValue> = {
     promptCacheKey: `sparky-chat-${userId}`,
@@ -1212,7 +1215,8 @@ export function classifyByKeywords(text: string): ChatToolCategorySlug[] {
 
 async function classifyUserIntent(
   messages: ChatMessage[],
-  modelInstance: any
+  modelInstance: Parameters<typeof generateText>[0]['model'],
+  providerOptions?: Record<string, Record<string, JSONValue>>
 ): Promise<ChatToolCategorySlug[]> {
   const lastUserMessage = [...messages]
     .reverse()
@@ -1266,6 +1270,7 @@ Your response must contain ONLY the matched domain names as a comma-separated li
       model: modelInstance,
       system: classificationPrompt,
       messages: contextMessages,
+      providerOptions,
       temperature: 0,
       maxRetries: 0,
       abortSignal: AbortSignal.timeout(10000), // 10s timeout to prevent hanging the chat turn
@@ -1365,7 +1370,15 @@ async function processChatMessage(
     );
     let activeCategories: readonly string[] | undefined = toolCategories;
     if (!process.env.VITEST && !categoriesAreManual) {
-      activeCategories = await classifyUserIntent(messages, modelInstance);
+      activeCategories = await classifyUserIntent(
+        messages,
+        modelInstance,
+        buildChatProviderOptions(
+          aiService.service_type,
+          authenticatedUserId,
+          modelName
+        )
+      );
     }
 
     const {
@@ -1887,7 +1900,15 @@ async function processChatMessageStream(
     );
     let activeCategories: readonly string[] | undefined = toolCategories;
     if (!process.env.VITEST && !categoriesAreManual) {
-      activeCategories = await classifyUserIntent(messages, modelInstance);
+      activeCategories = await classifyUserIntent(
+        messages,
+        modelInstance,
+        buildChatProviderOptions(
+          aiService.service_type,
+          authenticatedUserId,
+          modelName
+        )
+      );
     }
 
     const {

--- a/SparkyFitnessServer/tests/chatProviderOptions.test.ts
+++ b/SparkyFitnessServer/tests/chatProviderOptions.test.ts
@@ -1,3 +1,5 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import { generateText, streamText } from 'ai';
 import { vi, describe, expect, it } from 'vitest';
 import { buildChatProviderOptions } from '../services/chatService.js';
 
@@ -9,11 +11,60 @@ vi.mock('../config/logging', () => ({
   log: vi.fn(),
 }));
 
+interface RecordedOpenAiRequest {
+  messages?: Array<{ role?: string; content?: unknown }>;
+  stream?: boolean;
+}
+
+function createRecordingFetch(requests: RecordedOpenAiRequest[]): typeof fetch {
+  return async (_input, init) => {
+    const request = JSON.parse(String(init?.body)) as RecordedOpenAiRequest;
+    requests.push(request);
+
+    if (request.stream) {
+      const chunk = {
+        id: 'chatcmpl-test',
+        object: 'chat.completion.chunk',
+        created: 0,
+        model: 'gpt-5.6-sol',
+        choices: [
+          { index: 0, delta: { content: 'ok' }, finish_reason: 'stop' },
+        ],
+      };
+      return new Response(
+        `data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`,
+        { headers: { 'content-type': 'text/event-stream' } }
+      );
+    }
+
+    return Response.json({
+      id: 'chatcmpl-test',
+      object: 'chat.completion',
+      created: 0,
+      model: 'gpt-5.6-sol',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'ok' },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    });
+  };
+}
+
+function expectSystemMessage(request: RecordedOpenAiRequest) {
+  expect(request.messages?.[0]).toEqual({
+    role: 'system',
+    content: 'Keep this as a system message.',
+  });
+}
+
 describe('buildChatProviderOptions', () => {
   // Provider-gating: only the canonical 'openai' service type gets the
-  // openai-namespaced prompt_cache_* options. The OpenAI-compatible types share
-  // the `openai` namespace via createOpenAI(), so leaking these to them could
-  // send prompt_cache_key to backends that reject it.
+  // openai-namespaced prompt_cache_* options. OpenAI-compatible services share
+  // the namespace but receive only adapter-level compatibility options.
   it('sets a per-user promptCacheKey for openai without retention on the default model', () => {
     expect(buildChatProviderOptions('openai', 'user-1', 'gpt-4o-mini')).toEqual(
       {
@@ -45,7 +96,15 @@ describe('buildChatProviderOptions', () => {
     });
   });
 
-  it('returns undefined for every non-openai service type', () => {
+  it('keeps system instructions as the system role for OpenAI-compatible backends', () => {
+    expect(
+      buildChatProviderOptions('openai_compatible', 'user-1', 'gpt-5.6-sol')
+    ).toEqual({
+      openai: { systemMessageMode: 'system' },
+    });
+  });
+
+  it('returns undefined for unrelated non-openai service types', () => {
     for (const serviceType of [
       'anthropic',
       'google',
@@ -53,7 +112,6 @@ describe('buildChatProviderOptions', () => {
       'mistral',
       'openrouter',
       'ollama',
-      'openai_compatible',
       'custom',
     ]) {
       expect(
@@ -61,5 +119,54 @@ describe('buildChatProviderOptions', () => {
         serviceType
       ).toBeUndefined();
     }
+  });
+});
+
+describe('OpenAI-compatible system role requests', () => {
+  it('serializes the blocking system prompt with role system', async () => {
+    const requests: RecordedOpenAiRequest[] = [];
+    const model = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://openai-compatible.test/v1',
+      fetch: createRecordingFetch(requests),
+    }).chat('gpt-5.6-sol');
+
+    await generateText({
+      model,
+      system: 'Keep this as a system message.',
+      prompt: 'Hello',
+      providerOptions: buildChatProviderOptions(
+        'openai_compatible',
+        'user-1',
+        'gpt-5.6-sol'
+      ),
+    });
+
+    expect(requests).toHaveLength(1);
+    expectSystemMessage(requests[0]);
+  });
+
+  it('serializes the streaming system prompt with role system', async () => {
+    const requests: RecordedOpenAiRequest[] = [];
+    const model = createOpenAI({
+      apiKey: 'test-key',
+      baseURL: 'https://openai-compatible.test/v1',
+      fetch: createRecordingFetch(requests),
+    }).chat('gpt-5.6-sol');
+
+    const result = streamText({
+      model,
+      system: 'Keep this as a system message.',
+      prompt: 'Hello',
+      providerOptions: buildChatProviderOptions(
+        'openai_compatible',
+        'user-1',
+        'gpt-5.6-sol'
+      ),
+    });
+    await result.text;
+
+    expect(requests).toHaveLength(1);
+    expectSystemMessage(requests[0]);
   });
 });


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
OpenAI-compatible reasoning models can receive Sparky's system instructions as a `developer` message, which some compatible gateways reject or do not treat as system instructions. This affects intent classification, blocking chat, and streaming chat.

**How did you implement the solution?**
Set the AI SDK's OpenAI-namespaced `systemMessageMode` to `system` only for `openai_compatible` services and forward those provider options through all three chat paths. Canonical OpenAI keeps its existing prompt-cache options, while compatible gateways do not receive those OpenAI-only cache fields.

Linked Issue: Closes #1950

## How to Test

1. Run `pnpm run validate` from `SparkyFitnessServer/`.
2. Run `pnpm test` from `SparkyFitnessServer/`.
3. Run `pnpm exec vitest run tests/chatProviderOptions.test.ts` and verify both blocking and streaming request-body tests preserve the first message as `role: "system"`.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: **N/A — this is a bug fix, not a new feature.**

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: **N/A — no frontend changes.**
- [x] **[MANDATORY for Frontend changes] Translations**: **N/A — no frontend or translation changes.**

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: **N/A — no database changes or new tables.**

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: **N/A — no UI changes.**

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: **N/A — no mobile changes.**

## Screenshots

Not applicable — backend-only behavior change.

## Notes for Reviewers

- No database, API contract, frontend, mobile, or translation changes.
- `pnpm run validate`: passed.
- `pnpm test`: 202 test files and 2,444 tests passed; 2 integration files / 210 tests skipped by the repository's default test configuration.
- Request-boundary tests cover both `generateText` and `streamText` serialization through the same `.chat(model)` adapter used by `openai_compatible` production traffic.
- A production E2E run also covered intent classification, streaming, tool calling, tool-result follow-up, and the final assistant response through an OpenAI-compatible reasoning backend.
