### PR TITLE
fix: correct calculation for new medications' adherence

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Medications/Medications.tsx
+++ b/SparkyFitnessFrontend/src/pages/Medications/Medications.tsx
@@ -133,8 +133,12 @@ export default function Medications() {
   });
 
   const dueTodayCount = useMemo(() => {
-    return getDueDosesForDate(meds as MedicationDetail[], selectedDate).length;
-  }, [meds, selectedDate]);
+    return getDueDosesForDate(
+      meds as MedicationDetail[],
+      selectedDate,
+      timezone
+    ).length;
+  }, [meds, selectedDate, timezone]);
 
   // Mutations
   const removeMedMutation = useDeleteMedicationMutation();

--- a/SparkyFitnessFrontend/src/pages/Medications/TodayMedications.tsx
+++ b/SparkyFitnessFrontend/src/pages/Medications/TodayMedications.tsx
@@ -157,8 +157,8 @@ export default function TodayMedications({
   // Schedules evaluation
   const dueDoses = useMemo(() => {
     if (loadingMeds || meds.length === 0) return [];
-    return getDueDosesForDate(meds, selectedDate) as DueDose[];
-  }, [meds, selectedDate, loadingMeds]);
+    return getDueDosesForDate(meds, selectedDate, timezone) as DueDose[];
+  }, [meds, selectedDate, timezone, loadingMeds]);
 
   const prnMeds = useMemo(() => {
     return meds.filter((m) => {
@@ -202,7 +202,7 @@ export default function TodayMedications({
     }[] = [];
     for (let i = 13; i >= 0; i--) {
       const d = addDays(selectedDate, -i);
-      const dayDue = getDueDosesForDate(meds, d);
+      const dayDue = getDueDosesForDate(meds, d, timezone);
       let dayTaken = 0;
       for (const dd of dayDue) {
         const hit = recentEntries.some(
@@ -293,7 +293,7 @@ export default function TodayMedications({
       streak,
       pct: due > 0 ? Math.round((taken / due) * 100) : 100,
     };
-  }, [meds, selectedDate, recentEntries]);
+  }, [meds, selectedDate, recentEntries, timezone]);
 
   // The next GLP-1 dose due today (if any), for the next-injection banner.
   const nextGlpDue = useMemo(() => {

--- a/SparkyFitnessFrontend/src/pages/Medications/TodayMedications.tsx
+++ b/SparkyFitnessFrontend/src/pages/Medications/TodayMedications.tsx
@@ -22,6 +22,7 @@ import {
   localDateTimeToUtc,
   utcToLocalDateTimeInput,
   INJECTION_SITES,
+  type SharedScheduleRule,
 } from '@workspace/shared';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -71,7 +72,7 @@ import MedicationLogCalendar from './MedicationLogCalendar';
 
 export interface DueDose {
   medication: MedicationDetail;
-  schedule: MedicationSchedule & { id: string };
+  schedule: SharedScheduleRule & { id: string };
 }
 
 // GLP-1 injectable doses are logged as injection entries (single source of truth with
@@ -157,7 +158,7 @@ export default function TodayMedications({
   // Schedules evaluation
   const dueDoses = useMemo(() => {
     if (loadingMeds || meds.length === 0) return [];
-    return getDueDosesForDate(meds, selectedDate, timezone) as DueDose[];
+    return getDueDosesForDate(meds, selectedDate, timezone);
   }, [meds, selectedDate, timezone, loadingMeds]);
 
   const prnMeds = useMemo(() => {

--- a/SparkyFitnessFrontend/src/types/medications.ts
+++ b/SparkyFitnessFrontend/src/types/medications.ts
@@ -49,6 +49,8 @@ export interface MedicationSchedule {
   start_date: string | null;
   end_date: string | null;
   active: boolean;
+  created_at: string;
+  updated_at: string;
 }
 
 export type MedicationDetail = Medication & { schedules: MedicationSchedule[] };

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -162,7 +162,7 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
 
   const dueDoses = useMemo(() => {
     if (!medications) return [];
-    return getDueDosesForDate(medications, selectedDate, getDeviceTimezone()) as DueDose[];
+    return getDueDosesForDate(medications, selectedDate, getDeviceTimezone());
   }, [medications, selectedDate]);
 
   const prnMeds = useMemo(() => {

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -12,6 +12,7 @@ import Icon from './Icon';
 import { useMedications, useMedicationEntries, useCreateMedicationEntry, useDeleteMedicationEntry } from '../hooks/useMedications';
 import { useDiaryDateStore } from '../stores/diaryDateStore';
 import { getDueDosesForDate, type SharedScheduleRule } from '@workspace/shared';
+import { getDeviceTimezone } from '../utils/dateUtils';
 import type { RootStackParamList, TabParamList } from '../types/navigation';
 import type { Medication, MedicationDetail, MedicationEntry, MedicationEntryStatus } from '../types/medications';
 import { MEDICATION_TYPES } from '../types/medications';
@@ -161,7 +162,7 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
 
   const dueDoses = useMemo(() => {
     if (!medications) return [];
-    return getDueDosesForDate(medications, selectedDate) as DueDose[];
+    return getDueDosesForDate(medications, selectedDate, getDeviceTimezone()) as DueDose[];
   }, [medications, selectedDate]);
 
   const prnMeds = useMemo(() => {

--- a/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
@@ -10,6 +10,7 @@ import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 import { useScreenHeader } from '../hooks/useScreenHeader';
 import Icon from '../components/Icon';
 import { getDueDosesForDate } from '@workspace/shared';
+import { getDeviceTimezone } from '../utils/dateUtils';
 import type { RootStackScreenProps } from '../types/navigation';
 import { MEDICATION_TYPES, DAY_LABELS } from '../types/medications';
 import type { MedicationEntry, MedicationEntryStatus } from '../types/medications';
@@ -45,7 +46,7 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({ route, 
 
   const unloggedSchedules = useMemo(() => {
     if (!med) return [];
-    const dueDoses = getDueDosesForDate([med], selectedDate);
+    const dueDoses = getDueDosesForDate([med], selectedDate, getDeviceTimezone());
     return dueDoses
       .filter((due) =>
         !todayEntries.some(

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -103,7 +103,10 @@ export async function reconcileMedicationReminders(
     const dueDoses = getDueDosesForDate(medications, today, getDeviceTimezone());
 
     const unloggedKeys = new Set<string>();
-    const unloggedDoses: { due: ReturnType<typeof getDueDosesForDate>[number]; timeOfDay: string }[] = [];
+    const unloggedDoses: {
+      due: ReturnType<typeof getDueDosesForDate<MedicationDetail>>[number];
+      timeOfDay: string;
+    }[] = [];
 
     for (const due of dueDoses) {
       const timeOfDay = due.schedule.time_of_day;

--- a/SparkyFitnessMobile/src/services/medicationReminderService.ts
+++ b/SparkyFitnessMobile/src/services/medicationReminderService.ts
@@ -1,6 +1,6 @@
 import * as Notifications from 'expo-notifications';
 
-import { getTodayDate } from '../utils/dateUtils';
+import { getDeviceTimezone, getTodayDate } from '../utils/dateUtils';
 import { getDueDosesForDate } from '@workspace/shared';
 import {
   ensureMedicationReminderChannel,
@@ -100,7 +100,7 @@ export async function reconcileMedicationReminders(
     await ensureMedicationReminderChannel();
 
     const today = getTodayDate();
-    const dueDoses = getDueDosesForDate(medications, today);
+    const dueDoses = getDueDosesForDate(medications, today, getDeviceTimezone());
 
     const unloggedKeys = new Set<string>();
     const unloggedDoses: { due: ReturnType<typeof getDueDosesForDate>[number]; timeOfDay: string }[] = [];

--- a/SparkyFitnessServer/tests/schedules.test.ts
+++ b/SparkyFitnessServer/tests/schedules.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   isScheduleDueOnDate,
   getDueDosesForDate,
+  addDays,
   type SharedScheduleRule,
 } from '@workspace/shared';
+
+const TZ = 'UTC';
 
 describe('isScheduleDueOnDate helper', () => {
   it('handles inactive schedules', () => {
@@ -143,13 +146,13 @@ describe('getDueDosesForDate helper', () => {
     ];
 
     // June 25, 2026 is Thursday
-    const dosesOnThursday = getDueDosesForDate(meds, '2026-06-25');
+    const dosesOnThursday = getDueDosesForDate(meds, '2026-06-25', TZ);
     expect(dosesOnThursday).toHaveLength(1);
     expect(dosesOnThursday[0]?.medication.id).toBe('med-1');
     expect(dosesOnThursday[0]?.schedule.id).toBe('sched-1');
 
     // June 26, 2026 is Friday
-    const dosesOnFriday = getDueDosesForDate(meds, '2026-06-26');
+    const dosesOnFriday = getDueDosesForDate(meds, '2026-06-26', TZ);
     expect(dosesOnFriday).toHaveLength(2);
     expect(dosesOnFriday.map((d) => d.medication.id)).toContain('med-1');
     expect(dosesOnFriday.map((d) => d.medication.id)).toContain('med-2');
@@ -173,13 +176,13 @@ describe('getDueDosesForDate helper', () => {
     ];
 
     // Before creation -> no due doses
-    expect(getDueDosesForDate(meds, '2026-06-24')).toHaveLength(0);
-    expect(getDueDosesForDate(meds, '2026-06-23')).toHaveLength(0);
-    expect(getDueDosesForDate(meds, '2026-01-01')).toHaveLength(0);
+    expect(getDueDosesForDate(meds, '2026-06-24', TZ)).toHaveLength(0);
+    expect(getDueDosesForDate(meds, '2026-06-23', TZ)).toHaveLength(0);
+    expect(getDueDosesForDate(meds, '2026-01-01', TZ)).toHaveLength(0);
 
     // On/after creation -> daily dose is due
-    expect(getDueDosesForDate(meds, '2026-06-25')).toHaveLength(1);
-    expect(getDueDosesForDate(meds, '2026-06-26')).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2026-06-25', TZ)).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2026-06-26', TZ)).toHaveLength(1);
   });
 
   it('isolates adherence per schedule (morning kept, night added later)', () => {
@@ -207,11 +210,11 @@ describe('getDueDosesForDate helper', () => {
       },
     ];
 
-    const beforeNight = getDueDosesForDate(meds, '2026-06-22');
+    const beforeNight = getDueDosesForDate(meds, '2026-06-22', TZ);
     expect(beforeNight).toHaveLength(1);
     expect(beforeNight[0]?.schedule.id).toBe('sched-morning');
 
-    const onNight = getDueDosesForDate(meds, '2026-06-25');
+    const onNight = getDueDosesForDate(meds, '2026-06-25', TZ);
     expect(onNight).toHaveLength(2);
     expect(onNight.map((d) => d.schedule.id)).toEqual(
       expect.arrayContaining(['sched-morning', 'sched-night'])
@@ -238,8 +241,8 @@ describe('getDueDosesForDate helper', () => {
       },
     ];
 
-    expect(getDueDosesForDate(meds, '2026-06-22')).toHaveLength(1);
-    expect(getDueDosesForDate(meds, '2026-06-25')).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2026-06-22', TZ)).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2026-06-25', TZ)).toHaveLength(1);
   });
 
   it('still filters out schedules before explicit start_date when start_date is after created_at', () => {
@@ -260,9 +263,9 @@ describe('getDueDosesForDate helper', () => {
       },
     ];
 
-    expect(getDueDosesForDate(meds, '2026-06-15')).toHaveLength(0);
-    expect(getDueDosesForDate(meds, '2026-06-19')).toHaveLength(0);
-    expect(getDueDosesForDate(meds, '2026-06-20')).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2026-06-15', TZ)).toHaveLength(0);
+    expect(getDueDosesForDate(meds, '2026-06-19', TZ)).toHaveLength(0);
+    expect(getDueDosesForDate(meds, '2026-06-20', TZ)).toHaveLength(1);
   });
 
   it('handles schedules without created_at (legacy data) without regressing', () => {
@@ -277,8 +280,8 @@ describe('getDueDosesForDate helper', () => {
       },
     ];
 
-    expect(getDueDosesForDate(meds, '2020-01-01')).toHaveLength(1);
-    expect(getDueDosesForDate(meds, '2026-06-25')).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2020-01-01', TZ)).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2026-06-25', TZ)).toHaveLength(1);
   });
 
   it('handles a 14-day adherence window for a schedule added today', () => {
@@ -298,12 +301,12 @@ describe('getDueDosesForDate helper', () => {
       },
     ];
 
+    // Use shared calendar-day arithmetic so the test does not derive business
+    // dates from a UTC timestamp
     let dueAcrossWindow = 0;
     for (let i = 13; i >= 0; i--) {
-      const anchor = new Date('2026-07-25T12:00:00.000Z');
-      anchor.setUTCDate(anchor.getUTCDate() - i);
-      const dStr = anchor.toISOString().substring(0, 10);
-      dueAcrossWindow += getDueDosesForDate(meds, dStr).length;
+      const dStr = addDays('2026-07-25', -i);
+      dueAcrossWindow += getDueDosesForDate(meds, dStr, TZ).length;
     }
 
     expect(dueAcrossWindow).toBe(1);
@@ -332,11 +335,11 @@ describe('getDueDosesForDate helper', () => {
       },
     ];
 
-    const beforeAdded = getDueDosesForDate(meds, '2026-06-24');
+    const beforeAdded = getDueDosesForDate(meds, '2026-06-24', TZ);
     expect(beforeAdded).toHaveLength(1);
     expect(beforeAdded[0]?.schedule.id).toBe('sched-original');
 
-    const onAdded = getDueDosesForDate(meds, '2026-06-25');
+    const onAdded = getDueDosesForDate(meds, '2026-06-25', TZ);
     expect(onAdded).toHaveLength(2);
     expect(onAdded.map((d) => d.schedule.id)).toEqual(
       expect.arrayContaining(['sched-original', 'sched-added'])

--- a/SparkyFitnessServer/tests/schedules.test.ts
+++ b/SparkyFitnessServer/tests/schedules.test.ts
@@ -155,18 +155,19 @@ describe('getDueDosesForDate helper', () => {
     expect(dosesOnFriday.map((d) => d.medication.id)).toContain('med-2');
   });
 
-  it('skips past days when a medication was created after the queried date (issue #1915)', () => {
-    // A daily medication added on 2026-06-25 should not be "due" on 2026-06-24,
-    // otherwise the 14-day adherence window would falsely count missed doses
-    // on days when the medication didn't exist yet.
+  it('skips past days when a schedule was created after the queried date (issue #1915)', () => {
     const meds = [
       {
         id: 'med-new',
         is_active: true,
         name: 'New Med',
-        created_at: '2026-06-25T14:30:00.000Z',
         schedules: [
-          { id: 'sched-new', schedule_type_id: 'daily', active: true },
+          {
+            id: 'sched-new',
+            schedule_type_id: 'daily',
+            active: true,
+            created_at: '2026-06-25T14:30:00.000Z',
+          },
         ],
       },
     ];
@@ -177,13 +178,44 @@ describe('getDueDosesForDate helper', () => {
     expect(getDueDosesForDate(meds, '2026-01-01')).toHaveLength(0);
 
     // On/after creation -> daily dose is due
-    const onCreationDay = getDueDosesForDate(meds, '2026-06-25');
-    expect(onCreationDay).toHaveLength(1);
-    expect(onCreationDay[0]?.medication.id).toBe('med-new');
+    expect(getDueDosesForDate(meds, '2026-06-25')).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2026-06-26')).toHaveLength(1);
+  });
 
-    const afterCreation = getDueDosesForDate(meds, '2026-06-26');
-    expect(afterCreation).toHaveLength(1);
-    expect(afterCreation[0]?.medication.id).toBe('med-new');
+  it('isolates adherence per schedule (morning kept, night added later)', () => {
+    const meds = [
+      {
+        id: 'med-morning-night',
+        is_active: true,
+        name: 'Morning + Night Med',
+        schedules: [
+          {
+            id: 'sched-morning',
+            schedule_type_id: 'daily',
+            active: true,
+            time_of_day: '08:00',
+            created_at: '2026-06-20T09:00:00.000Z',
+          },
+          {
+            id: 'sched-night',
+            schedule_type_id: 'daily',
+            active: true,
+            time_of_day: '20:00',
+            created_at: '2026-06-25T21:00:00.000Z',
+          },
+        ],
+      },
+    ];
+
+    const beforeNight = getDueDosesForDate(meds, '2026-06-22');
+    expect(beforeNight).toHaveLength(1);
+    expect(beforeNight[0]?.schedule.id).toBe('sched-morning');
+
+    const onNight = getDueDosesForDate(meds, '2026-06-25');
+    expect(onNight).toHaveLength(2);
+    expect(onNight.map((d) => d.schedule.id)).toEqual(
+      expect.arrayContaining(['sched-morning', 'sched-night'])
+    );
   });
 
   it('honors explicit schedule start_date even when set before created_at', () => {
@@ -194,25 +226,20 @@ describe('getDueDosesForDate helper', () => {
         id: 'med-imported',
         is_active: true,
         name: 'Imported Med',
-        created_at: '2026-06-25T14:30:00.000Z',
         schedules: [
           {
             id: 'sched-imported',
             schedule_type_id: 'daily',
             start_date: '2026-06-20',
             active: true,
+            created_at: '2026-06-25T14:30:00.000Z',
           },
         ],
       },
     ];
 
-    // start_date wins -> historical doses are still due
-    const historical = getDueDosesForDate(meds, '2026-06-22');
-    expect(historical).toHaveLength(1);
-    expect(historical[0]?.medication.id).toBe('med-imported');
-
-    const onCreation = getDueDosesForDate(meds, '2026-06-25');
-    expect(onCreation).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2026-06-22')).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2026-06-25')).toHaveLength(1);
   });
 
   it('still filters out schedules before explicit start_date when start_date is after created_at', () => {
@@ -221,13 +248,13 @@ describe('getDueDosesForDate helper', () => {
         id: 'med-future',
         is_active: true,
         name: 'Future Start Med',
-        created_at: '2026-06-10T08:00:00.000Z',
         schedules: [
           {
             id: 'sched-future',
             schedule_type_id: 'daily',
             start_date: '2026-06-20',
             active: true,
+            created_at: '2026-06-10T08:00:00.000Z',
           },
         ],
       },
@@ -238,7 +265,7 @@ describe('getDueDosesForDate helper', () => {
     expect(getDueDosesForDate(meds, '2026-06-20')).toHaveLength(1);
   });
 
-  it('handles medications without created_at (legacy data) without regressing', () => {
+  it('handles schedules without created_at (legacy data) without regressing', () => {
     const meds = [
       {
         id: 'med-legacy',
@@ -254,18 +281,19 @@ describe('getDueDosesForDate helper', () => {
     expect(getDueDosesForDate(meds, '2026-06-25')).toHaveLength(1);
   });
 
-  it('handles a 14-day adherence window for a medication added today', () => {
-    // Reproduces the exact scenario from issue #1915: a daily medication added
-    // today should yield 1 due dose today and 0 due doses across the past 13
-    // days, not 14 missed doses.
+  it('handles a 14-day adherence window for a schedule added today', () => {
     const meds = [
       {
         id: 'med-today',
         is_active: true,
         name: 'Today Med',
-        created_at: '2026-07-25T12:00:00.000Z',
         schedules: [
-          { id: 'sched-today', schedule_type_id: 'daily', active: true },
+          {
+            id: 'sched-today',
+            schedule_type_id: 'daily',
+            active: true,
+            created_at: '2026-07-25T12:00:00.000Z',
+          },
         ],
       },
     ];
@@ -279,5 +307,39 @@ describe('getDueDosesForDate helper', () => {
     }
 
     expect(dueAcrossWindow).toBe(1);
+  });
+
+  it('keeps older schedules counting while skipping a newer sibling schedule', () => {
+    const meds = [
+      {
+        id: 'med-staggered',
+        is_active: true,
+        name: 'Staggered Med',
+        schedules: [
+          {
+            id: 'sched-original',
+            schedule_type_id: 'daily',
+            active: true,
+            created_at: '2026-06-20T09:00:00.000Z',
+          },
+          {
+            id: 'sched-added',
+            schedule_type_id: 'daily',
+            active: true,
+            created_at: '2026-06-25T12:00:00.000Z',
+          },
+        ],
+      },
+    ];
+
+    const beforeAdded = getDueDosesForDate(meds, '2026-06-24');
+    expect(beforeAdded).toHaveLength(1);
+    expect(beforeAdded[0]?.schedule.id).toBe('sched-original');
+
+    const onAdded = getDueDosesForDate(meds, '2026-06-25');
+    expect(onAdded).toHaveLength(2);
+    expect(onAdded.map((d) => d.schedule.id)).toEqual(
+      expect.arrayContaining(['sched-original', 'sched-added'])
+    );
   });
 });

--- a/SparkyFitnessServer/tests/schedules.test.ts
+++ b/SparkyFitnessServer/tests/schedules.test.ts
@@ -154,4 +154,130 @@ describe('getDueDosesForDate helper', () => {
     expect(dosesOnFriday.map((d) => d.medication.id)).toContain('med-1');
     expect(dosesOnFriday.map((d) => d.medication.id)).toContain('med-2');
   });
+
+  it('skips past days when a medication was created after the queried date (issue #1915)', () => {
+    // A daily medication added on 2026-06-25 should not be "due" on 2026-06-24,
+    // otherwise the 14-day adherence window would falsely count missed doses
+    // on days when the medication didn't exist yet.
+    const meds = [
+      {
+        id: 'med-new',
+        is_active: true,
+        name: 'New Med',
+        created_at: '2026-06-25T14:30:00.000Z',
+        schedules: [
+          { id: 'sched-new', schedule_type_id: 'daily', active: true },
+        ],
+      },
+    ];
+
+    // Before creation -> no due doses
+    expect(getDueDosesForDate(meds, '2026-06-24')).toHaveLength(0);
+    expect(getDueDosesForDate(meds, '2026-06-23')).toHaveLength(0);
+    expect(getDueDosesForDate(meds, '2026-01-01')).toHaveLength(0);
+
+    // On/after creation -> daily dose is due
+    const onCreationDay = getDueDosesForDate(meds, '2026-06-25');
+    expect(onCreationDay).toHaveLength(1);
+    expect(onCreationDay[0]?.medication.id).toBe('med-new');
+
+    const afterCreation = getDueDosesForDate(meds, '2026-06-26');
+    expect(afterCreation).toHaveLength(1);
+    expect(afterCreation[0]?.medication.id).toBe('med-new');
+  });
+
+  it('honors explicit schedule start_date even when set before created_at', () => {
+    // An imported schedule with start_date before the medication's created_at
+    // should still count historical doses (e.g. back-filled histories).
+    const meds = [
+      {
+        id: 'med-imported',
+        is_active: true,
+        name: 'Imported Med',
+        created_at: '2026-06-25T14:30:00.000Z',
+        schedules: [
+          {
+            id: 'sched-imported',
+            schedule_type_id: 'daily',
+            start_date: '2026-06-20',
+            active: true,
+          },
+        ],
+      },
+    ];
+
+    // start_date wins -> historical doses are still due
+    const historical = getDueDosesForDate(meds, '2026-06-22');
+    expect(historical).toHaveLength(1);
+    expect(historical[0]?.medication.id).toBe('med-imported');
+
+    const onCreation = getDueDosesForDate(meds, '2026-06-25');
+    expect(onCreation).toHaveLength(1);
+  });
+
+  it('still filters out schedules before explicit start_date when start_date is after created_at', () => {
+    const meds = [
+      {
+        id: 'med-future',
+        is_active: true,
+        name: 'Future Start Med',
+        created_at: '2026-06-10T08:00:00.000Z',
+        schedules: [
+          {
+            id: 'sched-future',
+            schedule_type_id: 'daily',
+            start_date: '2026-06-20',
+            active: true,
+          },
+        ],
+      },
+    ];
+
+    expect(getDueDosesForDate(meds, '2026-06-15')).toHaveLength(0);
+    expect(getDueDosesForDate(meds, '2026-06-19')).toHaveLength(0);
+    expect(getDueDosesForDate(meds, '2026-06-20')).toHaveLength(1);
+  });
+
+  it('handles medications without created_at (legacy data) without regressing', () => {
+    const meds = [
+      {
+        id: 'med-legacy',
+        is_active: true,
+        name: 'Legacy Med',
+        schedules: [
+          { id: 'sched-legacy', schedule_type_id: 'daily', active: true },
+        ],
+      },
+    ];
+
+    expect(getDueDosesForDate(meds, '2020-01-01')).toHaveLength(1);
+    expect(getDueDosesForDate(meds, '2026-06-25')).toHaveLength(1);
+  });
+
+  it('handles a 14-day adherence window for a medication added today', () => {
+    // Reproduces the exact scenario from issue #1915: a daily medication added
+    // today should yield 1 due dose today and 0 due doses across the past 13
+    // days, not 14 missed doses.
+    const meds = [
+      {
+        id: 'med-today',
+        is_active: true,
+        name: 'Today Med',
+        created_at: '2026-07-25T12:00:00.000Z',
+        schedules: [
+          { id: 'sched-today', schedule_type_id: 'daily', active: true },
+        ],
+      },
+    ];
+
+    let dueAcrossWindow = 0;
+    for (let i = 13; i >= 0; i--) {
+      const anchor = new Date('2026-07-25T12:00:00.000Z');
+      anchor.setUTCDate(anchor.getUTCDate() - i);
+      const dStr = anchor.toISOString().substring(0, 10);
+      dueAcrossWindow += getDueDosesForDate(meds, dStr).length;
+    }
+
+    expect(dueAcrossWindow).toBe(1);
+  });
 });

--- a/shared/src/medications/schedules.ts
+++ b/shared/src/medications/schedules.ts
@@ -13,6 +13,7 @@ export interface SharedScheduleRule {
   active?: boolean;
   dose_amount?: number | null;
   with_meal?: string | null;
+  created_at?: string | null;
 }
 
 /**
@@ -94,15 +95,6 @@ export function isScheduleDueOnDate(schedule: SharedScheduleRule, dateString: st
 }
 
 /**
- * Returns the calendar day (YYYY-MM-DD) the medication was created, or null.
- */
-function getMedicationCreatedDay(medication: {
-  created_at?: string | null;
-}): string | null {
-  return medication.created_at ? medication.created_at.substring(0, 10) : null;
-}
-
-/**
  * Filters and returns all scheduled dose slots for a given date.
  */
 export function getDueDosesForDate(
@@ -116,12 +108,14 @@ export function getDueDosesForDate(
   for (const med of medications) {
     if (!med.is_active) continue;
     if (!med.schedules || med.schedules.length === 0) continue;
-    const fallbackStart = med.created_at ? med.created_at.substring(0, 10) : null;
     for (const sched of med.schedules) {
       if (sched.schedule_type_id === 'prn') {
         // PRN is logged on demand, not scheduled on due list
         continue;
       }
+      const fallbackStart = sched.created_at
+        ? sched.created_at.substring(0, 10)
+        : null;
       if (!sched.start_date && fallbackStart && dateString < fallbackStart) {
         continue;
       }

--- a/shared/src/medications/schedules.ts
+++ b/shared/src/medications/schedules.ts
@@ -95,17 +95,26 @@ export function isScheduleDueOnDate(schedule: SharedScheduleRule, dateString: st
 }
 
 /**
+ * Medication shape required by `getDueDosesForDate`.
+ */
+export interface SharedMedication {
+  id: string;
+  is_active: boolean;
+  schedules?: SharedScheduleRule[];
+}
+
+/**
  * Filters and returns all scheduled dose slots for a given date.
  */
-export function getDueDosesForDate(
-  medications: Array<{ id: string; is_active: boolean; schedules?: SharedScheduleRule[] } & Record<string, any>>,
+export function getDueDosesForDate<M extends SharedMedication>(
+  medications: M[],
   dateString: string,
   tz: string
 ): Array<{
-  medication: any;
+  medication: M;
   schedule: SharedScheduleRule & { id: string };
 }> {
-  const result: Array<{ medication: any; schedule: SharedScheduleRule & { id: string } }> = [];
+  const result: Array<{ medication: M; schedule: SharedScheduleRule & { id: string } }> = [];
   for (const med of medications) {
     if (!med.is_active) continue;
     if (!med.schedules || med.schedules.length === 0) continue;

--- a/shared/src/medications/schedules.ts
+++ b/shared/src/medications/schedules.ts
@@ -94,6 +94,15 @@ export function isScheduleDueOnDate(schedule: SharedScheduleRule, dateString: st
 }
 
 /**
+ * Returns the calendar day (YYYY-MM-DD) the medication was created, or null.
+ */
+function getMedicationCreatedDay(medication: {
+  created_at?: string | null;
+}): string | null {
+  return medication.created_at ? medication.created_at.substring(0, 10) : null;
+}
+
+/**
  * Filters and returns all scheduled dose slots for a given date.
  */
 export function getDueDosesForDate(
@@ -107,9 +116,13 @@ export function getDueDosesForDate(
   for (const med of medications) {
     if (!med.is_active) continue;
     if (!med.schedules || med.schedules.length === 0) continue;
+    const fallbackStart = med.created_at ? med.created_at.substring(0, 10) : null;
     for (const sched of med.schedules) {
       if (sched.schedule_type_id === 'prn') {
         // PRN is logged on demand, not scheduled on due list
+        continue;
+      }
+      if (!sched.start_date && fallbackStart && dateString < fallbackStart) {
         continue;
       }
       if (isScheduleDueOnDate(sched, dateString)) {
@@ -122,4 +135,3 @@ export function getDueDosesForDate(
   }
   return result;
 }
-

--- a/shared/src/medications/schedules.ts
+++ b/shared/src/medications/schedules.ts
@@ -100,7 +100,7 @@ export function isScheduleDueOnDate(schedule: SharedScheduleRule, dateString: st
 export interface SharedMedication {
   id: string;
   is_active: boolean;
-  schedules?: SharedScheduleRule[];
+  schedules?: (SharedScheduleRule & { id: string })[];
 }
 
 /**
@@ -132,7 +132,7 @@ export function getDueDosesForDate<M extends SharedMedication>(
       if (isScheduleDueOnDate(sched, dateString)) {
         result.push({
           medication: med,
-          schedule: sched as SharedScheduleRule & { id: string }
+          schedule: sched
         });
       }
     }

--- a/shared/src/medications/schedules.ts
+++ b/shared/src/medications/schedules.ts
@@ -1,4 +1,4 @@
-import { dayOfWeek } from '../utils/timezone.ts';
+import { dayOfWeek, instantToDay } from '../utils/timezone.ts';
 
 export interface SharedScheduleRule {
   schedule_type_id: string;
@@ -99,7 +99,8 @@ export function isScheduleDueOnDate(schedule: SharedScheduleRule, dateString: st
  */
 export function getDueDosesForDate(
   medications: Array<{ id: string; is_active: boolean; schedules?: SharedScheduleRule[] } & Record<string, any>>,
-  dateString: string
+  dateString: string,
+  tz: string
 ): Array<{
   medication: any;
   schedule: SharedScheduleRule & { id: string };
@@ -114,7 +115,7 @@ export function getDueDosesForDate(
         continue;
       }
       const fallbackStart = sched.created_at
-        ? sched.created_at.substring(0, 10)
+        ? instantToDay(sched.created_at, tz)
         : null;
       if (!sched.start_date && fallbackStart && dateString < fallbackStart) {
         continue;


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Medication adherence doesn't calculate properly with new medications or schedules.

**How did you implement the solution?**
Only count days the medication schedules existed when calculating adherence percentage.

Linked Issue: Closes #1915 

## How to Test

1. Check out this branch and run the app
2. Navigate to medications section
3. Create a new medication
4. Add a daily schedule for the med
5. Adherence should correctly only include today (or past days it existed)

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Made due-dose, adherence, and reminder/reminder scheduling timezone-aware across web, mobile, and background reminder logic.
  - Improved due-dose eligibility rules for schedules with `created_at` and `start_date`, including correct backfilling and avoiding counts before a schedule becomes eligible.
  - Ensured legacy schedules without `created_at` continue to behave correctly.

- **New Features**
  - Added `created_at` and `updated_at` fields to medication schedule data.

- **Tests**
  - Expanded and stabilized schedule due-dose test coverage with deterministic timezone handling and new scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->