### PR TITLE
Support custom meal types in MCP food tools

### DIFF
--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -467,7 +467,7 @@ const DIARY_MEAL_DROP = [
 ] as const;
 
 interface ResolvedMealType {
-  id?: string;
+  id: string;
   name: string;
 }
 
@@ -483,7 +483,17 @@ async function resolveMealType(
     );
     return resolved ? { id: resolved.id, name: resolved.name } : null;
   }
-  return mealType ? { name: mealType } : null;
+  if (!mealType) {
+    return null;
+  }
+  // For built-in meal types (by name), resolve to actual ID
+  const mealTypes = await mealTypeRepository.getAllMealTypes(userId);
+  const normalizedName = mealType.trim().toLowerCase();
+  const resolved = mealTypes.find(
+    (type: { id: string; name: string }) =>
+      type.name.trim().toLowerCase() === normalizedName
+  );
+  return resolved ? { id: resolved.id, name: mealType.trim() } : null;
 }
 // Full food_entries dumps (`SELECT fe.*`, used by recent-entries and food-usage)
 // add audit/ownership columns on top of the diary projection's surrogate keys.
@@ -801,7 +811,7 @@ Actions:
 - update_entry(entry_id, entry_type, quantity?, unit?, meal_type_id?, meal_type?) — changes quantity/unit and/or moves the entry to another meal type.
 - update_food_variant(food_id?|variant_id?, serving_size?, serving_unit?, calories?, protein?, carbs?, fat?, saturated_fat?, fiber?, sugar?, sodium?, ..., update_existing_entries?) — updates an existing food variant without deleting the food. Defaults to leaving existing diary entries unchanged.
 - copy_from_yesterday(target_date?, source_date?, meal_type_id?|meal_type?)
-- save_as_meal_template(entry_date, meal_type_id?|meal_type?, meal_name, description?)
+- save_as_meal_template(entry_date, meal_type_id?|meal_type?, meal_name, description?) — REQUIRES EXPLICIT action field. Saves diary entries for a given date and meal type as a reusable meal template.
 - log_water(amount_ml, entry_date)
 - get_nutritional_summary(start_date, end_date) — returns macro breakdown for a range of dates
 - get_water_history(start_date?, end_date?)`,
@@ -839,6 +849,9 @@ Actions:
             if (args.food_name) {
               return 'lookup_food_nutrition';
             }
+            if (args.target_date || args.source_date) {
+              return 'copy_from_yesterday';
+            }
             if (args.meal_name && (args.meal_type || args.meal_type_id)) {
               return 'log_meal';
             }
@@ -863,23 +876,8 @@ Actions:
             if (args.food_id) {
               return 'delete_food';
             }
-            if (
-              args.target_date ||
-              args.source_date ||
-              args.meal_type ||
-              args.meal_type_id
-            ) {
-              return 'copy_from_yesterday';
-            }
             if (args.start_date || args.end_date) {
               return 'get_nutritional_summary';
-            }
-            if (
-              args.entry_date &&
-              args.meal_name &&
-              (args.meal_type || args.meal_type_id)
-            ) {
-              return 'save_as_meal_template';
             }
             if (args.entry_date) {
               return 'list_diary';
@@ -989,6 +987,7 @@ Actions:
           'log_food',
           'log_external_food',
           'log_meal',
+          'save_as_meal_template',
         ];
         if (
           mealTypeRequiredActions.includes(args.action) &&
@@ -1871,9 +1870,7 @@ Actions:
                 );
               }
               const mealTypeUpdate = mealType
-                ? mealType.id
-                  ? { meal_type_id: mealType.id }
-                  : { meal_type: mealType.name, meal_type_id: undefined }
+                ? { meal_type_id: mealType.id }
                 : {};
               try {
                 if (args.entry_type === 'food_entry') {
@@ -2061,9 +2058,9 @@ Actions:
                     userId,
                     userId,
                     sourceDate,
-                    mealType.id || mealType.name,
+                    mealType.name,
                     targetDate,
-                    mealType.id || mealType.name
+                    mealType.name
                   )
                 : await foodEntryService.copyAllFoodEntries(
                     userId,
@@ -2098,7 +2095,7 @@ Actions:
               const meal = await mealService.createMealFromDiaryEntries(
                 userId,
                 args.entry_date,
-                mealType.id || mealType.name,
+                mealType.name,
                 args.meal_name,
                 args.description ?? null
               );

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -825,6 +825,25 @@ Actions:
           tz,
           VALID_ACTIONS,
           (args) => {
+            // entry_id is an unambiguous identifier of an operation on an
+            // existing diary row. It must win over any incidental food_name /
+            // meal_name / external_id / date fields: list_diary naturally
+            // returns entry_id + entry_type together with food_name or
+            // meal_name, and letting a log/lookup action claim those fields
+            // would make the salvage logic drop entry_id and run a different
+            // data-writing operation.
+            if (
+              args.entry_id &&
+              (args.quantity !== undefined ||
+                args.unit ||
+                args.meal_type ||
+                args.meal_type_id)
+            ) {
+              return 'update_entry';
+            }
+            if (args.entry_id && args.entry_type) {
+              return 'delete_entry';
+            }
             if (args.amount_ml) {
               return 'log_water';
             }
@@ -880,18 +899,6 @@ Actions:
             // field: a model may add target_date/source_date to an
             // update/delete call, and the salvage logic would otherwise strip
             // the id fields and run a full-day copy instead.
-            if (
-              args.entry_id &&
-              (args.quantity !== undefined ||
-                args.unit ||
-                args.meal_type ||
-                args.meal_type_id)
-            ) {
-              return 'update_entry';
-            }
-            if (args.entry_id && args.entry_type) {
-              return 'delete_entry';
-            }
             if (args.food_id) {
               return 'delete_food';
             }

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -493,7 +493,7 @@ async function resolveMealType(
     (type: { id: string; name: string }) =>
       type.name.trim().toLowerCase() === normalizedName
   );
-  return resolved ? { id: resolved.id, name: mealType.trim() } : null;
+  return resolved ? { id: resolved.id, name: resolved.name } : null;
 }
 // Full food_entries dumps (`SELECT fe.*`, used by recent-entries and food-usage)
 // add audit/ownership columns on top of the diary projection's surrogate keys.
@@ -1494,7 +1494,7 @@ Actions:
                       args.meal_type
                     )
                   : undefined;
-              if (mealType === null) {
+              if (!mealType) {
                 return ERRORS.VALIDATION(
                   `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
                 );
@@ -1864,7 +1864,7 @@ Actions:
                       args.meal_type
                     )
                   : undefined;
-              if (mealType === null) {
+              if (!mealType) {
                 return ERRORS.VALIDATION(
                   `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
                 );
@@ -2048,7 +2048,7 @@ Actions:
                       args.meal_type
                     )
                   : undefined;
-              if (mealType === null) {
+              if (!mealType) {
                 return ERRORS.VALIDATION(
                   `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
                 );
@@ -2087,7 +2087,7 @@ Actions:
                       args.meal_type
                     )
                   : undefined;
-              if (mealType === null) {
+              if (!mealType) {
                 return ERRORS.VALIDATION(
                   `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
                 );

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -1494,7 +1494,7 @@ Actions:
                       args.meal_type
                     )
                   : undefined;
-              if (!mealType) {
+              if (mealType === null) {
                 return ERRORS.VALIDATION(
                   `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
                 );
@@ -1864,7 +1864,7 @@ Actions:
                       args.meal_type
                     )
                   : undefined;
-              if (!mealType) {
+              if (mealType === null) {
                 return ERRORS.VALIDATION(
                   `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
                 );
@@ -2048,7 +2048,7 @@ Actions:
                       args.meal_type
                     )
                   : undefined;
-              if (!mealType) {
+              if (mealType === null) {
                 return ERRORS.VALIDATION(
                   `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
                 );

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -486,12 +486,15 @@ async function resolveMealType(
   if (!mealType) {
     return null;
   }
-  // For built-in meal types (by name), resolve to actual ID
+  // For built-in meal types (by name), resolve to actual ID. The legacy
+  // fallback must only match system defaults (user_id IS NULL): custom types
+  // are selected exclusively via meal_type_id, and a custom type may share a
+  // name with a system default (uniqueness is per (name, user_id)).
   const mealTypes = await mealTypeRepository.getAllMealTypes(userId);
   const normalizedName = mealType.trim().toLowerCase();
   const resolved = mealTypes.find(
-    (type: { id: string; name: string }) =>
-      type.name.trim().toLowerCase() === normalizedName
+    (type: { id: string; name: string; user_id: string | null }) =>
+      type.user_id === null && type.name.trim().toLowerCase() === normalizedName
   );
   return resolved ? { id: resolved.id, name: resolved.name } : null;
 }
@@ -849,11 +852,19 @@ Actions:
             if (args.food_name) {
               return 'lookup_food_nutrition';
             }
+            // log_meal must be checked before copy_from_yesterday: small
+            // models often file a logging date under target_date/source_date,
+            // and the salvage logic remaps those to entry_date for logging
+            // actions. Inferring copy first would silently drop meal_name and
+            // run a different data-writing operation.
+            if (
+              (args.meal_name || args.meal_id) &&
+              (args.meal_type || args.meal_type_id)
+            ) {
+              return 'log_meal';
+            }
             if (args.target_date || args.source_date) {
               return 'copy_from_yesterday';
-            }
-            if (args.meal_name && (args.meal_type || args.meal_type_id)) {
-              return 'log_meal';
             }
             if (args.meal_name) {
               return 'search_meal';
@@ -2048,9 +2059,9 @@ Actions:
                     userId,
                     userId,
                     sourceDate,
-                    mealType.name,
+                    mealType.id,
                     targetDate,
-                    mealType.name
+                    mealType.id
                   )
                 : await foodEntryService.copyAllFoodEntries(
                     userId,
@@ -2085,7 +2096,7 @@ Actions:
               const meal = await mealService.createMealFromDiaryEntries(
                 userId,
                 args.entry_date,
-                mealType.name,
+                mealType.id,
                 args.meal_name,
                 args.description ?? null
               );

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -800,8 +800,8 @@ Actions:
 - delete_food(food_id?|food_name?) — deletes food + variants + all diary entries referencing it
 - update_entry(entry_id, entry_type, quantity?, unit?, meal_type_id?, meal_type?) — changes quantity/unit and/or moves the entry to another meal type.
 - update_food_variant(food_id?|variant_id?, serving_size?, serving_unit?, calories?, protein?, carbs?, fat?, saturated_fat?, fiber?, sugar?, sodium?, ..., update_existing_entries?) — updates an existing food variant without deleting the food. Defaults to leaving existing diary entries unchanged.
-- copy_from_yesterday(target_date?, source_date?, meal_type?)
-- save_as_meal_template(entry_date, meal_type, meal_name, description?)
+- copy_from_yesterday(target_date?, source_date?, meal_type_id?|meal_type?)
+- save_as_meal_template(entry_date, meal_type_id?|meal_type?, meal_name, description?)
 - log_water(amount_ml, entry_date)
 - get_nutritional_summary(start_date, end_date) — returns macro breakdown for a range of dates
 - get_water_history(start_date?, end_date?)`,
@@ -863,11 +863,23 @@ Actions:
             if (args.food_id) {
               return 'delete_food';
             }
-            if (args.target_date || args.source_date) {
+            if (
+              args.target_date ||
+              args.source_date ||
+              args.meal_type ||
+              args.meal_type_id
+            ) {
               return 'copy_from_yesterday';
             }
             if (args.start_date || args.end_date) {
               return 'get_nutritional_summary';
+            }
+            if (
+              args.entry_date &&
+              args.meal_name &&
+              (args.meal_type || args.meal_type_id)
+            ) {
+              return 'save_as_meal_template';
             }
             if (args.entry_date) {
               return 'list_diary';
@@ -2031,14 +2043,27 @@ Actions:
               const targetDate = args.target_date || todayInZone(tz);
               const sourceDate =
                 args.source_date || addDays(todayInZone(tz), -1);
-              const copied = args.meal_type
+              const mealType =
+                args.meal_type_id || args.meal_type
+                  ? await resolveMealType(
+                      userId,
+                      args.meal_type_id,
+                      args.meal_type
+                    )
+                  : undefined;
+              if (mealType === null) {
+                return ERRORS.VALIDATION(
+                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                );
+              }
+              const copied = mealType
                 ? await foodEntryService.copyFoodEntries(
                     userId,
                     userId,
                     sourceDate,
-                    args.meal_type,
+                    mealType.id || mealType.name,
                     targetDate,
-                    args.meal_type
+                    mealType.id || mealType.name
                   )
                 : await foodEntryService.copyAllFoodEntries(
                     userId,
@@ -2057,10 +2082,23 @@ Actions:
             }
 
             case 'save_as_meal_template': {
+              const mealType =
+                args.meal_type_id || args.meal_type
+                  ? await resolveMealType(
+                      userId,
+                      args.meal_type_id,
+                      args.meal_type
+                    )
+                  : undefined;
+              if (mealType === null) {
+                return ERRORS.VALIDATION(
+                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                );
+              }
               const meal = await mealService.createMealFromDiaryEntries(
                 userId,
                 args.entry_date,
-                args.meal_type,
+                mealType.id || mealType.name,
                 args.meal_name,
                 args.description ?? null
               );

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -873,12 +873,13 @@ Actions:
             ) {
               return 'log_meal';
             }
-            if (args.target_date || args.source_date) {
-              return 'copy_from_yesterday';
-            }
             if (args.meal_name) {
               return 'search_meal';
             }
+            // Entry/food-targeted operations win over an incidental date
+            // field: a model may add target_date/source_date to an
+            // update/delete call, and the salvage logic would otherwise strip
+            // the id fields and run a full-day copy instead.
             if (
               args.entry_id &&
               (args.quantity !== undefined ||
@@ -888,14 +889,17 @@ Actions:
             ) {
               return 'update_entry';
             }
-            if (args.meal_id || args.meal_type || args.meal_type_id) {
-              return 'log_meal';
-            }
             if (args.entry_id && args.entry_type) {
               return 'delete_entry';
             }
             if (args.food_id) {
               return 'delete_food';
+            }
+            if (args.target_date || args.source_date) {
+              return 'copy_from_yesterday';
+            }
+            if (args.meal_type || args.meal_type_id) {
+              return 'log_meal';
             }
             if (args.start_date || args.end_date) {
               return 'get_nutritional_summary';
@@ -1300,7 +1304,7 @@ Actions:
                   entry_date: entryDate,
                 });
                 return ERRORS.VALIDATION(
-                  `No external match found for "${args.food_name}". Please estimate the nutrition yourself and call create_food (include meal_type and entry_date to save and log in one step), for example: ${exampleCall}`
+                  `No external match found for "${args.food_name}". Please estimate the nutrition yourself and call create_food (include meal_type_id (or meal_type) and entry_date to save and log in one step), for example: ${exampleCall}`
                 );
               }
               // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -1186,7 +1186,7 @@ Actions:
               );
               if (!mealType) {
                 return ERRORS.VALIDATION(
-                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                  `Meal type "${args.meal_type_id ?? args.meal_type}" was not found or is not available to this user.`
                 );
               }
               let foodId = args.food_id;
@@ -1233,9 +1233,7 @@ Actions:
                   entry_date: entryDate,
                   quantity: resolvedLog.quantity,
                   unit: resolvedLog.unit,
-                  ...(mealType.id
-                    ? { meal_type_id: mealType.id }
-                    : { meal_type: mealType.name }),
+                  meal_type_id: mealType.id,
                   entry_time: args.entry_time,
                 }
               );
@@ -1252,7 +1250,7 @@ Actions:
               );
               if (!mealType) {
                 return ERRORS.VALIDATION(
-                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                  `Meal type "${args.meal_type_id ?? args.meal_type}" was not found or is not available to this user.`
                 );
               }
               const entryDate = args.entry_date || todayInZone(tz);
@@ -1319,9 +1317,7 @@ Actions:
                     entry_date: entryDate,
                     quantity: logged.quantity,
                     unit: logged.unit,
-                    ...(mealType.id
-                      ? { meal_type_id: mealType.id }
-                      : { meal_type: mealType.name }),
+                    meal_type_id: mealType.id,
                     entry_time: args.entry_time,
                   }
                 );
@@ -1470,9 +1466,7 @@ Actions:
                 entry_date: entryDate,
                 quantity: logged.quantity,
                 unit: logged.unit,
-                ...(mealType.id
-                  ? { meal_type_id: mealType.id }
-                  : { meal_type: mealType.name }),
+                meal_type_id: mealType.id,
                 entry_time: args.entry_time,
               });
               return formatConfirmation(
@@ -1496,7 +1490,7 @@ Actions:
                   : undefined;
               if (mealType === null) {
                 return ERRORS.VALIDATION(
-                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                  `Meal type "${args.meal_type_id ?? args.meal_type}" was not found or is not available to this user.`
                 );
               }
               // The `|| null` on optional fields is MCP's storage quirk
@@ -1537,9 +1531,7 @@ Actions:
                   entry_date: entryDate,
                   quantity: targetQuantity,
                   unit: targetUnit,
-                  ...(mealType.id
-                    ? { meal_type_id: mealType.id }
-                    : { meal_type: mealType.name }),
+                  meal_type_id: mealType.id,
                   entry_time: args.entry_time,
                 });
                 msg += ` Also logged to ${mealType.name} for ${entryDate}.`;
@@ -1584,7 +1576,7 @@ Actions:
               );
               if (!mealType) {
                 return ERRORS.VALIDATION(
-                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                  `Meal type "${args.meal_type_id ?? args.meal_type}" was not found or is not available to this user.`
                 );
               }
               if (!args.meal_id && !args.meal_name) {
@@ -1632,9 +1624,7 @@ Actions:
               await foodEntryService.createFoodEntryMeal(userId, userId, {
                 user_id: userId,
                 meal_template_id: mealId,
-                ...(mealType.id
-                  ? { meal_type_id: mealType.id }
-                  : { meal_type: mealType.name }),
+                meal_type_id: mealType.id,
                 entry_date: args.entry_date,
                 name: mealName,
                 quantity: args.quantity || 1,
@@ -1866,7 +1856,7 @@ Actions:
                   : undefined;
               if (mealType === null) {
                 return ERRORS.VALIDATION(
-                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                  `Meal type "${args.meal_type_id ?? args.meal_type}" was not found or is not available to this user.`
                 );
               }
               const mealTypeUpdate = mealType
@@ -2050,7 +2040,7 @@ Actions:
                   : undefined;
               if (mealType === null) {
                 return ERRORS.VALIDATION(
-                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                  `Meal type "${args.meal_type_id ?? args.meal_type}" was not found or is not available to this user.`
                 );
               }
               const copied = mealType
@@ -2089,7 +2079,7 @@ Actions:
                   : undefined;
               if (!mealType) {
                 return ERRORS.VALIDATION(
-                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                  `Meal type "${args.meal_type_id ?? args.meal_type}" was not found or is not available to this user.`
                 );
               }
               const meal = await mealService.createMealFromDiaryEntries(

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -13,6 +13,7 @@ import {
 } from '../../services/externalFoodSearchService.js';
 import foodRepository from '../../models/foodRepository.js';
 import foodEntryMealRepository from '../../models/foodEntryMealRepository.js';
+import mealTypeRepository from '../../models/mealType.js';
 import measurementRepository from '../../models/measurementRepository.js';
 import reportRepository from '../../models/reportRepository.js';
 import externalProviderRepository from '../../models/externalProviderRepository.js';
@@ -45,6 +46,7 @@ import {
 const VALID_ACTIONS = [
   'search_food',
   'lookup_food_nutrition',
+  'list_meal_types',
   'log_food',
   'log_external_food',
   'create_food',
@@ -445,11 +447,10 @@ function projectFoodItem(row: any) {
 // `user_id` is the authenticated caller on every row; never useful in output.
 const CATALOG_FOOD_DROP = ['user_id'] as const;
 const VARIANT_DROP = ['user_id'] as const;
-// food_entries internal surrogate keys with a human-readable equivalent already
-// present (meal_type label, serving_size/serving_unit) or no model use. `id`
-// (for edit/delete) and `food_id` (for food lookups / re-logging) are kept.
+// food_entries internal surrogate keys with no model use. `id` (for
+// edit/delete), `food_id` (for food lookups / re-logging), and meal_type_id
+// (for custom-meal round trips) are kept.
 const DIARY_ENTRY_DROP = [
-  'meal_type_id',
   'variant_id',
   'meal_plan_template_id',
   'food_entry_meal_id',
@@ -462,9 +463,28 @@ const DIARY_MEAL_DROP = [
   'created_by_user_id',
   'updated_by_user_id',
   'meal_template_id',
-  'meal_type_id',
   'legacy_serving_unit_math',
 ] as const;
+
+interface ResolvedMealType {
+  id?: string;
+  name: string;
+}
+
+async function resolveMealType(
+  userId: string,
+  mealTypeId?: string,
+  mealType?: string
+): Promise<ResolvedMealType | null> {
+  if (mealTypeId) {
+    const resolved = await mealTypeRepository.getMealTypeById(
+      mealTypeId,
+      userId
+    );
+    return resolved ? { id: resolved.id, name: resolved.name } : null;
+  }
+  return mealType ? { name: mealType } : null;
+}
 // Full food_entries dumps (`SELECT fe.*`, used by recent-entries and food-usage)
 // add audit/ownership columns on top of the diary projection's surrogate keys.
 const FULL_ENTRY_DROP: readonly string[] = [
@@ -769,15 +789,16 @@ export function buildFoodTools(userId: string, tz: string) {
 Actions:
 - search_food(food_name, search_type:"exact"|"broad", limit?, offset?)
 - lookup_food_nutrition(food_name, provider_type?) — AI MUST call this cascade lookup first before creating or estimating a food. Bypasses regular cascade to search specific provider (e.g. openfoodfacts, usda, yazio) if provider_type given.
-- log_food(quantity, meal_type:"breakfast"|"lunch"|"dinner"|"snacks", food_name?|food_id?, unit?, entry_date?, variant_id?) — provide food_name or food_id (an internal food UUID, never a lookup result's External ID); unit defaults to the food's serving unit, entry_date defaults to today. Works only for foods already in the database (source='internal').
-- log_external_food(food_name, meal_type, quantity?, unit?, entry_date?, external_id?, provider_type?) — PREFERRED way to log an external lookup_food_nutrition match (usda/openfoodfacts/...): the server re-fetches the provider result, saves it with full nutrition, and logs it in one call. quantity is in servings and defaults to 1.
-- create_food(food_name, calories, protein, carbs, fat, brand?, quantity?, unit?, meal_type?, entry_date?, saturated_fat?, fiber?, sugar?, sodium?, ...) — MANDATORY: You must run lookup_food_nutrition first. Call only when lookup returns source='ai_estimate' (no match anywhere) or for custom/homemade foods, using AI-estimated values; for external lookup matches use log_external_food instead. Include meal_type + entry_date to also log the food in the same call. Populate as many micro-nutrients, GI classification, and brand ('Homemade' or 'Traditional' if generic) as possible rather than just core macros.
+- list_meal_types() — lists the user's built-in and custom meal types with IDs, names, and sort order.
+- log_food(quantity, meal_type_id?|meal_type?, food_name?|food_id?, unit?, entry_date?, variant_id?) — use meal_type_id for custom meal types; the legacy meal_type fallback accepts "breakfast"|"lunch"|"dinner"|"snacks". meal_type_id takes precedence when both are supplied. Provide food_name or food_id (an internal food UUID, never a lookup result's External ID); unit defaults to the food's serving unit, entry_date defaults to today. Works only for foods already in the database (source='internal').
+- log_external_food(food_name, meal_type_id?|meal_type?, quantity?, unit?, entry_date?, external_id?, provider_type?) — PREFERRED way to log an external lookup_food_nutrition match (usda/openfoodfacts/...): the server re-fetches the provider result, saves it with full nutrition, and logs it in one call. quantity is in servings and defaults to 1.
+- create_food(food_name, calories, protein, carbs, fat, brand?, quantity?, unit?, meal_type_id?, meal_type?, entry_date?, saturated_fat?, fiber?, sugar?, sodium?, ...) — MANDATORY: You must run lookup_food_nutrition first. Call only when lookup returns source='ai_estimate' (no match anywhere) or for custom/homemade foods, using AI-estimated values; for external lookup matches use log_external_food instead. Include meal_type_id (or legacy meal_type) + entry_date to also log the food in the same call. Populate as many micro-nutrients, GI classification, and brand ('Homemade' or 'Traditional' if generic) as possible rather than just core macros.
 - search_meal(meal_name)
-- log_meal(meal_type, entry_date, meal_id?, meal_name?, quantity?)
+- log_meal(meal_type_id?|meal_type?, entry_date, meal_id?, meal_name?, quantity?)
 - list_diary(entry_date?)
 - delete_entry(entry_id, entry_type:"food_entry"|"food_entry_meal")
 - delete_food(food_id?|food_name?) — deletes food + variants + all diary entries referencing it
-- update_entry(entry_id, entry_type, quantity, unit)
+- update_entry(entry_id, entry_type, quantity?, unit?, meal_type_id?, meal_type?) — changes quantity/unit and/or moves the entry to another meal type.
 - update_food_variant(food_id?|variant_id?, serving_size?, serving_unit?, calories?, protein?, carbs?, fat?, saturated_fat?, fiber?, sugar?, sodium?, ..., update_existing_entries?) — updates an existing food variant without deleting the food. Defaults to leaving existing diary entries unchanged.
 - copy_from_yesterday(target_date?, source_date?, meal_type?)
 - save_as_meal_template(entry_date, meal_type, meal_name, description?)
@@ -799,8 +820,7 @@ Actions:
             }
             if (
               (args.food_name || args.food_id) &&
-              args.quantity &&
-              args.meal_type
+              (args.meal_type || args.meal_type_id)
             ) {
               if (
                 args.food_name?.toLowerCase() === 'water' ||
@@ -822,11 +842,17 @@ Actions:
             if (args.meal_name) {
               return 'search_meal';
             }
-            if (args.meal_id || args.meal_type) {
-              return 'log_meal';
-            }
-            if (args.entry_id && args.quantity) {
+            if (
+              args.entry_id &&
+              (args.quantity !== undefined ||
+                args.unit ||
+                args.meal_type ||
+                args.meal_type_id)
+            ) {
               return 'update_entry';
+            }
+            if (args.meal_id || args.meal_type || args.meal_type_id) {
+              return 'log_meal';
             }
             if (args.entry_id && args.entry_type) {
               return 'delete_entry';
@@ -938,6 +964,35 @@ Actions:
           );
         }
         const args: ManageFoodInput = parsed.data;
+        const optionalMealFields = args as {
+          meal_type_id?: string;
+          meal_type?: string;
+          quantity?: number;
+          unit?: string;
+        };
+        const mealTypeRequiredActions = [
+          'log_food',
+          'log_external_food',
+          'log_meal',
+        ];
+        if (
+          mealTypeRequiredActions.includes(args.action) &&
+          !optionalMealFields.meal_type_id &&
+          !optionalMealFields.meal_type
+        ) {
+          return ERRORS.MISSING_PARAMS(['meal_type_id (or meal_type)']);
+        }
+        if (
+          args.action === 'update_entry' &&
+          optionalMealFields.quantity === undefined &&
+          optionalMealFields.unit === undefined &&
+          !optionalMealFields.meal_type_id &&
+          !optionalMealFields.meal_type
+        ) {
+          return ERRORS.VALIDATION(
+            'update_entry requires quantity, unit, meal_type_id, or meal_type'
+          );
+        }
         try {
           switch (args.action) {
             case 'search_food': {
@@ -968,6 +1023,24 @@ Actions:
                   has_more: result.has_more,
                   next_offset: result.next_offset,
                 }
+              );
+            }
+
+            case 'list_meal_types': {
+              const mealTypes =
+                await mealTypeRepository.getAllMealTypes(userId);
+              return formatJsonResult(
+                mealTypes.map(
+                  (mealType: {
+                    id: string;
+                    name: string;
+                    sort_order: number;
+                  }) => ({
+                    id: mealType.id,
+                    name: mealType.name,
+                    sort_order: mealType.sort_order,
+                  })
+                )
               );
             }
 
@@ -1087,6 +1160,16 @@ Actions:
             }
 
             case 'log_food': {
+              const mealType = await resolveMealType(
+                userId,
+                args.meal_type_id,
+                args.meal_type
+              );
+              if (!mealType) {
+                return ERRORS.VALIDATION(
+                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                );
+              }
               let foodId = args.food_id;
               const variantId = args.variant_id;
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1131,16 +1214,28 @@ Actions:
                   entry_date: entryDate,
                   quantity: resolvedLog.quantity,
                   unit: resolvedLog.unit,
-                  meal_type: args.meal_type,
+                  ...(mealType.id
+                    ? { meal_type_id: mealType.id }
+                    : { meal_type: mealType.name }),
                   entry_time: args.entry_time,
                 }
               );
               return formatConfirmation(
-                `Logged "${entry.food_name}" (${resolvedLog.quantity} ${resolvedLog.unit}) for ${args.meal_type} on ${entryDate}.`
+                `Logged "${entry.food_name}" (${resolvedLog.quantity} ${resolvedLog.unit}) for ${mealType.name} on ${entryDate}.`
               );
             }
 
             case 'log_external_food': {
+              const mealType = await resolveMealType(
+                userId,
+                args.meal_type_id,
+                args.meal_type
+              );
+              if (!mealType) {
+                return ERRORS.VALIDATION(
+                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                );
+              }
               const entryDate = args.entry_date || todayInZone(tz);
               const quantity = args.quantity ?? 1;
               const result = await lookupFoodNutrition(
@@ -1205,12 +1300,14 @@ Actions:
                     entry_date: entryDate,
                     quantity: logged.quantity,
                     unit: logged.unit,
-                    meal_type: args.meal_type,
+                    ...(mealType.id
+                      ? { meal_type_id: mealType.id }
+                      : { meal_type: mealType.name }),
                     entry_time: args.entry_time,
                   }
                 );
                 return formatConfirmation(
-                  `"${entry.food_name}" was already in the food database — logged ${logged.quantity} ${logged.unit} for ${args.meal_type} on ${entryDate}.`
+                  `"${entry.food_name}" was already in the food database — logged ${logged.quantity} ${logged.unit} for ${mealType.name} on ${entryDate}.`
                 );
               }
 
@@ -1354,11 +1451,13 @@ Actions:
                 entry_date: entryDate,
                 quantity: logged.quantity,
                 unit: logged.unit,
-                meal_type: args.meal_type,
+                ...(mealType.id
+                  ? { meal_type_id: mealType.id }
+                  : { meal_type: mealType.name }),
                 entry_time: args.entry_time,
               });
               return formatConfirmation(
-                `Saved "${food.name}" from ${result.source} (${dv?.calories || 0} kcal per ${dv?.serving_size || 100}${dv?.serving_unit || 'g'}) and logged ${logged.quantity} ${logged.unit} to ${args.meal_type} on ${entryDate}.`
+                `Saved "${food.name}" from ${result.source} (${dv?.calories || 0} kcal per ${dv?.serving_size || 100}${dv?.serving_unit || 'g'}) and logged ${logged.quantity} ${logged.unit} to ${mealType.name} on ${entryDate}.`
               );
             }
 
@@ -1368,6 +1467,19 @@ Actions:
                 targetUnit.toLowerCase()
               );
               const targetQuantity = args.quantity || (isCountUnit ? 1 : 100);
+              const mealType =
+                args.meal_type_id || args.meal_type
+                  ? await resolveMealType(
+                      userId,
+                      args.meal_type_id,
+                      args.meal_type
+                    )
+                  : undefined;
+              if (mealType === null) {
+                return ERRORS.VALIDATION(
+                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                );
+              }
               // The `|| null` on optional fields is MCP's storage quirk
               // (an explicit 0 is stored as null), ported as-is.
               const food = await foodCoreService.createFood(userId, {
@@ -1397,7 +1509,7 @@ Actions:
               });
               const v = food.default_variant;
               let msg = `Food "${food.name}" created with ${v?.calories || 0} kcal per ${v?.serving_size || 100}${v?.serving_unit || 'g'}.`;
-              if (args.meal_type) {
+              if (mealType) {
                 const entryDate = args.entry_date || todayInZone(tz);
                 await foodEntryService.createFoodEntry(userId, userId, {
                   user_id: userId,
@@ -1406,10 +1518,12 @@ Actions:
                   entry_date: entryDate,
                   quantity: targetQuantity,
                   unit: targetUnit,
-                  meal_type: args.meal_type,
+                  ...(mealType.id
+                    ? { meal_type_id: mealType.id }
+                    : { meal_type: mealType.name }),
                   entry_time: args.entry_time,
                 });
-                msg += ` Also logged to ${args.meal_type} for ${entryDate}.`;
+                msg += ` Also logged to ${mealType.name} for ${entryDate}.`;
               }
               return formatConfirmation(msg);
             }
@@ -1444,6 +1558,16 @@ Actions:
             }
 
             case 'log_meal': {
+              const mealType = await resolveMealType(
+                userId,
+                args.meal_type_id,
+                args.meal_type
+              );
+              if (!mealType) {
+                return ERRORS.VALIDATION(
+                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                );
+              }
               if (!args.meal_id && !args.meal_name) {
                 return ERRORS.VALIDATION(
                   'Either meal_id or meal_name must be provided'
@@ -1489,7 +1613,9 @@ Actions:
               await foodEntryService.createFoodEntryMeal(userId, userId, {
                 user_id: userId,
                 meal_template_id: mealId,
-                meal_type: args.meal_type,
+                ...(mealType.id
+                  ? { meal_type_id: mealType.id }
+                  : { meal_type: mealType.name }),
                 entry_date: args.entry_date,
                 name: mealName,
                 quantity: args.quantity || 1,
@@ -1497,7 +1623,7 @@ Actions:
                 _clientMealModelVersion: 2,
               });
               return formatConfirmation(
-                `Meal "${mealName}" logged for ${args.meal_type} on ${args.entry_date}.`
+                `Meal "${mealName}" logged for ${mealType.name} on ${args.entry_date}.`
               );
             }
 
@@ -1551,9 +1677,10 @@ Actions:
                   food_name: row.food_name,
                   quantity,
                   unit: row.unit || 'g',
-                  meal_type: row.meal_type
-                    ? String(row.meal_type).toLowerCase()
-                    : 'snacks',
+                  meal_type: row.meal_type ? String(row.meal_type) : 'snacks',
+                  meal_type_id: row.meal_type_id
+                    ? String(row.meal_type_id)
+                    : undefined,
                   entry_type: 'food_entry' as const,
                   nutritional_values: isSet(row.calories)
                     ? {
@@ -1571,9 +1698,10 @@ Actions:
                 id: row.id,
                 meal_name: row.name,
                 quantity: Number(row.quantity),
-                meal_type: row.meal_type
-                  ? String(row.meal_type).toLowerCase()
-                  : 'snacks',
+                meal_type: row.meal_type ? String(row.meal_type) : 'snacks',
+                meal_type_id: row.meal_type_id
+                  ? String(row.meal_type_id)
+                  : undefined,
                 entry_type: 'food_entry_meal' as const,
               }));
 
@@ -1601,10 +1729,18 @@ Actions:
                         text += ` (${entry.nutritional_values.calories} ${eUnit})`;
                         totalEnergy += entry.nutritional_values.calories;
                       }
-                      text += `\n  ID: ${entry.id} | Type: food_entry\n`;
+                      text += `\n  ID: ${entry.id} | Type: food_entry`;
+                      if (entry.meal_type_id) {
+                        text += ` | Meal type: ${entry.meal_type} (${entry.meal_type_id})`;
+                      }
+                      text += '\n';
                     } else {
                       text += `- **${entry.meal_name}** (meal template) — ${entry.quantity}x`;
-                      text += `\n  ID: ${entry.id} | Type: food_entry_meal\n`;
+                      text += `\n  ID: ${entry.id} | Type: food_entry_meal`;
+                      if (entry.meal_type_id) {
+                        text += ` | Meal type: ${entry.meal_type} (${entry.meal_type_id})`;
+                      }
+                      text += '\n';
                     }
                   }
                   text += '\n';
@@ -1701,13 +1837,35 @@ Actions:
             }
 
             case 'update_entry': {
+              const mealType =
+                args.meal_type_id || args.meal_type
+                  ? await resolveMealType(
+                      userId,
+                      args.meal_type_id,
+                      args.meal_type
+                    )
+                  : undefined;
+              if (mealType === null) {
+                return ERRORS.VALIDATION(
+                  `Meal type "${args.meal_type_id}" was not found or is not available to this user.`
+                );
+              }
+              const mealTypeUpdate = mealType
+                ? mealType.id
+                  ? { meal_type_id: mealType.id }
+                  : { meal_type: mealType.name }
+                : {};
               try {
                 if (args.entry_type === 'food_entry') {
                   await foodEntryService.updateFoodEntry(
                     userId,
                     userId,
                     args.entry_id,
-                    { quantity: args.quantity, unit: args.unit }
+                    {
+                      quantity: args.quantity,
+                      unit: args.unit,
+                      ...mealTypeUpdate,
+                    }
                   );
                 } else {
                   // Round-trip the template link and component foods so the
@@ -1728,8 +1886,9 @@ Actions:
                     {
                       meal_template_id: existing.meal_template_id,
                       entry_date: dayString(existing.entry_date),
-                      quantity: args.quantity,
-                      unit: args.unit,
+                      quantity: args.quantity ?? existing.quantity,
+                      unit: args.unit ?? existing.unit,
+                      ...mealTypeUpdate,
                       foods: existing.foods,
                     }
                   );
@@ -1743,8 +1902,24 @@ Actions:
                 }
                 throw error;
               }
+              const updates = [
+                args.quantity !== undefined
+                  ? `quantity to ${args.quantity}`
+                  : '',
+                args.unit !== undefined ? `unit to ${args.unit}` : '',
+                mealType ? `meal type to ${mealType.name}` : '',
+              ].filter(Boolean);
+              if (
+                args.quantity !== undefined &&
+                args.unit !== undefined &&
+                !mealType
+              ) {
+                return formatConfirmation(
+                  `Entry updated to ${args.quantity} ${args.unit}.`
+                );
+              }
               return formatConfirmation(
-                `Entry updated to ${args.quantity} ${args.unit}.`
+                `Entry updated: ${updates.join(', ')}.`
               );
             }
 

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -855,11 +855,21 @@ Actions:
             // log_meal must be checked before copy_from_yesterday: small
             // models often file a logging date under target_date/source_date,
             // and the salvage logic remaps those to entry_date for logging
-            // actions. Inferring copy first would silently drop meal_name and
-            // run a different data-writing operation.
+            // actions. A meal_name or meal_id combined with any date (or a
+            // type selector) is a log intent — inferring copy first would
+            // silently drop meal_name/meal_id and run a different
+            // data-writing operation instead of a validation error when the
+            // type selector is missing.
+            if (args.meal_id) {
+              return 'log_meal';
+            }
             if (
-              (args.meal_name || args.meal_id) &&
-              (args.meal_type || args.meal_type_id)
+              args.meal_name &&
+              (args.meal_type ||
+                args.meal_type_id ||
+                args.entry_date ||
+                args.target_date ||
+                args.source_date)
             ) {
               return 'log_meal';
             }
@@ -1272,8 +1282,25 @@ Actions:
                 args.provider_type
               );
               if (result.source === 'ai_estimate' || !result.food) {
+                // Preserve the caller's meal selector in the retry example: a
+                // custom meal_type_id must not be silently replaced with the
+                // lunch fallback (that is exactly the kind of category
+                // substitution issue #1959 is about).
+                const mealSelector = args.meal_type_id
+                  ? { meal_type_id: args.meal_type_id }
+                  : { meal_type: args.meal_type ?? 'lunch' };
+                const exampleCall = JSON.stringify({
+                  action: 'create_food',
+                  food_name: args.food_name,
+                  calories: 300,
+                  protein: 15,
+                  carbs: 40,
+                  fat: 5,
+                  ...mealSelector,
+                  entry_date: entryDate,
+                });
                 return ERRORS.VALIDATION(
-                  `No external match found for "${args.food_name}". Please estimate the nutrition yourself and call create_food (include meal_type and entry_date to save and log in one step), for example: {"action":"create_food","food_name":"${args.food_name}","calories":300,"protein":15,"carbs":40,"fat":5,"meal_type":"${args.meal_type || 'lunch'}"}`
+                  `No external match found for "${args.food_name}". Please estimate the nutrition yourself and call create_food (include meal_type and entry_date to save and log in one step), for example: ${exampleCall}`
                 );
               }
               // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -1873,7 +1873,7 @@ Actions:
               const mealTypeUpdate = mealType
                 ? mealType.id
                   ? { meal_type_id: mealType.id }
-                  : { meal_type: mealType.name, meal_type_id: null }
+                  : { meal_type: mealType.name, meal_type_id: undefined }
                 : {};
               try {
                 if (args.entry_type === 'food_entry') {

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -819,6 +819,12 @@ Actions:
               return 'log_external_food';
             }
             if (
+              args.food_name &&
+              (args.calories !== undefined || args.protein !== undefined)
+            ) {
+              return 'create_food';
+            }
+            if (
               (args.food_name || args.food_id) &&
               (args.meal_type || args.meal_type_id)
             ) {
@@ -830,14 +836,11 @@ Actions:
               }
               return 'log_food';
             }
-            if (
-              args.food_name &&
-              (args.calories !== undefined || args.protein !== undefined)
-            ) {
-              return 'create_food';
-            }
             if (args.food_name) {
               return 'lookup_food_nutrition';
+            }
+            if (args.meal_name && (args.meal_type || args.meal_type_id)) {
+              return 'log_meal';
             }
             if (args.meal_name) {
               return 'search_meal';
@@ -1030,17 +1033,22 @@ Actions:
               const mealTypes =
                 await mealTypeRepository.getAllMealTypes(userId);
               return formatJsonResult(
-                mealTypes.map(
-                  (mealType: {
-                    id: string;
-                    name: string;
-                    sort_order: number;
-                  }) => ({
-                    id: mealType.id,
-                    name: mealType.name,
-                    sort_order: mealType.sort_order,
-                  })
-                )
+                mealTypes
+                  .filter(
+                    (mealType: { is_visible: boolean }) =>
+                      mealType.is_visible !== false
+                  )
+                  .map(
+                    (mealType: {
+                      id: string;
+                      name: string;
+                      sort_order: number;
+                    }) => ({
+                      id: mealType.id,
+                      name: mealType.name,
+                      sort_order: mealType.sort_order,
+                    })
+                  )
               );
             }
 
@@ -1853,7 +1861,7 @@ Actions:
               const mealTypeUpdate = mealType
                 ? mealType.id
                   ? { meal_type_id: mealType.id }
-                  : { meal_type: mealType.name }
+                  : { meal_type: mealType.name, meal_type_id: null }
                 : {};
               try {
                 if (args.entry_type === 'food_entry') {

--- a/SparkyFitnessServer/ai/tools/schemas/food.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/food.ts
@@ -493,6 +493,9 @@ const copyFromYesterdaySchema = z
     source_date: optionalDateSchema.describe(
       'Date to copy entries from (defaults to yesterday)'
     ),
+    meal_type_id: uuidSchema
+      .optional()
+      .describe('UUID of a built-in or custom meal type'),
     meal_type: z
       .string()
       .max(50)

--- a/SparkyFitnessServer/ai/tools/schemas/food.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/food.ts
@@ -4,6 +4,7 @@ import {
   optionalDateSchema,
   optionalEntryTimeSchema,
   uuidSchema,
+  mealTypeEnum,
   searchTypeEnum,
   entryTypeEnum,
   giIndexEnum,
@@ -87,13 +88,10 @@ const logFoodSchema = z
       .describe(
         "Unit of measurement (e.g., 'g', 'piece', 'serving'); defaults to the food's serving unit"
       ),
-    meal_type: z
-      .string()
-      .min(1)
-      .max(50)
+    meal_type: mealTypeEnum
       .optional()
       .describe(
-        'Legacy meal type name fallback (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
+        'Built-in meal type fallback; ignored when meal_type_id is provided'
       ),
     meal_type_id: uuidSchema
       .optional()
@@ -148,13 +146,10 @@ const logExternalFoodSchema = z
       .max(50)
       .optional()
       .describe("Unit of measurement (defaults to 'serving')"),
-    meal_type: z
-      .string()
-      .min(1)
-      .max(50)
+    meal_type: mealTypeEnum
       .optional()
       .describe(
-        'Legacy meal type name fallback (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
+        'Built-in meal type fallback; ignored when meal_type_id is provided'
       ),
     meal_type_id: uuidSchema
       .optional()
@@ -279,13 +274,10 @@ const createFoodSchema = z
       .optional()
       .describe('Default serving size value'),
     unit: z.string().max(50).optional().describe('Default serving size unit'),
-    meal_type: z
-      .string()
-      .min(1)
-      .max(50)
+    meal_type: mealTypeEnum
       .optional()
       .describe(
-        'Legacy meal type name fallback for automatic logging (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
+        'Optional built-in meal type fallback for automatic logging; ignored when meal_type_id is provided'
       ),
     meal_type_id: uuidSchema
       .optional()
@@ -322,13 +314,10 @@ const logMealSchema = z
       .max(200)
       .optional()
       .describe('Name of the meal template (alternative to ID)'),
-    meal_type: z
-      .string()
-      .min(1)
-      .max(50)
+    meal_type: mealTypeEnum
       .optional()
       .describe(
-        'Legacy meal type name fallback (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
+        'Built-in meal type fallback; ignored when meal_type_id is provided'
       ),
     meal_type_id: uuidSchema
       .optional()
@@ -374,13 +363,10 @@ const updateEntrySchema = z
       .max(50)
       .optional()
       .describe('New unit of measurement'),
-    meal_type: z
-      .string()
-      .min(1)
-      .max(50)
+    meal_type: mealTypeEnum
       .optional()
       .describe(
-        'Legacy meal type name fallback (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
+        'Built-in meal type fallback; ignored when meal_type_id is provided'
       ),
     meal_type_id: uuidSchema
       .optional()
@@ -700,13 +686,10 @@ export const manageFoodInput = z.object({
     .optional()
     .describe("Unit of measurement ('g', 'serving', 'piece', etc.)"),
   // meal / diary
-  meal_type: z
-    .string()
-    .min(1)
-    .max(50)
+  meal_type: mealTypeEnum
     .optional()
     .describe(
-      'Legacy meal type name fallback (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
+      'Built-in fallback: breakfast | lunch | dinner | snacks. Ignored when meal_type_id is provided.'
     ),
   meal_type_id: uuidSchema
     .optional()

--- a/SparkyFitnessServer/ai/tools/schemas/food.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/food.ts
@@ -50,6 +50,12 @@ const lookupFoodNutritionSchema = z
   })
   .strict();
 
+const listMealTypesSchema = z
+  .object({
+    action: z.literal('list_meal_types'),
+  })
+  .strict();
+
 // food_name/unit/quantity/entry_date are optional so a model holding a food_id
 // from a lookup can log with just (food_id, meal_type): the handler resolves
 // the unit from the food's default variant, defaults quantity to 1, and
@@ -82,7 +88,14 @@ const logFoodSchema = z
       .describe(
         "Unit of measurement (e.g., 'g', 'piece', 'serving'); defaults to the food's serving unit"
       ),
-    meal_type: mealTypeEnum.describe('Meal type category'),
+    meal_type: mealTypeEnum
+      .optional()
+      .describe(
+        'Built-in meal type fallback; ignored when meal_type_id is provided'
+      ),
+    meal_type_id: uuidSchema
+      .optional()
+      .describe('Meal type UUID, including custom meal types'),
     entry_date: optionalDateSchema,
     entry_time: optionalEntryTimeSchema,
   })
@@ -133,7 +146,14 @@ const logExternalFoodSchema = z
       .max(50)
       .optional()
       .describe("Unit of measurement (defaults to 'serving')"),
-    meal_type: mealTypeEnum.describe('Meal type category'),
+    meal_type: mealTypeEnum
+      .optional()
+      .describe(
+        'Built-in meal type fallback; ignored when meal_type_id is provided'
+      ),
+    meal_type_id: uuidSchema
+      .optional()
+      .describe('Meal type UUID, including custom meal types'),
     entry_date: optionalDateSchema,
     entry_time: optionalEntryTimeSchema,
   })
@@ -256,7 +276,14 @@ const createFoodSchema = z
     unit: z.string().max(50).optional().describe('Default serving size unit'),
     meal_type: mealTypeEnum
       .optional()
-      .describe('Optional: Automatically log this food to a meal'),
+      .describe(
+        'Optional built-in meal type fallback for automatic logging; ignored when meal_type_id is provided'
+      ),
+    meal_type_id: uuidSchema
+      .optional()
+      .describe(
+        'Optional meal type UUID for automatic logging, including custom meal types'
+      ),
     entry_date: optionalDateSchema.describe(
       'Optional: Date for automatic log (YYYY-MM-DD)'
     ),
@@ -287,7 +314,14 @@ const logMealSchema = z
       .max(200)
       .optional()
       .describe('Name of the meal template (alternative to ID)'),
-    meal_type: mealTypeEnum.describe('Meal type category'),
+    meal_type: mealTypeEnum
+      .optional()
+      .describe(
+        'Built-in meal type fallback; ignored when meal_type_id is provided'
+      ),
+    meal_type_id: uuidSchema
+      .optional()
+      .describe('Meal type UUID, including custom meal types'),
     entry_date: dateSchema,
     quantity: z.coerce
       .number()
@@ -322,8 +356,21 @@ const updateEntrySchema = z
     action: z.literal('update_entry'),
     entry_id: uuidSchema.describe('UUID of the entry to update'),
     entry_type: entryTypeEnum.describe('Type of diary entry'),
-    quantity: z.coerce.number().min(0).describe('New amount'),
-    unit: z.string().min(1).max(50).describe('New unit of measurement'),
+    quantity: z.coerce.number().min(0).optional().describe('New amount'),
+    unit: z
+      .string()
+      .min(1)
+      .max(50)
+      .optional()
+      .describe('New unit of measurement'),
+    meal_type: mealTypeEnum
+      .optional()
+      .describe(
+        'Built-in meal type fallback; ignored when meal_type_id is provided'
+      ),
+    meal_type_id: uuidSchema
+      .optional()
+      .describe('New meal type UUID, including custom meal types'),
   })
   .strict();
 
@@ -521,6 +568,7 @@ const getWaterHistorySchema = z
 export const manageFoodSchema = z.discriminatedUnion('action', [
   searchFoodSchema,
   lookupFoodNutritionSchema,
+  listMealTypesSchema,
   logFoodSchema,
   logExternalFoodSchema,
   createFoodSchema,
@@ -549,6 +597,7 @@ export const manageFoodInput = z.object({
     .enum([
       'search_food',
       'lookup_food_nutrition',
+      'list_meal_types',
       'log_food',
       'log_external_food',
       'create_food',
@@ -632,7 +681,14 @@ export const manageFoodInput = z.object({
   // meal / diary
   meal_type: mealTypeEnum
     .optional()
-    .describe('breakfast | lunch | dinner | snacks'),
+    .describe(
+      'Built-in fallback: breakfast | lunch | dinner | snacks. Ignored when meal_type_id is provided.'
+    ),
+  meal_type_id: uuidSchema
+    .optional()
+    .describe(
+      'Meal type UUID for logging or moving entries, including custom meal types'
+    ),
   entry_date: dateSchema.optional().describe('Date for the entry (YYYY-MM-DD)'),
   entry_time: optionalEntryTimeSchema,
   meal_id: uuidSchema.optional().describe('Meal template UUID'),

--- a/SparkyFitnessServer/ai/tools/schemas/food.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/food.ts
@@ -4,7 +4,6 @@ import {
   optionalDateSchema,
   optionalEntryTimeSchema,
   uuidSchema,
-  mealTypeEnum,
   searchTypeEnum,
   entryTypeEnum,
   giIndexEnum,
@@ -88,10 +87,13 @@ const logFoodSchema = z
       .describe(
         "Unit of measurement (e.g., 'g', 'piece', 'serving'); defaults to the food's serving unit"
       ),
-    meal_type: mealTypeEnum
+    meal_type: z
+      .string()
+      .min(1)
+      .max(50)
       .optional()
       .describe(
-        'Built-in meal type fallback; ignored when meal_type_id is provided'
+        'Legacy meal type name fallback (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
       ),
     meal_type_id: uuidSchema
       .optional()
@@ -146,10 +148,13 @@ const logExternalFoodSchema = z
       .max(50)
       .optional()
       .describe("Unit of measurement (defaults to 'serving')"),
-    meal_type: mealTypeEnum
+    meal_type: z
+      .string()
+      .min(1)
+      .max(50)
       .optional()
       .describe(
-        'Built-in meal type fallback; ignored when meal_type_id is provided'
+        'Legacy meal type name fallback (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
       ),
     meal_type_id: uuidSchema
       .optional()
@@ -274,10 +279,13 @@ const createFoodSchema = z
       .optional()
       .describe('Default serving size value'),
     unit: z.string().max(50).optional().describe('Default serving size unit'),
-    meal_type: mealTypeEnum
+    meal_type: z
+      .string()
+      .min(1)
+      .max(50)
       .optional()
       .describe(
-        'Optional built-in meal type fallback for automatic logging; ignored when meal_type_id is provided'
+        'Legacy meal type name fallback for automatic logging (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
       ),
     meal_type_id: uuidSchema
       .optional()
@@ -314,10 +322,13 @@ const logMealSchema = z
       .max(200)
       .optional()
       .describe('Name of the meal template (alternative to ID)'),
-    meal_type: mealTypeEnum
+    meal_type: z
+      .string()
+      .min(1)
+      .max(50)
       .optional()
       .describe(
-        'Built-in meal type fallback; ignored when meal_type_id is provided'
+        'Legacy meal type name fallback (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
       ),
     meal_type_id: uuidSchema
       .optional()
@@ -363,10 +374,13 @@ const updateEntrySchema = z
       .max(50)
       .optional()
       .describe('New unit of measurement'),
-    meal_type: mealTypeEnum
+    meal_type: z
+      .string()
+      .min(1)
+      .max(50)
       .optional()
       .describe(
-        'Built-in meal type fallback; ignored when meal_type_id is provided'
+        'Legacy meal type name fallback (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
       ),
     meal_type_id: uuidSchema
       .optional()
@@ -686,10 +700,13 @@ export const manageFoodInput = z.object({
     .optional()
     .describe("Unit of measurement ('g', 'serving', 'piece', etc.)"),
   // meal / diary
-  meal_type: mealTypeEnum
+  meal_type: z
+    .string()
+    .min(1)
+    .max(50)
     .optional()
     .describe(
-      'Built-in fallback: breakfast | lunch | dinner | snacks. Ignored when meal_type_id is provided.'
+      'Legacy meal type name fallback (e.g., "breakfast" or a custom meal type name); ignored when meal_type_id is provided'
     ),
   meal_type_id: uuidSchema
     .optional()

--- a/SparkyFitnessServer/ai/tools/schemas/food.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/food.ts
@@ -508,11 +508,15 @@ const saveAsMealTemplateSchema = z
   .object({
     action: z.literal('save_as_meal_template'),
     entry_date: dateSchema,
+    meal_type_id: uuidSchema
+      .optional()
+      .describe('UUID of a built-in or custom meal type'),
     meal_type: z
       .string()
       .min(1)
       .max(50)
-      .describe("Meal type to save (e.g., 'lunch')"),
+      .optional()
+      .describe("Built-in meal type fallback (e.g., 'lunch')"),
     meal_name: z
       .string()
       .min(1)

--- a/SparkyFitnessServer/services/foodEntryService.ts
+++ b/SparkyFitnessServer/services/foodEntryService.ts
@@ -50,11 +50,12 @@ interface MealTypeRow {
 // Resolves a meal type selector (a UUID or a legacy name) to its canonical
 // id. Exact id matches always win so a caller holding a meal_type_id gets
 // exactly that type back, even when a custom type shares its name with a
-// system default. The name fallback matches any type the user can see
-// (system defaults and custom types): this helper is shared with the REST
-// API, web and mobile clients, which still send custom type NAMES as
-// selectors. The MCP food tools restrict the legacy-name path to system
-// defaults on their side and pass the canonical id into the service.
+// system default. The name fallback is deterministic: when several types
+// share the same name (a custom type may collide with a system default
+// because uniqueness is per (name, user_id)), the system default wins
+// regardless of sort_order; otherwise the first name match is used. This
+// helper is shared with the REST API, web and mobile clients, which still
+// send custom type NAMES as selectors.
 async function resolveMealTypeId(
   userId: string,
   mealTypeSelector: string | null | undefined
@@ -68,9 +69,12 @@ async function resolveMealTypeId(
   const byId = types.find((type) => type.id.toLowerCase() === normalized);
   if (byId) return byId.id;
 
-  const byName = types.find(
+  const nameMatches = types.filter(
     (type) => type.name.trim().toLowerCase() === normalized
   );
+
+  const byName =
+    nameMatches.find((type) => type.user_id === null) ?? nameMatches[0];
 
   return byName?.id ?? null;
 }
@@ -920,18 +924,15 @@ async function copyFoodEntries(
       'info',
       `copyFoodEntries: Copying from ${sourceDate} (${sourceMealType}) to ${targetDate} (${targetMealType}) for user ${authenticatedUserId}`
     );
-    // 1. Fetch source entries
-    const sourceEntries = await foodRepository.getFoodEntriesByDateAndMealType(
+    // 1. Resolve both source and target to canonical ids: a name selector is
+    // ambiguous when a custom type shares its name with a system default, so
+    // the repository query and duplicate check must use the exact id.
+    const sourceMealTypeId = await resolveMealTypeId(
       authenticatedUserId,
-      sourceDate,
       sourceMealType
     );
-    if (sourceEntries.length === 0) {
-      log(
-        'debug',
-        `No food entries found for ${sourceMealType} on ${sourceDate} for user ${authenticatedUserId}. No entries to copy.`
-      );
-      return [];
+    if (!sourceMealTypeId) {
+      throw new Error(`Invalid source meal type: ${sourceMealType}`);
     }
     const targetMealTypeId = await resolveMealTypeId(
       authenticatedUserId,
@@ -939,6 +940,19 @@ async function copyFoodEntries(
     );
     if (!targetMealTypeId) {
       throw new Error(`Invalid target meal type: ${targetMealType}`);
+    }
+    // 2. Fetch source entries by canonical id
+    const sourceEntries = await foodRepository.getFoodEntriesByDateAndMealType(
+      authenticatedUserId,
+      sourceDate,
+      sourceMealTypeId
+    );
+    if (sourceEntries.length === 0) {
+      log(
+        'debug',
+        `No food entries found for ${sourceMealType} on ${sourceDate} for user ${authenticatedUserId}. No entries to copy.`
+      );
+      return [];
     }
     // Map to keep track of duplicated food_entry_meals
     // Key: old_food_entry_meal_id, Value: new_food_entry_meal_id
@@ -990,7 +1004,7 @@ async function copyFoodEntries(
       const existingEntry = await foodRepository.getFoodEntryByDetails(
         authenticatedUserId,
         entry.food_id,
-        targetMealType,
+        targetMealTypeId,
         targetDate,
         entry.variant_id,
         newFoodEntryMealId // Use the new meal container ID for the duplicate check
@@ -1098,10 +1112,17 @@ async function copyFoodEntriesFromUser(
         'Forbidden: You do not have permissions to copy from this family member.'
       );
     }
+    const sourceMealTypeId = await resolveMealTypeId(
+      sourceUserId,
+      sourceMealType
+    );
+    if (!sourceMealTypeId) {
+      throw new Error(`Invalid source meal type: ${sourceMealType}`);
+    }
     const sourceEntries = await foodRepository.getFoodEntriesByDateAndMealType(
       sourceUserId,
       sourceDate,
-      sourceMealType
+      sourceMealTypeId
     );
     if (sourceEntries.length === 0) {
       log(
@@ -1153,7 +1174,7 @@ async function copyFoodEntriesFromUser(
       const existingEntry = await foodRepository.getFoodEntryByDetails(
         authenticatedUserId,
         entry.food_id,
-        targetMealType,
+        targetMealTypeId,
         targetDate,
         entry.variant_id,
         newFoodEntryMealId
@@ -1246,10 +1267,17 @@ async function copyFoodEntriesToUser(
         'Forbidden: You do not have permissions to copy to this family member.'
       );
     }
+    const sourceMealTypeId = await resolveMealTypeId(
+      authenticatedUserId,
+      sourceMealType
+    );
+    if (!sourceMealTypeId) {
+      throw new Error(`Invalid source meal type: ${sourceMealType}`);
+    }
     const sourceEntries = await foodRepository.getFoodEntriesByDateAndMealType(
       authenticatedUserId,
       sourceDate,
-      sourceMealType
+      sourceMealTypeId
     );
     if (sourceEntries.length === 0) {
       log(
@@ -1301,7 +1329,7 @@ async function copyFoodEntriesToUser(
       const existingEntry = await foodRepository.getFoodEntryByDetails(
         targetUserId,
         entry.food_id,
-        targetMealType,
+        targetMealTypeId,
         targetDate,
         entry.variant_id,
         newFoodEntryMealId
@@ -1432,25 +1460,32 @@ async function copyAllFoodEntries(
       );
       return [];
     }
-    // 2. Identify unique meal types (slots) that have data
-    const usedMealTypes = [
+    // 2. Identify unique meal type selectors (slots) that have data. Group by
+    // the canonical id when present so two types that share a name (a custom
+    // type colliding with a system default) stay separate; the name is only a
+    // fallback for legacy rows without an id.
+    const usedMealTypeSelectors = [
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ...new Set(allSourceEntries.map((e: any) => e.meal_type)),
+      ...new Set(
+        allSourceEntries.map((e: any) => e.meal_type_id ?? e.meal_type)
+      ),
     ];
     log(
       'debug',
-      `copyAllFoodEntries: Found ${usedMealTypes.length} slots with data: ${usedMealTypes.join(', ')}`
+      `copyAllFoodEntries: Found ${usedMealTypeSelectors.length} slots with data: ${usedMealTypeSelectors.join(', ')}`
     );
     const allCopiedEntries = [];
-    // 3. Loop through each slot and perform a Deep Copy
-    for (const mealType of usedMealTypes) {
+    // 3. Loop through each slot and perform a Deep Copy. The selector may be
+    // a canonical id (normal rows) or a legacy name; copyFoodEntries resolves
+    // both to the exact id.
+    for (const mealTypeSelector of usedMealTypeSelectors) {
       const copiedEntries = await copyFoodEntries(
         authenticatedUserId,
         actingUserId,
         sourceDate,
-        mealType,
+        mealTypeSelector,
         targetDate,
-        mealType
+        mealTypeSelector
       );
       allCopiedEntries.push(...copiedEntries);
     }

--- a/SparkyFitnessServer/services/foodEntryService.ts
+++ b/SparkyFitnessServer/services/foodEntryService.ts
@@ -48,12 +48,13 @@ interface MealTypeRow {
 }
 
 // Resolves a meal type selector (a UUID or a legacy name) to its canonical
-// id. Callers that already hold a meal_type_id (e.g. the MCP food tools) pass
-// the UUID through and get exactly that type back, even when a custom type
-// shares its name with a system default. The name-based fallback only matches
-// system defaults (user_id IS NULL): custom types are selected by id, and a
-// custom type may share a name with a system default because uniqueness is
-// per (name, user_id).
+// id. Exact id matches always win so a caller holding a meal_type_id gets
+// exactly that type back, even when a custom type shares its name with a
+// system default. The name fallback matches any type the user can see
+// (system defaults and custom types): this helper is shared with the REST
+// API, web and mobile clients, which still send custom type NAMES as
+// selectors. The MCP food tools restrict the legacy-name path to system
+// defaults on their side and pass the canonical id into the service.
 async function resolveMealTypeId(
   userId: string,
   mealTypeSelector: string | null | undefined
@@ -67,12 +68,11 @@ async function resolveMealTypeId(
   const byId = types.find((type) => type.id.toLowerCase() === normalized);
   if (byId) return byId.id;
 
-  const systemByName = types.find(
-    (type) =>
-      type.user_id === null && type.name.trim().toLowerCase() === normalized
+  const byName = types.find(
+    (type) => type.name.trim().toLowerCase() === normalized
   );
 
-  return systemByName?.id ?? null;
+  return byName?.id ?? null;
 }
 
 // ── Diary CSV import ────────────────────────────────────────────────────────
@@ -3257,7 +3257,6 @@ export { copyFoodEntriesFromYesterday };
 export { copyAllFoodEntries };
 export { copyAllFoodEntriesFromYesterday };
 export { getDailyNutritionSummary };
-export { resolveMealTypeId };
 export { createFoodEntryMeal };
 export { updateFoodEntryMeal };
 export { getFoodEntryMealWithComponents };

--- a/SparkyFitnessServer/services/foodEntryService.ts
+++ b/SparkyFitnessServer/services/foodEntryService.ts
@@ -40,24 +40,39 @@ function getGlycemicIndexCategory(value: any) {
   if (value <= 90) return 'High';
   return 'Very High';
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function resolveMealTypeId(userId: any, mealTypeSelector: any) {
+
+interface MealTypeRow {
+  id: string;
+  name: string;
+  user_id: string | null;
+}
+
+// Resolves a meal type selector (a UUID or a legacy name) to its canonical
+// id. Callers that already hold a meal_type_id (e.g. the MCP food tools) pass
+// the UUID through and get exactly that type back, even when a custom type
+// shares its name with a system default. The name-based fallback only matches
+// system defaults (user_id IS NULL): custom types are selected by id, and a
+// custom type may share a name with a system default because uniqueness is
+// per (name, user_id).
+async function resolveMealTypeId(
+  userId: string,
+  mealTypeSelector: string | null | undefined
+): Promise<string | null> {
   if (!mealTypeSelector) return null;
-  const types = await mealTypeRepository.getAllMealTypes(userId);
-  const normalized = String(mealTypeSelector).toLowerCase();
-  // Prefer an exact id match: the MCP tools pass meal_type_id through to the
-  // service, so a selector that is a UUID must resolve to exactly that type
-  // even when a custom type shares its name with a system default.
-  const byId = types.find(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (t: any) => String(t.id).toLowerCase() === normalized
-  );
+
+  const types: MealTypeRow[] = await mealTypeRepository.getAllMealTypes(userId);
+
+  const normalized = mealTypeSelector.trim().toLowerCase();
+
+  const byId = types.find((type) => type.id.toLowerCase() === normalized);
   if (byId) return byId.id;
-  const match = types.find(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (t: any) => t.name.toLowerCase() === normalized
+
+  const systemByName = types.find(
+    (type) =>
+      type.user_id === null && type.name.trim().toLowerCase() === normalized
   );
-  return match ? match.id : null;
+
+  return systemByName?.id ?? null;
 }
 
 // ── Diary CSV import ────────────────────────────────────────────────────────
@@ -3242,6 +3257,7 @@ export { copyFoodEntriesFromYesterday };
 export { copyAllFoodEntries };
 export { copyAllFoodEntriesFromYesterday };
 export { getDailyNutritionSummary };
+export { resolveMealTypeId };
 export { createFoodEntryMeal };
 export { updateFoodEntryMeal };
 export { getFoodEntryMealWithComponents };

--- a/SparkyFitnessServer/services/foodEntryService.ts
+++ b/SparkyFitnessServer/services/foodEntryService.ts
@@ -41,12 +41,21 @@ function getGlycemicIndexCategory(value: any) {
   return 'Very High';
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function resolveMealTypeId(userId: any, mealTypeName: any) {
-  if (!mealTypeName) return null;
+async function resolveMealTypeId(userId: any, mealTypeSelector: any) {
+  if (!mealTypeSelector) return null;
   const types = await mealTypeRepository.getAllMealTypes(userId);
+  const normalized = String(mealTypeSelector).toLowerCase();
+  // Prefer an exact id match: the MCP tools pass meal_type_id through to the
+  // service, so a selector that is a UUID must resolve to exactly that type
+  // even when a custom type shares its name with a system default.
+  const byId = types.find(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (t: any) => String(t.id).toLowerCase() === normalized
+  );
+  if (byId) return byId.id;
   const match = types.find(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (t: any) => t.name.toLowerCase() === mealTypeName.toLowerCase()
+    (t: any) => t.name.toLowerCase() === normalized
   );
   return match ? match.id : null;
 }

--- a/SparkyFitnessServer/services/foodEntryService.ts
+++ b/SparkyFitnessServer/services/foodEntryService.ts
@@ -48,14 +48,19 @@ interface MealTypeRow {
 }
 
 // Resolves a meal type selector (a UUID or a legacy name) to its canonical
-// id. Exact id matches always win so a caller holding a meal_type_id gets
-// exactly that type back, even when a custom type shares its name with a
-// system default. The name fallback is deterministic: when several types
-// share the same name (a custom type may collide with a system default
-// because uniqueness is per (name, user_id)), the system default wins
-// regardless of sort_order; otherwise the first name match is used. This
-// helper is shared with the REST API, web and mobile clients, which still
-// send custom type NAMES as selectors.
+// id. Resolution order:
+//   1. Exact id match (a caller holding a meal_type_id gets exactly that
+//      type back, even when a custom type shares its name with a system
+//      default).
+//   2. Exact-case name match — web/mobile send the exact label of the
+//      selected item, so "Lunch" must resolve to the custom "Lunch" even
+//      when a system "lunch" exists (system defaults are stored lowercase;
+//      uniqueness is per (name, user_id)).
+//   3. Case-insensitive fallback, deterministic: the system default wins
+//      among same-named types regardless of sort_order, otherwise the first
+//      match is used.
+// This helper is shared with the REST API, web and mobile clients, which
+// still send custom type NAMES as selectors.
 async function resolveMealTypeId(
   userId: string,
   mealTypeSelector: string | null | undefined
@@ -64,19 +69,33 @@ async function resolveMealTypeId(
 
   const types: MealTypeRow[] = await mealTypeRepository.getAllMealTypes(userId);
 
-  const normalized = mealTypeSelector.trim().toLowerCase();
+  const selector = mealTypeSelector.trim();
 
-  const byId = types.find((type) => type.id.toLowerCase() === normalized);
+  const byId = types.find(
+    (type) => type.id.toLowerCase() === selector.toLowerCase()
+  );
   if (byId) return byId.id;
 
-  const nameMatches = types.filter(
+  const exactNameMatches = types.filter(
+    (type) => type.name.trim() === selector
+  );
+
+  const exactByName =
+    exactNameMatches.find((type) => type.user_id === null) ??
+    exactNameMatches[0];
+
+  if (exactByName) return exactByName.id;
+
+  const normalized = selector.toLowerCase();
+  const insensitiveMatches = types.filter(
     (type) => type.name.trim().toLowerCase() === normalized
   );
 
-  const byName =
-    nameMatches.find((type) => type.user_id === null) ?? nameMatches[0];
+  const fallback =
+    insensitiveMatches.find((type) => type.user_id === null) ??
+    insensitiveMatches[0];
 
-  return byName?.id ?? null;
+  return fallback?.id ?? null;
 }
 
 // ── Diary CSV import ────────────────────────────────────────────────────────

--- a/SparkyFitnessServer/tests/chatService.test.ts
+++ b/SparkyFitnessServer/tests/chatService.test.ts
@@ -11,6 +11,7 @@ import chatRepository from '../models/chatRepository.js';
 import measurementRepository from '../models/measurementRepository.js';
 import preferenceRepository from '../models/preferenceRepository.js';
 import foodRepository from '../models/foodRepository.js';
+import mealTypeRepository from '../models/mealType.js';
 import foodEntryService from '../services/foodEntryService.js';
 import { log } from '../config/logging.js';
 import { createOpenAI } from '@ai-sdk/openai';
@@ -44,6 +45,12 @@ vi.mock('../models/foodRepository', () => ({
     getFoodById: vi.fn(),
     getFoodVariantById: vi.fn(),
     getFoodVariantsByFoodId: vi.fn(),
+  },
+}));
+vi.mock('../models/mealType', () => ({
+  default: {
+    getAllMealTypes: vi.fn(),
+    getMealTypeById: vi.fn(),
   },
 }));
 vi.mock('../services/preferenceService', () => ({
@@ -422,6 +429,28 @@ describe('chatService', () => {
       vi.mocked(measurementRepository.getCustomCategories).mockResolvedValue(
         []
       );
+      vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+        {
+          id: 'breakfast-id',
+          name: 'Breakfast',
+          sort_order: 1,
+        },
+        {
+          id: 'lunch-id',
+          name: 'Lunch',
+          sort_order: 2,
+        },
+        {
+          id: 'dinner-id',
+          name: 'Dinner',
+          sort_order: 3,
+        },
+        {
+          id: 'snacks-id',
+          name: 'Snacks',
+          sort_order: 4,
+        },
+      ]);
     });
 
     it('executes a log_food tool call in-process, derives food_added from call input, and saves history', async () => {
@@ -476,7 +505,7 @@ describe('chatService', () => {
           entry_date: '2026-06-10',
           quantity: 2,
           unit: 'serving',
-          meal_type: 'breakfast',
+          meal_type_id: 'breakfast-id',
         }
       );
       expect(chatRepository.saveChatHistory).toHaveBeenCalledWith(

--- a/SparkyFitnessServer/tests/chatService.test.ts
+++ b/SparkyFitnessServer/tests/chatService.test.ts
@@ -47,7 +47,7 @@ vi.mock('../models/foodRepository', () => ({
     getFoodVariantsByFoodId: vi.fn(),
   },
 }));
-vi.mock('../models/mealType', () => ({
+vi.mock('../models/mealType.js', () => ({
   default: {
     getAllMealTypes: vi.fn(),
     getMealTypeById: vi.fn(),
@@ -434,21 +434,25 @@ describe('chatService', () => {
           id: 'breakfast-id',
           name: 'Breakfast',
           sort_order: 1,
+          user_id: null,
         },
         {
           id: 'lunch-id',
           name: 'Lunch',
           sort_order: 2,
+          user_id: null,
         },
         {
           id: 'dinner-id',
           name: 'Dinner',
           sort_order: 3,
+          user_id: null,
         },
         {
           id: 'snacks-id',
           name: 'Snacks',
           sort_order: 4,
+          user_id: null,
         },
       ]);
     });

--- a/SparkyFitnessServer/tests/chatbotToolSchemas.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolSchemas.test.ts
@@ -439,6 +439,33 @@ describe('strict discriminated-union validation schemas', () => {
     ).toBe(true);
   });
 
+  it('manageFoodSchema keeps meal_type as a built-in enum fallback (custom types go through meal_type_id)', () => {
+    // The legacy fallback accepts only the built-in slots...
+    expect(
+      manageFoodSchema.safeParse({
+        action: 'log_food',
+        food_name: 'Eggs',
+        meal_type: 'breakfast',
+      }).success
+    ).toBe(true);
+    // ...and rejects anything else: custom meal types must NOT be passed by name.
+    expect(
+      manageFoodSchema.safeParse({
+        action: 'log_food',
+        food_name: 'Eggs',
+        meal_type: 'invalid-slot',
+      }).success
+    ).toBe(false);
+    // Custom meal types are selected by ID, not by name.
+    expect(
+      manageFoodSchema.safeParse({
+        action: 'log_food',
+        food_name: 'Eggs',
+        meal_type_id: '66666666-6666-4666-8666-666666666666',
+      }).success
+    ).toBe(true);
+  });
+
   it('manageFoodSchema rejects fields that do not belong to the action', () => {
     const result = manageFoodSchema.safeParse({
       action: 'list_diary',

--- a/SparkyFitnessServer/tests/chatbotToolSchemas.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolSchemas.test.ts
@@ -81,6 +81,7 @@ describe('published (flat) chatbot tool schemas', () => {
         'quantity',
         'unit',
         'meal_type',
+        'meal_type_id',
         'entry_date',
         'entry_time',
         'meal_id',
@@ -119,6 +120,7 @@ describe('published (flat) chatbot tool schemas', () => {
       actions: [
         'search_food',
         'lookup_food_nutrition',
+        'list_meal_types',
         'log_food',
         'log_external_food',
         'create_food',
@@ -416,6 +418,25 @@ describe('strict discriminated-union validation schemas', () => {
       entry_date: '2026-06-11',
     });
     expect(result.success).toBe(true);
+  });
+
+  it('manageFoodSchema accepts custom meal type IDs for logging and moving entries', () => {
+    const customMealTypeId = '66666666-6666-4666-8666-666666666666';
+    expect(
+      manageFoodSchema.safeParse({
+        action: 'log_food',
+        food_name: 'Eggs',
+        meal_type_id: customMealTypeId,
+      }).success
+    ).toBe(true);
+    expect(
+      manageFoodSchema.safeParse({
+        action: 'update_entry',
+        entry_id: '33333333-3333-4333-8333-333333333333',
+        entry_type: 'food_entry',
+        meal_type_id: customMealTypeId,
+      }).success
+    ).toBe(true);
   });
 
   it('manageFoodSchema rejects fields that do not belong to the action', () => {

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -2007,7 +2007,7 @@ describe('update_entry', () => {
         quantity: undefined,
         unit: undefined,
         meal_type: 'breakfast',
-        meal_type_id: null,
+        meal_type_id: undefined,
       }
     );
   });

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -161,6 +161,13 @@ beforeEach(() => {
   vi.mocked(foodRepository.getFoodVariantsByFoodId).mockResolvedValue(
     undefined as any
   );
+  vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+    { id: 'default-id', name: 'Breakfast', sort_order: 1 },
+    { id: 'lunch-id', name: 'Lunch', sort_order: 2 },
+    { id: 'dinner-id', name: 'Dinner', sort_order: 3 },
+    { id: 'snacks-id', name: 'Snacks', sort_order: 4 },
+    { id: MEAL_TYPE_ID, name: 'Second breakfast', sort_order: 5 },
+  ]);
   tools = buildFoodTools('user-1', 'UTC');
 });
 
@@ -307,6 +314,34 @@ describe('list_meal_types', () => {
     expect(result).toBe(
       `[{"id":"default-id","name":"Breakfast","sort_order":1},{"id":"${MEAL_TYPE_ID}","name":"Second breakfast","sort_order":2}]`
     );
+  });
+
+  it('filters out meal types with is_visible: false', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: 'default-id', name: 'Breakfast', sort_order: 1, is_visible: true },
+      {
+        id: MEAL_TYPE_ID,
+        name: 'Second breakfast',
+        sort_order: 2,
+        is_visible: true,
+      },
+      {
+        id: 'hidden-id',
+        name: 'Hidden meal',
+        sort_order: 5,
+        is_visible: false,
+      },
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'list_meal_types' },
+      opts
+    );
+
+    expect(result).toBe(
+      `[{"id":"default-id","name":"Breakfast","sort_order":1},{"id":"${MEAL_TYPE_ID}","name":"Second breakfast","sort_order":2}]`
+    );
+    expect(result).not.toContain('Hidden meal');
   });
 });
 
@@ -765,7 +800,7 @@ describe('log_food', () => {
         entry_date: '2026-06-10',
         quantity: 2,
         unit: 'serving',
-        meal_type: 'breakfast',
+        meal_type_id: 'default-id',
       }
     );
   });
@@ -1257,7 +1292,7 @@ describe('log_external_food', () => {
         entry_date: '2026-06-10',
         quantity: 200,
         unit: 'g',
-        meal_type: 'breakfast',
+        meal_type_id: 'default-id',
       }
     );
   });
@@ -1558,7 +1593,7 @@ describe('create_food', () => {
         entry_date: '2026-06-10',
         quantity: 100,
         unit: 'g',
-        meal_type: 'lunch',
+        meal_type_id: 'lunch-id',
       }
     );
   });
@@ -1655,7 +1690,7 @@ describe('log_meal', () => {
       {
         user_id: 'user-1',
         meal_template_id: MEAL_ID,
-        meal_type: 'breakfast',
+        meal_type_id: 'default-id',
         entry_date: '2026-06-10',
         name: 'Overnight Oats',
         quantity: 1,
@@ -1982,8 +2017,11 @@ describe('update_entry', () => {
     );
   });
 
-  it('switches from a custom meal type to a built-in meal type by clearing meal_type_id', async () => {
-    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue(null);
+  it('switches from a custom meal type to a built-in meal type by resolving to ID', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: 'default-id', name: 'Breakfast', sort_order: 1 },
+      { id: MEAL_TYPE_ID, name: 'Second breakfast', sort_order: 2 },
+    ]);
     vi.mocked(foodEntryService.updateFoodEntry).mockResolvedValue({
       id: ENTRY_ID,
     });
@@ -2006,8 +2044,7 @@ describe('update_entry', () => {
       {
         quantity: undefined,
         unit: undefined,
-        meal_type: 'breakfast',
-        meal_type_id: undefined,
+        meal_type_id: 'default-id',
       }
     );
   });
@@ -2273,9 +2310,100 @@ describe('copy_from_yesterday', () => {
       'breakfast'
     );
   });
+
+  it('copies entries using meal_type_id and resolves to name', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(foodEntryService.copyFoodEntries).mockResolvedValue([{}]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'copy_from_yesterday',
+        source_date: '2026-06-09',
+        target_date: '2026-06-10',
+        meal_type_id: MEAL_TYPE_ID,
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Copied 1 entries to 2026-06-10.');
+    expect(foodEntryService.copyFoodEntries).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      '2026-06-09',
+      'Second breakfast',
+      '2026-06-10',
+      'Second breakfast'
+    );
+  });
 });
 
 describe('save_as_meal_template', () => {
+  // Regression tests for action inference
+  it('infers log_meal (not save_as_meal_template) when action is omitted', async () => {
+    vi.mocked(mealService.searchMeals).mockResolvedValue([
+      { id: MEAL_ID, name: 'Overnight Oats' },
+    ]);
+    vi.mocked(foodEntryService.createFoodEntryMeal).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        meal_name: 'Overnight Oats',
+        entry_date: '2026-06-10',
+        meal_type: 'breakfast',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Meal "Overnight Oats" logged for breakfast on 2026-06-10.'
+    );
+    expect(foodEntryService.createFoodEntryMeal).toHaveBeenCalled();
+    expect(mealService.createMealFromDiaryEntries).not.toHaveBeenCalled();
+  });
+
+  it('requires explicit action for save_as_meal_template', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(mealService.createMealFromDiaryEntries).mockResolvedValue({
+      id: MEAL_ID,
+      name: 'My Second Breakfast',
+    });
+    vi.mocked(mealService.getMealById).mockResolvedValue({
+      id: MEAL_ID,
+      name: 'My Second Breakfast',
+      foods: [{}, {}],
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'save_as_meal_template',
+        meal_name: 'My Second Breakfast',
+        entry_date: '2026-06-10',
+        meal_type_id: MEAL_TYPE_ID,
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Meal template "My Second Breakfast" saved with 2 food items.'
+    );
+    expect(mealService.createMealFromDiaryEntries).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-10',
+      'Second breakfast',
+      'My Second Breakfast',
+      null
+    );
+    expect(foodEntryService.createFoodEntryMeal).not.toHaveBeenCalled();
+  });
+
   it('saves the slot as a template and counts its foods', async () => {
     vi.mocked(mealService.createMealFromDiaryEntries).mockResolvedValue({
       id: MEAL_ID,
@@ -2303,6 +2431,43 @@ describe('save_as_meal_template', () => {
       '2026-06-10',
       'lunch',
       'My Lunch',
+      null
+    );
+  });
+
+  it('saves using meal_type_id and resolves to name', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(mealService.createMealFromDiaryEntries).mockResolvedValue({
+      id: MEAL_ID,
+      name: 'My Second Breakfast',
+    });
+    vi.mocked(mealService.getMealById).mockResolvedValue({
+      id: MEAL_ID,
+      name: 'My Second Breakfast',
+      foods: [{}, {}],
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'save_as_meal_template',
+        entry_date: '2026-06-10',
+        meal_type_id: MEAL_TYPE_ID,
+        meal_name: 'My Second Breakfast',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Meal template "My Second Breakfast" saved with 2 food items.'
+    );
+    expect(mealService.createMealFromDiaryEntries).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-10',
+      'Second breakfast',
+      'My Second Breakfast',
       null
     );
   });

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -719,7 +719,7 @@ describe('log_food', () => {
     expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
       'user-1',
       'user-1',
-      expect.not.objectContaining({ meal_type: 'snacks' })
+      expect.not.objectContaining({ meal_type: expect.anything() })
     );
   });
 
@@ -1978,6 +1978,36 @@ describe('update_entry', () => {
         quantity: undefined,
         unit: undefined,
         meal_type_id: MEAL_TYPE_ID,
+      }
+    );
+  });
+
+  it('switches from a custom meal type to a built-in meal type by clearing meal_type_id', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue(null);
+    vi.mocked(foodEntryService.updateFoodEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry',
+        meal_type: 'breakfast',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry updated: meal type to breakfast.');
+    expect(foodEntryService.updateFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      ENTRY_ID,
+      {
+        quantity: undefined,
+        unit: undefined,
+        meal_type: 'breakfast',
+        meal_type_id: null,
       }
     );
   });

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -162,11 +162,16 @@ beforeEach(() => {
     undefined as any
   );
   vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-    { id: 'default-id', name: 'Breakfast', sort_order: 1 },
-    { id: 'lunch-id', name: 'Lunch', sort_order: 2 },
-    { id: 'dinner-id', name: 'Dinner', sort_order: 3 },
-    { id: 'snacks-id', name: 'Snacks', sort_order: 4 },
-    { id: MEAL_TYPE_ID, name: 'Second breakfast', sort_order: 5 },
+    { id: 'default-id', name: 'Breakfast', sort_order: 1, user_id: null },
+    { id: 'lunch-id', name: 'Lunch', sort_order: 2, user_id: null },
+    { id: 'dinner-id', name: 'Dinner', sort_order: 3, user_id: null },
+    { id: 'snacks-id', name: 'Snacks', sort_order: 4, user_id: null },
+    {
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+      sort_order: 5,
+      user_id: 'user-1',
+    },
   ]);
   tools = buildFoodTools('user-1', 'UTC');
 });
@@ -302,8 +307,13 @@ describe('sparky_manage_food validation', () => {
 describe('list_meal_types', () => {
   it('lists built-in and custom meal types using the REST repository contract', async () => {
     vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-      { id: 'default-id', name: 'Breakfast', sort_order: 1 },
-      { id: MEAL_TYPE_ID, name: 'Second breakfast', sort_order: 2 },
+      { id: 'default-id', name: 'Breakfast', sort_order: 1, user_id: null },
+      {
+        id: MEAL_TYPE_ID,
+        name: 'Second breakfast',
+        sort_order: 2,
+        user_id: 'user-1',
+      },
     ]);
 
     const result = await tools.sparky_manage_food.execute!(
@@ -318,18 +328,26 @@ describe('list_meal_types', () => {
 
   it('filters out meal types with is_visible: false', async () => {
     vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-      { id: 'default-id', name: 'Breakfast', sort_order: 1, is_visible: true },
+      {
+        id: 'default-id',
+        name: 'Breakfast',
+        sort_order: 1,
+        is_visible: true,
+        user_id: null,
+      },
       {
         id: MEAL_TYPE_ID,
         name: 'Second breakfast',
         sort_order: 2,
         is_visible: true,
+        user_id: 'user-1',
       },
       {
         id: 'hidden-id',
         name: 'Hidden meal',
         sort_order: 5,
         is_visible: false,
+        user_id: null,
       },
     ]);
 
@@ -736,6 +754,58 @@ describe('log_food', () => {
     expect(result).toContain('Meal type "breakfast" was not found');
     expect(result).not.toContain('Meal type "undefined"');
     expect(foodEntryService.createFoodEntry).not.toHaveBeenCalled();
+  });
+
+  // The legacy meal_type fallback must only resolve to system defaults
+  // (user_id IS NULL). A user-defined type may share a name with a system
+  // default (uniqueness is per (name, user_id)); custom types are selected
+  // exclusively through meal_type_id.
+  it('resolves legacy meal_type only to system defaults, not same-named custom types', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      {
+        id: 'custom-breakfast-id',
+        name: 'Breakfast',
+        sort_order: 0,
+        user_id: 'user-1',
+      },
+      { id: 'default-id', name: 'Breakfast', sort_order: 1, user_id: null },
+    ]);
+    vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([
+      {
+        ...eggsRow,
+        name: 'eggs',
+        default_variant: {
+          ...eggsRow.default_variant,
+          serving_size: 1,
+          serving_unit: 'serving',
+        },
+      },
+    ]);
+    vi.mocked(foodEntryService.createFoodEntry).mockResolvedValue({
+      id: ENTRY_ID,
+      food_name: 'eggs',
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'log_food',
+        food_name: 'Eggs',
+        quantity: 1,
+        unit: 'serving',
+        meal_type: 'breakfast',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Logged "eggs" (1 serving) for Breakfast on 2026-06-10.'
+    );
+    expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.objectContaining({ meal_type_id: 'default-id' })
+    );
   });
 
   it('logs to a custom meal type by ID and gives the ID precedence over the legacy name', async () => {
@@ -2038,8 +2108,13 @@ describe('update_entry', () => {
 
   it('switches from a custom meal type to a built-in meal type by resolving to ID', async () => {
     vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-      { id: 'default-id', name: 'Breakfast', sort_order: 1 },
-      { id: MEAL_TYPE_ID, name: 'Second breakfast', sort_order: 2 },
+      { id: 'default-id', name: 'Breakfast', sort_order: 1, user_id: null },
+      {
+        id: MEAL_TYPE_ID,
+        name: 'Second breakfast',
+        sort_order: 2,
+        user_id: 'user-1',
+      },
     ]);
     vi.mocked(foodEntryService.updateFoodEntry).mockResolvedValue({
       id: ENTRY_ID,
@@ -2320,17 +2395,18 @@ describe('copy_from_yesterday', () => {
     );
 
     expect(result).toBe('✅ No entries found to copy from the source date.');
+    // The resolved system default is passed through as its ID.
     expect(foodEntryService.copyFoodEntries).toHaveBeenCalledWith(
       'user-1',
       'user-1',
       '2026-06-09',
-      'Breakfast',
+      'default-id',
       '2026-06-10',
-      'Breakfast'
+      'default-id'
     );
   });
 
-  it('copies entries using meal_type_id and resolves to name', async () => {
+  it('copies entries using meal_type_id and passes the ID through to the service', async () => {
     vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
       id: MEAL_TYPE_ID,
       name: 'Second breakfast',
@@ -2348,13 +2424,43 @@ describe('copy_from_yesterday', () => {
     );
 
     expect(result).toBe('✅ Copied 1 entries to 2026-06-10.');
+    // The resolved ID must survive to the end of the flow so the repository
+    // query matches exactly this meal type (not any same-named one).
     expect(foodEntryService.copyFoodEntries).toHaveBeenCalledWith(
       'user-1',
       'user-1',
       '2026-06-09',
-      'Second breakfast',
+      MEAL_TYPE_ID,
       '2026-06-10',
-      'Second breakfast'
+      MEAL_TYPE_ID
+    );
+  });
+
+  // Without a meal name or id, a target/source date must still infer
+  // copy_from_yesterday even when meal_type_id is present.
+  it('infers copy_from_yesterday for target_date + meal_type_id without meal name or id', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(foodEntryService.copyFoodEntries).mockResolvedValue([{}]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        target_date: '2026-06-10',
+        meal_type_id: MEAL_TYPE_ID,
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Copied 1 entries to 2026-06-10.');
+    expect(foodEntryService.copyFoodEntries).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.any(String),
+      MEAL_TYPE_ID,
+      '2026-06-10',
+      MEAL_TYPE_ID
     );
   });
 });
@@ -2385,6 +2491,48 @@ describe('save_as_meal_template', () => {
     expect(mealService.createMealFromDiaryEntries).not.toHaveBeenCalled();
   });
 
+  // Regression: a logging date misfiled under target_date must not be
+  // interpreted as copy_from_yesterday when a meal selector is present.
+  // The action inference checks log_meal before copy_from_yesterday so the
+  // salvage logic can remap target_date -> entry_date instead of running a
+  // different data-writing operation.
+  it('infers log_meal (not copy_from_yesterday) for meal_name + meal_type_id + target_date without action', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(mealService.searchMeals).mockResolvedValue([
+      { id: MEAL_ID, name: 'Overnight Oats' },
+    ]);
+    vi.mocked(foodEntryService.createFoodEntryMeal).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        meal_name: 'Overnight Oats',
+        meal_type_id: MEAL_TYPE_ID,
+        target_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Meal "Overnight Oats" logged for Second breakfast on 2026-06-10.'
+    );
+    expect(foodEntryService.createFoodEntryMeal).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.objectContaining({
+        meal_template_id: MEAL_ID,
+        meal_type_id: MEAL_TYPE_ID,
+        entry_date: '2026-06-10',
+      })
+    );
+    expect(foodEntryService.copyFoodEntries).not.toHaveBeenCalled();
+    expect(foodEntryService.copyAllFoodEntries).not.toHaveBeenCalled();
+  });
+
   it('requires explicit action for save_as_meal_template', async () => {
     vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
       id: MEAL_TYPE_ID,
@@ -2413,10 +2561,11 @@ describe('save_as_meal_template', () => {
     expect(result).toBe(
       '✅ Meal template "My Second Breakfast" saved with 2 food items.'
     );
+    // The resolved ID is passed through to the service, not the name.
     expect(mealService.createMealFromDiaryEntries).toHaveBeenCalledWith(
       'user-1',
       '2026-06-10',
-      'Second breakfast',
+      MEAL_TYPE_ID,
       'My Second Breakfast',
       null
     );
@@ -2445,16 +2594,17 @@ describe('save_as_meal_template', () => {
     );
 
     expect(result).toBe('✅ Meal template "My Lunch" saved with 2 food items.');
+    // The resolved system default is passed through as its ID.
     expect(mealService.createMealFromDiaryEntries).toHaveBeenCalledWith(
       'user-1',
       '2026-06-10',
-      'Lunch',
+      'lunch-id',
       'My Lunch',
       null
     );
   });
 
-  it('saves using meal_type_id and resolves to name', async () => {
+  it('saves using meal_type_id and passes the ID through to the service', async () => {
     vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
       id: MEAL_TYPE_ID,
       name: 'Second breakfast',
@@ -2482,10 +2632,12 @@ describe('save_as_meal_template', () => {
     expect(result).toBe(
       '✅ Meal template "My Second Breakfast" saved with 2 food items.'
     );
+    // The resolved ID must survive to the end of the flow so the repository
+    // query matches exactly this meal type (not any same-named one).
     expect(mealService.createMealFromDiaryEntries).toHaveBeenCalledWith(
       'user-1',
       '2026-06-10',
-      'Second breakfast',
+      MEAL_TYPE_ID,
       'My Second Breakfast',
       null
     );

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -1531,8 +1531,29 @@ describe('log_external_food', () => {
     );
 
     expect(result).toBe(
-      'Error [VALIDATION]: No external match found for "dragonfruit smoothie". Please estimate the nutrition yourself and call create_food (include meal_type and entry_date to save and log in one step), for example: {"action":"create_food","food_name":"dragonfruit smoothie","calories":300,"protein":15,"carbs":40,"fat":5,"meal_type":"snacks"}'
+      'Error [VALIDATION]: No external match found for "dragonfruit smoothie". Please estimate the nutrition yourself and call create_food (include meal_type and entry_date to save and log in one step), for example: {"action":"create_food","food_name":"dragonfruit smoothie","calories":300,"protein":15,"carbs":40,"fat":5,"meal_type":"snacks","entry_date":"2026-06-10"}'
     );
+    expect(foodCoreService.createFood).not.toHaveBeenCalled();
+    expect(foodEntryService.createFoodEntry).not.toHaveBeenCalled();
+  });
+
+  // Regression: a custom meal_type_id must survive into the retry example so
+  // the model is not steered back to a built-in category (issue #1959).
+  it('keeps a custom meal_type_id in the create_food retry example', async () => {
+    mockUsdaLookup([]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'log_external_food',
+        food_name: 'dragonfruit smoothie',
+        meal_type_id: MEAL_TYPE_ID,
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toContain('"meal_type_id":"' + MEAL_TYPE_ID + '"');
+    expect(result).not.toContain('"meal_type":');
     expect(foodCoreService.createFood).not.toHaveBeenCalled();
     expect(foodEntryService.createFoodEntry).not.toHaveBeenCalled();
   });
@@ -2529,6 +2550,44 @@ describe('save_as_meal_template', () => {
         entry_date: '2026-06-10',
       })
     );
+    expect(foodEntryService.copyFoodEntries).not.toHaveBeenCalled();
+    expect(foodEntryService.copyAllFoodEntries).not.toHaveBeenCalled();
+  });
+
+  // Regression: an incomplete log_meal (meal_name/meal_id + a date but no meal
+  // type selector) must surface a validation error instead of falling through
+  // to a full-day copy. The action inference routes any meal intent with a
+  // date to log_meal before copy_from_yesterday.
+  it('returns MISSING_PARAMS (not a copy) for meal_name + date without a meal type selector', async () => {
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        meal_name: 'Overnight Oats',
+        target_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toContain(
+      'Missing required parameters: meal_type_id (or meal_type)'
+    );
+    expect(foodEntryService.createFoodEntryMeal).not.toHaveBeenCalled();
+    expect(foodEntryService.copyFoodEntries).not.toHaveBeenCalled();
+    expect(foodEntryService.copyAllFoodEntries).not.toHaveBeenCalled();
+  });
+
+  it('returns MISSING_PARAMS (not a copy) for meal_id + date without a meal type selector', async () => {
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        meal_id: MEAL_ID,
+        target_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toContain(
+      'Missing required parameters: meal_type_id (or meal_type)'
+    );
+    expect(foodEntryService.createFoodEntryMeal).not.toHaveBeenCalled();
     expect(foodEntryService.copyFoodEntries).not.toHaveBeenCalled();
     expect(foodEntryService.copyAllFoodEntries).not.toHaveBeenCalled();
   });

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -70,7 +70,7 @@ vi.mock('../models/foodEntryMealRepository', () => ({
     getFoodEntryMealsByDateRange: vi.fn(),
   },
 }));
-vi.mock('../models/mealType', () => ({
+vi.mock('../models/mealType.js', () => ({
   default: {
     getAllMealTypes: vi.fn(),
     getMealTypeById: vi.fn(),
@@ -2658,6 +2658,80 @@ describe('save_as_meal_template', () => {
     expect(foodCoreService.deleteFood).toHaveBeenCalled();
     expect(foodEntryService.copyFoodEntries).not.toHaveBeenCalled();
     expect(foodEntryService.copyAllFoodEntries).not.toHaveBeenCalled();
+  });
+
+  // Regression: list_diary rows carry entry_id + entry_type together with
+  // food_name/meal_name, so entry-targeted operations must win over log/
+  // lookup inference — otherwise the salvage logic would drop entry_id and run
+  // a different data-writing operation.
+  it('infers update_entry (not log_food) for entry_id + food_name + quantity + meal_type_id', async () => {
+    vi.mocked(foodEntryService.updateFoodEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry',
+        food_name: 'Eggs',
+        quantity: 2,
+        meal_type_id: MEAL_TYPE_ID,
+      },
+      opts
+    );
+
+    expect(result).toContain('✅ Entry updated');
+    expect(foodEntryService.updateFoodEntry).toHaveBeenCalled();
+    expect(foodEntryService.createFoodEntry).not.toHaveBeenCalled();
+    expect(foodCoreService.createFood).not.toHaveBeenCalled();
+  });
+
+  it('infers update_entry (not log_meal) for entry_id + meal_name + meal_type_id', async () => {
+    vi.mocked(foodEntryService.updateFoodEntryMeal).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+    vi.mocked(
+      foodEntryService.getFoodEntryMealWithComponents
+    ).mockResolvedValue({
+      id: ENTRY_ID,
+      meal_template_id: MEAL_ID,
+      entry_date: new Date(2026, 5, 10),
+      foods: [],
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+        meal_name: 'Overnight Oats',
+        meal_type_id: MEAL_TYPE_ID,
+      },
+      opts
+    );
+
+    expect(result).toContain('✅ Entry updated');
+    expect(foodEntryService.updateFoodEntryMeal).toHaveBeenCalled();
+    expect(foodEntryService.createFoodEntryMeal).not.toHaveBeenCalled();
+  });
+
+  it('infers delete_entry (not lookup) for entry_id + entry_type + food_name', async () => {
+    vi.mocked(foodEntryService.deleteFoodEntry).mockResolvedValue(true);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry',
+        food_name: 'Eggs',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry deleted.');
+    expect(foodEntryService.deleteFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      ENTRY_ID
+    );
+    expect(foodRepository.getFoodsWithPagination).not.toHaveBeenCalled();
   });
 
   it('requires explicit action for save_as_meal_template', async () => {

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -8,6 +8,7 @@ import preferenceService from '../services/preferenceService.js';
 import { searchProviderFoods } from '../services/externalFoodSearchService.js';
 import foodRepository from '../models/foodRepository.js';
 import foodEntryMealRepository from '../models/foodEntryMealRepository.js';
+import mealTypeRepository from '../models/mealType.js';
 import measurementRepository from '../models/measurementRepository.js';
 import reportRepository from '../models/reportRepository.js';
 import externalProviderRepository from '../models/externalProviderRepository.js';
@@ -69,6 +70,12 @@ vi.mock('../models/foodEntryMealRepository', () => ({
     getFoodEntryMealsByDateRange: vi.fn(),
   },
 }));
+vi.mock('../models/mealType', () => ({
+  default: {
+    getAllMealTypes: vi.fn(),
+    getMealTypeById: vi.fn(),
+  },
+}));
 vi.mock('../models/measurementRepository', () => ({
   default: {
     insertWaterIntakeLog: vi.fn(),
@@ -101,6 +108,7 @@ const VARIANT_ID = '22222222-2222-4222-8222-222222222222';
 const ENTRY_ID = '33333333-3333-4333-8333-333333333333';
 const MEAL_ID = '44444444-4444-4444-8444-444444444444';
 const FOOD_ID_2 = '55555555-5555-4555-8555-555555555555';
+const MEAL_TYPE_ID = '66666666-6666-4666-8666-666666666666';
 
 const FOOD_PROVIDER_TYPES = [
   'fatsecret',
@@ -280,6 +288,24 @@ describe('sparky_manage_food validation', () => {
       'user-1',
       'user-1',
       expect.objectContaining({ entry_time: undefined })
+    );
+  });
+});
+
+describe('list_meal_types', () => {
+  it('lists built-in and custom meal types using the REST repository contract', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: 'default-id', name: 'Breakfast', sort_order: 1 },
+      { id: MEAL_TYPE_ID, name: 'Second breakfast', sort_order: 2 },
+    ]);
+
+    const result = await tools.sparky_manage_food.execute!(
+      { action: 'list_meal_types' },
+      opts
+    );
+
+    expect(result).toBe(
+      `[{"id":"default-id","name":"Breakfast","sort_order":1},{"id":"${MEAL_TYPE_ID}","name":"Second breakfast","sort_order":2}]`
     );
   });
 });
@@ -658,6 +684,45 @@ describe('lookup_food_nutrition', () => {
 });
 
 describe('log_food', () => {
+  it('logs to a custom meal type by ID and gives the ID precedence over the legacy name', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(foodRepository.getFoodById).mockResolvedValue(eggsRow);
+    vi.mocked(foodEntryService.createFoodEntry).mockResolvedValue({
+      id: ENTRY_ID,
+      food_name: 'Eggs',
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        food_id: FOOD_ID,
+        quantity: 1,
+        meal_type_id: MEAL_TYPE_ID,
+        meal_type: 'snacks',
+        entry_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Logged "Eggs" (1 g) for Second breakfast on 2026-06-10.'
+    );
+    expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.objectContaining({
+        meal_type_id: MEAL_TYPE_ID,
+      })
+    );
+    expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.not.objectContaining({ meal_type: 'snacks' })
+    );
+  });
+
   it('resolves the food by exact name and logs with the default variant', async () => {
     vi.mocked(foodRepository.getFoodsWithPagination).mockResolvedValue([
       {
@@ -1648,6 +1713,7 @@ describe('list_diary', () => {
         serving_size: 100,
         serving_unit: 'g',
         meal_type: 'breakfast',
+        meal_type_id: MEAL_TYPE_ID,
         calories: 380,
         protein: 13,
         carbs: 67,
@@ -1684,7 +1750,7 @@ describe('list_diary', () => {
     );
 
     expect(result).toBe(
-      `# Food Diary: 2026-06-10\n\n## Breakfast\n- **Oatmeal** — 50 g (190 kcal)\n  ID: ${ENTRY_ID} | Type: food_entry\n- **Protein Shake** (meal template) — 1x\n  ID: ${MEAL_ID} | Type: food_entry_meal\n\n## Snacks\n- **Banana** — 2 serving (178 kcal)\n  ID: ${FOOD_ID_2} | Type: food_entry\n\n---\n**Total Energy:** 368 kcal`
+      `# Food Diary: 2026-06-10\n\n## Breakfast\n- **Oatmeal** — 50 g (190 kcal)\n  ID: ${ENTRY_ID} | Type: food_entry | Meal type: breakfast (${MEAL_TYPE_ID})\n- **Protein Shake** (meal template) — 1x\n  ID: ${MEAL_ID} | Type: food_entry_meal\n\n## Snacks\n- **Banana** — 2 serving (178 kcal)\n  ID: ${FOOD_ID_2} | Type: food_entry\n\n---\n**Total Energy:** 368 kcal`
     );
   });
 
@@ -1884,6 +1950,38 @@ describe('delete_food', () => {
 });
 
 describe('update_entry', () => {
+  it('moves a food entry to a custom meal type without requiring a quantity change', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(foodEntryService.updateFoodEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry',
+        meal_type_id: MEAL_TYPE_ID,
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry updated: meal type to Second breakfast.');
+    expect(foodEntryService.updateFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      ENTRY_ID,
+      {
+        quantity: undefined,
+        unit: undefined,
+        meal_type_id: MEAL_TYPE_ID,
+      }
+    );
+  });
+
   it('updates a food entry quantity and unit', async () => {
     vi.mocked(foodEntryService.updateFoodEntry).mockResolvedValue({
       id: ENTRY_ID,
@@ -2622,22 +2720,22 @@ describe('sparky_get_food_diary', () => {
       calories: 155,
       protein: 13,
     });
-    // Nulls, empty objects, and redundant internal surrogate keys dropped.
+    // Nulls, empty objects, and non-actionable internal surrogate keys dropped.
     for (const dropped of [
       'meal_id',
       'brand_name',
       'vitamin_a',
       'vitamin_c',
       'custom_nutrients',
-      'meal_type_id',
       'variant_id',
       'meal_plan_template_id',
       'food_entry_meal_id',
     ]) {
       expect(entry).not.toHaveProperty(dropped);
     }
-    // Human-readable label kept in place of meal_type_id.
+    // Both fields are kept so MCP clients can round-trip custom meal types.
     expect(entry.meal_type).toBe('Breakfast');
+    expect(entry.meal_type_id).toBe('99999999-9999-4999-8999-999999999999');
 
     const meal = parsed.meal_entries[0];
     expect(meal).toMatchObject({
@@ -2652,11 +2750,11 @@ describe('sparky_get_food_diary', () => {
       'created_by_user_id',
       'updated_by_user_id',
       'meal_template_id',
-      'meal_type_id',
       'legacy_serving_unit_math',
     ]) {
       expect(meal).not.toHaveProperty(dropped);
     }
+    expect(meal.meal_type_id).toBe('99999999-9999-4999-8999-999999999999');
   });
 });
 

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -719,23 +719,23 @@ describe('lookup_food_nutrition', () => {
 });
 
 describe('log_food', () => {
-  // Regression: an invalid legacy meal_type name must surface the name itself
-  // in the not-found error (not "undefined"), proving the tool reports the
-  // resolved fallback value to the model.
-  it('reports the invalid legacy meal_type name in the not-found error', async () => {
+  it('reports the legacy meal_type name when resolution fails', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([]);
+
     const result = await tools.sparky_manage_food.execute!(
       {
         action: 'log_food',
         food_name: 'Eggs',
         quantity: 1,
         unit: 'serving',
-        meal_type: 'invalid-slot',
+        meal_type: 'breakfast',
       },
       opts
     );
 
-    expect(result).toContain('Meal type "invalid-slot" was not found');
+    expect(result).toContain('Meal type "breakfast" was not found');
     expect(result).not.toContain('Meal type "undefined"');
+    expect(foodEntryService.createFoodEntry).not.toHaveBeenCalled();
   });
 
   it('logs to a custom meal type by ID and gives the ID precedence over the legacy name', async () => {

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -230,7 +230,7 @@ describe('sparky_manage_food validation', () => {
     );
 
     expect(result).toBe(
-      '✅ Logged "Eggs" (2 piece) for breakfast on 2026-06-11.'
+      '✅ Logged "Eggs" (2 piece) for Breakfast on 2026-06-11.'
     );
   });
 
@@ -788,7 +788,7 @@ describe('log_food', () => {
     );
 
     expect(result).toBe(
-      '✅ Logged "eggs" (2 serving) for breakfast on 2026-06-10.'
+      '✅ Logged "eggs" (2 serving) for Breakfast on 2026-06-10.'
     );
     expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
       'user-1',
@@ -855,7 +855,7 @@ describe('log_food', () => {
     );
 
     expect(result).toBe(
-      '✅ Logged "Eggs" (2 serving) for breakfast on 2026-06-10.'
+      '✅ Logged "Eggs" (2 serving) for Breakfast on 2026-06-10.'
     );
     expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
       'user-1',
@@ -901,7 +901,7 @@ describe('log_food', () => {
 
     const today = todayInZone('UTC');
     expect(result).toBe(
-      `✅ Logged "Eggs" (1 ${eggsRow.default_variant.serving_unit}) for breakfast on ${today}.`
+      `✅ Logged "Eggs" (1 ${eggsRow.default_variant.serving_unit}) for Breakfast on ${today}.`
     );
     expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
       'user-1',
@@ -933,7 +933,7 @@ describe('log_food', () => {
 
     const today = todayInZone('UTC');
     expect(result).toBe(
-      `✅ Logged "Eggs" (1 ${eggsRow.default_variant.serving_unit}) for breakfast on ${today}.`
+      `✅ Logged "Eggs" (1 ${eggsRow.default_variant.serving_unit}) for Breakfast on ${today}.`
     );
     expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
       'user-1',
@@ -987,7 +987,7 @@ describe('log_food', () => {
       opts
     );
 
-    expect(result).toBe('✅ Logged "Eggs" (100 g) for lunch on 2026-06-10.');
+    expect(result).toBe('✅ Logged "Eggs" (100 g) for Lunch on 2026-06-10.');
     expect(foodRepository.getFoodsWithPagination).not.toHaveBeenCalled();
     expect(foodRepository.getFoodById).toHaveBeenCalledWith(FOOD_ID, 'user-1');
   });
@@ -1034,7 +1034,7 @@ describe('log_food', () => {
       opts
     );
 
-    expect(result).toBe('✅ Logged "Eggs" (100 g) for lunch on 2026-06-10.');
+    expect(result).toBe('✅ Logged "Eggs" (100 g) for Lunch on 2026-06-10.');
     expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
       'user-1',
       'user-1',
@@ -1101,9 +1101,9 @@ describe('log_food', () => {
     );
 
     expect(pieceResult).toBe(
-      '✅ Logged "Eggs" (2 piece) for lunch on 2026-06-10.'
+      '✅ Logged "Eggs" (2 piece) for Lunch on 2026-06-10.'
     );
-    expect(cupResult).toBe('✅ Logged "Eggs" (1 cup) for lunch on 2026-06-10.');
+    expect(cupResult).toBe('✅ Logged "Eggs" (1 cup) for Lunch on 2026-06-10.');
     expect(foodEntryService.createFoodEntry).toHaveBeenNthCalledWith(
       1,
       'user-1',
@@ -1249,7 +1249,7 @@ describe('log_external_food', () => {
     );
 
     expect(result).toBe(
-      '✅ Saved "Apple" from usda (52 kcal per 100g) and logged 200 g to breakfast on 2026-06-10.'
+      '✅ Saved "Apple" from usda (52 kcal per 100g) and logged 200 g to Breakfast on 2026-06-10.'
     );
     expect(foodCoreService.createFood).toHaveBeenCalledWith('user-1', {
       user_id: 'user-1',
@@ -1389,7 +1389,7 @@ describe('log_external_food', () => {
     );
 
     expect(result).toBe(
-      '✅ Saved "Apple pie" from usda (296 kcal per 125g) and logged 125 g to snacks on 2026-06-10.'
+      '✅ Saved "Apple pie" from usda (296 kcal per 125g) and logged 125 g to Snacks on 2026-06-10.'
     );
     expect(foodCoreService.createFood).toHaveBeenCalledWith(
       'user-1',
@@ -1418,7 +1418,7 @@ describe('log_external_food', () => {
     );
 
     expect(result).toBe(
-      '✅ "Eggs" was already in the food database — logged 200 g for breakfast on 2026-06-10.'
+      '✅ "Eggs" was already in the food database — logged 200 g for Breakfast on 2026-06-10.'
     );
     expect(foodCoreService.createFood).not.toHaveBeenCalled();
     expect(foodEntryService.createFoodEntry).toHaveBeenCalledWith(
@@ -1477,7 +1477,7 @@ describe('log_external_food', () => {
     );
 
     expect(result).toBe(
-      '✅ Saved "Apple" from usda (52 kcal per 100g) and logged 100 g to breakfast on 2026-06-10.'
+      '✅ Saved "Apple" from usda (52 kcal per 100g) and logged 100 g to Breakfast on 2026-06-10.'
     );
   });
 });
@@ -1577,7 +1577,7 @@ describe('create_food', () => {
     );
 
     expect(result).toBe(
-      '✅ Food "Rice" created with 130 kcal per 100g. Also logged to lunch for 2026-06-10.'
+      '✅ Food "Rice" created with 130 kcal per 100g. Also logged to Lunch for 2026-06-10.'
     );
     expect(foodCoreService.createFood).toHaveBeenCalledWith(
       'user-1',
@@ -1682,7 +1682,7 @@ describe('log_meal', () => {
     );
 
     expect(result).toBe(
-      '✅ Meal "Overnight Oats" logged for breakfast on 2026-06-10.'
+      '✅ Meal "Overnight Oats" logged for Breakfast on 2026-06-10.'
     );
     expect(foodEntryService.createFoodEntryMeal).toHaveBeenCalledWith(
       'user-1',
@@ -2036,7 +2036,7 @@ describe('update_entry', () => {
       opts
     );
 
-    expect(result).toBe('✅ Entry updated: meal type to breakfast.');
+    expect(result).toBe('✅ Entry updated: meal type to Breakfast.');
     expect(foodEntryService.updateFoodEntry).toHaveBeenCalledWith(
       'user-1',
       'user-1',
@@ -2305,9 +2305,9 @@ describe('copy_from_yesterday', () => {
       'user-1',
       'user-1',
       '2026-06-09',
-      'breakfast',
+      'Breakfast',
       '2026-06-10',
-      'breakfast'
+      'Breakfast'
     );
   });
 
@@ -2360,7 +2360,7 @@ describe('save_as_meal_template', () => {
     );
 
     expect(result).toBe(
-      '✅ Meal "Overnight Oats" logged for breakfast on 2026-06-10.'
+      '✅ Meal "Overnight Oats" logged for Breakfast on 2026-06-10.'
     );
     expect(foodEntryService.createFoodEntryMeal).toHaveBeenCalled();
     expect(mealService.createMealFromDiaryEntries).not.toHaveBeenCalled();
@@ -2429,7 +2429,7 @@ describe('save_as_meal_template', () => {
     expect(mealService.createMealFromDiaryEntries).toHaveBeenCalledWith(
       'user-1',
       '2026-06-10',
-      'lunch',
+      'Lunch',
       'My Lunch',
       null
     );
@@ -2474,7 +2474,7 @@ describe('save_as_meal_template', () => {
 
   it('surfaces an empty slot as a DB error (message lacks "not found")', async () => {
     vi.mocked(mealService.createMealFromDiaryEntries).mockRejectedValue(
-      new Error('No food entries found for lunch on 2026-06-10.')
+      new Error('No food entries found for Lunch on 2026-06-10.')
     );
 
     const result = await tools.sparky_manage_food.execute!(

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -1531,7 +1531,7 @@ describe('log_external_food', () => {
     );
 
     expect(result).toBe(
-      'Error [VALIDATION]: No external match found for "dragonfruit smoothie". Please estimate the nutrition yourself and call create_food (include meal_type and entry_date to save and log in one step), for example: {"action":"create_food","food_name":"dragonfruit smoothie","calories":300,"protein":15,"carbs":40,"fat":5,"meal_type":"snacks","entry_date":"2026-06-10"}'
+      'Error [VALIDATION]: No external match found for "dragonfruit smoothie". Please estimate the nutrition yourself and call create_food (include meal_type_id (or meal_type) and entry_date to save and log in one step), for example: {"action":"create_food","food_name":"dragonfruit smoothie","calories":300,"protein":15,"carbs":40,"fat":5,"meal_type":"snacks","entry_date":"2026-06-10"}'
     );
     expect(foodCoreService.createFood).not.toHaveBeenCalled();
     expect(foodEntryService.createFoodEntry).not.toHaveBeenCalled();
@@ -2588,6 +2588,74 @@ describe('save_as_meal_template', () => {
       'Missing required parameters: meal_type_id (or meal_type)'
     );
     expect(foodEntryService.createFoodEntryMeal).not.toHaveBeenCalled();
+    expect(foodEntryService.copyFoodEntries).not.toHaveBeenCalled();
+    expect(foodEntryService.copyAllFoodEntries).not.toHaveBeenCalled();
+  });
+
+  // Regression: an incidental date field on an update/delete call must not be
+  // reinterpreted as a full-day copy. Entry/food-targeted operations win over
+  // target_date/source_date in action inference.
+  it('infers update_entry (not a copy) for entry_id + quantity + target_date', async () => {
+    vi.mocked(foodEntryService.updateFoodEntry).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry',
+        quantity: 2,
+        target_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry updated: quantity to 2.');
+    expect(foodEntryService.updateFoodEntry).toHaveBeenCalled();
+    expect(foodEntryService.copyFoodEntries).not.toHaveBeenCalled();
+    expect(foodEntryService.copyAllFoodEntries).not.toHaveBeenCalled();
+  });
+
+  it('infers delete_entry (not a copy) for entry_id + entry_type + source_date', async () => {
+    vi.mocked(foodEntryService.deleteFoodEntry).mockResolvedValue(true);
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry',
+        source_date: '2026-06-09',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry deleted.');
+    expect(foodEntryService.deleteFoodEntry).toHaveBeenCalledWith(
+      'user-1',
+      ENTRY_ID
+    );
+    expect(foodEntryService.copyFoodEntries).not.toHaveBeenCalled();
+    expect(foodEntryService.copyAllFoodEntries).not.toHaveBeenCalled();
+  });
+
+  it('infers delete_food (not a copy) for food_id + target_date', async () => {
+    vi.mocked(foodRepository.getFoodById).mockResolvedValue(eggsRow);
+    vi.mocked(foodCoreService.deleteFood).mockResolvedValue({
+      message: 'Food and all its references deleted permanently.',
+      status: 'force_deleted',
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        food_id: FOOD_ID,
+        target_date: '2026-06-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Food "Eggs" deleted (including variants and diary entries).'
+    );
+    expect(foodCoreService.deleteFood).toHaveBeenCalled();
     expect(foodEntryService.copyFoodEntries).not.toHaveBeenCalled();
     expect(foodEntryService.copyAllFoodEntries).not.toHaveBeenCalled();
   });

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -719,6 +719,25 @@ describe('lookup_food_nutrition', () => {
 });
 
 describe('log_food', () => {
+  // Regression: an invalid legacy meal_type name must surface the name itself
+  // in the not-found error (not "undefined"), proving the tool reports the
+  // resolved fallback value to the model.
+  it('reports the invalid legacy meal_type name in the not-found error', async () => {
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'log_food',
+        food_name: 'Eggs',
+        quantity: 1,
+        unit: 'serving',
+        meal_type: 'invalid-slot',
+      },
+      opts
+    );
+
+    expect(result).toContain('Meal type "invalid-slot" was not found');
+    expect(result).not.toContain('Meal type "undefined"');
+  });
+
   it('logs to a custom meal type by ID and gives the ID precedence over the legacy name', async () => {
     vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
       id: MEAL_TYPE_ID,

--- a/SparkyFitnessServer/tests/foodEntryCopy.test.ts
+++ b/SparkyFitnessServer/tests/foodEntryCopy.test.ts
@@ -1,8 +1,10 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
 import {
+  copyAllFoodEntries,
+  copyFoodEntries,
   copyFoodEntriesFromUser,
+  copyFoodEntriesFromYesterday,
   copyFoodEntriesToUser,
-  resolveMealTypeId,
 } from '../services/foodEntryService.js';
 import familyAccessRepository from '../models/familyAccessRepository.js';
 import foodRepository from '../models/foodRepository.js';
@@ -11,7 +13,7 @@ import mealTypeRepository from '../models/mealType.js';
 vi.mock('../models/familyAccessRepository');
 vi.mock('../models/foodRepository');
 vi.mock('../models/foodEntryMealRepository');
-vi.mock('../models/mealType');
+vi.mock('../models/mealType.js');
 vi.mock('../config/logging', () => ({ log: vi.fn() }));
 
 const ACTOR_A = 'actor-a';
@@ -311,54 +313,178 @@ describe('foodEntryService symmetrical cross-user copy tests', () => {
   });
 });
 
-describe('resolveMealTypeId (service-level meal type resolution)', () => {
-  const SYSTEM_LUNCH_ID = 'system-lunch-id';
+describe('copy flows resolve custom meal types by name (shared service contract)', () => {
+  const CUSTOM_MEAL_TYPE_ID = 'custom-second-breakfast-id';
   const CUSTOM_LUNCH_ID = 'custom-lunch-id';
+  const SYSTEM_LUNCH_ID = 'system-lunch-id';
 
-  // A custom type may share its name with a system default (uniqueness is per
-  // (name, user_id)). The legacy-name fallback must resolve only to the system
-  // type, even when a same-named custom type sorts first; custom types are
-  // selected exclusively by id.
-  it('resolves a legacy name to the system type even when a same-named custom type sorts first', async () => {
+  // Source entry fixture: no food_entry_meal_id, so the copy path goes
+  // straight to the per-entry duplicate check and bulk create.
+  const mockEntry = {
+    id: 'entry-1',
+    food_id: 'food-abc',
+    variant_id: 'variant-xyz',
+    quantity: 1.5,
+    unit: 'serving',
+    food_name: 'Banana',
+    brand_name: 'Fresh',
+    serving_size: 1,
+    serving_unit: 'piece',
+    calories: 105,
+    protein: 1.3,
+    carbs: 27,
+    fat: 0.3,
+    saturated_fat: 0.1,
+    polyunsaturated_fat: 0.1,
+    monounsaturated_fat: 0.1,
+    trans_fat: 0,
+    cholesterol: 0,
+    sodium: 1,
+    potassium: 422,
+    dietary_fiber: 3.1,
+    sugars: 14,
+    vitamin_a: 1,
+    vitamin_c: 10,
+    calcium: 6,
+    iron: 0.3,
+    glycemic_index: 51,
+    custom_nutrients: {},
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(foodRepository.getFoodEntryByDetails).mockResolvedValue(
+      undefined
+    );
+  });
+
+  it('copyFoodEntries resolves a custom type by its name', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_MEAL_TYPE_ID, name: 'Second breakfast', user_id: 'user-1' },
+    ]);
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1', user_id: 'user-1', food_id: 'food-abc' },
+    ]);
+
+    const result = await copyFoodEntries(
+      'user-1',
+      'user-1',
+      '2026-06-09',
+      'Second breakfast',
+      '2026-06-10',
+      'Second breakfast'
+    );
+
+    expect(result).toEqual([
+      { id: 'entry-copied-1', user_id: 'user-1', food_id: 'food-abc' },
+    ]);
+    expect(foodRepository.bulkCreateFoodEntries).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ meal_type_id: CUSTOM_MEAL_TYPE_ID }),
+      ]),
+      'user-1'
+    );
+  });
+
+  it('copyFoodEntriesFromYesterday resolves a custom type by its name', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_MEAL_TYPE_ID, name: 'Second breakfast', user_id: 'user-1' },
+    ]);
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1' },
+    ]);
+
+    const result = await copyFoodEntriesFromYesterday(
+      'user-1',
+      'user-1',
+      'Second breakfast',
+      '2026-06-10'
+    );
+
+    expect(result).toHaveLength(1);
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-09',
+      'Second breakfast'
+    );
+  });
+
+  it('copyAllFoodEntries copies a day that contains a custom meal type', async () => {
+    vi.mocked(foodRepository.getFoodEntriesByDate).mockResolvedValue([
+      { ...mockEntry, meal_type: 'Second breakfast' },
+      {
+        ...mockEntry,
+        id: 'entry-2',
+        food_id: 'food-def',
+        meal_type: 'Lunch',
+      },
+    ]);
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_MEAL_TYPE_ID, name: 'Second breakfast', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
+    ]);
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1' },
+    ]);
+
+    const result = await copyAllFoodEntries(
+      'user-1',
+      'user-1',
+      '2026-06-09',
+      '2026-06-10'
+    );
+
+    expect(result.length).toBeGreaterThan(0);
+    // Both used slots were routed through copyFoodEntries by name.
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-09',
+      'Second breakfast'
+    );
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-09',
+      'Lunch'
+    );
+  });
+
+  it('copyFoodEntries prefers an exact id over a same-named system type', async () => {
+    // A custom type shares its name with a system default; passing the custom
+    // UUID must resolve to the custom type, not the system one.
     vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
       { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
       { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
     ]);
-
-    const id = await resolveMealTypeId('user-1', 'Lunch');
-
-    expect(id).toBe(SYSTEM_LUNCH_ID);
-  });
-
-  it('resolves an exact custom type id to that custom type', async () => {
-    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
-      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1' },
     ]);
 
-    const id = await resolveMealTypeId('user-1', CUSTOM_LUNCH_ID);
+    await copyFoodEntries(
+      'user-1',
+      'user-1',
+      '2026-06-09',
+      'Lunch',
+      '2026-06-10',
+      CUSTOM_LUNCH_ID
+    );
 
-    expect(id).toBe(CUSTOM_LUNCH_ID);
-  });
-
-  it('resolves an exact system type id to that system type', async () => {
-    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
-      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
-    ]);
-
-    const id = await resolveMealTypeId('user-1', SYSTEM_LUNCH_ID);
-
-    expect(id).toBe(SYSTEM_LUNCH_ID);
-  });
-
-  it('returns null for an unknown name', async () => {
-    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
-    ]);
-
-    const id = await resolveMealTypeId('user-1', 'Dinner');
-
-    expect(id).toBeNull();
+    expect(foodRepository.bulkCreateFoodEntries).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ meal_type_id: CUSTOM_LUNCH_ID }),
+      ]),
+      'user-1'
+    );
   });
 });

--- a/SparkyFitnessServer/tests/foodEntryCopy.test.ts
+++ b/SparkyFitnessServer/tests/foodEntryCopy.test.ts
@@ -2,6 +2,7 @@ import { vi, beforeEach, describe, expect, it } from 'vitest';
 import {
   copyFoodEntriesFromUser,
   copyFoodEntriesToUser,
+  resolveMealTypeId,
 } from '../services/foodEntryService.js';
 import familyAccessRepository from '../models/familyAccessRepository.js';
 import foodRepository from '../models/foodRepository.js';
@@ -51,7 +52,7 @@ describe('foodEntryService symmetrical cross-user copy tests', () => {
 
       // Mock mealType resolution
       vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-        { id: 'meal-type-lunch-id', name: 'Lunch' },
+        { id: 'meal-type-lunch-id', name: 'Lunch', user_id: null },
       ]);
 
       // Mock source food entries returned from B
@@ -165,7 +166,7 @@ describe('foodEntryService symmetrical cross-user copy tests', () => {
 
       // Mock mealType resolution for target user B
       vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-        { id: 'meal-type-lunch-id', name: 'Lunch' },
+        { id: 'meal-type-lunch-id', name: 'Lunch', user_id: null },
       ]);
 
       // Mock source food entries returned from A
@@ -307,5 +308,57 @@ describe('foodEntryService symmetrical cross-user copy tests', () => {
         familyAccessRepository.checkCopyPermissions
       ).not.toHaveBeenCalledWith(ACTIVE_VICTIM, MEMBER_B);
     });
+  });
+});
+
+describe('resolveMealTypeId (service-level meal type resolution)', () => {
+  const SYSTEM_LUNCH_ID = 'system-lunch-id';
+  const CUSTOM_LUNCH_ID = 'custom-lunch-id';
+
+  // A custom type may share its name with a system default (uniqueness is per
+  // (name, user_id)). The legacy-name fallback must resolve only to the system
+  // type, even when a same-named custom type sorts first; custom types are
+  // selected exclusively by id.
+  it('resolves a legacy name to the system type even when a same-named custom type sorts first', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
+    ]);
+
+    const id = await resolveMealTypeId('user-1', 'Lunch');
+
+    expect(id).toBe(SYSTEM_LUNCH_ID);
+  });
+
+  it('resolves an exact custom type id to that custom type', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
+    ]);
+
+    const id = await resolveMealTypeId('user-1', CUSTOM_LUNCH_ID);
+
+    expect(id).toBe(CUSTOM_LUNCH_ID);
+  });
+
+  it('resolves an exact system type id to that system type', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
+    ]);
+
+    const id = await resolveMealTypeId('user-1', SYSTEM_LUNCH_ID);
+
+    expect(id).toBe(SYSTEM_LUNCH_ID);
+  });
+
+  it('returns null for an unknown name', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
+    ]);
+
+    const id = await resolveMealTypeId('user-1', 'Dinner');
+
+    expect(id).toBeNull();
   });
 });

--- a/SparkyFitnessServer/tests/foodEntryCopy.test.ts
+++ b/SparkyFitnessServer/tests/foodEntryCopy.test.ts
@@ -516,8 +516,8 @@ describe('copy flows resolve custom meal types by name (shared service contract)
 
   // A plain name that collides between a custom type (sorts first) and the
   // system default must deterministically resolve to the system default,
-  // regardless of sort_order.
-  it('copyFoodEntries resolves a colliding plain name to the system type', async () => {
+  // regardless of sort_order, when the spellings are identical.
+  it('copyFoodEntries resolves a same-spelled colliding name to the system type', async () => {
     vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
       { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
       { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
@@ -557,6 +557,105 @@ describe('copy flows resolve custom meal types by name (shared service contract)
         expect.objectContaining({ meal_type_id: SYSTEM_LUNCH_ID }),
       ]),
       'user-1'
+    );
+  });
+
+  // System defaults are stored lowercase while a custom type may be created
+  // with a different casing ("Lunch"). An exact-case name match must win, so
+  // web/mobile sending the selected label "Lunch" resolves to the custom
+  // type, not the system "lunch".
+  it('copyFoodEntries resolves an exact-case name to the custom type over a lowercase system default', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'lunch', user_id: null },
+    ]);
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1' },
+    ]);
+
+    await copyFoodEntries(
+      'user-1',
+      'user-1',
+      '2026-06-09',
+      'Lunch',
+      '2026-06-10',
+      'Lunch'
+    );
+
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-09',
+      CUSTOM_LUNCH_ID
+    );
+    expect(foodRepository.getFoodEntryByDetails).toHaveBeenCalledWith(
+      'user-1',
+      'food-abc',
+      CUSTOM_LUNCH_ID,
+      '2026-06-10',
+      'variant-xyz',
+      null
+    );
+  });
+
+  // The lowercase system spelling resolves to the system type.
+  it('copyFoodEntries resolves the lowercase system name to the system type', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'lunch', user_id: null },
+    ]);
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1' },
+    ]);
+
+    await copyFoodEntries(
+      'user-1',
+      'user-1',
+      '2026-06-09',
+      'lunch',
+      '2026-06-10',
+      'lunch'
+    );
+
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-09',
+      SYSTEM_LUNCH_ID
+    );
+  });
+
+  // With no exact-case match, the case-insensitive fallback deterministically
+  // prefers the system default.
+  it('copyFoodEntries falls back to the system type for a differently-cased name', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'lunch', user_id: null },
+    ]);
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1' },
+    ]);
+
+    await copyFoodEntries(
+      'user-1',
+      'user-1',
+      '2026-06-09',
+      'LUNCH',
+      '2026-06-10',
+      'LUNCH'
+    );
+
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-09',
+      SYSTEM_LUNCH_ID
     );
   });
 
@@ -607,10 +706,20 @@ describe('copy flows resolve custom meal types by name (shared service contract)
     vi.mocked(familyAccessRepository.checkCopyPermissions).mockResolvedValue(
       true
     );
-    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
-      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
-    ]);
+    // Each user gets their own meal types so the test proves the resolver is
+    // called in the right user context.
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockImplementation(
+      async (userId) => {
+        if (userId === MEMBER_B) {
+          return [
+            { id: 'member-source-lunch-id', name: 'Lunch', user_id: MEMBER_B },
+          ];
+        }
+        return [
+          { id: 'active-target-lunch-id', name: 'Lunch', user_id: 'user-1' },
+        ];
+      }
+    );
     vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
       [mockEntry]
     );
@@ -628,17 +737,24 @@ describe('copy flows resolve custom meal types by name (shared service contract)
       'Lunch'
     );
 
-    // Source is resolved against MEMBER_B, target against user-1; both are
-    // queried/written by canonical id.
+    // Source resolved against MEMBER_B, target against user-1.
+    expect(mealTypeRepository.getAllMealTypes).toHaveBeenNthCalledWith(
+      1,
+      MEMBER_B
+    );
+    expect(mealTypeRepository.getAllMealTypes).toHaveBeenNthCalledWith(
+      2,
+      'user-1'
+    );
     expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
       MEMBER_B,
       '2026-06-17',
-      SYSTEM_LUNCH_ID
+      'member-source-lunch-id'
     );
     expect(foodRepository.getFoodEntryByDetails).toHaveBeenCalledWith(
       'user-1',
       'food-abc',
-      SYSTEM_LUNCH_ID,
+      'active-target-lunch-id',
       '2026-06-17',
       'variant-xyz',
       null
@@ -649,10 +765,18 @@ describe('copy flows resolve custom meal types by name (shared service contract)
     vi.mocked(familyAccessRepository.checkCopyPermissions).mockResolvedValue(
       true
     );
-    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
-      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
-      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
-    ]);
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockImplementation(
+      async (userId) => {
+        if (userId === MEMBER_B) {
+          return [
+            { id: 'member-target-lunch-id', name: 'Lunch', user_id: MEMBER_B },
+          ];
+        }
+        return [
+          { id: 'active-source-lunch-id', name: 'Lunch', user_id: 'user-1' },
+        ];
+      }
+    );
     vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
       [mockEntry]
     );
@@ -670,16 +794,24 @@ describe('copy flows resolve custom meal types by name (shared service contract)
       'Lunch'
     );
 
-    // Source is resolved against user-1, target against MEMBER_B.
+    // Source resolved against user-1, target against MEMBER_B.
+    expect(mealTypeRepository.getAllMealTypes).toHaveBeenNthCalledWith(
+      1,
+      'user-1'
+    );
+    expect(mealTypeRepository.getAllMealTypes).toHaveBeenNthCalledWith(
+      2,
+      MEMBER_B
+    );
     expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
       'user-1',
       '2026-06-17',
-      SYSTEM_LUNCH_ID
+      'active-source-lunch-id'
     );
     expect(foodRepository.getFoodEntryByDetails).toHaveBeenCalledWith(
       MEMBER_B,
       'food-abc',
-      SYSTEM_LUNCH_ID,
+      'member-target-lunch-id',
       '2026-06-17',
       'variant-xyz',
       null

--- a/SparkyFitnessServer/tests/foodEntryCopy.test.ts
+++ b/SparkyFitnessServer/tests/foodEntryCopy.test.ts
@@ -123,7 +123,7 @@ describe('foodEntryService symmetrical cross-user copy tests', () => {
       );
       expect(
         foodRepository.getFoodEntriesByDateAndMealType
-      ).toHaveBeenCalledWith(MEMBER_B, '2026-06-17', 'Lunch');
+      ).toHaveBeenCalledWith(MEMBER_B, '2026-06-17', 'meal-type-lunch-id');
       expect(foodRepository.bulkCreateFoodEntries).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({
@@ -237,7 +237,7 @@ describe('foodEntryService symmetrical cross-user copy tests', () => {
       );
       expect(
         foodRepository.getFoodEntriesByDateAndMealType
-      ).toHaveBeenCalledWith(ACTOR_A, '2026-06-17', 'Lunch');
+      ).toHaveBeenCalledWith(ACTOR_A, '2026-06-17', 'meal-type-lunch-id');
       expect(foodRepository.bulkCreateFoodEntries).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({
@@ -260,6 +260,9 @@ describe('foodEntryService symmetrical cross-user copy tests', () => {
       vi.mocked(familyAccessRepository.checkCopyPermissions).mockResolvedValue(
         true
       );
+      vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+        { id: 'meal-type-lunch-id', name: 'Lunch', user_id: null },
+      ]);
       // Empty source -> returns right after the permission check.
       vi.mocked(
         foodRepository.getFoodEntriesByDateAndMealType
@@ -288,6 +291,9 @@ describe('foodEntryService symmetrical cross-user copy tests', () => {
       vi.mocked(familyAccessRepository.checkCopyPermissions).mockResolvedValue(
         true
       );
+      vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+        { id: 'meal-type-lunch-id', name: 'Lunch', user_id: null },
+      ]);
       vi.mocked(
         foodRepository.getFoodEntriesByDateAndMealType
       ).mockResolvedValue([]);
@@ -358,7 +364,7 @@ describe('copy flows resolve custom meal types by name (shared service contract)
     );
   });
 
-  it('copyFoodEntries resolves a custom type by its name', async () => {
+  it('copyFoodEntries resolves a custom type by its name and queries by canonical id', async () => {
     vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
       { id: CUSTOM_MEAL_TYPE_ID, name: 'Second breakfast', user_id: 'user-1' },
     ]);
@@ -381,6 +387,21 @@ describe('copy flows resolve custom meal types by name (shared service contract)
     expect(result).toEqual([
       { id: 'entry-copied-1', user_id: 'user-1', food_id: 'food-abc' },
     ]);
+    // The source query uses the canonical id, not the raw name.
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-09',
+      CUSTOM_MEAL_TYPE_ID
+    );
+    // The duplicate check receives the canonical target id.
+    expect(foodRepository.getFoodEntryByDetails).toHaveBeenCalledWith(
+      'user-1',
+      'food-abc',
+      CUSTOM_MEAL_TYPE_ID,
+      '2026-06-10',
+      'variant-xyz',
+      null
+    );
     expect(foodRepository.bulkCreateFoodEntries).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({ meal_type_id: CUSTOM_MEAL_TYPE_ID }),
@@ -389,7 +410,7 @@ describe('copy flows resolve custom meal types by name (shared service contract)
     );
   });
 
-  it('copyFoodEntriesFromYesterday resolves a custom type by its name', async () => {
+  it('copyFoodEntriesFromYesterday resolves a custom type by its name and queries by id', async () => {
     vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
       { id: CUSTOM_MEAL_TYPE_ID, name: 'Second breakfast', user_id: 'user-1' },
     ]);
@@ -411,18 +432,23 @@ describe('copy flows resolve custom meal types by name (shared service contract)
     expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
       'user-1',
       '2026-06-09',
-      'Second breakfast'
+      CUSTOM_MEAL_TYPE_ID
     );
   });
 
   it('copyAllFoodEntries copies a day that contains a custom meal type', async () => {
     vi.mocked(foodRepository.getFoodEntriesByDate).mockResolvedValue([
-      { ...mockEntry, meal_type: 'Second breakfast' },
+      {
+        ...mockEntry,
+        meal_type: 'Second breakfast',
+        meal_type_id: CUSTOM_MEAL_TYPE_ID,
+      },
       {
         ...mockEntry,
         id: 'entry-2',
         food_id: 'food-def',
         meal_type: 'Lunch',
+        meal_type_id: SYSTEM_LUNCH_ID,
       },
     ]);
     vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
@@ -444,16 +470,16 @@ describe('copy flows resolve custom meal types by name (shared service contract)
     );
 
     expect(result.length).toBeGreaterThan(0);
-    // Both used slots were routed through copyFoodEntries by name.
+    // Both used slots are queried by their canonical ids.
     expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
       'user-1',
       '2026-06-09',
-      'Second breakfast'
+      CUSTOM_MEAL_TYPE_ID
     );
     expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
       'user-1',
       '2026-06-09',
-      'Lunch'
+      SYSTEM_LUNCH_ID
     );
   });
 
@@ -485,6 +511,178 @@ describe('copy flows resolve custom meal types by name (shared service contract)
         expect.objectContaining({ meal_type_id: CUSTOM_LUNCH_ID }),
       ]),
       'user-1'
+    );
+  });
+
+  // A plain name that collides between a custom type (sorts first) and the
+  // system default must deterministically resolve to the system default,
+  // regardless of sort_order.
+  it('copyFoodEntries resolves a colliding plain name to the system type', async () => {
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
+    ]);
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1' },
+    ]);
+
+    await copyFoodEntries(
+      'user-1',
+      'user-1',
+      '2026-06-09',
+      'Lunch',
+      '2026-06-10',
+      'Lunch'
+    );
+
+    // Both source query and duplicate check use the system id.
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-09',
+      SYSTEM_LUNCH_ID
+    );
+    expect(foodRepository.getFoodEntryByDetails).toHaveBeenCalledWith(
+      'user-1',
+      'food-abc',
+      SYSTEM_LUNCH_ID,
+      '2026-06-10',
+      'variant-xyz',
+      null
+    );
+    expect(foodRepository.bulkCreateFoodEntries).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ meal_type_id: SYSTEM_LUNCH_ID }),
+      ]),
+      'user-1'
+    );
+  });
+
+  // Two distinct types that share a name must be copied as two separate
+  // slots, never merged into one.
+  it('copyAllFoodEntries keeps same-named types with different ids separate', async () => {
+    vi.mocked(foodRepository.getFoodEntriesByDate).mockResolvedValue([
+      {
+        ...mockEntry,
+        meal_type: 'Lunch',
+        meal_type_id: SYSTEM_LUNCH_ID,
+      },
+      {
+        ...mockEntry,
+        id: 'entry-2',
+        food_id: 'food-def',
+        meal_type: 'Lunch',
+        meal_type_id: CUSTOM_LUNCH_ID,
+      },
+    ]);
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
+    ]);
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1' },
+    ]);
+
+    await copyAllFoodEntries('user-1', 'user-1', '2026-06-09', '2026-06-10');
+
+    // Two separate copy passes, one per canonical id.
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-09',
+      SYSTEM_LUNCH_ID
+    );
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-09',
+      CUSTOM_LUNCH_ID
+    );
+  });
+
+  it('copyFoodEntriesFromUser resolves source for the source user and target for the active user', async () => {
+    vi.mocked(familyAccessRepository.checkCopyPermissions).mockResolvedValue(
+      true
+    );
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
+    ]);
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1' },
+    ]);
+
+    await copyFoodEntriesFromUser(
+      'user-1',
+      'user-1',
+      MEMBER_B,
+      '2026-06-17',
+      'Lunch',
+      '2026-06-17',
+      'Lunch'
+    );
+
+    // Source is resolved against MEMBER_B, target against user-1; both are
+    // queried/written by canonical id.
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      MEMBER_B,
+      '2026-06-17',
+      SYSTEM_LUNCH_ID
+    );
+    expect(foodRepository.getFoodEntryByDetails).toHaveBeenCalledWith(
+      'user-1',
+      'food-abc',
+      SYSTEM_LUNCH_ID,
+      '2026-06-17',
+      'variant-xyz',
+      null
+    );
+  });
+
+  it('copyFoodEntriesToUser resolves source for the active user and target for the target user', async () => {
+    vi.mocked(familyAccessRepository.checkCopyPermissions).mockResolvedValue(
+      true
+    );
+    vi.mocked(mealTypeRepository.getAllMealTypes).mockResolvedValue([
+      { id: CUSTOM_LUNCH_ID, name: 'Lunch', user_id: 'user-1' },
+      { id: SYSTEM_LUNCH_ID, name: 'Lunch', user_id: null },
+    ]);
+    vi.mocked(foodRepository.getFoodEntriesByDateAndMealType).mockResolvedValue(
+      [mockEntry]
+    );
+    vi.mocked(foodRepository.bulkCreateFoodEntries).mockResolvedValue([
+      { id: 'entry-copied-1' },
+    ]);
+
+    await copyFoodEntriesToUser(
+      'user-1',
+      'user-1',
+      MEMBER_B,
+      '2026-06-17',
+      'Lunch',
+      '2026-06-17',
+      'Lunch'
+    );
+
+    // Source is resolved against user-1, target against MEMBER_B.
+    expect(foodRepository.getFoodEntriesByDateAndMealType).toHaveBeenCalledWith(
+      'user-1',
+      '2026-06-17',
+      SYSTEM_LUNCH_ID
+    );
+    expect(foodRepository.getFoodEntryByDetails).toHaveBeenCalledWith(
+      MEMBER_B,
+      'food-abc',
+      SYSTEM_LUNCH_ID,
+      '2026-06-17',
+      'variant-xyz',
+      null
     );
   });
 });

--- a/docs/content/8.developer/10.mcp/1.food.md
+++ b/docs/content/8.developer/10.mcp/1.food.md
@@ -78,10 +78,11 @@ The `manage_food` tool supports the following actions:
     - `meal_id` (string, optional): UUID of the meal template (if known).
     - `meal_name` (string, optional): Name of the meal template (alternative to ID).
     - `meal_type_id` (string, optional): UUID of a built-in or custom meal type.
-    - `meal_type` (string, optional): Backwards-compatible built-in fallback.
+    - `meal_type` (string, optional): Backwards-compatible built-in fallback (e.g., 'breakfast', 'lunch', 'dinner', 'snacks').
     - `entry_date` (string, YYYY-MM-DD): The date of the record.
     - `quantity` (number, optional): Multiplier for the meal template.
     - `unit` (string, optional): Unit for the meal template multiplier.
+- **Meal Type Requirement:** Provide at least one of `meal_type_id` or `meal_type`. When both are supplied, `meal_type_id` takes precedence.
 
 ### `list_diary`
 - **Description:** Retrieves all logged food and meal entries for a specific date.
@@ -102,19 +103,24 @@ The `manage_food` tool supports the following actions:
     - `quantity` (number, optional): The new amount.
     - `unit` (string, optional): The new unit of measurement.
     - `meal_type_id` (string, optional): UUID of the new built-in or custom meal type.
-    - `meal_type` (string, optional): Backwards-compatible built-in fallback.
+    - `meal_type` (string, optional): Backwards-compatible built-in fallback (e.g., 'breakfast', 'lunch', 'dinner', 'snacks').
+- **Requirement:** Provide at least one mutable field (`quantity`, `unit`, `meal_type_id`, or `meal_type`). When both meal type selectors are supplied, `meal_type_id` takes precedence.
 
 ### `copy_from_yesterday`
 - **Description:** Copies all food entries from a source date (defaults to yesterday) to a target date (defaults to today) for a specific meal type.
 - **Parameters:**
     - `target_date` (string, YYYY-MM-DD, optional): The date to copy entries to.
     - `source_date` (string, YYYY-MM-DD, optional): The date to copy entries from.
-    - `meal_type` (string, optional): The specific meal type to copy (e.g., 'breakfast').
+    - `meal_type_id` (string, optional): UUID of a built-in or custom meal type.
+    - `meal_type` (string, optional): Backwards-compatible built-in fallback (e.g., 'breakfast', 'lunch', 'dinner', 'snacks').
+- **Meal Type Precedence:** When both are supplied, `meal_type_id` takes precedence.
 
 ### `save_as_meal_template`
 - **Description:** Saves a set of food entries from a specific date and meal type as a new reusable meal template.
 - **Parameters:**
     - `entry_date` (string, YYYY-MM-DD): The date from which to save entries.
-    - `meal_type` (string): The meal type to save (e.g., 'lunch').
+    - `meal_type_id` (string, optional): UUID of a built-in or custom meal type.
+    - `meal_type` (string, optional): Backwards-compatible built-in fallback (e.g., 'breakfast', 'lunch', 'dinner', 'snacks').
     - `meal_name` (string): The name for the new meal template.
     - `description` (string, optional): A description for the meal template.
+- **Meal Type Requirement:** Provide at least one of `meal_type_id` or `meal_type`. When both are supplied, `meal_type_id` takes precedence.

--- a/docs/content/8.developer/10.mcp/1.food.md
+++ b/docs/content/8.developer/10.mcp/1.food.md
@@ -21,6 +21,9 @@ The `manage_food` tool supports the following actions:
     - `food_name` (string): The name of the food item to search for.
     - `search_type` (enum: "exact", "broad"): The type of search to perform.
 
+### `list_meal_types`
+- **Description:** Lists the built-in and custom meal types available to the user, including each type's `id`, `name`, and `sort_order`.
+
 ### `log_food`
 - **Description:** Logs a food item to your daily diary. Handles both existing and new food items.
 - **Parameters:**
@@ -29,8 +32,10 @@ The `manage_food` tool supports the following actions:
     - `variant_id` (string, optional): UUID of the food variant (if known).
     - `quantity` (number): The amount consumed.
     - `unit` (string): The unit of measurement (e.g., 'g', 'piece', 'serving').
-    - `meal_type` (string): The meal timeframe (e.g., 'breakfast', 'lunch', 'dinner', 'snacks').
+    - `meal_type_id` (string, optional): UUID of a built-in or custom meal type.
+    - `meal_type` (string, optional): Backwards-compatible built-in fallback (e.g., 'breakfast', 'lunch', 'dinner', 'snacks').
     - `entry_date` (string, YYYY-MM-DD): The date of the record.
+- **Meal Type Precedence:** Provide at least one of `meal_type_id` or `meal_type`. When both are supplied, `meal_type_id` takes precedence.
 - **Special Handling for Unknown Foods:** If `food_name` is not found, the AI will be instructed to infer nutritional details and create the food via `create_food` before re-attempting to log.
 
 ### `create_food`
@@ -59,6 +64,8 @@ The `manage_food` tool supports the following actions:
         - `gi` (string, enum: "None", "Very Low", "Low", "Medium", "High", "Very High")
     - `quantity` (number, optional): The default serving size value.
     - `unit` (string, optional): The default serving size unit.
+    - `meal_type_id` (string, optional): UUID of a built-in or custom meal type for automatic logging.
+    - `meal_type` (string, optional): Backwards-compatible built-in fallback for automatic logging.
 
 ### `search_meal`
 - **Description:** Search for existing meal templates.
@@ -70,7 +77,8 @@ The `manage_food` tool supports the following actions:
 - **Parameters:**
     - `meal_id` (string, optional): UUID of the meal template (if known).
     - `meal_name` (string, optional): Name of the meal template (alternative to ID).
-    - `meal_type` (string): The meal timeframe.
+    - `meal_type_id` (string, optional): UUID of a built-in or custom meal type.
+    - `meal_type` (string, optional): Backwards-compatible built-in fallback.
     - `entry_date` (string, YYYY-MM-DD): The date of the record.
     - `quantity` (number, optional): Multiplier for the meal template.
     - `unit` (string, optional): Unit for the meal template multiplier.
@@ -87,12 +95,14 @@ The `manage_food` tool supports the following actions:
     - `entry_type` (enum: "food_entry", "food_entry_meal"): The type of entry.
 
 ### `update_entry`
-- **Description:** Updates the quantity or unit of an existing food or meal entry.
+- **Description:** Updates the quantity, unit, or meal type of an existing food or meal entry.
 - **Parameters:**
     - `entry_id` (string): UUID of the entry to update.
     - `entry_type` (enum: "food_entry", "food_entry_meal"): The type of entry.
-    - `quantity` (number): The new amount.
-    - `unit` (string): The new unit of measurement.
+    - `quantity` (number, optional): The new amount.
+    - `unit` (string, optional): The new unit of measurement.
+    - `meal_type_id` (string, optional): UUID of the new built-in or custom meal type.
+    - `meal_type` (string, optional): Backwards-compatible built-in fallback.
 
 ### `copy_from_yesterday`
 - **Description:** Copies all food entries from a source date (defaults to yesterday) to a target date (defaults to today) for a specific meal type.

--- a/docs/content/8.developer/10.mcp/1.food.md
+++ b/docs/content/8.developer/10.mcp/1.food.md
@@ -116,7 +116,6 @@ The `manage_food` tool supports the following actions:
 - **Meal Type Precedence:** When both are supplied, `meal_type_id` takes precedence.
 
 ### `save_as_meal_template`
-
 - **Action Requirement:** This action cannot be inferred unambiguously. Always provide `action: "save_as_meal_template".`
 - **Description:** Saves a set of food entries from a specific date and meal type as a new reusable meal template.
 - **Parameters:**

--- a/docs/content/8.developer/10.mcp/1.food.md
+++ b/docs/content/8.developer/10.mcp/1.food.md
@@ -116,6 +116,8 @@ The `manage_food` tool supports the following actions:
 - **Meal Type Precedence:** When both are supplied, `meal_type_id` takes precedence.
 
 ### `save_as_meal_template`
+
+- **Action Requirement:** This action cannot be inferred unambiguously. Always provide `action: "save_as_meal_template".`
 - **Description:** Saves a set of food entries from a specific date and meal type as a new reusable meal template.
 - **Parameters:**
     - `entry_date` (string, YYYY-MM-DD): The date from which to save entries.


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
MCP food tools could only use four fixed meal types, while the REST API already supports custom meal types by ID.

**How did you implement the solution?**
Added meal type discovery, meal_type_id support with ID precedence and legacy fallback, entry moves, and resolved meal type data in diary reads. The shared foodEntryService keeps name-based resolution for existing REST/web/mobile clients; MCP passes the canonical ID through.

Linked Issue: Closes #1959

## How to Test

1. Run the targeted MCP tests: tests/chatbotToolSchemas.test.ts and tests/chatbotToolsFood.test.ts.
2. List meal types and log food using a custom meal_type_id.
3. Move an existing entry to a custom meal type and verify diary reads include its ID and name.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).
- [x] **[MANDATORY for Backend changes] Code Quality**: Typecheck and full ESLint pass; the full server test suite passes (2498 tests, 203 files; targeted MCP + service tests included). Changed TypeScript files pass Prettier. The repository-wide Prettier check reports 552 pre-existing differences in untouched files.

## Notes for Reviewers

The PR changes the MCP food tool, its tests, MCP documentation, and a small shared-service helper (foodEntryService.resolveMealTypeId). No REST route or request-schema changes were made. The shared copy service now canonicalizes meal type selectors to IDs, which corrects ambiguous name-based behavior for existing REST/web/mobile clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browse built-in and custom meal types, with hidden types excluded.
  * Select meal types by ID or name when logging, updating, copying entries, and saving templates.
  * View meal-type and entry identifiers in diary results.
* **Bug Fixes / Validation**
  * Support partial updates to quantity, unit, and meal type.
  * Improve validation and prioritize matching IDs over names.
  * Preserve omitted template quantity and unit values during updates.
* **Documentation**
  * Updated food management guidance for meal-type selection and listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### AI assistance disclosure

Parts of this implementation were drafted with Open WebUI.
All changes were manually reviewed, iteratively corrected, and validated by
Dragonk. The full server test suite, typecheck, lint, and formatting checks
were run before the final update.




