### PR TITLE
Update WorkoutPlanAssignements to prevent double conversion

### DIFF
--- a/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPlanAssignments.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPlanAssignments.tsx
@@ -31,7 +31,7 @@ export function useWorkoutPlanAssignments(
     () => presetData?.pages.flatMap((page) => page.presets) ?? [],
     [presetData]
   );
- 
+
   const [assignments, setAssignments] = useState<WorkoutPlanAssignment[]>(
     () =>
       initialData?.assignments?.map((a) => ({

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPlanAssignments.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPlanAssignments.tsx
@@ -24,14 +24,14 @@ export function useWorkoutPlanAssignments(
 ) {
   const { t } = useTranslation();
   const { user } = useAuth();
-  const { weightUnit, loggingLevel, convertWeight } = usePreferences();
+  const { loggingLevel } = usePreferences();
 
   const { data: presetData } = useWorkoutPresets(user?.id);
   const workoutPresets = useMemo(
     () => presetData?.pages.flatMap((page) => page.presets) ?? [],
     [presetData]
   );
-
+ 
   const [assignments, setAssignments] = useState<WorkoutPlanAssignment[]>(
     () =>
       initialData?.assignments?.map((a) => ({
@@ -41,13 +41,7 @@ export function useWorkoutPlanAssignments(
           a.sets?.map((s) => ({
             ...s,
             id: s.id ? String(s.id) : generateClientId(),
-            // null means no weight (e.g. a time-only set) and must survive the round trip.
-            weight:
-              s.weight != null
-                ? parseFloat(
-                    convertWeight(s.weight, 'kg', weightUnit).toFixed(1)
-                  )
-                : null,
+            weight: s.weight != null ? Number(s.weight) : null,
           })) || [],
       })) || []
   );
@@ -343,17 +337,10 @@ export function useWorkoutPlanAssignments(
           return {
             ...a,
             sort_order: dayAssignments.indexOf(a),
-            sets:
-              a.sets?.map((s) => ({
-                ...s,
-                weight:
-                  s.weight != null
-                    ? convertWeight(s.weight, weightUnit, 'kg')
-                    : null,
-              })) || [],
+            sets: a.sets || [],
           };
         }),
-    [assignments, convertWeight, weightUnit]
+    [assignments]
   );
 
   return {

--- a/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPlanAssignments.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPlanAssignments.test.tsx
@@ -62,6 +62,31 @@ const planWithTimedSet = {
   ],
 } as unknown as WorkoutPlanTemplate;
 
+const planWithWeightedSet = {
+  id: 'plan-2',
+  user_id: 'user-1',
+  plan_name: 'Push',
+  assignments: [
+    {
+      id: 'assignment-2',
+      template_id: 'plan-2',
+      day_of_week: 1,
+      exercise_id: 'exercise-4',
+      exercise_name: 'Bench Press',
+      sets: [
+        {
+          id: 3,
+          set_number: 1,
+          set_type: 'Working Set',
+          reps: 5,
+          weight: 100,
+          duration: null,
+        },
+      ],
+    },
+  ],
+} as unknown as WorkoutPlanTemplate;
+
 const addExercise = (exercise: Partial<Exercise>) => {
   const { result } = renderHook(() => useWorkoutPlanAssignments(null));
 
@@ -88,6 +113,18 @@ describe('useWorkoutPlanAssignments weight handling', () => {
     );
     // An explicit 0 is a real value and must not be nulled.
     expect(savedSets?.[1]).toEqual(expect.objectContaining({ weight: 0 }));
+  });
+
+  it('keeps a populated weight unchanged through load and save (no unit conversion)', () => {
+    const { result } = renderHook(() =>
+      useWorkoutPlanAssignments(planWithWeightedSet)
+    );
+
+    expect(result.current.assignments[0]?.sets?.[0]?.weight).toBe(100);
+
+    const savedSets = result.current.buildAssignmentsForSave()[0]?.sets;
+
+    expect(savedSets?.[0]).toEqual(expect.objectContaining({ weight: 100 }));
   });
 });
 


### PR DESCRIPTION


## Description

**What problem does this PR solve?**
Workout Plan converts lbs to KG twice.

**How did you implement the solution?**
Removed redundant weight conversion: UnitInput handles the conversion already, so no conversion is necessary in the WorkoutPlanAssignments

Linked Issue: Closes https://github.com/CodeWithCJ/SparkyFitness/issues/1957
## How to Test

1. Built prod locally
2. Edit and sav workout preset in lbs
3. Verify weight value via API call/DB is accurate in KG

## PR Type

- [X] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**Frontend changes (`SparkyFitnessFrontend/`):**

- [X] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] ~**[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.~ **Not Applicable**

## Screenshots

<details>
<summary>Click to expand</summary>

### Before
```
        "sets": [
          {
            "id": 110,
            "set_number": 1,
            "set_type": "Working Set",
            "reps": 10,
            "weight": 24.69, #Converted twice
            "duration": null,
            "rest_time": null,
            "notes": null
          }
```
### After
```
        "sets": [
          {
            "id": 110,
            "set_number": 1,
            "set_type": "Working Set",
            "reps": 10,
            "weight": 54.43, #Converted once
            "duration": null,
            "rest_time": null,
            "notes": null
          }
```
</details>

## Notes for Reviewers

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workout plan assignment set weights now load and save consistently, without any automatic unit conversion or rounding.
  * Saved assignment set details (including weight) are preserved exactly as entered, with no remapping during save.
* **Tests**
  * Added coverage to verify weighted set handling, ensuring an entered numeric weight remains unchanged through load and save.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->