### PR TITLE
feat: add garmin connect nix module options

### DIFF
--- a/docs/content/1.install/10.nixos.md
+++ b/docs/content/1.install/10.nixos.md
@@ -48,7 +48,7 @@ configuration:
 
 Use `nixosModules.sparkyfitness` to wire in this flake's package builds
 automatically, or `nixosModules.default` and set `backendPackage` /
-`frontendPackage` yourself.
+`frontendPackage` (and `garmin.package`, if you enable Garmin) yourself.
 
 ## 2. Provide the secrets
 
@@ -93,16 +93,42 @@ On first activation the module:
 | `nginx.enable` | `true` | Serve the frontend and reverse-proxy the API through nginx. |
 | `nginx.virtualHost` | `localhost` | nginx virtual host name. |
 | `extraEnvironment` | `{}` | Additional environment variables for the backend. |
+| `garmin.enable` | `false` | Run the Garmin Connect microservice (see below). |
 
 To point at an external database instead, set `database.createLocally = false`
 and configure `database.host`, `database.port`, `database.name`,
 `database.user` and the corresponding passwords in `environmentFile`.
+
+## Garmin Connect integration
+
+The Garmin integration needs a separate Python microservice
+(`SparkyFitnessGarmin`) that the backend calls over HTTP. Enable it with:
+
+```nix
+services.sparkyfitness.garmin.enable = true;
+```
+
+That starts a `sparkyfitness-garmin.service` systemd unit and sets
+`GARMIN_MICROSERVICE_URL` on the backend for you. No extra secrets are needed:
+Garmin credentials are entered per user in the web UI and stored by the backend.
+
+| Option | Default | Description |
+|---|---|---|
+| `garmin.enable` | `false` | Run the microservice as a systemd unit and point the backend at it. |
+| `garmin.port` | `8000` | Listen port. |
+| `garmin.bindAddress` | `127.0.0.1` | Listen address. |
+| `garmin.isCN` | `false` | Use the Garmin China (CN) region endpoints. |
+| `garmin.stateDir` | `/var/lib/sparkyfitness-garmin` | Working directory (holds `mock_data`). |
+| `garmin.user` / `garmin.group` | `sparkyfitness-garmin` | Service account, separate from the backend's. |
+| `garmin.extraEnvironment` | `{}` | Additional environment variables (e.g. `SPARKY_FITNESS_GARMIN_DATA_SOURCE`). |
+
 
 ## Local build and development
 
 ```bash
 nix build .#sparkyfitness-server
 nix build .#sparkyfitness-frontend
+nix build .#sparkyfitness-garmin
 
 nix develop   # dev shell with node 24, pnpm and postgresql
 ```
@@ -116,6 +142,9 @@ nix/update-hashes.sh
 # or, if nix is not on PATH:
 NIX=/path/to/nix nix/update-hashes.sh
 ```
+
+The Garmin package needs no hash refresh: its dependencies come from nixpkgs
+Python packages rather than a lockfile.
 
 See [`nix/README.md`](https://github.com/CodeWithCJ/SparkyFitness/blob/main/nix/README.md)
 in the repository for the full layout and additional detail.

--- a/flake.nix
+++ b/flake.nix
@@ -35,10 +35,16 @@
         sparkyfitness-frontend = pkgs.callPackage ./nix/frontend.nix {
           inherit nodejs pnpm fetchPnpmDeps pnpmConfigHook;
         };
+
+        sparkyfitness-garmin = pkgs.callPackage ./nix/garmin.nix { };
       in
       {
         packages = {
-          inherit sparkyfitness-server sparkyfitness-frontend;
+          inherit
+            sparkyfitness-server
+            sparkyfitness-frontend
+            sparkyfitness-garmin
+            ;
           default = sparkyfitness-server;
         };
 
@@ -51,7 +57,11 @@
         };
 
         checks = {
-          inherit sparkyfitness-server sparkyfitness-frontend;
+          inherit
+            sparkyfitness-server
+            sparkyfitness-frontend
+            sparkyfitness-garmin
+            ;
         };
       }
     )
@@ -71,6 +81,7 @@
           config.services.sparkyfitness = {
             backendPackage = self.packages.${pkgs.system}.sparkyfitness-server;
             frontendPackage = self.packages.${pkgs.system}.sparkyfitness-frontend;
+            garmin.package = self.packages.${pkgs.system}.sparkyfitness-garmin;
           };
         };
     };

--- a/nix/README.md
+++ b/nix/README.md
@@ -8,8 +8,10 @@ This directory contains a Nix flake and a NixOS module for running SparkyFitness
 - [`../flake.nix`](../flake.nix) — packages, dev shell and NixOS modules.
 - [`backend.nix`](./backend.nix) — the Express API server (`tsx index.ts`).
 - [`frontend.nix`](./frontend.nix) — the static Vite build.
+- [`garmin.nix`](./garmin.nix) — the Garmin Connect microservice
 - [`module.nix`](./module.nix) — the `services.sparkyfitness` NixOS module
-  (systemd backend service, optional local PostgreSQL, nginx reverse proxy).
+  (systemd backend service, optional local PostgreSQL, optional Garmin
+  microservice, nginx reverse proxy).
 - [`update-hashes.sh`](./update-hashes.sh) — recompute the pnpm dependency
   hashes after `pnpm-lock.yaml` changes.
 
@@ -18,6 +20,7 @@ This directory contains a Nix flake and a NixOS module for running SparkyFitness
 ```bash
 nix build .#sparkyfitness-server
 nix build .#sparkyfitness-frontend
+nix build .#sparkyfitness-garmin
 ```
 
 > **Updating dependency hashes:** the `pnpmDeps.hash` values in `backend.nix`
@@ -67,7 +70,17 @@ nix develop
 
 Use `nixosModules.sparkyfitness` to get this flake's package builds wired in
 automatically, or `nixosModules.default` and set `backendPackage` /
-`frontendPackage` yourself.
+`frontendPackage` (and `garmin.package`, if Garmin is enabled) yourself.
+
+### Garmin Connect microservice
+
+```nix
+services.sparkyfitness.garmin.enable = true;
+```
+
+Starts `sparkyfitness-garmin.service` under its own `sparkyfitness-garmin`
+system user and sets `GARMIN_MICROSERVICE_URL` on the backend. It listens on
+`127.0.0.1:8000` by default.
 
 ### Required secrets (`environmentFile`)
 

--- a/nix/garmin.nix
+++ b/nix/garmin.nix
@@ -1,0 +1,59 @@
+# Garmin Connect microservice package (SparkyFitnessGarmin).
+
+{
+  lib,
+  stdenvNoCC,
+  python3,
+  makeWrapper,
+}:
+let
+  # Mirrors SparkyFitnessGarmin/requirements.txt.
+  pythonEnv = python3.withPackages (ps: [
+    ps.fastapi
+    ps.uvicorn
+    ps.garminconnect
+    ps.curl-cffi
+    ps.ua-generator
+    ps.python-dotenv
+  ]);
+in
+stdenvNoCC.mkDerivation {
+  pname = "sparkyfitness-garmin";
+  version = (lib.importJSON ../SparkyFitnessServer/package.json).version;
+
+  src = lib.cleanSource ../SparkyFitnessGarmin;
+
+  nativeBuildInputs = [
+    makeWrapper
+    pythonEnv
+  ];
+
+  dontBuild = true;
+
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+    python -m compileall -q main.py routes.py schemas.py service.py
+    runHook postCheck
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    appDir="$out/libexec/sparkyfitness-garmin"
+    install -Dm644 -t "$appDir" main.py routes.py schemas.py service.py
+
+    makeWrapper ${pythonEnv.interpreter} "$out/bin/sparkyfitness-garmin" \
+      --add-flags "-m uvicorn" \
+      --add-flags "main:app" \
+      --prefix PYTHONPATH : "$appDir"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "SparkyFitness Garmin Connect microservice (FastAPI)";
+    mainProgram = "sparkyfitness-garmin";
+    platforms = lib.platforms.all;
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -323,6 +323,16 @@ in
         sparkyfitness-garmin = { };
       };
 
+    # State directories under /var/lib are provisioned via StateDirectory.
+    # custom locations need explicit creation 
+    systemd.tmpfiles.rules =
+      lib.optional (
+        !lib.hasPrefix "/var/lib/" cfg.stateDir
+      ) "d ${cfg.stateDir} 0750 ${cfg.user} ${cfg.group} -"
+      ++ lib.optional (
+        cfg.garmin.enable && !lib.hasPrefix "/var/lib/" cfg.garmin.stateDir
+      ) "d ${cfg.garmin.stateDir} 0750 ${cfg.garmin.user} ${cfg.garmin.group} -";
+
     # --- Local PostgreSQL -----------------------------------------------------
     services.postgresql = lib.mkIf cfg.database.createLocally {
       enable = lib.mkDefault true;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -13,6 +13,13 @@
 let
   cfg = config.services.sparkyfitness;
 
+  # bracket the IPv6 addresses
+  garminHost =
+    if lib.hasInfix ":" cfg.garmin.bindAddress then
+      "[${cfg.garmin.bindAddress}]"
+    else
+      cfg.garmin.bindAddress;
+
   # Non-secret runtime environment derived from the module options. Secrets
   # (passwords, encryption key, auth secret) come from cfg.environmentFile.
   baseEnv = {
@@ -30,7 +37,7 @@ let
     SPARKY_FITNESS_LOG_LEVEL = cfg.logLevel;
   }
   // lib.optionalAttrs cfg.garmin.enable {
-    GARMIN_MICROSERVICE_URL = "http://${cfg.garmin.bindAddress}:${toString cfg.garmin.port}";
+    GARMIN_MICROSERVICE_URL = "http://${garminHost}:${toString cfg.garmin.port}";
   }
   // cfg.extraEnvironment;
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -13,12 +13,26 @@
 let
   cfg = config.services.sparkyfitness;
 
-  # bracket the IPv6 addresses
+  # Backend-facing host for the Garmin service URL
   garminHost =
-    if lib.hasInfix ":" cfg.garmin.bindAddress then
-      "[${cfg.garmin.bindAddress}]"
-    else
-      cfg.garmin.bindAddress;
+    let
+      addr =
+        if cfg.garmin.bindAddress == "0.0.0.0" then
+          "127.0.0.1"
+        else if cfg.garmin.bindAddress == "::" then
+          "::1"
+        else
+          cfg.garmin.bindAddress;
+    in
+    if lib.hasInfix ":" addr then "[${addr}]" else addr;
+
+  isSharedSystemDir =
+    dir:
+    builtins.elem (lib.removeSuffix "/" dir) [
+      ""
+      "/var"
+      "/var/lib"
+    ];
 
   # Non-secret runtime environment derived from the module options. Secrets
   # (passwords, encryption key, auth secret) come from cfg.environmentFile.
@@ -296,6 +310,14 @@ in
       {
         assertion = cfg.environmentFile != null;
         message = "services.sparkyfitness.environmentFile must be set with the required secrets.";
+      }
+      {
+        assertion = !isSharedSystemDir cfg.stateDir;
+        message = "services.sparkyfitness.stateDir must be a dedicated directory such as /var/lib/sparkyfitness, not ${cfg.stateDir}.";
+      }
+      {
+        assertion = !cfg.garmin.enable || !isSharedSystemDir cfg.garmin.stateDir;
+        message = "services.sparkyfitness.garmin.stateDir must be a dedicated directory such as /var/lib/sparkyfitness-garmin, not ${cfg.garmin.stateDir}.";
       }
     ];
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -29,7 +29,19 @@ let
     SPARKY_FITNESS_CUSTOM_TEMP_DIRECTORY = "${cfg.stateDir}/temp_uploads";
     SPARKY_FITNESS_LOG_LEVEL = cfg.logLevel;
   }
+  // lib.optionalAttrs cfg.garmin.enable {
+    GARMIN_MICROSERVICE_URL = "http://${cfg.garmin.bindAddress}:${toString cfg.garmin.port}";
+  }
   // cfg.extraEnvironment;
+
+  # Non-secret runtime environment for the Garmin microservice. Garmin
+  # credentials are supplied per-user through the web UI, not through the
+  # environment, so this service normally needs no secrets file.
+  garminEnv = {
+    GARMIN_SERVICE_PORT = toString cfg.garmin.port;
+    GARMIN_SERVICE_IS_CN = lib.boolToString cfg.garmin.isCN;
+  }
+  // cfg.garmin.extraEnvironment;
 in
 {
   options.services.sparkyfitness = {
@@ -177,6 +189,86 @@ in
       };
     };
 
+    garmin = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = ''
+          Run the Garmin Connect microservice (`SparkyFitnessGarmin`) as a local
+          systemd service and point the backend at it via
+          GARMIN_MICROSERVICE_URL.
+        '';
+      };
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        description = "The SparkyFitness Garmin microservice package.";
+      };
+
+      user = lib.mkOption {
+        type = lib.types.str;
+        default = "sparkyfitness-garmin";
+        description = ''
+          User account under which the Garmin microservice runs. Kept separate
+          from the backend user by default: the service handles Garmin
+          credentials and needs none of the backend's state.
+        '';
+      };
+
+      group = lib.mkOption {
+        type = lib.types.str;
+        default = "sparkyfitness-garmin";
+        description = "Group under which the Garmin microservice runs.";
+      };
+
+      stateDir = lib.mkOption {
+        type = lib.types.path;
+        default = "/var/lib/sparkyfitness-garmin";
+        description = ''
+          Working directory for the microservice. It creates a `mock_data`
+          subdirectory here on startup.
+        '';
+      };
+
+      port = lib.mkOption {
+        type = lib.types.port;
+        default = 8000;
+        description = "Port the Garmin microservice listens on.";
+      };
+
+      bindAddress = lib.mkOption {
+        type = lib.types.str;
+        default = "127.0.0.1";
+        description = ''
+          Address the Garmin microservice binds to.'';
+      };
+
+      isCN = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Use the Garmin China (CN) region endpoints.";
+      };
+
+      environmentFile = lib.mkOption {
+        type = lib.types.nullOr lib.types.path;
+        default = null;
+        description = ''
+          Optional EnvironmentFile for the Garmin microservice. Not normally
+          needed: Garmin credentials are entered per user in the web UI and
+          stored by the backend.
+        '';
+      };
+
+      extraEnvironment = lib.mkOption {
+        type = lib.types.attrsOf lib.types.str;
+        default = { };
+        example = {
+          SPARKY_FITNESS_GARMIN_DATA_SOURCE = "local";
+        };
+        description = "Additional environment variables passed to the Garmin microservice.";
+      };
+    };
+
     nginx = {
       enable = lib.mkOption {
         type = lib.types.bool;
@@ -200,17 +292,29 @@ in
       }
     ];
 
-    users.users = lib.mkIf (cfg.user == "sparkyfitness") {
-      sparkyfitness = {
-        isSystemUser = true;
-        group = cfg.group;
-        home = cfg.stateDir;
+    users.users =
+      lib.optionalAttrs (cfg.user == "sparkyfitness") {
+        sparkyfitness = {
+          isSystemUser = true;
+          group = cfg.group;
+          home = cfg.stateDir;
+        };
+      }
+      // lib.optionalAttrs (cfg.garmin.enable && cfg.garmin.user == "sparkyfitness-garmin") {
+        sparkyfitness-garmin = {
+          isSystemUser = true;
+          group = cfg.garmin.group;
+          home = cfg.garmin.stateDir;
+        };
       };
-    };
 
-    users.groups = lib.mkIf (cfg.group == "sparkyfitness") {
-      sparkyfitness = { };
-    };
+    users.groups =
+      lib.optionalAttrs (cfg.group == "sparkyfitness") {
+        sparkyfitness = { };
+      }
+      // lib.optionalAttrs (cfg.garmin.enable && cfg.garmin.group == "sparkyfitness-garmin") {
+        sparkyfitness-garmin = { };
+      };
 
     # --- Local PostgreSQL -----------------------------------------------------
     services.postgresql = lib.mkIf cfg.database.createLocally {
@@ -289,7 +393,10 @@ in
       ++ lib.optionals cfg.database.createLocally [
         "postgresql.service"
         "sparkyfitness-db-init.service"
-      ];
+      ]
+      # Ordering only: the backend calls the microservice lazily per sync, so it
+      # must not fail to start when Garmin is down.
+      ++ lib.optionals cfg.garmin.enable [ "sparkyfitness-garmin.service" ];
       requires = lib.optionals cfg.database.createLocally [
         "sparkyfitness-db-init.service"
       ];
@@ -318,6 +425,54 @@ in
 
       preStart = ''
         mkdir -p ${cfg.stateDir}/uploads ${cfg.stateDir}/backup ${cfg.stateDir}/temp_uploads
+      '';
+    };
+
+    # --- Garmin Connect microservice -----------------------------------------
+    systemd.services.sparkyfitness-garmin = lib.mkIf cfg.garmin.enable {
+      description = "SparkyFitness Garmin Connect microservice";
+      wantedBy = [ "multi-user.target" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+
+      environment = garminEnv;
+
+      serviceConfig = {
+        # The package entrypoint is `python -m uvicorn main:app`; host and port
+        # are passed here because main.py would otherwise bind 0.0.0.0.
+        ExecStart = "${lib.getExe cfg.garmin.package} --host ${cfg.garmin.bindAddress} --port ${toString cfg.garmin.port}";
+        User = cfg.garmin.user;
+        Group = cfg.garmin.group;
+        EnvironmentFile = lib.mkIf (cfg.garmin.environmentFile != null) cfg.garmin.environmentFile;
+        StateDirectory = lib.mkIf (lib.hasPrefix "/var/lib/" cfg.garmin.stateDir) (
+          lib.removePrefix "/var/lib/" cfg.garmin.stateDir
+        );
+        WorkingDirectory = cfg.garmin.stateDir;
+        Restart = "on-failure";
+        RestartSec = 5;
+
+        NoNewPrivileges = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        PrivateTmp = true;
+        PrivateDevices = true;
+        ProtectKernelTunables = true;
+        ProtectKernelModules = true;
+        ProtectControlGroups = true;
+        RestrictAddressFamilies = [
+          "AF_INET"
+          "AF_INET6"
+          "AF_UNIX"
+        ];
+        RestrictNamespaces = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = false;
+        SystemCallArchitectures = "native";
+        ReadWritePaths = [ cfg.garmin.stateDir ];
+      };
+
+      preStart = ''
+        mkdir -p ${cfg.garmin.stateDir}/mock_data
       '';
     };
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Makes it easier to run the garmin connect service on NixOS.

**How did you implement the solution?**
Created a nix derivation for the garmin connect service, and a systemd unit for it. Then extended the NixOS
module to allow configuring it.

Linked Issue: Closes https://github.com/CodeWithCJ/SparkyFitness/issues/1971

## How to Test
1. Replace your nix module input with my branch.
2. Set `services.sparkyfitness.garmin.enable = true;` in your nix config.
3. Rebuild and confirm the systemd service starts.
4. Try and sync through the UI.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots


## Notes for Reviewers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional Garmin Connect integration for NixOS deployments with a dedicated microservice.
  * Added a buildable `sparkyfitness-garmin` package to the flake and included it in automated checks.
  * Expanded NixOS options for enabling Garmin, binding/port, region/CN mode, state directory, and extra environment settings.
* **Improvements**
  * Hardened the Garmin service startup with dedicated runtime identity, safer state directory handling, and automatic mock-data directory preparation.
* **Documentation**
  * Updated NixOS installation and Nix build/development/deployment docs with Garmin Connect setup and commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->