### PR TITLE
fix: make meal container meal-type moves metadata-only

### DIFF
--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -1924,30 +1924,49 @@ Actions:
                     }
                   );
                 } else {
-                  // Round-trip the template link and component foods so the
-                  // server's edit path rescales components instead of
-                  // detaching them.
-                  const existing =
-                    await foodEntryService.getFoodEntryMealWithComponents(
+                  // Changing ONLY the meal type of a meal container is a
+                  // metadata-only operation: route it through
+                  // moveFoodEntryMealToMealType so the component food_entries
+                  // and their historical nutrition snapshots are preserved.
+                  // The full round-trip below (delete + rebuild) is only for
+                  // actual quantity/unit changes.
+                  if (
+                    mealType &&
+                    args.quantity === undefined &&
+                    args.unit === undefined
+                  ) {
+                    await foodEntryService.moveFoodEntryMealToMealType(
                       userId,
-                      args.entry_id
+                      userId,
+                      args.entry_id,
+                      mealType.id
                     );
-                  if (!existing) {
-                    return ERRORS.NOT_FOUND('Entry', args.entry_id);
-                  }
-                  await foodEntryService.updateFoodEntryMeal(
-                    userId,
-                    userId,
-                    args.entry_id,
-                    {
-                      meal_template_id: existing.meal_template_id,
-                      entry_date: dayString(existing.entry_date),
-                      quantity: args.quantity ?? existing.quantity,
-                      unit: args.unit ?? existing.unit,
-                      ...mealTypeUpdate,
-                      foods: existing.foods,
+                  } else {
+                    // Round-trip the template link and component foods so the
+                    // server's edit path rescales components instead of
+                    // detaching them.
+                    const existing =
+                      await foodEntryService.getFoodEntryMealWithComponents(
+                        userId,
+                        args.entry_id
+                      );
+                    if (!existing) {
+                      return ERRORS.NOT_FOUND('Entry', args.entry_id);
                     }
-                  );
+                    await foodEntryService.updateFoodEntryMeal(
+                      userId,
+                      userId,
+                      args.entry_id,
+                      {
+                        meal_template_id: existing.meal_template_id,
+                        entry_date: dayString(existing.entry_date),
+                        quantity: args.quantity ?? existing.quantity,
+                        unit: args.unit ?? existing.unit,
+                        ...mealTypeUpdate,
+                        foods: existing.foods,
+                      }
+                    );
+                  }
                 }
               } catch (error) {
                 if (

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -1913,6 +1913,11 @@ Actions:
                 : {};
               let quantityChanged = args.quantity !== undefined;
               let unitChanged = args.unit !== undefined;
+              // For a food_entry the type is written whenever a selector is
+              // present; for a food_entry_meal it is refined below against the
+              // container's current meal_type_id so unchanged categories are
+              // not reported as changed.
+              let mealTypeChanged = mealType !== undefined;
               try {
                 if (args.entry_type === 'food_entry') {
                   await foodEntryService.updateFoodEntry(
@@ -1944,7 +1949,7 @@ Actions:
                     Number(args.quantity) !== Number(existingMeta.quantity);
                   unitChanged =
                     args.unit !== undefined && args.unit !== existingMeta.unit;
-                  const mealTypeChanged =
+                  mealTypeChanged =
                     mealType !== undefined &&
                     mealType.id !== existingMeta.meal_type_id;
 
@@ -1952,6 +1957,11 @@ Actions:
                     // No effective quantity/unit change: either a metadata-only
                     // category move, or a genuine no-op.
                     if (mealTypeChanged) {
+                      if (!mealType) {
+                        return ERRORS.VALIDATION(
+                          'Meal type could not be resolved.'
+                        );
+                      }
                       await foodEntryService.moveFoodEntryMealToMealType(
                         userId,
                         userId,
@@ -2004,9 +2014,9 @@ Actions:
               const updates = [
                 quantityChanged ? `quantity to ${args.quantity}` : '',
                 unitChanged ? `unit to ${args.unit}` : '',
-                mealType ? `meal type to ${mealType.name}` : '',
+                mealTypeChanged ? `meal type to ${mealType?.name}` : '',
               ].filter(Boolean);
-              if (quantityChanged && unitChanged && !mealType) {
+              if (quantityChanged && unitChanged && !mealTypeChanged) {
                 return formatConfirmation(
                   `Entry updated to ${args.quantity} ${args.unit}.`
                 );

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -1911,6 +1911,8 @@ Actions:
               const mealTypeUpdate = mealType
                 ? { meal_type_id: mealType.id }
                 : {};
+              let quantityChanged = args.quantity !== undefined;
+              let unitChanged = args.unit !== undefined;
               try {
                 if (args.entry_type === 'food_entry') {
                   await foodEntryService.updateFoodEntry(
@@ -1924,17 +1926,26 @@ Actions:
                     }
                   );
                 } else {
-                  // Changing ONLY the meal type of a meal container is a
-                  // metadata-only operation: route it through
-                  // moveFoodEntryMealToMealType so the component food_entries
-                  // and their historical nutrition snapshots are preserved.
-                  // The full round-trip below (delete + rebuild) is only for
-                  // actual quantity/unit changes.
-                  if (
-                    mealType &&
-                    args.quantity === undefined &&
-                    args.unit === undefined
-                  ) {
+                  // Lightweight parent read (no components) to decide whether
+                  // the quantity/unit actually change. A redundant quantity or
+                  // unit copied from list_diary must not trigger the full
+                  // delete-and-rebuild path — only a real quantity/unit change
+                  // (or no meal type change at all) goes through
+                  // updateFoodEntryMeal.
+                  const existingMeta =
+                    await foodEntryService.getFoodEntryMealMeta(
+                      userId,
+                      args.entry_id
+                    );
+                  if (!existingMeta) {
+                    return ERRORS.NOT_FOUND('Entry', args.entry_id);
+                  }
+                  quantityChanged =
+                    args.quantity !== undefined &&
+                    Number(args.quantity) !== Number(existingMeta.quantity);
+                  unitChanged =
+                    args.unit !== undefined && args.unit !== existingMeta.unit;
+                  if (mealType && !quantityChanged && !unitChanged) {
                     await foodEntryService.moveFoodEntryMealToMealType(
                       userId,
                       userId,
@@ -1978,17 +1989,11 @@ Actions:
                 throw error;
               }
               const updates = [
-                args.quantity !== undefined
-                  ? `quantity to ${args.quantity}`
-                  : '',
-                args.unit !== undefined ? `unit to ${args.unit}` : '',
+                quantityChanged ? `quantity to ${args.quantity}` : '',
+                unitChanged ? `unit to ${args.unit}` : '',
                 mealType ? `meal type to ${mealType.name}` : '',
               ].filter(Boolean);
-              if (
-                args.quantity !== undefined &&
-                args.unit !== undefined &&
-                !mealType
-              ) {
+              if (quantityChanged && unitChanged && !mealType) {
                 return formatConfirmation(
                   `Entry updated to ${args.quantity} ${args.unit}.`
                 );

--- a/SparkyFitnessServer/ai/tools/foodTools.ts
+++ b/SparkyFitnessServer/ai/tools/foodTools.ts
@@ -1928,10 +1928,9 @@ Actions:
                 } else {
                   // Lightweight parent read (no components) to decide whether
                   // the quantity/unit actually change. A redundant quantity or
-                  // unit copied from list_diary must not trigger the full
-                  // delete-and-rebuild path — only a real quantity/unit change
-                  // (or no meal type change at all) goes through
-                  // updateFoodEntryMeal.
+                  // unit copied from list_diary (or a plain no-op) must never
+                  // trigger the destructive delete-and-rebuild path — only a
+                  // real quantity/unit change does.
                   const existingMeta =
                     await foodEntryService.getFoodEntryMealMeta(
                       userId,
@@ -1945,39 +1944,53 @@ Actions:
                     Number(args.quantity) !== Number(existingMeta.quantity);
                   unitChanged =
                     args.unit !== undefined && args.unit !== existingMeta.unit;
-                  if (mealType && !quantityChanged && !unitChanged) {
-                    await foodEntryService.moveFoodEntryMealToMealType(
-                      userId,
-                      userId,
-                      args.entry_id,
-                      mealType.id
-                    );
-                  } else {
-                    // Round-trip the template link and component foods so the
-                    // server's edit path rescales components instead of
-                    // detaching them.
-                    const existing =
-                      await foodEntryService.getFoodEntryMealWithComponents(
+                  const mealTypeChanged =
+                    mealType !== undefined &&
+                    mealType.id !== existingMeta.meal_type_id;
+
+                  if (!quantityChanged && !unitChanged) {
+                    // No effective quantity/unit change: either a metadata-only
+                    // category move, or a genuine no-op.
+                    if (mealTypeChanged) {
+                      await foodEntryService.moveFoodEntryMealToMealType(
                         userId,
-                        args.entry_id
+                        userId,
+                        args.entry_id,
+                        mealType.id
                       );
-                    if (!existing) {
-                      return ERRORS.NOT_FOUND('Entry', args.entry_id);
+                      return formatConfirmation(
+                        `Entry updated: meal type to ${mealType.name}.`
+                      );
                     }
-                    await foodEntryService.updateFoodEntryMeal(
-                      userId,
-                      userId,
-                      args.entry_id,
-                      {
-                        meal_template_id: existing.meal_template_id,
-                        entry_date: dayString(existing.entry_date),
-                        quantity: args.quantity ?? existing.quantity,
-                        unit: args.unit ?? existing.unit,
-                        ...mealTypeUpdate,
-                        foods: existing.foods,
-                      }
+                    return formatConfirmation(
+                      'Entry already has the requested values.'
                     );
                   }
+
+                  // Real quantity/unit change: round-trip the template link and
+                  // component foods so the server's edit path rescales
+                  // components instead of detaching them.
+                  const existing =
+                    await foodEntryService.getFoodEntryMealWithComponents(
+                      userId,
+                      args.entry_id
+                    );
+                  if (!existing) {
+                    return ERRORS.NOT_FOUND('Entry', args.entry_id);
+                  }
+                  await foodEntryService.updateFoodEntryMeal(
+                    userId,
+                    userId,
+                    args.entry_id,
+                    {
+                      meal_template_id: existing.meal_template_id,
+                      entry_date: dayString(existing.entry_date),
+                      quantity: args.quantity ?? existing.quantity,
+                      unit: args.unit ?? existing.unit,
+                      ...mealTypeUpdate,
+                      foods: existing.foods,
+                    }
+                  );
                 }
               } catch (error) {
                 if (

--- a/SparkyFitnessServer/models/foodEntryMealRepository.ts
+++ b/SparkyFitnessServer/models/foodEntryMealRepository.ts
@@ -299,8 +299,7 @@ async function moveFoodEntryMealToMealType(
     await client.query(
       `UPDATE food_entries
        SET meal_type_id = $1,
-           updated_by_user_id = $2,
-           updated_at = CURRENT_TIMESTAMP
+           updated_by_user_id = $2
        WHERE food_entry_meal_id = $3 AND user_id = $4`,
       [mealTypeId, updatedByUserId, foodEntryMealId, userId]
     );

--- a/SparkyFitnessServer/models/foodEntryMealRepository.ts
+++ b/SparkyFitnessServer/models/foodEntryMealRepository.ts
@@ -261,20 +261,22 @@ async function deleteFoodEntryMeal(foodEntryMealId: any, userId: any) {
     client.release();
   }
 }
+// Result of a metadata-only meal-type move.
+export interface MealEntryMoveResult {
+  id: string;
+  meal_type_id: string;
+}
+
 // Metadata-only move of a meal container (and its component food_entries) to
 // another meal type, in one transaction. Unlike updateFoodEntryMeal, this
 // does NOT delete and rebuild the components, so historical nutrition
 // snapshots and quantities are preserved untouched.
 async function moveFoodEntryMealToMealType(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  foodEntryMealId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  mealTypeId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  updatedByUserId: any
-) {
+  foodEntryMealId: string,
+  mealTypeId: string,
+  userId: string,
+  updatedByUserId: string
+): Promise<MealEntryMoveResult> {
   log(
     'info',
     `moveFoodEntryMealToMealType in foodEntryMealRepository: foodEntryMealId: ${foodEntryMealId}, mealTypeId: ${mealTypeId}, userId: ${userId}`
@@ -288,7 +290,7 @@ async function moveFoodEntryMealToMealType(
            updated_by_user_id = $2,
            updated_at = CURRENT_TIMESTAMP
        WHERE id = $3 AND user_id = $4
-       RETURNING id`,
+       RETURNING id, meal_type_id`,
       [mealTypeId, updatedByUserId, foodEntryMealId, userId]
     );
     if (parent.rows.length === 0) {
@@ -303,7 +305,7 @@ async function moveFoodEntryMealToMealType(
       [mealTypeId, updatedByUserId, foodEntryMealId, userId]
     );
     await client.query('COMMIT');
-    return parent.rows[0];
+    return parent.rows[0] as MealEntryMoveResult;
   } catch (error) {
     await client.query('ROLLBACK');
     log(

--- a/SparkyFitnessServer/models/foodEntryMealRepository.ts
+++ b/SparkyFitnessServer/models/foodEntryMealRepository.ts
@@ -261,12 +261,68 @@ async function deleteFoodEntryMeal(foodEntryMealId: any, userId: any) {
     client.release();
   }
 }
+// Metadata-only move of a meal container (and its component food_entries) to
+// another meal type, in one transaction. Unlike updateFoodEntryMeal, this
+// does NOT delete and rebuild the components, so historical nutrition
+// snapshots and quantities are preserved untouched.
+async function moveFoodEntryMealToMealType(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  foodEntryMealId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mealTypeId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  updatedByUserId: any
+) {
+  log(
+    'info',
+    `moveFoodEntryMealToMealType in foodEntryMealRepository: foodEntryMealId: ${foodEntryMealId}, mealTypeId: ${mealTypeId}, userId: ${userId}`
+  );
+  const client = await getClient(userId, updatedByUserId);
+  try {
+    await client.query('BEGIN');
+    const parent = await client.query(
+      `UPDATE food_entry_meals
+       SET meal_type_id = $1,
+           updated_by_user_id = $2,
+           updated_at = CURRENT_TIMESTAMP
+       WHERE id = $3 AND user_id = $4
+       RETURNING id`,
+      [mealTypeId, updatedByUserId, foodEntryMealId, userId]
+    );
+    if (parent.rows.length === 0) {
+      throw new Error('Food entry meal not found or not authorized to update.');
+    }
+    await client.query(
+      `UPDATE food_entries
+       SET meal_type_id = $1,
+           updated_by_user_id = $2,
+           updated_at = CURRENT_TIMESTAMP
+       WHERE food_entry_meal_id = $3 AND user_id = $4`,
+      [mealTypeId, updatedByUserId, foodEntryMealId, userId]
+    );
+    await client.query('COMMIT');
+    return parent.rows[0];
+  } catch (error) {
+    await client.query('ROLLBACK');
+    log(
+      'error',
+      `Error moving food entry meal ${foodEntryMealId} to meal type ${mealTypeId} in repository:`,
+      error
+    );
+    throw error;
+  } finally {
+    client.release();
+  }
+}
 export { createFoodEntryMeal };
 export { updateFoodEntryMeal };
 export { getFoodEntryMealById };
 export { getFoodEntryMealsByDate };
 export { getFoodEntryMealsByDateRange };
 export { deleteFoodEntryMeal };
+export { moveFoodEntryMealToMealType };
 export default {
   createFoodEntryMeal,
   updateFoodEntryMeal,
@@ -274,4 +330,5 @@ export default {
   getFoodEntryMealsByDate,
   getFoodEntryMealsByDateRange,
   deleteFoodEntryMeal,
+  moveFoodEntryMealToMealType,
 };

--- a/SparkyFitnessServer/services/foodEntryService.ts
+++ b/SparkyFitnessServer/services/foodEntryService.ts
@@ -1,5 +1,7 @@
 import foodRepository from '../models/foodRepository.js';
-import foodEntryMealRepository from '../models/foodEntryMealRepository.js';
+import foodEntryMealRepository, {
+  type MealEntryMoveResult,
+} from '../models/foodEntryMealRepository.js';
 import mealRepository from '../models/mealRepository.js';
 import familyAccessRepository from '../models/familyAccessRepository.js';
 import { log } from '../config/logging.js';
@@ -1906,21 +1908,47 @@ async function createFoodEntryMeal(
     throw error;
   }
 }
+// Lightweight parent read for a meal container, without its component
+// food_entries. Used to decide whether a quantity/unit change is real before
+// choosing between the metadata-only move and the full rebuild path.
+export interface FoodEntryMealMeta {
+  id: string;
+  quantity: number | null;
+  unit: string | null;
+  meal_type_id: string | null;
+}
+
+async function getFoodEntryMealMeta(
+  userId: string,
+  foodEntryMealId: string
+): Promise<FoodEntryMealMeta | null> {
+  const row = await foodEntryMealRepository.getFoodEntryMealById(
+    foodEntryMealId,
+    userId
+  );
+  if (!row) return null;
+  return {
+    id: row.id,
+    quantity:
+      row.quantity !== null && row.quantity !== undefined
+        ? Number(row.quantity)
+        : null,
+    unit: row.unit ?? null,
+    meal_type_id: row.meal_type_id ?? null,
+  };
+}
+
 // Metadata-only move of a meal container (and its components) to another meal
 // type. This intentionally avoids the delete-and-rebuild path used by
 // updateFoodEntryMeal: moving a meal between categories must not re-read
 // current food variants or rewrite the historical nutrition snapshots, and
 // must not drop components when a food/variant is no longer available.
 async function moveFoodEntryMealToMealType(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authenticatedUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  actingUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  foodEntryMealId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  mealTypeId: any
-) {
+  authenticatedUserId: string,
+  actingUserId: string,
+  foodEntryMealId: string,
+  mealTypeId: string
+): Promise<MealEntryMoveResult> {
   try {
     const updated = await foodEntryMealRepository.moveFoodEntryMealToMealType(
       foodEntryMealId,
@@ -3345,6 +3373,7 @@ export { copyAllFoodEntriesFromYesterday };
 export { getDailyNutritionSummary };
 export { createFoodEntryMeal };
 export { moveFoodEntryMealToMealType };
+export { getFoodEntryMealMeta };
 export { updateFoodEntryMeal };
 export { getFoodEntryMealWithComponents };
 export { getFoodEntryMealsByDate };
@@ -3366,6 +3395,7 @@ export default {
   getDailyNutritionSummary,
   createFoodEntryMeal,
   moveFoodEntryMealToMealType,
+  getFoodEntryMealMeta,
   updateFoodEntryMeal,
   getFoodEntryMealWithComponents,
   getFoodEntryMealsByDate,

--- a/SparkyFitnessServer/services/foodEntryService.ts
+++ b/SparkyFitnessServer/services/foodEntryService.ts
@@ -1906,6 +1906,38 @@ async function createFoodEntryMeal(
     throw error;
   }
 }
+// Metadata-only move of a meal container (and its components) to another meal
+// type. This intentionally avoids the delete-and-rebuild path used by
+// updateFoodEntryMeal: moving a meal between categories must not re-read
+// current food variants or rewrite the historical nutrition snapshots, and
+// must not drop components when a food/variant is no longer available.
+async function moveFoodEntryMealToMealType(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authenticatedUserId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  actingUserId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  foodEntryMealId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mealTypeId: any
+) {
+  try {
+    const updated = await foodEntryMealRepository.moveFoodEntryMealToMealType(
+      foodEntryMealId,
+      mealTypeId,
+      authenticatedUserId,
+      actingUserId
+    );
+    return updated;
+  } catch (error) {
+    log(
+      'error',
+      `Error moving food entry meal ${foodEntryMealId} to meal type ${mealTypeId} for user ${authenticatedUserId}:`,
+      error
+    );
+    throw error;
+  }
+}
 async function updateFoodEntryMeal(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   authenticatedUserId: any,
@@ -3312,6 +3344,7 @@ export { copyAllFoodEntries };
 export { copyAllFoodEntriesFromYesterday };
 export { getDailyNutritionSummary };
 export { createFoodEntryMeal };
+export { moveFoodEntryMealToMealType };
 export { updateFoodEntryMeal };
 export { getFoodEntryMealWithComponents };
 export { getFoodEntryMealsByDate };
@@ -3332,6 +3365,7 @@ export default {
   copyAllFoodEntriesFromYesterday,
   getDailyNutritionSummary,
   createFoodEntryMeal,
+  moveFoodEntryMealToMealType,
   updateFoodEntryMeal,
   getFoodEntryMealWithComponents,
   getFoodEntryMealsByDate,

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -33,6 +33,7 @@ vi.mock('../services/foodEntryService', () => ({
     updateFoodEntry: vi.fn(),
     updateFoodEntryMeal: vi.fn(),
     moveFoodEntryMealToMealType: vi.fn(),
+    getFoodEntryMealMeta: vi.fn(),
     getFoodEntryMealWithComponents: vi.fn(),
     copyFoodEntries: vi.fn(),
     copyAllFoodEntries: vi.fn(),
@@ -2194,6 +2195,12 @@ describe('update_entry', () => {
     const componentFoods = [
       { food_id: FOOD_ID, variant_id: VARIANT_ID, quantity: 100, unit: 'g' },
     ];
+    vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue({
+      id: ENTRY_ID,
+      quantity: 1,
+      unit: 'g',
+      meal_type_id: null,
+    });
     vi.mocked(
       foodEntryService.getFoodEntryMealWithComponents
     ).mockResolvedValue({
@@ -2241,8 +2248,15 @@ describe('update_entry', () => {
       id: MEAL_TYPE_ID,
       name: 'Second breakfast',
     });
+    vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue({
+      id: ENTRY_ID,
+      quantity: 1,
+      unit: 'serving',
+      meal_type_id: null,
+    });
     vi.mocked(foodEntryService.moveFoodEntryMealToMealType).mockResolvedValue({
       id: ENTRY_ID,
+      meal_type_id: MEAL_TYPE_ID,
     });
 
     const result = await tools.sparky_manage_food.execute!(
@@ -2268,10 +2282,134 @@ describe('update_entry', () => {
     expect(foodEntryService.updateFoodEntryMeal).not.toHaveBeenCalled();
   });
 
-  it('maps a missing meal entry to NOT_FOUND', async () => {
+  // A redundant quantity copied from list_diary must not trigger a rebuild:
+  // when the value equals the container's current quantity the move stays
+  // metadata-only.
+  it('moves a meal entry when a redundant quantity equals the existing value', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue({
+      id: ENTRY_ID,
+      quantity: 1,
+      unit: 'serving',
+      meal_type_id: null,
+    });
+    vi.mocked(foodEntryService.moveFoodEntryMealToMealType).mockResolvedValue({
+      id: ENTRY_ID,
+      meal_type_id: MEAL_TYPE_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+        meal_type_id: MEAL_TYPE_ID,
+        quantity: 1,
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry updated: meal type to Second breakfast.');
+    expect(foodEntryService.moveFoodEntryMealToMealType).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      ENTRY_ID,
+      MEAL_TYPE_ID
+    );
+    expect(foodEntryService.updateFoodEntryMeal).not.toHaveBeenCalled();
+    expect(
+      foodEntryService.getFoodEntryMealWithComponents
+    ).not.toHaveBeenCalled();
+  });
+
+  // Same for a redundant unit that equals the existing unit.
+  it('moves a meal entry when a redundant unit equals the existing value', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue({
+      id: ENTRY_ID,
+      quantity: 1,
+      unit: 'serving',
+      meal_type_id: null,
+    });
+    vi.mocked(foodEntryService.moveFoodEntryMealToMealType).mockResolvedValue({
+      id: ENTRY_ID,
+      meal_type_id: MEAL_TYPE_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+        meal_type_id: MEAL_TYPE_ID,
+        unit: 'serving',
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry updated: meal type to Second breakfast.');
+    expect(foodEntryService.moveFoodEntryMealToMealType).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      ENTRY_ID,
+      MEAL_TYPE_ID
+    );
+    expect(foodEntryService.updateFoodEntryMeal).not.toHaveBeenCalled();
+  });
+
+  // A REAL quantity change still uses the full rebuild path (components are
+  // re-scaled to the new portion).
+  it('rebuilds components when the quantity actually changes', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue({
+      id: ENTRY_ID,
+      quantity: 1,
+      unit: 'serving',
+      meal_type_id: null,
+    });
     vi.mocked(
       foodEntryService.getFoodEntryMealWithComponents
-    ).mockResolvedValue(null);
+    ).mockResolvedValue({
+      id: ENTRY_ID,
+      meal_template_id: MEAL_ID,
+      entry_date: new Date(2026, 5, 10),
+      foods: [
+        { food_id: FOOD_ID, variant_id: VARIANT_ID, quantity: 100, unit: 'g' },
+      ],
+    });
+    vi.mocked(foodEntryService.updateFoodEntryMeal).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+        meal_type_id: MEAL_TYPE_ID,
+        quantity: 2,
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Entry updated: quantity to 2, meal type to Second breakfast.'
+    );
+    expect(foodEntryService.updateFoodEntryMeal).toHaveBeenCalled();
+    expect(foodEntryService.moveFoodEntryMealToMealType).not.toHaveBeenCalled();
+  });
+
+  it('maps a missing meal entry to NOT_FOUND', async () => {
+    vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue(null);
 
     const result = await tools.sparky_manage_food.execute!(
       {
@@ -2728,8 +2866,15 @@ describe('save_as_meal_template', () => {
       id: MEAL_TYPE_ID,
       name: 'Second breakfast',
     });
+    vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue({
+      id: ENTRY_ID,
+      quantity: 1,
+      unit: 'serving',
+      meal_type_id: null,
+    });
     vi.mocked(foodEntryService.moveFoodEntryMealToMealType).mockResolvedValue({
       id: ENTRY_ID,
+      meal_type_id: MEAL_TYPE_ID,
     });
 
     const result = await tools.sparky_manage_food.execute!(

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -32,6 +32,7 @@ vi.mock('../services/foodEntryService', () => ({
     deleteFoodEntryMeal: vi.fn(),
     updateFoodEntry: vi.fn(),
     updateFoodEntryMeal: vi.fn(),
+    moveFoodEntryMealToMealType: vi.fn(),
     getFoodEntryMealWithComponents: vi.fn(),
     copyFoodEntries: vi.fn(),
     copyAllFoodEntries: vi.fn(),
@@ -2231,6 +2232,42 @@ describe('update_entry', () => {
     );
   });
 
+  // Changing ONLY the meal type of a meal container must be a metadata-only
+  // move: it must not round-trip/rebuild the component food_entries (which
+  // would rewrite historical nutrition snapshots or drop components whose
+  // food/variant no longer exists).
+  it('moves a meal entry to a custom meal type without rebuilding its components', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(foodEntryService.moveFoodEntryMealToMealType).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+        meal_type_id: MEAL_TYPE_ID,
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry updated: meal type to Second breakfast.');
+    expect(foodEntryService.moveFoodEntryMealToMealType).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      ENTRY_ID,
+      MEAL_TYPE_ID
+    );
+    expect(
+      foodEntryService.getFoodEntryMealWithComponents
+    ).not.toHaveBeenCalled();
+    expect(foodEntryService.updateFoodEntryMeal).not.toHaveBeenCalled();
+  });
+
   it('maps a missing meal entry to NOT_FOUND', async () => {
     vi.mocked(
       foodEntryService.getFoodEntryMealWithComponents
@@ -2687,16 +2724,12 @@ describe('save_as_meal_template', () => {
   });
 
   it('infers update_entry (not log_meal) for entry_id + meal_name + meal_type_id', async () => {
-    vi.mocked(foodEntryService.updateFoodEntryMeal).mockResolvedValue({
-      id: ENTRY_ID,
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
     });
-    vi.mocked(
-      foodEntryService.getFoodEntryMealWithComponents
-    ).mockResolvedValue({
+    vi.mocked(foodEntryService.moveFoodEntryMealToMealType).mockResolvedValue({
       id: ENTRY_ID,
-      meal_template_id: MEAL_ID,
-      entry_date: new Date(2026, 5, 10),
-      foods: [],
     });
 
     const result = await tools.sparky_manage_food.execute!(
@@ -2710,7 +2743,7 @@ describe('save_as_meal_template', () => {
     );
 
     expect(result).toContain('✅ Entry updated');
-    expect(foodEntryService.updateFoodEntryMeal).toHaveBeenCalled();
+    expect(foodEntryService.moveFoodEntryMealToMealType).toHaveBeenCalled();
     expect(foodEntryService.createFoodEntryMeal).not.toHaveBeenCalled();
   });
 

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -2363,6 +2363,63 @@ describe('update_entry', () => {
     expect(foodEntryService.updateFoodEntryMeal).not.toHaveBeenCalled();
   });
 
+  // A plain no-op (redundant quantity, no meal type change) must not rebuild
+  // components and must not fabricate a change message.
+  it('no-ops when a redundant quantity equals the existing value and no meal type is given', async () => {
+    vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue({
+      id: ENTRY_ID,
+      quantity: 1,
+      unit: 'serving',
+      meal_type_id: 'default-id',
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+        quantity: 1,
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry already has the requested values.');
+    expect(foodEntryService.moveFoodEntryMealToMealType).not.toHaveBeenCalled();
+    expect(foodEntryService.updateFoodEntryMeal).not.toHaveBeenCalled();
+    expect(
+      foodEntryService.getFoodEntryMealWithComponents
+    ).not.toHaveBeenCalled();
+  });
+
+  // Same meal type + redundant quantity/unit: nothing to do, no fake message.
+  it('no-ops when the meal type and quantity are unchanged', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue({
+      id: ENTRY_ID,
+      quantity: 1,
+      unit: 'serving',
+      meal_type_id: MEAL_TYPE_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+        meal_type_id: MEAL_TYPE_ID,
+        quantity: 1,
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry already has the requested values.');
+    expect(foodEntryService.moveFoodEntryMealToMealType).not.toHaveBeenCalled();
+    expect(foodEntryService.updateFoodEntryMeal).not.toHaveBeenCalled();
+  });
+
   // A REAL quantity change still uses the full rebuild path (components are
   // re-scaled to the new portion).
   it('rebuilds components when the quantity actually changes', async () => {

--- a/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsFood.test.ts
@@ -2465,6 +2465,51 @@ describe('update_entry', () => {
     expect(foodEntryService.moveFoodEntryMealToMealType).not.toHaveBeenCalled();
   });
 
+  // A real quantity change with an UNCHANGED meal type must still use the full
+  // rebuild path, but the confirmation must mention only the quantity — the
+  // category did not change.
+  it('rebuilds on a real quantity change but does not report an unchanged meal type', async () => {
+    vi.mocked(mealTypeRepository.getMealTypeById).mockResolvedValue({
+      id: MEAL_TYPE_ID,
+      name: 'Second breakfast',
+    });
+    vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue({
+      id: ENTRY_ID,
+      quantity: 1,
+      unit: 'serving',
+      meal_type_id: MEAL_TYPE_ID,
+    });
+    vi.mocked(
+      foodEntryService.getFoodEntryMealWithComponents
+    ).mockResolvedValue({
+      id: ENTRY_ID,
+      meal_template_id: MEAL_ID,
+      entry_date: new Date(2026, 5, 10),
+      foods: [
+        { food_id: FOOD_ID, variant_id: VARIANT_ID, quantity: 100, unit: 'g' },
+      ],
+    });
+    vi.mocked(foodEntryService.updateFoodEntryMeal).mockResolvedValue({
+      id: ENTRY_ID,
+    });
+
+    const result = await tools.sparky_manage_food.execute!(
+      {
+        action: 'update_entry',
+        entry_id: ENTRY_ID,
+        entry_type: 'food_entry_meal',
+        meal_type_id: MEAL_TYPE_ID,
+        quantity: 2,
+      },
+      opts
+    );
+
+    expect(result).toBe('✅ Entry updated: quantity to 2.');
+    expect(result).not.toContain('meal type');
+    expect(foodEntryService.updateFoodEntryMeal).toHaveBeenCalled();
+    expect(foodEntryService.moveFoodEntryMealToMealType).not.toHaveBeenCalled();
+  });
+
   it('maps a missing meal entry to NOT_FOUND', async () => {
     vi.mocked(foodEntryService.getFoodEntryMealMeta).mockResolvedValue(null);
 

--- a/SparkyFitnessServer/tests/foodEntryMealRepository.test.ts
+++ b/SparkyFitnessServer/tests/foodEntryMealRepository.test.ts
@@ -1,0 +1,153 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { moveFoodEntryMealToMealType } from '../models/foodEntryMealRepository.js';
+import { getClient } from '../db/poolManager.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+describe('foodEntryMealRepository.moveFoodEntryMealToMealType', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+  const MEAL_ENTRY_ID = 'meal-entry-1';
+  const MEAL_TYPE_ID = 'custom-breakfast-id';
+  const USER_ID = 'user-1';
+  const ACTOR_ID = 'actor-1';
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    vi.clearAllMocks();
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  const updateCalls = () =>
+    mockClient.query.mock.calls.filter(
+      ([sql]: [string]) =>
+        typeof sql === 'string' && sql.trim().startsWith('UPDATE')
+    );
+  const rawCalls = () =>
+    mockClient.query.mock.calls.map(([sql]: [string]) =>
+      typeof sql === 'string' ? sql.trim() : String(sql)
+    );
+
+  it('runs BEGIN → UPDATE parent → UPDATE components → COMMIT and releases the client', async () => {
+    mockClient.query.mockImplementation((sql: string) => {
+      const trimmed = sql.trim();
+      if (trimmed.startsWith('UPDATE food_entry_meals')) {
+        return Promise.resolve({
+          rows: [{ id: MEAL_ENTRY_ID, meal_type_id: MEAL_TYPE_ID }],
+        });
+      }
+      if (trimmed.startsWith('UPDATE food_entries')) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const result = await moveFoodEntryMealToMealType(
+      MEAL_ENTRY_ID,
+      MEAL_TYPE_ID,
+      USER_ID,
+      ACTOR_ID
+    );
+
+    expect(result).toEqual({ id: MEAL_ENTRY_ID, meal_type_id: MEAL_TYPE_ID });
+
+    // RLS context: owner + real actor.
+    expect(getClient).toHaveBeenCalledWith(USER_ID, ACTOR_ID);
+
+    const calls = rawCalls();
+    expect(calls).toEqual([
+      'BEGIN',
+      expect.stringContaining('UPDATE food_entry_meals'),
+      expect.stringContaining('UPDATE food_entries'),
+      'COMMIT',
+    ]);
+    expect(calls).not.toContain('ROLLBACK');
+
+    // Parent UPDATE params: mealTypeId, actor, mealEntryId, userId.
+    const parentParams = updateCalls()[0][1];
+    expect(parentParams).toEqual([
+      MEAL_TYPE_ID,
+      ACTOR_ID,
+      MEAL_ENTRY_ID,
+      USER_ID,
+    ]);
+    // Components UPDATE params: same mealTypeId, actor, mealEntryId, userId.
+    const componentsParams = updateCalls()[1][1];
+    expect(componentsParams).toEqual([
+      MEAL_TYPE_ID,
+      ACTOR_ID,
+      MEAL_ENTRY_ID,
+      USER_ID,
+    ]);
+
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back and never runs the components UPDATE when the parent is not found', async () => {
+    mockClient.query.mockImplementation((sql: string) => {
+      const trimmed = sql.trim();
+      if (trimmed.startsWith('UPDATE food_entry_meals')) {
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await expect(
+      moveFoodEntryMealToMealType(
+        MEAL_ENTRY_ID,
+        MEAL_TYPE_ID,
+        USER_ID,
+        ACTOR_ID
+      )
+    ).rejects.toThrow('Food entry meal not found or not authorized to update.');
+
+    const calls = rawCalls();
+    expect(calls[0]).toBe('BEGIN');
+    expect(calls).toContain('ROLLBACK');
+    expect(calls).not.toContain('COMMIT');
+    // No components UPDATE after the parent failed.
+    expect(
+      updateCalls().filter(([sql]: [string]) => sql.includes('food_entries'))
+    ).toHaveLength(0);
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back when the components UPDATE fails', async () => {
+    mockClient.query.mockImplementation((sql: string) => {
+      const trimmed = sql.trim();
+      if (trimmed.startsWith('UPDATE food_entry_meals')) {
+        return Promise.resolve({
+          rows: [{ id: MEAL_ENTRY_ID, meal_type_id: MEAL_TYPE_ID }],
+        });
+      }
+      if (trimmed.startsWith('UPDATE food_entries')) {
+        return Promise.reject(new Error('db exploded'));
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    await expect(
+      moveFoodEntryMealToMealType(
+        MEAL_ENTRY_ID,
+        MEAL_TYPE_ID,
+        USER_ID,
+        ACTOR_ID
+      )
+    ).rejects.toThrow('db exploded');
+
+    const calls = rawCalls();
+    expect(calls[0]).toBe('BEGIN');
+    expect(calls).toContain('ROLLBACK');
+    expect(calls).not.toContain('COMMIT');
+    expect(mockClient.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/SparkyFitnessServer/tests/foodEntryMealRepository.test.ts
+++ b/SparkyFitnessServer/tests/foodEntryMealRepository.test.ts
@@ -10,9 +10,13 @@ vi.mock('../config/logging', () => ({
   log: vi.fn(),
 }));
 
+interface MockDbClient {
+  query: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+}
+
 describe('foodEntryMealRepository.moveFoodEntryMealToMealType', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockClient: any;
+  let mockClient: MockDbClient;
   const MEAL_ENTRY_ID = 'meal-entry-1';
   const MEAL_TYPE_ID = 'custom-breakfast-id';
   const USER_ID = 'user-1';
@@ -29,11 +33,10 @@ describe('foodEntryMealRepository.moveFoodEntryMealToMealType', () => {
 
   const updateCalls = () =>
     mockClient.query.mock.calls.filter(
-      ([sql]: [string]) =>
-        typeof sql === 'string' && sql.trim().startsWith('UPDATE')
+      ([sql]) => typeof sql === 'string' && sql.trim().startsWith('UPDATE')
     );
   const rawCalls = () =>
-    mockClient.query.mock.calls.map(([sql]: [string]) =>
+    mockClient.query.mock.calls.map(([sql]) =>
       typeof sql === 'string' ? sql.trim() : String(sql)
     );
 
@@ -88,6 +91,10 @@ describe('foodEntryMealRepository.moveFoodEntryMealToMealType', () => {
       MEAL_ENTRY_ID,
       USER_ID,
     ]);
+    // food_entries has no updated_at column — it must not appear in the
+    // components UPDATE (the real schema would reject it).
+    const componentsSql = String(updateCalls()[1][0]);
+    expect(componentsSql).not.toContain('updated_at');
 
     expect(mockClient.release).toHaveBeenCalledTimes(1);
   });
@@ -116,7 +123,7 @@ describe('foodEntryMealRepository.moveFoodEntryMealToMealType', () => {
     expect(calls).not.toContain('COMMIT');
     // No components UPDATE after the parent failed.
     expect(
-      updateCalls().filter(([sql]: [string]) => sql.includes('food_entries'))
+      updateCalls().filter(([sql]) => sql.includes('food_entries'))
     ).toHaveLength(0);
     expect(mockClient.release).toHaveBeenCalledTimes(1);
   });

--- a/SparkyFitnessServer/tests/foodEntryMealService.test.ts
+++ b/SparkyFitnessServer/tests/foodEntryMealService.test.ts
@@ -14,6 +14,7 @@ vi.mock('../models/foodEntryMealRepository.js', () => ({
   default: {
     createFoodEntryMeal: vi.fn(),
     updateFoodEntryMeal: vi.fn(),
+    moveFoodEntryMealToMealType: vi.fn(),
   },
 }));
 
@@ -29,6 +30,7 @@ vi.mock('../config/logging.js', () => ({
 
 import {
   createFoodEntryMeal,
+  moveFoodEntryMealToMealType,
   updateFoodEntryMeal,
 } from '../services/foodEntryService.js';
 import foodRepository from '../models/foodRepository.js';
@@ -328,6 +330,45 @@ describe('foodEntryMealService', () => {
         ],
         'user-1'
       );
+    });
+  });
+
+  describe('moveFoodEntryMealToMealType', () => {
+    it('moves parent and components to the new meal type without rebuilding components or re-reading foods', async () => {
+      (
+        foodEntryMealRepository.moveFoodEntryMealToMealType as any
+      ).mockResolvedValue({
+        id: 'meal-entry-1',
+        meal_type_id: 'custom-breakfast-id',
+      });
+
+      const result = await moveFoodEntryMealToMealType(
+        'user-1',
+        'user-1',
+        'meal-entry-1',
+        'custom-breakfast-id'
+      );
+
+      expect(result).toEqual({
+        id: 'meal-entry-1',
+        meal_type_id: 'custom-breakfast-id',
+      });
+      // The repository move is a single metadata-only transaction: no
+      // component delete, no food/variant re-read, no bulk create.
+      expect(
+        foodEntryMealRepository.moveFoodEntryMealToMealType
+      ).toHaveBeenCalledWith(
+        'meal-entry-1',
+        'custom-breakfast-id',
+        'user-1',
+        'user-1'
+      );
+      expect(
+        foodRepository.deleteFoodEntryComponentsByFoodEntryMealId
+      ).not.toHaveBeenCalled();
+      expect(foodRepository.getFoodById).not.toHaveBeenCalled();
+      expect(foodRepository.getFoodVariantById).not.toHaveBeenCalled();
+      expect(foodRepository.bulkCreateFoodEntries).not.toHaveBeenCalled();
     });
   });
 });

--- a/SparkyFitnessServer/tests/foodEntryMealService.test.ts
+++ b/SparkyFitnessServer/tests/foodEntryMealService.test.ts
@@ -335,8 +335,8 @@ describe('foodEntryMealService', () => {
 
   describe('moveFoodEntryMealToMealType', () => {
     it('moves parent and components to the new meal type without rebuilding components or re-reading foods', async () => {
-      (
-        foodEntryMealRepository.moveFoodEntryMealToMealType as any
+      vi.mocked(
+        foodEntryMealRepository.moveFoodEntryMealToMealType
       ).mockResolvedValue({
         id: 'meal-entry-1',
         meal_type_id: 'custom-breakfast-id',


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Moving a `food_entry_meal` container to another meal type used the full
`updateFoodEntryMeal()` path, which deletes all component `food_entries` and
rebuilds them from the *current* food variants. A meal-type-only change could
therefore rewrite historical nutrition snapshots, swap names/brands/portions,
or drop components whose food/variant no longer exists.

**How did you implement the solution?**
Added a dedicated metadata-only operation:

- `foodEntryMealRepository.moveFoodEntryMealToMealType()` — one transaction:
  - `UPDATE food_entry_meals SET meal_type_id = $1, ... WHERE id = $3 AND user_id = $4`
  - `UPDATE food_entries SET meal_type_id = $1, ... WHERE food_entry_meal_id = $3 AND user_id = $4`
  - No component delete, no food/variant re-read, no snapshot rewrite.
- `foodEntryService.moveFoodEntryMealToMealType()` — thin service wrapper.
- MCP `update_entry` first reads lightweight meal-container metadata and compares the requested quantity and unit with their stored values. It uses the metadata-only move when the meal type changes without an effective quantity or unit change (redundant values copied from `list_diary` no longer trigger a rebuild). A genuine no-op returns a no-op confirmation. A real quantity/unit change continues to use the full component-rescaling path.

## How to Test

1. `pnpm vitest run tests/foodEntryMealService.test.ts tests/chatbotToolsFood.test.ts`
2. Full server suite: `pnpm test`
3. Manual: move a meal container between categories via MCP and verify
   component entries keep their historical nutrition/quantities.

Linked Issue: Follow-up to #1959 and #1961

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).
- [x] **[MANDATORY for Backend changes] Code Quality**: Typecheck and full ESLint pass; full server test suite passes (2512 tests, 204 files). Changed TypeScript files pass Prettier.

## Notes for Reviewers

Follow-up review fixes:
- Meal-type-only moves now compare `quantity`/`unit` against the container's
  current values via a lightweight parent read (`getFoodEntryMealMeta`), so a
  redundant `quantity`/`unit` copied from `list_diary` no longer triggers the
  destructive component rebuild — only a real quantity/unit change does.
- All new functions are fully typed (`string` parameters, `MealEntryMoveResult`
  result with `RETURNING id, meal_type_id`); no `any` or suppressions. The final polish commit also drops the `as any`
  cast in the service test, reports only actually-changed fields in
  confirmations (`mealTypeChanged`), and resolves the CodeRabbit export thread
  (the operation is exported on both surfaces).
- Added `foodEntryMealRepository.test.ts` covering the transaction
  (BEGIN/UPDATE/UPDATE/COMMIT and ROLLBACK on missing parent / component
  failure) with a fake client.


Follow-up to merged PR #1961: that PR introduced `meal_type_id` support in the
MCP food tools; this PR fixes the data-integrity gap for meal containers moved
between categories.

### AI assistance disclosure

Parts of this implementation were drafted with Open WebUI.
All changes were manually reviewed, iteratively corrected, and validated by
Dragonk. The full server test suite, typecheck, lint, and formatting checks
were run before the final update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meal-entry editing when changing only the meal type.
  * Preserves existing meal components and details during meal-type moves.
  * Prevents unnecessary rebuilding when quantity and unit remain unchanged.
  * Confirmation messages now report only fields that changed.
  * Maintains update tracking and prevents partial changes if an operation fails.

* **Tests**
  * Added coverage for meal-type moves, failure handling, component preservation, and unchanged quantity or unit values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




