### PR TITLE
fix: support legacy migration replay without API key table

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -252,8 +252,29 @@ jobs:
       # The schema + RLS policies are now applied and the non-superuser app role
       # exists, so the permission matrix can verify every table's real RLS
       # behaviour as the app role (superuser DB user seeds, app role is enforced).
-      - name: Verify RLS permission matrix
-        run: pnpm exec vitest run tests/rlsPermissionMatrix.integration.test.ts
+      - name: Verify RLS permission matrix and legacy migration replay
+        run: |
+          set -euo pipefail
+          pnpm exec vitest run tests/rlsPermissionMatrix.integration.test.ts
+
+          # Reproduce a legacy deployment that has the pre-api-key migrations
+          # but no deprecated user_api_keys table, then replay the remainder.
+          PGPASSWORD="$SPARKY_FITNESS_DB_PASSWORD" \
+            psql -h "$SPARKY_FITNESS_DB_HOST" -U "$SPARKY_FITNESS_DB_USER" \
+              -d postgres -v ON_ERROR_STOP=1 \
+              -c 'CREATE DATABASE sparky_legacy_test'
+          MIGRATION_STOP_BEFORE=20251019013300_merged_rls_policies.sql \
+            SPARKY_FITNESS_DB_NAME=sparky_legacy_test \
+            pnpm run test:migrations
+          PGPASSWORD="$SPARKY_FITNESS_DB_PASSWORD" \
+            psql -h "$SPARKY_FITNESS_DB_HOST" -U "$SPARKY_FITNESS_DB_USER" \
+              -d sparky_legacy_test -v ON_ERROR_STOP=1 \
+              -c 'DROP TABLE public.user_api_keys CASCADE'
+          SPARKY_FITNESS_DB_NAME=sparky_legacy_test pnpm run test:migrations
+          test "$(PGPASSWORD="$SPARKY_FITNESS_DB_PASSWORD" \
+            psql -h "$SPARKY_FITNESS_DB_HOST" -U "$SPARKY_FITNESS_DB_USER" \
+              -d sparky_legacy_test -Atc \
+              "SELECT to_regclass('public.api_key')")" = "api_key"
         env:
           # Default-on (SKIP_RLS_MATRIX unset) — runs against the Postgres this
           # job provisions, with policies already applied by the steps above.

--- a/SparkyFitnessServer/db/migrations/20251019013300_merged_rls_policies.sql
+++ b/SparkyFitnessServer/db/migrations/20251019013300_merged_rls_policies.sql
@@ -28,7 +28,17 @@ ALTER TABLE public.meal_plans ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.mood_entries ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.sparky_chat_history ENABLE ROW LEVEL SECURITY;
-ALTER TABLE public.user_api_keys ENABLE ROW LEVEL SECURITY;
+-- Some legacy installations no longer have this deprecated table but still
+-- need to replay the historical migration set when migration tracking is
+-- missing. Preserve the old policy setup when the table exists and otherwise
+-- allow the replay to continue to the migration that creates `api_key`.
+DO $$
+BEGIN
+    IF to_regclass('public.user_api_keys') IS NOT NULL THEN
+        ALTER TABLE public.user_api_keys ENABLE ROW LEVEL SECURITY;
+    END IF;
+END;
+$$;
 ALTER TABLE public.user_goals ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.user_nutrient_display_preferences ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.user_oidc_links ENABLE ROW LEVEL SECURITY;
@@ -403,7 +413,13 @@ SELECT create_user_centric_policy('custom_measurements');
 SELECT create_user_centric_policy('external_data_providers');
 SELECT create_user_centric_policy('meal_plans');
 SELECT create_user_centric_policy('sparky_chat_history');
-SELECT create_user_centric_policy('user_api_keys');
+DO $$
+BEGIN
+    IF to_regclass('public.user_api_keys') IS NOT NULL THEN
+        PERFORM create_user_centric_policy('user_api_keys');
+    END IF;
+END;
+$$;
 SELECT create_user_centric_policy('user_goals');
 SELECT create_user_centric_policy('user_nutrient_display_preferences');
 SELECT create_user_centric_policy('water_intake');

--- a/SparkyFitnessServer/db/migrations/20251020032200_add_all_owner_centric_policies.sql
+++ b/SparkyFitnessServer/db/migrations/20251020032200_add_all_owner_centric_policies.sql
@@ -38,7 +38,15 @@ SELECT create_owner_centric_all_policy('mood_entries');
 -- SELECT create_owner_centric_all_policy('oidc_providers'); -- No user_id
 -- SELECT create_owner_centric_all_policy('session'); -- No user_id
 SELECT create_owner_centric_all_policy('sparky_chat_history');
-SELECT create_owner_centric_all_policy('user_api_keys');
+-- Legacy databases may have dropped this deprecated table before replaying
+-- their untracked migrations.
+DO $$
+BEGIN
+    IF to_regclass('public.user_api_keys') IS NOT NULL THEN
+        PERFORM create_owner_centric_all_policy('user_api_keys');
+    END IF;
+END;
+$$;
 SELECT create_owner_centric_all_policy('user_goals');
 SELECT create_owner_centric_all_policy('user_ignored_updates');
 SELECT create_owner_centric_all_policy('user_nutrient_display_preferences');

--- a/SparkyFitnessServer/tests/migrate.script.ts
+++ b/SparkyFitnessServer/tests/migrate.script.ts
@@ -1,4 +1,4 @@
-// Standalone migration runner used by CI to prove a fresh install boots cleanly.
+// Standalone migration runner used by CI for full and partial migration checks.
 import { applyMigrations } from '../utils/dbMigrations.js';
 import { applyRlsPolicies } from '../utils/applyRlsPolicies.js';
 import { endPool } from '../db/poolManager.js';
@@ -10,8 +10,13 @@ import { log } from '../config/logging.js';
 // so a failure closing the pool can't surface as an unhandled rejection.
 async function run() {
   try {
-    await applyMigrations();
-    await applyRlsPolicies();
+    const stopBefore = process.env.MIGRATION_STOP_BEFORE;
+    await applyMigrations(stopBefore ? { stopBefore } : undefined);
+    if (stopBefore) {
+      log('info', `Migration check stopped before ${stopBefore}.`);
+    } else {
+      await applyRlsPolicies();
+    }
     log('info', 'Migration check completed successfully.');
   } catch (error) {
     log('error', 'Migration check failed:', error);

--- a/SparkyFitnessServer/utils/dbMigrations.ts
+++ b/SparkyFitnessServer/utils/dbMigrations.ts
@@ -8,7 +8,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const migrationsDir = path.join(__dirname, '../db/migrations');
-async function applyMigrations() {
+
+interface ApplyMigrationsOptions {
+  stopBefore?: string;
+}
+
+async function applyMigrations(options: ApplyMigrationsOptions = {}) {
   const client = await getSystemClient();
   try {
     // The preflightChecks.js script now ensures these variables are set.
@@ -56,7 +61,13 @@ async function applyMigrations() {
       .readdirSync(migrationsDir)
       .filter((file) => file.endsWith('.sql'))
       .sort();
+    let reachedStopBefore = options.stopBefore === undefined;
     for (const file of migrationFiles) {
+      if (file === options.stopBefore) {
+        reachedStopBefore = true;
+        log('info', `Stopping migration check before: ${file}`);
+        break;
+      }
       if (!appliedMigrations.has(file)) {
         log('info', `Applying migration: ${file}`);
         const filePath = path.join(migrationsDir, file);
@@ -72,6 +83,11 @@ async function applyMigrations() {
       } else {
         //log("info", `Migration already applied: ${file}`);
       }
+    }
+    if (!reachedStopBefore) {
+      throw new Error(
+        `Requested stop-before migration was not found: ${options.stopBefore}`
+      );
     }
     // After all migrations are applied, grant necessary permissions to the app user
     await grantPermissions();

--- a/SparkyFitnessServer/utils/dbMigrations.ts
+++ b/SparkyFitnessServer/utils/dbMigrations.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import type { QueryResult } from 'pg';
 import { getSystemClient } from '../db/poolManager.js';
 import { log } from '../config/logging.js';
 import { grantPermissions } from '../db/grantPermissions.js';
@@ -14,6 +15,19 @@ interface ApplyMigrationsOptions {
 }
 
 async function applyMigrations(options: ApplyMigrationsOptions = {}) {
+  const migrationFiles = fs
+    .readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+  if (
+    options.stopBefore !== undefined &&
+    !migrationFiles.includes(options.stopBefore)
+  ) {
+    throw new Error(
+      `Requested stop-before migration was not found: ${options.stopBefore}`
+    );
+  }
+
   const client = await getSystemClient();
   try {
     // The preflightChecks.js script now ensures these variables are set.
@@ -49,22 +63,15 @@ async function applyMigrations(options: ApplyMigrationsOptions = {}) {
       );
     `);
     log('info', 'Ensured schema_migrations table exists.');
-    const appliedMigrationsResult = await client.query(
+    const appliedMigrationsResult = (await client.query(
       'SELECT name FROM system.schema_migrations ORDER BY name'
-    );
+    )) as QueryResult<{ name: string }>;
     const appliedMigrations = new Set(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      appliedMigrationsResult.rows.map((row: any) => row.name)
+      appliedMigrationsResult.rows.map((row) => row.name)
     );
     log('info', 'Applied migrations:', Array.from(appliedMigrations));
-    const migrationFiles = fs
-      .readdirSync(migrationsDir)
-      .filter((file) => file.endsWith('.sql'))
-      .sort();
-    let reachedStopBefore = options.stopBefore === undefined;
     for (const file of migrationFiles) {
       if (file === options.stopBefore) {
-        reachedStopBefore = true;
         log('info', `Stopping migration check before: ${file}`);
         break;
       }
@@ -83,11 +90,6 @@ async function applyMigrations(options: ApplyMigrationsOptions = {}) {
       } else {
         //log("info", `Migration already applied: ${file}`);
       }
-    }
-    if (!reachedStopBefore) {
-      throw new Error(
-        `Requested stop-before migration was not found: ${options.stopBefore}`
-      );
     }
     // After all migrations are applied, grant necessary permissions to the app user
     await grantPermissions();


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Legacy installations that no longer have the deprecated `user_api_keys` table can fail while replaying untracked RLS migrations, before the later migration creates the replacement `api_key` table.

**How did you implement the solution?**
Guard the historical `user_api_keys` policy operations with `to_regclass`, preserving their behavior when the table exists. Add a partial-migration test mode and a PostgreSQL CI fixture that removes the legacy table before replaying the remaining migration history.

Linked Issue: Closes #1988

## How to Test

1. Run `pnpm run validate` and `pnpm test` in `SparkyFitnessServer/`.
2. Run migrations up to `20251019013300_merged_rls_policies.sql` with `MIGRATION_STOP_BEFORE` against an empty PostgreSQL 18 database.
3. Drop `public.user_api_keys`, then run `pnpm run test:migrations` normally.
4. Verify all migrations complete, `public.api_key` exists, and its RLS is enabled.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

Not applicable; this is a server migration compatibility fix.

## Notes for Reviewers

This does not change the final schema or the normal startup order. The migration replay was verified both with and without the deprecated table, and a fresh install plus restart simulation still succeeds.

AI assistance was used for repository navigation and test scaffolding. The implementation, test results, and this description were manually reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database migration reliability for existing installations, including legacy databases.
  - Prevented migration failures when deprecated API-key data is absent.
  - Ensured required API-key storage and security permissions are correctly restored during upgrades.

- **Tests**
  - Expanded migration validation to cover partial upgrades, legacy migration replay, row-level security permissions, and fresh installations.
  - Added checks confirming migrations can complete successfully across supported database states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->