### PR TITLE
fix: request iOS local network access

### DIFF
--- a/SparkyFitnessMobile/app.config.ts
+++ b/SparkyFitnessMobile/app.config.ts
@@ -127,6 +127,8 @@ export default ({ config }: ConfigContext): Partial<ExpoConfig> => {
       appleTeamId: isDev ? DEV_APPLE_TEAM_ID : PROD_APPLE_TEAM_ID,
       supportsTablet: false,
       infoPlist: {
+        NSLocalNetworkUsageDescription:
+          'SparkyFitness connects to self-hosted servers on your local network.',
         NSAppTransportSecurity: {
           NSAllowsArbitraryLoads: false,
         },


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
iOS cannot reach a self-hosted SparkyFitness server on the local network when the app has not declared local-network usage. Safari still succeeds because it is exempt from iOS local-network privacy checks.

**How did you implement the solution?**
Add `NSLocalNetworkUsageDescription` through the Expo config so signed iOS builds can request LAN access. Existing ATS restrictions remain unchanged.

Linked Issue: N/A

## How to Test

1. Run `pnpm exec expo config --type public --json` and verify `ios.infoPlist.NSLocalNetworkUsageDescription` is present.
2. Build and install the iOS app on a physical device.
3. Enter an HTTPS SparkyFitness URL that resolves to an RFC 1918 address, allow local-network access, and verify onboarding loads `/api/auth/settings`.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: A signed iOS build is required to validate the permission prompt; device validation is pending.

## Screenshots

Not applicable; this changes the native permission prompt configuration rather than application UI.

## Notes for Reviewers

- `pnpm exec tsc --noEmit` passes.
- ESLint passes with zero warnings.
- Expo public config output contains the expected `NSLocalNetworkUsageDescription` value.
- iOS prebuild/device testing is not available in the Windows environment used for this patch.
- Apple documents that outgoing `URLSession` connections to local addresses require local-network permission, while Safari is exempt: https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an iOS permission message explaining why the app requires local-network access to connect to self-hosted servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->