### PR TITLE
Fix timed workout playback

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
@@ -52,10 +52,7 @@ const WorkoutPlaybackExercisesList = ({
         const isTimedExercise =
           exercise.modality === 'duration' ||
           exercise.modality === 'duration_distance' ||
-          exercise.sets.some(
-            (set) =>
-              set.duration != null && set.reps == null && set.weight == null
-          );
+          exercise.sets.some((set) => set.duration != null && set.reps == null);
         const completedSets = exercise.sets.filter(
           (set) => set.completed
         ).length;

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
@@ -49,10 +49,12 @@ const WorkoutPlaybackExercisesList = ({
   return (
     <div className="space-y-2">
       {exercises.map((exercise, exerciseIndex) => {
-        const isTimedExercise =
-          exercise.modality === 'duration' ||
-          exercise.modality === 'duration_distance' ||
-          exercise.sets.some((set) => set.duration != null && set.reps == null);
+        const isTimedExercise = exercise.modality
+          ? exercise.modality === 'duration' ||
+            exercise.modality === 'duration_distance'
+          : exercise.sets.some(
+              (set) => set.duration != null && set.reps == null
+            );
         const completedSets = exercise.sets.filter(
           (set) => set.completed
         ).length;

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackExercisesList.tsx
@@ -19,7 +19,7 @@ interface WorkoutPlaybackExercisesListProps {
   onUncompleteSet: (pointer: WorkoutSetPointer) => void;
   onSetFieldChange: (
     pointer: WorkoutSetPointer,
-    field: 'reps' | 'weight' | 'rest_time' | 'set_type' | 'notes',
+    field: 'reps' | 'weight' | 'duration' | 'rest_time' | 'set_type' | 'notes',
     value: number | string | null
   ) => void;
   onOpenRestEditor: (pointer: WorkoutSetPointer) => void;
@@ -49,6 +49,13 @@ const WorkoutPlaybackExercisesList = ({
   return (
     <div className="space-y-2">
       {exercises.map((exercise, exerciseIndex) => {
+        const isTimedExercise =
+          exercise.modality === 'duration' ||
+          exercise.modality === 'duration_distance' ||
+          exercise.sets.some(
+            (set) =>
+              set.duration != null && set.reps == null && set.weight == null
+          );
         const completedSets = exercise.sets.filter(
           (set) => set.completed
         ).length;
@@ -118,15 +125,26 @@ const WorkoutPlaybackExercisesList = ({
                       <div className="flex justify-center px-3">
                         {t('exercise.workoutPlaybackPage.columnType', 'Type')}
                       </div>
-                      <div className="flex justify-center px-3">
-                        {t('exercise.workoutPlaybackPage.columnReps', 'Reps')}
-                      </div>
-                      <div className="flex justify-center px-3">
-                        {t(
-                          'exercise.workoutPlaybackPage.columnWeight',
-                          'Weight'
-                        )}
-                      </div>
+                      {isTimedExercise ? (
+                        <div className="flex justify-center px-3 sm:col-span-2">
+                          {t('workout.durationSec', 'Duration (s)')}
+                        </div>
+                      ) : (
+                        <>
+                          <div className="flex justify-center px-3">
+                            {t(
+                              'exercise.workoutPlaybackPage.columnReps',
+                              'Reps'
+                            )}
+                          </div>
+                          <div className="flex justify-center px-3">
+                            {t(
+                              'exercise.workoutPlaybackPage.columnWeight',
+                              'Weight'
+                            )}
+                          </div>
+                        </>
+                      )}
                       <div className="flex justify-center px-3">
                         {t('exercise.workoutPlaybackPage.columnRest', 'Rest')}
                       </div>
@@ -146,8 +164,10 @@ const WorkoutPlaybackExercisesList = ({
                         setIndex={setIndex}
                         setNumber={set.set_number}
                         setType={set.set_type}
+                        isTimedExercise={isTimedExercise}
                         reps={set.reps}
                         weight={set.weight}
+                        duration={set.duration}
                         restTime={set.rest_time}
                         notes={set.notes}
                         completed={set.completed}

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackPage.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackPage.tsx
@@ -321,7 +321,13 @@ const WorkoutPlaybackPage = () => {
   const handleSetFieldChange = useCallback(
     (
       pointer: WorkoutSetPointer,
-      field: 'reps' | 'weight' | 'rest_time' | 'set_type' | 'notes',
+      field:
+        | 'reps'
+        | 'weight'
+        | 'duration'
+        | 'rest_time'
+        | 'set_type'
+        | 'notes',
       value: number | string | null
     ) => {
       updateDraft((currentDraft) =>

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSetRow.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSetRow.tsx
@@ -172,7 +172,11 @@ const WorkoutPlaybackSetRow = ({
               inputMode="numeric"
               min={0}
               step={1}
-              aria-label={`Duration set ${setNumber}`}
+              aria-label={t(
+                'workout.durationSet',
+                'Duration set {{setNumber}}',
+                { setNumber }
+              )}
               value={duration ?? ''}
               onClick={(event) => event.stopPropagation()}
               onChange={(event) =>

--- a/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSetRow.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/WorkoutPlaybackSetRow.tsx
@@ -47,8 +47,10 @@ interface WorkoutPlaybackSetRowProps {
   setIndex: number;
   setNumber: number;
   setType: string | null | undefined;
+  isTimedExercise: boolean;
   reps: number | null | undefined;
   weight: number | null | undefined;
+  duration: number | null | undefined;
   restTime: number | null | undefined;
   notes: string | null | undefined;
   completed: boolean;
@@ -59,7 +61,7 @@ interface WorkoutPlaybackSetRowProps {
   onUncompleteSet: (pointer: WorkoutSetPointer) => void;
   onSetFieldChange: (
     pointer: WorkoutSetPointer,
-    field: 'reps' | 'weight' | 'rest_time' | 'set_type' | 'notes',
+    field: 'reps' | 'weight' | 'duration' | 'rest_time' | 'set_type' | 'notes',
     value: number | string | null
   ) => void;
   onOpenRestEditor: (pointer: WorkoutSetPointer) => void;
@@ -75,8 +77,10 @@ const WorkoutPlaybackSetRow = ({
   setIndex,
   setNumber,
   setType,
+  isTimedExercise,
   reps,
   weight,
+  duration,
   restTime,
   notes,
   completed,
@@ -162,39 +166,64 @@ const WorkoutPlaybackSetRow = ({
             </SelectContent>
           </Select>
 
-          <Input
-            type="number"
-            inputMode="numeric"
-            min={0}
-            step={1}
-            aria-label={`Reps set ${setNumber}`}
-            value={reps ?? ''}
-            onClick={(event) => event.stopPropagation()}
-            onChange={(event) =>
-              onSetFieldChange(
-                pointer,
-                'reps',
-                parseNullableInteger(event.target.value)
-              )
-            }
-            placeholder={t('common.reps', 'reps')}
-            className="col-span-1 w-full focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:col-start-3"
-          />
-
-          <div
-            className="col-span-1 w-full sm:col-start-4"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <UnitInput
-              value={weight ?? ''}
-              unit={weightUnit}
-              type="weight"
-              placeholder={t('common.weight', 'Weight')}
-              onChange={(value) => onSetFieldChange(pointer, 'weight', value)}
-              inputClassName="focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
-              aria-label={`Weight set ${setNumber}`}
+          {isTimedExercise ? (
+            <Input
+              type="number"
+              inputMode="numeric"
+              min={0}
+              step={1}
+              aria-label={`Duration set ${setNumber}`}
+              value={duration ?? ''}
+              onClick={(event) => event.stopPropagation()}
+              onChange={(event) =>
+                onSetFieldChange(
+                  pointer,
+                  'duration',
+                  parseNullableInteger(event.target.value)
+                )
+              }
+              placeholder={t('workout.durationSec', 'Duration (s)')}
+              className="col-span-2 w-full focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:col-start-3 sm:col-span-2"
             />
-          </div>
+          ) : (
+            <>
+              <Input
+                type="number"
+                inputMode="numeric"
+                min={0}
+                step={1}
+                aria-label={`Reps set ${setNumber}`}
+                value={reps ?? ''}
+                onClick={(event) => event.stopPropagation()}
+                onChange={(event) =>
+                  onSetFieldChange(
+                    pointer,
+                    'reps',
+                    parseNullableInteger(event.target.value)
+                  )
+                }
+                placeholder={t('common.reps', 'reps')}
+                className="col-span-1 w-full focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 sm:col-start-3"
+              />
+
+              <div
+                className="col-span-1 w-full sm:col-start-4"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <UnitInput
+                  value={weight ?? ''}
+                  unit={weightUnit}
+                  type="weight"
+                  placeholder={t('common.weight', 'Weight')}
+                  onChange={(value) =>
+                    onSetFieldChange(pointer, 'weight', value)
+                  }
+                  inputClassName="focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0"
+                  aria-label={`Weight set ${setNumber}`}
+                />
+              </div>
+            </>
+          )}
 
           <Button
             type="button"

--- a/SparkyFitnessFrontend/src/tests/components/WorkoutPlaybackPage.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/WorkoutPlaybackPage.test.tsx
@@ -174,6 +174,56 @@ describe('WorkoutPlaybackPage', () => {
     expect(screen.queryByLabelText('Weight set 2')).not.toBeInTheDocument();
   });
 
+  it('trusts exercise modality over stale set data', () => {
+    const mixedPreset = {
+      ...presetFixture,
+      exercises: [
+        {
+          exercise_id: 'exercise-plank',
+          exercise_name: 'Plank',
+          category: 'isometric',
+          sets: [
+            {
+              set_number: 1,
+              duration: null,
+              reps: null,
+              weight: null,
+              rest_time: 60,
+            },
+          ],
+        },
+        {
+          exercise_id: 'exercise-bench',
+          exercise_name: 'Bench Press',
+          sets: [
+            {
+              set_number: 1,
+              duration: 600,
+              reps: null,
+              weight: 80,
+              rest_time: 90,
+            },
+          ],
+        },
+      ],
+    } as unknown as WorkoutPreset;
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      mixedPreset,
+      '2026-04-27'
+    );
+    expect(draft.exercises[0]?.modality).toBe('duration');
+    expect(draft.exercises[1]?.modality).toBe('weight_reps');
+    mockLocationState = { returnTo: '/?date=2026-04-27', draft };
+
+    render(<WorkoutPlaybackPage />);
+
+    // Plank is timed by modality even with no duration values yet.
+    expect(screen.getByLabelText('Duration set 1')).toHaveValue(null);
+    // Bench keeps reps/weight despite a stale duration on its set.
+    expect(screen.getByLabelText('Reps set 1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Weight set 1')).toBeInTheDocument();
+  });
+
   it('restores a draft from localStorage on reload', async () => {
     const draft = createWorkoutPlaybackDraftFromPreset(
       presetFixture,

--- a/SparkyFitnessFrontend/src/tests/components/WorkoutPlaybackPage.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/WorkoutPlaybackPage.test.tsx
@@ -11,7 +11,15 @@ let mockLocationState: { returnTo?: string; draft?: unknown } | null = null;
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string, defaultValue?: string) => defaultValue || key,
+    t: (
+      key: string,
+      defaultValue?: string,
+      values?: Record<string, string | number>
+    ) =>
+      (defaultValue || key).replace(
+        '{{setNumber}}',
+        String(values?.['setNumber'] ?? '{{setNumber}}')
+      ),
   }),
 }));
 
@@ -134,7 +142,7 @@ describe('WorkoutPlaybackPage', () => {
               set_number: 1,
               duration: 600,
               reps: null,
-              weight: null,
+              weight: 0,
               rest_time: 60,
             },
           ],
@@ -160,6 +168,7 @@ describe('WorkoutPlaybackPage', () => {
     render(<WorkoutPlaybackPage />);
 
     expect(screen.getByText('Duration (s)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Duration set 1')).toHaveValue(600);
     expect(screen.getByLabelText('Duration set 2')).toHaveValue(null);
     expect(screen.queryByLabelText('Reps set 2')).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Weight set 2')).not.toBeInTheDocument();

--- a/SparkyFitnessFrontend/src/tests/components/WorkoutPlaybackPage.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/WorkoutPlaybackPage.test.tsx
@@ -78,6 +78,93 @@ describe('WorkoutPlaybackPage', () => {
     expect(screen.getAllByRole('checkbox').length).toBeGreaterThanOrEqual(1);
   });
 
+  it('renders duration instead of reps and weight for a timed set', () => {
+    const timedPreset = {
+      ...presetFixture,
+      exercises: [
+        {
+          exercise_id: 'exercise-treadmill',
+          exercise_name: 'Treadmill Warm Up',
+          category: 'cardio',
+          sets: [
+            {
+              set_number: 1,
+              set_type: 'Warm-up',
+              duration: 600,
+              reps: null,
+              weight: null,
+              rest_time: 60,
+            },
+          ],
+        },
+      ],
+    } as unknown as WorkoutPreset;
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      timedPreset,
+      '2026-04-27'
+    );
+    expect(draft.exercises[0]?.modality).toBe('duration_distance');
+    // Pre-modality local drafts must retain their time-based rendering.
+    delete (draft.exercises[0] as { modality?: unknown }).modality;
+    mockLocationState = { returnTo: '/?date=2026-04-27', draft };
+
+    render(<WorkoutPlaybackPage />);
+
+    expect(screen.getByText('Duration (s)')).toBeInTheDocument();
+    const durationInput = screen.getByLabelText(
+      'Duration set 1'
+    ) as HTMLInputElement;
+    expect(durationInput).toHaveValue(600);
+    fireEvent.change(durationInput, { target: { value: '300' } });
+    expect(durationInput).toHaveValue(300);
+    expect(screen.queryByLabelText('Reps set 1')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Weight set 1')).not.toBeInTheDocument();
+  });
+
+  it('keeps blank rows duration-based in legacy timed drafts', () => {
+    const timedPreset = {
+      ...presetFixture,
+      exercises: [
+        {
+          exercise_id: 'exercise-treadmill',
+          exercise_name: 'Treadmill Warm Up',
+          category: 'cardio',
+          sets: [
+            {
+              set_number: 1,
+              duration: 600,
+              reps: null,
+              weight: null,
+              rest_time: 60,
+            },
+          ],
+        },
+      ],
+    } as unknown as WorkoutPreset;
+    const draft = createWorkoutPlaybackDraftFromPreset(
+      timedPreset,
+      '2026-04-27'
+    );
+    delete (draft.exercises[0] as { modality?: unknown }).modality;
+    draft.exercises[0]?.sets.push({
+      set_number: 2,
+      duration: null,
+      reps: null,
+      weight: null,
+      rest_time: 60,
+      completed: false,
+      completed_at: null,
+    });
+    mockLocationState = { returnTo: '/?date=2026-04-27', draft };
+
+    render(<WorkoutPlaybackPage />);
+
+    expect(screen.getByText('Duration (s)')).toBeInTheDocument();
+    expect(screen.getByLabelText('Duration set 2')).toHaveValue(null);
+    expect(screen.queryByLabelText('Reps set 2')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Weight set 2')).not.toBeInTheDocument();
+  });
+
   it('restores a draft from localStorage on reload', async () => {
     const draft = createWorkoutPlaybackDraftFromPreset(
       presetFixture,

--- a/SparkyFitnessFrontend/src/utils/workoutPlayback.ts
+++ b/SparkyFitnessFrontend/src/utils/workoutPlayback.ts
@@ -1,5 +1,10 @@
-import type { CreatePresetSessionRequest } from '@workspace/shared';
-import { instantHourMinute, setsDurationMinutes } from '@workspace/shared';
+import {
+  instantHourMinute,
+  resolveExerciseModality,
+  setsDurationMinutes,
+  type CreatePresetSessionRequest,
+  type ExerciseModality,
+} from '@workspace/shared';
 import type { WorkoutPreset, WorkoutPresetSet } from '@/types/workout';
 
 export const DEFAULT_REST_SECONDS = 90;
@@ -26,6 +31,7 @@ export interface WorkoutPlaybackSetDraft extends WorkoutPresetSet {
 export interface WorkoutPlaybackExerciseDraft {
   exercise_id: string;
   exercise_name: string;
+  modality?: ExerciseModality;
   image_url?: string;
   notes: string | null;
   started_at?: string | null;
@@ -301,6 +307,10 @@ export function createWorkoutPlaybackDraftFromPreset(
         exercise.exercise?.name ||
         `Exercise ${exerciseIndex + 1}`,
       image_url: exercise.image_url || exercise.exercise?.images?.[0],
+      modality: resolveExerciseModality(
+        exercise.modality ?? exercise.exercise?.modality,
+        exercise.category ?? exercise.exercise?.category
+      ),
       notes: null,
       started_at: null,
       ended_at: null,


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Timed exercises opened in workout playback with Reps and Weight fields instead of Duration, so saved durations such as 600 seconds could not be viewed or edited.

**How did you implement the solution?**
Playback now uses the exercise modality first and falls back to legacy set data when modality is missing. Duration rows keep localized labels and are covered for blank durations and legacy zero-weight data.

Linked Issue: Closes #2007

## How to Test

1. From `SparkyFitnessFrontend`, run `pnpm run validate`, `pnpm run test:ci`, and `pnpm run build`.
2. Create a duration-based cardio exercise and a preset with a 600-second set.
3. Start the preset and verify the playback table shows `Duration (s)` with `600`, not Reps and Weight.
4. Add or clear a set and verify the blank row remains a duration input after reloading the page.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before
<img width="1024" height="172" alt="image" src="https://github.com/user-attachments/assets/25bbe26e-7dfc-4887-8008-86c4ad8766bc" />

### After
<img width="1024" height="230" alt="image" src="https://github.com/user-attachments/assets/9d6919a0-a48c-48dc-bdeb-7b96fbc83d92" />


</details>

## Notes for Reviewers

This PR fixes the web frontend playback path. Issue #2007 also lists Android; no mobile files are changed or claimed as tested here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timed exercises now display and edit duration values during workout playback.
  * Timed workouts show a combined Duration column, while standard exercises retain Reps and Weight fields.
  * Exercise modality is preserved when creating workout playback drafts.

* **Bug Fixes**
  * Improved handling of legacy workouts and exercises with missing modality or duration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->