### PR TITLE
feat: import Garmin daily calorie totals

### DIFF
--- a/SparkyFitnessGarmin/routes.py
+++ b/SparkyFitnessGarmin/routes.py
@@ -35,6 +35,7 @@ from service import (
     grams_to_kg,
     map_garmin_stress_to_mood,
     meters_to_km,
+    project_daily_calorie_metrics,
     safe_convert,
     seconds_to_minutes,
 )
@@ -236,7 +237,7 @@ async def get_health_and_wellness(request_data: HealthAndWellnessRequest):
         for current_date in dates_to_fetch:
             logger.info(f"[GARMIN_SYNC] Fetching data for date: {current_date}")
 
-            # Daily Summary (steps, total_distance, highly_active_seconds, active_seconds, sedentary_seconds, body_battery)
+            # Daily Summary (steps, distance, activity time, calories, body battery)
             if any(
                 metric in metric_types_to_fetch
                 for metric in [
@@ -245,6 +246,9 @@ async def get_health_and_wellness(request_data: HealthAndWellnessRequest):
                     "highly_active_seconds",
                     "active_seconds",
                     "sedentary_seconds",
+                    "active_calories",
+                    "bmr_calories",
+                    "total_calories",
                     "body_battery",
                     "daily_summary",
                 ]
@@ -316,6 +320,13 @@ async def get_health_and_wellness(request_data: HealthAndWellnessRequest):
                                 ),
                             }
                         )
+                    calorie_metrics = project_daily_calorie_metrics(
+                        summary_data,
+                        current_date,
+                        set(metric_types_to_fetch),
+                    )
+                    for metric, records in calorie_metrics.items():
+                        health_data[metric].extend(records)
                     # Body Battery from user_summary (preferred source)
                     if "body_battery" in metric_types_to_fetch:
                         bb_highest = summary_data.get("bodyBatteryHighestValue")

--- a/SparkyFitnessGarmin/service.py
+++ b/SparkyFitnessGarmin/service.py
@@ -1,6 +1,7 @@
-import os
 import json
 import logging
+import math
+import os
 import time
 from datetime import date, timedelta
 
@@ -27,6 +28,9 @@ ALL_HEALTH_METRICS = [
     "highly_active_seconds",
     "active_seconds",
     "sedentary_seconds",
+    "active_calories",
+    "bmr_calories",
+    "total_calories",
     # Health metrics
     "heart_rates",
     "sleep",
@@ -53,6 +57,42 @@ ALL_HEALTH_METRICS = [
     "training_load",
     "acute_load",
 ]
+
+DAILY_CALORIE_FIELD_ALIASES = {
+    "active_calories": ("activeKilocalories", "activeCalories"),
+    "bmr_calories": ("bmrKilocalories", "bmrCalories"),
+    "total_calories": ("totalKilocalories", "totalCalories"),
+}
+
+
+def extract_daily_calories(summary_data):
+    """Normalize Garmin daily-summary calorie fields across known API aliases."""
+    normalized = {}
+    for metric, aliases in DAILY_CALORIE_FIELD_ALIASES.items():
+        for alias in aliases:
+            value = summary_data.get(alias)
+            if value is None or isinstance(value, bool):
+                continue
+            try:
+                numeric_value = float(value)
+            except (TypeError, ValueError):
+                continue
+            if not math.isfinite(numeric_value) or numeric_value < 0:
+                continue
+            normalized[metric] = numeric_value
+            break
+    return normalized
+
+
+def project_daily_calorie_metrics(summary_data, current_date, requested_metrics):
+    """Build health-data records for requested Garmin daily calorie metrics."""
+    normalized = extract_daily_calories(summary_data)
+    return {
+        metric: [{"date": current_date, "value": value}]
+        for metric, value in normalized.items()
+        if metric in requested_metrics
+    }
+
 
 MFA_STATE_STORE: dict[str, dict] = {}
 MFA_TTL_SECONDS = 5 * 60  # 5 minutes

--- a/SparkyFitnessGarmin/tests/test_daily_calories.py
+++ b/SparkyFitnessGarmin/tests/test_daily_calories.py
@@ -1,0 +1,98 @@
+import sys
+import unittest
+from pathlib import Path
+
+GARMIN_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(GARMIN_DIR))
+
+from service import (
+    ALL_HEALTH_METRICS,
+    extract_daily_calories,
+    project_daily_calorie_metrics,
+)
+
+
+class ExtractDailyCaloriesTests(unittest.TestCase):
+    def test_extracts_canonical_garmin_daily_calorie_fields(self):
+        summary = {
+            "activeKilocalories": 2180,
+            "bmrKilocalories": 2414,
+            "totalKilocalories": 4594,
+        }
+
+        self.assertEqual(
+            extract_daily_calories(summary),
+            {
+                "active_calories": 2180.0,
+                "bmr_calories": 2414.0,
+                "total_calories": 4594.0,
+            },
+        )
+
+    def test_uses_known_fallback_aliases(self):
+        summary = {
+            "activeCalories": "540",
+            "bmrCalories": "1800",
+            "totalCalories": "2340",
+        }
+
+        self.assertEqual(
+            extract_daily_calories(summary),
+            {
+                "active_calories": 540.0,
+                "bmr_calories": 1800.0,
+                "total_calories": 2340.0,
+            },
+        )
+
+    def test_preserves_zero_and_omits_missing_or_invalid_values(self):
+        summary = {
+            "activeKilocalories": 0,
+            "bmrKilocalories": None,
+            "bmrCalories": float("inf"),
+            "totalKilocalories": "not-a-number",
+        }
+
+        self.assertEqual(extract_daily_calories(summary), {"active_calories": 0.0})
+
+
+class ProjectDailyCalorieMetricsTests(unittest.TestCase):
+    def test_daily_calorie_metrics_are_enabled_by_default(self):
+        self.assertTrue(
+            {"active_calories", "bmr_calories", "total_calories"}.issubset(
+                ALL_HEALTH_METRICS
+            )
+        )
+
+    def test_projects_only_requested_available_metrics(self):
+        summary = {
+            "activeKilocalories": 2180,
+            "bmrKilocalories": 2414,
+            "totalKilocalories": 4594,
+        }
+
+        self.assertEqual(
+            project_daily_calorie_metrics(
+                summary,
+                "2026-08-02",
+                {"active_calories", "total_calories"},
+            ),
+            {
+                "active_calories": [{"date": "2026-08-02", "value": 2180.0}],
+                "total_calories": [{"date": "2026-08-02", "value": 4594.0}],
+            },
+        )
+
+    def test_omits_requested_metric_when_garmin_did_not_return_it(self):
+        self.assertEqual(
+            project_daily_calorie_metrics(
+                {"activeKilocalories": 300},
+                "2026-08-02",
+                {"bmr_calories"},
+            ),
+            {},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/SparkyFitnessServer/integrations/garminconnect/garminMeasurementMapping.ts
+++ b/SparkyFitnessServer/integrations/garminconnect/garminMeasurementMapping.ts
@@ -48,6 +48,27 @@ const garminMeasurementMapping = {
     dataType: 'integer',
     measurementType: 'count',
   },
+  active_calories: {
+    targetType: 'custom',
+    name: 'Active Calories',
+    dataType: 'numeric',
+    measurementType: 'kcal',
+    frequency: 'Daily',
+  },
+  bmr_calories: {
+    targetType: 'custom',
+    name: 'basal_metabolic_rate',
+    dataType: 'numeric',
+    measurementType: 'kcal',
+    frequency: 'Daily',
+  },
+  total_calories: {
+    targetType: 'custom',
+    name: 'total_calories',
+    dataType: 'numeric',
+    measurementType: 'kcal',
+    frequency: 'Daily',
+  },
   bmi: {
     targetType: 'custom',
     name: 'BMI',

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -1478,15 +1478,25 @@ async function deleteExerciseEntriesByEntrySourceAndDateWithClient(
   userId: string,
   startDate: string,
   endDate: string,
-  entrySource: string
+  entrySource: string,
+  excludedExerciseName?: string
 ) {
   // Get IDs of exercise entries to be deleted
   const entryIdsResult = await client.query(
     `SELECT id FROM exercise_entries
      WHERE user_id = $1
        AND entry_date BETWEEN $2 AND $3
-       AND source = $4`,
-    [userId, startDate, endDate, entrySource]
+       AND source = $4
+       AND (
+         $5::text IS NULL
+         OR NOT EXISTS (
+           SELECT 1
+           FROM exercises e
+           WHERE e.id = exercise_entries.exercise_id
+             AND e.name = $5
+         )
+       )`,
+    [userId, startDate, endDate, entrySource, excludedExerciseName ?? null]
   );
   const entryIds = entryIdsResult.rows.map((row: { id: string }) => row.id);
   if (entryIds.length > 0) {
@@ -1530,7 +1540,8 @@ async function deleteExerciseEntriesByEntrySourceAndDate(
   userId: string,
   startDate: string,
   endDate: string,
-  entrySource: string
+  entrySource: string,
+  excludedExerciseName?: string
 ) {
   const client = await getClient(userId);
   try {
@@ -1541,7 +1552,8 @@ async function deleteExerciseEntriesByEntrySourceAndDate(
         userId,
         startDate,
         endDate,
-        entrySource
+        entrySource,
+        excludedExerciseName
       );
     await client.query('COMMIT');
     return deletedCount;

--- a/SparkyFitnessServer/services/garmin/garminActivityProcessor.ts
+++ b/SparkyFitnessServer/services/garmin/garminActivityProcessor.ts
@@ -217,7 +217,8 @@ export async function processActivitiesAndWorkouts(
       userId,
       startDate,
       endDate,
-      'garmin'
+      'garmin',
+      'Active Calories'
     );
     await exercisePresetEntryRepository.deleteExercisePresetEntriesByEntrySourceAndDateWithClient(
       client,

--- a/SparkyFitnessServer/tests/dailySummaryService.test.ts
+++ b/SparkyFitnessServer/tests/dailySummaryService.test.ts
@@ -155,6 +155,49 @@ describe('dailySummaryService', () => {
     vi.useRealTimers();
   });
 
+  test('does not double-count Garmin active calories with workouts and steps', async () => {
+    const garminActiveCalories: ExerciseSessionResponse = {
+      ...activeCaloriesSession,
+      calories_burned: 2180,
+      source: 'garmin',
+    };
+    const garminWorkout: ExerciseSessionResponse = {
+      ...activeCaloriesSession,
+      id: 'garmin-workout-entry',
+      exercise_id: 'garmin-walking',
+      calories_burned: 347,
+      source: 'garmin',
+      name: 'Walking',
+      steps: 6603,
+    };
+    vi.mocked(getExerciseEntriesByDateV2).mockResolvedValue([
+      garminActiveCalories,
+      garminWorkout,
+    ]);
+    vi.mocked(measurementRepository.getStepCaloriesForDate).mockResolvedValue(
+      250
+    );
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      bmr_algorithm: 'Mifflin-St Jeor',
+      activity_level: 'not_much',
+      calorie_goal_adjustment_mode: 'dynamic',
+      exercise_calorie_percentage: 100,
+      include_bmr_in_net_calories: false,
+      tdee_allow_negative_adjustment: false,
+      timezone: 'UTC',
+    });
+
+    const result = await getDailySummary({
+      actorUserId,
+      targetUserId,
+      date,
+      includeCheckin: true,
+    });
+
+    expect(result.calorieBalance.burned).toBe(2180);
+    expect(result.calorieBalance.exerciseSource).toBe('active');
+  });
+
   test('returns the TDEE projection used for remaining calories', async () => {
     const result = await getDailySummary({
       actorUserId,

--- a/SparkyFitnessServer/tests/exerciseEntryGarminCleanup.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntryGarminCleanup.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import exerciseEntryRepository from '../models/exerciseEntry.js';
 import { getClient } from '../db/poolManager.js';
+import { createMockDbClient } from './helpers/mockDbClient.js';
 
 vi.mock('../db/poolManager', () => ({
   getClient: vi.fn(),
@@ -19,14 +20,10 @@ vi.mock('../models/activityDetailsRepository', () => ({
 }));
 
 describe('Garmin exercise cleanup', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockClient: any;
+  let mockClient: ReturnType<typeof createMockDbClient>;
 
   beforeEach(() => {
-    mockClient = {
-      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
-      release: vi.fn(),
-    };
+    mockClient = createMockDbClient([]);
     vi.mocked(getClient).mockResolvedValue(mockClient);
   });
 

--- a/SparkyFitnessServer/tests/exerciseEntryGarminCleanup.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntryGarminCleanup.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import exerciseEntryRepository from '../models/exerciseEntry.js';
+import { getClient } from '../db/poolManager.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('../models/exercise', () => ({
+  default: {},
+}));
+
+vi.mock('../models/activityDetailsRepository', () => ({
+  default: {},
+}));
+
+describe('Garmin exercise cleanup', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      release: vi.fn(),
+    };
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  it('can preserve the synthetic Active Calories row', async () => {
+    await exerciseEntryRepository.deleteExerciseEntriesByEntrySourceAndDate(
+      'user-1',
+      '2026-08-02',
+      '2026-08-02',
+      'garmin',
+      'Active Calories'
+    );
+
+    const [selectSql, params] = mockClient.query.mock.calls[1];
+    expect(selectSql).toContain('NOT EXISTS');
+    expect(selectSql).toContain('exercises');
+    expect(params).toEqual([
+      'user-1',
+      '2026-08-02',
+      '2026-08-02',
+      'garmin',
+      'Active Calories',
+    ]);
+  });
+});

--- a/SparkyFitnessServer/tests/garminActivityProcessor.transaction.test.ts
+++ b/SparkyFitnessServer/tests/garminActivityProcessor.transaction.test.ts
@@ -100,7 +100,8 @@ describe('processActivitiesAndWorkouts transaction boundary', () => {
       UID,
       '2026-08-01',
       '2026-08-02',
-      'garmin'
+      'garmin',
+      'Active Calories'
     );
     expect(
       exercisePresetEntryRepository.deleteExercisePresetEntriesByEntrySourceAndDateWithClient
@@ -149,7 +150,8 @@ describe('processActivitiesAndWorkouts transaction boundary', () => {
       UID,
       '2026-08-01',
       '2026-08-02',
-      'garmin'
+      'garmin',
+      'Active Calories'
     );
     expect(clientRelease).toHaveBeenCalled();
   });

--- a/SparkyFitnessServer/tests/garminMeasurementMapping.test.ts
+++ b/SparkyFitnessServer/tests/garminMeasurementMapping.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import garminMeasurementMapping from '../integrations/garminconnect/garminMeasurementMapping.js';
+
+describe('Garmin daily calorie measurement mapping', () => {
+  it('routes active calories through the deduplicated Active Calories path', () => {
+    expect(garminMeasurementMapping.active_calories).toEqual({
+      targetType: 'custom',
+      name: 'Active Calories',
+      dataType: 'numeric',
+      measurementType: 'kcal',
+      frequency: 'Daily',
+    });
+  });
+
+  it('stores Garmin resting calories as the external BMR category', () => {
+    expect(garminMeasurementMapping.bmr_calories).toEqual({
+      targetType: 'custom',
+      name: 'basal_metabolic_rate',
+      dataType: 'numeric',
+      measurementType: 'kcal',
+      frequency: 'Daily',
+    });
+  });
+
+  it('stores Garmin total calories as a reportable daily measurement', () => {
+    expect(garminMeasurementMapping.total_calories).toEqual({
+      targetType: 'custom',
+      name: 'total_calories',
+      dataType: 'numeric',
+      measurementType: 'kcal',
+      frequency: 'Daily',
+    });
+  });
+});


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Garmin workouts were imported, but Garmin's daily active, resting/BMR, and total calorie summaries were not. Adding active calories naively would also double-count workout calories because Garmin includes them in `activeKilocalories`.

**How did you implement the solution?**

The Garmin service now normalizes and emits the three daily calorie metrics. Active calories use SparkyFitness's existing `Active Calories` and `resolveExerciseCalories()` path, while BMR and total calories are stored as daily measurements. Garmin activity cleanup preserves the synthetic active-calorie row.

Linked Issue: #1875

## How to Test

1. Check out `kreativmonkey:feat/garmin-daily-calories` and configure a Garmin connection.
2. Sync a day containing both Garmin daily calories and at least one Garmin workout.
3. Verify that active, resting/BMR, and total calories are imported.
4. Verify that exercise calories equal Garmin's daily active calories instead of daily active calories plus workout and step calories.
5. Re-sync the same range and verify the daily active-calorie row remains present without duplicates.

Automated verification:

- `python3 -m unittest discover -s SparkyFitnessGarmin/tests -v` — 6 passed
- `python3 -m py_compile SparkyFitnessGarmin/service.py SparkyFitnessGarmin/routes.py` — passed
- `pnpm exec vitest run tests/exerciseEntryGarminCleanup.test.ts tests/garminMeasurementMapping.test.ts tests/dailySummaryService.test.ts` — 17 passed
- `pnpm run validate` — passed
- `pnpm test` — 209 test files passed, 2 skipped; 2,560 tests passed, 210 skipped

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Notes for Reviewers

- Garmin activities remain separate records for history and statistics.
- This partially addresses #1875 without adding a new "Garmin authoritative" preference.
- No production deployment or production-data change was performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Garmin daily summaries now include active, basal metabolic rate (BMR), and total calories.
  * Calorie measurements are recorded in kcal and support common Garmin field formats.

* **Bug Fixes**
  * Prevented Garmin active calories from being double-counted with workouts and step calories.
  * Garmin synchronization now preserves active-calorie entries during exercise cleanup.
  * Improved handling of missing or invalid calorie values to prevent inaccurate records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->