### PR TITLE
fix(frontend): match schedule-less medication entries to due doses 

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Medications/TodayMedications.tsx
+++ b/SparkyFitnessFrontend/src/pages/Medications/TodayMedications.tsx
@@ -50,6 +50,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
+import { entryMatchesDue } from '@/utils/medicationUtils';
 import { formatTimeOfDayString } from '@/utils/timeFormatters';
 import { useActiveUser } from '@/contexts/ActiveUserContext';
 import { usePreferences } from '@/contexts/PreferencesContext';
@@ -81,15 +82,6 @@ export interface DueDose {
 // the Cabinet), same rule as Glp1Coach. Oral GLP-1 meds stay on the adherence path.
 const isGlp1Injectable = (med: Medication) =>
   med.is_glp1 && med.type_id === 'injection';
-
-// Injection rows merged into the entries feed carry no schedule_id, so GLP-1
-// injectable doses fall back to matching by medication.
-const entryMatchesDue = (
-  e: MedicationEntry,
-  due: { medication: { id: string }; schedule: { id: string } }
-) =>
-  e.schedule_id === due.schedule.id ||
-  (e.entry_type === 'injection' && e.medication_id === due.medication.id);
 
 export interface TodayMedicationsProps {
   selectedDate: string;
@@ -572,7 +564,7 @@ export default function TodayMedications({
             </div>
             {!entries.some(
               (e) =>
-                e.schedule_id === nextGlpDue.schedule.id &&
+                entryMatchesDue(e, nextGlpDue) &&
                 (e.status === 'taken' || e.status === 'skipped')
             ) && (
               <Button

--- a/SparkyFitnessFrontend/src/tests/components/TodayMedications.test.ts
+++ b/SparkyFitnessFrontend/src/tests/components/TodayMedications.test.ts
@@ -1,0 +1,76 @@
+import { entryMatchesDue } from '@/utils/medicationUtils';
+import type { MedicationEntry } from '@/types/medications';
+
+describe('entryMatchesDue', () => {
+  const due = {
+    medication: { id: 'med-123' },
+    schedule: { id: 'sched-456' },
+  };
+
+  const createBaseEntry = (
+    overrides: Partial<MedicationEntry>
+  ): MedicationEntry => ({
+    id: 'entry-1',
+    medication_id: 'med-123',
+    schedule_id: 'sched-456',
+    user_id: 'user-1',
+    status: 'taken',
+    taken_at: '2026-07-28T12:00:00Z',
+    scheduled_for: '2026-07-28T12:00:00Z',
+    entry_date: '2026-07-28',
+    notes: null,
+    source: 'web',
+    custom_fields: {},
+    created_at: '2026-07-28T12:00:00Z',
+    updated_at: '2026-07-28T12:00:00Z',
+    med_name_snapshot: 'Metformin',
+    dose_amount_snapshot: 500,
+    dose_unit_snapshot: 'mg',
+    entry_type: 'entry',
+    ...overrides,
+  });
+
+  test('matches when schedule_id matches due schedule id', () => {
+    const entry = createBaseEntry({
+      schedule_id: 'sched-456',
+    });
+
+    expect(entryMatchesDue(entry, due)).toBe(true);
+  });
+
+  test('matches schedule-less entries logged via API for the same medication', () => {
+    const entry = createBaseEntry({
+      schedule_id: null,
+      scheduled_for: null,
+    });
+
+    expect(entryMatchesDue(entry, due)).toBe(true);
+  });
+
+  test('matches injection entries for the same medication', () => {
+    const entry = createBaseEntry({
+      schedule_id: null,
+      entry_type: 'injection',
+    });
+
+    expect(entryMatchesDue(entry, due)).toBe(true);
+  });
+
+  test('does NOT match PRN entries to scheduled due doses', () => {
+    const entry = createBaseEntry({
+      schedule_id: null,
+      status: 'prn_taken',
+    });
+
+    expect(entryMatchesDue(entry, due)).toBe(false);
+  });
+
+  test('does NOT match entries for a different medication', () => {
+    const entry = createBaseEntry({
+      medication_id: 'med-999',
+      schedule_id: null,
+    });
+
+    expect(entryMatchesDue(entry, due)).toBe(false);
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/components/TodayMedications.test.ts
+++ b/SparkyFitnessFrontend/src/tests/components/TodayMedications.test.ts
@@ -56,7 +56,16 @@ describe('entryMatchesDue', () => {
     expect(entryMatchesDue(entry, due)).toBe(true);
   });
 
-  test('does NOT match PRN entries to scheduled due doses', () => {
+  test('does NOT match PRN entries to scheduled due doses even if schedule_id matches', () => {
+    const entry = createBaseEntry({
+      schedule_id: 'sched-456',
+      status: 'prn_taken',
+    });
+
+    expect(entryMatchesDue(entry, due)).toBe(false);
+  });
+
+  test('does NOT match PRN entries with null schedule_id to scheduled due doses', () => {
     const entry = createBaseEntry({
       schedule_id: null,
       status: 'prn_taken',

--- a/SparkyFitnessFrontend/src/utils/medicationUtils.ts
+++ b/SparkyFitnessFrontend/src/utils/medicationUtils.ts
@@ -1,0 +1,18 @@
+import type { MedicationEntry } from '@/types/medications';
+
+/**
+ * True when a logged entry belongs to a scheduled due dose slot.
+ *
+ * Entries logged without schedule attribution (e.g. via API or iOS Shortcuts)
+ * count for any of the medication's scheduled doses, except PRN logs, which
+ * never cover a scheduled slot.
+ */
+export const entryMatchesDue = (
+  e: MedicationEntry,
+  due: { medication: { id: string }; schedule: { id: string } }
+): boolean =>
+  e.schedule_id === due.schedule.id ||
+  (e.entry_type === 'injection' && e.medication_id === due.medication.id) ||
+  (e.medication_id === due.medication.id &&
+    !e.schedule_id &&
+    e.status !== 'prn_taken');

--- a/SparkyFitnessFrontend/src/utils/medicationUtils.ts
+++ b/SparkyFitnessFrontend/src/utils/medicationUtils.ts
@@ -10,9 +10,12 @@ import type { MedicationEntry } from '@/types/medications';
 export const entryMatchesDue = (
   e: MedicationEntry,
   due: { medication: { id: string }; schedule: { id: string } }
-): boolean =>
-  e.schedule_id === due.schedule.id ||
-  (e.entry_type === 'injection' && e.medication_id === due.medication.id) ||
-  (e.medication_id === due.medication.id &&
-    !e.schedule_id &&
-    e.status !== 'prn_taken');
+): boolean => {
+  if (e.status === 'prn_taken') return false;
+
+  return (
+    e.schedule_id === due.schedule.id ||
+    (e.entry_type === 'injection' && e.medication_id === due.medication.id) ||
+    (e.medication_id === due.medication.id && !e.schedule_id)
+  );
+};


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)


Fixes an issue where medication doses logged via API POST (/api/v2/medications/entries) without specifying a schedule_id (e.g. via iOS Shortcuts, Action Buttons, or cURL) failed to update the Adherence Overview, Today's Checklist, Streak graph, and Due Today card status.

- Extracted and updated `entryMatchesDue` helper in `medicationUtils.ts` to allow schedule-less adherence entries (`!schedule_id` and `status !== 'prn_taken'`) to fulfill scheduled due doses for that medication.
- Aligned frontend matching behavior with mobile's `entryMatchesDose` logic in `SparkyFitnessMobile/src/utils/medications.ts`.
- Added unit test suite in `TodayMedications.test.ts` covering schedule-less API entries, injections, and PRN exclusions.

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #1942

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved medication dose tracking so eligible unscheduled injection entries are recognized as logged.
  - Prevented PRN entries or entries for different medications from incorrectly satisfying scheduled doses.
  - Improved consistency when matching scheduled and unscheduled medication entries.

- **Tests**
  - Added coverage for scheduled, unscheduled injection, non-PRN, PRN, and mismatched medication entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->