### PR TITLE
fix(auth): align signup password length validation

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1273,7 +1273,7 @@
       "updatePassword": "Update Password",
       "updating": "Updating...",
       "newPasswordsDoNotMatch": "New passwords do not match",
-      "passwordLengthError": "Password must be at least 6 characters long",
+      "passwordLengthError": "Password must be at least 8 characters long",
       "enterNewEmailAddress": "Please enter a new email address"
     }
   },

--- a/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
@@ -245,8 +245,8 @@ const Auth = () => {
   );
 
   const validatePassword = (pwd: string) => {
-    if (pwd.length < 6) {
-      return 'Password must be at least 6 characters long.';
+    if (pwd.length < 8) {
+      return 'Password must be at least 8 characters long.';
     }
     if (!/[A-Z]/.test(pwd)) {
       return 'Password must contain at least one uppercase letter.';
@@ -622,6 +622,7 @@ const Auth = () => {
                               );
                             }}
                             required
+                            minLength={8}
                             autoComplete="new-password"
                           />
                           <PasswordToggle

--- a/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
@@ -34,9 +34,11 @@ import { MagicLinkRequestDialog } from './MagicLinkRequestDialog';
 import { useQueryClient } from '@tanstack/react-query';
 import { AuthResponse } from '@/types/auth';
 import { getErrorMessage } from '@/utils/api';
+import { useTranslation } from 'react-i18next';
 
 const Auth = () => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const { loggingLevel } = usePreferences();
   const { signIn, user: authUser, loading: authLoading } = useAuth();
   debug(loggingLevel, 'Auth: Component rendered.');
@@ -246,7 +248,7 @@ const Auth = () => {
 
   const validatePassword = (pwd: string) => {
     if (pwd.length < 8) {
-      return 'Password must be at least 8 characters long.';
+      return t('settings.accountSecurity.passwordLengthError');
     }
     if (!/[A-Z]/.test(pwd)) {
       return 'Password must contain at least one uppercase letter.';

--- a/SparkyFitnessFrontend/src/pages/Auth/ResetPassword.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/ResetPassword.tsx
@@ -17,9 +17,11 @@ import useToggle from '@/hooks/use-toggle';
 import PasswordToggle from '@/components/PasswordToggle';
 import { useResetPasswordMutation } from '@/hooks/Auth/useAuth';
 import { getErrorMessage } from '@/utils/api';
+import { useTranslation } from 'react-i18next';
 
 const ResetPassword = () => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const { loggingLevel } = usePreferences();
   debug(loggingLevel, 'ResetPassword: Component rendered.');
@@ -48,7 +50,7 @@ const ResetPassword = () => {
 
   const validatePassword = (pwd: string) => {
     if (pwd.length < 8) {
-      return 'Password must be at least 8 characters long.';
+      return t('settings.accountSecurity.passwordLengthError');
     }
     if (!/[A-Z]/.test(pwd)) {
       return 'Password must contain at least one uppercase letter.';

--- a/SparkyFitnessFrontend/src/pages/Auth/ResetPassword.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/ResetPassword.tsx
@@ -47,8 +47,8 @@ const ResetPassword = () => {
   }, [token]);
 
   const validatePassword = (pwd: string) => {
-    if (pwd.length < 6) {
-      return 'Password must be at least 6 characters long.';
+    if (pwd.length < 8) {
+      return 'Password must be at least 8 characters long.';
     }
     if (!/[A-Z]/.test(pwd)) {
       return 'Password must contain at least one uppercase letter.';
@@ -135,6 +135,7 @@ const ResetPassword = () => {
                   setPasswordError(validatePassword(e.target.value));
                 }}
                 required
+                minLength={8}
                 autoComplete="new-password"
               />
               <PasswordToggle

--- a/SparkyFitnessFrontend/src/pages/Settings/AccountSecurity.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/AccountSecurity.tsx
@@ -71,10 +71,10 @@ export const AccountSecurity = () => {
       return;
     }
 
-    if (passwordForm.new_password.length < 6) {
+    if (passwordForm.new_password.length < 8) {
       toast({
         title: 'Error',
-        description: 'Password must be at least 6 characters long',
+        description: 'Password must be at least 8 characters long',
         variant: 'destructive',
       });
       return;

--- a/SparkyFitnessFrontend/src/pages/Settings/AccountSecurity.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/AccountSecurity.tsx
@@ -74,7 +74,7 @@ export const AccountSecurity = () => {
     if (passwordForm.new_password.length < 8) {
       toast({
         title: 'Error',
-        description: 'Password must be at least 8 characters long',
+        description: t('settings.accountSecurity.passwordLengthError'),
         variant: 'destructive',
       });
       return;

--- a/SparkyFitnessServer/auth.ts
+++ b/SparkyFitnessServer/auth.ts
@@ -220,6 +220,7 @@ const auth = betterAuth({
   emailAndPassword: {
     enabled: process.env.SPARKY_FITNESS_DISABLE_EMAIL_LOGIN !== 'true',
     requireEmailVerification: false,
+    minPasswordLength: 8,
     sendResetPassword: async ({ user, url }) => {
       await sendPasswordResetEmail(user.email, url);
     },

--- a/SparkyFitnessServer/validation/authValidation.ts
+++ b/SparkyFitnessServer/validation/authValidation.ts
@@ -3,8 +3,8 @@ import { body } from 'express-validator';
 const registerValidation = [
   body('email').isEmail().withMessage('Invalid email address'),
   body('password')
-    .isLength({ min: 6 })
-    .withMessage('Password must be at least 6 characters long')
+    .isLength({ min: 8 })
+    .withMessage('Password must be at least 8 characters long')
     .matches(/[A-Z]/)
     .withMessage('Password must contain at least one uppercase letter')
     .matches(/[!@#$%^&*(),.?":{}|<>]/)
@@ -24,8 +24,8 @@ const forgotPasswordValidation = [
 const resetPasswordValidation = [
   body('token').notEmpty().withMessage('Reset token is required'),
   body('newPassword')
-    .isLength({ min: 6 })
-    .withMessage('Password must be at least 6 characters long')
+    .isLength({ min: 8 })
+    .withMessage('Password must be at least 8 characters long')
     .matches(/[A-Z]/)
     .withMessage('Password must contain at least one uppercase letter')
     .matches(/[!@#$%^&*(),.?":{}|<>]/)


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**

The signup form allowed 6- and 7-character passwords even though Better Auth requires at least 8 characters, causing a generic signup error after submission.

**How did you implement the solution?**

Aligned client-side password validation, native input constraints, translation copy, legacy server validation, and the explicit Better Auth configuration to an 8-character minimum.

Linked Issue: Closes #2038

## How to Test

1. Check out this branch and start the application with `./docker/docker-helper.sh dev up`.
2. Enter a valid name and email, plus a 6- or 7-character password that meets the other complexity requirements.
3. Verify the form displays `Password must be at least 8 characters long` and does not submit.
4. Enter an 8-character password that meets all complexity requirements and verify signup can proceed.
5. Repeat the minimum-length check through password reset and account security.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="2842" height="1273" alt="Screenshot From 2026-08-04 13-54-49" src="https://github.com/user-attachments/assets/32b1bf45-bfbf-41c3-acaf-71fef26b20ec" />

### After

<img width="2842" height="1273" alt="Screenshot From 2026-08-04 13-53-19" src="https://github.com/user-attachments/assets/582acca6-349e-4968-91ac-a80459b527fa" />

</details>

## Notes for Reviewers

The server log recorded Better Auth rejecting the prior signup attempt with `Password is too short`. No database schema, RLS policy, mobile code, or new endpoint is included in this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Increased the minimum password length to 8 characters for sign-up, password resets, and password changes.
  * Added matching input restrictions and updated translated validation messages across authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->