### PR TITLE
fix(tandoor): normalize recipe nutrition per serving

### DIFF
--- a/SparkyFitnessServer/integrations/tandoor/tandoorService.ts
+++ b/SparkyFitnessServer/integrations/tandoor/tandoorService.ts
@@ -40,11 +40,13 @@ export interface TandoorRecipe {
 // food_properties dictionary, and the generic properties array — which is where
 // instance-defined custom properties like "Magnesium" live), keyed by the
 // property's exact name, for alias discovery and custom-nutrient matching on
-// import. Values are per serving, matching the standard fields.
+// import. Tandoor's food_properties values are recipe totals, so normalize
+// those while preserving the per-serving values from its other response shapes.
 function extractTandoorProviderNutrients(
   nutritionData: TandoorRecipe['nutrition'],
   foodProperties: TandoorRecipe['food_properties'],
-  properties: TandoorRecipe['properties']
+  properties: TandoorRecipe['properties'],
+  recipeYield: number
 ): Record<string, number> {
   const out: Record<string, number> = {};
   const add = (rawName: unknown, rawValue: unknown) => {
@@ -63,7 +65,7 @@ function extractTandoorProviderNutrients(
     for (const key of Object.keys(foodProperties)) {
       const prop = foodProperties[key];
       if (prop && prop.total_value !== undefined) {
-        add(prop.name, prop.total_value);
+        add(prop.name, Number(prop.total_value) / recipeYield);
       }
     }
   }
@@ -451,6 +453,9 @@ class TandoorService {
     const properties = tandoorRecipe.properties || [];
     const foodProperties = tandoorRecipe.food_properties || {};
     const nutritionData = tandoorRecipe.nutrition;
+    const servings = Number(tandoorRecipe.servings);
+    const recipeYield =
+      Number.isFinite(servings) && servings > 0 ? servings : 1;
     // Generic getter that checks multiple candidate names across:
     // 1. nutrition object (explicit structured data)
     // 2. food_properties (auto-calculated data)
@@ -541,8 +546,9 @@ class TandoorService {
                     'debug',
                     `[Tandoor Mapping] Food Property Match: Found "${label}" via "${prop.name}" (slug: ${prop.open_data_slug}) = ${num}`
                   );
-                  if (num > 0) return num;
-                  if (bestValue === null) bestValue = num;
+                  const perServingValue = num / recipeYield;
+                  if (perServingValue > 0) return perServingValue;
+                  if (bestValue === null) bestValue = perServingValue;
                 }
               }
             }
@@ -701,23 +707,9 @@ class TandoorService {
         `Derived nutrition from properties for recipe ${tandoorRecipe.id}: calories=${calories}, protein=${protein}, carbs=${carbs}, fat=${fat}`
       );
     }
-    // Default serving information: preserve recipe servings count when provided (numeric)
-    let recipeYield = 1;
-    if (
-      tandoorRecipe.servings &&
-      !Number.isNaN(Number(tandoorRecipe.servings))
-    ) {
-      recipeYield = Number(tandoorRecipe.servings);
-    } else if (
-      Array.isArray(tandoorRecipe.servings_text) &&
-      tandoorRecipe.servings_text.length &&
-      !Number.isNaN(Number(tandoorRecipe.servings_text[0]))
-    ) {
-      recipeYield = Number(tandoorRecipe.servings_text[0]);
-    }
     log(
       'debug',
-      `[Tandoor Mapping] Recipe makes ${recipeYield} servings. Data is per-serving.`
+      `[Tandoor Mapping] Recipe makes ${recipeYield} servings. food_properties totals are normalized per serving.`
     );
     return {
       food: {
@@ -747,7 +739,7 @@ class TandoorService {
         is_quick_food: false,
       },
       variant: {
-        // Tandoor nutrition values are alway for 1 serving
+        // Food variants represent one serving.
         serving_size: 1,
         serving_unit: 'serving',
         // Map nutrition values (fallbacks may be null -> coerce to 0)
@@ -774,7 +766,8 @@ class TandoorService {
         provider_nutrients: extractTandoorProviderNutrients(
           nutritionData,
           foodProperties,
-          properties
+          properties,
+          recipeYield
         ),
         is_default: true,
       },

--- a/SparkyFitnessServer/tests/tandoorService.test.ts
+++ b/SparkyFitnessServer/tests/tandoorService.test.ts
@@ -12,6 +12,69 @@ describe('TandoorService.mapTandoorRecipeToSparkyFood', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
+  it('should normalize aggregate food_properties nutrition to one serving', () => {
+    const mockRecipe = {
+      id: 2,
+      name: 'Multi-Serving Recipe',
+      nutrition: null,
+      properties: [],
+      food_properties: {
+        1: { name: 'Calories', total_value: 600 },
+        2: { name: 'Proteins', total_value: 60 },
+        3: { name: 'Fats', total_value: 30 },
+        4: { name: 'Carbohydrates', total_value: 150 },
+      },
+      servings: 3,
+    };
+
+    const result = service.mapTandoorRecipeToSparkyFood(mockRecipe, userId);
+
+    expect(result.variant.serving_size).toBe(1);
+    expect(result.variant.serving_unit).toBe('serving');
+    expect(result.variant.calories).toBe(200);
+    expect(result.variant.protein).toBe(20);
+    expect(result.variant.carbs).toBe(50);
+    expect(result.variant.fat).toBe(10);
+    expect(result.variant.provider_nutrients?.Calories).toBe(200);
+  });
+  it.each([0, -1, 'not-a-number', null, undefined])(
+    'should retain aggregate nutrition when servings is invalid: %p',
+    (servings) => {
+      const result = service.mapTandoorRecipeToSparkyFood(
+        {
+          id: 3,
+          name: 'Invalid Yield Recipe',
+          nutrition: null,
+          properties: [],
+          food_properties: {
+            1: { name: 'Calories', total_value: 600 },
+          },
+          servings,
+        },
+        userId
+      );
+
+      expect(result.variant.calories).toBe(600);
+      expect(result.variant.provider_nutrients?.Calories).toBe(600);
+    }
+  );
+  it('should not derive a yield from servings_text', () => {
+    const result = service.mapTandoorRecipeToSparkyFood(
+      {
+        id: 4,
+        name: 'Display Yield Recipe',
+        nutrition: null,
+        properties: [],
+        food_properties: {
+          1: { name: 'Calories', total_value: 600 },
+        },
+        servings_text: ['3 servings'],
+      },
+      userId
+    );
+
+    expect(result.variant.calories).toBe(600);
+  });
   it('should map nutrition from food_properties (Spanish screenshot example)', () => {
     const mockRecipe = {
       id: 2,
@@ -42,10 +105,10 @@ describe('TandoorService.mapTandoorRecipeToSparkyFood', () => {
     };
     const result = service.mapTandoorRecipeToSparkyFood(mockRecipe, userId);
     expect(result.food.name).toBe(mockRecipe.name);
-    expect(result.variant.protein).toBe(237.57);
-    expect(result.variant.fat).toBe(69.838);
-    expect(result.variant.carbs).toBe(86.365);
-    expect(result.variant.serving_size).toBe(1); // mapped data is per serving
+    expect(result.variant.protein).toBe(59.3925);
+    expect(result.variant.fat).toBe(17.4595);
+    expect(result.variant.carbs).toBe(21.59125);
+    expect(result.variant.serving_size).toBe(1);
   });
   it('should map nutrition from nutrition object (explicit structured data)', () => {
     const mockRecipe = {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**

Tandoor recipe imports stored whole-recipe `food_properties` nutrition as one food serving. For multi-serving recipes, this overstated calories and nutrients by the recipe yield.

**How did you implement the solution?**

Normalize Tandoor `food_properties.total_value` values by a valid, positive `servings` value before mapping standard and provider nutrients to a one-serving food variant. Invalid or absent yields safely default to one, and `servings_text` is intentionally not parsed.

Added generic mapper coverage for multi-serving recipes and invalid yields.

Linked Issue: Closes #2040

## How to Test

1. Configure a Tandoor provider with a recipe that has aggregate `food_properties` totals and more than one serving.
2. Import the recipe through the food search flow.
3. Verify the imported variant uses `serving_size: 1` and `serving_unit: "serving"`.
4. Verify calories, macronutrients, and provider nutrients equal the recipe totals divided by `servings`.
5. Run `pnpm exec vitest run tests/tandoorService.test.ts` from `SparkyFitnessServer/`.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before
From Tandoor:
<img width="672" height="282" alt="image" src="https://github.com/user-attachments/assets/a61a5a01-0916-44ca-8f8b-7b853ad6a585" />

Sparkyfitness:
<img width="973" height="427" alt="image" src="https://github.com/user-attachments/assets/12a8f1b4-4bb1-4a79-a024-6f45ff0b6387" />

### After

<img width="973" height="427" alt="image" src="https://github.com/user-attachments/assets/07ca636b-bcac-4cc3-ac3a-0d333dd4fa7b" />

</details>

## Notes for Reviewers

`food_properties` values are whole-recipe totals. The mapper now divides them by only a valid positive `servings` value; it does not infer yield from display text. No endpoint, schema, database, RLS, frontend, or mobile changes are
included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Tandoor nutrition calculations so aggregate food properties are accurately reported per serving.
  * Improved handling of recipes with valid, missing, or invalid serving information.
  * Updated nutrition values for Spanish recipes to reflect per-serving amounts.

* **Tests**
  * Added coverage for serving-based nutrition normalization and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->