### PR TITLE
fix: aggregate based on metric time not on start time day

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/backgroundSyncService.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/backgroundSyncService.test.ts
@@ -201,7 +201,7 @@ describe('performBackgroundSync (via triggerManualSync)', () => {
       const lastSynced = new Date('2024-01-15T08:00:00Z');
       storage.loadLastSyncedTime.mockResolvedValue(lastSynced.toISOString());
       healthService.loadHealthPreference.mockResolvedValue(true);
-      healthService.readHealthRecords.mockResolvedValue([{ value: 72 }]);
+      healthService.readHealthRecords.mockResolvedValue([{ value: 480 }]);
 
       await triggerManualSync();
 
@@ -209,8 +209,30 @@ describe('performBackgroundSync (via triggerManualSync)', () => {
       const expectedSessionStart = new Date(lastSynced.getTime() - 6 * 60 * 60 * 1000);
 
       expect(healthService.readHealthRecords).toHaveBeenCalledWith(
-        'HeartRate',
+        'SleepSession',
         expectedSessionStart,
+        now
+      );
+    });
+
+    test('uses start-of-day for min-max-avg raw reads (issue #1978)', async () => {
+      const lastSynced = new Date('2024-01-15T08:00:00Z');
+      storage.loadLastSyncedTime.mockResolvedValue(lastSynced.toISOString());
+      healthService.loadHealthPreference.mockResolvedValue(true);
+      healthService.readHealthRecords.mockResolvedValue([{ value: 72 }]);
+
+      await triggerManualSync();
+
+      const now = new Date('2024-01-15T14:30:00Z');
+      const sessionStart = new Date(lastSynced.getTime() - 6 * 60 * 60 * 1000);
+      const expectedAggregatedStart = new Date(sessionStart);
+      expectedAggregatedStart.setHours(0, 0, 0, 0);
+
+      // A mid-day start would recompute heart_rate_min over a partial day and
+      // overwrite the server's full-day value (losing the overnight low).
+      expect(healthService.readHealthRecords).toHaveBeenCalledWith(
+        'HeartRate',
+        expectedAggregatedStart,
         now
       );
     });

--- a/SparkyFitnessMobile/__tests__/services/healthConnectService.ios.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthConnectService.ios.test.ts
@@ -31,6 +31,7 @@ jest.mock('../../src/HealthMetrics', () => ({
     { recordType: 'ActiveCaloriesBurned', stateKey: 'isCaloriesSyncEnabled', unit: 'kcal', type: 'active_calories', readKind: 'cumulative-day' },
     { recordType: 'TotalCaloriesBurned', stateKey: 'isTotalCaloriesSyncEnabled', unit: 'kcal', type: 'total_calories', readKind: 'cumulative-day' },
     { recordType: 'RunningSpeed', stateKey: 'isRunningSpeedSyncEnabled', unit: 'm/s', type: 'running_speed', aggregationStrategy: 'min-max-avg' },
+    { recordType: 'RestingHeartRate', stateKey: 'isRestingHeartRateSyncEnabled', unit: 'bpm', type: 'resting_heart_rate' },
   ],
 }));
 
@@ -298,11 +299,13 @@ describe('syncHealthData (iOS)', () => {
       jest.useRealTimers();
     });
 
-    test('cumulative reads filter from local midnight while raw reads keep the rolling start', async () => {
-      // Regression: cumulative reads emit per-day totals, so a mid-afternoon '24h' sync
-      // with the raw rolling start produced a partial first day that overwrote yesterday's
-      // full-day server value. Pin the clock mid-afternoon so the rolling start (yesterday
-      // 15:30) is distinguishable from its local midnight.
+    test('day-aggregated reads filter from local midnight while plain raw reads keep the rolling start', async () => {
+      // Regression: day-aggregated payloads (cumulative totals and min/max/avg)
+      // land as full-day SETs on the server, so a mid-afternoon '24h' sync with
+      // the raw rolling start produced a partial first day that overwrote
+      // yesterday's full-day server value (issue #1978). Pin the clock
+      // mid-afternoon so the rolling start (yesterday 15:30) is distinguishable
+      // from its local midnight.
       jest.useFakeTimers({ now: new Date(2026, 6, 3, 15, 30, 0) });
 
       mockQueryStatisticsCollection.mockResolvedValue([sumBucket(5000, 'count')]);
@@ -312,6 +315,7 @@ describe('syncHealthData (iOS)', () => {
       const result = await syncHealthData('24h' as SyncDuration, {
         isStepsSyncEnabled: true,
         isRunningSpeedSyncEnabled: true,
+        isRestingHeartRateSyncEnabled: true,
       });
 
       expect(result.success).toBe(true);
@@ -322,11 +326,19 @@ describe('syncHealthData (iOS)', () => {
       const statsOptions = mockQueryStatisticsCollection.mock.calls[0][4];
       expect(statsOptions.filter.date.startDate).toEqual(new Date(2026, 6, 2, 0, 0, 0, 0));
 
-      // RunningSpeed (raw sample fallback — no day-statistics spec) must keep the
+      const sampleCallsByIdentifier = Object.fromEntries(
+        mockQueryQuantitySamples.mock.calls.map((call: [string, { filter: { date: { startDate: Date } } }]) => [call[0], call[1]])
+      );
+
+      // RunningSpeed (min-max-avg raw fallback — no day-statistics spec) emits
+      // full-day min/max/avg values, so its read must also cover the whole day.
+      expect(sampleCallsByIdentifier['HKQuantityTypeIdentifierRunningSpeed'].filter.date.startDate)
+        .toEqual(new Date(2026, 6, 2, 0, 0, 0, 0));
+
+      // RestingHeartRate (plain raw, no aggregation strategy) must keep the
       // requested rolling window untouched.
-      expect(mockQueryQuantitySamples).toHaveBeenCalledTimes(1);
-      const sampleOptions = mockQueryQuantitySamples.mock.calls[0][1];
-      expect(sampleOptions.filter.date.startDate).toEqual(new Date(2026, 6, 2, 15, 30, 0));
+      expect(sampleCallsByIdentifier['HKQuantityTypeIdentifierRestingHeartRate'].filter.date.startDate)
+        .toEqual(new Date(2026, 6, 2, 15, 30, 0));
     });
   });
 

--- a/SparkyFitnessMobile/__tests__/services/healthConnectService.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthConnectService.test.ts
@@ -309,6 +309,36 @@ describe('healthConnectService.ts (Android)', () => {
       expect(hrAvg.value).toBe(70);
     });
 
+    test('HeartRate samples in a record spanning midnight bucket to their own days', async () => {
+      // Local-naive timestamps keep the local-day bucketing deterministic
+      // regardless of the machine timezone the test runs in.
+      mockReadRecords.mockResolvedValue({
+        records: [
+          {
+            startTime: '2024-01-15T22:00:00',
+            samples: [
+              { time: '2024-01-15T23:30:00', beatsPerMinute: 55 },
+              { time: '2024-01-16T00:15:00', beatsPerMinute: 48 },
+              { time: '2024-01-16T00:45:00', beatsPerMinute: 52 },
+            ],
+          },
+        ],
+      });
+
+      const healthMetricStates: HealthMetricStates = { isHeartRateSyncEnabled: true };
+
+      await androidService.syncHealthData('24h', healthMetricStates);
+
+      const payload = mockApiSyncHealthData.mock.calls[0][0];
+      const minByDate = Object.fromEntries(
+        payload
+          .filter((r: { type: string }) => r.type === 'heart_rate_min')
+          .map((r: { date: string; value: number }) => [r.date, r.value])
+      );
+
+      expect(minByDate).toEqual({ '2024-01-15': 55, '2024-01-16': 48 });
+    });
+
     test('HeartRateVariabilityRmssd records are aggregated with min/max/avg by date', async () => {
       mockReadRecords.mockResolvedValue({
         records: [

--- a/SparkyFitnessMobile/__tests__/services/shared/healthSyncEngine.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/shared/healthSyncEngine.test.ts
@@ -161,7 +161,7 @@ describe('collectHealthData', () => {
     expect(outcomes[0].data).toBe(dayStats);
   });
 
-  test('min-max-avg-day null (no verified spec) falls back to raw samples with the ORIGINAL window plus the aggregation tail', async () => {
+  test('min-max-avg-day null (no verified spec) falls back to raw samples with the DAY-ALIGNED window plus the aggregation tail', async () => {
     const rawSamples = [
       { value: 2.5, type: 'running_speed', date: '2026-07-02', unit: 'm/s' },
       { value: 4.0, type: 'running_speed', date: '2026-07-02', unit: 'm/s' },
@@ -173,7 +173,11 @@ describe('collectHealthData', () => {
 
     const outcomes = await collectHealthData(provider, [runningSpeed], windows, { timeoutLabelPrefix: 'Test query' });
 
-    expect(provider.readRaw).toHaveBeenCalledWith('RunningSpeed', windows.sessionStart, windows.end);
+    // Day-aligned, not sessionStart: the aggregates land as full-day SETs on
+    // the server, so a mid-day window start would clobber the stored day
+    // values with partial-window ones (issue #1978 — heart_rate_min losing
+    // the overnight low to an afternoon sync).
+    expect(provider.readRaw).toHaveBeenCalledWith('RunningSpeed', windows.aggregatedStart, windows.end);
     expect(provider.transform).toHaveBeenCalledWith(rawSamples, runningSpeed);
     // The aggregateByDay tail runs: exactly 3 records per day.
     expect(outcomes[0].data.map((r: { type: string }) => r.type)).toEqual([
@@ -181,6 +185,15 @@ describe('collectHealthData', () => {
       'running_speed_max',
       'running_speed_avg',
     ]);
+  });
+
+  test('sum-strategy metrics also read from the day-aligned window on the raw path', async () => {
+    const provider = fakeProvider();
+    const standTime = metric({ recordType: 'AppleStandTime', type: 'apple_stand_time', unit: 'seconds', aggregationStrategy: 'sum' });
+
+    await collectHealthData(provider, [standTime], windows, { timeoutLabelPrefix: 'Test query' });
+
+    expect(provider.readRaw).toHaveBeenCalledWith('AppleStandTime', windows.aggregatedStart, windows.end);
   });
 
   test('rollingLookbackDays widens the raw window to the day-aligned lookback', async () => {

--- a/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
@@ -547,15 +547,17 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
   },
 
   HeartRate: (rec, _record, metricConfig, output) => {
-    const samples = rec.samples as { beatsPerMinute: number }[] | undefined;
+    const samples = rec.samples as { time?: string; beatsPerMinute: number }[] | undefined;
     if (!rec.startTime || !samples) return;
 
     const { unit, type } = metricConfig;
-    const date = getDateString(rec.startTime);
-    if (!date) return;
 
     for (const sample of samples) {
       if (sample.beatsPerMinute != null && !isNaN(sample.beatsPerMinute)) {
+        // Series records can span local midnight, so each sample buckets to
+        // its own day rather than the record's start day.
+        const date = getDateString(sample.time ?? rec.startTime);
+        if (!date) continue;
         output.push({ value: sample.beatsPerMinute, type, date, unit, source: HEALTH_CONNECT_SOURCE });
       }
     }
@@ -719,13 +721,14 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
   },
 
   CyclingPedalingCadence: (rec, _record, metricConfig, output) => {
-    const samples = rec.samples as { revolutionsPerMinute: number }[] | undefined;
+    const samples = rec.samples as { time?: string; revolutionsPerMinute: number }[] | undefined;
     if (!rec.startTime || !samples) return;
 
     const { unit, type } = metricConfig;
-    const date = toLocalDateString(rec.startTime as string);
 
     samples.forEach(sample => {
+      const date = getDateString(sample.time ?? rec.startTime);
+      if (!date) return;
       output.push({
         value: sample.revolutionsPerMinute,
         type,
@@ -737,13 +740,14 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
   },
 
   StepsCadence: (rec, _record, metricConfig, output) => {
-    const samples = rec.samples as { rate: number }[] | undefined;
+    const samples = rec.samples as { time?: string; rate: number }[] | undefined;
     if (!rec.startTime || !samples) return;
 
     const { unit, type } = metricConfig;
-    const date = toLocalDateString(rec.startTime as string);
 
     samples.forEach(sample => {
+      const date = getDateString(sample.time ?? rec.startTime);
+      if (!date) return;
       output.push({
         value: sample.rate,
         type,

--- a/SparkyFitnessMobile/src/services/shared/healthSyncEngine.ts
+++ b/SparkyFitnessMobile/src/services/shared/healthSyncEngine.ts
@@ -144,12 +144,15 @@ const collectMetric = async (
       ))
     : windows.sessionStart;
 
-  // Day-aggregated water lands as a full-day SET on the receiving server, so
-  // its read must cover complete local days: the background sessionStart
-  // (lastSynced − 6h) can fall mid-day, and summing that slice would replace
-  // the server's real day total with a fraction of it.
+  // Day-aggregated payloads (aggregationStrategy metrics and the water day-sum
+  // fallback) land as full-day SETs on the receiving server, so their reads
+  // must cover complete local days: the background sessionStart
+  // (lastSynced − 6h) can fall mid-day, and aggregating that slice would
+  // replace the server's real full-day values with partial-window ones
+  // (e.g. heart_rate_min losing the overnight low).
   const readStart =
-    waterFallbackToSum && metric.type === 'water'
+    metric.aggregationStrategy != null ||
+    (waterFallbackToSum && metric.type === 'water')
       ? windows.aggregatedStart
       : rawStart;
 


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**

heart_rate_min for a day didn't match the actual minimum. User saw 78 bpm stored as a daily min on a day whose overnight low was in the 40s. Health Connect only.

**How did you implement the solution?**


raw path reads for aggregationStrategy metrics now start at the dazy aligned windows.aggregatedStart
Heartrate/cycling pedaling cadence/steps cadence samples now bucket by each samples own time instead of the record's start day, so series records spanning midnight put the correct day

Linked Issue: Closes #1978 

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health and fitness samples crossing midnight are now assigned to the correct calendar day.
  * Daily heart-rate, cadence, step, running-speed, and other aggregated metrics now use complete day-aligned time windows.
  * Improved daily minimum, maximum, average, and total calculations by preventing partial-day results.
  * Sleep readings continue using their session-based time window for accurate synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->