### PR TITLE
docs: validation for water containers and update docs

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Settings/WaterContainerManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/WaterContainerManager.tsx
@@ -87,6 +87,8 @@ const WaterContainerManager: React.FC = () => {
             <Input
               id="volume"
               type="number"
+              min="0.001"
+              step="any"
               value={volume}
               onChange={(e) => setVolume(Number(e.target.value))}
               placeholder="e.g., 500"
@@ -98,6 +100,7 @@ const WaterContainerManager: React.FC = () => {
             <Input
               id="servingsPerContainer"
               type="number"
+              min="1"
               value={servingsPerContainer}
               onChange={(e) => setServingsPerContainer(Number(e.target.value))}
               placeholder="e.g., 4"

--- a/SparkyFitnessServer/config/swagger.ts
+++ b/SparkyFitnessServer/config/swagger.ts
@@ -1020,7 +1020,7 @@ const options = {
         WaterContainer: {
           type: 'object',
           properties: {
-            id: { type: 'string', format: 'uuid' },
+            id: { type: 'integer' },
             user_id: { type: 'string', format: 'uuid' },
             name: { type: 'string' },
             volume: { type: 'number', description: 'Volume in specified unit' },

--- a/SparkyFitnessServer/models/waterContainerRepository.ts
+++ b/SparkyFitnessServer/models/waterContainerRepository.ts
@@ -46,13 +46,6 @@ async function updateWaterContainer(id: any, userId: any, updateData: any) {
   const client = await getClient(userId); // User-specific operation
   try {
     await client.query('BEGIN');
-    if (is_primary === true) {
-      // A user has at most one primary container
-      await client.query(
-        'UPDATE user_water_containers SET is_primary = false WHERE user_id = $1 AND id != $2',
-        [userId, id]
-      );
-    }
     const result = await client.query(
       `UPDATE user_water_containers SET
         name = COALESCE($1, name),
@@ -65,6 +58,15 @@ async function updateWaterContainer(id: any, userId: any, updateData: any) {
        RETURNING *`,
       [name, volume, unit, is_primary, servings_per_container, id, userId]
     );
+    // Demote competing primaries only after the target row is confirmed to
+    // exist and belong to this user
+    if (result.rows[0] && is_primary === true) {
+      // A user has at most one primary container
+      await client.query(
+        'UPDATE user_water_containers SET is_primary = false WHERE user_id = $1 AND id != $2',
+        [userId, id]
+      );
+    }
     await client.query('COMMIT');
     return result.rows[0];
   } catch (error) {
@@ -92,16 +94,18 @@ async function setPrimaryWaterContainer(id: any, userId: any) {
   const client = await getClient(userId); // User-specific operation
   try {
     await client.query('BEGIN');
-    // First, set all containers for this user to not be primary
-    await client.query(
-      'UPDATE user_water_containers SET is_primary = false WHERE user_id = $1',
-      [userId]
-    );
-    // Then, set the specified container to be primary
     const result = await client.query(
       'UPDATE user_water_containers SET is_primary = true, updated_at = now() WHERE id = $1 AND user_id = $2 RETURNING *',
       [id, userId]
     );
+    // Demote the other containers only after the target row is confirmed to
+    // exist and belong to this user
+    if (result.rows[0]) {
+      await client.query(
+        'UPDATE user_water_containers SET is_primary = false WHERE user_id = $1 AND id != $2',
+        [userId, id]
+      );
+    }
     await client.query('COMMIT');
     return result.rows[0];
   } catch (error) {

--- a/SparkyFitnessServer/models/waterContainerRepository.ts
+++ b/SparkyFitnessServer/models/waterContainerRepository.ts
@@ -5,12 +5,24 @@ async function createWaterContainer(userId: any, containerData: any) {
     containerData;
   const client = await getClient(userId); // User-specific operation
   try {
+    await client.query('BEGIN');
+    if (is_primary === true) {
+      // A user has at most one primary container
+      await client.query(
+        'UPDATE user_water_containers SET is_primary = false WHERE user_id = $1',
+        [userId]
+      );
+    }
     const result = await client.query(
       `INSERT INTO user_water_containers (user_id, name, volume, unit, is_primary, servings_per_container)
        VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
       [userId, name, volume, unit, is_primary, servings_per_container]
     );
+    await client.query('COMMIT');
     return result.rows[0];
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
   } finally {
     client.release();
   }
@@ -33,6 +45,14 @@ async function updateWaterContainer(id: any, userId: any, updateData: any) {
   const { name, volume, unit, is_primary, servings_per_container } = updateData;
   const client = await getClient(userId); // User-specific operation
   try {
+    await client.query('BEGIN');
+    if (is_primary === true) {
+      // A user has at most one primary container
+      await client.query(
+        'UPDATE user_water_containers SET is_primary = false WHERE user_id = $1 AND id != $2',
+        [userId, id]
+      );
+    }
     const result = await client.query(
       `UPDATE user_water_containers SET
         name = COALESCE($1, name),
@@ -45,7 +65,11 @@ async function updateWaterContainer(id: any, userId: any, updateData: any) {
        RETURNING *`,
       [name, volume, unit, is_primary, servings_per_container, id, userId]
     );
+    await client.query('COMMIT');
     return result.rows[0];
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
   } finally {
     client.release();
   }

--- a/SparkyFitnessServer/routes/waterContainerRoutes.ts
+++ b/SparkyFitnessServer/routes/waterContainerRoutes.ts
@@ -2,7 +2,24 @@ import express from 'express';
 import { authenticate } from '../middleware/authMiddleware.js';
 import waterContainerService from '../services/waterContainerService.js';
 import { canAccessUserData } from '../utils/permissionUtils.js';
+import {
+  WaterContainerIdParamSchema,
+  CreateWaterContainerBodySchema,
+  UpdateWaterContainerBodySchema,
+} from '../schemas/waterContainerSchemas.js';
 const router = express.Router();
+
+// Small helper to send a uniform 400 for Zod failures.
+function badRequest(res: express.Response, error: unknown): void {
+  res.status(400).json({
+    error: 'Invalid request',
+    details:
+      error && typeof error === 'object' && 'flatten' in error
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (error as any).flatten().fieldErrors
+        : undefined,
+  });
+}
 /**
  * @swagger
  * /water-containers:
@@ -23,9 +40,11 @@ const router = express.Router();
  */
 router.post('/', authenticate, async (req, res, next) => {
   try {
+    const body = CreateWaterContainerBodySchema.safeParse(req.body);
+    if (!body.success) return badRequest(res, body.error);
     const container = await waterContainerService.createWaterContainer(
       req.userId,
-      req.body
+      body.data
     );
     res.status(201).json(container);
   } catch (error) {
@@ -97,11 +116,14 @@ router.get('/', authenticate, async (req, res, next) => {
  */
 router.put('/:id', authenticate, async (req, res, next) => {
   try {
+    const params = WaterContainerIdParamSchema.safeParse(req.params);
+    if (!params.success) return badRequest(res, params.error);
+    const body = UpdateWaterContainerBodySchema.safeParse(req.body);
+    if (!body.success) return badRequest(res, body.error);
     const container = await waterContainerService.updateWaterContainer(
-      req.params.id,
-
+      params.data.id,
       req.userId,
-      req.body
+      body.data
     );
     if (!container) {
       return res
@@ -133,9 +155,10 @@ router.put('/:id', authenticate, async (req, res, next) => {
  */
 router.delete('/:id', authenticate, async (req, res, next) => {
   try {
+    const params = WaterContainerIdParamSchema.safeParse(req.params);
+    if (!params.success) return badRequest(res, params.error);
     const result = await waterContainerService.deleteWaterContainer(
-      req.params.id,
-
+      params.data.id,
       req.userId
     );
     res.status(200).json(result);
@@ -168,9 +191,10 @@ router.delete('/:id', authenticate, async (req, res, next) => {
  */
 router.put('/:id/set-primary', authenticate, async (req, res, next) => {
   try {
+    const params = WaterContainerIdParamSchema.safeParse(req.params);
+    if (!params.success) return badRequest(res, params.error);
     const container = await waterContainerService.setPrimaryWaterContainer(
-      req.params.id,
-
+      params.data.id,
       req.userId
     );
     if (!container) {

--- a/SparkyFitnessServer/routes/waterContainerRoutes.ts
+++ b/SparkyFitnessServer/routes/waterContainerRoutes.ts
@@ -85,8 +85,7 @@ router.get('/', authenticate, async (req, res, next) => {
  *         name: id
  *         required: true
  *         schema:
- *           type: string
- *           format: uuid
+ *           type: integer
  *     requestBody:
  *       content:
  *         application/json:
@@ -127,8 +126,7 @@ router.put('/:id', authenticate, async (req, res, next) => {
  *         name: id
  *         required: true
  *         schema:
- *           type: string
- *           format: uuid
+ *           type: integer
  *     responses:
  *       200:
  *         description: Deleted successfully.
@@ -163,8 +161,7 @@ router.delete('/:id', authenticate, async (req, res, next) => {
  *         name: id
  *         required: true
  *         schema:
- *           type: string
- *           format: uuid
+ *           type: integer
  *     responses:
  *       200:
  *         description: Primary container set successfully.

--- a/SparkyFitnessServer/routes/waterContainerRoutes.ts
+++ b/SparkyFitnessServer/routes/waterContainerRoutes.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import { z } from 'zod/v4';
 import { authenticate } from '../middleware/authMiddleware.js';
 import waterContainerService from '../services/waterContainerService.js';
 import { canAccessUserData } from '../utils/permissionUtils.js';
@@ -10,14 +11,10 @@ import {
 const router = express.Router();
 
 // Small helper to send a uniform 400 for Zod failures.
-function badRequest(res: express.Response, error: unknown): void {
+function badRequest(res: express.Response, error: z.ZodError): void {
   res.status(400).json({
     error: 'Invalid request',
-    details:
-      error && typeof error === 'object' && 'flatten' in error
-        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (error as any).flatten().fieldErrors
-        : undefined,
+    details: error.flatten().fieldErrors,
   });
 }
 /**

--- a/SparkyFitnessServer/schemas/waterContainerSchemas.ts
+++ b/SparkyFitnessServer/schemas/waterContainerSchemas.ts
@@ -7,9 +7,10 @@ export const WaterContainerIdParamSchema = z.object({
 });
 
 const nameSchema = z.string().min(1).max(255);
-// Stored as numeric(10,3) after unit conversion; the bound keeps the
-// worst-case liter -> ml conversion inside the column's range
-const volumeSchema = z.number().positive().max(9999.999);
+// Stored as numeric(10,3) after unit conversion; the min stops ml values
+// from rounding to 0.000 and the max keeps the worst-case liter -> ml
+// conversion inside the column's range
+const volumeSchema = z.number().min(0.001).max(9999.999);
 const unitSchema = z.enum(WATER_CONTAINER_UNITS);
 const servingsSchema = z.number().int().min(1);
 

--- a/SparkyFitnessServer/schemas/waterContainerSchemas.ts
+++ b/SparkyFitnessServer/schemas/waterContainerSchemas.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod/v4';
+
+export const WATER_CONTAINER_UNITS = ['ml', 'oz', 'liter'] as const;
+
+export const WaterContainerIdParamSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+const nameSchema = z.string().min(1).max(255);
+// Stored as numeric(10,3) after unit conversion; the bound keeps the
+// worst-case liter -> ml conversion inside the column's range
+const volumeSchema = z.number().positive().max(9999.999);
+const unitSchema = z.enum(WATER_CONTAINER_UNITS);
+const servingsSchema = z.number().int().min(1);
+
+export const CreateWaterContainerBodySchema = z.object({
+  name: nameSchema,
+  volume: volumeSchema,
+  unit: unitSchema,
+  is_primary: z.boolean().default(false),
+  servings_per_container: servingsSchema.default(1),
+});
+
+export const UpdateWaterContainerBodySchema = z.object({
+  name: nameSchema.optional(),
+  volume: volumeSchema.optional(),
+  unit: unitSchema.optional(),
+  is_primary: z.boolean().optional(),
+  servings_per_container: servingsSchema.optional(),
+});
+
+export type CreateWaterContainerBody = z.infer<
+  typeof CreateWaterContainerBodySchema
+>;
+export type UpdateWaterContainerBody = z.infer<
+  typeof UpdateWaterContainerBodySchema
+>;

--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -510,8 +510,13 @@ async function upsertWaterIntake(
         authenticatedUserId
       );
       if (container) {
-        amountPerDrink =
-          Number(container.volume) / Number(container.servings_per_container);
+        // Stored rows can carry servings_per_container = 0; clamp so the
+        // division can't produce Infinity
+        const servings = Math.max(
+          1,
+          Number(container.servings_per_container) || 1
+        );
+        amountPerDrink = Number(container.volume) / servings;
         containerName = container.name || null;
       } else {
         // Fallback to default if container not found

--- a/SparkyFitnessServer/services/waterContainerService.ts
+++ b/SparkyFitnessServer/services/waterContainerService.ts
@@ -1,6 +1,7 @@
 import waterContainerRepository from '../models/waterContainerRepository.js';
 import { log } from '../config/logging.js';
-const VALID_UNITS = ['ml', 'oz', 'liter']; // Changed 'cup' to 'liter'
+import { WATER_CONTAINER_UNITS } from '../schemas/waterContainerSchemas.js';
+const VALID_UNITS: readonly string[] = WATER_CONTAINER_UNITS;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function convertToMl(volume: any, unit: any) {
   if (!VALID_UNITS.includes(unit)) {

--- a/SparkyFitnessServer/tests/measurementService.waterIntake.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.waterIntake.test.ts
@@ -1,9 +1,11 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
 import measurementService from '../services/measurementService.js';
 import measurementRepository from '../models/measurementRepository.js';
+import waterContainerRepository from '../models/waterContainerRepository.js';
 import { UpsertWaterIntakeBodySchema } from '../schemas/measurementSchemas.js';
 // Mock the repository functions
 vi.mock('../models/measurementRepository');
+vi.mock('../models/waterContainerRepository');
 describe('Measurement Service - Water Intake', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -97,6 +99,76 @@ describe('Measurement Service - Water Intake', () => {
       expect(
         measurementRepository.getWaterIntakeEntryOwnerId
       ).toHaveBeenCalledWith(mockEntryId, mockUserId);
+    });
+  });
+  describe('upsertWaterIntake', () => {
+    const mockUserId = 'test-user-id';
+    const entryDate = '2026-08-05';
+
+    beforeEach(() => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      measurementRepository.incrementWaterData.mockResolvedValue({});
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      measurementRepository.insertWaterIntakeLog.mockResolvedValue({});
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      measurementRepository.getWaterIntakeByDate.mockResolvedValue({});
+    });
+
+    it('divides container volume by servings_per_container per drink', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      waterContainerRepository.getWaterContainerById.mockResolvedValue({
+        id: 3,
+        name: 'Jug',
+        volume: '2000.000',
+        servings_per_container: 8,
+      });
+      await measurementService.upsertWaterIntake(
+        mockUserId,
+        mockUserId,
+        entryDate,
+        1,
+        3
+      );
+      expect(measurementRepository.incrementWaterData).toHaveBeenCalledWith(
+        mockUserId,
+        mockUserId,
+        250,
+        entryDate,
+        'manual'
+      );
+      expect(measurementRepository.insertWaterIntakeLog).toHaveBeenCalledWith(
+        mockUserId,
+        mockUserId,
+        entryDate,
+        250,
+        3,
+        'Jug',
+        'manual'
+      );
+    });
+
+    it('falls back to the full container volume when servings_per_container is 0', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      waterContainerRepository.getWaterContainerById.mockResolvedValue({
+        id: 3,
+        name: 'Broken Row',
+        volume: '750.000',
+        servings_per_container: 0,
+      });
+      await measurementService.upsertWaterIntake(
+        mockUserId,
+        mockUserId,
+        entryDate,
+        1,
+        3
+      );
+      expect(measurementRepository.incrementWaterData).toHaveBeenCalledWith(
+        mockUserId,
+        mockUserId,
+        750,
+        entryDate,
+        'manual'
+      );
     });
   });
   describe('updateWaterIntake', () => {

--- a/SparkyFitnessServer/tests/waterContainerRepository.test.ts
+++ b/SparkyFitnessServer/tests/waterContainerRepository.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import waterContainerRepository from '../models/waterContainerRepository.js';
+import { getClient } from '../db/poolManager.js';
+
+vi.mock('../db/poolManager.js', () => ({
+  getClient: vi.fn(),
+}));
+
+describe('waterContainerRepository single-primary enforcement', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  const queryTexts = (): string[] =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockClient.query.mock.calls.map((call: any[]) => call[0] as string);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const demoteQueries = (): Array<{ text: string; values: any[] }> =>
+    mockClient.query.mock.calls
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .map((call: any[]) => ({ text: call[0] as string, values: call[1] }))
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .filter((call: any) => call.text.includes('SET is_primary = false'));
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn().mockResolvedValue({ rows: [{}] }),
+      release: vi.fn(),
+    };
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createWaterContainer', () => {
+    it('demotes existing primaries before inserting a primary container', async () => {
+      await waterContainerRepository.createWaterContainer('user-1', {
+        name: 'Bottle',
+        volume: 750,
+        unit: 'ml',
+        is_primary: true,
+        servings_per_container: 1,
+      });
+
+      const demotes = demoteQueries();
+      expect(demotes).toHaveLength(1);
+      expect(demotes[0].values).toEqual(['user-1']);
+
+      const texts = queryTexts();
+      const demoteIndex = texts.findIndex((text) =>
+        text.includes('SET is_primary = false')
+      );
+      const insertIndex = texts.findIndex((text) =>
+        text.includes('INSERT INTO user_water_containers')
+      );
+      expect(demoteIndex).toBeLessThan(insertIndex);
+      expect(texts.indexOf('BEGIN')).toBeLessThan(demoteIndex);
+      expect(texts.indexOf('COMMIT')).toBeGreaterThan(insertIndex);
+    });
+
+    it('does not demote anything for a non-primary container', async () => {
+      await waterContainerRepository.createWaterContainer('user-1', {
+        name: 'Bottle',
+        volume: 750,
+        unit: 'ml',
+        is_primary: false,
+        servings_per_container: 1,
+      });
+
+      expect(demoteQueries()).toHaveLength(0);
+    });
+
+    it('does not demote anything when is_primary is omitted', async () => {
+      await waterContainerRepository.createWaterContainer('user-1', {
+        name: 'Bottle',
+        volume: 750,
+        unit: 'ml',
+      });
+
+      expect(demoteQueries()).toHaveLength(0);
+    });
+
+    it('rolls back when the insert fails', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockClient.query.mockImplementation(async (text: any) => {
+        if (typeof text === 'string' && text.includes('INSERT INTO')) {
+          throw new Error('insert failed');
+        }
+        return { rows: [{}] };
+      });
+
+      await expect(
+        waterContainerRepository.createWaterContainer('user-1', {
+          name: 'Bottle',
+          volume: 750,
+          unit: 'ml',
+          is_primary: true,
+        })
+      ).rejects.toThrow('insert failed');
+
+      expect(queryTexts()).toContain('ROLLBACK');
+      expect(queryTexts()).not.toContain('COMMIT');
+      expect(mockClient.release).toHaveBeenCalled();
+    });
+  });
+
+  describe('updateWaterContainer', () => {
+    it('demotes other containers when promoting one to primary', async () => {
+      await waterContainerRepository.updateWaterContainer(7, 'user-1', {
+        is_primary: true,
+      });
+
+      const demotes = demoteQueries();
+      expect(demotes).toHaveLength(1);
+      expect(demotes[0].values).toEqual(['user-1', 7]);
+      expect(demotes[0].text).toContain('id != $2');
+    });
+
+    it('does not demote anything when is_primary is not in the payload', async () => {
+      await waterContainerRepository.updateWaterContainer(7, 'user-1', {
+        name: 'Renamed',
+      });
+
+      expect(demoteQueries()).toHaveLength(0);
+    });
+
+    it('does not demote anything when setting is_primary to false', async () => {
+      await waterContainerRepository.updateWaterContainer(7, 'user-1', {
+        is_primary: false,
+      });
+
+      expect(demoteQueries()).toHaveLength(0);
+    });
+  });
+});

--- a/SparkyFitnessServer/tests/waterContainerRepository.test.ts
+++ b/SparkyFitnessServer/tests/waterContainerRepository.test.ts
@@ -133,5 +133,53 @@ describe('waterContainerRepository single-primary enforcement', () => {
 
       expect(demoteQueries()).toHaveLength(0);
     });
+
+    it('does not demote anything when the target container is missing or foreign', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockClient.query.mockImplementation(async (text: any) => {
+        if (typeof text === 'string' && text.includes('COALESCE')) {
+          return { rows: [] };
+        }
+        return { rows: [{}] };
+      });
+
+      const result = await waterContainerRepository.updateWaterContainer(
+        999,
+        'user-1',
+        { is_primary: true }
+      );
+
+      expect(result).toBeUndefined();
+      expect(demoteQueries()).toHaveLength(0);
+    });
+  });
+
+  describe('setPrimaryWaterContainer', () => {
+    it('demotes the other containers after promoting the target', async () => {
+      await waterContainerRepository.setPrimaryWaterContainer(7, 'user-1');
+
+      const demotes = demoteQueries();
+      expect(demotes).toHaveLength(1);
+      expect(demotes[0].values).toEqual(['user-1', 7]);
+      expect(demotes[0].text).toContain('id != $2');
+    });
+
+    it('does not demote anything when the target container is missing or foreign', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockClient.query.mockImplementation(async (text: any) => {
+        if (typeof text === 'string' && text.includes('is_primary = true')) {
+          return { rows: [] };
+        }
+        return { rows: [{}] };
+      });
+
+      const result = await waterContainerRepository.setPrimaryWaterContainer(
+        999,
+        'user-1'
+      );
+
+      expect(result).toBeUndefined();
+      expect(demoteQueries()).toHaveLength(0);
+    });
   });
 });

--- a/SparkyFitnessServer/tests/waterContainerRoutes.test.ts
+++ b/SparkyFitnessServer/tests/waterContainerRoutes.test.ts
@@ -18,8 +18,11 @@ vi.mock('../services/waterContainerService.js', () => ({
 }));
 
 vi.mock('../middleware/authMiddleware.js', () => ({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authenticate: (req: any, res: any, next: any) => {
+  authenticate: (
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction
+  ) => {
     req.userId = 'test-user-id';
     next();
   },
@@ -91,6 +94,14 @@ describe('Water Container Routes', () => {
       const res = await request(app)
         .post('/api/water-containers')
         .send({ ...validBody, volume: 0 });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('rejects a volume below the numeric(10,3) precision floor', async () => {
+      const res = await request(app)
+        .post('/api/water-containers')
+        .send({ ...validBody, volume: 0.0001 });
 
       expect(res.statusCode).toBe(400);
     });

--- a/SparkyFitnessServer/tests/waterContainerRoutes.test.ts
+++ b/SparkyFitnessServer/tests/waterContainerRoutes.test.ts
@@ -1,0 +1,212 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'
+import request from 'supertest';
+import express from 'express';
+import waterContainerService from '../services/waterContainerService.js';
+import errorHandler from '../middleware/errorHandler.js';
+import waterContainerRoutes from '../routes/waterContainerRoutes.js';
+
+vi.mock('../services/waterContainerService.js', () => ({
+  default: {
+    createWaterContainer: vi.fn(),
+    getWaterContainersByUserId: vi.fn(),
+    updateWaterContainer: vi.fn(),
+    deleteWaterContainer: vi.fn(),
+    setPrimaryWaterContainer: vi.fn(),
+    getPrimaryWaterContainerByUserId: vi.fn(),
+  },
+}));
+
+vi.mock('../middleware/authMiddleware.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authenticate: (req: any, res: any, next: any) => {
+    req.userId = 'test-user-id';
+    next();
+  },
+}));
+
+vi.mock('../utils/permissionUtils.js', () => ({
+  canAccessUserData: vi.fn().mockResolvedValue(true),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/water-containers', waterContainerRoutes);
+app.use(errorHandler);
+
+describe('Water Container Routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('POST /api/water-containers', () => {
+    const validBody = { name: 'Jug', volume: 2000, unit: 'ml' };
+
+    it('creates a container and applies defaults for omitted fields', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist
+      waterContainerService.createWaterContainer.mockResolvedValue({ id: 1 });
+
+      const res = await request(app)
+        .post('/api/water-containers')
+        .send(validBody);
+
+      expect(res.statusCode).toBe(201);
+      expect(waterContainerService.createWaterContainer).toHaveBeenCalledWith(
+        'test-user-id',
+        {
+          name: 'Jug',
+          volume: 2000,
+          unit: 'ml',
+          is_primary: false,
+          servings_per_container: 1,
+        }
+      );
+    });
+
+    it('strips unknown fields before they reach the service', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist
+      waterContainerService.createWaterContainer.mockResolvedValue({ id: 1 });
+
+      await request(app)
+        .post('/api/water-containers')
+        .send({ ...validBody, user_id: 'someone-else', id: 99 });
+
+      const passed =
+        // @ts-expect-error TS(2339): Property 'mock' does not exist
+        waterContainerService.createWaterContainer.mock.calls[0][1];
+      expect(passed).not.toHaveProperty('user_id');
+      expect(passed).not.toHaveProperty('id');
+    });
+
+    it('rejects an unknown unit', async () => {
+      const res = await request(app)
+        .post('/api/water-containers')
+        .send({ ...validBody, unit: 'cup' });
+
+      expect(res.statusCode).toBe(400);
+      expect(waterContainerService.createWaterContainer).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-positive volume', async () => {
+      const res = await request(app)
+        .post('/api/water-containers')
+        .send({ ...validBody, volume: 0 });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('rejects servings_per_container of 0', async () => {
+      const res = await request(app)
+        .post('/api/water-containers')
+        .send({ ...validBody, servings_per_container: 0 });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('rejects a missing name', async () => {
+      const res = await request(app)
+        .post('/api/water-containers')
+        .send({ volume: 2000, unit: 'ml' });
+
+      expect(res.statusCode).toBe(400);
+    });
+  });
+
+  describe('PUT /api/water-containers/:id', () => {
+    it('accepts a partial body and passes the numeric id through', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist
+      waterContainerService.updateWaterContainer.mockResolvedValue({ id: 7 });
+
+      const res = await request(app)
+        .put('/api/water-containers/7')
+        .send({ name: 'Renamed' });
+
+      expect(res.statusCode).toBe(200);
+      expect(waterContainerService.updateWaterContainer).toHaveBeenCalledWith(
+        7,
+        'test-user-id',
+        { name: 'Renamed' }
+      );
+    });
+
+    it('rejects a non-integer id', async () => {
+      const res = await request(app)
+        .put('/api/water-containers/not-a-number')
+        .send({ name: 'Renamed' });
+
+      expect(res.statusCode).toBe(400);
+      expect(waterContainerService.updateWaterContainer).not.toHaveBeenCalled();
+    });
+
+    it('rejects servings_per_container of 0', async () => {
+      const res = await request(app)
+        .put('/api/water-containers/7')
+        .send({ servings_per_container: 0 });
+
+      expect(res.statusCode).toBe(400);
+    });
+
+    it('returns 404 when the container is not found', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist
+      waterContainerService.updateWaterContainer.mockResolvedValue(undefined);
+
+      const res = await request(app)
+        .put('/api/water-containers/7')
+        .send({ name: 'Renamed' });
+
+      expect(res.statusCode).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/water-containers/:id', () => {
+    it('deletes by numeric id', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist
+      waterContainerService.deleteWaterContainer.mockResolvedValue({
+        message: 'Water container deleted successfully.',
+      });
+
+      const res = await request(app).delete('/api/water-containers/7');
+
+      expect(res.statusCode).toBe(200);
+      expect(waterContainerService.deleteWaterContainer).toHaveBeenCalledWith(
+        7,
+        'test-user-id'
+      );
+    });
+
+    it('rejects a non-integer id', async () => {
+      const res = await request(app).delete('/api/water-containers/abc');
+
+      expect(res.statusCode).toBe(400);
+      expect(waterContainerService.deleteWaterContainer).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('PUT /api/water-containers/:id/set-primary', () => {
+    it('sets primary by numeric id', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist
+      waterContainerService.setPrimaryWaterContainer.mockResolvedValue({
+        id: 7,
+        is_primary: true,
+      });
+
+      const res = await request(app).put('/api/water-containers/7/set-primary');
+
+      expect(res.statusCode).toBe(200);
+      expect(
+        waterContainerService.setPrimaryWaterContainer
+      ).toHaveBeenCalledWith(7, 'test-user-id');
+    });
+
+    it('rejects a non-integer id', async () => {
+      const res = await request(app).put(
+        '/api/water-containers/abc/set-primary'
+      );
+
+      expect(res.statusCode).toBe(400);
+      expect(
+        waterContainerService.setPrimaryWaterContainer
+      ).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
The system lets you have two water containers but the clients expect 1. It also let you add one with 0 servings and 0 volume which can cause issues.
Docs had uuid as id when its an integer for water containers
No validation for water containers

**How did you implement the solution?**
(Brief technical approach.)

Added zod schema and updated web frontend to match (servings >= 1, volume >= 0.001)
Enforce only one container
Fix docs
Also fixed a divide by zero issue

Linked Issue: Closes #2043 

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for water container names, volumes, units, servings, and IDs.
  * Added clearer error responses for invalid water container requests.
  * Enforced a single primary water container per account when creating or updating containers.
  * Added minimum values for container volume and servings per container.

* **Bug Fixes**
  * Prevented invalid serving values from causing incorrect water-intake calculations or division errors.
  * Improved transaction handling to avoid partial updates when container changes fail.
  * Updated API documentation to accurately represent container IDs as numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->