### PR TITLE
fix: add logging for all mcp requests

### DIFF
--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -11,6 +11,7 @@ import { bridgeBearerAuthHeader } from './utils/bearerAuthBridge.js';
 import { endPool } from './db/poolManager.js';
 import { log } from './config/logging.js';
 import { authenticate } from './middleware/authMiddleware.js';
+import { requestLogger } from './middleware/requestLogger.js';
 import { applySignOutCookieCleanup } from './middleware/signOutCookieCleanup.js';
 import foodRoutes from './routes/foodRoutes.js';
 import favoritesRoutes from './routes/favoritesRoutes.js';
@@ -180,9 +181,11 @@ app.use(
 // before the global 50mb parser so its route-local 1mb parser wins (the global
 // parser would set req._body first and no-op the local one). cookieParser is
 // local because the global one also runs after the 50mb parser, and
-// authenticate reads req.cookies.
+// authenticate reads req.cookies. requestLogger is local because the global
+// one also runs after this mount, so /mcp requests would never reach it.
 app.use(
   '/mcp',
+  requestLogger,
   express.json({ limit: '1mb' }),
   cookieParser(),
   authenticate,
@@ -252,13 +255,7 @@ app.use(async (req, res, next) => {
   next();
 });
 // Log all incoming requests - AFTER auth to see what falls through
-app.use((req, _res, next) => {
-  log(
-    'info',
-    `Incoming request: ${req.method} ${req.originalUrl} (Path: ${req.path})`
-  );
-  next();
-});
+app.use(requestLogger);
 // Serve static files from the 'uploads' directory
 const UPLOADS_BASE_DIR = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
   ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY)

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -185,7 +185,7 @@ app.use(
 // one also runs after this mount, so /mcp requests would never reach it.
 app.use(
   '/mcp',
-  requestLogger,
+  requestLogger({ logCompletion: true }),
   express.json({ limit: '1mb' }),
   cookieParser(),
   authenticate,
@@ -255,7 +255,7 @@ app.use(async (req, res, next) => {
   next();
 });
 // Log all incoming requests - AFTER auth to see what falls through
-app.use(requestLogger);
+app.use(requestLogger());
 // Serve static files from the 'uploads' directory
 const UPLOADS_BASE_DIR = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
   ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY)

--- a/SparkyFitnessServer/middleware/requestLogger.ts
+++ b/SparkyFitnessServer/middleware/requestLogger.ts
@@ -1,17 +1,52 @@
 import type { Request, Response, NextFunction } from 'express';
 import { log } from '../config/logging.js';
 
+// Extracts "[<jsonrpc method> <tool name>]" from an MCP request body; returns
+// '' for any body that isn't JSON-RPC (every non-MCP route).
+function rpcContext(body: unknown): string {
+  const { method, params } = (body ?? {}) as {
+    method?: unknown;
+    params?: { name?: unknown } | null;
+  };
+  if (typeof method !== 'string') return '';
+  const toolName = typeof params?.name === 'string' ? ` ${params.name}` : '';
+  return ` [${method}${toolName}]`;
+}
+
 // Logs every request that reaches it. Used in two places: globally after the
 // /api/auth interceptor, and locally on the /mcp chain, which is mounted above
 // the global logger so its route-local body parser beats the global 50mb one.
-export function requestLogger(
-  req: Request,
-  _res: Response,
-  next: NextFunction
-): void {
-  log(
-    'info',
-    `Incoming request: ${req.method} ${req.originalUrl} (Path: ${req.path})`
-  );
-  next();
+// logCompletion adds a status + duration + JSON-RPC context line when the
+// response finishes (or aborts); only the /mcp chain enables it, to keep
+// global log volume down.
+export function requestLogger(options: { logCompletion?: boolean } = {}) {
+  return function (req: Request, res: Response, next: NextFunction): void {
+    log(
+      'info',
+      `Incoming request: ${req.method} ${req.originalUrl} (Path: ${req.path})`
+    );
+    if (options.logCompletion) {
+      const start = Date.now();
+      // req.body is unparsed here (the JSON parser is mounted after this
+      // middleware), but these events fire after the whole chain has run, so
+      // the body is populated by then on any request that got past the parser.
+      res.on('finish', () => {
+        log(
+          'info',
+          `Request finished: ${req.method} ${req.originalUrl} ${res.statusCode} in ${Date.now() - start}ms${rpcContext(req.body)}`
+        );
+      });
+      // 'close' without a completed write means the connection died before the
+      // response went out — the "response lost in transit" case.
+      res.on('close', () => {
+        if (!res.writableFinished) {
+          log(
+            'warn',
+            `Request aborted: ${req.method} ${req.originalUrl} after ${Date.now() - start}ms${rpcContext(req.body)}`
+          );
+        }
+      });
+    }
+    next();
+  };
 }

--- a/SparkyFitnessServer/middleware/requestLogger.ts
+++ b/SparkyFitnessServer/middleware/requestLogger.ts
@@ -1,0 +1,17 @@
+import type { Request, Response, NextFunction } from 'express';
+import { log } from '../config/logging.js';
+
+// Logs every request that reaches it. Used in two places: globally after the
+// /api/auth interceptor, and locally on the /mcp chain, which is mounted above
+// the global logger so its route-local body parser beats the global 50mb one.
+export function requestLogger(
+  req: Request,
+  _res: Response,
+  next: NextFunction
+): void {
+  log(
+    'info',
+    `Incoming request: ${req.method} ${req.originalUrl} (Path: ${req.path})`
+  );
+  next();
+}

--- a/SparkyFitnessServer/middleware/requestLogger.ts
+++ b/SparkyFitnessServer/middleware/requestLogger.ts
@@ -1,6 +1,13 @@
 import type { Request, Response, NextFunction } from 'express';
 import { log } from '../config/logging.js';
 
+// Client-supplied strings go into single-line log records; anything outside
+// printable ASCII (newlines especially) could forge extra log lines, so it
+// becomes '?', and length is capped well above any real MCP method/tool name.
+function sanitizeRpcField(value: string): string {
+  return value.replace(/[^\x20-\x7e]/g, '?').slice(0, 64);
+}
+
 // Extracts "[<jsonrpc method> <tool name>]" from an MCP request body; returns
 // '' for any body that isn't JSON-RPC (every non-MCP route).
 function rpcContext(body: unknown): string {
@@ -9,8 +16,9 @@ function rpcContext(body: unknown): string {
     params?: { name?: unknown } | null;
   };
   if (typeof method !== 'string') return '';
-  const toolName = typeof params?.name === 'string' ? ` ${params.name}` : '';
-  return ` [${method}${toolName}]`;
+  const toolName =
+    typeof params?.name === 'string' ? ` ${sanitizeRpcField(params.name)}` : '';
+  return ` [${sanitizeRpcField(method)}${toolName}]`;
 }
 
 // Logs every request that reaches it. Used in two places: globally after the

--- a/SparkyFitnessServer/tests/mcpRoutes.test.ts
+++ b/SparkyFitnessServer/tests/mcpRoutes.test.ts
@@ -2,6 +2,7 @@ import { vi, beforeEach, describe, expect, it } from 'vitest';
 // @ts-expect-error TS(7016): no types for supertest
 import request from 'supertest';
 import express from 'express';
+import type { Request } from 'express';
 // @ts-expect-error TS(7016): no types for cookie-parser
 import cookieParser from 'cookie-parser';
 import { todayInZone } from '@workspace/shared';
@@ -116,7 +117,7 @@ function fakeAuthenticate(req: any, res: any, next: any) {
 const app = express();
 app.use(
   '/mcp',
-  requestLogger,
+  requestLogger({ logCompletion: true }),
   express.json({ limit: '1mb' }),
   cookieParser(),
   fakeAuthenticate,
@@ -279,6 +280,63 @@ describe('POST /mcp', () => {
       'info',
       'Incoming request: POST /mcp (Path: /)'
     );
+  });
+
+  it('logs status, duration, and the JSON-RPC tool name when the response finishes', async () => {
+    vi.mocked(goalService.getUserGoals).mockResolvedValue({ calories: 2000 });
+
+    const res = await request(app)
+      .post('/mcp')
+      .set(MCP_HEADERS)
+      .set('Authorization', 'Bearer valid')
+      .send({
+        jsonrpc: '2.0',
+        id: 9,
+        method: 'tools/call',
+        params: { name: 'sparky_get_goal_snapshot', arguments: {} },
+      });
+
+    expect(res.status).toBe(200);
+    expect(log).toHaveBeenCalledWith(
+      'info',
+      expect.stringMatching(
+        /^Request finished: POST \/mcp 200 in \d+ms \[tools\/call sparky_get_goal_snapshot\]$/
+      )
+    );
+  });
+
+  it('logs a warn line when the connection dies before the response finishes', async () => {
+    // The real chain always responds, so a local app whose handler kills the
+    // socket stands in for a client abort mid-request.
+    const abortApp = express();
+    abortApp.use(
+      '/mcp',
+      requestLogger({ logCompletion: true }),
+      express.json({ limit: '1mb' }),
+      (req: Request) => {
+        req.socket.destroy();
+      }
+    );
+
+    await request(abortApp)
+      .post('/mcp')
+      .set(MCP_HEADERS)
+      .send({
+        jsonrpc: '2.0',
+        id: 10,
+        method: 'tools/call',
+        params: { name: 'sparky_get_goal_snapshot', arguments: {} },
+      })
+      .catch(() => undefined);
+
+    await vi.waitFor(() => {
+      expect(log).toHaveBeenCalledWith(
+        'warn',
+        expect.stringMatching(
+          /^Request aborted: POST \/mcp after \d+ms \[tools\/call sparky_get_goal_snapshot\]$/
+        )
+      );
+    });
   });
 
   it('rejects bodies over the route-local 1mb limit with 413', async () => {

--- a/SparkyFitnessServer/tests/mcpRoutes.test.ts
+++ b/SparkyFitnessServer/tests/mcpRoutes.test.ts
@@ -305,6 +305,30 @@ describe('POST /mcp', () => {
     );
   });
 
+  it('neutralizes control characters in JSON-RPC fields so a crafted body cannot forge log lines', async () => {
+    const res = await request(app)
+      .post('/mcp')
+      .set(MCP_HEADERS)
+      .set('Authorization', 'Bearer valid')
+      .send({
+        jsonrpc: '2.0',
+        id: 11,
+        method: 'tools/call',
+        params: {
+          name: 'evil\n[2026-01-01] [INFO] forged line',
+          arguments: {},
+        },
+      });
+
+    expect(res.status).toBe(200);
+    expect(log).toHaveBeenCalledWith(
+      'info',
+      expect.stringMatching(
+        /^Request finished: POST \/mcp 200 in \d+ms \[tools\/call evil\?\[2026-01-01\] \[INFO\] forged line\]$/
+      )
+    );
+  });
+
   it('logs a warn line when the connection dies before the response finishes', async () => {
     // The real chain always responds, so a local app whose handler kills the
     // socket stands in for a client abort mid-request.

--- a/SparkyFitnessServer/tests/mcpRoutes.test.ts
+++ b/SparkyFitnessServer/tests/mcpRoutes.test.ts
@@ -5,7 +5,9 @@ import express from 'express';
 // @ts-expect-error TS(7016): no types for cookie-parser
 import cookieParser from 'cookie-parser';
 import { todayInZone } from '@workspace/shared';
+import { log } from '../config/logging.js';
 import mcpRoutes from '../routes/mcpRoutes.js';
+import { requestLogger } from '../middleware/requestLogger.js';
 import { buildChatbotTools } from '../ai/tools/index.js';
 import { buildDevTools } from '../ai/tools/devTools.js';
 import goalService from '../services/goalService.js';
@@ -114,6 +116,7 @@ function fakeAuthenticate(req: any, res: any, next: any) {
 const app = express();
 app.use(
   '/mcp',
+  requestLogger,
   express.json({ limit: '1mb' }),
   cookieParser(),
   fakeAuthenticate,
@@ -263,6 +266,19 @@ describe('POST /mcp', () => {
 
     expect(res.status).toBe(401);
     expect(goalService.getUserGoals).not.toHaveBeenCalled();
+  });
+
+  it('logs the incoming request even when auth fails (the chain must log itself — the global logger is mounted below /mcp and never sees it)', async () => {
+    const res = await request(app)
+      .post('/mcp')
+      .set(MCP_HEADERS)
+      .send({ jsonrpc: '2.0', id: 3, method: 'tools/list' });
+
+    expect(res.status).toBe(401);
+    expect(log).toHaveBeenCalledWith(
+      'info',
+      'Incoming request: POST /mcp (Path: /)'
+    );
   });
 
   it('rejects bodies over the route-local 1mb limit with 413', async () => {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Due to route mount order, mcp POST requests were not logged.

**How did you implement the solution?**
Created a logger middleware since it's needed in two now places and hooked it up to the mcp route and the inline global logger.

Linked Issue: Closes #2025 

## How to Test

1. Log an MCP request

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved server request logging, including unauthenticated `/mcp` activity.
  * Requests now consistently record their method, URL, and path before processing.
  * Completed requests include status, duration, and relevant operation details.
  * Sensitive operation details are sanitized and limited for safer logging.

* **Bug Fixes**
  * Ensured `/mcp` activity is logged even when authentication fails.
  * Added warnings when connections end before a response is completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->