### PR TITLE
feat: crossfade for exercise images

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/ExerciseImageCrossfade.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/ExerciseImageCrossfade.test.tsx
@@ -30,6 +30,10 @@ describe('ExerciseImageCrossfade', () => {
     expect(images[1].props.source).toEqual(frameB);
     expect(images[0].props.fallback).toBe(fallback);
     expect(images[1].props.fallback).toBe(fallback);
+    // The detail screen owns exercise animation, so its frames override
+    // SafeImage's play-nothing default.
+    expect(images[0].props.autoplay).toBe(true);
+    expect(images[1].props.autoplay).toBe(true);
   });
 
   it('contains transparent-capable frames on a white backdrop and covers opaque JPEG frames', () => {

--- a/SparkyFitnessMobile/__tests__/components/ExerciseImageCrossfade.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/ExerciseImageCrossfade.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Image } from 'react-native';
+import { fireEvent, render } from '@testing-library/react-native';
+import ExerciseImageCrossfade, {
+  sourceMayHaveTransparency,
+} from '../../src/components/ExerciseImageCrossfade';
+
+jest.mock('../../src/components/Icon', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: (props: { name: string }) => <View testID={`icon-${props.name}`} />,
+  };
+});
+
+const frameA = { uri: 'https://server/images/a.png', headers: { Authorization: 'Bearer t' } };
+const frameB = { uri: 'https://server/images/b.png', headers: { Authorization: 'Bearer t' } };
+
+describe('ExerciseImageCrossfade', () => {
+  it('renders both frames stacked so the dissolve has both images loaded', () => {
+    const { UNSAFE_getAllByType } = render(
+      <ExerciseImageCrossfade sources={[frameA, frameB]} />,
+    );
+
+    const images = UNSAFE_getAllByType(Image);
+    expect(images).toHaveLength(2);
+    expect(images[0].props.source).toEqual(frameA);
+    expect(images[1].props.source).toEqual(frameB);
+  });
+
+  it('toggles pause on tap and resumes on a second tap', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ExerciseImageCrossfade sources={[frameA, frameB]} />,
+    );
+
+    expect(queryByTestId('exercise-image-crossfade-paused')).toBeNull();
+
+    fireEvent.press(getByTestId('exercise-image-crossfade'));
+    expect(queryByTestId('exercise-image-crossfade-paused')).not.toBeNull();
+
+    fireEvent.press(getByTestId('exercise-image-crossfade'));
+    expect(queryByTestId('exercise-image-crossfade-paused')).toBeNull();
+  });
+});
+
+describe('sourceMayHaveTransparency', () => {
+  it('treats JPEGs as opaque regardless of case or query string', () => {
+    expect(sourceMayHaveTransparency('https://server/uploads/0.jpg')).toBe(false);
+    expect(sourceMayHaveTransparency('https://server/uploads/0.JPEG')).toBe(false);
+    expect(sourceMayHaveTransparency('https://server/uploads/0.jpg?token=abc')).toBe(
+      false,
+    );
+  });
+
+  it('treats alpha-capable and unknown formats as possibly transparent', () => {
+    expect(sourceMayHaveTransparency('https://server/uploads/0.png')).toBe(true);
+    expect(sourceMayHaveTransparency('https://server/uploads/0.webp')).toBe(true);
+    expect(sourceMayHaveTransparency('https://cdn.example/image/12345')).toBe(true);
+  });
+});

--- a/SparkyFitnessMobile/__tests__/components/ExerciseImageCrossfade.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/ExerciseImageCrossfade.test.tsx
@@ -28,6 +28,32 @@ describe('ExerciseImageCrossfade', () => {
     expect(images[1].props.source).toEqual(frameB);
   });
 
+  it('contains transparent-capable frames and covers opaque JPEG frames', () => {
+    const pngPair = render(
+      <ExerciseImageCrossfade
+        sources={[
+          { uri: 'https://server/images/a.png', headers: {} },
+          { uri: 'https://server/images/b.png', headers: {} },
+        ]}
+      />,
+    );
+    for (const image of pngPair.UNSAFE_getAllByType(Image)) {
+      expect(image.props.resizeMode).toBe('contain');
+    }
+
+    const jpgPair = render(
+      <ExerciseImageCrossfade
+        sources={[
+          { uri: 'https://server/images/a.jpg', headers: {} },
+          { uri: 'https://server/images/b.jpg', headers: {} },
+        ]}
+      />,
+    );
+    for (const image of jpgPair.UNSAFE_getAllByType(Image)) {
+      expect(image.props.resizeMode).toBe('cover');
+    }
+  });
+
   it('toggles pause on tap and resumes on a second tap', () => {
     const { getByTestId, queryByTestId } = render(
       <ExerciseImageCrossfade sources={[frameA, frameB]} />,

--- a/SparkyFitnessMobile/__tests__/components/ExerciseImageCrossfade.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/ExerciseImageCrossfade.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Image } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 import ExerciseImageCrossfade, {
   sourceMayHaveTransparency,
 } from '../../src/components/ExerciseImageCrossfade';
+import SafeImage from '../../src/components/SafeImage';
 
 jest.mock('../../src/components/Icon', () => {
   const { View } = require('react-native');
@@ -18,17 +19,20 @@ const frameB = { uri: 'https://server/images/b.png', headers: { Authorization: '
 
 describe('ExerciseImageCrossfade', () => {
   it('renders both frames stacked so the dissolve has both images loaded', () => {
+    const fallback = <></>;
     const { UNSAFE_getAllByType } = render(
-      <ExerciseImageCrossfade sources={[frameA, frameB]} />,
+      <ExerciseImageCrossfade sources={[frameA, frameB]} fallback={fallback} />,
     );
 
-    const images = UNSAFE_getAllByType(Image);
+    const images = UNSAFE_getAllByType(SafeImage);
     expect(images).toHaveLength(2);
     expect(images[0].props.source).toEqual(frameA);
     expect(images[1].props.source).toEqual(frameB);
+    expect(images[0].props.fallback).toBe(fallback);
+    expect(images[1].props.fallback).toBe(fallback);
   });
 
-  it('contains transparent-capable frames and covers opaque JPEG frames', () => {
+  it('contains transparent-capable frames on a white backdrop and covers opaque JPEG frames', () => {
     const pngPair = render(
       <ExerciseImageCrossfade
         sources={[
@@ -37,9 +41,13 @@ describe('ExerciseImageCrossfade', () => {
         ]}
       />,
     );
-    for (const image of pngPair.UNSAFE_getAllByType(Image)) {
-      expect(image.props.resizeMode).toBe('contain');
+    for (const image of pngPair.UNSAFE_getAllByType(SafeImage)) {
+      expect(image.props.contentFit).toBe('contain');
     }
+    expect(
+      StyleSheet.flatten(pngPair.getByTestId('exercise-image-crossfade').props.style)
+        .backgroundColor,
+    ).toBe('#ffffff');
 
     const jpgPair = render(
       <ExerciseImageCrossfade
@@ -49,9 +57,13 @@ describe('ExerciseImageCrossfade', () => {
         ]}
       />,
     );
-    for (const image of jpgPair.UNSAFE_getAllByType(Image)) {
-      expect(image.props.resizeMode).toBe('cover');
+    for (const image of jpgPair.UNSAFE_getAllByType(SafeImage)) {
+      expect(image.props.contentFit).toBe('cover');
     }
+    expect(
+      StyleSheet.flatten(jpgPair.getByTestId('exercise-image-crossfade').props.style)
+        .backgroundColor,
+    ).toBeUndefined();
   });
 
   it('toggles pause on tap and resumes on a second tap', () => {

--- a/SparkyFitnessMobile/__tests__/components/SafeImage.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/SafeImage.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Image } from 'expo-image';
+import { render } from '@testing-library/react-native';
+import SafeImage from '../../src/components/SafeImage';
+
+const source = { uri: 'https://server/uploads/exercises/demo/0.gif', headers: {} };
+
+describe('SafeImage autoplay', () => {
+  it('holds animated formats on their first frame by default', () => {
+    // Regression: animated GIF exercise images used to loop inside list
+    // thumbnails everywhere SafeImage is used, because expo-image autoplays
+    // unless told otherwise.
+    const { UNSAFE_getByType } = render(
+      <SafeImage source={source} style={{ width: 42, height: 42 }} />,
+    );
+
+    expect(UNSAFE_getByType(Image).props.autoplay).toBe(false);
+  });
+
+  it('plays animated formats when the caller opts in', () => {
+    const { UNSAFE_getByType } = render(
+      <SafeImage source={source} style={{ width: 42, height: 42 }} autoplay />,
+    );
+
+    expect(UNSAFE_getByType(Image).props.autoplay).toBe(true);
+  });
+});

--- a/SparkyFitnessMobile/__tests__/hooks/useExerciseImageSource.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useExerciseImageSource.test.ts
@@ -185,6 +185,38 @@ describe('useImagePairAspectMatch', () => {
     expect(loadedRef.release).toHaveBeenCalled();
   });
 
+  it('resets the verdict during render when the sources change', async () => {
+    loadSpy
+      .mockResolvedValueOnce(makeRef(800, 600))
+      .mockResolvedValueOnce(makeRef(400, 300));
+
+    const { result, rerender } = renderHook(
+      (sources: typeof pair) => useImagePairAspectMatch(sources),
+      { initialProps: pair },
+    );
+
+    await waitFor(() => expect(result.current).toBe(true));
+
+    // Gate the new pair's measurements so the reset is observable before the
+    // new verdict lands.
+    let openGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      openGate = resolve;
+    });
+    const gatedRefs = [makeRef(1600, 900), makeRef(800, 600)];
+    loadSpy.mockImplementation(() => gate.then(() => gatedRefs.shift()));
+
+    rerender([
+      { uri: 'https://example.com/c.png', headers: {} },
+      { uri: 'https://example.com/d.png', headers: {} },
+    ]);
+
+    expect(result.current).toBeUndefined();
+
+    await act(async () => openGate());
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
   it('stays undecided without measuring when the array is not a pair', async () => {
     const single = [pair[0]];
 

--- a/SparkyFitnessMobile/__tests__/hooks/useExerciseImageSource.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useExerciseImageSource.test.ts
@@ -1,5 +1,9 @@
-import { renderHook, act } from '@testing-library/react-native';
-import { useExerciseImageSource } from '../../src/hooks/useExerciseImageSource';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { Image } from 'react-native';
+import {
+  useExerciseImageSource,
+  useImagePairAspectMatch,
+} from '../../src/hooks/useExerciseImageSource';
 import { getActiveServerConfig, proxyHeadersToRecord } from '../../src/services/storage';
 
 jest.mock('../../src/services/storage', () => ({
@@ -111,5 +115,66 @@ describe('useExerciseImageSource', () => {
 
     // Config hasn't loaded yet
     expect(result.current.getImageSource('image.jpg')).toBeNull();
+  });
+});
+
+describe('useImagePairAspectMatch', () => {
+  // The hook's effect keys on array identity, so test inputs must be stable
+  // across re-renders — same contract the screen meets via useMemo.
+  const pair = [
+    { uri: 'https://example.com/a.png', headers: {} },
+    { uri: 'https://example.com/b.png', headers: {} },
+  ];
+
+  let getSizeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getSizeSpy = jest.spyOn(Image, 'getSizeWithHeaders');
+  });
+
+  afterEach(() => {
+    getSizeSpy.mockRestore();
+  });
+
+  it('matches a pair whose aspect ratios are close despite resolution differences', async () => {
+    getSizeSpy
+      .mockResolvedValueOnce({ width: 840, height: 630 })
+      .mockResolvedValueOnce({ width: 420, height: 315 });
+
+    const { result } = renderHook(() => useImagePairAspectMatch(pair));
+
+    expect(result.current).toBeUndefined();
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('rejects a pair whose aspect ratios differ', async () => {
+    getSizeSpy
+      .mockResolvedValueOnce({ width: 800, height: 600 })
+      .mockResolvedValueOnce({ width: 1600, height: 900 });
+
+    const { result } = renderHook(() => useImagePairAspectMatch(pair));
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('stays undecided when a size lookup fails', async () => {
+    getSizeSpy
+      .mockResolvedValueOnce({ width: 800, height: 600 })
+      .mockRejectedValueOnce(new Error('not found'));
+
+    const { result } = renderHook(() => useImagePairAspectMatch(pair));
+
+    await act(async () => {});
+    expect(result.current).toBeUndefined();
+  });
+
+  it('stays undecided without measuring when the array is not a pair', async () => {
+    const single = [pair[0]];
+
+    const { result } = renderHook(() => useImagePairAspectMatch(single));
+
+    await act(async () => {});
+    expect(result.current).toBeUndefined();
+    expect(getSizeSpy).not.toHaveBeenCalled();
   });
 });

--- a/SparkyFitnessMobile/__tests__/hooks/useExerciseImageSource.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useExerciseImageSource.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
-import { Image } from 'react-native';
+import { Image, type ImageRef } from 'expo-image';
 import {
   useExerciseImageSource,
   useImagePairAspectMatch,
@@ -126,20 +126,23 @@ describe('useImagePairAspectMatch', () => {
     { uri: 'https://example.com/b.png', headers: {} },
   ];
 
-  let getSizeSpy: jest.SpyInstance;
+  const makeRef = (width: number, height: number) =>
+    ({ width, height, release: jest.fn() }) as unknown as ImageRef;
+
+  let loadSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    getSizeSpy = jest.spyOn(Image, 'getSizeWithHeaders');
+    loadSpy = jest.spyOn(Image, 'loadAsync');
   });
 
   afterEach(() => {
-    getSizeSpy.mockRestore();
+    loadSpy.mockRestore();
   });
 
   it('matches a pair whose aspect ratios are close despite resolution differences', async () => {
-    getSizeSpy
-      .mockResolvedValueOnce({ width: 840, height: 630 })
-      .mockResolvedValueOnce({ width: 420, height: 315 });
+    loadSpy
+      .mockResolvedValueOnce(makeRef(840, 630))
+      .mockResolvedValueOnce(makeRef(420, 315));
 
     const { result } = renderHook(() => useImagePairAspectMatch(pair));
 
@@ -148,24 +151,38 @@ describe('useImagePairAspectMatch', () => {
   });
 
   it('rejects a pair whose aspect ratios differ', async () => {
-    getSizeSpy
-      .mockResolvedValueOnce({ width: 800, height: 600 })
-      .mockResolvedValueOnce({ width: 1600, height: 900 });
+    loadSpy
+      .mockResolvedValueOnce(makeRef(800, 600))
+      .mockResolvedValueOnce(makeRef(1600, 900));
 
     const { result } = renderHook(() => useImagePairAspectMatch(pair));
 
     await waitFor(() => expect(result.current).toBe(false));
   });
 
-  it('stays undecided when a size lookup fails', async () => {
-    getSizeSpy
-      .mockResolvedValueOnce({ width: 800, height: 600 })
+  it('releases the loaded image refs once measured', async () => {
+    const refA = makeRef(800, 600);
+    const refB = makeRef(400, 300);
+    loadSpy.mockResolvedValueOnce(refA).mockResolvedValueOnce(refB);
+
+    const { result } = renderHook(() => useImagePairAspectMatch(pair));
+
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(refA.release).toHaveBeenCalled();
+    expect(refB.release).toHaveBeenCalled();
+  });
+
+  it('stays undecided when a load fails, releasing the ref that did load', async () => {
+    const loadedRef = makeRef(800, 600);
+    loadSpy
+      .mockResolvedValueOnce(loadedRef)
       .mockRejectedValueOnce(new Error('not found'));
 
     const { result } = renderHook(() => useImagePairAspectMatch(pair));
 
     await act(async () => {});
     expect(result.current).toBeUndefined();
+    expect(loadedRef.release).toHaveBeenCalled();
   });
 
   it('stays undecided without measuring when the array is not a pair', async () => {
@@ -175,6 +192,6 @@ describe('useImagePairAspectMatch', () => {
 
     await act(async () => {});
     expect(result.current).toBeUndefined();
-    expect(getSizeSpy).not.toHaveBeenCalled();
+    expect(loadSpy).not.toHaveBeenCalled();
   });
 });

--- a/SparkyFitnessMobile/__tests__/screens/ExerciseDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ExerciseDetailScreen.test.tsx
@@ -19,7 +19,10 @@ import { useExerciseStats } from '../../src/hooks/useExerciseStats';
 import { useExerciseHistory } from '../../src/hooks/useExerciseHistory';
 import { fetchExerciseById } from '../../src/services/api/exerciseApi';
 import { importExercise } from '../../src/services/api/externalExerciseSearchApi';
-import { useExerciseImageSource } from '../../src/hooks/useExerciseImageSource';
+import {
+  useExerciseImageSource,
+  useImagePairAspectMatch,
+} from '../../src/hooks/useExerciseImageSource';
 import * as reanimated from 'react-native-reanimated';
 import type { Exercise } from '../../src/types/exercise';
 
@@ -53,6 +56,7 @@ jest.mock('../../src/components/ActiveWorkoutBar', () => ({
 
 jest.mock('../../src/hooks/useExerciseImageSource', () => ({
   useExerciseImageSource: jest.fn(() => ({ getImageSource: jest.fn(() => null) })),
+  useImagePairAspectMatch: jest.fn(() => undefined),
 }));
 
 jest.mock('../../src/hooks/useStartLiveWorkout', () => ({
@@ -106,6 +110,9 @@ const mockImportExercise = importExercise as jest.MockedFunction<
 >;
 const mockUseExerciseImageSource = useExerciseImageSource as jest.MockedFunction<
   typeof useExerciseImageSource
+>;
+const mockUseImagePairAspectMatch = useImagePairAspectMatch as jest.MockedFunction<
+  typeof useImagePairAspectMatch
 >;
 const mockConfirmAndDelete = jest.fn();
 
@@ -732,6 +739,7 @@ describe('ExerciseDetailScreen', () => {
       mockUseExerciseImageSource.mockReturnValue({
         getImageSource: jest.fn(() => null),
       } as any);
+      mockUseImagePairAspectMatch.mockReturnValue(undefined);
     });
 
     it('renders the crossfade instead of the pager for exactly two images', () => {
@@ -753,6 +761,15 @@ describe('ExerciseDetailScreen', () => {
       } finally {
         spy.mockRestore();
       }
+    });
+
+    it('falls back to the pager when the pair aspect ratios mismatch', () => {
+      mockUseImagePairAspectMatch.mockReturnValue(false);
+
+      const screen = renderScreen({ images: ['a.png', 'b.png'] });
+
+      expect(screen.queryByTestId('exercise-image-crossfade')).toBeNull();
+      expect(screen.getByTestId('pager-view')).toBeTruthy();
     });
 
     it('keeps the pager for more than two images', () => {

--- a/SparkyFitnessMobile/__tests__/screens/ExerciseDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ExerciseDetailScreen.test.tsx
@@ -19,6 +19,8 @@ import { useExerciseStats } from '../../src/hooks/useExerciseStats';
 import { useExerciseHistory } from '../../src/hooks/useExerciseHistory';
 import { fetchExerciseById } from '../../src/services/api/exerciseApi';
 import { importExercise } from '../../src/services/api/externalExerciseSearchApi';
+import { useExerciseImageSource } from '../../src/hooks/useExerciseImageSource';
+import * as reanimated from 'react-native-reanimated';
 import type { Exercise } from '../../src/types/exercise';
 
 jest.mock('../../src/hooks', () => ({
@@ -101,6 +103,9 @@ const mockFetchExerciseById = fetchExerciseById as jest.MockedFunction<
 >;
 const mockImportExercise = importExercise as jest.MockedFunction<
   typeof importExercise
+>;
+const mockUseExerciseImageSource = useExerciseImageSource as jest.MockedFunction<
+  typeof useExerciseImageSource
 >;
 const mockConfirmAndDelete = jest.fn();
 
@@ -710,6 +715,51 @@ describe('ExerciseDetailScreen', () => {
       await waitFor(() => expect(mockImportExercise).toHaveBeenCalled());
       await act(async () => {});
       expect(navigation.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('image carousel selection', () => {
+    beforeEach(() => {
+      mockUseExerciseImageSource.mockReturnValue({
+        getImageSource: (path: string) => ({
+          uri: `https://server/uploads/${path}`,
+          headers: {},
+        }),
+      } as any);
+    });
+
+    afterEach(() => {
+      mockUseExerciseImageSource.mockReturnValue({
+        getImageSource: jest.fn(() => null),
+      } as any);
+    });
+
+    it('renders the crossfade instead of the pager for exactly two images', () => {
+      const screen = renderScreen({ images: ['a.png', 'b.png'] });
+
+      expect(screen.getByTestId('exercise-image-crossfade')).toBeTruthy();
+      expect(screen.queryByTestId('pager-view')).toBeNull();
+    });
+
+    it('falls back to the pager for two images when reduce motion is on', () => {
+      const spy = jest
+        .spyOn(reanimated, 'useReducedMotion')
+        .mockReturnValue(true);
+      try {
+        const screen = renderScreen({ images: ['a.png', 'b.png'] });
+
+        expect(screen.queryByTestId('exercise-image-crossfade')).toBeNull();
+        expect(screen.getByTestId('pager-view')).toBeTruthy();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('keeps the pager for more than two images', () => {
+      const screen = renderScreen({ images: ['a.png', 'b.png', 'c.png'] });
+
+      expect(screen.queryByTestId('exercise-image-crossfade')).toBeNull();
+      expect(screen.getByTestId('pager-view')).toBeTruthy();
     });
   });
 });

--- a/SparkyFitnessMobile/__tests__/screens/ExerciseDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ExerciseDetailScreen.test.tsx
@@ -732,13 +732,13 @@ describe('ExerciseDetailScreen', () => {
           uri: `https://server/uploads/${path}`,
           headers: {},
         }),
-      } as any);
+      });
     });
 
     afterEach(() => {
       mockUseExerciseImageSource.mockReturnValue({
         getImageSource: jest.fn(() => null),
-      } as any);
+      });
       mockUseImagePairAspectMatch.mockReturnValue(undefined);
     });
 

--- a/SparkyFitnessMobile/src/components/ExerciseImageCrossfade.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseImageCrossfade.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import { Image, Pressable, StyleSheet, View } from 'react-native';
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+import Icon from './Icon';
+
+type ImageSource = { uri: string; headers: Record<string, string> };
+
+interface ExerciseImageCrossfadeProps {
+  sources: readonly [ImageSource, ImageSource];
+}
+
+// Cadence tuned to read like the two-frame exercise GIFs this stands in for:
+// hold each position, then dissolve to the other.
+const HOLD_MS = 800;
+const DISSOLVE_MS = 800;
+
+// JPEGs cannot carry an alpha channel; anything else (png/webp/extension-less
+// URLs) is assumed transparent-capable.
+export const sourceMayHaveTransparency = (uri: string): boolean => {
+  const path = uri.split(/[?#]/)[0];
+  return !/\.jpe?g$/i.test(path);
+};
+
+/**
+ * Loops a cross-dissolve between an exercise's two position images, standing
+ * in for the paid animated GIFs at full image quality. Tap pauses and resumes.
+ * Callers own the frame (size, background, rounding) and should fall back to
+ * a static presentation when the OS reduce-motion setting is on.
+ */
+const ExerciseImageCrossfade: React.FC<ExerciseImageCrossfadeProps> = ({ sources }) => {
+  const [paused, setPaused] = useState(false);
+  const fade = useSharedValue(0);
+
+  useEffect(() => {
+    if (paused) return;
+    fade.value = withRepeat(
+      withSequence(
+        withDelay(HOLD_MS, withTiming(1, { duration: DISSOLVE_MS })),
+        withDelay(HOLD_MS, withTiming(0, { duration: DISSOLVE_MS })),
+      ),
+      -1,
+    );
+    return () => cancelAnimation(fade);
+  }, [paused, fade]);
+
+  // A transparent-capable top frame never fully covers the base, so the base
+  // must fade out in counter-phase or it ghosts through the top frame's
+  // background during its hold. Opaque JPEGs keep the base at full opacity
+  // instead: their top frame covers it completely once faded in, and holding
+  // the base avoids the mid-dissolve dip a symmetric cross-fade shows where
+  // both layers sit at partial opacity.
+  const mayHaveTransparency =
+    sourceMayHaveTransparency(sources[0].uri) ||
+    sourceMayHaveTransparency(sources[1].uri);
+
+  const baseStyle = useAnimatedStyle(() => ({
+    opacity: mayHaveTransparency ? 1 - fade.value : 1,
+  }));
+  const overlayStyle = useAnimatedStyle(() => ({ opacity: fade.value }));
+
+  return (
+    <Pressable
+      testID="exercise-image-crossfade"
+      accessibilityRole="button"
+      accessibilityLabel={paused ? 'Play exercise animation' : 'Pause exercise animation'}
+      onPress={() => setPaused((value) => !value)}
+      style={styles.fill}
+    >
+      <Animated.View style={[StyleSheet.absoluteFill, baseStyle]}>
+        <Image source={sources[0]} style={StyleSheet.absoluteFill} resizeMode="cover" />
+      </Animated.View>
+      <Animated.View style={[StyleSheet.absoluteFill, overlayStyle]}>
+        <Image source={sources[1]} style={StyleSheet.absoluteFill} resizeMode="cover" />
+      </Animated.View>
+      {paused && (
+        <View
+          testID="exercise-image-crossfade-paused"
+          className="absolute bottom-2 right-2 bg-black/50 rounded-full p-1.5"
+        >
+          <Icon name="play" size={12} color="#ffffff" />
+        </View>
+      )}
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({ fill: { flex: 1 } });
+
+export default ExerciseImageCrossfade;

--- a/SparkyFitnessMobile/src/components/ExerciseImageCrossfade.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseImageCrossfade.tsx
@@ -66,6 +66,12 @@ const ExerciseImageCrossfade: React.FC<ExerciseImageCrossfadeProps> = ({ sources
   }));
   const overlayStyle = useAnimatedStyle(() => ({ opacity: fade.value }));
 
+  // Contain keeps the full pose visible; its letterbox is invisible because
+  // the frame's own background shows through the transparency anyway. Opaque
+  // frames cover-fill instead so the card never shows hard image edges. The
+  // pair shares one mode so the two frames stay aligned mid-dissolve.
+  const resizeMode = mayHaveTransparency ? 'contain' : 'cover';
+
   return (
     <Pressable
       testID="exercise-image-crossfade"
@@ -75,10 +81,10 @@ const ExerciseImageCrossfade: React.FC<ExerciseImageCrossfadeProps> = ({ sources
       style={styles.fill}
     >
       <Animated.View style={[StyleSheet.absoluteFill, baseStyle]}>
-        <Image source={sources[0]} style={StyleSheet.absoluteFill} resizeMode="cover" />
+        <Image source={sources[0]} style={StyleSheet.absoluteFill} resizeMode={resizeMode} />
       </Animated.View>
       <Animated.View style={[StyleSheet.absoluteFill, overlayStyle]}>
-        <Image source={sources[1]} style={StyleSheet.absoluteFill} resizeMode="cover" />
+        <Image source={sources[1]} style={StyleSheet.absoluteFill} resizeMode={resizeMode} />
       </Animated.View>
       {paused && (
         <View

--- a/SparkyFitnessMobile/src/components/ExerciseImageCrossfade.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseImageCrossfade.tsx
@@ -94,6 +94,7 @@ const ExerciseImageCrossfade: React.FC<ExerciseImageCrossfadeProps> = ({
           style={StyleSheet.absoluteFill}
           contentFit={contentFit}
           fallback={fallback}
+          autoplay
         />
       </Animated.View>
       <Animated.View style={[StyleSheet.absoluteFill, overlayStyle]}>
@@ -102,6 +103,7 @@ const ExerciseImageCrossfade: React.FC<ExerciseImageCrossfadeProps> = ({
           style={StyleSheet.absoluteFill}
           contentFit={contentFit}
           fallback={fallback}
+          autoplay
         />
       </Animated.View>
       {paused && (

--- a/SparkyFitnessMobile/src/components/ExerciseImageCrossfade.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseImageCrossfade.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Image, Pressable, StyleSheet, View } from 'react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 import Animated, {
   cancelAnimation,
   useAnimatedStyle,
@@ -10,11 +10,13 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import Icon from './Icon';
+import SafeImage from './SafeImage';
 
 type ImageSource = { uri: string; headers: Record<string, string> };
 
 interface ExerciseImageCrossfadeProps {
   sources: readonly [ImageSource, ImageSource];
+  fallback?: React.ReactNode;
 }
 
 // Cadence tuned to read like the two-frame exercise GIFs this stands in for:
@@ -32,10 +34,15 @@ export const sourceMayHaveTransparency = (uri: string): boolean => {
 /**
  * Loops a cross-dissolve between an exercise's two position images, standing
  * in for the paid animated GIFs at full image quality. Tap pauses and resumes.
- * Callers own the frame (size, background, rounding) and should fall back to
- * a static presentation when the OS reduce-motion setting is on.
+ * Frames that fail to load show `fallback`; both failing reads as one static
+ * placeholder since the layers are identical. Callers own the frame (size,
+ * rounding) and should fall back to a static presentation when the OS
+ * reduce-motion setting is on.
  */
-const ExerciseImageCrossfade: React.FC<ExerciseImageCrossfadeProps> = ({ sources }) => {
+const ExerciseImageCrossfade: React.FC<ExerciseImageCrossfadeProps> = ({
+  sources,
+  fallback = null,
+}) => {
   const [paused, setPaused] = useState(false);
   const fade = useSharedValue(0);
 
@@ -66,11 +73,12 @@ const ExerciseImageCrossfade: React.FC<ExerciseImageCrossfadeProps> = ({ sources
   }));
   const overlayStyle = useAnimatedStyle(() => ({ opacity: fade.value }));
 
-  // Contain keeps the full pose visible; its letterbox is invisible because
-  // the frame's own background shows through the transparency anyway. Opaque
-  // frames cover-fill instead so the card never shows hard image edges. The
-  // pair shares one mode so the two frames stay aligned mid-dissolve.
-  const resizeMode = mayHaveTransparency ? 'contain' : 'cover';
+  // Contain keeps the full pose visible; transparent frames also get a white
+  // backdrop because the exercise art is drawn for light backgrounds and
+  // disappears against dark theme surfaces. Opaque frames cover-fill instead
+  // so the card never shows hard image edges. The pair shares one mode so the
+  // two frames stay aligned mid-dissolve.
+  const contentFit = mayHaveTransparency ? 'contain' : 'cover';
 
   return (
     <Pressable
@@ -78,13 +86,23 @@ const ExerciseImageCrossfade: React.FC<ExerciseImageCrossfadeProps> = ({ sources
       accessibilityRole="button"
       accessibilityLabel={paused ? 'Play exercise animation' : 'Pause exercise animation'}
       onPress={() => setPaused((value) => !value)}
-      style={styles.fill}
+      style={[styles.fill, mayHaveTransparency && styles.whiteBackdrop]}
     >
       <Animated.View style={[StyleSheet.absoluteFill, baseStyle]}>
-        <Image source={sources[0]} style={StyleSheet.absoluteFill} resizeMode={resizeMode} />
+        <SafeImage
+          source={sources[0]}
+          style={StyleSheet.absoluteFill}
+          contentFit={contentFit}
+          fallback={fallback}
+        />
       </Animated.View>
       <Animated.View style={[StyleSheet.absoluteFill, overlayStyle]}>
-        <Image source={sources[1]} style={StyleSheet.absoluteFill} resizeMode={resizeMode} />
+        <SafeImage
+          source={sources[1]}
+          style={StyleSheet.absoluteFill}
+          contentFit={contentFit}
+          fallback={fallback}
+        />
       </Animated.View>
       {paused && (
         <View
@@ -98,6 +116,9 @@ const ExerciseImageCrossfade: React.FC<ExerciseImageCrossfadeProps> = ({ sources
   );
 };
 
-const styles = StyleSheet.create({ fill: { flex: 1 } });
+const styles = StyleSheet.create({
+  fill: { flex: 1 },
+  whiteBackdrop: { backgroundColor: '#ffffff' },
+});
 
 export default ExerciseImageCrossfade;

--- a/SparkyFitnessMobile/src/components/SafeImage.tsx
+++ b/SparkyFitnessMobile/src/components/SafeImage.tsx
@@ -8,6 +8,13 @@ interface SafeImageProps {
   style: StyleProp<ImageStyle>;
   contentFit?: ImageContentFit;
   fallback?: React.ReactNode;
+  /**
+   * Whether animated formats (GIF, animated WebP) play. Off by default: most
+   * SafeImage slots are list thumbnails, where a looping GIF next to static
+   * JPEG exercises reads as broken. Screens that own the animation (exercise
+   * detail) opt in.
+   */
+  autoplay?: boolean;
 }
 
 function getImageSourceSignature(
@@ -42,7 +49,13 @@ const UNDERLAY_DELAY_MS = 200;
  * removed once the image has fully faded in so images with transparency don't
  * show it through.
  */
-const SafeImage: React.FC<SafeImageProps> = ({ source, style, contentFit, fallback = null }) => {
+const SafeImage: React.FC<SafeImageProps> = ({
+  source,
+  style,
+  contentFit,
+  fallback = null,
+  autoplay = false,
+}) => {
   const [error, setError] = useState(false);
   const [attempt, setAttempt] = useState(0);
   const [loaded, setLoaded] = useState(false);
@@ -107,6 +120,7 @@ const SafeImage: React.FC<SafeImageProps> = ({ source, style, contentFit, fallba
           source={source}
           style={StyleSheet.absoluteFill}
           contentFit={contentFit}
+          autoplay={autoplay}
           cachePolicy="memory-disk"
           transition={TRANSITION_MS}
           onLoad={() => setLoaded(true)}

--- a/SparkyFitnessMobile/src/hooks/useExerciseImageSource.ts
+++ b/SparkyFitnessMobile/src/hooks/useExerciseImageSource.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { Image } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { getActiveServerConfig, proxyHeadersToRecord } from '../services/storage';
 import { normalizeUrl } from '../services/api/apiClient';
@@ -58,4 +59,57 @@ export function useExerciseImageSource() {
   );
 
   return { getImageSource };
+}
+
+// Aspect ratios within this relative tolerance overlay cleanly; beyond it the
+// subject visibly re-scales or shifts mid-dissolve.
+const PAIR_ASPECT_TOLERANCE = 0.1;
+
+/**
+ * Resolves whether two images share roughly one aspect ratio, so callers can
+ * reserve the crossfade for frames that overlay cleanly (user uploads are
+ * arbitrary). `undefined` while measuring, `false` only on a confirmed
+ * mismatch. An unreadable size also stays `undefined`: the image itself
+ * likely fails to render too, and a fallback presentation shouldn't switch
+ * modes over it. Ignores arrays that are not exactly a pair.
+ */
+export function useImagePairAspectMatch(
+  sources: readonly ImageSource[],
+): boolean | undefined {
+  const [match, setMatch] = useState<boolean | undefined>(undefined);
+
+  // Reset during render (not in the effect) so a source change never shows
+  // the previous pair's verdict for a frame.
+  const [prevSources, setPrevSources] = useState(sources);
+  if (sources !== prevSources) {
+    setPrevSources(sources);
+    setMatch(undefined);
+  }
+
+  useEffect(() => {
+    if (sources.length !== 2) return;
+
+    let cancelled = false;
+    Promise.all(
+      sources.map((source) => Image.getSizeWithHeaders(source.uri, source.headers)),
+    )
+      .then((sizes) => {
+        if (cancelled) return;
+        const [a, b] = sizes.map(({ width, height }) =>
+          height > 0 ? width / height : 0,
+        );
+        if (a > 0 && b > 0) {
+          setMatch(Math.abs(a - b) / Math.max(a, b) <= PAIR_ASPECT_TOLERANCE);
+        }
+      })
+      .catch(() => {
+        // Verdict stays undefined; see the contract above.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sources]);
+
+  return match;
 }

--- a/SparkyFitnessMobile/src/hooks/useExerciseImageSource.ts
+++ b/SparkyFitnessMobile/src/hooks/useExerciseImageSource.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { Image } from 'react-native';
+import { Image } from 'expo-image';
 import { useFocusEffect } from '@react-navigation/native';
 import { getActiveServerConfig, proxyHeadersToRecord } from '../services/storage';
 import { normalizeUrl } from '../services/api/apiClient';
@@ -90,21 +90,26 @@ export function useImagePairAspectMatch(
     if (sources.length !== 2) return;
 
     let cancelled = false;
-    Promise.all(
-      sources.map((source) => Image.getSizeWithHeaders(source.uri, source.headers)),
-    )
-      .then((sizes) => {
-        if (cancelled) return;
-        const [a, b] = sizes.map(({ width, height }) =>
-          height > 0 ? width / height : 0,
+    // The pair is about to render through expo-image, so measuring through the
+    // same pipeline means one download and one disk-cache entry serve both the
+    // probe and the render. A failed load leaves its ratio at 0, keeping the
+    // verdict undefined per the contract above.
+    Promise.allSettled(sources.map((source) => Image.loadAsync(source))).then(
+      (results) => {
+        const refs = results.map((result) =>
+          result.status === 'fulfilled' ? result.value : null,
         );
-        if (a > 0 && b > 0) {
+        const [a, b] = refs.map((ref) =>
+          ref && ref.height > 0 ? ref.width / ref.height : 0,
+        );
+        if (!cancelled && a > 0 && b > 0) {
           setMatch(Math.abs(a - b) / Math.max(a, b) <= PAIR_ASPECT_TOLERANCE);
         }
-      })
-      .catch(() => {
-        // Verdict stays undefined; see the contract above.
-      });
+        // ImageRefs pin the decoded bitmaps in native memory; only the
+        // dimensions are needed here.
+        for (const ref of refs) ref?.release();
+      },
+    );
 
     return () => {
       cancelled = true;

--- a/SparkyFitnessMobile/src/screens/ExerciseDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ExerciseDetailScreen.tsx
@@ -295,6 +295,7 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
           style={{ width: '100%', aspectRatio: IMAGE_ASPECT_RATIO }}
           contentFit={sourceMayHaveTransparency(imageSources[0].uri) ? 'contain' : 'cover'}
           fallback={imageFallback}
+          autoplay={!reducedMotion}
         />
       </View>
     ) : imageSources.length === 2 && !reducedMotion && pairAspectMatch !== false ? (
@@ -328,6 +329,7 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
                   style={{ width: '100%', height: '100%' }}
                   contentFit={sourceMayHaveTransparency(source.uri) ? 'contain' : 'cover'}
                   fallback={imageFallback}
+                  autoplay={!reducedMotion}
                 />
               </View>
             ))}

--- a/SparkyFitnessMobile/src/screens/ExerciseDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ExerciseDetailScreen.tsx
@@ -5,9 +5,11 @@ import { Directions, Gesture, GestureDetector } from 'react-native-gesture-handl
 import Toast from 'react-native-toast-message';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import PagerView from 'react-native-pager-view';
+import { useReducedMotion } from 'react-native-reanimated';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCSSVariable } from 'uniwind';
 import Button from '../components/ui/Button';
+import ExerciseImageCrossfade from '../components/ExerciseImageCrossfade';
 import Icon from '../components/Icon';
 import SegmentedControl, { type Segment } from '../components/SegmentedControl';
 import ExerciseHistoryList from '../components/ExerciseHistoryList';
@@ -91,6 +93,7 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
   const textPrimary = useCSSVariable('--color-text-primary') as string;
   const { getImageSource } = useExerciseImageSource();
+  const reducedMotion = useReducedMotion();
   const { profile } = useProfile();
   const { isConnected } = useServerConnection();
 
@@ -264,6 +267,13 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
           style={{ width: '100%', aspectRatio: 16 / 9 }}
           resizeMode="cover"
         />
+      </View>
+    ) : imageSources.length === 2 && !reducedMotion ? (
+      <View
+        className="bg-surface rounded-xl overflow-hidden"
+        style={{ width: '100%', aspectRatio: 16 / 9 }}
+      >
+        <ExerciseImageCrossfade sources={[imageSources[0], imageSources[1]]} />
       </View>
     ) : imageSources.length > 1 ? (
       <View>

--- a/SparkyFitnessMobile/src/screens/ExerciseDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ExerciseDetailScreen.tsx
@@ -9,7 +9,9 @@ import { useReducedMotion } from 'react-native-reanimated';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCSSVariable } from 'uniwind';
 import Button from '../components/ui/Button';
-import ExerciseImageCrossfade from '../components/ExerciseImageCrossfade';
+import ExerciseImageCrossfade, {
+  sourceMayHaveTransparency,
+} from '../components/ExerciseImageCrossfade';
 import Icon from '../components/Icon';
 import SegmentedControl, { type Segment } from '../components/SegmentedControl';
 import ExerciseHistoryList from '../components/ExerciseHistoryList';
@@ -47,6 +49,10 @@ type TabKey = 'summary' | 'history' | 'how-to';
 
 const DESCRIPTION_PREVIEW_LINES = 3;
 const DESCRIPTION_PREVIEW_THRESHOLD = 180;
+
+// Matches the dominant exercise image sets (4:3 photos), so cover-filled
+// frames crop little to nothing.
+const IMAGE_ASPECT_RATIO = 4 / 3;
 
 // Tab-change flings ignore touches starting this close to the left screen
 // edge so the native-stack back swipe keeps the edge to itself.
@@ -264,14 +270,14 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
       <View className="bg-surface rounded-xl overflow-hidden">
         <Image
           source={imageSources[0]}
-          style={{ width: '100%', aspectRatio: 16 / 9 }}
-          resizeMode="cover"
+          style={{ width: '100%', aspectRatio: IMAGE_ASPECT_RATIO }}
+          resizeMode={sourceMayHaveTransparency(imageSources[0].uri) ? 'contain' : 'cover'}
         />
       </View>
     ) : imageSources.length === 2 && !reducedMotion ? (
       <View
         className="bg-surface rounded-xl overflow-hidden"
-        style={{ width: '100%', aspectRatio: 16 / 9 }}
+        style={{ width: '100%', aspectRatio: IMAGE_ASPECT_RATIO }}
       >
         <ExerciseImageCrossfade sources={[imageSources[0], imageSources[1]]} />
       </View>
@@ -279,7 +285,7 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
       <View>
         <View
           className="bg-surface rounded-xl overflow-hidden"
-          style={{ width: '100%', aspectRatio: 16 / 9 }}
+          style={{ width: '100%', aspectRatio: IMAGE_ASPECT_RATIO }}
         >
           <PagerView
             style={{ flex: 1 }}
@@ -291,7 +297,7 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
                 <Image
                   source={source}
                   style={{ width: '100%', height: '100%' }}
-                  resizeMode="cover"
+                  resizeMode={sourceMayHaveTransparency(source.uri) ? 'contain' : 'cover'}
                 />
               </View>
             ))}

--- a/SparkyFitnessMobile/src/screens/ExerciseDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ExerciseDetailScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { View, Text, ScrollView, TouchableOpacity, Image, Alert } from 'react-native';
+import { View, Text, ScrollView, TouchableOpacity, Alert } from 'react-native';
 import { CommonActions, StackActions } from '@react-navigation/native';
 import { Directions, Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Toast from 'react-native-toast-message';
@@ -13,6 +13,7 @@ import ExerciseImageCrossfade, {
   sourceMayHaveTransparency,
 } from '../components/ExerciseImageCrossfade';
 import Icon from '../components/Icon';
+import SafeImage from '../components/SafeImage';
 import SegmentedControl, { type Segment } from '../components/SegmentedControl';
 import ExerciseHistoryList from '../components/ExerciseHistoryList';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
@@ -20,7 +21,10 @@ import { fetchExerciseById } from '../services/api/exerciseApi';
 import { importExercise } from '../services/api/externalExerciseSearchApi';
 import { getApiErrorMessage } from '../services/api/errors';
 import { exerciseDetailQueryKey, suggestedExercisesQueryKey } from '../hooks/queryKeys';
-import { useExerciseImageSource } from '../hooks/useExerciseImageSource';
+import {
+  useExerciseImageSource,
+  useImagePairAspectMatch,
+} from '../hooks/useExerciseImageSource';
 import {
   useDeleteExerciseLibrary,
   usePreferences,
@@ -33,6 +37,7 @@ import { useStartLiveWorkout } from '../hooks/useStartLiveWorkout';
 import { useDiaryDateStore } from '../stores/diaryDateStore';
 import {
   buildSingleExerciseStartPayload,
+  CATEGORY_ICON_MAP,
   formatRecentSessionSet,
   normalizeWeightUnit,
   resolveSnapshotModality,
@@ -98,6 +103,7 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
   const usesNativeHeader = useNativeIOSHeadersActive();
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
   const textPrimary = useCSSVariable('--color-text-primary') as string;
+  const textMuted = useCSSVariable('--color-text-muted') as string;
   const { getImageSource } = useExerciseImageSource();
   const reducedMotion = useReducedMotion();
   const { profile } = useProfile();
@@ -193,6 +199,8 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
       );
   }, [exercise.images, getImageSource]);
 
+  const pairAspectMatch = useImagePairAspectMatch(imageSources);
+
   const equipmentText = formatList(exercise.equipment ?? []);
   const primaryMusclesText = formatList(exercise.primary_muscles ?? []);
   const secondaryMusclesText = formatList(exercise.secondary_muscles ?? []);
@@ -265,21 +273,39 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
 
   const descriptionIsLong = description.length > DESCRIPTION_PREVIEW_THRESHOLD;
 
+  const imageFallback = (
+    <View className="bg-raised items-center justify-center" style={{ flex: 1 }}>
+      <Icon
+        name={(exercise.category && CATEGORY_ICON_MAP[exercise.category]) || 'exercise-weights'}
+        size={48}
+        color={textMuted}
+      />
+    </View>
+  );
+
   const imageCarousel =
     imageSources.length === 1 ? (
-      <View className="bg-surface rounded-xl overflow-hidden">
-        <Image
+      <View
+        className={`${
+          sourceMayHaveTransparency(imageSources[0].uri) ? 'bg-white' : 'bg-surface'
+        } rounded-xl overflow-hidden`}
+      >
+        <SafeImage
           source={imageSources[0]}
           style={{ width: '100%', aspectRatio: IMAGE_ASPECT_RATIO }}
-          resizeMode={sourceMayHaveTransparency(imageSources[0].uri) ? 'contain' : 'cover'}
+          contentFit={sourceMayHaveTransparency(imageSources[0].uri) ? 'contain' : 'cover'}
+          fallback={imageFallback}
         />
       </View>
-    ) : imageSources.length === 2 && !reducedMotion ? (
+    ) : imageSources.length === 2 && !reducedMotion && pairAspectMatch !== false ? (
       <View
         className="bg-surface rounded-xl overflow-hidden"
         style={{ width: '100%', aspectRatio: IMAGE_ASPECT_RATIO }}
       >
-        <ExerciseImageCrossfade sources={[imageSources[0], imageSources[1]]} />
+        <ExerciseImageCrossfade
+          sources={[imageSources[0], imageSources[1]]}
+          fallback={imageFallback}
+        />
       </View>
     ) : imageSources.length > 1 ? (
       <View>
@@ -293,11 +319,15 @@ const ExerciseDetailScreen: React.FC<ExerciseDetailScreenProps> = ({ navigation,
             onPageSelected={handleImagePageSelected}
           >
             {imageSources.map((source, index) => (
-              <View key={`${source.uri}-${index}`}>
-                <Image
+              <View
+                key={`${source.uri}-${index}`}
+                className={sourceMayHaveTransparency(source.uri) ? 'bg-white' : undefined}
+              >
+                <SafeImage
                   source={source}
                   style={{ width: '100%', height: '100%' }}
-                  resizeMode={sourceMayHaveTransparency(source.uri) ? 'contain' : 'cover'}
+                  contentFit={sourceMayHaveTransparency(source.uri) ? 'contain' : 'cover'}
+                  fallback={imageFallback}
                 />
               </View>
             ))}


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Exercise images are static and we can't get a free license for videos larger than 180x180.

**How did you implement the solution?**
The videos are just the 2 images crossfaded so I faked it using react native reanimated
Only activates when there is exactly 2 images that are the same size
Only animates on detail pages, not in a list

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

https://github.com/user-attachments/assets/8bb43d7a-2377-4a73-8267-093460a8f0b0


## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exercise images now support smooth crossfade transitions when two compatible images are available.
  - Tap animated transitions to pause or resume playback, with a play indicator while paused.
  - Image presentation adapts to transparency, aspect ratio, reduced-motion preferences, and loading failures.
  - Animated images remain paused by default unless playback is explicitly enabled.
  - Exercise details now use improved 4:3 layouts with appropriate fallbacks and image browsing behavior.

- **Tests**
  - Expanded coverage for image transitions, loading, aspect-ratio handling, playback, transparency, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->