### PR TITLE
fix: filter unused custom nutrients from food search 

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -44,6 +44,7 @@ import {
   searchNutritionixOptions,
 } from '@/hooks/Foods/useNutrionix.ts';
 import { DEFAULT_NUTRIENTS } from '@/constants/nutrients.ts';
+import { visibleCustomNutrients } from '@/utils/nutrientUtils.ts';
 import {
   convertNutritionixToFood,
   pinDefaultVariantToServing,
@@ -1078,15 +1079,31 @@ const EnhancedFoodSearch = ({
       (p) => p.view_group === 'quick_info' && p.platform === 'desktop'
     );
 
+  // Custom nutrients are gated by the food_database view group, the group the
+  // settings page adds them to by default — supplement-scoped nutrients are
+  // deliberately absent from it and must not become columns on every result card.
+  const foodDatabasePreferences =
+    nutrientDisplayPreferences.find(
+      (p) => p.view_group === 'food_database' && p.platform === platform
+    ) ||
+    nutrientDisplayPreferences.find(
+      (p) => p.view_group === 'food_database' && p.platform === 'desktop'
+    );
+
   const visibleNutrients = useMemo(() => {
     const base = quickInfoPreferences
       ? quickInfoPreferences.visible_nutrients
       : DEFAULT_NUTRIENTS;
 
-    const allKeys = [...base, ...(customNutrients?.map((cn) => cn.name) || [])];
+    const allKeys = [
+      ...base,
+      ...visibleCustomNutrients(customNutrients, foodDatabasePreferences).map(
+        (cn) => cn.name
+      ),
+    ];
 
     return Array.from(new Set(allKeys));
-  }, [quickInfoPreferences, customNutrients]);
+  }, [quickInfoPreferences, foodDatabasePreferences, customNutrients]);
 
   const nutrientConfig = {
     visibleNutrients,

--- a/SparkyFitnessFrontend/src/pages/Medications/AddMedicationDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Medications/AddMedicationDialog.tsx
@@ -42,6 +42,8 @@ import {
   MED_TYPE_COLORS,
   SUPPLEMENT_FORMS,
   positiveDoseOrNull,
+  collectNutrientsToProvision,
+  isStoredNutrientAmount,
   type NutrientPick,
 } from './medicationUtils';
 import { NutrientPicker } from './NutrientPicker';
@@ -304,8 +306,7 @@ export default function AddMedicationDialog({
     FOOD_VARIANT_NUTRIENT_FIELDS.forEach((field) => {
       if (!selected.has(field)) return;
       const value = nutrientVariant[field];
-      if (typeof value === 'number' && Number.isFinite(value))
-        nutrients[field] = value;
+      if (isStoredNutrientAmount(value)) nutrients[field] = value;
     });
     // Two provisional keys can resolve onto the SAME existing nutrient (the user's
     // "Vitamin D" absorbing both "Vitamin D2" and "Vitamin D3"), so build the object by
@@ -316,7 +317,7 @@ export default function AddMedicationDialog({
       nutrientVariant.custom_nutrients ?? {}
     )) {
       if (!selected.has(name)) continue;
-      if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+      if (!isStoredNutrientAmount(value)) continue;
       const key = rename[name] ?? name;
       custom[key] = (custom[key] ?? 0) + value;
     }
@@ -333,20 +334,16 @@ export default function AddMedicationDialog({
     string,
     string
   > | null> => {
-    const selected = new Set(selectedNutrients);
-    const catalogIds: string[] = [];
-    const provisionalByCatalogId: Record<string, string> = {};
-    const freeText: { key: string; unit: string }[] = [];
-
-    for (const [key, pending] of Object.entries(pendingNutrients)) {
-      if (!selected.has(key)) continue; // picked, then removed again
-      if (pending.catalogId) {
-        catalogIds.push(pending.catalogId);
-        provisionalByCatalogId[pending.catalogId] = key;
-      } else if (pending.isNew) {
-        freeText.push({ key, unit: pending.unit });
-      }
-    }
+    // Rows left blank are skipped: getNutrients() won't store them, so creating their
+    // nutrient (plus goal and display-preference fan-out) would leave orphan rows the
+    // supplement never references. They stay pending, so filling one in later and
+    // re-saving still creates it.
+    const { catalogIds, provisionalByCatalogId, freeText } =
+      collectNutrientsToProvision(
+        pendingNutrients,
+        selectedNutrients,
+        nutrientVariant.custom_nutrients
+      );
 
     const prunePending = (key: string) =>
       setPendingNutrients((current) => {

--- a/SparkyFitnessFrontend/src/pages/Medications/medicationUtils.ts
+++ b/SparkyFitnessFrontend/src/pages/Medications/medicationUtils.ts
@@ -331,6 +331,51 @@ export interface NutrientPick {
 }
 
 /**
+ * True when a staged nutrient value would actually be written into the saved payload —
+ * a real finite number. A cleared input holds `''` and an untouched row `undefined`.
+ */
+export const isStoredNutrientAmount = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isFinite(value);
+
+/**
+ * Which pending picker rows to find-or-create when the supplement is saved.
+ *
+ * A row qualifies only if it is still in the editor (`selectedNutrients`) AND carries
+ * an amount the payload will store. The amount check is load-bearing: the multivitamin
+ * panel stages ~20 rows in one click, and saving with only two filled in must not
+ * materialize the other eighteen — every created nutrient also fans out into goal
+ * targets and report/goal display preferences on all platforms.
+ */
+export function collectNutrientsToProvision(
+  pendingNutrients: Record<
+    string,
+    Pick<NutrientPick, 'catalogId' | 'unit' | 'isNew'>
+  >,
+  selectedNutrients: string[],
+  customValues: Record<string, string | number> | undefined
+): {
+  catalogIds: string[];
+  provisionalByCatalogId: Record<string, string>;
+  freeText: { key: string; unit: string }[];
+} {
+  const selected = new Set(selectedNutrients);
+  const catalogIds: string[] = [];
+  const provisionalByCatalogId: Record<string, string> = {};
+  const freeText: { key: string; unit: string }[] = [];
+  for (const [key, pending] of Object.entries(pendingNutrients)) {
+    if (!selected.has(key)) continue; // picked, then removed again
+    if (!isStoredNutrientAmount(customValues?.[key])) continue; // left blank
+    if (pending.catalogId) {
+      catalogIds.push(pending.catalogId);
+      provisionalByCatalogId[pending.catalogId] = key;
+    } else if (pending.isNew) {
+      freeText.push({ key, unit: pending.unit });
+    }
+  }
+  return { catalogIds, provisionalByCatalogId, freeText };
+}
+
+/**
  * Every name the rows already in the supplement editor answer to: each row's own key,
  * plus the aliases of the custom nutrient behind it.
  *

--- a/SparkyFitnessFrontend/src/tests/utils/collectNutrientsToProvision.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/collectNutrientsToProvision.test.ts
@@ -1,0 +1,93 @@
+import {
+  collectNutrientsToProvision,
+  isStoredNutrientAmount,
+} from '@/pages/Medications/medicationUtils';
+
+// Saving a supplement find-or-creates a user_custom_nutrients row for each picked
+// nutrient, and every created row fans out into goal targets and report/goal display
+// preferences. The multivitamin panel stages ~20 rows in one click, so provisioning
+// must be keyed to "carries an amount the payload will store", not "row present in
+// the editor" — otherwise two filled-in fields create twenty nutrients.
+describe('collectNutrientsToProvision', () => {
+  const pending = {
+    'Vitamin B6': { catalogId: 'vitamin_b6', unit: 'mg' },
+    'Vitamin B12': { catalogId: 'vitamin_b12', unit: 'µg' },
+    Zinc: { catalogId: 'zinc', unit: 'mg' },
+    Selenium: { catalogId: 'selenium', unit: 'µg' },
+    'Bee Pollen': { unit: 'mg', isNew: true },
+  };
+  const allSelected = Object.keys(pending);
+
+  it('provisions only the staged rows that carry an amount', () => {
+    const result = collectNutrientsToProvision(pending, allSelected, {
+      'Vitamin B6': 2,
+      'Vitamin B12': 500,
+    });
+    expect(result.catalogIds).toEqual(['vitamin_b6', 'vitamin_b12']);
+    expect(result.freeText).toEqual([]);
+  });
+
+  it('skips rows whose input was cleared back to empty string', () => {
+    const result = collectNutrientsToProvision(pending, allSelected, {
+      'Vitamin B6': 2,
+      Zinc: '',
+    });
+    expect(result.catalogIds).toEqual(['vitamin_b6']);
+  });
+
+  it('provisions nothing when no amounts were entered at all', () => {
+    const result = collectNutrientsToProvision(pending, allSelected, undefined);
+    expect(result.catalogIds).toEqual([]);
+    expect(result.freeText).toEqual([]);
+    expect(result.provisionalByCatalogId).toEqual({});
+  });
+
+  it('skips rows picked and then removed from the editor, even with a value', () => {
+    const result = collectNutrientsToProvision(pending, ['Vitamin B6'], {
+      'Vitamin B6': 2,
+      Zinc: 15,
+    });
+    expect(result.catalogIds).toEqual(['vitamin_b6']);
+  });
+
+  it('includes free-text rows with an amount, carrying their unit', () => {
+    const result = collectNutrientsToProvision(pending, allSelected, {
+      'Bee Pollen': 100,
+    });
+    expect(result.catalogIds).toEqual([]);
+    expect(result.freeText).toEqual([{ key: 'Bee Pollen', unit: 'mg' }]);
+  });
+
+  it('maps each provisioned catalog id back to its editor key', () => {
+    const result = collectNutrientsToProvision(pending, allSelected, {
+      'Vitamin B12': 500,
+    });
+    expect(result.provisionalByCatalogId).toEqual({
+      vitamin_b12: 'Vitamin B12',
+    });
+  });
+
+  // An explicit 0 is stored by the payload builder, so the key reaches the server and
+  // its nutrient row must exist — the predicate has to agree with getNutrients().
+  it('treats an explicit 0 as a stored amount', () => {
+    const result = collectNutrientsToProvision(pending, allSelected, {
+      Zinc: 0,
+    });
+    expect(result.catalogIds).toEqual(['zinc']);
+  });
+});
+
+describe('isStoredNutrientAmount', () => {
+  it('accepts finite numbers including 0', () => {
+    expect(isStoredNutrientAmount(0)).toBe(true);
+    expect(isStoredNutrientAmount(2.5)).toBe(true);
+  });
+
+  it('rejects blank, non-numeric, and non-finite values', () => {
+    expect(isStoredNutrientAmount('')).toBe(false);
+    expect(isStoredNutrientAmount(undefined)).toBe(false);
+    expect(isStoredNutrientAmount('5')).toBe(false);
+    expect(isStoredNutrientAmount(NaN)).toBe(false);
+    expect(isStoredNutrientAmount(Infinity)).toBe(false);
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/utils/visibleCustomNutrients.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/visibleCustomNutrients.test.ts
@@ -1,0 +1,41 @@
+import { visibleCustomNutrients } from '@/utils/nutrientUtils';
+import type { UserCustomNutrient } from '@/types/customNutrient';
+
+const nutrient = (name: string): UserCustomNutrient =>
+  ({ id: name, name, unit: 'mg' }) as UserCustomNutrient;
+
+// Food surfaces must honor the food_database view-group preference for custom
+// nutrients: supplement-picked nutrients are scoped to goal/report groups only, so
+// rendering the user's full custom-nutrient list would resurface them as always-0.0
+// columns on every food card.
+describe('visibleCustomNutrients', () => {
+  const customs = [
+    nutrient('Chemical X'),
+    nutrient('Zinc'),
+    nutrient('Iodine'),
+  ];
+
+  it('keeps only the nutrients the view group lists', () => {
+    const result = visibleCustomNutrients(customs, {
+      visible_nutrients: ['calories', 'protein', 'Chemical X'],
+    });
+    expect(result.map((n) => n.name)).toEqual(['Chemical X']);
+  });
+
+  it('hides every custom nutrient when the group lists none of them', () => {
+    const result = visibleCustomNutrients(customs, {
+      visible_nutrients: ['calories', 'protein'],
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('shows all custom nutrients when no preference row exists', () => {
+    expect(visibleCustomNutrients(customs, undefined)).toEqual(customs);
+  });
+
+  it('returns an empty list when the user has no custom nutrients', () => {
+    expect(
+      visibleCustomNutrients(undefined, { visible_nutrients: ['Chemical X'] })
+    ).toEqual([]);
+  });
+});

--- a/SparkyFitnessFrontend/src/utils/nutrientUtils.ts
+++ b/SparkyFitnessFrontend/src/utils/nutrientUtils.ts
@@ -169,3 +169,28 @@ export const withNetCarbsSubstitution = <
     };
   });
 };
+
+/**
+ * The custom nutrients a food surface should render, per the user's display
+ * preference for that view group.
+ *
+ * Custom nutrients are NOT all food-facing: ones created through settings are added
+ * to the food_database view group by default, but supplement-picked ones are scoped
+ * to the goal/report groups only, so a multivitamin's 19 micronutrients don't render
+ * as always-0.0 columns on every food card. Rendering the full list would bypass
+ * that scoping.
+ *
+ * No preference row means the group was never configured (or preferences haven't
+ * loaded yet); every custom nutrient stays visible, matching the pre-preference
+ * behavior.
+ */
+export const visibleCustomNutrients = (
+  customNutrients: UserCustomNutrient[] | undefined,
+  preference: { visible_nutrients: string[] } | undefined
+): UserCustomNutrient[] => {
+  if (!customNutrients) return [];
+  if (!preference) return customNutrients;
+  return customNutrients.filter((nutrient) =>
+    preference.visible_nutrients.includes(nutrient.name)
+  );
+};


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Clicking "multivitamin panel" when adding a supplement loads all custom nutrients in the users preferences, not just the ones that have values. This was adding 19 extra columns in food search

**How did you implement the solution?**

Fix the insert bug
FoodSearch.tsx now works via the food_database view-group preference instead of appending all nutrients

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Custom nutrients now follow configured visibility preferences, with sensible fallback behavior when preferences are unavailable.
  * Medication nutrient entries are validated more reliably, including support for zero values.
  * Nutrients are provisioned only when selected and complete; blank or removed entries are excluded.
  * Catalog and free-text nutrients are handled separately when saving medications.

* **Tests**
  * Added coverage for nutrient visibility, validation, selection, mapping, and save-time provisioning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->