### PR TITLE
fix: browser refresh when api returns html

### DIFF
--- a/SparkyFitnessFrontend/src/api/api.ts
+++ b/SparkyFitnessFrontend/src/api/api.ts
@@ -23,6 +23,12 @@ export const API_BASE_URL = '/api';
 const GATEWAY_RELOAD_GUARD_KEY = 'sparky_gateway_reload_guard';
 const GATEWAY_RELOAD_GUARD_TTL_MS = 10000;
 
+// Indirection so tests can observe the reload without jsdom's unimplemented
+// window.location.reload (same seam pattern as chunkRecoveryRuntime).
+export const gatewayReloadRuntime = {
+  reloadWindowLocation: () => window.location.reload(),
+};
+
 // Detects when a reverse-proxy auth gateway (e.g. Cloudflare Access) has
 // intercepted an internal API call and returned its own login/redirect page
 // instead of letting the request reach the backend. Such responses are not a
@@ -40,6 +46,13 @@ function isGatewayInterceptedResponse(response: Response): boolean {
       // Ignore malformed URLs; fall through to content-type check.
     }
   }
+  // Only sniff HTML on success responses. On an error status, an HTML body is
+  // a proxy error page (nginx 502/504, a rate-limit page, Express's default
+  // 404), not a gateway login page; reloading on those drops in-progress UI
+  // state (issue #2051), so they take the normal error-toast path instead.
+  if (!response.ok) {
+    return false;
+  }
   const contentType = response.headers.get('content-type') || '';
   return contentType.includes('text/html');
 }
@@ -52,7 +65,7 @@ function reloadOnceForGatewayInterception(): void {
     return;
   }
   sessionStorage.setItem(GATEWAY_RELOAD_GUARD_KEY, String(Date.now()));
-  window.location.reload();
+  gatewayReloadRuntime.reloadWindowLocation();
 }
 
 // A blob response is always a Blob, never the caller's generic T — the overload

--- a/SparkyFitnessFrontend/src/tests/api/api.test.ts
+++ b/SparkyFitnessFrontend/src/tests/api/api.test.ts
@@ -1,0 +1,126 @@
+import { apiCall, gatewayReloadRuntime } from '@/api/api';
+import { toast } from '@/hooks/use-toast';
+
+jest.mock('@/hooks/use-toast', () => ({
+  toast: jest.fn(),
+}));
+jest.mock('@/utils/logging');
+
+const mockToast = jest.mocked(toast);
+const mockReload = jest.fn();
+
+interface FakeResponseOptions {
+  status?: number;
+  contentType?: string | null;
+  body?: string;
+  redirected?: boolean;
+  url?: string;
+}
+
+const makeResponse = ({
+  status = 200,
+  contentType = 'application/json',
+  body = '{}',
+  redirected = false,
+  url = 'http://localhost/api/test',
+}: FakeResponseOptions = {}): Response =>
+  ({
+    ok: status >= 200 && status < 300,
+    status,
+    type: 'basic',
+    redirected,
+    url,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type' ? contentType : null,
+    },
+    text: () => Promise.resolve(body),
+    json: () => Promise.resolve(JSON.parse(body)),
+  }) as unknown as Response;
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('apiCall gateway interception handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    jest
+      .spyOn(gatewayReloadRuntime, 'reloadWindowLocation')
+      .mockImplementation(mockReload);
+    global.fetch = jest.fn();
+  });
+
+  it('returns parsed JSON on a normal success response without reloading', async () => {
+    jest
+      .mocked(global.fetch)
+      .mockResolvedValue(makeResponse({ body: '{"value":1}' }));
+
+    await expect(apiCall('/test')).resolves.toEqual({ value: 1 });
+    expect(mockReload).not.toHaveBeenCalled();
+  });
+
+  // Regression for issue #2051: proxy error pages (nginx 502/504, Express's
+  // default HTML 404) must surface as normal API errors, not page reloads.
+  it('rejects without reloading when an error status carries an HTML body', async () => {
+    jest.mocked(global.fetch).mockResolvedValue(
+      makeResponse({
+        status: 502,
+        contentType: 'text/html',
+        body: '<html><body>502 Bad Gateway</body></html>',
+      })
+    );
+
+    await expect(apiCall('/v2/foods/search/openfoodfacts')).rejects.toThrow();
+    expect(mockReload).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'destructive' })
+    );
+  });
+
+  it('reloads when a success response carries an HTML body', async () => {
+    jest
+      .mocked(global.fetch)
+      .mockResolvedValue(
+        makeResponse({ contentType: 'text/html', body: '<html></html>' })
+      );
+
+    // The gateway path intentionally returns a never-settling promise, so the
+    // call is not awaited.
+    void apiCall('/test');
+    await flushMicrotasks();
+
+    expect(mockReload).toHaveBeenCalledTimes(1);
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('reloads at most once within the guard window', async () => {
+    jest
+      .mocked(global.fetch)
+      .mockResolvedValue(
+        makeResponse({ contentType: 'text/html', body: '<html></html>' })
+      );
+
+    void apiCall('/test');
+    void apiCall('/test');
+    await flushMicrotasks();
+
+    expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads on a cross-origin redirect even with an error status', async () => {
+    jest.mocked(global.fetch).mockResolvedValue(
+      makeResponse({
+        status: 403,
+        contentType: 'text/html',
+        body: '<html></html>',
+        redirected: true,
+        url: 'https://team.cloudflareaccess.com/login',
+      })
+    );
+
+    void apiCall('/test');
+    await flushMicrotasks();
+
+    expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Browser refreshing when the api returned html. This was also causing issues with the 404 page and several others. 

**How did you implement the solution?**
Make sure the response is 200 before we look for HTML.

Linked Issue: Closes #2051

## How to Test

1. Search for a food for an api that returns HTML (unauthed OFF should do it)
2. Verify it doesnt refresh

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of gateway responses so HTML error pages follow standard error handling without triggering unnecessary reloads.
  * Ensured successful gateway interceptions reload the application correctly and only once.
  * Added support for handling redirected gateway errors consistently.

* **Tests**
  * Added coverage for successful responses, gateway errors, redirects, reload behavior, and duplicate reload prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->