### PR TITLE
fix: prevent reports RangeError on large custom-measurement datasets

### DIFF
--- a/SparkyFitnessServer/models/reportRepository.ts
+++ b/SparkyFitnessServer/models/reportRepository.ts
@@ -363,9 +363,26 @@ async function getCustomMeasurementsData(
 ) {
   const client = await getClient(userId); // User-specific operation
   try {
+    // Cap the points returned per category so large datasets (e.g. years of
+    // intraday heart-rate samples) do not blow up the call stack or payload.
+    // When the range exceeds maxPoints rows, return an evenly-spaced sample
+    // (always including the first row) so charts keep the overall trend.
+    const maxPoints = 3000;
     const result = await client.query(
-      "SELECT category_id, TO_CHAR(entry_date, 'YYYY-MM-DD') AS entry_date, entry_hour, value, notes, entry_timestamp FROM custom_measurements WHERE user_id = $1 AND category_id = $2 AND entry_date BETWEEN $3 AND $4 ORDER BY entry_date, entry_timestamp",
-      [userId, categoryId, startDate, endDate]
+      `WITH ranked AS (
+           SELECT category_id,
+                  TO_CHAR(entry_date, 'YYYY-MM-DD') AS entry_date,
+                  entry_hour, value, notes, entry_timestamp,
+                  row_number() OVER (ORDER BY entry_date, entry_timestamp) AS rn,
+                  count(*) OVER () AS total
+           FROM custom_measurements
+           WHERE user_id = $1 AND category_id = $2 AND entry_date BETWEEN $3 AND $4
+         )
+         SELECT category_id, entry_date, entry_hour, value, notes, entry_timestamp
+         FROM ranked
+         WHERE total <= $5 OR rn = 1 OR rn % GREATEST(1, CEIL(total::float / $5)::bigint) = 0
+         ORDER BY entry_date, entry_timestamp`,
+      [userId, categoryId, startDate, endDate, maxPoints]
     );
     return result.rows;
   } finally {

--- a/SparkyFitnessServer/models/reportRepository.ts
+++ b/SparkyFitnessServer/models/reportRepository.ts
@@ -380,7 +380,7 @@ async function getCustomMeasurementsData(
          )
          SELECT category_id, entry_date, entry_hour, value, notes, entry_timestamp
          FROM ranked
-         WHERE total <= $5 OR rn = 1 OR rn % GREATEST(1, CEIL(total::float / $5)::bigint) = 0
+         WHERE total <= $5 OR (rn - 1) % GREATEST(1, CEIL(total::float / $5)::bigint) = 0
          ORDER BY entry_date, entry_timestamp`,
       [userId, categoryId, startDate, endDate, maxPoints]
     );

--- a/SparkyFitnessServer/services/reportService.ts
+++ b/SparkyFitnessServer/services/reportService.ts
@@ -193,7 +193,9 @@ async function getReportsData(
           startDate,
           endDate
         );
-      customMeasurementsData.push(...customMeasurementResult);
+      for (let i = 0; i < customMeasurementResult.length; i++) {
+        customMeasurementsData.push(customMeasurementResult[i]);
+      }
     }
     const tabularData = tabularDataRaw.map((row: TabularFoodRow) => {
       // Custom nutrients are now already in the row, scaled and summed by the repository

--- a/SparkyFitnessServer/tests/reportRepository.downsample.test.ts
+++ b/SparkyFitnessServer/tests/reportRepository.downsample.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as reportRepository from '../models/reportRepository.js';
+import { getClient } from '../db/poolManager.js';
+
+vi.mock('../db/poolManager.js', () => ({
+  getClient: vi.fn(),
+}));
+
+describe('getCustomMeasurementsData - large dataset downsampling', () => {
+  const mockQuery = vi.fn();
+  const mockClient = { query: mockQuery, release: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getClient as ReturnType<typeof vi.fn>).mockResolvedValue(mockClient);
+  });
+
+  it('caps returned points via an evenly-spaced window-function downsample', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await reportRepository.getCustomMeasurementsData(
+      'user-1',
+      'cat-1',
+      '2020-01-01',
+      '2026-08-07'
+    );
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockQuery.mock.calls[0];
+
+    // The downsample guard must be present to avoid a RangeError when a
+    // category contains a very large number of rows (e.g. years of intraday
+    // heart-rate samples). See reportService.getReportsData which pushes every
+    // returned row into a single array.
+    expect(sql).toMatch(/row_number\(\)\s+OVER/i);
+    expect(sql).toMatch(/count\(\*\)\s+OVER\s*\(\)/i);
+    expect(sql).toMatch(/GREATEST\(1,\s*CEIL\(total::float/i);
+    // The cap is bound as the 5th query parameter and must stay bounded.
+    expect(params).toHaveLength(5);
+    expect(params[4]).toBeLessThanOrEqual(3000);
+    expect(params[4]).toBeGreaterThan(1000);
+  });
+
+  it('returns the (already downsampled) rows unchanged', async () => {
+    const rows = [
+      {
+        category_id: 'cat-1',
+        entry_date: '2026-01-01',
+        entry_hour: 8,
+        value: '72',
+        notes: null,
+        entry_timestamp: null,
+      },
+      {
+        category_id: 'cat-1',
+        entry_date: '2026-01-02',
+        entry_hour: 9,
+        value: '75',
+        notes: null,
+        entry_timestamp: null,
+      },
+    ];
+    mockQuery.mockResolvedValueOnce({ rows });
+
+    const result = await reportRepository.getCustomMeasurementsData(
+      'user-1',
+      'cat-1',
+      '2026-01-01',
+      '2026-01-02'
+    );
+
+    expect(result).toEqual(rows);
+  });
+});

--- a/SparkyFitnessServer/tests/reportRepository.downsample.test.ts
+++ b/SparkyFitnessServer/tests/reportRepository.downsample.test.ts
@@ -35,6 +35,9 @@ describe('getCustomMeasurementsData - large dataset downsampling', () => {
     expect(sql).toMatch(/row_number\(\)\s+OVER/i);
     expect(sql).toMatch(/count\(\*\)\s+OVER\s*\(\)/i);
     expect(sql).toMatch(/GREATEST\(1,\s*CEIL\(total::float/i);
+    // First row is included via (rn - 1) % step = 0, not a separate OR clause,
+    // guaranteeing the result never exceeds maxPoints.
+    expect(sql).toMatch(/\(rn\s*-\s*1\)\s*%\s*GREATEST/i);
     // The cap is bound as the 5th query parameter and must stay bounded.
     expect(params).toHaveLength(5);
     expect(params[4]).toBeLessThanOrEqual(3000);


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
`GET /api/reports` over a wide date range returns `500 RangeError: Maximum call stack size exceeded` when any custom measurement category contains a very large number of rows (e.g. years of intraday heart-rate samples — 2.6M+ rows in a real-world dataset). This makes the Reports page fail for long time ranges.

**How did you implement the solution?**
Two changes, both required:
1. `reportRepository.getCustomMeasurementsData` — cap the rows returned per category to ~3000 evenly-spaced points using `row_number()` / `count(*)` window functions (`CEIL(total / maxPoints)` stride; the full dataset is still returned when a range has ≤ `maxPoints` rows). The selected column list is unchanged, so the response shape — and therefore the frontend — is unaffected. **No data is deleted or migrated**; downsample happens at query time only.
2. `reportService.getReportsData` — replace `arr.push(...bigArray)` with a plain loop, so the call stack can no longer be exhausted by a large category result set (defense-in-depth).

Root cause: `getCustomMeasurementsData` returned every matching row (no limit) and `getReportsData` then spread-pushed them (`customMeasurementsData.push(...result)`), which expands the large array as function arguments and overflows the stack.

Linked Issue: (none — bug fix)

## How to Test

1. Check out this branch and run the backend against a DB containing a large custom measurement category (e.g. millions of `heart_rate` rows).
2. `GET /api/reports?startDate=2020-01-01&endDate=2026-08-07` (wide range).
3. Verify it returns **200** (previously 500 RangeError) and `customMeasurementsData` is bounded: large categories return ≤ ~3000 points while small categories return all their rows.
4. `cd SparkyFitnessServer && pnpm run typecheck && pnpm run lint && pnpm run test`.

Measured on a 2.6M-row dataset: **before** → `500 RangeError` after ~22s; **after** → `200` with `heart_rate` downsampled to ~3000 points.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests (all pass). New files use TypeScript. No new endpoints are added (Zod schemas / endpoint tests N/A); a new unit test `tests/reportRepository.downsample.test.ts` is included.
- [x] **[MANDATORY for Backend changes] Database Security**: No new user-specific tables are introduced, so `rls_policies.sql` is unchanged.

## Notes for Reviewers

- The cap (`maxPoints = 3000`) is a local constant in `getCustomMeasurementsData`; happy to make it configurable or adjust the value if maintainers prefer.
- Behavior is identical for ranges that already return ≤ 3000 rows per category (e.g. single-day/intraday views) — only wide ranges are downsampled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Custom measurement reports now limit results to 3,000 points.
  * Large datasets are evenly sampled while preserving the earliest measurement.
  * Smaller datasets continue to display all available measurements.

* **Bug Fixes**
  * Improved handling of large custom measurement result sets without changing report output for already-limited data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->