### PR TITLE
feat: add table type filter to reports table view

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Reports/Reports.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/Reports.tsx
@@ -13,7 +13,9 @@ import {
   generateReportsMeasurementsDefaultLayouts,
   useMeasurementChartWidgets,
 } from '@/pages/Reports/MeasurementChartsGrid';
-import ReportsTables from '@/pages/Reports/ReportsTables';
+import ReportsTables, {
+  type TableFilterValue,
+} from '@/pages/Reports/ReportsTables';
 import ExerciseReportsDashboard from '@/pages/Reports/ExerciseReportsDashboard';
 import SleepReport from '@/pages/Reports/SleepReport';
 import BodyBatteryCard from '@/pages/Reports/BodyBatteryCard';
@@ -95,6 +97,8 @@ const Reports = () => {
   const [activeTab, setActiveTab] = useState(
     searchParams.get('tab') || 'charts'
   );
+
+  const [selectedTable, setSelectedTable] = useState<TableFilterValue>('all');
 
   const handleTabChange = (value: string) => {
     setActiveTab(value);
@@ -303,6 +307,8 @@ const Reports = () => {
               customCategories={customCategories}
               customMeasurementsData={customMeasurementsData}
               prData={exerciseDashboardData?.prData}
+              selectedTable={selectedTable}
+              onSelectedTableChange={setSelectedTable}
               onExportFoodDiary={() =>
                 exportFoodDiary({
                   loggingLevel,

--- a/SparkyFitnessFrontend/src/pages/Reports/ReportsTables.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/ReportsTables.tsx
@@ -395,7 +395,10 @@ const ReportsTables = ({
             onSelectedTableChange(value as TableFilterValue)
           }
         >
-          <SelectTrigger className="w-full max-w-xs">
+          <SelectTrigger
+            className="w-full max-w-xs"
+            aria-label={t('reportsTables.showTable', 'Show table')}
+          >
             <SelectValue
               placeholder={t('reportsTables.showTable', 'Show table')}
             />

--- a/SparkyFitnessFrontend/src/pages/Reports/ReportsTables.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/ReportsTables.tsx
@@ -4,6 +4,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
   Table,
   TableBody,
   TableCell,
@@ -74,6 +81,13 @@ const formatTonnage = (
   );
 };
 
+export type TableFilterValue =
+  | 'all'
+  | 'food'
+  | 'exercise'
+  | 'measurements'
+  | `category:${string}`;
+
 interface ReportsTablesProps {
   tabularData: DailyFoodEntry[];
   exerciseEntries: DailyExerciseEntry[];
@@ -81,6 +95,8 @@ interface ReportsTablesProps {
   customCategories: CustomCategoriesResponse[];
   customMeasurementsData: CustomMeasurementsResponse[];
   prData: PersonalRecordsMap | undefined;
+  selectedTable: TableFilterValue;
+  onSelectedTableChange: (value: TableFilterValue) => void;
   onExportFoodDiary: () => void;
   onExportBodyMeasurements: () => void;
   onExportCustomMeasurements: (category: CustomCategoriesResponse) => void;
@@ -95,6 +111,8 @@ const ReportsTables = ({
   customCategories,
   customMeasurementsData,
   prData,
+  selectedTable,
+  onSelectedTableChange,
   onExportFoodDiary,
   onExportBodyMeasurements,
   onExportCustomMeasurements,
@@ -369,419 +387,477 @@ const ReportsTables = ({
 
   return (
     <div className="space-y-6">
-      {/* Food Diary Table with Export Button */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle>
+      {/* Table type filter */}
+      <div className="flex items-center gap-2">
+        <Select
+          value={selectedTable}
+          onValueChange={(value) =>
+            onSelectedTableChange(value as TableFilterValue)
+          }
+        >
+          <SelectTrigger className="w-full max-w-xs">
+            <SelectValue
+              placeholder={t('reportsTables.showTable', 'Show table')}
+            />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">
+              {t('reportsTables.allTables', 'All tables')}
+            </SelectItem>
+            <SelectItem value="food">
               {t('reportsTables.foodDiaryTable', 'Food Diary Table')}
-            </CardTitle>
-            <Button onClick={onExportFoodDiary} variant="outline" size="sm">
-              <Download className="w-4 h-4" />
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t('reportsTables.date', 'Date')}</TableHead>
-                  <TableHead>{t('reportsTables.meal', 'Meal')}</TableHead>
-                  <TableHead className="min-w-[250px]">
-                    {t('reportsTables.food', 'Food')}
-                  </TableHead>
-                  <TableHead>
-                    {t('reportsTables.quantity', 'Quantity')}
-                  </TableHead>
-                  {visibleNutrients.map((nutrient) => {
-                    const metadata = getNutrientMetadata(
-                      nutrient,
-                      customNutrients
-                    );
-                    const isNetCarbs = nutrient === 'carbs' && showNetCarbs;
-                    const label = isNetCarbs
-                      ? t('nutrition.netCarbs', 'Net Carbs')
-                      : t(metadata.label, metadata.defaultLabel);
-                    const unit =
-                      nutrient === 'calories'
-                        ? getEnergyUnitString(energyUnit)
-                        : metadata.unit;
-
-                    return (
-                      <TableHead key={nutrient}>
-                        {label}
-                        {unit ? ` (${unit})` : ''}
-                      </TableHead>
-                    );
-                  })}
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {foodDataWithTotals.map((entry, index) => {
-                  debug(
-                    loggingLevel,
-                    `ReportsTables: Processing entry for food: ${entry.food_name}, custom_nutrients:`,
-                    entry.custom_nutrients
-                  );
-                  return (
-                    <TableRow
-                      key={index}
-                      className={
-                        entry.isTotal
-                          ? 'bg-gray-50 dark:bg-gray-900 font-semibold border-t-2'
-                          : ''
-                      }
-                    >
-                      <TableCell>
-                        {formatDateInUserTimezone(
-                          parseISO(entry.entry_date),
-                          dateFormat
-                        )}
-                      </TableCell>
-                      <TableCell className="capitalize">
-                        {entry.meal_type}
-                      </TableCell>
-                      <TableCell className="min-w-[250px]">
-                        {!entry.isTotal && (
-                          <div>
-                            <div className="font-medium">
-                              {(entry.food_name as string) ||
-                                (entry.foods?.name as string)}
-                            </div>
-                            {(entry.brand_name || entry.foods?.brand) && (
-                              <div className="text-sm text-gray-500">
-                                {(entry.brand_name as string) ||
-                                  (entry.foods?.brand as string)}
-                              </div>
-                            )}
-                          </div>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        {entry.isTotal ? '' : `${entry.quantity} ${entry.unit}`}
-                      </TableCell>
-                      {visibleNutrients.map((nutrient) => {
-                        // Special-case glycemic_index because it's a categorical value (string), not numeric
-                        if (nutrient === 'glycemic_index') {
-                          const giValue = entry.isTotal
-                            ? ''
-                            : (entry.glycemic_index as string) ||
-                              (entry.foods?.glycemic_index as string) ||
-                              'None';
-                          return (
-                            <TableCell key={nutrient}>{giValue}</TableCell>
-                          );
-                        }
-
-                        // Directly use the pre-calculated nutrient value from the entry,
-                        // substituting net carbs when the user preference is enabled.
-                        const rawValue =
-                          (entry[nutrient as keyof DailyFoodEntry] as number) ||
-                          0;
-                        const value =
-                          nutrient === 'carbs' && showNetCarbs
-                            ? getNetCarbsValue(rawValue, entry.dietary_fiber)
-                            : rawValue;
-
-                        const displayValue =
-                          nutrient === 'calories'
-                            ? Math.round(
-                                convertEnergy(value, 'kcal', energyUnit)
-                              ).toString()
-                            : formatNutrientValue(
-                                nutrient,
-                                value,
-                                customNutrients
-                              );
-
-                        return (
-                          <TableCell key={nutrient}>
-                            {entry.isTotal && Number(value) === 0
-                              ? ''
-                              : displayValue}
-                          </TableCell>
-                        );
-                      })}
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Exercise Entries Table with Export Button */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle>
+            </SelectItem>
+            <SelectItem value="exercise">
               {t(
                 'reportsTables.exerciseEntriesTable',
                 'Exercise Entries Table'
               )}
-            </CardTitle>
-            <Button
-              onClick={onExportExerciseEntries}
-              variant="outline"
-              size="sm"
-            >
-              <Download className="w-4 h-4" />
-            </Button>
-          </div>
-          <div className="flex items-center space-x-2 mt-4">
-            <Input
-              placeholder={t(
-                'reportsTables.filterByExerciseName',
-                'Filter by exercise name...'
+            </SelectItem>
+            <SelectItem value="measurements">
+              {t(
+                'reportsTables.bodyMeasurementsTable',
+                'Body Measurements Table'
               )}
-              value={exerciseNameFilter}
-              onChange={(e) => setExerciseNameFilter(e.target.value)}
-              className="max-w-sm"
-            />
-            <Input
-              placeholder={t(
-                'reportsTables.filterBySetType',
-                'Filter by set type...'
-              )}
-              value={setTypeFilter}
-              onChange={(e) => setSetTypeFilter(e.target.value)}
-              className="max-w-sm"
-            />
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead onClick={() => requestSort('entry_date')}>
-                    {t('reportsTables.date', 'Date')}
-                  </TableHead>
-                  <TableHead onClick={() => requestSort('exercise_name')}>
-                    {t('reportsTables.exercise', 'Exercise')}
-                  </TableHead>
-                  <TableHead onClick={() => requestSort('set_number')}>
-                    {t('reportsTables.set', 'Set')}
-                  </TableHead>
-                  <TableHead onClick={() => requestSort('set_type')}>
-                    {t('reportsTables.type', 'Type')}
-                  </TableHead>
-                  <TableHead onClick={() => requestSort('reps')}>
-                    {t('reportsTables.reps', 'Reps')}
-                  </TableHead>
-                  <TableHead onClick={() => requestSort('weight')}>
-                    {t('reportsTables.weight', 'Weight')} ({weightUnit})
-                  </TableHead>
-                  <TableHead>{t('reportsTables.tonnage', 'Tonnage')}</TableHead>
-                  <TableHead onClick={() => requestSort('duration')}>
-                    {t('reportsTables.durationSec', 'Duration (s)')}
-                  </TableHead>
-                  <TableHead onClick={() => requestSort('rest_time')}>
-                    {t('reportsTables.restS', 'Rest (s)')}
-                  </TableHead>
-                  <TableHead>{t('reportsTables.notes', 'Notes')}</TableHead>
-                  <TableHead onClick={() => requestSort('calories_burned')}>
-                    {t(
-                      'reportsTables.caloriesBurned',
-                      `Calories Burned (${getEnergyUnitString(energyUnit)})`
-                    )}
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {filteredExerciseEntries.map((entry) => {
-                  const isPr =
-                    prData &&
-                    prData[entry.exercises.id] &&
-                    prData[entry.exercises.id]?.date === entry.entry_date;
-                  const isExpanded = expandedRows[entry.id];
+            </SelectItem>
+            {customCategories.map((category) => (
+              <SelectItem key={category.id} value={`category:${category.id}`}>
+                {category.display_name || category.name} (
+                {category.measurement_type})
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
 
-                  return (
-                    <React.Fragment key={entry.id}>
+      {/* Food Diary Table with Export Button */}
+      {(selectedTable === 'all' || selectedTable === 'food') && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle>
+                {t('reportsTables.foodDiaryTable', 'Food Diary Table')}
+              </CardTitle>
+              <Button onClick={onExportFoodDiary} variant="outline" size="sm">
+                <Download className="w-4 h-4" />
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t('reportsTables.date', 'Date')}</TableHead>
+                    <TableHead>{t('reportsTables.meal', 'Meal')}</TableHead>
+                    <TableHead className="min-w-[250px]">
+                      {t('reportsTables.food', 'Food')}
+                    </TableHead>
+                    <TableHead>
+                      {t('reportsTables.quantity', 'Quantity')}
+                    </TableHead>
+                    {visibleNutrients.map((nutrient) => {
+                      const metadata = getNutrientMetadata(
+                        nutrient,
+                        customNutrients
+                      );
+                      const isNetCarbs = nutrient === 'carbs' && showNetCarbs;
+                      const label = isNetCarbs
+                        ? t('nutrition.netCarbs', 'Net Carbs')
+                        : t(metadata.label, metadata.defaultLabel);
+                      const unit =
+                        nutrient === 'calories'
+                          ? getEnergyUnitString(energyUnit)
+                          : metadata.unit;
+
+                      return (
+                        <TableHead key={nutrient}>
+                          {label}
+                          {unit ? ` (${unit})` : ''}
+                        </TableHead>
+                      );
+                    })}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {foodDataWithTotals.map((entry, index) => {
+                    debug(
+                      loggingLevel,
+                      `ReportsTables: Processing entry for food: ${entry.food_name}, custom_nutrients:`,
+                      entry.custom_nutrients
+                    );
+                    return (
                       <TableRow
+                        key={index}
                         className={
-                          isPr ? 'bg-yellow-100 dark:bg-yellow-900' : ''
+                          entry.isTotal
+                            ? 'bg-gray-50 dark:bg-gray-900 font-semibold border-t-2'
+                            : ''
                         }
                       >
                         <TableCell>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() =>
-                              setExpandedRows((prev) => ({
-                                ...prev,
-                                [entry.id]: !prev[entry.id],
-                              }))
-                            }
-                          >
-                            {isExpanded ? '▼' : '▶'}
-                          </Button>
                           {formatDateInUserTimezone(
                             parseISO(entry.entry_date),
                             dateFormat
                           )}
                         </TableCell>
-                        <TableCell>{entry.exercises.name}</TableCell>
-                        <TableCell>{entry.sets.length}</TableCell>
-                        <TableCell></TableCell>
-                        <TableCell>{formatRepRange(entry.sets)}</TableCell>
-                        <TableCell>
-                          {formatAvgWeight(entry.sets, weightUnit)}
+                        <TableCell className="capitalize">
+                          {entry.meal_type}
                         </TableCell>
-                        <TableCell>
-                          {formatTonnage(entry.sets, weightUnit)}
-                        </TableCell>
-                        <TableCell>
-                          {entry.sets.reduce(
-                            (acc, s) => acc + (s.duration || 0),
-                            0
+                        <TableCell className="min-w-[250px]">
+                          {!entry.isTotal && (
+                            <div>
+                              <div className="font-medium">
+                                {(entry.food_name as string) ||
+                                  (entry.foods?.name as string)}
+                              </div>
+                              {(entry.brand_name || entry.foods?.brand) && (
+                                <div className="text-sm text-gray-500">
+                                  {(entry.brand_name as string) ||
+                                    (entry.foods?.brand as string)}
+                                </div>
+                              )}
+                            </div>
                           )}
                         </TableCell>
                         <TableCell>
-                          {entry.sets.reduce(
-                            (acc, s) => acc + (s.rest_time || 0),
-                            0
-                          )}
+                          {entry.isTotal
+                            ? ''
+                            : `${entry.quantity} ${entry.unit}`}
                         </TableCell>
-                        <TableCell>{entry.notes || ''}</TableCell>
-                        <TableCell>
-                          {Math.round(
-                            convertEnergy(
-                              entry.calories_burned,
-                              'kcal',
-                              energyUnit
-                            )
-                          )}
-                        </TableCell>
+                        {visibleNutrients.map((nutrient) => {
+                          // Special-case glycemic_index because it's a categorical value (string), not numeric
+                          if (nutrient === 'glycemic_index') {
+                            const giValue = entry.isTotal
+                              ? ''
+                              : (entry.glycemic_index as string) ||
+                                (entry.foods?.glycemic_index as string) ||
+                                'None';
+                            return (
+                              <TableCell key={nutrient}>{giValue}</TableCell>
+                            );
+                          }
+
+                          // Directly use the pre-calculated nutrient value from the entry,
+                          // substituting net carbs when the user preference is enabled.
+                          const rawValue =
+                            (entry[
+                              nutrient as keyof DailyFoodEntry
+                            ] as number) || 0;
+                          const value =
+                            nutrient === 'carbs' && showNetCarbs
+                              ? getNetCarbsValue(rawValue, entry.dietary_fiber)
+                              : rawValue;
+
+                          const displayValue =
+                            nutrient === 'calories'
+                              ? Math.round(
+                                  convertEnergy(value, 'kcal', energyUnit)
+                                ).toString()
+                              : formatNutrientValue(
+                                  nutrient,
+                                  value,
+                                  customNutrients
+                                );
+
+                          return (
+                            <TableCell key={nutrient}>
+                              {entry.isTotal && Number(value) === 0
+                                ? ''
+                                : displayValue}
+                            </TableCell>
+                          );
+                        })}
                       </TableRow>
-                      {isExpanded &&
-                        entry.sets.map((set, setIndex) => (
-                          <TableRow
-                            key={`${entry.id}-set-${set.id || setIndex}`}
-                            className="bg-gray-50 dark:bg-gray-800"
-                          >
-                            <TableCell></TableCell>
-                            <TableCell></TableCell>
-                            <TableCell>{set.set_number}</TableCell>
-                            <TableCell>{set.set_type}</TableCell>
-                            <TableCell>{set.reps ?? '-'}</TableCell>
-                            <TableCell>
-                              {set.weight != null
-                                ? formatWeight(set.weight, weightUnit)
-                                : '-'}
-                            </TableCell>
-                            <TableCell>
-                              {set.weight != null
-                                ? formatWeight(
-                                    set.weight * Number(set.reps ?? 0),
-                                    weightUnit
-                                  )
-                                : '-'}
-                            </TableCell>
-                            <TableCell>{set.duration || '-'}</TableCell>
-                            <TableCell>{set.rest_time || '-'}</TableCell>
-                            <TableCell colSpan={2}>
-                              {set.notes || '-'}
-                            </TableCell>
-                          </TableRow>
-                        ))}
-                    </React.Fragment>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </div>
-        </CardContent>
-      </Card>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Exercise Entries Table with Export Button */}
+      {(selectedTable === 'all' || selectedTable === 'exercise') && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle>
+                {t(
+                  'reportsTables.exerciseEntriesTable',
+                  'Exercise Entries Table'
+                )}
+              </CardTitle>
+              <Button
+                onClick={onExportExerciseEntries}
+                variant="outline"
+                size="sm"
+              >
+                <Download className="w-4 h-4" />
+              </Button>
+            </div>
+            <div className="flex items-center space-x-2 mt-4">
+              <Input
+                placeholder={t(
+                  'reportsTables.filterByExerciseName',
+                  'Filter by exercise name...'
+                )}
+                value={exerciseNameFilter}
+                onChange={(e) => setExerciseNameFilter(e.target.value)}
+                className="max-w-sm"
+              />
+              <Input
+                placeholder={t(
+                  'reportsTables.filterBySetType',
+                  'Filter by set type...'
+                )}
+                value={setTypeFilter}
+                onChange={(e) => setSetTypeFilter(e.target.value)}
+                className="max-w-sm"
+              />
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead onClick={() => requestSort('entry_date')}>
+                      {t('reportsTables.date', 'Date')}
+                    </TableHead>
+                    <TableHead onClick={() => requestSort('exercise_name')}>
+                      {t('reportsTables.exercise', 'Exercise')}
+                    </TableHead>
+                    <TableHead onClick={() => requestSort('set_number')}>
+                      {t('reportsTables.set', 'Set')}
+                    </TableHead>
+                    <TableHead onClick={() => requestSort('set_type')}>
+                      {t('reportsTables.type', 'Type')}
+                    </TableHead>
+                    <TableHead onClick={() => requestSort('reps')}>
+                      {t('reportsTables.reps', 'Reps')}
+                    </TableHead>
+                    <TableHead onClick={() => requestSort('weight')}>
+                      {t('reportsTables.weight', 'Weight')} ({weightUnit})
+                    </TableHead>
+                    <TableHead>
+                      {t('reportsTables.tonnage', 'Tonnage')}
+                    </TableHead>
+                    <TableHead onClick={() => requestSort('duration')}>
+                      {t('reportsTables.durationSec', 'Duration (s)')}
+                    </TableHead>
+                    <TableHead onClick={() => requestSort('rest_time')}>
+                      {t('reportsTables.restS', 'Rest (s)')}
+                    </TableHead>
+                    <TableHead>{t('reportsTables.notes', 'Notes')}</TableHead>
+                    <TableHead onClick={() => requestSort('calories_burned')}>
+                      {t(
+                        'reportsTables.caloriesBurned',
+                        `Calories Burned (${getEnergyUnitString(energyUnit)})`
+                      )}
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {filteredExerciseEntries.map((entry) => {
+                    const isPr =
+                      prData &&
+                      prData[entry.exercises.id] &&
+                      prData[entry.exercises.id]?.date === entry.entry_date;
+                    const isExpanded = expandedRows[entry.id];
+
+                    return (
+                      <React.Fragment key={entry.id}>
+                        <TableRow
+                          className={
+                            isPr ? 'bg-yellow-100 dark:bg-yellow-900' : ''
+                          }
+                        >
+                          <TableCell>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() =>
+                                setExpandedRows((prev) => ({
+                                  ...prev,
+                                  [entry.id]: !prev[entry.id],
+                                }))
+                              }
+                            >
+                              {isExpanded ? '▼' : '▶'}
+                            </Button>
+                            {formatDateInUserTimezone(
+                              parseISO(entry.entry_date),
+                              dateFormat
+                            )}
+                          </TableCell>
+                          <TableCell>{entry.exercises.name}</TableCell>
+                          <TableCell>{entry.sets.length}</TableCell>
+                          <TableCell></TableCell>
+                          <TableCell>{formatRepRange(entry.sets)}</TableCell>
+                          <TableCell>
+                            {formatAvgWeight(entry.sets, weightUnit)}
+                          </TableCell>
+                          <TableCell>
+                            {formatTonnage(entry.sets, weightUnit)}
+                          </TableCell>
+                          <TableCell>
+                            {entry.sets.reduce(
+                              (acc, s) => acc + (s.duration || 0),
+                              0
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {entry.sets.reduce(
+                              (acc, s) => acc + (s.rest_time || 0),
+                              0
+                            )}
+                          </TableCell>
+                          <TableCell>{entry.notes || ''}</TableCell>
+                          <TableCell>
+                            {Math.round(
+                              convertEnergy(
+                                entry.calories_burned,
+                                'kcal',
+                                energyUnit
+                              )
+                            )}
+                          </TableCell>
+                        </TableRow>
+                        {isExpanded &&
+                          entry.sets.map((set, setIndex) => (
+                            <TableRow
+                              key={`${entry.id}-set-${set.id || setIndex}`}
+                              className="bg-gray-50 dark:bg-gray-800"
+                            >
+                              <TableCell></TableCell>
+                              <TableCell></TableCell>
+                              <TableCell>{set.set_number}</TableCell>
+                              <TableCell>{set.set_type}</TableCell>
+                              <TableCell>{set.reps ?? '-'}</TableCell>
+                              <TableCell>
+                                {set.weight != null
+                                  ? formatWeight(set.weight, weightUnit)
+                                  : '-'}
+                              </TableCell>
+                              <TableCell>
+                                {set.weight != null
+                                  ? formatWeight(
+                                      set.weight * Number(set.reps ?? 0),
+                                      weightUnit
+                                    )
+                                  : '-'}
+                              </TableCell>
+                              <TableCell>{set.duration || '-'}</TableCell>
+                              <TableCell>{set.rest_time || '-'}</TableCell>
+                              <TableCell colSpan={2}>
+                                {set.notes || '-'}
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                      </React.Fragment>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Body Measurements Table with Export Button */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle>
-              {t(
-                'reportsTables.bodyMeasurementsTable',
-                'Body Measurements Table'
-              )}
-            </CardTitle>
-            <Button
-              onClick={onExportBodyMeasurements}
-              variant="outline"
-              size="sm"
-            >
-              <Download className="w-4 h-4" />
-            </Button>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t('reportsTables.date', 'Date')}</TableHead>
-                  <TableHead>
-                    {t('reportsTables.weight', 'Weight')} ({weightUnit})
-                  </TableHead>
-                  <TableHead>
-                    {t('reportsTables.neck', 'Neck')} ({measurementUnit})
-                  </TableHead>
-                  <TableHead>
-                    {t('reportsTables.waist', 'Waist')} ({measurementUnit})
-                  </TableHead>
-                  <TableHead>
-                    {t('reportsTables.hips', 'Hips')} ({measurementUnit})
-                  </TableHead>
-                  <TableHead>{t('reportsTables.steps', 'Steps')}</TableHead>
-                  <TableHead>
-                    {t('reportsTables.height', 'Height')} ({measurementUnit})
-                  </TableHead>
-                  <TableHead>
-                    {t('reportsTables.bodyFatPercentage', 'Body Fat %')}
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sortedMeasurementData.map((measurement, index) => (
-                  <TableRow key={index}>
-                    <TableCell>
-                      {formatDateInUserTimezone(
-                        parseISO(measurement.entry_date),
-                        dateFormat
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      {formatWeight(measurement.weight, weightUnit)}
-                    </TableCell>
-                    <TableCell>
-                      {formatMeasurement(measurement.neck, measurementUnit)}
-                    </TableCell>
-                    <TableCell>
-                      {formatMeasurement(measurement.waist, measurementUnit)}
-                    </TableCell>
-                    <TableCell>
-                      {formatMeasurement(measurement.hips, measurementUnit)}
-                    </TableCell>
-                    <TableCell>{measurement.steps || '-'}</TableCell>
-                    <TableCell>
-                      {formatHeight(measurement.height, measurementUnit)}
-                    </TableCell>
-                    <TableCell>
-                      {measurement.body_fat_percentage
-                        ? measurement.body_fat_percentage.toFixed(1)
-                        : '-'}
-                    </TableCell>
+      {(selectedTable === 'all' || selectedTable === 'measurements') && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <CardTitle>
+                {t(
+                  'reportsTables.bodyMeasurementsTable',
+                  'Body Measurements Table'
+                )}
+              </CardTitle>
+              <Button
+                onClick={onExportBodyMeasurements}
+                variant="outline"
+                size="sm"
+              >
+                <Download className="w-4 h-4" />
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t('reportsTables.date', 'Date')}</TableHead>
+                    <TableHead>
+                      {t('reportsTables.weight', 'Weight')} ({weightUnit})
+                    </TableHead>
+                    <TableHead>
+                      {t('reportsTables.neck', 'Neck')} ({measurementUnit})
+                    </TableHead>
+                    <TableHead>
+                      {t('reportsTables.waist', 'Waist')} ({measurementUnit})
+                    </TableHead>
+                    <TableHead>
+                      {t('reportsTables.hips', 'Hips')} ({measurementUnit})
+                    </TableHead>
+                    <TableHead>{t('reportsTables.steps', 'Steps')}</TableHead>
+                    <TableHead>
+                      {t('reportsTables.height', 'Height')} ({measurementUnit})
+                    </TableHead>
+                    <TableHead>
+                      {t('reportsTables.bodyFatPercentage', 'Body Fat %')}
+                    </TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
-        </CardContent>
-      </Card>
+                </TableHeader>
+                <TableBody>
+                  {sortedMeasurementData.map((measurement, index) => (
+                    <TableRow key={index}>
+                      <TableCell>
+                        {formatDateInUserTimezone(
+                          parseISO(measurement.entry_date),
+                          dateFormat
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        {formatWeight(measurement.weight, weightUnit)}
+                      </TableCell>
+                      <TableCell>
+                        {formatMeasurement(measurement.neck, measurementUnit)}
+                      </TableCell>
+                      <TableCell>
+                        {formatMeasurement(measurement.waist, measurementUnit)}
+                      </TableCell>
+                      <TableCell>
+                        {formatMeasurement(measurement.hips, measurementUnit)}
+                      </TableCell>
+                      <TableCell>{measurement.steps || '-'}</TableCell>
+                      <TableCell>
+                        {formatHeight(measurement.height, measurementUnit)}
+                      </TableCell>
+                      <TableCell>
+                        {measurement.body_fat_percentage
+                          ? measurement.body_fat_percentage.toFixed(1)
+                          : '-'}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Custom Measurements Tables */}
       {customCategories.map((category: CustomCategoriesResponse) => {
+        if (
+          selectedTable !== 'all' &&
+          selectedTable !== `category:${category.id}`
+        )
+          return null;
         const data = customMeasurementsData.filter(
           (m) => m.category_id === category.id
         );

--- a/SparkyFitnessFrontend/src/tests/components/ReportsTables.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/ReportsTables.test.tsx
@@ -5,6 +5,10 @@ import ReportsTables, {
   type TableFilterValue,
 } from '@/pages/Reports/ReportsTables';
 import type { DailyExerciseEntry } from '@/types/reports';
+import type {
+  CustomCategoriesResponse,
+  CustomMeasurementsResponse,
+} from '@workspace/shared';
 
 let mockShowNetCarbs = false;
 
@@ -168,5 +172,63 @@ describe('ReportsTables table type filter', () => {
     expect(
       screen.queryByText('Exercise Entries Table')
     ).not.toBeInTheDocument();
+  });
+
+  it('shows only the selected custom category when filtered', async () => {
+    const customCategory = {
+      id: 'cat-hr',
+      name: 'Heart Rate',
+      display_name: 'Heart Rate',
+      measurement_type: 'bpm',
+    } as unknown as CustomCategoriesResponse;
+    const customMeasurement = {
+      category_id: 'cat-hr',
+      entry_date: '2026-05-15',
+      entry_timestamp: null,
+      value: '72',
+      notes: null,
+    } as unknown as CustomMeasurementsResponse;
+
+    const Wrapper = () => {
+      const [selectedTable, setSelectedTable] =
+        useState<TableFilterValue>('all');
+      return (
+        <ReportsTables
+          tabularData={[baseEntry]}
+          exerciseEntries={[]}
+          measurementData={[]}
+          customCategories={[customCategory]}
+          customMeasurementsData={[customMeasurement]}
+          prData={undefined}
+          selectedTable={selectedTable}
+          onSelectedTableChange={setSelectedTable}
+          onExportFoodDiary={() => {}}
+          onExportBodyMeasurements={() => {}}
+          onExportCustomMeasurements={() => {}}
+          onExportExerciseEntries={() => {}}
+          customNutrients={[]}
+        />
+      );
+    };
+    render(<Wrapper />);
+
+    expect(screen.getByText('Food Diary Table')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('combobox'));
+    const option = await screen.findByRole('option', {
+      name: /heart rate/i,
+    });
+    fireEvent.click(option);
+
+    expect(screen.queryByText('Food Diary Table')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Exercise Entries Table')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Body Measurements Table')
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByText('Heart Rate (bpm)').length
+    ).toBeGreaterThanOrEqual(1);
   });
 });

--- a/SparkyFitnessFrontend/src/tests/components/ReportsTables.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/ReportsTables.test.tsx
@@ -1,6 +1,9 @@
-import { render, screen, within } from '@testing-library/react';
+import { useState } from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import ReportsTables from '@/pages/Reports/ReportsTables';
+import ReportsTables, {
+  type TableFilterValue,
+} from '@/pages/Reports/ReportsTables';
 import type { DailyExerciseEntry } from '@/types/reports';
 
 let mockShowNetCarbs = false;
@@ -67,22 +70,33 @@ const durationOnlyExerciseEntry = {
   ],
 } as unknown as DailyExerciseEntry;
 
-const renderTable = (exerciseEntries: DailyExerciseEntry[] = []) =>
-  render(
-    <ReportsTables
-      tabularData={[baseEntry]}
-      exerciseEntries={exerciseEntries}
-      measurementData={[]}
-      customCategories={[]}
-      customMeasurementsData={[]}
-      prData={undefined}
-      onExportFoodDiary={() => {}}
-      onExportBodyMeasurements={() => {}}
-      onExportCustomMeasurements={() => {}}
-      onExportExerciseEntries={() => {}}
-      customNutrients={[]}
-    />
-  );
+const renderTable = (
+  exerciseEntries: DailyExerciseEntry[] = [],
+  initialTable: TableFilterValue = 'all'
+) => {
+  const Wrapper = () => {
+    const [selectedTable, setSelectedTable] =
+      useState<TableFilterValue>(initialTable);
+    return (
+      <ReportsTables
+        tabularData={[baseEntry]}
+        exerciseEntries={exerciseEntries}
+        measurementData={[]}
+        customCategories={[]}
+        customMeasurementsData={[]}
+        prData={undefined}
+        selectedTable={selectedTable}
+        onSelectedTableChange={setSelectedTable}
+        onExportFoodDiary={() => {}}
+        onExportBodyMeasurements={() => {}}
+        onExportCustomMeasurements={() => {}}
+        onExportExerciseEntries={() => {}}
+        customNutrients={[]}
+      />
+    );
+  };
+  return render(<Wrapper />);
+};
 
 describe('ReportsTables net carbs', () => {
   beforeEach(() => {
@@ -127,5 +141,32 @@ describe('ReportsTables duration-only exercise sets', () => {
     expect(
       cells.filter((c) => c.textContent === '-').length
     ).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('ReportsTables table type filter', () => {
+  it('renders all tables by default', () => {
+    renderTable();
+    expect(screen.getByText('Food Diary Table')).toBeInTheDocument();
+    expect(screen.getByText('Exercise Entries Table')).toBeInTheDocument();
+    expect(screen.getByText('Body Measurements Table')).toBeInTheDocument();
+  });
+
+  it('shows only the selected table when a filter is chosen', async () => {
+    renderTable();
+
+    fireEvent.click(screen.getByRole('combobox'));
+    const option = await screen.findByRole('option', {
+      name: /body measurements/i,
+    });
+    fireEvent.click(option);
+
+    expect(
+      screen.getAllByText('Body Measurements Table').length
+    ).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('Food Diary Table')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Exercise Entries Table')
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The Reports table view stacks all tables (Food Diary, Exercise, Body Measurements, + custom categories) vertically at once. With large datasets this is overwhelming and hard to navigate.

**How did you implement the solution?**
Added a Select dropdown to ReportsTables that lets users pick one table at a time. State is lifted to the Reports parent so the filter persists across date range changes.

Linked Issue: Closes #2084

## How to Test

1. Go to Reports → Table tab
2. Use the "Show table" dropdown to select a single table type
3. Verify only that table renders
4. Change the date range — verify the filter selection persists
5. Select "All tables" to return to the default view

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue (#2084) and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

## Notes for Reviewers

- Default is "All tables" (preserves existing behavior)
- Exported `TableFilterValue` type shared between parent and child
- Uses existing `t(key, Default)` i18n fallback pattern — no locale file changes needed
- 7/7 tests passing