### PR TITLE
feat: add recording timezone and UTC offset to sleep entries

### DIFF
--- a/SparkyFitnessFrontend/src/constants/healthDataImport.ts
+++ b/SparkyFitnessFrontend/src/constants/healthDataImport.ts
@@ -130,7 +130,10 @@ export const HEALTH_IMPORT_CATEGORIES: HealthImportCategoryConfig[] = [
     description:
       'One sleep session per row. Provide bedtime/wake_time as ISO timestamps. ' +
       'The deep/light/rem/awake columns are aggregate seconds per stage. For a ' +
-      'full stage timeline, optionally put a JSON array in stage_events.',
+      'full stage timeline, optionally put a JSON array in stage_events. ' +
+      'Optional record_timezone (IANA name, e.g. America/New_York) and/or ' +
+      'record_utc_offset_minutes columns pin display to the zone the sleep ' +
+      'was recorded in; without them times display in your profile timezone.',
     requiredHeaders: [
       'date',
       'bedtime',

--- a/SparkyFitnessFrontend/src/pages/CheckIn/SleepEntrySection.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/SleepEntrySection.tsx
@@ -10,7 +10,11 @@ import { usePreferences } from '@/contexts/PreferencesContext';
 import { debug, info, warn, error } from '@/utils/logging';
 import { Trash2, Edit, Save, X } from 'lucide-react';
 import { toast } from '@/hooks/use-toast';
-import { formatSecondsToHHMM } from '@/utils/timeFormatters';
+import {
+  formatSecondsToHHMM,
+  formatTimeInZone,
+  sleepEntryZone,
+} from '@/utils/timeFormatters';
 import {
   Tooltip,
   TooltipContent,
@@ -36,7 +40,7 @@ const SleepEntrySection: React.FC<SleepEntrySectionProps> = ({
 }) => {
   const { t } = useTranslation();
   const { activeUserId } = useActiveUser();
-  const { formatDateInUserTimezone, formatTime, loggingLevel } =
+  const { formatDateInUserTimezone, timeFormat, timezone, loggingLevel } =
     usePreferences();
 
   const [sleepSessions, setSleepSessions] = useState<
@@ -115,6 +119,10 @@ const SleepEntrySection: React.FC<SleepEntrySectionProps> = ({
           wake_time: parsedWakeTime.toISOString(),
           duration_in_seconds: Number(durationInSeconds) || 0,
           source: 'manual',
+          // Typed wall-clock times are interpreted by the browser clock, so
+          // the browser zone is the recording zone; stamping it makes
+          // read-back exact regardless of the profile timezone.
+          record_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
           stage_events: session.stageEvents
             .filter((event) => event)
             .map((event) => ({
@@ -197,6 +205,17 @@ const SleepEntrySection: React.FC<SleepEntrySectionProps> = ({
     const durationInSeconds =
       differenceInMinutes(parseISO(newWakeTime), parseISO(newBedtime)) * 60;
 
+    // A bed/wake edit is typed against the browser clock, so it relabels the
+    // recording zone; a stage-only or no-op save must not — omitting the key
+    // leaves an imported entry's zone metadata untouched server-side.
+    const originalEntry = sleepEntries.find((e) => e.id === entryId);
+    const timesChanged =
+      originalEntry != null &&
+      (new Date(newBedtime).getTime() !==
+        new Date(originalEntry.bedtime).getTime() ||
+        new Date(newWakeTime).getTime() !==
+          new Date(originalEntry.wake_time).getTime());
+
     await updateSleepEntry({
       id: entryId,
       data: {
@@ -204,6 +223,14 @@ const SleepEntrySection: React.FC<SleepEntrySectionProps> = ({
         bedtime: newBedtime,
         wake_time: newWakeTime,
         duration_in_seconds: durationInSeconds,
+        ...(timesChanged
+          ? {
+              record_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+              // Clear any stale offset so the relabel doesn't leave
+              // contradictory zone metadata from the original import.
+              record_utc_offset_minutes: null,
+            }
+          : {}),
       },
     });
 
@@ -490,8 +517,16 @@ const SleepEntrySection: React.FC<SleepEntrySectionProps> = ({
                         }}
                         // Pass basic sleep entry details to SleepTimelineEditor for display
                         entryDetails={{
-                          bedtime: formatTime(entry.bedtime),
-                          wakeTime: formatTime(entry.wake_time),
+                          bedtime: formatTimeInZone(
+                            entry.bedtime,
+                            sleepEntryZone(entry, timezone),
+                            timeFormat
+                          ),
+                          wakeTime: formatTimeInZone(
+                            entry.wake_time,
+                            sleepEntryZone(entry, timezone),
+                            timeFormat
+                          ),
                           duration: formatSecondsToHHMM(
                             entry.duration_in_seconds
                           ),

--- a/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsCharts.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsCharts.tsx
@@ -9,7 +9,8 @@ import {
   type SleepChartData,
   type SleepEntry,
 } from '@/types';
-import { formatSecondsToHHMM } from '@/utils/timeFormatters';
+import { formatSecondsToHHMM, sleepEntryZone } from '@/utils/timeFormatters';
+import { instantHourMinuteInZone } from '@workspace/shared';
 import {
   DEBT_ZONE_COLOR,
   SURPLUS_ZONE_COLOR,
@@ -90,7 +91,7 @@ const SleepAnalyticsCharts = ({
   heartRateData,
   latestSleepEntry,
 }: SleepAnalyticsChartsProps) => {
-  const { formatDateInUserTimezone, dateFormat } = usePreferences();
+  const { formatDateInUserTimezone, dateFormat, timezone } = usePreferences();
   const { resolvedTheme } = useTheme();
   const { t } = useTranslation();
   const { data: sleepDebtData } = useSleepDebtQuery();
@@ -121,19 +122,34 @@ const SleepAnalyticsCharts = ({
         (data.stagePercentages.light || 0) +
         (data.stagePercentages.awake || 0);
 
-      const bedtimeDate = new Date(data.earliestBedtime || 0);
-      let bedtimeHours = bedtimeDate.getHours() + bedtimeDate.getMinutes() / 60;
-
-      // CROSS-MIDNIGHT FIX:
-      // If bedtime is between 00:00 and 12:00 (midday), treat it as 24:00+
-      // This keeps the trend line continuous (e.g. 23:00 -> 01:00 becomes 23:00 -> 25:00)
-      if (bedtimeHours >= 0 && bedtimeHours < 12) {
-        bedtimeHours += 24;
+      // Consistency hours derive from the day's recording zone (profile
+      // timezone when absent) so travel weeks chart the wall clock the user
+      // actually slept by. Missing instants stay null so recharts skips the
+      // point instead of charting the 1970 epoch.
+      const zone = sleepEntryZone(data, timezone);
+      let bedtimeHours: number | null = null;
+      if (data.earliestBedtime) {
+        const { hour, minute } = instantHourMinuteInZone(
+          data.earliestBedtime,
+          zone
+        );
+        bedtimeHours = hour + minute / 60;
+        // CROSS-MIDNIGHT FIX:
+        // If bedtime is between 00:00 and 12:00 (midday), treat it as 24:00+
+        // This keeps the trend line continuous (e.g. 23:00 -> 01:00 becomes 23:00 -> 25:00)
+        if (bedtimeHours >= 0 && bedtimeHours < 12) {
+          bedtimeHours += 24;
+        }
       }
 
-      const wakeTimeDate = new Date(data.latestWakeTime || 0);
-      const wakeTimeHours =
-        wakeTimeDate.getHours() + wakeTimeDate.getMinutes() / 60;
+      let wakeTimeHours: number | null = null;
+      if (data.latestWakeTime) {
+        const { hour, minute } = instantHourMinuteInZone(
+          data.latestWakeTime,
+          zone
+        );
+        wakeTimeHours = hour + minute / 60;
+      }
 
       return {
         date: data.date,

--- a/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsTable.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsTable.tsx
@@ -15,7 +15,11 @@ import { usePreferences } from '@/contexts/PreferencesContext';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { debug } from '@/utils/logging';
 import { getUserLoggingLevel } from '@/utils/userPreferences';
-import { formatSecondsToHHMM } from '@/utils/timeFormatters';
+import {
+  formatSecondsToHHMM,
+  formatTimeInZone,
+  sleepEntryZone,
+} from '@/utils/timeFormatters';
 import {
   HIGH_DEBT_THRESHOLD_HOURS,
   GOOD_SLEEP_SCORE_THRESHOLD,
@@ -39,7 +43,8 @@ const SleepAnalyticsTable = ({
     'SleepAnalyticsTable received combinedSleepData:',
     combinedSleepData
   );
-  const { formatDateInUserTimezone, dateFormat, formatTime } = usePreferences();
+  const { formatDateInUserTimezone, dateFormat, timeFormat, timezone } =
+    usePreferences();
   const [expandedRows, setExpandedRows] = React.useState<Set<string>>(
     new Set()
   );
@@ -147,6 +152,11 @@ const SleepAnalyticsTable = ({
 
               const insight = t(insightKey, insightDefault);
 
+              // Aggregated rows carry the day zone (earliest-bedtime
+              // session's recording zone), so stage labels agree with the
+              // hypnogram axis and header dates.
+              const zone = sleepEntryZone(sleepEntry, timezone);
+
               const aggregatedStages = sleepEntry.stage_events?.reduce(
                 (acc, event) => {
                   acc[event.stage_type] =
@@ -179,8 +189,12 @@ const SleepAnalyticsTable = ({
                         dateFormat
                       )}
                     </TableCell>
-                    <TableCell>{formatTime(sleepEntry.bedtime)}</TableCell>
-                    <TableCell>{formatTime(sleepEntry.wake_time)}</TableCell>
+                    <TableCell>
+                      {formatTimeInZone(sleepEntry.bedtime, zone, timeFormat)}
+                    </TableCell>
+                    <TableCell>
+                      {formatTimeInZone(sleepEntry.wake_time, zone, timeFormat)}
+                    </TableCell>
                     <TableCell>{totalSleepDuration}</TableCell>
                     <TableCell>{timeAsleep}</TableCell>
                     <TableCell>
@@ -283,8 +297,17 @@ const SleepAnalyticsTable = ({
                                     )}
                                   </div>
                                   <div className="text-xs opacity-80">
-                                    {formatTime(event.start_time)} -{' '}
-                                    {formatTime(event.end_time)}
+                                    {formatTimeInZone(
+                                      event.start_time,
+                                      zone,
+                                      timeFormat
+                                    )}{' '}
+                                    -{' '}
+                                    {formatTimeInZone(
+                                      event.end_time,
+                                      zone,
+                                      timeFormat
+                                    )}
                                   </div>
                                 </div>
                               ))}

--- a/SparkyFitnessFrontend/src/pages/Reports/SleepReport.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SleepReport.tsx
@@ -13,7 +13,11 @@ import type {
 import { useTranslation } from 'react-i18next';
 import { toast as sonnerToast } from 'sonner';
 import { formatDateToYYYYMMDD } from '@/lib/utils';
-import { formatSecondsToHHMM } from '@/utils/timeFormatters';
+import {
+  formatSecondsToHHMM,
+  formatTimeInZone,
+  sleepEntryZone,
+} from '@/utils/timeFormatters';
 import {
   HIGH_DEBT_THRESHOLD_HOURS,
   GOOD_SLEEP_SCORE_THRESHOLD,
@@ -28,7 +32,8 @@ interface SleepReportProps {
 
 const SleepReport = ({ startDate, endDate }: SleepReportProps) => {
   const { t } = useTranslation();
-  const { formatDateInUserTimezone, dateFormat, formatTime } = usePreferences();
+  const { formatDateInUserTimezone, dateFormat, timeFormat, timezone } =
+    usePreferences();
   const { data: sleepEntries = [], isLoading: loadingEntries } =
     useSleepEntriesQuery(startDate, endDate);
   const { data: sleepDebtData, isLoading: loadingDebt } = useSleepDebtQuery();
@@ -69,10 +74,11 @@ const SleepReport = ({ startDate, endDate }: SleepReportProps) => {
         insight = t('sleepReport.goodSleep', 'Good Sleep');
       }
 
+      const zone = sleepEntryZone(sleepEntry, timezone);
       return [
         formatDateInUserTimezone(sleepEntry.entry_date, dateFormat),
-        formatTime(sleepEntry.bedtime),
-        formatTime(sleepEntry.wake_time),
+        formatTimeInZone(sleepEntry.bedtime, zone, timeFormat),
+        formatTimeInZone(sleepEntry.wake_time, zone, timeFormat),
         formatSecondsToHHMM(sleepEntry.duration_in_seconds),
         sleepEntry.time_asleep_in_seconds
           ? formatSecondsToHHMM(sleepEntry.time_asleep_in_seconds)
@@ -216,6 +222,12 @@ const SleepReport = ({ startDate, endDate }: SleepReportProps) => {
             entries.reduce((acc, e) => acc + (e.awake_count || 0), 0) ||
             allStageEvents.filter((e) => e.stage_type === 'awake').length,
           totalAwakeDuration: aggregatedStages.awake,
+          // Day zone rule: the earliest-bedtime session's recording zone
+          // labels the whole day (all stage labels included); a zone-less
+          // day falls back to the profile timezone, never a sibling
+          // session's zone.
+          record_timezone: mainEntry.record_timezone,
+          record_utc_offset_minutes: mainEntry.record_utc_offset_minutes,
         };
 
         const combinedEntry: SleepEntry & { is_aggregated?: boolean } = {
@@ -248,20 +260,31 @@ const SleepReport = ({ startDate, endDate }: SleepReportProps) => {
   };
 
   const processSleepChartData = (): SleepChartData[] => {
-    const grouped: Record<string, SleepStageEvent[]> = {};
+    const grouped: Record<string, typeof sleepEntries> = {};
     sleepEntries.forEach((entry) => {
       const dateKey = entry.entry_date.split('T')[0] as string;
       if (!dateKey) return;
       if (!grouped[dateKey]) grouped[dateKey] = [];
-      if (entry.stage_events) {
-        grouped[dateKey].push(...entry.stage_events.filter((ev) => ev != null));
-      }
+      grouped[dateKey].push(entry);
     });
     return Object.entries(grouped)
-      .map(([date, segments]) => ({
-        date,
-        segments,
-      }))
+      .map(([date, entries]) => {
+        // Same day-zone rule as processSleepData: the earliest-bedtime
+        // session's recording zone labels the whole day's hypnogram.
+        const mainEntry = [...entries].sort(
+          (a, b) =>
+            new Date(a.bedtime).getTime() - new Date(b.bedtime).getTime()
+        )[0];
+        const segments: SleepStageEvent[] = entries.flatMap((entry) =>
+          (entry.stage_events ?? []).filter((ev) => ev != null)
+        );
+        return {
+          date,
+          segments,
+          record_timezone: mainEntry?.record_timezone,
+          record_utc_offset_minutes: mainEntry?.record_utc_offset_minutes,
+        };
+      })
       .sort((a, b) => b.date.localeCompare(a.date));
   };
 

--- a/SparkyFitnessFrontend/src/pages/Reports/SleepStageChart.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SleepStageChart.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { type SleepChartData, SLEEP_STAGE_COLORS } from '@/types';
 import { usePreferences } from '@/contexts/PreferencesContext';
-import { formatTimeWithPreference } from '@/utils/timeFormatters';
+import { formatTimeInZone, sleepEntryZone } from '@/utils/timeFormatters';
 import ZoomableChart from '@/components/ZoomableChart';
 import { useTheme } from '@/contexts/ThemeContext';
 
@@ -34,7 +34,8 @@ const stageLabels: { [key: string]: string } = {
 
 const SleepStageChart = ({ sleepChartData }: SleepStageChartProps) => {
   const { t } = useTranslation();
-  const { formatDateInUserTimezone, dateFormat, timeFormat } = usePreferences();
+  const { formatDateInUserTimezone, dateFormat, timeFormat, timezone } =
+    usePreferences();
   const { resolvedTheme } = useTheme();
   const [isMounted, setIsMounted] = React.useState(false);
 
@@ -231,13 +232,15 @@ const SleepStageChart = ({ sleepChartData }: SleepStageChartProps) => {
       );
     });
 
-    // Vertical grid lines and time labels
+    // Vertical grid lines and time labels. Axis times render in the day's
+    // recording zone (profile timezone when absent) so they agree with the
+    // header date and the analytics table.
+    const zone = sleepEntryZone(sleepChartData, timezone);
     const numTimeLabels = 5; // Number of time labels to display
     for (let i = 0; i <= numTimeLabels; i++) {
       const timeMs = minTime + (totalDurationMs / numTimeLabels) * i;
       const xPos = getX(timeMs);
-      const date = new Date(timeMs);
-      const timeString = formatTimeWithPreference(date, timeFormat);
+      const timeString = formatTimeInZone(timeMs, zone, timeFormat);
 
       gridLines.push(
         <line

--- a/SparkyFitnessFrontend/src/tests/components/SleepEntrySection.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/SleepEntrySection.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SleepEntrySection from '@/pages/CheckIn/SleepEntrySection';
+
+// Issue #2033: a bed/wake edit is typed against the browser clock and must
+// relabel record_timezone; a stage-only or no-op save must NOT relabel an
+// imported entry's recording zone.
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, defaultValue?: unknown) =>
+      typeof defaultValue === 'string' ? defaultValue : String(defaultValue),
+  }),
+}));
+
+jest.mock('@/contexts/ActiveUserContext', () => ({
+  useActiveUser: () => ({ activeUserId: 'user-1' }),
+}));
+
+jest.mock('@/contexts/PreferencesContext', () => ({
+  usePreferences: () => ({
+    formatDateInUserTimezone: (d: string) => d,
+    timeFormat: 'HH:mm',
+    timezone: 'UTC',
+    loggingLevel: 'ERROR',
+  }),
+}));
+
+jest.mock('@/utils/logging', () => ({
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('@/hooks/use-toast', () => ({ toast: jest.fn() }));
+
+jest.mock('lucide-react', () => ({
+  Trash2: () => <span data-testid="icon-delete" />,
+  Edit: () => <span data-testid="icon-edit" />,
+  Save: () => <span data-testid="icon-save" />,
+  X: () => <span data-testid="icon-cancel" />,
+}));
+
+// Stub timeline editor: exposes a button that simulates the user dragging
+// bed/wake to new times.
+jest.mock('@/pages/CheckIn/SleepTimelineEditor', () => ({
+  __esModule: true,
+  default: ({
+    onTimeChange,
+  }: {
+    onTimeChange?: (b: string, w: string) => void;
+  }) => (
+    <button
+      data-testid="change-times"
+      onClick={() => onTimeChange && onTimeChange('21:00', '05:00')}
+    >
+      change times
+    </button>
+  ),
+}));
+
+const updateMutateAsync = jest.fn().mockResolvedValue(undefined);
+
+const importedEntry = {
+  id: 'entry-1',
+  user_id: 'user-1',
+  entry_date: '2026-08-01',
+  bedtime: '2026-08-01T03:00:00.000Z',
+  wake_time: '2026-08-01T11:00:00.000Z',
+  duration_in_seconds: 28800,
+  time_asleep_in_seconds: 27000,
+  sleep_score: 80,
+  source: 'garmin',
+  record_utc_offset_minutes: 120,
+  stage_events: [],
+};
+
+jest.mock('@/hooks/CheckIn/useSleep', () => ({
+  useSleepEntriesQuery: () => ({ data: [importedEntry], isLoading: false }),
+  useSaveSleepEntryMutation: () => ({ mutateAsync: jest.fn() }),
+  useUpdateSleepEntryMutation: () => ({ mutateAsync: updateMutateAsync }),
+  useDeleteSleepEntryMutation: () => ({ mutateAsync: jest.fn() }),
+}));
+
+const clickIconButton = (testId: string) => {
+  const button = screen.getByTestId(testId).closest('button');
+  expect(button).not.toBeNull();
+  fireEvent.click(button!);
+};
+
+describe('SleepEntrySection existing-entry save and the recording zone', () => {
+  beforeEach(() => {
+    updateMutateAsync.mockClear();
+  });
+
+  it('a no-op save omits record_timezone so imported zone metadata survives', async () => {
+    render(<SleepEntrySection selectedDate="2026-08-01" />);
+
+    clickIconButton('icon-edit');
+    clickIconButton('icon-save');
+
+    expect(updateMutateAsync).toHaveBeenCalledTimes(1);
+    const { data } = updateMutateAsync.mock.calls[0][0];
+    expect(data).not.toHaveProperty('record_timezone');
+    expect(data).not.toHaveProperty('record_utc_offset_minutes');
+    // Unchanged times pass through as the original instants.
+    expect(data.bedtime).toBe(importedEntry.bedtime);
+    expect(data.wake_time).toBe(importedEntry.wake_time);
+  });
+
+  it('a bed/wake edit stamps the browser IANA zone', async () => {
+    render(<SleepEntrySection selectedDate="2026-08-01" />);
+
+    clickIconButton('icon-edit');
+    fireEvent.click(screen.getByTestId('change-times'));
+    clickIconButton('icon-save');
+
+    expect(updateMutateAsync).toHaveBeenCalledTimes(1);
+    const { data } = updateMutateAsync.mock.calls[0][0];
+    expect(data.record_timezone).toBe(
+      Intl.DateTimeFormat().resolvedOptions().timeZone
+    );
+    // The relabel must also clear a stale imported offset, or precedence
+    // metadata contradicts itself on the stored row.
+    expect(data.record_utc_offset_minutes).toBeNull();
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/utils/formatTimeInZoneDstGap.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/formatTimeInZoneDstGap.test.ts
@@ -1,9 +1,20 @@
 // The regression only manifests when the HOST zone has a DST spring-forward
 // gap at the rendered wall clock, so pin the host zone before any Date math
 // runs (Node re-reads process.env.TZ at each local-time computation).
+const originalTz = process.env['TZ'];
 process.env['TZ'] = 'America/New_York';
 
 import { formatTimeInZone } from '@/utils/timeFormatters';
+
+// Jest workers run several test files in one process, so the pinned zone
+// must not leak into whichever suite this worker picks up next.
+afterAll(() => {
+  if (originalTz === undefined) {
+    delete process.env['TZ'];
+  } else {
+    process.env['TZ'] = originalTz;
+  }
+});
 
 // Issue #2033 review finding: rendering a record-zone wall clock by building
 // a host-local Date normalizes nonexistent local times — New York turns

--- a/SparkyFitnessFrontend/src/tests/utils/formatTimeInZoneDstGap.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/formatTimeInZoneDstGap.test.ts
@@ -1,0 +1,36 @@
+// The regression only manifests when the HOST zone has a DST spring-forward
+// gap at the rendered wall clock, so pin the host zone before any Date math
+// runs (Node re-reads process.env.TZ at each local-time computation).
+process.env['TZ'] = 'America/New_York';
+
+import { formatTimeInZone } from '@/utils/timeFormatters';
+
+// Issue #2033 review finding: rendering a record-zone wall clock by building
+// a host-local Date normalizes nonexistent local times — New York turns
+// 2024-03-10 02:30 into 03:30 — so sleep times whose record-zone wall clock
+// lands inside the browser's spring-forward gap displayed an hour late.
+describe('formatTimeInZone across the host DST gap', () => {
+  it('renders an offset-zone wall clock that does not exist in the host zone', () => {
+    // 07:30Z at -05:00 is 02:30 wall clock — inside New York's 02:00–03:00
+    // gap on 2024-03-10.
+    expect(
+      formatTimeInZone(
+        '2024-03-10T07:30:00Z',
+        { kind: 'offset', minutes: -300 },
+        'HH:mm'
+      )
+    ).toBe('02:30');
+  });
+
+  it('renders an IANA-zone wall clock that does not exist in the host zone', () => {
+    // 2024-03-09T17:30Z is 02:30 on Mar 10 in Tokyo (no DST), which is still
+    // a nonexistent local time for a New York host on that date.
+    expect(
+      formatTimeInZone(
+        '2024-03-09T17:30:00Z',
+        { kind: 'tz', tz: 'Asia/Tokyo' },
+        'HH:mm'
+      )
+    ).toBe('02:30');
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/utils/healthDataImport.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/healthDataImport.test.ts
@@ -268,6 +268,40 @@ describe('mapRowsToHealthItems', () => {
     expect(items).toEqual([]);
     expect(errors[0]!.error).toContain('stage_events');
   });
+
+  it('maps the optional recording-zone columns through (issue #2033)', () => {
+    const { items, errors } = mapRowsToHealthItems('sleep', [
+      row({
+        date: '2026-01-02',
+        bedtime: '2026-01-02T23:00:00',
+        wake_time: '2026-01-03T07:00:00',
+        duration_in_seconds: '28800',
+        record_timezone: 'America/New_York',
+        record_utc_offset_minutes: '-300',
+        source: '',
+      }),
+    ]);
+    expect(errors).toEqual([]);
+    expect(items[0]).toMatchObject({
+      type: 'SleepSession',
+      record_timezone: 'America/New_York',
+      record_utc_offset_minutes: -300,
+    });
+  });
+
+  it('omits absent recording-zone columns instead of sending empty values', () => {
+    const { items } = mapRowsToHealthItems('sleep', [
+      row({
+        date: '2026-01-02',
+        bedtime: '2026-01-02T23:00:00',
+        wake_time: '2026-01-03T07:00:00',
+        duration_in_seconds: '28800',
+        source: '',
+      }),
+    ]);
+    expect(items[0]!['record_timezone']).toBeUndefined();
+    expect(items[0]!['record_utc_offset_minutes']).toBeUndefined();
+  });
 });
 
 describe('parseHealthCSV', () => {

--- a/SparkyFitnessFrontend/src/tests/utils/timeFormatters.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/timeFormatters.test.ts
@@ -228,3 +228,91 @@ describe('formatTimeWithPreference — edge cases', () => {
     expect(a).toBe(b);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Recording-zone rendering (issue #2033)
+// ---------------------------------------------------------------------------
+import { formatTimeInZone, sleepEntryZone } from '@/utils/timeFormatters';
+
+describe('formatTimeInZone', () => {
+  // DST-unambiguous instant: mid-June (Tokyo has no DST anyway; New York is
+  // solidly in EDT).
+  const INSTANT = '2024-06-15T15:45:00Z';
+
+  it('renders in a named IANA zone', () => {
+    // 15:45 UTC = 00:45 next day in Tokyo (+9)
+    expect(
+      formatTimeInZone(INSTANT, { kind: 'tz', tz: 'Asia/Tokyo' }, 'HH:mm')
+    ).toBe('00:45');
+  });
+
+  it('renders with a fixed UTC offset, honoring the 24h preference', () => {
+    expect(
+      formatTimeInZone(INSTANT, { kind: 'offset', minutes: -240 }, 'HH:mm')
+    ).toBe('11:45');
+  });
+
+  it('honors the 12h preference', () => {
+    expect(
+      formatTimeInZone(INSTANT, { kind: 'offset', minutes: -240 }, 'h:mm A')
+    ).toMatch(/^11:45\s?AM$/);
+  });
+
+  it('returns empty string for an unparseable instant', () => {
+    expect(
+      formatTimeInZone('garbage', { kind: 'tz', tz: 'Asia/Tokyo' }, 'HH:mm')
+    ).toBe('');
+  });
+
+  it('does not inherit the PreferencesContext literal-date-string bug for …T00:0…Z instants', () => {
+    // PreferencesContext.isLiteralDateString treats any "…T00:0…Z" instant as
+    // a bare calendar date and renders 00:00. This path must project it.
+    // 00:05 UTC = 20:05 previous day in EDT (-4).
+    expect(
+      formatTimeInZone(
+        '2024-06-15T00:05:00Z',
+        { kind: 'tz', tz: 'America/New_York' },
+        'HH:mm'
+      )
+    ).toBe('20:05');
+  });
+});
+
+describe('sleepEntryZone', () => {
+  it('prefers the entry IANA zone', () => {
+    expect(
+      sleepEntryZone(
+        { record_timezone: 'Asia/Tokyo', record_utc_offset_minutes: -300 },
+        'UTC'
+      )
+    ).toEqual({ kind: 'tz', tz: 'Asia/Tokyo' });
+  });
+
+  it('falls back to the entry offset for an invalid or missing zone', () => {
+    expect(
+      sleepEntryZone(
+        { record_timezone: 'Not/AZone', record_utc_offset_minutes: -300 },
+        'UTC'
+      )
+    ).toEqual({ kind: 'offset', minutes: -300 });
+    expect(
+      sleepEntryZone(
+        { record_timezone: null, record_utc_offset_minutes: 0 },
+        'UTC'
+      )
+    ).toEqual({ kind: 'offset', minutes: 0 });
+  });
+
+  it('falls back to the profile timezone for zone-less entries', () => {
+    expect(sleepEntryZone({}, 'America/Chicago')).toEqual({
+      kind: 'tz',
+      tz: 'America/Chicago',
+    });
+    expect(
+      sleepEntryZone(
+        { record_timezone: null, record_utc_offset_minutes: null },
+        'America/Chicago'
+      )
+    ).toEqual({ kind: 'tz', tz: 'America/Chicago' });
+  });
+});

--- a/SparkyFitnessFrontend/src/types.ts
+++ b/SparkyFitnessFrontend/src/types.ts
@@ -51,6 +51,8 @@ export interface SleepEntry {
   avg_overnight_hrv: number | null;
   body_battery_change: number | null;
   resting_heart_rate: number | null;
+  record_timezone?: string | null;
+  record_utc_offset_minutes?: number | null;
   stage_events?: SleepStageEvent[];
 }
 
@@ -75,6 +77,8 @@ export interface SleepAnalyticsData {
   stagePercentages: SleepStageSummary;
   awakePeriods: number;
   totalAwakeDuration: number;
+  record_timezone?: string | null;
+  record_utc_offset_minutes?: number | null;
 }
 
 export interface CombinedSleepData {
@@ -85,6 +89,8 @@ export interface CombinedSleepData {
 export interface SleepChartData {
   date: string;
   segments: SleepStageEvent[];
+  record_timezone?: string | null;
+  record_utc_offset_minutes?: number | null;
 }
 
 export const SLEEP_STAGE_COLORS = {

--- a/SparkyFitnessFrontend/src/utils/healthDataImport.ts
+++ b/SparkyFitnessFrontend/src/utils/healthDataImport.ts
@@ -213,6 +213,15 @@ const mapSleepRow = (
   const wakeTime = cell(row, 'wake_time');
   if (!isBlank(bedtime)) item['bedtime'] = bedtime.trim();
   if (!isBlank(wakeTime)) item['wake_time'] = wakeTime.trim();
+  // Optional recording-zone columns: an IANA zone name and/or a UTC offset
+  // in minutes. Rows without them display in the profile timezone.
+  const recordTimezone = cell(row, 'record_timezone');
+  if (!isBlank(recordTimezone)) item['record_timezone'] = recordTimezone.trim();
+  const offsetRead = readNumber(row, 'record_utc_offset_minutes', format);
+  if (!offsetRead.ok)
+    return numberError(row, 'record_utc_offset_minutes', offsetRead.raw);
+  if (offsetRead.value !== undefined)
+    item['record_utc_offset_minutes'] = offsetRead.value;
   for (const field of SLEEP_NUMERIC_FIELDS) {
     const read = readNumber(row, field, format);
     if (!read.ok) return numberError(row, field, read.raw);

--- a/SparkyFitnessFrontend/src/utils/timeFormatters.ts
+++ b/SparkyFitnessFrontend/src/utils/timeFormatters.ts
@@ -1,4 +1,9 @@
 import { format } from 'date-fns';
+import {
+  instantHourMinuteInZone,
+  resolveRecordZone,
+  type RecordZone,
+} from '@workspace/shared';
 
 export function normalizeTimeFormat(timeFormat: string): string {
   if (timeFormat === 'h:mm A') return 'h:mm aa'; // date-fns `aa` -> AM/PM
@@ -73,6 +78,48 @@ export function formatTimeOfDayString(
   const date = new Date(2000, 0, 1, h, m, 0, 0);
   if (isNaN(date.getTime())) return '';
   return formatTimeWithPreference(date, timeFormat);
+}
+
+/**
+ * Formats a UTC instant as a time-of-day string in the given record zone
+ * (IANA timezone or fixed UTC offset), honoring the user's 12h/24h
+ * time-format preference. Renders from extracted hour/minute rather than a
+ * host-local Date so a wall clock that falls inside the browser zone's DST
+ * spring-forward gap is not normalized an hour forward. Deliberately
+ * independent of PreferencesContext so nothing routes through its
+ * literal-date-string heuristics.
+ */
+export function formatTimeInZone(
+  instant: Date | string | number,
+  zone: RecordZone,
+  timeFormat: string
+): string {
+  const date = instant instanceof Date ? instant : new Date(instant);
+  if (isNaN(date.getTime())) return '';
+  const { hour, minute } = instantHourMinuteInZone(date, zone);
+  return formatTimeOfDayString(`${hour}:${minute}`, timeFormat);
+}
+
+/**
+ * Resolves the display zone for a sleep entry: the entry's recorded IANA
+ * timezone, else its recorded UTC offset, else the profile timezone.
+ */
+export function sleepEntryZone(
+  entry: {
+    record_timezone?: string | null;
+    record_utc_offset_minutes?: number | null;
+  },
+  fallbackTz: string
+): RecordZone {
+  return (
+    resolveRecordZone(
+      entry.record_timezone,
+      entry.record_utc_offset_minutes
+    ) ?? {
+      kind: 'tz',
+      tz: fallbackTz,
+    }
+  );
 }
 
 export const formatSecondsClock = (totalSeconds: number): string => {

--- a/SparkyFitnessGarmin/routes.py
+++ b/SparkyFitnessGarmin/routes.py
@@ -555,6 +555,7 @@ async def get_health_and_wellness(request_data: HealthAndWellnessRequest):
 
                         bedtime_dt = None
                         wake_time_dt = None
+                        record_utc_offset_minutes = None
 
                         # Prioritize sleep_summary's sleepStartTimestampGMT and sleepEndTimestampGMT
                         if sleep_summary.get(
@@ -568,6 +569,19 @@ async def get_health_and_wellness(request_data: HealthAndWellnessRequest):
                                 sleep_summary["sleepEndTimestampGMT"] / 1000,
                                 tz=timezone.utc,
                             )
+                            # The Local/GMT timestamp pair encodes the watch's
+                            # UTC offset at recording time; the server uses it
+                            # to display bed/wake in the recording zone.
+                            start_local = sleep_summary.get(
+                                "sleepStartTimestampLocal"
+                            )
+                            start_gmt = sleep_summary.get("sleepStartTimestampGMT")
+                            if isinstance(start_local, (int, float)) and isinstance(
+                                start_gmt, (int, float)
+                            ):
+                                offset_min = round((start_local - start_gmt) / 60000)
+                                if -960 <= offset_min <= 960:
+                                    record_utc_offset_minutes = offset_min
                         else:
                             # Fallback to SleepStageLevel timestamps if summary timestamps are missing
                             stage_events_raw = sleep_data_raw.get("sleepLevels", [])
@@ -615,7 +629,7 @@ async def get_health_and_wellness(request_data: HealthAndWellnessRequest):
                                 or 0
                             )
                             logger.info(
-                                f"[GARMIN_SYNC] Sleep stages from dailySleepDTO: deep={deep_sleep}, light={light_sleep}, rem={rem_sleep}, awake={awake_sleep}"
+                                f"[GARMIN_SYNC] Sleep stages from dailySleepDTO: deep={deep_sleep}, light={light_sleep}, rem={rem_sleep}, awake={awake_sleep}, record_utc_offset_minutes={record_utc_offset_minutes}"
                             )
 
                             sleep_entry_data = {
@@ -673,6 +687,10 @@ async def get_health_and_wellness(request_data: HealthAndWellnessRequest):
                                 ),
                                 "stage_events": [],  # This will be populated below
                             }
+                            if record_utc_offset_minutes is not None:
+                                sleep_entry_data["record_utc_offset_minutes"] = (
+                                    record_utc_offset_minutes
+                                )
 
                             # Process Sleep Levels (Stages) - only sum if dailySleepDTO didn't have the values
                             sleep_levels_intraday = sleep_data_raw.get("sleepLevels")

--- a/SparkyFitnessGarmin/routes.py
+++ b/SparkyFitnessGarmin/routes.py
@@ -580,7 +580,9 @@ async def get_health_and_wellness(request_data: HealthAndWellnessRequest):
                                 start_gmt, (int, float)
                             ):
                                 offset_min = round((start_local - start_gmt) / 60000)
-                                if -960 <= offset_min <= 960:
+                                # Real-world offsets top out at +/-14:00; a
+                                # pair outside that range is corrupt data.
+                                if -840 <= offset_min <= 840:
                                     record_utc_offset_minutes = offset_min
                         else:
                             # Fallback to SleepStageLevel timestamps if summary timestamps are missing

--- a/SparkyFitnessServer/ai/tools/checkinTools.ts
+++ b/SparkyFitnessServer/ai/tools/checkinTools.ts
@@ -1,5 +1,10 @@
 import { tool } from 'ai';
-import { dayToUtcRange, todayInZone, BUILT_IN_MOODS } from '@workspace/shared';
+import {
+  dayToUtcRange,
+  todayInZone,
+  utcOffsetMinutesFromIsoString,
+  BUILT_IN_MOODS,
+} from '@workspace/shared';
 import { log } from '../../config/logging.js';
 import measurementService from '../../services/measurementService.js';
 import preferenceService from '../../services/preferenceService.js';
@@ -435,6 +440,12 @@ Actions:
               let bedtime = args.bedtime;
               let wakeTime = args.wake_time;
               const duration = args.duration_seconds ?? 28800; // Default 8h
+              // An explicit ±HH:MM suffix on a caller-supplied timestamp is a
+              // recording-zone claim worth stamping; generated defaults are
+              // profile-tz wall clocks and stay unstamped (Z suffix → null).
+              const recordUtcOffsetMinutes =
+                utcOffsetMinutesFromIsoString(args.bedtime) ??
+                utcOffsetMinutesFromIsoString(args.wake_time);
 
               if (!bedtime && !wakeTime) {
                 // Default: wake time is 7 AM on entry_date in the user's
@@ -464,6 +475,7 @@ Actions:
                 wake_time: wakeTime,
                 duration_in_seconds: duration,
                 source: args.source || 'manual',
+                record_utc_offset_minutes: recordUtcOffsetMinutes ?? undefined,
               });
 
               const parts: string[] = [];

--- a/SparkyFitnessServer/config/swagger.ts
+++ b/SparkyFitnessServer/config/swagger.ts
@@ -958,6 +958,18 @@ const options = {
             duration_in_seconds: { type: 'integer' },
             source: { type: 'string' },
             sleep_score: { type: 'integer', nullable: true },
+            record_timezone: {
+              type: 'string',
+              nullable: true,
+              description:
+                'IANA timezone the entry was recorded in. NULL falls back to record_utc_offset_minutes, then the profile timezone.',
+            },
+            record_utc_offset_minutes: {
+              type: 'integer',
+              nullable: true,
+              description:
+                'UTC offset in minutes at recording time; used when record_timezone is absent.',
+            },
             created_at: { type: 'string', format: 'date-time' },
             updated_at: { type: 'string', format: 'date-time' },
           },

--- a/SparkyFitnessServer/db/migrations/20260807000000_add_record_timezone_to_sleep_entries.sql
+++ b/SparkyFitnessServer/db/migrations/20260807000000_add_record_timezone_to_sleep_entries.sql
@@ -1,0 +1,24 @@
+-- Migration: Add record timezone metadata to sleep_entries
+--
+-- Issue #2033: bed/wake times are stored as UTC instants with no memory of
+-- the timezone they were recorded in, so displays fall back to the viewer's
+-- current timezone and a trip across timezones re-labels historical nights
+-- (a 7am wake-up shows as noon). Providers already have zone data in hand at
+-- import time (Health Connect zone offsets, HealthKit HKTimeZone, Garmin
+-- Local/GMT timestamp pairs, Oura/Polar offset-suffixed ISO strings, Fitbit
+-- profile offset); these columns let import paths stamp it per entry.
+--
+-- Purely additive: both columns are nullable and NULL means "no recording
+-- zone known" — read paths fall back to the user's profile timezone, so
+-- pre-existing rows keep rendering exactly as before. entry_date bucketing
+-- and the (user_id, entry_date, source) dedup key are unchanged.
+
+ALTER TABLE public.sleep_entries
+  ADD COLUMN IF NOT EXISTS record_timezone text;
+
+ALTER TABLE public.sleep_entries
+  ADD COLUMN IF NOT EXISTS record_utc_offset_minutes integer;
+
+COMMENT ON COLUMN public.sleep_entries.record_timezone IS 'IANA timezone the entry was recorded in (e.g. America/New_York). NULL when the source provided no zone; read paths fall back to record_utc_offset_minutes, then the profile timezone.';
+
+COMMENT ON COLUMN public.sleep_entries.record_utc_offset_minutes IS 'UTC offset in minutes at recording time (e.g. -300). Used when record_timezone is absent; NULL when the source provided no zone information.';

--- a/SparkyFitnessServer/integrations/fitbit/fitbitDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/fitbit/fitbitDataProcessor.ts
@@ -466,7 +466,12 @@ async function processFitbitSleep(
   createdByUserId: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: any,
-  timezoneOffset = 0
+  timezoneOffset = 0,
+  // Offset-only zone stamp (Fitbit exposes no per-record IANA zone): the
+  // exact offset the parser applied, so display round-trips the wall clock
+  // Fitbit reported. null when the profile carried no offset — a missing
+  // profile must not become a false UTC claim.
+  recordUtcOffsetMinutes: number | null = null
 ) {
   if (!data || !data.sleep || data.sleep.length === 0) return;
   for (const entry of data.sleep) {
@@ -474,6 +479,7 @@ async function processFitbitSleep(
       entry_date: entry.dateOfSleep,
       bedtime: parseFitbitTime(entry.startTime, timezoneOffset),
       wake_time: parseFitbitTime(entry.endTime, timezoneOffset),
+      record_utc_offset_minutes: recordUtcOffsetMinutes,
       duration_in_seconds: Math.round(entry.duration / 1000),
       // Fitbit's minutesAsleep is often the most accurate representation of "Time Asleep"
       time_asleep_in_seconds: entry.minutesAsleep * 60,

--- a/SparkyFitnessServer/integrations/googlehealth/googleHealthDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/googlehealth/googleHealthDataProcessor.ts
@@ -4,7 +4,11 @@ import exerciseRepository from '../../models/exercise.js';
 import activityDetailsRepository from '../../models/activityDetailsRepository.js';
 import sleepRepository from '../../models/sleepRepository.js';
 import { log } from '../../config/logging.js';
-import { todayInZone, instantToDay } from '@workspace/shared';
+import {
+  todayInZone,
+  instantToDay,
+  utcOffsetMinutesFromIsoString,
+} from '@workspace/shared';
 import {
   parseDurationToSeconds,
   googleTimeToIso,
@@ -616,12 +620,11 @@ async function processGoogleSleep(
     const interval = sleepPayload.interval || {};
     const stages = sleepPayload.stages || [];
 
-    const startIso = googleTimeToIso(
-      (interval.startTime ?? point.startTime) as
-        | string
-        | Record<string, unknown>
-        | undefined
-    );
+    const rawStartTime = (interval.startTime ?? point.startTime) as
+      | string
+      | Record<string, unknown>
+      | undefined;
+    const startIso = googleTimeToIso(rawStartTime);
     const endIso = googleTimeToIso(
       (interval.endTime ?? point.endTime) as
         | string
@@ -629,6 +632,14 @@ async function processGoogleSleep(
         | undefined
     );
     if (!startIso) continue;
+
+    // Only the string form can carry an explicit ±HH:MM recording-zone
+    // suffix; the {date,time} object form and Z/naive strings make no zone
+    // claim, so those rows fall back to the profile timezone at read time.
+    const recordUtcOffsetMinutes =
+      typeof rawStartTime === 'string'
+        ? utcOffsetMinutesFromIsoString(rawStartTime)
+        : null;
 
     // Anchor to the wake-up day, matching how Google Health / Fitbit file a
     // sleep session (it belongs to the day the session ends, not the day you
@@ -686,6 +697,9 @@ async function processGoogleSleep(
       entry_date: sleepDate,
       bedtime: startIso,
       wake_time: endIso,
+      ...(recordUtcOffsetMinutes !== null
+        ? { record_utc_offset_minutes: recordUtcOffsetMinutes }
+        : {}),
       duration_in_seconds: durationSec,
       time_asleep_in_seconds: minutesAsleep * 60,
       sleep_score: efficiency,

--- a/SparkyFitnessServer/integrations/healthData/healthDataRoutes.ts
+++ b/SparkyFitnessServer/integrations/healthData/healthDataRoutes.ts
@@ -76,7 +76,13 @@ router.post(
   checkPermissionMiddleware('diary'),
   async (req, res, next) => {
     try {
-      const { bedtime, wake_time, duration_in_seconds } = req.body;
+      const {
+        bedtime,
+        wake_time,
+        duration_in_seconds,
+        record_timezone,
+        record_utc_offset_minutes,
+      } = req.body;
       if (!bedtime || !wake_time || !duration_in_seconds) {
         return res.status(400).json({
           error:
@@ -91,6 +97,8 @@ router.post(
         wake_time: new Date(wake_time),
         duration_in_seconds: duration_in_seconds,
         source: 'manual',
+        record_timezone: record_timezone,
+        record_utc_offset_minutes: record_utc_offset_minutes,
       };
       const result = await measurementService.processSleepEntry(
         req.userId,

--- a/SparkyFitnessServer/integrations/oura/ouraDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/oura/ouraDataProcessor.ts
@@ -4,7 +4,11 @@ import exerciseRepository from '../../models/exercise.js';
 import exerciseEntryRepository from '../../models/exerciseEntry.js';
 import sleepRepository from '../../models/sleepRepository.js';
 import activityDetailsRepository from '../../models/activityDetailsRepository.js';
-import { instantToDay, instantHourMinute } from '@workspace/shared';
+import {
+  instantToDay,
+  instantHourMinute,
+  utcOffsetMinutesFromIsoString,
+} from '@workspace/shared';
 import type {
   OuraSleepPeriod,
   OuraDailySleep,
@@ -232,6 +236,11 @@ async function processOuraSleep(
       entry_date: day,
       bedtime: new Date(period.bedtime_start).toISOString(),
       wake_time: new Date(period.bedtime_end).toISOString(),
+      // Oura's bedtime_start carries the recording zone as a ±HH:MM suffix
+      // that toISOString() discards; keep it as an offset stamp.
+      record_utc_offset_minutes: utcOffsetMinutesFromIsoString(
+        period.bedtime_start
+      ),
       duration_in_seconds: period.time_in_bed || 0,
       time_asleep_in_seconds: period.total_sleep_duration || 0,
       sleep_score: scoreByDay.get(day) || 0,
@@ -288,6 +297,9 @@ async function processOuraSleep(
       entry_date: day,
       bedtime: new Date(naps[0].bedtime_start).toISOString(),
       wake_time: new Date(naps[naps.length - 1].bedtime_end).toISOString(),
+      record_utc_offset_minutes: utcOffsetMinutesFromIsoString(
+        naps[0].bedtime_start
+      ),
       duration_in_seconds: timeInBed,
       time_asleep_in_seconds: timeAsleep,
       sleep_score: 0,

--- a/SparkyFitnessServer/integrations/polar/polarDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/polar/polarDataProcessor.ts
@@ -4,6 +4,7 @@ import exerciseRepository from '../../models/exercise.js';
 import exerciseEntryRepository from '../../models/exerciseEntry.js';
 import sleepRepository from '../../models/sleepRepository.js';
 import activityDetailsRepository from '../../models/activityDetailsRepository.js';
+import { utcOffsetMinutesFromIsoString } from '@workspace/shared';
 /**
  * Helper to get a value from a Polar object regardless of hyphen or underscore usage.
  */
@@ -436,10 +437,17 @@ async function processPolarSleep(
         0;
       const totalDurationSec =
         lightSleepSec + deepSleepSec + remSleepSec + awakeSec;
+      // The raw sleep-start-time string carries the recording zone as a
+      // ±HH:MM suffix that parsePolarToUTC normalizes away; naive or
+      // date-only strings yield null and stamp nothing.
+      const recordUtcOffsetMinutes = utcOffsetMinutesFromIsoString(startTime);
       const sleepEntryData = {
         entry_date: entryDate,
         bedtime: parsePolarToUTC(startTime),
         wake_time: parsePolarToUTC(endTime),
+        ...(recordUtcOffsetMinutes !== null
+          ? { record_utc_offset_minutes: recordUtcOffsetMinutes }
+          : {}),
         duration_in_seconds: totalDurationSec,
         time_asleep_in_seconds: lightSleepSec + deepSleepSec + remSleepSec,
         sleep_score: getVal(night, 'sleep-score'),

--- a/SparkyFitnessServer/integrations/withings/withingsDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/withings/withingsDataProcessor.ts
@@ -3,7 +3,7 @@ import { log } from '../../config/logging.js';
 import exerciseRepository from '../../models/exercise.js';
 import exerciseEntryRepository from '../../models/exerciseEntry.js';
 import sleepRepository from '../../models/sleepRepository.js';
-import { instantToDay } from '@workspace/shared';
+import { instantToDay, isValidTimeZone } from '@workspace/shared';
 import activityDetailsRepository from '../../models/activityDetailsRepository.js';
 // Define a mapping for Withings metric types to SparkyFitness measurement types
 // This can be extended as more Withings metrics are integrated
@@ -609,10 +609,25 @@ async function processWithingsSleepData(
     }
     const bedtime = new Date(bedtimeTs * 1000).toISOString();
     const wakeTime = new Date(wakeTimeTs * 1000).toISOString();
+    // Sleep v2 getsummary items carry their own IANA `timezone` (sibling of
+    // date/startdate/data) — the device's zone at recording time. The
+    // caller-level `timezone` param is the profile zone and must NOT be
+    // stamped: it is redundant with the read-side fallback and one caller
+    // defaults it to 'UTC'. Only a validating value is stamped, so an
+    // absent or malformed field just falls back.
+    // @ts-expect-error TS(2339): Property 'timezone' does not exist on type 'never'.
+    const summaryTimezone: unknown = summary.timezone;
+    const recordTimezone =
+      typeof summaryTimezone === 'string' &&
+      summaryTimezone.trim() !== '' &&
+      isValidTimeZone(summaryTimezone)
+        ? summaryTimezone
+        : null;
     const sleepEntryData = {
       entry_date: entryDate,
       bedtime: bedtime,
       wake_time: wakeTime,
+      ...(recordTimezone ? { record_timezone: recordTimezone } : {}),
       // @ts-expect-error TS(2339): Property 'data' does not exist on type 'never'.
       duration_in_seconds: summary.data.total_timeinbed || 0,
       // @ts-expect-error TS(2339): Property 'data' does not exist on type 'never'.

--- a/SparkyFitnessServer/models/sleepRepository.ts
+++ b/SparkyFitnessServer/models/sleepRepository.ts
@@ -37,6 +37,8 @@ async function upsertSleepEntry(
       avg_overnight_hrv,
       body_battery_change,
       resting_heart_rate,
+      record_timezone,
+      record_utc_offset_minutes,
     } = sleepEntryData;
     let sleepEntryId = id;
     // If no ID is provided, check for an existing entry for this user, date, and source to prevent duplicates
@@ -54,7 +56,11 @@ async function upsertSleepEntry(
       }
     }
     if (sleepEntryId) {
-      // Attempt to update existing entry
+      // Attempt to update existing entry. The recording-zone columns use
+      // COALESCE so a payload without zone metadata (older mobile client,
+      // provider fallback branch) preserves a previously captured zone
+      // instead of erasing it; clearing to NULL is only possible through
+      // updateSleepEntry's explicit-null path.
       const updateQuery = `
                 UPDATE sleep_entries
                 SET
@@ -81,6 +87,8 @@ async function upsertSleepEntry(
                     avg_overnight_hrv = $23,
                     body_battery_change = $24,
                     resting_heart_rate = $25,
+                    record_timezone = COALESCE($26, record_timezone),
+                    record_utc_offset_minutes = COALESCE($27, record_utc_offset_minutes),
                     updated_at = CURRENT_TIMESTAMP
                 WHERE id = $1 AND user_id = $2
                 RETURNING id;
@@ -111,6 +119,8 @@ async function upsertSleepEntry(
         avg_overnight_hrv,
         body_battery_change,
         resting_heart_rate,
+        record_timezone,
+        record_utc_offset_minutes,
       ]);
       if (updateResult.rows.length > 0) {
         sleepEntryId = updateResult.rows[0].id;
@@ -124,8 +134,8 @@ async function upsertSleepEntry(
     } else {
       // Insert new entry
       const insertQuery = `
-                INSERT INTO sleep_entries (user_id, entry_date, bedtime, wake_time, duration_in_seconds, time_asleep_in_seconds, sleep_score, source, deep_sleep_seconds, light_sleep_seconds, rem_sleep_seconds, awake_sleep_seconds, average_spo2_value, lowest_spo2_value, highest_spo2_value, average_respiration_value, lowest_respiration_value, highest_respiration_value, awake_count, avg_sleep_stress, restless_moments_count, avg_overnight_hrv, body_battery_change, resting_heart_rate)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
+                INSERT INTO sleep_entries (user_id, entry_date, bedtime, wake_time, duration_in_seconds, time_asleep_in_seconds, sleep_score, source, deep_sleep_seconds, light_sleep_seconds, rem_sleep_seconds, awake_sleep_seconds, average_spo2_value, lowest_spo2_value, highest_spo2_value, average_respiration_value, lowest_respiration_value, highest_respiration_value, awake_count, avg_sleep_stress, restless_moments_count, avg_overnight_hrv, body_battery_change, resting_heart_rate, record_timezone, record_utc_offset_minutes)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26)
                 RETURNING id;
             `;
       const insertResult = await client.query(insertQuery, [
@@ -153,6 +163,8 @@ async function upsertSleepEntry(
         avg_overnight_hrv,
         body_battery_change,
         resting_heart_rate,
+        record_timezone,
+        record_utc_offset_minutes,
       ]);
       sleepEntryId = insertResult.rows[0].id;
       log(
@@ -557,6 +569,8 @@ async function getSleepEntriesByUserIdAndDateRange(
             se.avg_overnight_hrv,
             se.body_battery_change,
             se.resting_heart_rate,
+            se.record_timezone,
+            se.record_utc_offset_minutes,
             se.created_at,
             se.updated_at,
             COALESCE(
@@ -620,6 +634,8 @@ async function updateSleepEntry(
       avg_overnight_hrv,
       body_battery_change,
       resting_heart_rate,
+      record_timezone,
+      record_utc_offset_minutes,
       stage_events, // Extract stage_events
     } = updateData;
     const updateFields = [];
@@ -716,6 +732,14 @@ async function updateSleepEntry(
     if (resting_heart_rate !== undefined) {
       updateFields.push(`resting_heart_rate = $${paramIndex++} `);
       updateValues.push(resting_heart_rate);
+    }
+    if (record_timezone !== undefined) {
+      updateFields.push(`record_timezone = $${paramIndex++} `);
+      updateValues.push(record_timezone);
+    }
+    if (record_utc_offset_minutes !== undefined) {
+      updateFields.push(`record_utc_offset_minutes = $${paramIndex++} `);
+      updateValues.push(record_utc_offset_minutes);
     }
     // Add updated_by_user_id
     updateFields.push(`updated_by_user_id = $${paramIndex++}`);
@@ -914,6 +938,8 @@ async function getSleepEntriesWithAllDetailsByUserIdAndDateRange(
             se.avg_overnight_hrv,
             se.body_battery_change,
             se.resting_heart_rate,
+            se.record_timezone,
+            se.record_utc_offset_minutes,
             se.created_at,
             se.updated_at,
             json_agg(

--- a/SparkyFitnessServer/models/sleepScienceRepository.ts
+++ b/SparkyFitnessServer/models/sleepScienceRepository.ts
@@ -33,6 +33,8 @@ async function getSleepHistory(userId: any, days = 90, timezone = 'UTC') {
         se.time_asleep_in_seconds / 3600.0 AS "timeAsleepHours",
         EXTRACT(EPOCH FROM se.bedtime) * 1000 AS "sleepStartTimestampGMT",
         EXTRACT(EPOCH FROM se.wake_time) * 1000 AS "sleepEndTimestampGMT",
+        se.record_timezone,
+        se.record_utc_offset_minutes,
         se.sleep_score AS "sleepScore"
       FROM sleep_entries se
       WHERE se.user_id = $1

--- a/SparkyFitnessServer/routes/sleepRoutes.ts
+++ b/SparkyFitnessServer/routes/sleepRoutes.ts
@@ -103,6 +103,14 @@ router.get(
  *                 type: array
  *                 items:
  *                   type: object
+ *               record_timezone:
+ *                 type: string
+ *                 nullable: true
+ *                 description: IANA timezone the entry was recorded in.
+ *               record_utc_offset_minutes:
+ *                 type: integer
+ *                 nullable: true
+ *                 description: UTC offset in minutes at recording time.
  *             required: [entry_date, bedtime, wake_time, duration_in_seconds]
  *     responses:
  *       200:
@@ -124,6 +132,8 @@ router.post(
         wake_time,
         duration_in_seconds,
         stage_events,
+        record_timezone,
+        record_utc_offset_minutes,
       } = req.body;
       if (!entry_date || !bedtime || !wake_time || !duration_in_seconds) {
         return res.status(400).json({
@@ -138,6 +148,8 @@ router.post(
         duration_in_seconds: duration_in_seconds,
         source: 'manual',
         stage_events: stage_events,
+        record_timezone: record_timezone,
+        record_utc_offset_minutes: record_utc_offset_minutes,
       };
       const result = await measurementService.processSleepEntry(
         req.userId,
@@ -326,6 +338,14 @@ router.get(
  *                 type: array
  *                 items:
  *                   type: object
+ *               record_timezone:
+ *                 type: string
+ *                 nullable: true
+ *                 description: IANA timezone the entry was recorded in. Omit to preserve the stored value.
+ *               record_utc_offset_minutes:
+ *                 type: integer
+ *                 nullable: true
+ *                 description: UTC offset in minutes at recording time. Omit to preserve the stored value.
  *     responses:
  *       200:
  *         description: Sleep entry updated successfully.
@@ -337,13 +357,23 @@ router.put(
   async (req, res, next) => {
     try {
       const { id } = req.params;
-      const { bedtime, wake_time, duration_in_seconds, stage_events } =
-        req.body;
+      const {
+        bedtime,
+        wake_time,
+        duration_in_seconds,
+        stage_events,
+        record_timezone,
+        record_utc_offset_minutes,
+      } = req.body;
+      // Omitted zone fields stay undefined so the dynamic update builder
+      // leaves the stored recording-zone metadata untouched.
       const updatedSleepEntryData = {
         bedtime: bedtime ? new Date(bedtime) : undefined,
         wake_time: wake_time ? new Date(wake_time) : undefined,
         duration_in_seconds: duration_in_seconds,
         stage_events: stage_events,
+        record_timezone: record_timezone,
+        record_utc_offset_minutes: record_utc_offset_minutes,
       };
       const result = await measurementService.updateSleepEntry(
         req.userId,

--- a/SparkyFitnessServer/schemas/measurementSchemas.ts
+++ b/SparkyFitnessServer/schemas/measurementSchemas.ts
@@ -55,6 +55,21 @@ const nullableOptionalLegacyNumber = z.preprocess((value) => {
   return coerceLegacyNumber(value);
 }, z.number().nullable().optional());
 
+// Same coercion as nullableOptionalLegacyNumber, but whole numbers only.
+// Used for integer columns like record_utc_offset_minutes, where a fractional
+// value must fail validation here instead of erroring at the database layer.
+const nullableOptionalLegacyInteger = z.preprocess((value) => {
+  if (value === '') {
+    return undefined;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  return coerceLegacyNumber(value);
+}, z.number().int().nullable().optional());
+
 // Same coercion as nullableOptionalLegacyNumber, plus a domain range. Used for
 // the smart-scale columns so this route enforces the same bounds as the other
 // two write paths (ai/tools/schemas/checkin.ts and the processHealthData
@@ -250,7 +265,7 @@ export const ImportHealthDataItemSchema = z
     source: optionalLegacyString,
     source_id: optionalLegacyString,
     record_timezone: nullableOptionalLegacyString,
-    record_utc_offset_minutes: nullableOptionalLegacyNumber,
+    record_utc_offset_minutes: nullableOptionalLegacyInteger,
     // Sleep session fields (only present on SleepSession rows).
     bedtime: optionalLegacyString,
     wake_time: optionalLegacyString,

--- a/SparkyFitnessServer/services/fitbitService.ts
+++ b/SparkyFitnessServer/services/fitbitService.ts
@@ -63,6 +63,10 @@ async function syncFitbitData(
       // 1. Extract Unit Preferences and Timezone from Profil/Responses if available
       const profileResponse = responses['raw_profile']?.data;
       const timezoneOffset = profileResponse?.user?.offsetFromUTCMillis || 0;
+      const recordUtcOffsetMinutes: number | null =
+        typeof profileResponse?.user?.offsetFromUTCMillis === 'number'
+          ? Math.round(profileResponse.user.offsetFromUTCMillis / 60000)
+          : null;
       // 2. Process all raw items from bundle
       log('debug', `[fitbitService] Processing raw data for ${userId}...`);
       if (responses['raw_profile'])
@@ -151,7 +155,8 @@ async function syncFitbitData(
           userId,
           userId,
           responses['raw_sleep'].data,
-          timezoneOffset
+          timezoneOffset,
+          recordUtcOffsetMinutes
         );
       if (responses['raw_activities_list'])
         await fitbitDataProcessor.processFitbitActivities(
@@ -217,6 +222,10 @@ async function syncFitbitData(
       accessToken
     );
     const timezoneOffset = profileData?.user?.offsetFromUTCMillis || 0;
+    const recordUtcOffsetMinutes: number | null =
+      typeof profileData?.user?.offsetFromUTCMillis === 'number'
+        ? Math.round(profileData.user.offsetFromUTCMillis / 60000)
+        : null;
     // 2. Fetch all other data sequentially to avoid 429 Resource Exhausted errors
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const safeFetch = async (fetchFn: any, name: any) => {
@@ -456,7 +465,8 @@ async function syncFitbitData(
         userId,
         userId,
         sleepData,
-        timezoneOffset
+        timezoneOffset,
+        recordUtcOffsetMinutes
       );
     if (activitiesData)
       await fitbitDataProcessor.processFitbitActivities(

--- a/SparkyFitnessServer/services/healthDataHandlers.ts
+++ b/SparkyFitnessServer/services/healthDataHandlers.ts
@@ -952,6 +952,8 @@ const sleepSessionHandler: HealthTypeHandler = {
         light_sleep_seconds: Number(entry.light_sleep_seconds) || 0,
         rem_sleep_seconds: Number(entry.rem_sleep_seconds) || 0,
         awake_sleep_seconds: Number(entry.awake_sleep_seconds) || 0,
+        record_timezone: entry.record_timezone,
+        record_utc_offset_minutes: entry.record_utc_offset_minutes,
       };
       const sleepEntryResult = await ctx.processSleepEntry(
         ctx.userId,

--- a/SparkyFitnessServer/services/sleepScienceService.ts
+++ b/SparkyFitnessServer/services/sleepScienceService.ts
@@ -2,9 +2,10 @@ import sleepScienceRepository from '../models/sleepScienceRepository.js';
 import { log } from '../config/logging.js';
 import { loadUserTimezone } from '../utils/timezoneLoader.js';
 import {
-  instantHourMinute,
   dayOfWeek,
+  instantHourMinuteInZone,
   localDateToDay,
+  resolveRecordZone,
   userHourMinute,
 } from '@workspace/shared';
 import {
@@ -80,12 +81,18 @@ function standardDeviation(values: any) {
     squaredDiffs.reduce((a: any, b: any) => a + b, 0) / (values.length - 1)
   );
 }
+// Wall-clock hours derive from the zone the entry was recorded in when the
+// row carries one; zone-less rows fall back to the profile timezone.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getWakeHour(entry: any, timezone = 'UTC') {
   if (!entry.sleepEndTimestampGMT) return null;
   const ts = Number(entry.sleepEndTimestampGMT);
   if (isNaN(ts)) return null;
-  const { hour, minute } = instantHourMinute(ts, timezone);
+  const zone = resolveRecordZone(
+    entry.record_timezone,
+    entry.record_utc_offset_minutes
+  ) ?? { kind: 'tz', tz: timezone };
+  const { hour, minute } = instantHourMinuteInZone(ts, zone);
   return hour + minute / 60;
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -93,7 +100,11 @@ function getSleepHour(entry: any, timezone = 'UTC') {
   if (!entry.sleepStartTimestampGMT) return null;
   const ts = Number(entry.sleepStartTimestampGMT);
   if (isNaN(ts)) return null;
-  const { hour, minute } = instantHourMinute(ts, timezone);
+  const zone = resolveRecordZone(
+    entry.record_timezone,
+    entry.record_utc_offset_minutes
+  ) ?? { kind: 'tz', tz: timezone };
+  const { hour, minute } = instantHourMinuteInZone(ts, zone);
   return hour + minute / 60;
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/SparkyFitnessServer/services/sleepScienceService.ts
+++ b/SparkyFitnessServer/services/sleepScienceService.ts
@@ -81,10 +81,18 @@ function standardDeviation(values: any) {
     squaredDiffs.reduce((a: any, b: any) => a + b, 0) / (values.length - 1)
   );
 }
+// The fields the wall-clock helpers read from a sleep-history row: epoch-ms
+// GMT instants (pg returns the EXTRACT(EPOCH ...) numerics as strings) plus
+// the optional recording-zone metadata columns.
+type SleepZoneEntry = {
+  sleepStartTimestampGMT?: number | string | null;
+  sleepEndTimestampGMT?: number | string | null;
+  record_timezone?: string | null;
+  record_utc_offset_minutes?: number | null;
+};
 // Wall-clock hours derive from the zone the entry was recorded in when the
 // row carries one; zone-less rows fall back to the profile timezone.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getWakeHour(entry: any, timezone = 'UTC') {
+function getWakeHour(entry: SleepZoneEntry, timezone = 'UTC') {
   if (!entry.sleepEndTimestampGMT) return null;
   const ts = Number(entry.sleepEndTimestampGMT);
   if (isNaN(ts)) return null;
@@ -95,8 +103,7 @@ function getWakeHour(entry: any, timezone = 'UTC') {
   const { hour, minute } = instantHourMinuteInZone(ts, zone);
   return hour + minute / 60;
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function getSleepHour(entry: any, timezone = 'UTC') {
+function getSleepHour(entry: SleepZoneEntry, timezone = 'UTC') {
   if (!entry.sleepStartTimestampGMT) return null;
   const ts = Number(entry.sleepStartTimestampGMT);
   if (isNaN(ts)) return null;

--- a/SparkyFitnessServer/tests/chatbotToolsCheckin.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsCheckin.test.ts
@@ -599,6 +599,67 @@ describe('log_sleep', () => {
       }
     );
   });
+
+  it('stamps record_utc_offset_minutes from an explicit-offset caller timestamp', async () => {
+    vi.mocked(measurementService.processSleepEntry).mockResolvedValue({
+      id: 's1',
+    });
+
+    await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_sleep',
+        entry_date: '2026-06-01',
+        bedtime: '2026-05-31T22:00:00+05:30',
+      },
+      opts
+    );
+
+    expect(measurementService.processSleepEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.objectContaining({ record_utc_offset_minutes: 330 })
+    );
+  });
+
+  it('falls back to the wake_time offset when bedtime carries none', async () => {
+    vi.mocked(measurementService.processSleepEntry).mockResolvedValue({
+      id: 's1',
+    });
+
+    await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_sleep',
+        entry_date: '2026-06-01',
+        wake_time: '2026-06-01T06:00:00-04:00',
+      },
+      opts
+    );
+
+    expect(measurementService.processSleepEntry).toHaveBeenCalledWith(
+      'user-1',
+      'user-1',
+      expect.objectContaining({ record_utc_offset_minutes: -240 })
+    );
+  });
+
+  it('leaves the stamp unset for Z-suffixed and generated timestamps', async () => {
+    vi.mocked(measurementService.processSleepEntry).mockResolvedValue({
+      id: 's1',
+    });
+
+    await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_sleep',
+        entry_date: '2026-06-01',
+        bedtime: '2026-05-31T22:00:00.000Z',
+      },
+      opts
+    );
+
+    const payload = vi.mocked(measurementService.processSleepEntry).mock
+      .calls[0][2];
+    expect(payload.record_utc_offset_minutes).toBeUndefined();
+  });
 });
 
 describe('list_checkin_diary', () => {

--- a/SparkyFitnessServer/tests/fitbitDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/fitbitDataProcessor.test.ts
@@ -1,7 +1,12 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { instantHourMinuteWithOffset } from '@workspace/shared';
 import exerciseRepository from '../models/exercise.js';
 import exerciseEntryRepository from '../models/exerciseEntry.js';
-import { processFitbitActivities } from '../integrations/fitbit/fitbitDataProcessor.js';
+import sleepRepository from '../models/sleepRepository.js';
+import {
+  processFitbitActivities,
+  processFitbitSleep,
+} from '../integrations/fitbit/fitbitDataProcessor.js';
 
 vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
 vi.mock('../models/measurementRepository.js', () => ({ default: {} }));
@@ -16,7 +21,13 @@ vi.mock('../models/exerciseEntry.js', () => ({
     createExerciseEntry: vi.fn(),
   },
 }));
-vi.mock('../models/sleepRepository.js', () => ({ default: {} }));
+vi.mock('../models/sleepRepository.js', () => ({
+  default: {
+    upsertSleepEntry: vi.fn(),
+    deleteSleepStageEventsByEntryId: vi.fn(),
+    upsertSleepStageEvent: vi.fn(),
+  },
+}));
 vi.mock('../models/activityDetailsRepository.js', () => ({
   default: { createActivityDetail: vi.fn() },
 }));
@@ -60,5 +71,51 @@ describe('processFitbitActivities duration units', () => {
       CID,
       'Fitbit'
     );
+  });
+});
+
+describe('processFitbitSleep recording-zone stamp (issue #2033)', () => {
+  const sleepData = {
+    sleep: [
+      {
+        dateOfSleep: '2026-01-16',
+        startTime: '2026-01-15T23:00:00.000', // offset-less local time
+        endTime: '2026-01-16T07:00:00.000',
+        duration: 28800000,
+        minutesAsleep: 450,
+        efficiency: 94,
+        levels: { summary: {}, data: [] },
+      },
+    ],
+  };
+  const offsetMs = -4 * 3600000; // profile offset fetched in summer (EDT)
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sleepRepository.upsertSleepEntry).mockResolvedValue({
+      id: 'sleep-1',
+    });
+  });
+
+  it('stamps the exact offset the parser used, so display round-trips the reported wall clock across DST', async () => {
+    await processFitbitSleep(UID, CID, sleepData, offsetMs, -240);
+
+    const entry = vi.mocked(sleepRepository.upsertSleepEntry).mock.calls[0][2];
+    expect(entry.record_utc_offset_minutes).toBe(-240);
+    // A January night parsed with the summer offset: displaying with the
+    // same stored offset must reproduce Fitbit's reported 23:00, even though
+    // the historical zone offset that January was -300.
+    const { hour, minute } = instantHourMinuteWithOffset(
+      new Date(entry.bedtime),
+      entry.record_utc_offset_minutes
+    );
+    expect({ hour, minute }).toEqual({ hour: 23, minute: 0 });
+  });
+
+  it('stamps NULL when the profile carried no offset (no false UTC claim)', async () => {
+    await processFitbitSleep(UID, CID, sleepData, 0, null);
+
+    const entry = vi.mocked(sleepRepository.upsertSleepEntry).mock.calls[0][2];
+    expect(entry.record_utc_offset_minutes).toBeNull();
   });
 });

--- a/SparkyFitnessServer/tests/googleHealthDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/googleHealthDataProcessor.test.ts
@@ -385,3 +385,55 @@ describe('processGoogleActivities — exercise record null guard', () => {
     );
   });
 });
+
+// ─── Sleep recording-zone stamp (issue #2033) ───────────────────────────────
+
+describe('processGoogleSleep — recording-zone stamp', () => {
+  it('stamps record_utc_offset_minutes for a string startTime with an explicit offset', async () => {
+    await processGoogleSleep(
+      UID,
+      CID,
+      dataPoints(
+        sleepPoint('2026-05-01T23:30:00-04:00', '2026-05-02T07:00:00-04:00')
+      )
+    );
+    const entry = vi.mocked(sleepRepository.upsertSleepEntry).mock.calls[0][2];
+    expect(entry.record_utc_offset_minutes).toBe(-240);
+  });
+
+  it('stamps nothing for a Z-suffixed string (no zone claim)', async () => {
+    await processGoogleSleep(
+      UID,
+      CID,
+      dataPoints(sleepPoint('2026-05-01T23:30:00Z', '2026-05-02T07:00:00Z'))
+    );
+    const entry = vi.mocked(sleepRepository.upsertSleepEntry).mock.calls[0][2];
+    expect(entry.record_utc_offset_minutes).toBeUndefined();
+  });
+
+  it('stamps nothing for the {date,time} object form', async () => {
+    const point = {
+      sleep: {
+        summary: {
+          minutesAsleep: '420',
+          minutesInSleepPeriod: '450',
+          minutesToFallAsleep: '10',
+        },
+        interval: {
+          startTime: {
+            date: { year: 2026, month: 5, day: 1 },
+            time: { hours: 23, minutes: 30 },
+          },
+          endTime: {
+            date: { year: 2026, month: 5, day: 2 },
+            time: { hours: 7, minutes: 0 },
+          },
+        },
+        stages: [],
+      },
+    };
+    await processGoogleSleep(UID, CID, dataPoints(point));
+    const entry = vi.mocked(sleepRepository.upsertSleepEntry).mock.calls[0][2];
+    expect(entry.record_utc_offset_minutes).toBeUndefined();
+  });
+});

--- a/SparkyFitnessServer/tests/measurementImportRoutes.test.ts
+++ b/SparkyFitnessServer/tests/measurementImportRoutes.test.ts
@@ -5,6 +5,7 @@ import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import measurementService from '../services/measurementService.js';
 import errorHandler from '../middleware/errorHandler.js';
+import { ImportHealthDataItemSchema } from '../schemas/measurementSchemas.js';
 
 // Toggle used by the mocked permission middleware so a single test can assert
 // the 403 path without re-registering the route.
@@ -216,5 +217,46 @@ describe('POST /api/measurements/import-health-data', () => {
 
     expect(res.statusCode).toBe(200);
     expect(measurementService.processHealthData).toHaveBeenCalledTimes(1);
+    const [forwardedItems] = vi.mocked(measurementService.processHealthData)
+      .mock.calls[0];
+    expect(forwardedItems[0].record_utc_offset_minutes).toBe(-300);
+  });
+});
+
+// Direct schema coverage for the legacy-coercion surface the route tests
+// don't reach: CSV cells arrive as strings, and the integer constraint must
+// hold after coercion, not just for JSON numbers.
+describe('ImportHealthDataItemSchema record_utc_offset_minutes coercion', () => {
+  const row = (offset: unknown) => ({
+    type: 'SleepSession',
+    date: '2026-05-05',
+    record_utc_offset_minutes: offset,
+  });
+
+  it('accepts whole minutes as numbers and coerces numeric strings', () => {
+    const numeric = ImportHealthDataItemSchema.safeParse(row(-300));
+    expect(numeric.success).toBe(true);
+    expect(numeric.data?.record_utc_offset_minutes).toBe(-300);
+
+    const stringy = ImportHealthDataItemSchema.safeParse(row('90'));
+    expect(stringy.success).toBe(true);
+    expect(stringy.data?.record_utc_offset_minutes).toBe(90);
+  });
+
+  it('treats an empty string as absent and preserves null', () => {
+    const blank = ImportHealthDataItemSchema.safeParse(row(''));
+    expect(blank.success).toBe(true);
+    expect(blank.data?.record_utc_offset_minutes).toBeUndefined();
+
+    const cleared = ImportHealthDataItemSchema.safeParse(row(null));
+    expect(cleared.success).toBe(true);
+    expect(cleared.data?.record_utc_offset_minutes).toBeNull();
+  });
+
+  it('rejects fractional values whether numbers or strings', () => {
+    expect(ImportHealthDataItemSchema.safeParse(row(90.5)).success).toBe(false);
+    expect(ImportHealthDataItemSchema.safeParse(row('90.5')).success).toBe(
+      false
+    );
   });
 });

--- a/SparkyFitnessServer/tests/measurementImportRoutes.test.ts
+++ b/SparkyFitnessServer/tests/measurementImportRoutes.test.ts
@@ -173,4 +173,48 @@ describe('POST /api/measurements/import-health-data', () => {
     expect(res.statusCode).toBe(400);
     expect(measurementService.processHealthData).not.toHaveBeenCalled();
   });
+
+  it('returns 400 for a fractional record_utc_offset_minutes (integer column)', async () => {
+    const res = await post({
+      items: [
+        {
+          type: 'SleepSession',
+          date: '2026-05-05',
+          bedtime: '2026-05-05T03:00:00Z',
+          wake_time: '2026-05-05T11:00:00Z',
+          duration_in_seconds: 28800,
+          record_utc_offset_minutes: 90.5,
+        },
+      ],
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(measurementService.processHealthData).not.toHaveBeenCalled();
+  });
+
+  it('accepts a whole-minute record_utc_offset_minutes', async () => {
+    // @ts-expect-error mock
+    measurementService.processHealthData.mockResolvedValue({
+      message: 'ok',
+      processed: [],
+      errors: [],
+      skipped: [],
+    });
+
+    const res = await post({
+      items: [
+        {
+          type: 'SleepSession',
+          date: '2026-05-05',
+          bedtime: '2026-05-05T03:00:00Z',
+          wake_time: '2026-05-05T11:00:00Z',
+          duration_in_seconds: 28800,
+          record_utc_offset_minutes: -300,
+        },
+      ],
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(measurementService.processHealthData).toHaveBeenCalledTimes(1);
+  });
 });

--- a/SparkyFitnessServer/tests/measurementService.healthConnectSleepStages.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.healthConnectSleepStages.test.ts
@@ -97,6 +97,7 @@ describe('processHealthData Health Connect sleep stages', () => {
         light_sleep_seconds: 22500,
         rem_sleep_seconds: 1800,
         awake_sleep_seconds: 900,
+        record_timezone: 'America/New_York',
         record_utc_offset_minutes: -300,
         stage_events: [
           {
@@ -170,6 +171,10 @@ describe('processHealthData Health Connect sleep stages', () => {
         light_sleep_seconds: 22500,
         rem_sleep_seconds: 1800,
         awake_sleep_seconds: 900,
+        // Issue #2033: mobile-sent recording-zone metadata must survive the
+        // sleepSessionHandler field whitelist all the way to the upsert.
+        record_timezone: 'America/New_York',
+        record_utc_offset_minutes: -300,
       })
     );
     expect(

--- a/SparkyFitnessServer/tests/ouraDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/ouraDataProcessor.test.ts
@@ -231,6 +231,51 @@ describe('processOuraSleep', () => {
     });
   });
 
+  it('stamps record_utc_offset_minutes from the offset-suffixed bedtime_start for main sleep and naps', async () => {
+    await processOuraSleep(
+      UID,
+      CID,
+      [
+        sleepPeriod({
+          bedtime_start: '2026-07-14T23:00:00+02:00',
+          bedtime_end: '2026-07-15T07:00:00+02:00',
+        }),
+        sleepPeriod({
+          id: 'nap-1',
+          type: 'late_nap',
+          bedtime_start: '2026-07-15T13:00:00-04:00',
+          bedtime_end: '2026-07-15T13:30:00-04:00',
+          time_in_bed: 1800,
+          total_sleep_duration: 1500,
+        }),
+      ],
+      []
+    );
+
+    expect(sleepRepository.upsertSleepEntry).toHaveBeenCalledTimes(2);
+    const calls = vi.mocked(sleepRepository.upsertSleepEntry).mock.calls;
+    const main = calls.find((c) => c[2].source === 'Oura')![2];
+    const nap = calls.find((c) => c[2].source === 'Oura Nap')![2];
+    expect(main.record_utc_offset_minutes).toBe(120);
+    expect(nap.record_utc_offset_minutes).toBe(-240);
+  });
+
+  it('stamps no offset when bedtime_start is UTC-normalized with Z (no zone claim)', async () => {
+    await processOuraSleep(
+      UID,
+      CID,
+      [
+        sleepPeriod({
+          bedtime_start: '2026-07-14T23:00:00Z',
+          bedtime_end: '2026-07-15T07:00:00Z',
+        }),
+      ],
+      []
+    );
+    const entry = vi.mocked(sleepRepository.upsertSleepEntry).mock.calls[0][2];
+    expect(entry.record_utc_offset_minutes).toBeNull();
+  });
+
   it('skips rest and deleted sleep periods', async () => {
     await processOuraSleep(
       UID,

--- a/SparkyFitnessServer/tests/polarDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/polarDataProcessor.test.ts
@@ -1,7 +1,11 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
 import exerciseRepository from '../models/exercise.js';
 import exerciseEntryRepository from '../models/exerciseEntry.js';
-import { processPolarExercises } from '../integrations/polar/polarDataProcessor.js';
+import sleepRepository from '../models/sleepRepository.js';
+import {
+  processPolarExercises,
+  processPolarSleep,
+} from '../integrations/polar/polarDataProcessor.js';
 
 vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
 vi.mock('../models/measurementRepository.js', () => ({ default: {} }));
@@ -18,7 +22,13 @@ vi.mock('../models/exerciseEntry.js', () => ({
     createExerciseEntry: vi.fn(),
   },
 }));
-vi.mock('../models/sleepRepository.js', () => ({ default: {} }));
+vi.mock('../models/sleepRepository.js', () => ({
+  default: {
+    upsertSleepEntry: vi.fn(),
+    deleteSleepStageEventsByEntryId: vi.fn(),
+    upsertSleepStageEvent: vi.fn(),
+  },
+}));
 vi.mock('../models/activityDetailsRepository.js', () => ({
   default: { createActivityDetail: vi.fn() },
 }));
@@ -59,5 +69,39 @@ describe('processPolarExercises duration units', () => {
       CID,
       'Polar'
     );
+  });
+});
+
+describe('processPolarSleep recording-zone stamp (issue #2033)', () => {
+  // processPolarSleep's untyped `sleepData = []` default infers never[].
+  const night = (startTime: string) =>
+    ({
+      date: '2026-07-15',
+      'sleep-start-time': startTime,
+      'sleep-end-time': '2026-07-15T07:00:00+03:00',
+      'light-sleep': 15000,
+      'deep-sleep': 6000,
+      'rem-sleep': 6000,
+      'total-interruption-duration': 1800,
+      'sleep-score': 80,
+    }) as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sleepRepository.upsertSleepEntry).mockResolvedValue({
+      id: 'sleep-1',
+    });
+  });
+
+  it('stamps the offset from the raw offset-suffixed sleep-start-time', async () => {
+    await processPolarSleep(UID, CID, [night('2026-07-14T23:39:07+03:00')]);
+    const entry = vi.mocked(sleepRepository.upsertSleepEntry).mock.calls[0][2];
+    expect(entry.record_utc_offset_minutes).toBe(180);
+  });
+
+  it('omits the stamp for a naive sleep-start-time (no zone claim)', async () => {
+    await processPolarSleep(UID, CID, [night('2026-07-14T23:39:07')]);
+    const entry = vi.mocked(sleepRepository.upsertSleepEntry).mock.calls[0][2];
+    expect(entry.record_utc_offset_minutes).toBeUndefined();
   });
 });

--- a/SparkyFitnessServer/tests/sleepRepository.placeholders.test.ts
+++ b/SparkyFitnessServer/tests/sleepRepository.placeholders.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createMockDbClient,
+  type MockDbClient,
+} from './helpers/mockDbClient.js';
 import sleepRepository from '../models/sleepRepository.js';
 import { getClient } from '../db/poolManager.js';
 
@@ -70,13 +74,10 @@ const boundValueFor = (
 };
 
 describe('sleepRepository placeholder integrity', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockClient: any;
+  let mockClient: MockDbClient;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const queryCalls = (): Array<{ text: string; values?: any[] }> =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    mockClient.query.mock.calls.map((call: any[]) => ({
+  const queryCalls = (): Array<{ text: string; values?: unknown[] }> =>
+    mockClient.query.mock.calls.map((call) => ({
       text: call[0],
       values: call[1],
     }));
@@ -88,10 +89,7 @@ describe('sleepRepository placeholder integrity', () => {
   };
 
   beforeEach(() => {
-    mockClient = {
-      query: vi.fn().mockResolvedValue({ rows: [] }),
-      release: vi.fn(),
-    };
+    mockClient = createMockDbClient([]);
     vi.mocked(getClient).mockResolvedValue(mockClient);
   });
 
@@ -100,7 +98,6 @@ describe('sleepRepository placeholder integrity', () => {
   });
 
   it('upsertSleepEntry INSERT: placeholders, columns, and params line up', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockClient.query.mockImplementation(async (text: string) => {
       if (text.includes('INSERT INTO sleep_entries')) {
         return { rows: [{ id: 'sleep-1' }] };
@@ -131,7 +128,6 @@ describe('sleepRepository placeholder integrity', () => {
   });
 
   it('upsertSleepEntry UPDATE: placeholders and zone-column bindings line up', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockClient.query.mockImplementation(async (text: string) => {
       if (text.includes('SELECT id FROM sleep_entries')) {
         return { rows: [{ id: 'sleep-1' }] };
@@ -160,7 +156,6 @@ describe('sleepRepository placeholder integrity', () => {
   });
 
   it('upsertSleepEntry UPDATE preserves stored zone metadata when the payload omits it', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockClient.query.mockImplementation(async (text: string) => {
       if (text.includes('SELECT id FROM sleep_entries')) {
         return { rows: [{ id: 'sleep-1' }] };
@@ -193,7 +188,6 @@ describe('sleepRepository placeholder integrity', () => {
   });
 
   it('updateSleepEntry dynamic builder: zone fields update when present', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockClient.query.mockImplementation(async (text: string) => {
       if (text.includes('UPDATE sleep_entries')) {
         return { rows: [{ id: 'sleep-1' }] };
@@ -219,7 +213,6 @@ describe('sleepRepository placeholder integrity', () => {
   });
 
   it('updateSleepEntry dynamic builder: omitted zone fields stay untouched', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     mockClient.query.mockImplementation(async (text: string) => {
       if (text.includes('UPDATE sleep_entries')) {
         return { rows: [{ id: 'sleep-1' }] };

--- a/SparkyFitnessServer/tests/sleepRepository.placeholders.test.ts
+++ b/SparkyFitnessServer/tests/sleepRepository.placeholders.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import sleepRepository from '../models/sleepRepository.js';
+import { getClient } from '../db/poolManager.js';
+
+vi.mock('../db/poolManager.js', () => ({
+  getClient: vi.fn(),
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+// Placeholder-integrity guard for the hand-numbered SQL in sleepRepository:
+// a miscounted $N corrupts every provider's sleep writes silently (values
+// land in the wrong columns), so these tests pin placeholder count to param
+// count and pin the recording-zone columns to their bound values.
+
+const FULL_ENTRY = {
+  entry_date: '2026-08-01',
+  bedtime: new Date('2026-08-01T03:00:00Z'),
+  wake_time: new Date('2026-08-01T11:00:00Z'),
+  duration_in_seconds: 28800,
+  time_asleep_in_seconds: 27000,
+  sleep_score: 82,
+  source: 'Health Connect',
+  deep_sleep_seconds: 5400,
+  light_sleep_seconds: 14400,
+  rem_sleep_seconds: 5400,
+  awake_sleep_seconds: 1800,
+  average_spo2_value: 96,
+  lowest_spo2_value: 91,
+  highest_spo2_value: 99,
+  average_respiration_value: 14,
+  lowest_respiration_value: 12,
+  highest_respiration_value: 17,
+  awake_count: 2,
+  avg_sleep_stress: 18,
+  restless_moments_count: 5,
+  avg_overnight_hrv: 52,
+  body_battery_change: 40,
+  resting_heart_rate: 54,
+  record_timezone: 'America/New_York',
+  record_utc_offset_minutes: -300,
+};
+
+const maxPlaceholder = (sql: string): number => {
+  const matches = sql.match(/\$(\d+)/g) || [];
+  return matches.reduce((max, m) => Math.max(max, Number(m.slice(1))), 0);
+};
+
+const distinctPlaceholders = (sql: string): number =>
+  new Set(sql.match(/\$(\d+)/g) || []).size;
+
+// Returns the param bound to `column = $N` (or `column = COALESCE($N, ...)`)
+// in an UPDATE without building a dynamic RegExp
+// (security/detect-non-literal-regexp).
+const boundValueFor = (
+  sql: string,
+  values: unknown[],
+  column: string
+): unknown => {
+  for (const marker of [`${column} = $`, `${column} = COALESCE($`]) {
+    const at = sql.indexOf(marker);
+    if (at !== -1) {
+      const digits = sql.slice(at + marker.length).match(/^\d+/);
+      expect(digits).toBeTruthy();
+      return values[Number(digits![0]) - 1];
+    }
+  }
+  throw new Error(`expected "${column} = $N" in the UPDATE`);
+};
+
+describe('sleepRepository placeholder integrity', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const queryCalls = (): Array<{ text: string; values?: any[] }> =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockClient.query.mock.calls.map((call: any[]) => ({
+      text: call[0],
+      values: call[1],
+    }));
+
+  const findCall = (fragment: string) => {
+    const call = queryCalls().find((c) => c.text.includes(fragment));
+    expect(call, `expected a query containing "${fragment}"`).toBeDefined();
+    return call!;
+  };
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn().mockResolvedValue({ rows: [] }),
+      release: vi.fn(),
+    };
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('upsertSleepEntry INSERT: placeholders, columns, and params line up', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockClient.query.mockImplementation(async (text: string) => {
+      if (text.includes('INSERT INTO sleep_entries')) {
+        return { rows: [{ id: 'sleep-1' }] };
+      }
+      return { rows: [] }; // existing-entry check finds nothing
+    });
+
+    await sleepRepository.upsertSleepEntry('user-1', 'user-1', FULL_ENTRY);
+
+    const insert = findCall('INSERT INTO sleep_entries');
+    const columns = insert.text
+      .slice(insert.text.indexOf('(') + 1, insert.text.indexOf(')'))
+      .split(',')
+      .map((c) => c.trim());
+
+    expect(columns.length).toBe(insert.values!.length);
+    expect(distinctPlaceholders(insert.text)).toBe(insert.values!.length);
+    expect(maxPlaceholder(insert.text)).toBe(insert.values!.length);
+
+    expect(insert.values![columns.indexOf('record_timezone')]).toBe(
+      'America/New_York'
+    );
+    expect(insert.values![columns.indexOf('record_utc_offset_minutes')]).toBe(
+      -300
+    );
+    // Spot-check a neighbor to catch off-by-one shifts.
+    expect(insert.values![columns.indexOf('resting_heart_rate')]).toBe(54);
+  });
+
+  it('upsertSleepEntry UPDATE: placeholders and zone-column bindings line up', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockClient.query.mockImplementation(async (text: string) => {
+      if (text.includes('SELECT id FROM sleep_entries')) {
+        return { rows: [{ id: 'sleep-1' }] };
+      }
+      if (text.includes('UPDATE sleep_entries')) {
+        return { rows: [{ id: 'sleep-1' }] };
+      }
+      return { rows: [] };
+    });
+
+    await sleepRepository.upsertSleepEntry('user-1', 'user-1', FULL_ENTRY);
+
+    const update = findCall('UPDATE sleep_entries');
+    expect(distinctPlaceholders(update.text)).toBe(update.values!.length);
+    expect(maxPlaceholder(update.text)).toBe(update.values!.length);
+
+    expect(boundValueFor(update.text, update.values!, 'record_timezone')).toBe(
+      'America/New_York'
+    );
+    expect(
+      boundValueFor(update.text, update.values!, 'record_utc_offset_minutes')
+    ).toBe(-300);
+    expect(
+      boundValueFor(update.text, update.values!, 'resting_heart_rate')
+    ).toBe(54);
+  });
+
+  it('upsertSleepEntry UPDATE preserves stored zone metadata when the payload omits it', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockClient.query.mockImplementation(async (text: string) => {
+      if (text.includes('SELECT id FROM sleep_entries')) {
+        return { rows: [{ id: 'sleep-1' }] };
+      }
+      if (text.includes('UPDATE sleep_entries')) {
+        return { rows: [{ id: 'sleep-1' }] };
+      }
+      return { rows: [] };
+    });
+
+    const {
+      record_timezone: _tz,
+      record_utc_offset_minutes: _offset,
+      ...zonelessEntry
+    } = FULL_ENTRY;
+    await sleepRepository.upsertSleepEntry('user-1', 'user-1', zonelessEntry);
+
+    const update = findCall('UPDATE sleep_entries');
+    // A metadata-less re-sync (older client, provider fallback branch) binds
+    // NULL for both zone params; COALESCE keeps the stored values instead of
+    // erasing them.
+    expect(update.text).toContain('record_timezone = COALESCE(');
+    expect(update.text).toContain('record_utc_offset_minutes = COALESCE(');
+    expect(
+      boundValueFor(update.text, update.values!, 'record_timezone')
+    ).toBeUndefined();
+    expect(
+      boundValueFor(update.text, update.values!, 'record_utc_offset_minutes')
+    ).toBeUndefined();
+  });
+
+  it('updateSleepEntry dynamic builder: zone fields update when present', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockClient.query.mockImplementation(async (text: string) => {
+      if (text.includes('UPDATE sleep_entries')) {
+        return { rows: [{ id: 'sleep-1' }] };
+      }
+      return { rows: [] };
+    });
+
+    await sleepRepository.updateSleepEntry('user-1', 'sleep-1', 'acting-1', {
+      record_timezone: 'Asia/Tokyo',
+      record_utc_offset_minutes: 540,
+    });
+
+    const update = findCall('UPDATE sleep_entries');
+    expect(distinctPlaceholders(update.text)).toBe(update.values!.length);
+    expect(maxPlaceholder(update.text)).toBe(update.values!.length);
+
+    expect(boundValueFor(update.text, update.values!, 'record_timezone')).toBe(
+      'Asia/Tokyo'
+    );
+    expect(
+      boundValueFor(update.text, update.values!, 'record_utc_offset_minutes')
+    ).toBe(540);
+  });
+
+  it('updateSleepEntry dynamic builder: omitted zone fields stay untouched', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockClient.query.mockImplementation(async (text: string) => {
+      if (text.includes('UPDATE sleep_entries')) {
+        return { rows: [{ id: 'sleep-1' }] };
+      }
+      return { rows: [] };
+    });
+
+    await sleepRepository.updateSleepEntry('user-1', 'sleep-1', 'acting-1', {
+      duration_in_seconds: 25200,
+    });
+
+    const update = findCall('UPDATE sleep_entries');
+    expect(update.text).not.toContain('record_timezone');
+    expect(update.text).not.toContain('record_utc_offset_minutes');
+    expect(distinctPlaceholders(update.text)).toBe(update.values!.length);
+  });
+});

--- a/SparkyFitnessServer/tests/sleepScienceService.recordZone.test.ts
+++ b/SparkyFitnessServer/tests/sleepScienceService.recordZone.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getChronotype } from '../services/sleepScienceService.js';
+import sleepScienceRepository from '../models/sleepScienceRepository.js';
+import { loadUserTimezone } from '../utils/timezoneLoader.js';
+
+vi.mock('../models/sleepScienceRepository');
+vi.mock('../utils/timezoneLoader', () => ({
+  loadUserTimezone: vi.fn(),
+}));
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+// Issue #2033: sleep-science wall-clock hours must derive from the zone each
+// entry was recorded in (record_timezone, else record_utc_offset_minutes),
+// falling back to the profile timezone only for zone-less rows. Otherwise a
+// Tokyo-recorded 23:00 bedtime reads as 14:00 for a UTC-profile user.
+
+type ChronotypeResult = {
+  success: boolean;
+  averageSleepTime: string | null;
+  averageWakeTime: string;
+};
+
+// Seven identical nights: bedtime 14:00 UTC (= 23:00 in Tokyo), wake
+// 22:00 UTC (= 07:00 in Tokyo). Identical values make the medians exact.
+const NIGHTS = ['24', '25', '26', '27', '28', '29', '30'].map((d) => ({
+  date: `2026-05-${d}`,
+  sleepStartTimestampGMT: new Date(`2026-05-${d}T14:00:00Z`).getTime(),
+  sleepEndTimestampGMT: new Date(`2026-05-${d}T22:00:00Z`).getTime(),
+}));
+
+const withZone = (
+  record_timezone: string | null,
+  record_utc_offset_minutes: number | null
+) => NIGHTS.map((n) => ({ ...n, record_timezone, record_utc_offset_minutes }));
+
+describe('sleep science hours honor the per-entry recording zone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(loadUserTimezone).mockResolvedValue('UTC');
+  });
+
+  it('derives hours from record_timezone when it differs from the profile tz', async () => {
+    vi.mocked(sleepScienceRepository.getSleepHistory).mockResolvedValue(
+      withZone('Asia/Tokyo', null)
+    );
+    const res = (await getChronotype('user-1')) as unknown as ChronotypeResult;
+    expect(res.success).toBe(true);
+    expect(res.averageSleepTime).toBe('23:00');
+    expect(res.averageWakeTime).toBe('07:00');
+  });
+
+  it('derives hours from record_utc_offset_minutes when no IANA zone is stored', async () => {
+    vi.mocked(sleepScienceRepository.getSleepHistory).mockResolvedValue(
+      withZone(null, 540)
+    );
+    const res = (await getChronotype('user-1')) as unknown as ChronotypeResult;
+    expect(res.success).toBe(true);
+    expect(res.averageSleepTime).toBe('23:00');
+    expect(res.averageWakeTime).toBe('07:00');
+  });
+
+  it('prefers a valid record_timezone over a contradictory offset', async () => {
+    vi.mocked(sleepScienceRepository.getSleepHistory).mockResolvedValue(
+      withZone('Asia/Tokyo', -300)
+    );
+    const res = (await getChronotype('user-1')) as unknown as ChronotypeResult;
+    expect(res.success).toBe(true);
+    expect(res.averageWakeTime).toBe('07:00');
+  });
+
+  it('falls back to the offset when the stored IANA zone is invalid', async () => {
+    vi.mocked(sleepScienceRepository.getSleepHistory).mockResolvedValue(
+      withZone('Not/AZone', 540)
+    );
+    const res = (await getChronotype('user-1')) as unknown as ChronotypeResult;
+    expect(res.success).toBe(true);
+    expect(res.averageWakeTime).toBe('07:00');
+  });
+
+  it('falls back to the profile timezone for zone-less rows (pre-migration data)', async () => {
+    vi.mocked(sleepScienceRepository.getSleepHistory).mockResolvedValue(
+      withZone(null, null)
+    );
+    const res = (await getChronotype('user-1')) as unknown as ChronotypeResult;
+    expect(res.success).toBe(true);
+    expect(res.averageSleepTime).toBe('14:00');
+    expect(res.averageWakeTime).toBe('22:00');
+  });
+});

--- a/SparkyFitnessServer/tests/timezone.test.ts
+++ b/SparkyFitnessServer/tests/timezone.test.ts
@@ -444,6 +444,23 @@ describe('resolveRecordZone', () => {
     expect(resolveRecordZone('', NaN)).toBeNull();
     expect(resolveRecordZone(null, Infinity)).toBeNull();
   });
+  it('rejects fractional and out-of-range offsets (falls back to profile tz)', () => {
+    expect(resolveRecordZone(null, 90.5)).toBeNull();
+    expect(resolveRecordZone(null, 100000)).toBeNull();
+    expect(resolveRecordZone(null, -100000)).toBeNull();
+  });
+  it('accepts the ±14:00 spec boundary but nothing past it', () => {
+    expect(resolveRecordZone(null, 840)).toEqual({
+      kind: 'offset',
+      minutes: 840,
+    });
+    expect(resolveRecordZone(null, -840)).toEqual({
+      kind: 'offset',
+      minutes: -840,
+    });
+    expect(resolveRecordZone(null, 841)).toBeNull();
+    expect(resolveRecordZone(null, -841)).toBeNull();
+  });
 });
 // ---------------------------------------------------------------------------
 // instantHourMinuteInZone
@@ -498,5 +515,17 @@ describe('utcOffsetMinutesFromIsoString', () => {
     expect(
       utcOffsetMinutesFromIsoString('2024-06-15T22:15:00+05:99')
     ).toBeNull();
+  });
+  it('ignores a ±HH:MM suffix on a malformed datetime', () => {
+    expect(utcOffsetMinutesFromIsoString('T+05:30')).toBeNull();
+    expect(utcOffsetMinutesFromIsoString('yesterday 10pm +05:30')).toBeNull();
+    expect(utcOffsetMinutesFromIsoString('2024-06-15 +05:30')).toBeNull();
+    expect(utcOffsetMinutesFromIsoString('22:15:00+05:30')).toBeNull();
+  });
+  it('accepts seconds-less and space-separated datetimes with offsets', () => {
+    expect(utcOffsetMinutesFromIsoString('2024-06-15T22:15+05:30')).toBe(330);
+    expect(utcOffsetMinutesFromIsoString('2024-06-15 22:15:00-04:00')).toBe(
+      -240
+    );
   });
 });

--- a/SparkyFitnessServer/tests/timezone.test.ts
+++ b/SparkyFitnessServer/tests/timezone.test.ts
@@ -12,6 +12,9 @@ import {
   instantHourMinute,
   instantToDayWithOffset,
   instantHourMinuteWithOffset,
+  instantHourMinuteInZone,
+  resolveRecordZone,
+  utcOffsetMinutesFromIsoString,
   dayToUtcRange,
   dayRangeToUtcRange,
 } from '@workspace/shared';
@@ -408,5 +411,92 @@ describe('instantHourMinuteWithOffset', () => {
     const fromOffset = instantHourMinuteWithOffset(ts, 540);
     const fromIana = instantHourMinute(ts, 'Asia/Tokyo');
     expect(fromOffset).toEqual(fromIana);
+  });
+});
+// ---------------------------------------------------------------------------
+// resolveRecordZone
+// ---------------------------------------------------------------------------
+describe('resolveRecordZone', () => {
+  it('prefers a valid IANA timezone over an offset', () => {
+    expect(resolveRecordZone('Asia/Tokyo', -300)).toEqual({
+      kind: 'tz',
+      tz: 'Asia/Tokyo',
+    });
+  });
+  it('falls back to the offset for an invalid or empty timezone', () => {
+    expect(resolveRecordZone('Not/AZone', -300)).toEqual({
+      kind: 'offset',
+      minutes: -300,
+    });
+    expect(resolveRecordZone('', 60)).toEqual({ kind: 'offset', minutes: 60 });
+    expect(resolveRecordZone(null, 330)).toEqual({
+      kind: 'offset',
+      minutes: 330,
+    });
+  });
+  it('honors offset 0 (UTC is a real zone claim, not "absent")', () => {
+    expect(resolveRecordZone(null, 0)).toEqual({ kind: 'offset', minutes: 0 });
+  });
+  it('returns null when neither field is usable', () => {
+    expect(resolveRecordZone(null, null)).toBeNull();
+    expect(resolveRecordZone(undefined, undefined)).toBeNull();
+    expect(resolveRecordZone('Not/AZone', null)).toBeNull();
+    expect(resolveRecordZone('', NaN)).toBeNull();
+    expect(resolveRecordZone(null, Infinity)).toBeNull();
+  });
+});
+// ---------------------------------------------------------------------------
+// instantHourMinuteInZone
+// ---------------------------------------------------------------------------
+describe('instantHourMinuteInZone', () => {
+  const ts = new Date('2024-06-15T15:45:00Z');
+  it('dispatches to the IANA path for tz zones', () => {
+    expect(
+      instantHourMinuteInZone(ts, { kind: 'tz', tz: 'Asia/Tokyo' })
+    ).toEqual({ hour: 0, minute: 45 });
+  });
+  it('dispatches to the fixed-offset path for offset zones', () => {
+    expect(
+      instantHourMinuteInZone(ts, { kind: 'offset', minutes: -240 })
+    ).toEqual({ hour: 11, minute: 45 });
+  });
+});
+// ---------------------------------------------------------------------------
+// utcOffsetMinutesFromIsoString
+// ---------------------------------------------------------------------------
+describe('utcOffsetMinutesFromIsoString', () => {
+  it('parses explicit positive and negative offsets', () => {
+    expect(utcOffsetMinutesFromIsoString('2024-06-15T22:15:00+05:30')).toBe(
+      330
+    );
+    expect(utcOffsetMinutesFromIsoString('2024-06-15T22:15:00-04:00')).toBe(
+      -240
+    );
+    expect(utcOffsetMinutesFromIsoString('2024-06-15T22:15:00.123+01:00')).toBe(
+      60
+    );
+    expect(utcOffsetMinutesFromIsoString('2024-06-15T22:15:00+0000')).toBe(0);
+  });
+  it('treats Z as no zone claim (APIs normalize instants to UTC)', () => {
+    expect(utcOffsetMinutesFromIsoString('2024-06-15T22:15:00Z')).toBeNull();
+    expect(
+      utcOffsetMinutesFromIsoString('2024-06-15T22:15:00.000Z')
+    ).toBeNull();
+  });
+  it('returns null for naive, date-only, and unparseable input', () => {
+    expect(utcOffsetMinutesFromIsoString('2024-06-15T22:15:00')).toBeNull();
+    expect(utcOffsetMinutesFromIsoString('2024-06-15')).toBeNull();
+    expect(utcOffsetMinutesFromIsoString('garbage')).toBeNull();
+    expect(utcOffsetMinutesFromIsoString('')).toBeNull();
+    expect(utcOffsetMinutesFromIsoString(null)).toBeNull();
+    expect(utcOffsetMinutesFromIsoString(undefined)).toBeNull();
+  });
+  it('rejects offsets outside the real-world range', () => {
+    expect(
+      utcOffsetMinutesFromIsoString('2024-06-15T22:15:00+15:00')
+    ).toBeNull();
+    expect(
+      utcOffsetMinutesFromIsoString('2024-06-15T22:15:00+05:99')
+    ).toBeNull();
   });
 });

--- a/SparkyFitnessServer/tests/timezone.test.ts
+++ b/SparkyFitnessServer/tests/timezone.test.ts
@@ -500,6 +500,15 @@ describe('utcOffsetMinutesFromIsoString', () => {
       utcOffsetMinutesFromIsoString('2024-06-15T22:15:00.000Z')
     ).toBeNull();
   });
+  it('treats -00:00 as unknown offset (RFC 3339 §4.3), unlike +00:00', () => {
+    expect(
+      utcOffsetMinutesFromIsoString('2024-06-15T22:15:00-00:00')
+    ).toBeNull();
+    expect(
+      utcOffsetMinutesFromIsoString('2024-06-15T22:15:00-0000')
+    ).toBeNull();
+    expect(utcOffsetMinutesFromIsoString('2024-06-15T22:15:00+00:00')).toBe(0);
+  });
   it('returns null for naive, date-only, and unparseable input', () => {
     expect(utcOffsetMinutesFromIsoString('2024-06-15T22:15:00')).toBeNull();
     expect(utcOffsetMinutesFromIsoString('2024-06-15')).toBeNull();

--- a/shared/src/schemas/database/SleepEntries.zod.ts
+++ b/shared/src/schemas/database/SleepEntries.zod.ts
@@ -39,6 +39,8 @@ export const sleepEntriesSchema = z.object({
   resting_heart_rate: z.number().nullable(),
   created_by_user_id: userIdSchema.nullable(),
   updated_by_user_id: userIdSchema.nullable(),
+  record_timezone: z.string().nullable(),
+  record_utc_offset_minutes: z.number().nullable(),
 });
 
 export const sleepEntriesInitializerSchema = z.object({
@@ -71,6 +73,8 @@ export const sleepEntriesInitializerSchema = z.object({
   resting_heart_rate: z.number().optional().nullable(),
   created_by_user_id: userIdSchema.optional().nullable(),
   updated_by_user_id: userIdSchema.optional().nullable(),
+  record_timezone: z.string().optional().nullable(),
+  record_utc_offset_minutes: z.number().optional().nullable(),
 });
 
 export const sleepEntriesMutatorSchema = z.object({
@@ -103,6 +107,8 @@ export const sleepEntriesMutatorSchema = z.object({
   resting_heart_rate: z.number().optional().nullable(),
   created_by_user_id: userIdSchema.optional().nullable(),
   updated_by_user_id: userIdSchema.optional().nullable(),
+  record_timezone: z.string().optional().nullable(),
+  record_utc_offset_minutes: z.number().optional().nullable(),
 });
 
 export type SleepEntries = z.infer<typeof sleepEntriesSchema>;

--- a/shared/src/utils/timezone.ts
+++ b/shared/src/utils/timezone.ts
@@ -283,9 +283,10 @@ export function instantHourMinuteInZone(
  * Extracts the UTC offset (in minutes) from an ISO datetime string's explicit
  * `±HH:MM` (or `±HHMM`) suffix. An explicit offset is a recording-zone claim;
  * `Z` is not (APIs routinely normalize instants to UTC), so `Z`-suffixed,
- * naive, date-only, and unparseable strings all return null. The suffix only
- * counts on a complete `YYYY-MM-DD` + time datetime — a stray `±HH:MM` on a
- * malformed string (e.g. free-text from a chat model) is not a zone claim.
+ * naive, date-only, and unparseable strings all return null, as does the
+ * RFC 3339 unknown-offset form `-00:00`. The suffix only counts on a
+ * complete `YYYY-MM-DD` + time datetime — a stray `±HH:MM` on a malformed
+ * string (e.g. free-text from a chat model) is not a zone claim.
  */
 export function utcOffsetMinutesFromIsoString(
   timeStr: string | null | undefined,
@@ -301,6 +302,9 @@ export function utcOffsetMinutesFromIsoString(
   if (mins > 59) return null;
   const total = hours * 60 + mins;
   if (total > MAX_UTC_OFFSET_MINUTES) return null;
+  // RFC 3339 §4.3: "-00:00" declares the local offset unknown — like `Z`,
+  // not a zone claim. "+00:00" is a genuine UTC claim and stays 0.
+  if (m[1] === "-" && total === 0) return null;
   return m[1] === "-" ? -total : total;
 }
 

--- a/shared/src/utils/timezone.ts
+++ b/shared/src/utils/timezone.ts
@@ -220,6 +220,81 @@ export function instantHourMinuteWithOffset(
 }
 
 // ---------------------------------------------------------------------------
+// Record-zone precedence (per-entry recording timezone metadata)
+// ---------------------------------------------------------------------------
+
+/**
+ * The zone a health record was captured in: a full IANA timezone, or a fixed
+ * UTC offset in minutes for sources that only report an offset. A fixed
+ * offset cannot follow DST, so a session spanning a transition can show up to
+ * 1h skew on one endpoint — accepted trade-off.
+ */
+export type RecordZone =
+  | { kind: "tz"; tz: string }
+  | { kind: "offset"; minutes: number };
+
+/**
+ * Resolves per-record timezone metadata with the standard precedence:
+ * valid IANA timezone -> finite UTC offset minutes -> null (caller falls back
+ * to the profile timezone). Never throws.
+ *
+ * The finite-number check is deliberately stricter than the inline precedence
+ * chains in measurementService.resolveHealthEntryDate, which pass NaN through;
+ * moving those chains onto this helper is a behavior change, not a pure
+ * refactor.
+ */
+export function resolveRecordZone(
+  recordTimezone: string | null | undefined,
+  recordUtcOffsetMinutes: number | null | undefined,
+): RecordZone | null {
+  if (
+    typeof recordTimezone === "string" &&
+    recordTimezone !== "" &&
+    isValidTimeZone(recordTimezone)
+  ) {
+    return { kind: "tz", tz: recordTimezone };
+  }
+  if (
+    typeof recordUtcOffsetMinutes === "number" &&
+    Number.isFinite(recordUtcOffsetMinutes)
+  ) {
+    return { kind: "offset", minutes: recordUtcOffsetMinutes };
+  }
+  return null;
+}
+
+/** Returns the hour and minute of an instant in a record zone (IANA or fixed offset). */
+export function instantHourMinuteInZone(
+  ts: Date | string | number,
+  zone: RecordZone,
+): { hour: number; minute: number } {
+  return zone.kind === "tz"
+    ? instantHourMinute(ts, zone.tz)
+    : instantHourMinuteWithOffset(ts, zone.minutes);
+}
+
+/**
+ * Extracts the UTC offset (in minutes) from an ISO datetime string's explicit
+ * `±HH:MM` (or `±HHMM`) suffix. An explicit offset is a recording-zone claim;
+ * `Z` is not (APIs routinely normalize instants to UTC), so `Z`-suffixed,
+ * naive, date-only, and unparseable strings all return null.
+ */
+export function utcOffsetMinutesFromIsoString(
+  timeStr: string | null | undefined,
+): number | null {
+  if (typeof timeStr !== "string") return null;
+  const m = /[T ].*([+-])(\d{2}):?(\d{2})$/.exec(timeStr.trim());
+  if (!m) return null;
+  const hours = Number(m[2]);
+  const mins = Number(m[3]);
+  if (mins > 59) return null;
+  const total = hours * 60 + mins;
+  // Real-world offsets top out at ±14:00 (spec maximum)
+  if (total > 14 * 60) return null;
+  return m[1] === "-" ? -total : total;
+}
+
+// ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 

--- a/shared/src/utils/timezone.ts
+++ b/shared/src/utils/timezone.ts
@@ -223,6 +223,9 @@ export function instantHourMinuteWithOffset(
 // Record-zone precedence (per-entry recording timezone metadata)
 // ---------------------------------------------------------------------------
 
+/** Real-world UTC offsets top out at ±14:00 (spec maximum). */
+const MAX_UTC_OFFSET_MINUTES = 14 * 60;
+
 /**
  * The zone a health record was captured in: a full IANA timezone, or a fixed
  * UTC offset in minutes for sources that only report an offset. A fixed
@@ -235,13 +238,15 @@ export type RecordZone =
 
 /**
  * Resolves per-record timezone metadata with the standard precedence:
- * valid IANA timezone -> finite UTC offset minutes -> null (caller falls back
- * to the profile timezone). Never throws.
+ * valid IANA timezone -> integer UTC offset within ±14h -> null (caller falls
+ * back to the profile timezone). Never throws.
  *
- * The finite-number check is deliberately stricter than the inline precedence
- * chains in measurementService.resolveHealthEntryDate, which pass NaN through;
- * moving those chains onto this helper is a behavior change, not a pure
- * refactor.
+ * The integer-within-range check is deliberately stricter than the inline
+ * precedence chains in measurementService.resolveHealthEntryDate, which pass
+ * NaN through; moving those chains onto this helper is a behavior change, not
+ * a pure refactor. Stored metadata bypasses the ingestion caps (direct API
+ * writes forward offsets raw), so an out-of-range value must fail here rather
+ * than drive display.
  */
 export function resolveRecordZone(
   recordTimezone: string | null | undefined,
@@ -256,7 +261,8 @@ export function resolveRecordZone(
   }
   if (
     typeof recordUtcOffsetMinutes === "number" &&
-    Number.isFinite(recordUtcOffsetMinutes)
+    Number.isInteger(recordUtcOffsetMinutes) &&
+    Math.abs(recordUtcOffsetMinutes) <= MAX_UTC_OFFSET_MINUTES
   ) {
     return { kind: "offset", minutes: recordUtcOffsetMinutes };
   }
@@ -277,20 +283,24 @@ export function instantHourMinuteInZone(
  * Extracts the UTC offset (in minutes) from an ISO datetime string's explicit
  * `±HH:MM` (or `±HHMM`) suffix. An explicit offset is a recording-zone claim;
  * `Z` is not (APIs routinely normalize instants to UTC), so `Z`-suffixed,
- * naive, date-only, and unparseable strings all return null.
+ * naive, date-only, and unparseable strings all return null. The suffix only
+ * counts on a complete `YYYY-MM-DD` + time datetime — a stray `±HH:MM` on a
+ * malformed string (e.g. free-text from a chat model) is not a zone claim.
  */
 export function utcOffsetMinutesFromIsoString(
   timeStr: string | null | undefined,
 ): number | null {
   if (typeof timeStr !== "string") return null;
-  const m = /[T ].*([+-])(\d{2}):?(\d{2})$/.exec(timeStr.trim());
+  const m =
+    /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?([+-])(\d{2}):?(\d{2})$/.exec(
+      timeStr.trim(),
+    );
   if (!m) return null;
   const hours = Number(m[2]);
   const mins = Number(m[3]);
   if (mins > 59) return null;
   const total = hours * 60 + mins;
-  // Real-world offsets top out at ±14:00 (spec maximum)
-  if (total > 14 * 60) return null;
+  if (total > MAX_UTC_OFFSET_MINUTES) return null;
   return m[1] === "-" ? -total : total;
 }
 


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Sleep bed/wake times were stored as UTC instants without data on how they were recorded so every display falls back to the user's current time zone. Travel across time zones relabeled history.

**How did you implement the solution?**

Add two columns to sleep_entries, record_timezone (IANA) and record_utc_offset_minutes. When importing the system will fill in the timezone based on the data provided and the priority: IANA timezone, then the offset, and finally use the users saved time zone preference. Entry date bucketing is untouched and there's no backfill. This will only apply to new sleep entries.

Known limitations to be addressed in a follow up PR:

- fixed offset can't follow daylight savings time inside a session. So in november when clocks fall back things will be 1hr off
- Sleep timeline editor still shows browser local times.

Linked Issue: Closes #2033 

## How to Test

1. Check out branch
2. Import or manually add sleep data
3. Change time zones
4. Verify the times still display correctly

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sleep records now preserve their original timezone or UTC offset when available.
  * Imported and manually entered sleep data retains recording-time metadata.
  * Sleep reports, charts, timelines, and analytics display times in the recorded timezone, with profile timezone fallback.
  * Sleep imports support optional recording timezone and UTC offset fields.

* **Bug Fixes**
  * Improved daylight-saving and cross-midnight sleep handling.
  * Prevented missing timestamps from appearing as incorrect chart points.
  * Invalid fractional UTC offsets are now rejected during import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->