### PR TITLE
feat(mobile): Add Per Set Rest Periods Editing and Functionality

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/WorkoutFormExerciseList.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/WorkoutFormExerciseList.test.tsx
@@ -189,20 +189,20 @@ jest.mock('../../src/components/ActionSheet', () => {
 
 const mockRestSheet: {
   present: jest.Mock;
-  onChange: ((seconds: number) => void) | null;
-} = { present: jest.fn(), onChange: null };
+  onApply: ((updates: { setId: string; seconds: number }[]) => void) | null;
+} = { present: jest.fn(), onApply: null };
 
-jest.mock('../../src/components/RestPeriodSheet', () => {
+jest.mock('../../src/components/ExerciseSetRestSheet', () => {
   const React = require('react');
   return {
     __esModule: true,
-    default: React.forwardRef(({ onChange }: any, ref: any) => {
+    default: React.forwardRef(({ onApply }: any, ref: any) => {
       React.useImperativeHandle(ref, () => ({
         present: mockRestSheet.present,
         dismiss: jest.fn(),
       }));
       React.useEffect(() => {
-        mockRestSheet.onChange = onChange;
+        mockRestSheet.onApply = onApply;
       });
       return null;
     }),
@@ -731,9 +731,35 @@ describe('WorkoutFormExerciseList', () => {
   it('targets the rest sheet at the pressed exercise', () => {
     const utils = renderList([makeExercise('a'), makeExercise('b')]);
     fireEvent.press(utils.getByTestId('card-b-rest'));
-    expect(mockRestSheet.present).toHaveBeenCalledWith(90);
+    expect(mockRestSheet.present).toHaveBeenCalledWith('B', [
+      {
+        setId: 'b-s1',
+        setNumber: 1,
+        restSec: 90,
+      },
+    ], false);
 
-    mockRestSheet.onChange?.(120);
+    mockRestSheet.onApply?.([{ setId: 'b-s1', seconds: 120 }]);
+    expect(utils.callbacks.setExerciseRest).toHaveBeenCalledWith('b', 120);
+  });
+
+  it('targets the rest sheet for superset members and calls setExerciseRest', () => {
+    const supersetExerciseA = makeExercise('a', { supersetGroup: 1 });
+    const supersetExerciseB = makeExercise('b', { supersetGroup: 1 });
+    const utils = renderList([supersetExerciseA, supersetExerciseB]);
+    
+    fireEvent.press(utils.getByTestId('card-b-rest'));
+    // For superset members, isSupersetRound should be true
+    expect(mockRestSheet.present).toHaveBeenCalledWith('B', [
+      {
+        setId: 'b-s1',
+        setNumber: 1,
+        restSec: 90,
+      },
+    ], true);
+
+    // When superset member rest is applied, use setExerciseRest regardless of matching sets
+    mockRestSheet.onApply?.([{ setId: 'b-s1', seconds: 120 }]);
     expect(utils.callbacks.setExerciseRest).toHaveBeenCalledWith('b', 120);
   });
 

--- a/SparkyFitnessMobile/__tests__/screens/WorkoutPresetDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/WorkoutPresetDetailScreen.test.tsx
@@ -318,7 +318,7 @@ describe('WorkoutPresetDetailScreen', () => {
     expect(screen.getByText('220.5')).toBeTruthy();
   });
 
-  it('shows one exercise-level rest chip from the first set (mixed rest degrades to it)', () => {
+  it('shows one exercise-level rest chip spanning the min-max of its sets when rest times differ', () => {
     const preset = buildPreset({
       exercises: [
         {
@@ -336,7 +336,8 @@ describe('WorkoutPresetDetailScreen', () => {
     });
     const screen = renderScreen(preset);
 
-    expect(screen.getByLabelText('Rest 45s')).toBeTruthy();
+    expect(screen.getByLabelText('Rest 45s-2:00')).toBeTruthy();
+    expect(screen.queryByLabelText('Rest 45s')).toBeNull();
     expect(screen.queryByLabelText('Rest 1:30')).toBeNull();
     expect(screen.queryByLabelText('Rest 2:00')).toBeNull();
   });

--- a/SparkyFitnessMobile/__tests__/stores/activeWorkoutStore.test.ts
+++ b/SparkyFitnessMobile/__tests__/stores/activeWorkoutStore.test.ts
@@ -296,13 +296,13 @@ describe('activeWorkoutStore', () => {
       expect(steps[2].restSec).toBe(120);
     });
 
-    it('falls back to 90s when rest_time is null', () => {
+    it('falls back to 90s when a set rest_time is null', () => {
       const session = makeSession();
       session.exercises[0].sets[0].rest_time = null;
       useActiveWorkoutStore.getState().startWorkout(session);
       const { steps } = useActiveWorkoutStore.getState();
       expect(steps[0].restSec).toBe(90);
-      expect(steps[1].restSec).toBe(90);
+      expect(steps[1].restSec).toBe(60);
     });
 
     it('snapshots exerciseName and exerciseImage per step', () => {
@@ -1861,15 +1861,15 @@ describe('activeWorkoutStore', () => {
       expect(completedSetIds['101']).toBe(FIXED_NOW);
     });
 
-    it('refreshes restSec on every step when first set rest_time changes', () => {
+    it('keeps each set restSec tied to that set when one set rest_time changes', () => {
       const updated = makeSession();
       updated.exercises[0].sets[0].rest_time = 180;
-      updated.exercises[0].sets[1].rest_time = 60; // unchanged; should still be overridden
+      updated.exercises[0].sets[1].rest_time = 60;
 
       useActiveWorkoutStore.getState().reconcileWithSession(updated);
       const { steps } = useActiveWorkoutStore.getState();
       expect(steps[0].restSec).toBe(180);
-      expect(steps[1].restSec).toBe(180);
+      expect(steps[1].restSec).toBe(60);
     });
 
     it('reorders steps to match new session order', () => {

--- a/SparkyFitnessMobile/__tests__/stores/activeWorkoutStore.test.ts
+++ b/SparkyFitnessMobile/__tests__/stores/activeWorkoutStore.test.ts
@@ -288,20 +288,24 @@ describe('activeWorkoutStore', () => {
       expect(state.activeSetId).toBe('101');
     });
 
-    it('derives restSec from the first set per exercise', () => {
-      useActiveWorkoutStore.getState().startWorkout(makeSession());
+    it('derives restSec from each set individually, not just the first', () => {
+      const session = makeSession();
+      session.exercises[0].sets[0].rest_time = 45;
+      session.exercises[0].sets[1].rest_time = 75;
+      useActiveWorkoutStore.getState().startWorkout(session);
       const { steps } = useActiveWorkoutStore.getState();
-      expect(steps[0].restSec).toBe(60);
-      expect(steps[1].restSec).toBe(60);
+      expect(steps[0].restSec).toBe(45);
+      expect(steps[1].restSec).toBe(75);
       expect(steps[2].restSec).toBe(120);
     });
 
-    it('falls back to 90s when a set rest_time is null', () => {
+    it('falls back to 90s only for the set whose rest_time is null', () => {
       const session = makeSession();
       session.exercises[0].sets[0].rest_time = null;
       useActiveWorkoutStore.getState().startWorkout(session);
       const { steps } = useActiveWorkoutStore.getState();
       expect(steps[0].restSec).toBe(90);
+      // Unaffected — each set uses its own rest_time, not the first set's.
       expect(steps[1].restSec).toBe(60);
     });
 
@@ -1233,10 +1237,45 @@ describe('activeWorkoutStore', () => {
     });
   });
 
+  describe('completeSet rest respects each set\'s own rest_time', () => {
+    it('uses the just-completed set\'s own rest_time, not the exercise\'s first set (regression)', async () => {
+      const session = makeSession();
+      session.exercises[0].sets[0].rest_time = 45;
+      session.exercises[0].sets[1].rest_time = 75;
+      useActiveWorkoutStore.getState().startWorkout(session);
+
+      useActiveWorkoutStore.getState().completeSet('101');
+      expect(useActiveWorkoutStore.getState().rest.durationSec).toBe(45);
+      await flushPromises();
+
+      useActiveWorkoutStore.getState().completeSet('102');
+      expect(useActiveWorkoutStore.getState().rest.durationSec).toBe(75);
+      await flushPromises();
+    });
+  });
+
   describe('completeSet rest (supersets)', () => {
     // Steps: 301(90), 401(0), 302(90), 402(0).
     beforeEach(() => {
       useActiveWorkoutStore.getState().startWorkout(makeSupersetSession(2));
+    });
+
+    it('uses the round-specific rest, not always round 0\'s (regression)', async () => {
+      const session = makeSupersetSession(3);
+      // Round 1 (index 1) has a shorter rest than round 0 and round 2.
+      session.exercises[0].sets[1].rest_time = 60;
+      session.exercises[1].sets[1].rest_time = 60;
+      useActiveWorkoutStore.getState().startWorkout(session);
+
+      useActiveWorkoutStore.getState().completeSet('301');
+      useActiveWorkoutStore.getState().completeSet('401'); // finishes round 0
+      expect(useActiveWorkoutStore.getState().rest.durationSec).toBe(90);
+      await flushPromises();
+
+      useActiveWorkoutStore.getState().completeSet('302');
+      useActiveWorkoutStore.getState().completeSet('402'); // finishes round 1
+      expect(useActiveWorkoutStore.getState().rest.durationSec).toBe(60);
+      await flushPromises();
     });
 
     it('rests between rounds but not between partners when logged in order', async () => {

--- a/SparkyFitnessMobile/src/components/ActiveWorkoutExerciseCard.tsx
+++ b/SparkyFitnessMobile/src/components/ActiveWorkoutExerciseCard.tsx
@@ -674,6 +674,7 @@ function ActiveWorkoutExerciseCard({
             {showRestChip && !cardioForm && (
               <RestPeriodChip
                 value={exercise.sets[0]?.rest_time}
+                values={exercise.sets.map((set) => set.rest_time)}
                 readOnly={readOnly}
                 onPress={
                   readOnly

--- a/SparkyFitnessMobile/src/components/DurationWheel.tsx
+++ b/SparkyFitnessMobile/src/components/DurationWheel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Text, View } from 'react-native';
 import WheelPicker, { type PickerOption as WheelPickerOption } from './ui/wheel-picker';
 import { useCSSVariable } from 'uniwind';
@@ -51,9 +51,24 @@ function DurationWheel({ valueSec, onChangeSec, maxSec = 900 }: DurationWheelPro
     [],
   );
 
-  // Map the logical seconds value to the middle repetition so the wheel has
-  // equal room to scroll in both directions before hitting an edge.
-  const secondsWheelValue = SEC_MID_OFFSET + currentSec;
+  // Raw seconds-wheel index (0..SEC_TOTAL-1), kept in local state instead of
+  // recomputed from currentSec every render. Recomputing it (always mid-offset
+  // + currentSec) would snap the wheel back to the middle repetition on its
+  // own echoed onChangeSec, which is jarring right when a scroll crosses a
+  // repetition boundary (e.g. index 359 "59" -> 360 "00"). We only reconcile
+  // this index below when valueSec changes for a reason other than our own
+  // handleSecondChange call.
+  const [secondsIndex, setSecondsIndex] = useState(() => SEC_MID_OFFSET + currentSec);
+  const lastEmittedSecRef = useRef(currentSec);
+
+  useEffect(() => {
+    if (currentSec !== lastEmittedSecRef.current) {
+      lastEmittedSecRef.current = currentSec;
+      setSecondsIndex(SEC_MID_OFFSET + currentSec);
+    }
+  }, [currentSec]);
+
+  const secondsWheelValue = secondsIndex;
 
   const indicatorStyle = useMemo(
     () => ({ backgroundColor: borderSubtle, borderRadius: 8 }),
@@ -72,8 +87,13 @@ function DurationWheel({ valueSec, onChangeSec, maxSec = 900 }: DurationWheelPro
   };
 
   const handleSecondChange = (v: number | string) => {
+    // Preserve the wheel's actual raw index (don't rebase to the middle
+    // repetition) so a scroll across a repetition boundary doesn't snap back.
+    const index = Number(v);
     // Strip the loop offset; the canonical value is always 0–59.
-    const s = Number(v) % 60;
+    const s = index % 60;
+    lastEmittedSecRef.current = s;
+    setSecondsIndex(index);
     const total = Math.max(0, Math.min(maxSec, currentMin * 60 + s));
     onChangeSec(total);
   };

--- a/SparkyFitnessMobile/src/components/DurationWheel.tsx
+++ b/SparkyFitnessMobile/src/components/DurationWheel.tsx
@@ -85,39 +85,48 @@ function DurationWheel({ valueSec, onChangeSec, maxSec = 900 }: DurationWheelPro
   };
 
   return (
-    <View
-      className="flex-row items-center justify-center"
-      style={{ height: ITEM_HEIGHT * 5 }}
-    >
-      <View className="flex-1">
-        <WheelPicker
-          value={currentMin}
-          options={minuteOptions}
-          onChange={handleMinuteChange}
-          selectedIndicatorStyle={indicatorStyle}
-          itemTextStyle={textStyle}
-          itemHeight={ITEM_HEIGHT}
-          decelerationRate="fast"
-        />
+    <View style={{ height: ITEM_HEIGHT * 5 + 22 }}>
+      <View className="flex-row items-center justify-center mb-1">
+        <Text className="flex-1 text-center text-xs font-semibold uppercase text-text-muted">
+          Minutes
+        </Text>
+        <View style={{ width: 18 }} />
+        <Text className="flex-1 text-center text-xs font-semibold uppercase text-text-muted">
+          Seconds
+        </Text>
       </View>
 
-      <Text
-        className="text-text-primary"
-        style={{ fontSize: 26, fontWeight: '300', marginHorizontal: 4, marginBottom: 2 }}
-      >
-        :
-      </Text>
+      <View className="flex-row items-center justify-center">
+        <View className="flex-1">
+          <WheelPicker
+            value={currentMin}
+            options={minuteOptions}
+            onChange={handleMinuteChange}
+            selectedIndicatorStyle={indicatorStyle}
+            itemTextStyle={textStyle}
+            itemHeight={ITEM_HEIGHT}
+            decelerationRate="fast"
+          />
+        </View>
 
-      <View className="flex-1">
-        <WheelPicker
-          value={secondsWheelValue}
-          options={secondOptions}
-          onChange={handleSecondChange}
-          selectedIndicatorStyle={indicatorStyle}
-          itemTextStyle={textStyle}
-          itemHeight={ITEM_HEIGHT}
-          decelerationRate="fast"
-        />
+        <Text
+          className="text-text-primary"
+          style={{ fontSize: 26, fontWeight: '300', marginHorizontal: 4, marginBottom: 2 }}
+        >
+          :
+        </Text>
+
+        <View className="flex-1">
+          <WheelPicker
+            value={secondsWheelValue}
+            options={secondOptions}
+            onChange={handleSecondChange}
+            selectedIndicatorStyle={indicatorStyle}
+            itemTextStyle={textStyle}
+            itemHeight={ITEM_HEIGHT}
+            decelerationRate="fast"
+          />
+        </View>
       </View>
     </View>
   );

--- a/SparkyFitnessMobile/src/components/DurationWheel.tsx
+++ b/SparkyFitnessMobile/src/components/DurationWheel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Text, View } from 'react-native';
 import WheelPicker, { type PickerOption as WheelPickerOption } from './ui/wheel-picker';
 import { useCSSVariable } from 'uniwind';
@@ -59,14 +59,14 @@ function DurationWheel({ valueSec, onChangeSec, maxSec = 900 }: DurationWheelPro
   // this index below when valueSec changes for a reason other than our own
   // handleSecondChange call.
   const [secondsIndex, setSecondsIndex] = useState(() => SEC_MID_OFFSET + currentSec);
-  const lastEmittedSecRef = useRef(currentSec);
+  const [lastEmittedSec, setLastEmittedSec] = useState(currentSec);
 
-  useEffect(() => {
-    if (currentSec !== lastEmittedSecRef.current) {
-      lastEmittedSecRef.current = currentSec;
-      setSecondsIndex(SEC_MID_OFFSET + currentSec);
-    }
-  }, [currentSec]);
+  // valueSec changes are reflected in the same commit rather than triggering an extra render.
+  // The "last known" value is plain state rather than a ref.
+  if (currentSec !== lastEmittedSec) {
+    setLastEmittedSec(currentSec);
+    setSecondsIndex(SEC_MID_OFFSET + currentSec);
+  }
 
   const secondsWheelValue = secondsIndex;
 
@@ -92,7 +92,7 @@ function DurationWheel({ valueSec, onChangeSec, maxSec = 900 }: DurationWheelPro
     const index = Number(v);
     // Strip the loop offset; the canonical value is always 0–59.
     const s = index % 60;
-    lastEmittedSecRef.current = s;
+    setLastEmittedSec(s);
     setSecondsIndex(index);
     const total = Math.max(0, Math.min(maxSec, currentMin * 60 + s));
     onChangeSec(total);

--- a/SparkyFitnessMobile/src/components/DurationWheel.tsx
+++ b/SparkyFitnessMobile/src/components/DurationWheel.tsx
@@ -1,11 +1,6 @@
 import { useMemo } from 'react';
 import { Text, View } from 'react-native';
-// Deep import: Metro resolves react-native-ui-datepicker via its "react-native"
-// field → src/index, so sub-path imports from src/ work at runtime and give us
-// the exact wheel component the library uses for its own time picker columns.
-import WheelPicker, {
-  type WheelPickerOption,
-} from 'react-native-ui-datepicker/src/components/time-picker/wheel-picker';
+import WheelPicker, { type PickerOption as WheelPickerOption } from './ui/wheel-picker';
 import { useCSSVariable } from 'uniwind';
 
 interface DurationWheelProps {

--- a/SparkyFitnessMobile/src/components/DurationWheel.tsx
+++ b/SparkyFitnessMobile/src/components/DurationWheel.tsx
@@ -3,7 +3,6 @@ import { Text, View } from 'react-native';
 // Deep import: Metro resolves react-native-ui-datepicker via its "react-native"
 // field → src/index, so sub-path imports from src/ work at runtime and give us
 // the exact wheel component the library uses for its own time picker columns.
-// eslint-disable-next-line import/no-internal-modules
 import WheelPicker, {
   type WheelPickerOption,
 } from 'react-native-ui-datepicker/src/components/time-picker/wheel-picker';

--- a/SparkyFitnessMobile/src/components/DurationWheel.tsx
+++ b/SparkyFitnessMobile/src/components/DurationWheel.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FlatList, Text, View } from 'react-native';
+import DateTimePicker, { type DateType } from 'react-native-ui-datepicker';
+import { useCSSVariable } from 'uniwind';
+
+interface DurationWheelProps {
+  valueSec: number;
+  onChangeSec: (seconds: number) => void;
+  maxSec?: number;
+}
+
+function dateTypeToDate(date: DateType): Date | null {
+  if (!date) return null;
+  if (date instanceof Date) return date;
+  if (typeof date === 'object' && 'toDate' in date) return date.toDate();
+  if (typeof date === 'string') return new Date(date);
+  return new Date(date);
+}
+
+function secondsToDate(seconds: number): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  const mins = Math.max(0, Math.floor(seconds / 60));
+  d.setMinutes(mins);
+  return d;
+}
+
+function dateToSeconds(date: Date): number {
+  return date.getHours() * 3600 + date.getMinutes() * 60;
+}
+
+const WHEEL_ROW_HEIGHT = 44;
+
+function splitSeconds(totalSec: number): { minuteSec: number; secondsPart: number } {
+  const clamped = Math.max(0, totalSec);
+  const minuteSec = Math.floor(clamped / 60) * 60;
+  const secondsPart = clamped % 60;
+  return { minuteSec, secondsPart };
+}
+
+function DurationWheel({ valueSec, onChangeSec, maxSec = 900 }: DurationWheelProps) {
+  const [accentPrimary, textPrimary, borderSubtle, textMuted] = useCSSVariable([
+    '--color-accent-primary',
+    '--color-text-primary',
+    '--color-border-subtle',
+    '--color-text-muted',
+  ]) as [string, string, string, string];
+
+  const [minuteSec, setMinuteSec] = useState(() => splitSeconds(valueSec).minuteSec);
+  const [secondsPart, setSecondsPart] = useState(() => splitSeconds(valueSec).secondsPart);
+  const secondsListRef = useRef<FlatList<number>>(null);
+
+  useEffect(() => {
+    const next = splitSeconds(Math.max(0, Math.min(maxSec, valueSec)));
+    setMinuteSec(next.minuteSec);
+    setSecondsPart(next.secondsPart);
+    secondsListRef.current?.scrollToOffset({
+      offset: next.secondsPart * WHEEL_ROW_HEIGHT,
+      animated: false,
+    });
+  }, [maxSec, valueSec]);
+
+  const pickerStyles = useMemo(
+    () => ({
+      time_selector_label: { color: textPrimary, fontWeight: '600' as const },
+      time_label: { color: textPrimary, fontSize: 24, fontWeight: '500' as const },
+      time_selected_indicator: { backgroundColor: borderSubtle, borderRadius: 10 },
+      selected_month: { backgroundColor: accentPrimary },
+      selected_month_label: { color: '#FFFFFF' },
+    }),
+    [accentPrimary, textPrimary, borderSubtle],
+  );
+
+  const secondOptions = useMemo(() => Array.from({ length: 60 }, (_, i) => i), []);
+
+  const emitNext = (nextMinuteSec: number, nextSecondsPart: number) => {
+    const total = nextMinuteSec + nextSecondsPart;
+    const clamped = Math.max(0, Math.min(maxSec, total));
+    const split = splitSeconds(clamped);
+    setMinuteSec(split.minuteSec);
+    setSecondsPart(split.secondsPart);
+    onChangeSec(clamped);
+    if (split.secondsPart !== nextSecondsPart) {
+      secondsListRef.current?.scrollToOffset({
+        offset: split.secondsPart * WHEEL_ROW_HEIGHT,
+        animated: true,
+      });
+    }
+  };
+
+  const onSecondsScrollEnd = (offsetY: number) => {
+    const raw = Math.round(offsetY / WHEEL_ROW_HEIGHT);
+    const nextSeconds = Math.max(0, Math.min(59, raw));
+    emitNext(minuteSec, nextSeconds);
+  };
+
+  return (
+    <View className="flex-row items-center">
+      <View style={{ flex: 1 }}>
+        <DateTimePicker
+          mode="single"
+          date={secondsToDate(minuteSec)}
+          timePicker
+          initialView="time"
+          hideHeader
+          use12Hours={false}
+          onChange={({ date }) => {
+            const parsed = dateTypeToDate(date);
+            if (!parsed || Number.isNaN(parsed.getTime())) return;
+            emitNext(dateToSeconds(parsed), secondsPart);
+          }}
+          styles={pickerStyles}
+          containerHeight={220}
+        />
+      </View>
+
+      <View style={{ width: 90, height: 220 }}>
+        <Text className="text-center text-xs font-semibold mb-1" style={{ color: textMuted }}>
+          SEC
+        </Text>
+        <View style={{ flex: 1 }}>
+          <FlatList
+            ref={secondsListRef}
+            data={secondOptions}
+            keyExtractor={(item) => String(item)}
+            getItemLayout={(_, index) => ({
+              length: WHEEL_ROW_HEIGHT,
+              offset: WHEEL_ROW_HEIGHT * index,
+              index,
+            })}
+            initialScrollIndex={secondsPart}
+            showsVerticalScrollIndicator={false}
+            snapToInterval={WHEEL_ROW_HEIGHT}
+            decelerationRate="fast"
+            contentContainerStyle={{
+              paddingVertical: WHEEL_ROW_HEIGHT * 2,
+            }}
+            onMomentumScrollEnd={(e) => onSecondsScrollEnd(e.nativeEvent.contentOffset.y)}
+            renderItem={({ item }) => (
+              <View style={{ height: WHEEL_ROW_HEIGHT }} className="items-center justify-center">
+                <Text style={{ color: item === secondsPart ? textPrimary : textMuted, fontSize: 22 }}>
+                  {String(item).padStart(2, '0')}
+                </Text>
+              </View>
+            )}
+          />
+          <View
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              top: WHEEL_ROW_HEIGHT * 2,
+              height: WHEEL_ROW_HEIGHT,
+              borderTopWidth: 1,
+              borderBottomWidth: 1,
+              borderColor: borderSubtle,
+              borderRadius: 8,
+            }}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export default DurationWheel;

--- a/SparkyFitnessMobile/src/components/DurationWheel.tsx
+++ b/SparkyFitnessMobile/src/components/DurationWheel.tsx
@@ -1,6 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { FlatList, Text, View } from 'react-native';
-import DateTimePicker, { type DateType } from 'react-native-ui-datepicker';
+import { useMemo } from 'react';
+import { Text, View } from 'react-native';
+// Deep import: Metro resolves react-native-ui-datepicker via its "react-native"
+// field → src/index, so sub-path imports from src/ work at runtime and give us
+// the exact wheel component the library uses for its own time picker columns.
+// eslint-disable-next-line import/no-internal-modules
+import WheelPicker, {
+  type WheelPickerOption,
+} from 'react-native-ui-datepicker/src/components/time-picker/wheel-picker';
 import { useCSSVariable } from 'uniwind';
 
 interface DurationWheelProps {
@@ -9,156 +15,109 @@ interface DurationWheelProps {
   maxSec?: number;
 }
 
-function dateTypeToDate(date: DateType): Date | null {
-  if (!date) return null;
-  if (date instanceof Date) return date;
-  if (typeof date === 'object' && 'toDate' in date) return date.toDate();
-  if (typeof date === 'string') return new Date(date);
-  return new Date(date);
-}
+const ITEM_HEIGHT = 44;
 
-function secondsToDate(seconds: number): Date {
-  const d = new Date();
-  d.setHours(0, 0, 0, 0);
-  const mins = Math.max(0, Math.floor(seconds / 60));
-  d.setMinutes(mins);
-  return d;
-}
-
-function dateToSeconds(date: Date): number {
-  return date.getHours() * 3600 + date.getMinutes() * 60;
-}
-
-const WHEEL_ROW_HEIGHT = 44;
-
-function splitSeconds(totalSec: number): { minuteSec: number; secondsPart: number } {
-  const clamped = Math.max(0, totalSec);
-  const minuteSec = Math.floor(clamped / 60) * 60;
-  const secondsPart = clamped % 60;
-  return { minuteSec, secondsPart };
-}
+// Seconds rollover: give the wheel 10× the real range (600 items) so the user
+// can scroll up or down through many full rotations without hitting an edge.
+// The displayed text is `index % 60`; onChange strips the loop offset back to
+// the canonical 0–59 value. Start position is always the center repetition so
+// equal runway exists in both directions.
+const SEC_LOOP = 10;
+const SEC_TOTAL = 60 * SEC_LOOP; // 600
+const SEC_MID_OFFSET = Math.floor(SEC_LOOP / 2) * 60; // 300
 
 function DurationWheel({ valueSec, onChangeSec, maxSec = 900 }: DurationWheelProps) {
-  const [accentPrimary, textPrimary, borderSubtle, textMuted] = useCSSVariable([
-    '--color-accent-primary',
+  const [textPrimary, borderSubtle] = useCSSVariable([
     '--color-text-primary',
     '--color-border-subtle',
-    '--color-text-muted',
-  ]) as [string, string, string, string];
+  ]) as [string, string];
 
-  const [minuteSec, setMinuteSec] = useState(() => splitSeconds(valueSec).minuteSec);
-  const [secondsPart, setSecondsPart] = useState(() => splitSeconds(valueSec).secondsPart);
-  const secondsListRef = useRef<FlatList<number>>(null);
+  const clamped = Math.max(0, Math.min(maxSec, valueSec));
+  const currentMin = Math.floor(clamped / 60);
+  const currentSec = clamped % 60;
+  const maxMinutes = Math.floor(maxSec / 60);
 
-  useEffect(() => {
-    const next = splitSeconds(Math.max(0, Math.min(maxSec, valueSec)));
-    setMinuteSec(next.minuteSec);
-    setSecondsPart(next.secondsPart);
-    secondsListRef.current?.scrollToOffset({
-      offset: next.secondsPart * WHEEL_ROW_HEIGHT,
-      animated: false,
-    });
-  }, [maxSec, valueSec]);
-
-  const pickerStyles = useMemo(
-    () => ({
-      time_selector_label: { color: textPrimary, fontWeight: '600' as const },
-      time_label: { color: textPrimary, fontSize: 24, fontWeight: '500' as const },
-      time_selected_indicator: { backgroundColor: borderSubtle, borderRadius: 10 },
-      selected_month: { backgroundColor: accentPrimary },
-      selected_month_label: { color: '#FFFFFF' },
-    }),
-    [accentPrimary, textPrimary, borderSubtle],
+  const minuteOptions = useMemo<WheelPickerOption[]>(
+    () =>
+      Array.from({ length: maxMinutes + 1 }, (_, i) => ({
+        value: i,
+        text: String(i).padStart(2, '0'),
+      })),
+    [maxMinutes],
   );
 
-  const secondOptions = useMemo(() => Array.from({ length: 60 }, (_, i) => i), []);
+  // Each item has a unique numeric `value` (its index) so WheelPicker's
+  // findIndex lookup always lands on the correct row. Text wraps mod 60.
+  const secondOptions = useMemo<WheelPickerOption[]>(
+    () =>
+      Array.from({ length: SEC_TOTAL }, (_, i) => ({
+        value: i,
+        text: String(i % 60).padStart(2, '0'),
+      })),
+    [],
+  );
 
-  const emitNext = (nextMinuteSec: number, nextSecondsPart: number) => {
-    const total = nextMinuteSec + nextSecondsPart;
-    const clamped = Math.max(0, Math.min(maxSec, total));
-    const split = splitSeconds(clamped);
-    setMinuteSec(split.minuteSec);
-    setSecondsPart(split.secondsPart);
-    onChangeSec(clamped);
-    if (split.secondsPart !== nextSecondsPart) {
-      secondsListRef.current?.scrollToOffset({
-        offset: split.secondsPart * WHEEL_ROW_HEIGHT,
-        animated: true,
-      });
-    }
+  // Map the logical seconds value to the middle repetition so the wheel has
+  // equal room to scroll in both directions before hitting an edge.
+  const secondsWheelValue = SEC_MID_OFFSET + currentSec;
+
+  const indicatorStyle = useMemo(
+    () => ({ backgroundColor: borderSubtle, borderRadius: 8 }),
+    [borderSubtle],
+  );
+
+  const textStyle = useMemo(
+    () => ({ color: textPrimary, fontSize: 22, fontWeight: '500' as const }),
+    [textPrimary],
+  );
+
+  const handleMinuteChange = (v: number | string) => {
+    const m = Number(v);
+    const total = Math.max(0, Math.min(maxSec, m * 60 + currentSec));
+    onChangeSec(total);
   };
 
-  const onSecondsScrollEnd = (offsetY: number) => {
-    const raw = Math.round(offsetY / WHEEL_ROW_HEIGHT);
-    const nextSeconds = Math.max(0, Math.min(59, raw));
-    emitNext(minuteSec, nextSeconds);
+  const handleSecondChange = (v: number | string) => {
+    // Strip the loop offset; the canonical value is always 0–59.
+    const s = Number(v) % 60;
+    const total = Math.max(0, Math.min(maxSec, currentMin * 60 + s));
+    onChangeSec(total);
   };
 
   return (
-    <View className="flex-row items-center">
-      <View style={{ flex: 1 }}>
-        <DateTimePicker
-          mode="single"
-          date={secondsToDate(minuteSec)}
-          timePicker
-          initialView="time"
-          hideHeader
-          use12Hours={false}
-          onChange={({ date }) => {
-            const parsed = dateTypeToDate(date);
-            if (!parsed || Number.isNaN(parsed.getTime())) return;
-            emitNext(dateToSeconds(parsed), secondsPart);
-          }}
-          styles={pickerStyles}
-          containerHeight={220}
+    <View
+      className="flex-row items-center justify-center"
+      style={{ height: ITEM_HEIGHT * 5 }}
+    >
+      <View className="flex-1">
+        <WheelPicker
+          value={currentMin}
+          options={minuteOptions}
+          onChange={handleMinuteChange}
+          selectedIndicatorStyle={indicatorStyle}
+          itemTextStyle={textStyle}
+          itemHeight={ITEM_HEIGHT}
+          decelerationRate="fast"
         />
       </View>
 
-      <View style={{ width: 90, height: 220 }}>
-        <Text className="text-center text-xs font-semibold mb-1" style={{ color: textMuted }}>
-          SEC
-        </Text>
-        <View style={{ flex: 1 }}>
-          <FlatList
-            ref={secondsListRef}
-            data={secondOptions}
-            keyExtractor={(item) => String(item)}
-            getItemLayout={(_, index) => ({
-              length: WHEEL_ROW_HEIGHT,
-              offset: WHEEL_ROW_HEIGHT * index,
-              index,
-            })}
-            initialScrollIndex={secondsPart}
-            showsVerticalScrollIndicator={false}
-            snapToInterval={WHEEL_ROW_HEIGHT}
-            decelerationRate="fast"
-            contentContainerStyle={{
-              paddingVertical: WHEEL_ROW_HEIGHT * 2,
-            }}
-            onMomentumScrollEnd={(e) => onSecondsScrollEnd(e.nativeEvent.contentOffset.y)}
-            renderItem={({ item }) => (
-              <View style={{ height: WHEEL_ROW_HEIGHT }} className="items-center justify-center">
-                <Text style={{ color: item === secondsPart ? textPrimary : textMuted, fontSize: 22 }}>
-                  {String(item).padStart(2, '0')}
-                </Text>
-              </View>
-            )}
-          />
-          <View
-            pointerEvents="none"
-            style={{
-              position: 'absolute',
-              left: 0,
-              right: 0,
-              top: WHEEL_ROW_HEIGHT * 2,
-              height: WHEEL_ROW_HEIGHT,
-              borderTopWidth: 1,
-              borderBottomWidth: 1,
-              borderColor: borderSubtle,
-              borderRadius: 8,
-            }}
-          />
-        </View>
+      <Text
+        className="text-text-primary"
+        style={{ fontSize: 26, fontWeight: '300', marginHorizontal: 4, marginBottom: 2 }}
+      >
+        :
+      </Text>
+
+      <View className="flex-1">
+        <WheelPicker
+          value={secondsWheelValue}
+          options={secondOptions}
+          onChange={handleSecondChange}
+          selectedIndicatorStyle={indicatorStyle}
+          itemTextStyle={textStyle}
+          itemHeight={ITEM_HEIGHT}
+          decelerationRate="fast"
+        />
       </View>
     </View>
   );

--- a/SparkyFitnessMobile/src/components/ExerciseSetRestSheet.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseSetRestSheet.tsx
@@ -6,12 +6,12 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Platform, Pressable, Text, View } from 'react-native';
+import { Alert, Platform, Pressable, Text, View } from 'react-native';
 import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
 import { useCSSVariable } from 'uniwind';
 import DurationWheel from './DurationWheel';
 import Button from './ui/Button';
-import { formatRestLabel } from './RestPeriodChip';
+import { formatRestLabel, formatRestRangeLabel } from './RestPeriodChip';
 import { sheetContainer, useSheetBackdrop } from './ui/sheetChrome';
 import { getDefaultRestSec } from '../utils/workoutSession';
 
@@ -27,7 +27,7 @@ export interface ExerciseSetRestUpdate {
 }
 
 export interface ExerciseSetRestSheetRef {
-  present: (exerciseName: string, sets: ExerciseSetRestItem[]) => void;
+  present: (exerciseName: string, sets: ExerciseSetRestItem[], isSupersetRound?: boolean) => void;
   dismiss: () => void;
 }
 
@@ -57,9 +57,20 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
     const [selectedKey, setSelectedKey] = useState<string>(ALL_KEY);
     const [initialBySetId, setInitialBySetId] = useState<Record<string, number>>({});
     const [draftBySetId, setDraftBySetId] = useState<Record<string, number>>({});
+    const [isSupersetRound, setIsSupersetRound] = useState(false);
+    const [allOverwriteConfirmed, setAllOverwriteConfirmed] = useState(false);
+    const [wheelResetNonce, setWheelResetNonce] = useState(0);
+
+    // Detect if initial rest times are mixed (not all equal)
+    const initialTimesMixed = useMemo(() => {
+      const values = Object.values(initialBySetId);
+      if (values.length <= 1) return false;
+      const first = values[0];
+      return values.some((v) => v !== first);
+    }, [initialBySetId]);
 
     useImperativeHandle(ref, () => ({
-      present: (exerciseName, incomingSets) => {
+      present: (exerciseName, incomingSets, supersetRound = false) => {
         const normalizedSets = incomingSets.map((s) => ({
           ...s,
           restSec: clampRestSeconds(s.restSec ?? getDefaultRestSec()),
@@ -70,7 +81,10 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
         setSets(normalizedSets);
         setInitialBySetId(byId);
         setDraftBySetId(byId);
-        setSelectedKey(normalizedSets[0]?.setId ?? ALL_KEY);
+        setIsSupersetRound(supersetRound);
+        setSelectedKey(ALL_KEY);
+        setAllOverwriteConfirmed(false);
+        setWheelResetNonce(0);
         sheetRef.current?.present();
       },
       dismiss: () => sheetRef.current?.dismiss(),
@@ -85,29 +99,54 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
       return draftBySetId[selectedKey] ?? getDefaultRestSec();
     }, [draftBySetId, selectedKey, sets]);
 
-    const highestSetRest = useMemo(() => {
-      if (sets.length === 0) return getDefaultRestSec();
-      let max = 0;
-      for (const set of sets) {
-        const value = draftBySetId[set.setId] ?? getDefaultRestSec();
-        if (value > max) max = value;
-      }
-      return max;
+    const allSetRests = useMemo(() => {
+      return sets.map((set) => draftBySetId[set.setId] ?? getDefaultRestSec());
     }, [draftBySetId, sets]);
 
     const handleChangeSeconds = useCallback(
       (seconds: number) => {
         const next = clampRestSeconds(seconds);
-        setDraftBySetId((prev) => {
-          if (selectedKey === ALL_KEY) {
-            const out = { ...prev };
-            for (const set of sets) out[set.setId] = next;
-            return out;
-          }
-          return { ...prev, [selectedKey]: next };
-        });
+
+        const applyChange = () => {
+          setDraftBySetId((prev) => {
+            if (selectedKey === ALL_KEY) {
+              const out = { ...prev };
+              for (const set of sets) out[set.setId] = next;
+              return out;
+            }
+            return { ...prev, [selectedKey]: next };
+          });
+        };
+
+        // If changing all sets from mixed initial state, confirm once.
+        if (selectedKey === ALL_KEY && initialTimesMixed && !allOverwriteConfirmed) {
+          Alert.alert(
+            'Overwrite rest times?',
+            `These sets have different rest times. Set all to ${formatRestLabel(next)}?`,
+            [
+              {
+                text: 'Cancel',
+                style: 'cancel',
+                onPress: () => {
+                  // Reset wheel position to the current selected value.
+                  setWheelResetNonce((n) => n + 1);
+                },
+              },
+              {
+                text: 'Overwrite',
+                onPress: () => {
+                  setAllOverwriteConfirmed(true);
+                  applyChange();
+                },
+              },
+            ],
+          );
+          return;
+        }
+
+        applyChange();
       },
-      [selectedKey, sets],
+      [selectedKey, sets, initialTimesMixed, allOverwriteConfirmed],
     );
 
     const handleDone = useCallback(() => {
@@ -135,7 +174,7 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
       >
         <BottomSheetView className="px-5 pb-safe-or-8">
           <Text className="text-lg font-semibold text-text-primary text-center mb-3">
-            Rest for {title}
+            {isSupersetRound ? 'Round Rest' : 'Rest'} — {title}
           </Text>
 
           <View className="flex-row flex-wrap" style={{ gap: 8 }}>
@@ -165,7 +204,7 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
                 }
                 style={selectedKey === ALL_KEY ? { color: accentPrimary } : undefined}
               >
-                {formatRestLabel(highestSetRest)}
+                {formatRestRangeLabel(allSetRests, getDefaultRestSec())}
               </Text>
             </Pressable>
             {sets.map((set) => {
@@ -185,7 +224,7 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
                       className={selected ? 'font-semibold text-text-primary' : 'text-text-secondary'}
                       style={selected ? { color: accentPrimary } : undefined}
                     >
-                      Set {set.setNumber}
+                      {isSupersetRound ? 'Round' : 'Set'} {set.setNumber}
                     </Text>
                     <Text
                       className={
@@ -203,10 +242,12 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
           </View>
 
           <View className="pt-3 pb-2">
-            <DurationWheel valueSec={selectedSeconds} onChangeSec={handleChangeSeconds} maxSec={MAX_REST_SEC} />
-            <Text className="text-center text-text-secondary mt-1">
-              {selectedKey === ALL_KEY ? 'Applying to all sets' : 'Selected'}: {formatRestLabel(selectedSeconds)}
-            </Text>
+            <DurationWheel
+              key={`${selectedKey}:${wheelResetNonce}`}
+              valueSec={selectedSeconds}
+              onChangeSec={handleChangeSeconds}
+              maxSec={MAX_REST_SEC}
+            />
           </View>
 
           <Button variant="primary" onPress={handleDone}>

--- a/SparkyFitnessMobile/src/components/ExerciseSetRestSheet.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseSetRestSheet.tsx
@@ -61,13 +61,13 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
     const [allOverwriteConfirmed, setAllOverwriteConfirmed] = useState(false);
     const [wheelResetNonce, setWheelResetNonce] = useState(0);
 
-    // Detect if initial rest times are mixed (not all equal)
-    const initialTimesMixed = useMemo(() => {
-      const values = Object.values(initialBySetId);
+    // Detect if the current draft rest times are mixed (not all equal)
+    const restTimesMixed = useMemo(() => {
+      const values = Object.values(draftBySetId);
       if (values.length <= 1) return false;
       const first = values[0];
       return values.some((v) => v !== first);
-    }, [initialBySetId]);
+    }, [draftBySetId]);
 
     useImperativeHandle(ref, () => ({
       present: (exerciseName, incomingSets, supersetRound = false) => {
@@ -118,8 +118,8 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
           });
         };
 
-        // If changing all sets from mixed initial state, confirm once.
-        if (selectedKey === ALL_KEY && initialTimesMixed && !allOverwriteConfirmed) {
+        // If changing all sets from a currently-mixed state, confirm once.
+        if (selectedKey === ALL_KEY && restTimesMixed && !allOverwriteConfirmed) {
           Alert.alert(
             'Overwrite rest times?',
             `These sets have different rest times. Set all to ${formatRestLabel(next)}?`,
@@ -146,7 +146,7 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
 
         applyChange();
       },
-      [selectedKey, sets, initialTimesMixed, allOverwriteConfirmed],
+      [selectedKey, sets, restTimesMixed, allOverwriteConfirmed],
     );
 
     const handleDone = useCallback(() => {

--- a/SparkyFitnessMobile/src/components/ExerciseSetRestSheet.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseSetRestSheet.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Pressable, ScrollView, Text, View } from 'react-native';
+import { Platform, Pressable, Text, View } from 'react-native';
 import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
 import { useCSSVariable } from 'uniwind';
 import DurationWheel from './DurationWheel';
@@ -36,7 +36,7 @@ interface ExerciseSetRestSheetProps {
 }
 
 const ALL_KEY = 'all';
-const MAX_REST_SEC = 900;
+const MAX_REST_SEC = 1800;
 
 function clampRestSeconds(seconds: number): number {
   if (!Number.isFinite(seconds)) return getDefaultRestSec();
@@ -85,6 +85,16 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
       return draftBySetId[selectedKey] ?? getDefaultRestSec();
     }, [draftBySetId, selectedKey, sets]);
 
+    const highestSetRest = useMemo(() => {
+      if (sets.length === 0) return getDefaultRestSec();
+      let max = 0;
+      for (const set of sets) {
+        const value = draftBySetId[set.setId] ?? getDefaultRestSec();
+        if (value > max) max = value;
+      }
+      return max;
+    }, [draftBySetId, sets]);
+
     const handleChangeSeconds = useCallback(
       (seconds: number) => {
         const next = clampRestSeconds(seconds);
@@ -115,6 +125,9 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
       <BottomSheetModal
         ref={sheetRef}
         enableDynamicSizing
+        // On Android the sheet's content pan gesture steals vertical drags from
+        // the wheel picker's FlatLists. Must stay static; toggling it remounts content.
+        enableContentPanningGesture={Platform.OS !== 'android'}
         containerComponent={sheetContainer}
         backdropComponent={renderBackdrop}
         backgroundStyle={{ backgroundColor: surfaceBg }}
@@ -125,34 +138,47 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
             Rest for {title}
           </Text>
 
-          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 8 }}>
+          <View className="flex-row flex-wrap" style={{ gap: 8 }}>
             <Pressable
               onPress={() => setSelectedKey(ALL_KEY)}
-              className="px-3 py-2 rounded-full border"
+              className="px-3 py-2 rounded-lg border items-center"
               style={{
                 borderColor: selectedKey === ALL_KEY ? accentPrimary : textMuted,
                 backgroundColor: selectedKey === ALL_KEY ? accentPrimary : 'transparent',
               }}
             >
               <Text style={{ color: selectedKey === ALL_KEY ? '#fff' : textMuted }}>All</Text>
+              <Text
+                className="text-xs mt-0.5"
+                style={{ color: selectedKey === ALL_KEY ? '#fff' : textMuted }}
+              >
+                {formatRestLabel(highestSetRest)}
+              </Text>
             </Pressable>
             {sets.map((set) => {
               const selected = selectedKey === set.setId;
+              const setRest = draftBySetId[set.setId] ?? getDefaultRestSec();
               return (
                 <Pressable
                   key={set.setId}
                   onPress={() => setSelectedKey(set.setId)}
-                  className="px-3 py-2 rounded-full border"
+                  className="px-3 py-2 rounded-lg border items-center"
                   style={{
                     borderColor: selected ? accentPrimary : textMuted,
                     backgroundColor: selected ? accentPrimary : 'transparent',
                   }}
                 >
                   <Text style={{ color: selected ? '#fff' : textMuted }}>Set {set.setNumber}</Text>
+                  <Text
+                    className="text-xs mt-0.5"
+                    style={{ color: selected ? '#fff' : textMuted }}
+                  >
+                    {formatRestLabel(setRest)}
+                  </Text>
                 </Pressable>
               );
             })}
-          </ScrollView>
+          </View>
 
           <View className="pt-3 pb-2">
             <DurationWheel valueSec={selectedSeconds} onChangeSec={handleChangeSeconds} maxSec={MAX_REST_SEC} />

--- a/SparkyFitnessMobile/src/components/ExerciseSetRestSheet.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseSetRestSheet.tsx
@@ -1,0 +1,175 @@
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+import { BottomSheetModal, BottomSheetView } from '@gorhom/bottom-sheet';
+import { useCSSVariable } from 'uniwind';
+import DurationWheel from './DurationWheel';
+import Button from './ui/Button';
+import { formatRestLabel } from './RestPeriodChip';
+import { sheetContainer, useSheetBackdrop } from './ui/sheetChrome';
+import { getDefaultRestSec } from '../utils/workoutSession';
+
+export interface ExerciseSetRestItem {
+  setId: string;
+  setNumber: number;
+  restSec: number | null | undefined;
+}
+
+export interface ExerciseSetRestUpdate {
+  setId: string;
+  seconds: number;
+}
+
+export interface ExerciseSetRestSheetRef {
+  present: (exerciseName: string, sets: ExerciseSetRestItem[]) => void;
+  dismiss: () => void;
+}
+
+interface ExerciseSetRestSheetProps {
+  onApply: (updates: ExerciseSetRestUpdate[]) => void;
+}
+
+const ALL_KEY = 'all';
+const MAX_REST_SEC = 900;
+
+function clampRestSeconds(seconds: number): number {
+  if (!Number.isFinite(seconds)) return getDefaultRestSec();
+  return Math.max(0, Math.min(MAX_REST_SEC, Math.round(seconds)));
+}
+
+const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRestSheetProps>(
+  ({ onApply }, ref) => {
+    const sheetRef = useRef<BottomSheetModal>(null);
+    const [surfaceBg, textMuted, accentPrimary] = useCSSVariable([
+      '--color-surface',
+      '--color-text-muted',
+      '--color-accent-primary',
+    ]) as [string, string, string];
+
+    const [title, setTitle] = useState('Exercise');
+    const [sets, setSets] = useState<ExerciseSetRestItem[]>([]);
+    const [selectedKey, setSelectedKey] = useState<string>(ALL_KEY);
+    const [initialBySetId, setInitialBySetId] = useState<Record<string, number>>({});
+    const [draftBySetId, setDraftBySetId] = useState<Record<string, number>>({});
+
+    useImperativeHandle(ref, () => ({
+      present: (exerciseName, incomingSets) => {
+        const normalizedSets = incomingSets.map((s) => ({
+          ...s,
+          restSec: clampRestSeconds(s.restSec ?? getDefaultRestSec()),
+        }));
+        const byId: Record<string, number> = {};
+        for (const set of normalizedSets) byId[set.setId] = set.restSec ?? getDefaultRestSec();
+        setTitle(exerciseName);
+        setSets(normalizedSets);
+        setInitialBySetId(byId);
+        setDraftBySetId(byId);
+        setSelectedKey(ALL_KEY);
+        sheetRef.current?.present();
+      },
+      dismiss: () => sheetRef.current?.dismiss(),
+    }));
+
+    const renderBackdrop = useSheetBackdrop();
+
+    const selectedSeconds = useMemo(() => {
+      if (selectedKey === ALL_KEY) {
+        return sets[0] ? draftBySetId[sets[0].setId] ?? getDefaultRestSec() : getDefaultRestSec();
+      }
+      return draftBySetId[selectedKey] ?? getDefaultRestSec();
+    }, [draftBySetId, selectedKey, sets]);
+
+    const handleChangeSeconds = useCallback(
+      (seconds: number) => {
+        const next = clampRestSeconds(seconds);
+        setDraftBySetId((prev) => {
+          if (selectedKey === ALL_KEY) {
+            const out = { ...prev };
+            for (const set of sets) out[set.setId] = next;
+            return out;
+          }
+          return { ...prev, [selectedKey]: next };
+        });
+      },
+      [selectedKey, sets],
+    );
+
+    const handleDone = useCallback(() => {
+      const updates: ExerciseSetRestUpdate[] = [];
+      for (const set of sets) {
+        const next = draftBySetId[set.setId];
+        const initial = initialBySetId[set.setId];
+        if (next !== initial) updates.push({ setId: set.setId, seconds: next });
+      }
+      if (updates.length > 0) onApply(updates);
+      sheetRef.current?.dismiss();
+    }, [draftBySetId, initialBySetId, onApply, sets]);
+
+    return (
+      <BottomSheetModal
+        ref={sheetRef}
+        enableDynamicSizing
+        containerComponent={sheetContainer}
+        backdropComponent={renderBackdrop}
+        backgroundStyle={{ backgroundColor: surfaceBg }}
+        handleIndicatorStyle={{ backgroundColor: textMuted }}
+      >
+        <BottomSheetView className="px-5 pb-safe-or-8">
+          <Text className="text-lg font-semibold text-text-primary text-center mb-3">
+            Rest for {title}
+          </Text>
+
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 8 }}>
+            <Pressable
+              onPress={() => setSelectedKey(ALL_KEY)}
+              className="px-3 py-2 rounded-full border"
+              style={{
+                borderColor: selectedKey === ALL_KEY ? accentPrimary : textMuted,
+                backgroundColor: selectedKey === ALL_KEY ? accentPrimary : 'transparent',
+              }}
+            >
+              <Text style={{ color: selectedKey === ALL_KEY ? '#fff' : textMuted }}>All</Text>
+            </Pressable>
+            {sets.map((set) => {
+              const selected = selectedKey === set.setId;
+              return (
+                <Pressable
+                  key={set.setId}
+                  onPress={() => setSelectedKey(set.setId)}
+                  className="px-3 py-2 rounded-full border"
+                  style={{
+                    borderColor: selected ? accentPrimary : textMuted,
+                    backgroundColor: selected ? accentPrimary : 'transparent',
+                  }}
+                >
+                  <Text style={{ color: selected ? '#fff' : textMuted }}>Set {set.setNumber}</Text>
+                </Pressable>
+              );
+            })}
+          </ScrollView>
+
+          <View className="pt-3 pb-2">
+            <DurationWheel valueSec={selectedSeconds} onChangeSec={handleChangeSeconds} maxSec={MAX_REST_SEC} />
+            <Text className="text-center text-text-secondary mt-1">
+              {selectedKey === ALL_KEY ? 'Applying to all sets' : 'Selected'}: {formatRestLabel(selectedSeconds)}
+            </Text>
+          </View>
+
+          <Button variant="primary" onPress={handleDone}>
+            Done
+          </Button>
+        </BottomSheetView>
+      </BottomSheetModal>
+    );
+  },
+);
+
+ExerciseSetRestSheet.displayName = 'ExerciseSetRestSheet';
+
+export default ExerciseSetRestSheet;

--- a/SparkyFitnessMobile/src/components/ExerciseSetRestSheet.tsx
+++ b/SparkyFitnessMobile/src/components/ExerciseSetRestSheet.tsx
@@ -70,7 +70,7 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
         setSets(normalizedSets);
         setInitialBySetId(byId);
         setDraftBySetId(byId);
-        setSelectedKey(ALL_KEY);
+        setSelectedKey(normalizedSets[0]?.setId ?? ALL_KEY);
         sheetRef.current?.present();
       },
       dismiss: () => sheetRef.current?.dismiss(),
@@ -144,13 +144,26 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
               className="px-3 py-2 rounded-lg border items-center"
               style={{
                 borderColor: selectedKey === ALL_KEY ? accentPrimary : textMuted,
-                backgroundColor: selectedKey === ALL_KEY ? accentPrimary : 'transparent',
+                backgroundColor: 'transparent',
               }}
             >
-              <Text style={{ color: selectedKey === ALL_KEY ? '#fff' : textMuted }}>All</Text>
               <Text
-                className="text-xs mt-0.5"
-                style={{ color: selectedKey === ALL_KEY ? '#fff' : textMuted }}
+                className={
+                  selectedKey === ALL_KEY
+                    ? 'font-semibold text-text-primary'
+                    : 'text-text-secondary'
+                }
+                style={selectedKey === ALL_KEY ? { color: accentPrimary } : undefined}
+              >
+                All
+              </Text>
+              <Text
+                className={
+                  selectedKey === ALL_KEY
+                    ? 'text-xs mt-0.5 font-semibold text-text-primary'
+                    : 'text-xs mt-0.5 text-text-primary'
+                }
+                style={selectedKey === ALL_KEY ? { color: accentPrimary } : undefined}
               >
                 {formatRestLabel(highestSetRest)}
               </Text>
@@ -165,16 +178,25 @@ const ExerciseSetRestSheet = forwardRef<ExerciseSetRestSheetRef, ExerciseSetRest
                   className="px-3 py-2 rounded-lg border items-center"
                   style={{
                     borderColor: selected ? accentPrimary : textMuted,
-                    backgroundColor: selected ? accentPrimary : 'transparent',
+                    backgroundColor: 'transparent',
                   }}
                 >
-                  <Text style={{ color: selected ? '#fff' : textMuted }}>Set {set.setNumber}</Text>
-                  <Text
-                    className="text-xs mt-0.5"
-                    style={{ color: selected ? '#fff' : textMuted }}
-                  >
+                    <Text
+                      className={selected ? 'font-semibold text-text-primary' : 'text-text-secondary'}
+                      style={selected ? { color: accentPrimary } : undefined}
+                    >
+                      Set {set.setNumber}
+                    </Text>
+                    <Text
+                      className={
+                        selected
+                          ? 'text-xs mt-0.5 font-semibold text-text-primary'
+                          : 'text-xs mt-0.5 text-text-primary'
+                      }
+                      style={selected ? { color: accentPrimary } : undefined}
+                    >
                     {formatRestLabel(setRest)}
-                  </Text>
+                    </Text>
                 </Pressable>
               );
             })}

--- a/SparkyFitnessMobile/src/components/RestPeriodChip.tsx
+++ b/SparkyFitnessMobile/src/components/RestPeriodChip.tsx
@@ -19,19 +19,40 @@ export function formatRestLabel(seconds: number | null | undefined): string {
   return seconds === 0 ? 'Off' : formatRest(seconds);
 }
 
+/** Label a rest range as `min-max`, collapsing to a single value when equal. */
+export function formatRestRangeLabel(
+  values: Array<number | null | undefined>,
+  defaultRestSec: number,
+): string {
+  const normalized = values.map((v) => (v ?? defaultRestSec));
+  if (normalized.length === 0) return formatRestLabel(defaultRestSec);
+  let min = normalized[0];
+  let max = normalized[0];
+  for (const value of normalized) {
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  if (min === max) return formatRestLabel(min);
+  return `${formatRestLabel(min)}-${formatRestLabel(max)}`;
+}
+
 interface RestPeriodChipProps {
   value: number | null | undefined;
+  values?: Array<number | null | undefined>;
   onPress?: () => void;
   readOnly?: boolean;
 }
 
-function RestPeriodChip({ value, onPress, readOnly = false }: RestPeriodChipProps) {
+function RestPeriodChip({ value, values, onPress, readOnly = false }: RestPeriodChipProps) {
   const [textMuted, accentPrimary] = useCSSVariable([
     '--color-text-muted',
     '--color-accent-primary',
   ]) as [string, string];
   const defaultRestSec = useAppPreferencesStore((s) => s.defaultRestSec);
-  const label = formatRestLabel(value ?? defaultRestSec);
+  const label =
+    values != null && values.length > 0
+      ? formatRestRangeLabel(values, defaultRestSec)
+      : formatRestLabel(value ?? defaultRestSec);
 
   if (readOnly) {
     return (

--- a/SparkyFitnessMobile/src/components/RestPeriodChip.tsx
+++ b/SparkyFitnessMobile/src/components/RestPeriodChip.tsx
@@ -21,7 +21,7 @@ export function formatRestLabel(seconds: number | null | undefined): string {
 
 /** Label a rest range as `min-max`, collapsing to a single value when equal. */
 export function formatRestRangeLabel(
-  values: Array<number | null | undefined>,
+  values: (number | null | undefined)[],
   defaultRestSec: number,
 ): string {
   const normalized = values.map((v) => (v ?? defaultRestSec));
@@ -38,7 +38,7 @@ export function formatRestRangeLabel(
 
 interface RestPeriodChipProps {
   value: number | null | undefined;
-  values?: Array<number | null | undefined>;
+  values?: (number | null | undefined)[];
   onPress?: () => void;
   readOnly?: boolean;
 }

--- a/SparkyFitnessMobile/src/components/WorkoutFormExerciseList.tsx
+++ b/SparkyFitnessMobile/src/components/WorkoutFormExerciseList.tsx
@@ -410,6 +410,7 @@ const WorkoutFormExerciseList = forwardRef<
     const exercise = exercises.find((e) => e.clientId === entryId);
     if (!exercise) return;
     restSheetEntryIdRef.current = entryId;
+    const isSupersetMember = exercise.supersetGroup != null;
     restSheetRef.current?.present(
       exercise.exerciseName,
       exercise.sets.map((set, index) => ({
@@ -417,6 +418,7 @@ const WorkoutFormExerciseList = forwardRef<
         setNumber: index + 1,
         restSec: set.restTime,
       })),
+      isSupersetMember,
     );
   }, [exercises]);
   const handleRestApply = useCallback((updates: ExerciseSetRestUpdate[]) => {
@@ -425,6 +427,16 @@ const WorkoutFormExerciseList = forwardRef<
     const exercise = exercises.find((e) => e.clientId === owner);
     if (!exercise) return;
 
+    // Superset members: always use setExerciseRest to harmonize all members
+    if (exercise.supersetGroup != null) {
+      if (updates.length > 0) {
+        // All updates should have the same value for superset members
+        setExerciseRest(owner, updates[0].seconds);
+      }
+      return;
+    }
+
+    // Solo exercise: check if all sets have the same rest, then use setExerciseRest
     if (updates.length === exercise.sets.length && updates.length > 0) {
       const [first, ...rest] = updates;
       if (rest.every((u) => u.seconds === first.seconds)) {
@@ -433,6 +445,7 @@ const WorkoutFormExerciseList = forwardRef<
       }
     }
 
+    // Otherwise update individual sets
     for (const update of updates) {
       updateSetMeta(owner, update.setId, { restTime: update.seconds });
     }

--- a/SparkyFitnessMobile/src/components/WorkoutFormExerciseList.tsx
+++ b/SparkyFitnessMobile/src/components/WorkoutFormExerciseList.tsx
@@ -14,7 +14,10 @@ import ActiveWorkoutExerciseCard from './ActiveWorkoutExerciseCard';
 import { MetricColumnMenu, SetTypeMenu } from './WorkoutMenus';
 import ActionSheet, { type ActionSheetItem, type ActionSheetRef } from './ActionSheet';
 import { type AnchorRect } from './AnchoredMenu';
-import RestPeriodSheet, { type RestPeriodSheetRef } from './RestPeriodSheet';
+import ExerciseSetRestSheet, {
+  type ExerciseSetRestSheetRef,
+  type ExerciseSetRestUpdate,
+} from './ExerciseSetRestSheet';
 import WorkoutReorderList from './WorkoutReorderList';
 import { distanceFromKm, weightFromKg } from '../utils/unitConversions';
 import {
@@ -400,20 +403,40 @@ const WorkoutFormExerciseList = forwardRef<
     [exercises, onViewExercise],
   );
 
-  // Rest sheet (per-exercise rest duration).
-  const restSheetRef = useRef<RestPeriodSheetRef>(null);
-  const restSheetTargetRef = useRef<string | null>(null);
-  const handlePressRestChip = useCallback((entryId: string, currentSec: number | null) => {
-    restSheetTargetRef.current = entryId;
-    restSheetRef.current?.present(currentSec);
-  }, []);
-  const handleRestChange = useCallback(
-    (seconds: number) => {
-      const target = restSheetTargetRef.current;
-      if (target != null) setExerciseRest(target, seconds);
-    },
-    [setExerciseRest],
-  );
+  // Rest sheet (All/per-set rest duration, committed on Done).
+  const restSheetRef = useRef<ExerciseSetRestSheetRef>(null);
+  const restSheetEntryIdRef = useRef<string | null>(null);
+  const handlePressRestChip = useCallback((entryId: string, _currentSec: number | null) => {
+    const exercise = exercises.find((e) => e.clientId === entryId);
+    if (!exercise) return;
+    restSheetEntryIdRef.current = entryId;
+    restSheetRef.current?.present(
+      exercise.exerciseName,
+      exercise.sets.map((set, index) => ({
+        setId: set.clientId,
+        setNumber: index + 1,
+        restSec: set.restTime,
+      })),
+    );
+  }, [exercises]);
+  const handleRestApply = useCallback((updates: ExerciseSetRestUpdate[]) => {
+    const owner = restSheetEntryIdRef.current;
+    if (!owner) return;
+    const exercise = exercises.find((e) => e.clientId === owner);
+    if (!exercise) return;
+
+    if (updates.length === exercise.sets.length && updates.length > 0) {
+      const [first, ...rest] = updates;
+      if (rest.every((u) => u.seconds === first.seconds)) {
+        setExerciseRest(owner, first.seconds);
+        return;
+      }
+    }
+
+    for (const update of updates) {
+      updateSetMeta(owner, update.setId, { restTime: update.seconds });
+    }
+  }, [exercises, setExerciseRest, updateSetMeta]);
 
   // Metric column is shared with the active-workout screen (intended).
   // Preset sets store no RPE, so the preset form hides RPE from the column
@@ -645,7 +668,7 @@ const WorkoutFormExerciseList = forwardRef<
         </TouchableOpacity>
       </Animated.View>
 
-      <RestPeriodSheet ref={restSheetRef} onChange={handleRestChange} />
+      <ExerciseSetRestSheet ref={restSheetRef} onApply={handleRestApply} />
 
       <MetricColumnMenu
         anchor={metricMenu?.anchor ?? null}

--- a/SparkyFitnessMobile/src/components/ui/wheel-picker/index.ts
+++ b/SparkyFitnessMobile/src/components/ui/wheel-picker/index.ts
@@ -1,0 +1,4 @@
+import WheelPicker from './wheel-picker';
+
+export type { PickerOption } from './types';
+export default WheelPicker;

--- a/SparkyFitnessMobile/src/components/ui/wheel-picker/types.ts
+++ b/SparkyFitnessMobile/src/components/ui/wheel-picker/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Vendored wheel-picker component from react-native-ui-datepicker
+ * Original source: https://github.com/farhoudshapouran/react-native-ui-datepicker
+ * License: MIT
+ * 
+ * This component is vendored to:
+ * 1. Allow Jest to resolve the internal module structure
+ * 2. Apply iOS bug fix: prevent over-scrolling animation when value wraps (59->00)
+ */
+
+export interface PickerOption {
+  value: number | string;
+  text: string;
+}

--- a/SparkyFitnessMobile/src/components/ui/wheel-picker/wheel-picker-item.tsx
+++ b/SparkyFitnessMobile/src/components/ui/wheel-picker/wheel-picker-item.tsx
@@ -1,0 +1,153 @@
+/**
+ * Vendored from react-native-ui-datepicker
+ * License: MIT
+ */
+
+import React from 'react';
+import { StyleProp, TextStyle, Animated, ViewStyle, Text } from 'react-native';
+import styles from './wheel-picker.style';
+import { PickerOption } from './types';
+
+interface ItemProps {
+  textStyle: StyleProp<TextStyle>;
+  textClassName: string;
+  style: StyleProp<ViewStyle>;
+  option: PickerOption | null;
+  height: number;
+  index: number;
+  currentScrollIndex: Animated.AnimatedAddition<number>;
+  visibleRest: number;
+  rotationFunction: (x: number) => number;
+  opacityFunction: (x: number) => number;
+  scaleFunction: (x: number) => number;
+}
+
+const WheelPickerItem: React.FC<ItemProps> = ({
+  textStyle,
+  textClassName,
+  style,
+  height,
+  option,
+  index,
+  visibleRest,
+  currentScrollIndex,
+  opacityFunction,
+  rotationFunction,
+  scaleFunction,
+}) => {
+  const relativeScrollIndex = Animated.subtract(index, currentScrollIndex);
+
+  const translateY = relativeScrollIndex.interpolate({
+    inputRange: (() => {
+      const range = [0];
+      for (let i = 1; i <= visibleRest + 1; i++) {
+        range.unshift(-i);
+        range.push(i);
+      }
+      return range;
+    })(),
+    outputRange: (() => {
+      const range = [0];
+      for (let i = 1; i <= visibleRest + 1; i++) {
+        let y =
+          (height / 2) * (1 - Math.sin(Math.PI / 2 - rotationFunction(i)));
+        for (let j = 1; j < i; j++) {
+          y += height * (1 - Math.sin(Math.PI / 2 - rotationFunction(j)));
+        }
+        range.unshift(y);
+        range.push(-y);
+      }
+      return range;
+    })(),
+  });
+
+  const opacity = relativeScrollIndex.interpolate({
+    inputRange: (() => {
+      const range = [0];
+      for (let i = 1; i <= visibleRest + 1; i++) {
+        range.unshift(-i);
+        range.push(i);
+      }
+      return range;
+    })(),
+    outputRange: (() => {
+      const range = [1];
+      for (let x = 1; x <= visibleRest + 1; x++) {
+        const y = opacityFunction(x);
+        range.unshift(y);
+        range.push(y);
+      }
+      return range;
+    })(),
+  });
+
+  const scale = relativeScrollIndex.interpolate({
+    inputRange: (() => {
+      const range = [0];
+      for (let i = 1; i <= visibleRest + 1; i++) {
+        range.unshift(-i);
+        range.push(i);
+      }
+      return range;
+    })(),
+    outputRange: (() => {
+      const range = [1.0];
+      for (let x = 1; x <= visibleRest + 1; x++) {
+        const y = scaleFunction(x);
+        range.unshift(y);
+        range.push(y);
+      }
+      return range;
+    })(),
+  });
+
+  const rotateX = relativeScrollIndex.interpolate({
+    inputRange: (() => {
+      const range = [0];
+      for (let i = 1; i <= visibleRest + 1; i++) {
+        range.unshift(-i);
+        range.push(i);
+      }
+      return range;
+    })(),
+    outputRange: (() => {
+      const range = ['0deg'];
+      for (let x = 1; x <= visibleRest + 1; x++) {
+        const y = rotationFunction(x);
+        range.unshift(`${y}deg`);
+        range.push(`${y}deg`);
+      }
+      return range;
+    })(),
+  });
+
+  return (
+    <Animated.View
+      style={[
+        styles.option,
+        style,
+        {
+          height,
+          opacity,
+          transform: [{ translateY }, { rotateX }, { scale }],
+        },
+      ]}
+    >
+      <Text style={textStyle} className={textClassName}>
+        {option?.text}
+      </Text>
+    </Animated.View>
+  );
+};
+
+const customComparator = (
+  prevProps: Readonly<ItemProps>,
+  nextProps: Readonly<ItemProps>
+) => {
+  return (
+    prevProps.textClassName === nextProps.textClassName &&
+    JSON.stringify(prevProps.textStyle) === JSON.stringify(nextProps.textStyle)
+  );
+};
+
+export default React.memo(WheelPickerItem, customComparator);

--- a/SparkyFitnessMobile/src/components/ui/wheel-picker/wheel-picker.style.ts
+++ b/SparkyFitnessMobile/src/components/ui/wheel-picker/wheel-picker.style.ts
@@ -1,0 +1,22 @@
+import { StyleSheet } from 'react-native';
+
+export default StyleSheet.create({
+  container: {
+    position: 'relative',
+  },
+  selectedIndicator: {
+    position: 'absolute',
+    width: '100%',
+    top: '50%',
+  },
+  scrollView: {
+    overflow: 'hidden',
+    flex: 1,
+  },
+  option: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 16,
+    zIndex: 100,
+  },
+});

--- a/SparkyFitnessMobile/src/components/ui/wheel-picker/wheel-picker.tsx
+++ b/SparkyFitnessMobile/src/components/ui/wheel-picker/wheel-picker.tsx
@@ -126,14 +126,21 @@ const WheelPicker: React.FC<Props> = ({
     handleScrollEnd(event);
   };
 
+  const scrollEndDragTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const handleScrollEndDrag = (
     event: NativeSyntheticEvent<NativeScrollEvent>
   ) => {
     // Capture the offset value immediately
     const offsetY = event.nativeEvent.contentOffset?.y;
 
+    if (scrollEndDragTimeoutRef.current != null) {
+      clearTimeout(scrollEndDragTimeoutRef.current);
+    }
+
     // We'll start a short timer to see if momentum scroll begins
-    setTimeout(() => {
+    scrollEndDragTimeoutRef.current = setTimeout(() => {
+      scrollEndDragTimeoutRef.current = null;
       // If momentum scroll hasn't started within the timeout,
       // then it was a slow scroll that won't trigger momentum
       if (!momentumStarted.current && offsetY !== undefined) {
@@ -147,6 +154,17 @@ const WheelPicker: React.FC<Props> = ({
       }
     }, 50);
   };
+
+  // Stale-timer guard: without this a pending timeout from a drag can fire
+  // handleScrollEnd/onChange after this WheelPicker instance has unmounted
+  // (e.g. DurationWheel remounts on a `key` change when switching tabs).
+  useEffect(() => {
+    return () => {
+      if (scrollEndDragTimeoutRef.current != null) {
+        clearTimeout(scrollEndDragTimeoutRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (selectedIndex < 0 || selectedIndex >= options.length) {

--- a/SparkyFitnessMobile/src/components/ui/wheel-picker/wheel-picker.tsx
+++ b/SparkyFitnessMobile/src/components/ui/wheel-picker/wheel-picker.tsx
@@ -1,0 +1,254 @@
+/**
+ * Vendored from react-native-ui-datepicker
+ * Original source: https://github.com/farhoudshapouran/react-native-ui-datepicker
+ * License: MIT
+ * 
+ * iOS bug fix: Track user-scroll state to avoid over-scrolling animation when
+ * wrapping values (e.g., 59->00 in seconds). When a user scroll triggers onChange,
+ * we skip the animated scrollToIndex since the FlatList is already positioned correctly.
+ */
+
+import React, { useEffect, useMemo, useRef, useState, memo } from 'react';
+import {
+  StyleProp,
+  TextStyle,
+  NativeSyntheticEvent,
+  NativeScrollEvent,
+  Animated,
+  ViewStyle,
+  View,
+  ViewProps,
+  FlatListProps,
+  FlatList,
+  Platform,
+} from 'react-native';
+import styles from './wheel-picker.style';
+import WheelPickerItem from './wheel-picker-item';
+import { PickerOption } from './types';
+
+interface Props {
+  value: number | string;
+  options: PickerOption[];
+  onChange: (index: number | string) => void;
+  selectedIndicatorStyle?: StyleProp<ViewStyle>;
+  itemTextStyle?: TextStyle;
+  itemTextClassName?: string;
+  itemStyle?: ViewStyle;
+  selectedIndicatorClassName?: string;
+  itemHeight?: number;
+  containerStyle?: ViewStyle;
+  containerProps?: Omit<ViewProps, 'style'>;
+  scaleFunction?: (x: number) => number;
+  rotationFunction?: (x: number) => number;
+  opacityFunction?: (x: number) => number;
+  visibleRest?: number;
+  decelerationRate?: 'normal' | 'fast' | number;
+  flatListProps?: Omit<FlatListProps<PickerOption | null>, 'data' | 'renderItem'>;
+}
+
+const WheelPicker: React.FC<Props> = ({
+  value,
+  options,
+  onChange,
+  selectedIndicatorStyle = {},
+  containerStyle = {},
+  itemStyle = {},
+  itemTextStyle = {},
+  selectedIndicatorClassName = '',
+  itemTextClassName = '',
+  itemHeight = 40,
+  scaleFunction = (x: number) => 1.0 ** x,
+  rotationFunction = (x: number) => 1 - Math.pow(1 / 2, x),
+  opacityFunction = (x: number) => Math.pow(1 / 3, x),
+  visibleRest = 2,
+  decelerationRate = 'normal',
+  containerProps = {},
+  flatListProps = {},
+}) => {
+  const momentumStarted = useRef(false);
+  // Track if we just handled a user scroll to avoid over-scrolling animation
+  const handledUserScroll = useRef(false);
+  const lastEmittedValueRef = useRef<number | string>(value);
+  
+  const selectedIndex = options.findIndex((item) => item.value === value);
+
+  const flatListRef = useRef<FlatList>(null);
+  const [scrollY] = useState(new Animated.Value(selectedIndex * itemHeight));
+
+  const containerHeight = (1 + visibleRest * 2) * itemHeight;
+  const paddedOptions = useMemo(() => {
+    const array: (PickerOption | null)[] = [...options];
+    for (let i = 0; i < visibleRest; i++) {
+      array.unshift(null);
+      array.push(null);
+    }
+    return array;
+  }, [options, visibleRest]);
+
+  const offsets = useMemo(
+    () => [...Array(paddedOptions.length)].map((_, i) => i * itemHeight),
+    [paddedOptions, itemHeight]
+  );
+
+  const currentScrollIndex = useMemo(
+    () => Animated.add(Animated.divide(scrollY, itemHeight), visibleRest),
+    [visibleRest, scrollY, itemHeight]
+  );
+
+  const handleScrollEnd = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const offsetY = Math.min(
+      itemHeight * (options.length - 1),
+      Math.max(event.nativeEvent.contentOffset.y, 0)
+    );
+
+    let index = Math.floor(offsetY / itemHeight);
+    const remainder = offsetY % itemHeight;
+    if (remainder > itemHeight / 2) {
+      index++;
+    }
+
+    const nextValue = options[index]?.value || 0;
+    if (index !== selectedIndex && nextValue !== lastEmittedValueRef.current) {
+      lastEmittedValueRef.current = nextValue;
+      handledUserScroll.current = true;
+      onChange(nextValue);
+    }
+  };
+
+  const handleMomentumScrollBegin = () => {
+    momentumStarted.current = true;
+  };
+
+  const handleMomentumScrollEnd = (
+    event: NativeSyntheticEvent<NativeScrollEvent>
+  ) => {
+    momentumStarted.current = false;
+    handleScrollEnd(event);
+  };
+
+  const handleScrollEndDrag = (
+    event: NativeSyntheticEvent<NativeScrollEvent>
+  ) => {
+    // Capture the offset value immediately
+    const offsetY = event.nativeEvent.contentOffset?.y;
+
+    // We'll start a short timer to see if momentum scroll begins
+    setTimeout(() => {
+      // If momentum scroll hasn't started within the timeout,
+      // then it was a slow scroll that won't trigger momentum
+      if (!momentumStarted.current && offsetY !== undefined) {
+        // Create a synthetic event with just the data we need
+        const syntheticEvent = {
+          nativeEvent: {
+            contentOffset: { y: offsetY },
+          },
+        };
+        handleScrollEnd(syntheticEvent as any);
+      }
+    }, 50);
+  };
+
+  useEffect(() => {
+    if (selectedIndex < 0 || selectedIndex >= options.length) {
+      throw new Error(
+        `Selected index ${selectedIndex} is out of bounds [0, ${
+          options.length - 1
+        }]`
+      );
+    }
+  }, [selectedIndex, options]);
+
+  useEffect(() => {
+    // Keep the dedupe ref aligned with controlled updates from outside.
+    lastEmittedValueRef.current = value;
+  }, [value]);
+
+  /**
+   * If selectedIndex is changed from outside (not via onChange) we need to scroll to the specified index.
+   * This ensures that what the user sees as selected in the picker always corresponds to the value state.
+   *
+   * User-scroll fix: when onChange came from this picker's own scroll gesture, the FlatList is already
+   * on the correct row. Forcing scrollToIndex can cause rollover artifacts (iOS overscroll, Android flash),
+   * especially when parent state canonicalizes values (e.g., looped seconds wheel).
+   */
+  useEffect(() => {
+    if (handledUserScroll.current) {
+      handledUserScroll.current = false;
+      return;
+    }
+
+    const shouldAnimate = Platform.OS === 'ios';
+    flatListRef.current?.scrollToIndex({
+      index: selectedIndex,
+      animated: shouldAnimate,
+    });
+  }, [selectedIndex, itemHeight]);
+
+  return (
+    <View
+      style={[styles.container, { height: containerHeight }, containerStyle]}
+      {...containerProps}
+    >
+      <View
+        style={[
+          styles.selectedIndicator,
+          selectedIndicatorStyle,
+          {
+            transform: [{ translateY: -itemHeight / 2 }],
+            height: itemHeight,
+          },
+        ]}
+        className={selectedIndicatorClassName}
+      />
+      <Animated.FlatList
+        {...flatListProps}
+        ref={flatListRef}
+        nestedScrollEnabled
+        removeClippedSubviews
+        windowSize={7}
+        initialNumToRender={Math.max(8, visibleRest * 4)}
+        maxToRenderPerBatch={12}
+        updateCellsBatchingPeriod={16}
+        style={styles.scrollView}
+        showsVerticalScrollIndicator={false}
+        onScroll={Animated.event(
+          [{ nativeEvent: { contentOffset: { y: scrollY } } }],
+          { useNativeDriver: true }
+        )}
+        onScrollEndDrag={handleScrollEndDrag}
+        onMomentumScrollBegin={handleMomentumScrollBegin}
+        onMomentumScrollEnd={handleMomentumScrollEnd}
+        snapToOffsets={offsets}
+        decelerationRate={decelerationRate}
+        initialScrollIndex={selectedIndex}
+        getItemLayout={(_, index) => ({
+          length: itemHeight,
+          offset: itemHeight * index,
+          index,
+        })}
+        data={paddedOptions}
+        keyExtractor={(item, index) =>
+          item ? `${item.value}-${item.text}-${index}` : `null-${index}`
+        }
+        renderItem={({ item: option, index }) => (
+          <WheelPickerItem
+            key={`option-${index}`}
+            index={index}
+            option={option}
+            style={itemStyle}
+            textStyle={itemTextStyle}
+            textClassName={itemTextClassName}
+            height={itemHeight}
+            currentScrollIndex={currentScrollIndex}
+            scaleFunction={scaleFunction}
+            rotationFunction={rotationFunction}
+            opacityFunction={opacityFunction}
+            visibleRest={visibleRest}
+          />
+        )}
+      />
+    </View>
+  );
+};
+
+export default memo(WheelPicker);

--- a/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
@@ -523,11 +523,19 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
     );
     
     if (run) {
-      // Superset: use setExerciseRest to harmonize all members
-      // All updates should have the same seconds value
-      if (updates.length > 0) {
-        const seconds = updates[0].seconds;
-        store.setExerciseRest(exercise.id, seconds);
+      // Superset rest is per-round and shared across members: applies each
+      // changed round (matched by set_number) to every member's matching
+      // set, so editing one round doesn't overwrite the others.
+      const memberExercises = store.session.exercises.filter((e) =>
+        run.entryIds.includes(e.id),
+      );
+      for (const update of updates) {
+        const changedSet = exercise.sets.find((s) => String(s.id) === update.setId);
+        if (!changedSet) continue;
+        for (const member of memberExercises) {
+          const roundSet = member.sets.find((s) => s.set_number === changedSet.set_number);
+          if (roundSet) store.updateSetField(String(roundSet.id), { rest_time: update.seconds });
+        }
       }
     } else {
       // Solo exercise: update individual sets

--- a/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
@@ -74,6 +74,7 @@ import {
   exerciseFromSnapshot,
   formatDuration,
   formatSetLoad,
+  getSupersetRuns,
   rendersCardioEffortForm,
   summarizeWorkoutSpan,
 } from '../utils/workoutSession';
@@ -484,10 +485,16 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
   // Exercise rest drawer (All / per-set rest editing, committed on Done).
   const setRestSheetRef = useRef<ExerciseSetRestSheetRef>(null);
   const handlePressRestChip = useCallback((entryId: string, _currentSec: number | null) => {
-    const exercise = useActiveWorkoutStore
-      .getState()
-      .session?.exercises.find((e) => e.id === entryId);
-    if (!exercise) return;
+    const store = useActiveWorkoutStore.getState();
+    const exercise = store.session?.exercises.find((e) => e.id === entryId);
+    if (!exercise || !store.session) return;
+    
+    // Check if this exercise is part of a superset
+    const run = getSupersetRuns(store.session.exercises).find((r) =>
+      r.entryIds.includes(entryId),
+    );
+    const isSupersetMember = run != null;
+    
     setRestSheetRef.current?.present(
       exercise.exercise_snapshot?.name ?? 'Exercise',
       exercise.sets.map((set) => ({
@@ -495,12 +502,38 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
         setNumber: set.set_number,
         restSec: set.rest_time,
       })),
+      isSupersetMember,
     );
   }, []);
   const handleApplySetRests = useCallback((updates: ExerciseSetRestUpdate[]) => {
     const store = useActiveWorkoutStore.getState();
-    for (const update of updates) {
-      store.updateSetField(update.setId, { rest_time: update.seconds });
+    if (!store.session) return;
+    
+    // Find which exercise these updates belong to by matching the first set ID
+    const firstUpdate = updates[0];
+    if (!firstUpdate) return;
+    const exercise = store.session.exercises.find((e) =>
+      e.sets.some((s) => String(s.id) === firstUpdate.setId),
+    );
+    if (!exercise) return;
+    
+    // Check if this is a superset member
+    const run = getSupersetRuns(store.session.exercises).find((r) =>
+      r.entryIds.includes(exercise.id),
+    );
+    
+    if (run) {
+      // Superset: use setExerciseRest to harmonize all members
+      // All updates should have the same seconds value
+      if (updates.length > 0) {
+        const seconds = updates[0].seconds;
+        store.setExerciseRest(exercise.id, seconds);
+      }
+    } else {
+      // Solo exercise: update individual sets
+      for (const update of updates) {
+        store.updateSetField(update.setId, { rest_time: update.seconds });
+      }
     }
   }, []);
 

--- a/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
@@ -45,7 +45,10 @@ import ActionSheet, {
   type ActionSheetRef,
 } from '../components/ActionSheet';
 import { type AnchorRect } from '../components/AnchoredMenu';
-import RestPeriodSheet, { type RestPeriodSheetRef } from '../components/RestPeriodSheet';
+import ExerciseSetRestSheet, {
+  type ExerciseSetRestSheetRef,
+  type ExerciseSetRestUpdate,
+} from '../components/ExerciseSetRestSheet';
 import WorkoutDurationSheet, {
   type WorkoutDurationSheetRef,
 } from '../components/WorkoutDurationSheet';
@@ -478,17 +481,26 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
     [navigation, runNavigationAction],
   );
 
-  // Rest sheet (per-exercise rest duration).
-  const restSheetRef = useRef<RestPeriodSheetRef>(null);
-  const restSheetEntryIdRef = useRef<string | null>(null);
-  const handlePressRestChip = useCallback((entryId: string, currentSec: number | null) => {
-    restSheetEntryIdRef.current = entryId;
-    restSheetRef.current?.present(currentSec);
+  // Exercise rest drawer (All / per-set rest editing, committed on Done).
+  const setRestSheetRef = useRef<ExerciseSetRestSheetRef>(null);
+  const handlePressRestChip = useCallback((entryId: string, _currentSec: number | null) => {
+    const exercise = useActiveWorkoutStore
+      .getState()
+      .session?.exercises.find((e) => e.id === entryId);
+    if (!exercise) return;
+    setRestSheetRef.current?.present(
+      exercise.exercise_snapshot?.name ?? 'Exercise',
+      exercise.sets.map((set) => ({
+        setId: String(set.id),
+        setNumber: set.set_number,
+        restSec: set.rest_time,
+      })),
+    );
   }, []);
-  const handleRestChanged = useCallback((seconds: number) => {
-    const entryId = restSheetEntryIdRef.current;
-    if (entryId != null) {
-      useActiveWorkoutStore.getState().setExerciseRest(entryId, seconds);
+  const handleApplySetRests = useCallback((updates: ExerciseSetRestUpdate[]) => {
+    const store = useActiveWorkoutStore.getState();
+    for (const update of updates) {
+      store.updateSetField(update.setId, { rest_time: update.seconds });
     }
   }, []);
 
@@ -1257,7 +1269,7 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
         </KeyboardStickyView>
       )}
 
-      <RestPeriodSheet ref={restSheetRef} onChange={handleRestChanged} />
+      <ExerciseSetRestSheet ref={setRestSheetRef} onApply={handleApplySetRests} />
 
       <WorkoutDurationSheet ref={durationSheetRef} onSave={handleDurationSave} />
 

--- a/SparkyFitnessMobile/src/stores/activeWorkoutStore.ts
+++ b/SparkyFitnessMobile/src/stores/activeWorkoutStore.ts
@@ -365,7 +365,7 @@ export interface ActiveWorkoutState {
 export type ActiveSetPatch = Partial<
   Pick<
     ExerciseEntrySetResponse,
-    'weight' | 'reps' | 'duration' | 'distance' | 'rpe' | 'set_type' | 'notes'
+    'weight' | 'reps' | 'duration' | 'distance' | 'rpe' | 'set_type' | 'notes' | 'rest_time'
   >
 >;
 
@@ -411,13 +411,17 @@ const initialData: Pick<
 /**
  * Flatten a session into the step sequence the cursor walks.
  *
- * Solo exercises contribute one step per set. Superset runs (adjacent 2+
- * exercises sharing a `superset_group`) are interleaved into rounds: round
+ * Solo exercises contribute one step per set, each carrying its own set's
+ * configured `rest_time`. A preset can vary rest per set (e.g. shorter rest
+ * after warm-up sets), and every set must speak for itself rather than the
+ * exercise's first set standing in for all of them. Superset runs (adjacent
+ * 2+ exercises sharing a `superset_group`) are interleaved into rounds: round
  * `n` is one set of each member in order (positional — members whose sets
  * are exhausted drop out). `restSec` is the rest taken *before* a step, so
- * each round's first step carries the group rest and the rest of the round
- * carries 0 — rest happens after a full round, not between partners. Drop-set
- * steps always carry 0: a drop continues the previous set with no pause.
+ * each round's first step carries that round's group rest (the anchor
+ * member's same-round set) and the rest of the round carries 0 and rest
+ * happens after a full round, not between partners. Drop-set steps always
+ * carry 0: a drop continues the previous set with no pause.
  */
 export function buildStepsFromSession(session: PresetSessionResponse): WorkoutStep[] {
   const steps: WorkoutStep[] = [];
@@ -446,9 +450,8 @@ export function buildStepsFromSession(session: PresetSessionResponse): WorkoutSt
 
     const run = runByFirstEntryId.get(exercise.id);
     if (!run) {
-      const restSec = exercise.sets[0]?.rest_time ?? getDefaultRestSec();
       for (const set of exercise.sets) {
-        pushStep(exercise, set, restSec);
+        pushStep(exercise, set, set.rest_time ?? getDefaultRestSec());
       }
       continue;
     }
@@ -456,11 +459,12 @@ export function buildStepsFromSession(session: PresetSessionResponse): WorkoutSt
     const members = run.entryIds.map((id) => byEntryId.get(id)!);
     for (const id of run.entryIds) consumed.add(id);
 
-    // Rest is per-round; group actions harmonize every member's rest_time,
-    // so the anchor's first set speaks for the whole group.
-    const groupRest = members[0].sets[0]?.rest_time ?? getDefaultRestSec();
+    // Rest is per-round; group actions harmonize every member's rest_time
+    // within a round, so the anchor's set for that round speaks for the
+    // whole group, but different rounds may still carry different rest.
     const roundCount = Math.max(...members.map((m) => m.sets.length));
     for (let round = 0; round < roundCount; round++) {
+      const groupRest = members[0].sets[round]?.rest_time ?? getDefaultRestSec();
       let firstInRound = true;
       for (const member of members) {
         const set = member.sets[round];
@@ -671,9 +675,10 @@ function adoptAssumedSetValues(
  * the planned interleaving — out-of-order logging makes the cursor land on an
  * interior partner (baked 0) when a real between-rounds rest is actually owed,
  * so derive the rest from the true relationship between the two sets instead.
- * Rest is per-exercise and recovers from the work just done: the completed
- * exercise's `sets[0]` speaks for it, so the timer after an exercise's final
- * set still uses that exercise's rest, not the next one's.
+ * Rest recovers from the work just done: the completed set's own `rest_time`
+ * speaks for it (not another set's — a preset can vary rest per set), so the
+ * timer after an exercise's final set still uses that set's own rest, not the
+ * next one's.
  * Drop sets take no rest before them regardless of what was just logged.
  */
 function restSecBeforeNextSet(
@@ -686,7 +691,7 @@ function restSecBeforeNextSet(
   if (isDropSetType(to.exercise.sets[to.setIndex]?.set_type)) return 0;
 
   const from = locateSet(session, completedSetId);
-  if (!from) return to.exercise.sets[0]?.rest_time ?? getDefaultRestSec();
+  if (!from) return to.exercise.sets[to.setIndex]?.rest_time ?? getDefaultRestSec();
 
   // Back-to-back superset partners: same run, different member, same round.
   const toRun = getSupersetRuns(session.exercises).find((r) =>
@@ -700,7 +705,7 @@ function restSecBeforeNextSet(
   ) {
     return 0;
   }
-  return from.exercise.sets[0]?.rest_time ?? getDefaultRestSec();
+  return from.exercise.sets[from.setIndex]?.rest_time ?? getDefaultRestSec();
 }
 
 /**

--- a/SparkyFitnessMobile/src/types/assets.d.ts
+++ b/SparkyFitnessMobile/src/types/assets.d.ts
@@ -9,26 +9,3 @@ declare module '*.wav' {
   const asset: number;
   export default asset;
 }
-
-// Deep import of the internal WheelPicker used by react-native-ui-datepicker's
-// time columns. Metro resolves via the package's "react-native" \u2192 src/index
-// field, so the sub-path works at runtime; this declaration satisfies tsc.
-declare module 'react-native-ui-datepicker/src/components/time-picker/wheel-picker' {
-  import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
-  export interface WheelPickerOption {
-    value: number | string;
-    text: string;
-  }
-  interface WheelPickerProps {
-    value: number | string;
-    options: WheelPickerOption[];
-    onChange: (value: number | string) => void;
-    selectedIndicatorStyle?: StyleProp<ViewStyle>;
-    itemTextStyle?: TextStyle;
-    itemHeight?: number;
-    decelerationRate?: 'normal' | 'fast' | number;
-    containerStyle?: StyleProp<ViewStyle>;
-  }
-  const WheelPicker: React.FC<WheelPickerProps>;
-  export default WheelPicker;
-}

--- a/SparkyFitnessMobile/src/types/assets.d.ts
+++ b/SparkyFitnessMobile/src/types/assets.d.ts
@@ -9,3 +9,26 @@ declare module '*.wav' {
   const asset: number;
   export default asset;
 }
+
+// Deep import of the internal WheelPicker used by react-native-ui-datepicker's
+// time columns. Metro resolves via the package's "react-native" \u2192 src/index
+// field, so the sub-path works at runtime; this declaration satisfies tsc.
+declare module 'react-native-ui-datepicker/src/components/time-picker/wheel-picker' {
+  import type { StyleProp, TextStyle, ViewStyle } from 'react-native';
+  export interface WheelPickerOption {
+    value: number | string;
+    text: string;
+  }
+  interface WheelPickerProps {
+    value: number | string;
+    options: WheelPickerOption[];
+    onChange: (value: number | string) => void;
+    selectedIndicatorStyle?: StyleProp<ViewStyle>;
+    itemTextStyle?: TextStyle;
+    itemHeight?: number;
+    decelerationRate?: 'normal' | 'fast' | number;
+    containerStyle?: StyleProp<ViewStyle>;
+  }
+  const WheelPicker: React.FC<WheelPickerProps>;
+  export default WheelPicker;
+}

--- a/SparkyFitnessMobile/src/types/drafts.ts
+++ b/SparkyFitnessMobile/src/types/drafts.ts
@@ -30,6 +30,8 @@ export interface WorkoutSetMetaPatch {
   setType?: string;
   rpe?: number | null;
   notes?: string | null;
+  /** Rest time in seconds for this set. */
+  restTime?: number | null;
   /** ISO string to mark the set complete, null to clear it. */
   completedAt?: string | null;
 }


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description
Added functionality to support per set rest duration and the ability to edit it.

**What problem does this PR solve?**
Per set rest functionality

**How did you implement the solution?**
Via Android Studio with AI Assistance for React elements

Linked Issue: Closes #
https://github.com/CodeWithCJ/SparkyFitness/issues/1977

## How to Test

1. Check out this branch and build mobile
2. Edit or Activate a workout
3. Press the "Rest .." time to view edit
4. Complete a few sets to verify rest times are honored.

## PR Type

- [ ] Issue (bug fix)
- [X] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [X] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [X] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [X] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="395" height="366" alt="image" src="https://github.com/user-attachments/assets/444b4be8-ee20-44cd-8c07-a613411d7836" />

### After

<img width="400" height="361" alt="image" src="https://github.com/user-attachments/assets/5998b59e-dac9-4870-95a1-76276f38a2db" />

<img width="408" height="612" alt="image" src="https://github.com/user-attachments/assets/534bbbdd-f943-4df2-970a-d0a925d692ff" />


</details>

## Notes for Reviewers

I would like a review of AI's implementation of the duration wheel aspects.

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, questions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-set and per-round rest-time editing through a new bottom sheet.
  * Added a minute-and-second duration picker for rest periods.
  * Rest displays now show ranges when sets have different durations.
  * Added support for editing rest times across superset rounds.

* **Bug Fixes**
  * Rest periods now use each set’s configured duration instead of incorrectly reusing the first set’s value.
  * Improved handling of rest-time updates and workout session reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->