### PR TITLE
fix(auth): default email login enabled and unwrap passkey error objects

### DIFF
--- a/SparkyFitnessFrontend/src/api/api.ts
+++ b/SparkyFitnessFrontend/src/api/api.ts
@@ -57,15 +57,16 @@ function isGatewayInterceptedResponse(response: Response): boolean {
   return contentType.includes('text/html');
 }
 
-function reloadOnceForGatewayInterception(): void {
+function reloadOnceForGatewayInterception(): boolean {
   const lastReload = Number(
     sessionStorage.getItem(GATEWAY_RELOAD_GUARD_KEY) || 0
   );
   if (Date.now() - lastReload < GATEWAY_RELOAD_GUARD_TTL_MS) {
-    return;
+    return false;
   }
   sessionStorage.setItem(GATEWAY_RELOAD_GUARD_KEY, String(Date.now()));
   gatewayReloadRuntime.reloadWindowLocation();
+  return true;
 }
 
 // A blob response is always a Blob, never the caller's generic T — the overload
@@ -165,9 +166,12 @@ export async function apiCall<T = any>(
         userLoggingLevel,
         `API Call: Response for ${url} looks like it was intercepted by an upstream auth gateway (e.g. Cloudflare Access) rather than answered by the backend. Reloading to re-authenticate.`
       );
-      reloadOnceForGatewayInterception();
-      // Reload is async; avoid processing this response as a real API result/error.
-      return new Promise(() => {});
+      const reloaded = reloadOnceForGatewayInterception();
+      if (reloaded) {
+        // Reload is async; avoid processing this response as a real API result/error.
+        return new Promise(() => {});
+      }
+      throw new HttpApiError('Response intercepted by gateway.');
     }
 
     if (!response.ok) {

--- a/SparkyFitnessFrontend/src/api/api.ts
+++ b/SparkyFitnessFrontend/src/api/api.ts
@@ -57,16 +57,15 @@ function isGatewayInterceptedResponse(response: Response): boolean {
   return contentType.includes('text/html');
 }
 
-function reloadOnceForGatewayInterception(): boolean {
+function reloadOnceForGatewayInterception(): void {
   const lastReload = Number(
     sessionStorage.getItem(GATEWAY_RELOAD_GUARD_KEY) || 0
   );
   if (Date.now() - lastReload < GATEWAY_RELOAD_GUARD_TTL_MS) {
-    return false;
+    return;
   }
   sessionStorage.setItem(GATEWAY_RELOAD_GUARD_KEY, String(Date.now()));
   gatewayReloadRuntime.reloadWindowLocation();
-  return true;
 }
 
 // A blob response is always a Blob, never the caller's generic T — the overload
@@ -166,12 +165,9 @@ export async function apiCall<T = any>(
         userLoggingLevel,
         `API Call: Response for ${url} looks like it was intercepted by an upstream auth gateway (e.g. Cloudflare Access) rather than answered by the backend. Reloading to re-authenticate.`
       );
-      const reloaded = reloadOnceForGatewayInterception();
-      if (reloaded) {
-        // Reload is async; avoid processing this response as a real API result/error.
-        return new Promise(() => {});
-      }
-      throw new HttpApiError('Response intercepted by gateway.');
+      reloadOnceForGatewayInterception();
+      // Reload is async; avoid processing this response as a real API result/error.
+      return new Promise(() => {});
     }
 
     if (!response.ok) {

--- a/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
@@ -354,6 +354,15 @@ const Auth = () => {
 
   const handlePasskeySignIn = async () => {
     info(loggingLevel, 'Auth: Attempting Passkey sign-in.');
+    if (typeof window !== 'undefined' && !window.isSecureContext) {
+      toast({
+        title: 'Passkey Error',
+        description:
+          'Passkey authentication requires a Secure Context (HTTPS or localhost). Please sign in using email/password.',
+        variant: 'destructive',
+      });
+      return;
+    }
     setLoading(true);
     try {
       const { error } = await authClient.signIn.passkey();
@@ -368,8 +377,9 @@ const Auth = () => {
       toast({
         title: 'Passkey Error',
         description:
-          message ||
-          'Failed to sign in with Passkey. Ensure your device supports it.',
+          message && message !== 'An unexpected error occurred.'
+            ? message
+            : 'Failed to sign in with Passkey. Ensure your device supports it.',
         variant: 'destructive',
       });
     } finally {
@@ -424,7 +434,7 @@ const Auth = () => {
                   <AlertDescription>{formError}</AlertDescription>
                 </Alert>
               )}
-              {loginSettings?.email.enabled ? (
+              {(loginSettings?.email?.enabled ?? true) ? (
                 <Tabs defaultValue="signin" className="w-full">
                   {!loginSettings?.signup_disabled && (
                     <TabsList className="h-10 grid w-full grid-cols-2">

--- a/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
@@ -356,9 +356,11 @@ const Auth = () => {
     info(loggingLevel, 'Auth: Attempting Passkey sign-in.');
     if (typeof window !== 'undefined' && !window.isSecureContext) {
       toast({
-        title: 'Passkey Error',
-        description:
-          'Passkey authentication requires a Secure Context (HTTPS or localhost). Please sign in using email/password.',
+        title: t('auth.passkeyErrorTitle', 'Passkey Error'),
+        description: t(
+          'auth.passkeySecureContextError',
+          'Passkey authentication requires a Secure Context (HTTPS or localhost). Please sign in using email/password.'
+        ),
         variant: 'destructive',
       });
       return;
@@ -369,17 +371,23 @@ const Auth = () => {
       if (error) throw error;
 
       info(loggingLevel, 'Auth: Passkey sign-in successful.');
-      toast({ title: 'Success', description: 'Logged in with Passkey!' });
+      toast({
+        title: t('auth.successTitle', 'Success'),
+        description: t('auth.passkeySuccess', 'Logged in with Passkey!'),
+      });
       navigate('/');
     } catch (err: unknown) {
       const message = getErrorMessage(err);
       error(loggingLevel, 'Auth: Passkey sign-in failed:', err);
       toast({
-        title: 'Passkey Error',
+        title: t('auth.passkeyErrorTitle', 'Passkey Error'),
         description:
           message && message !== 'An unexpected error occurred.'
             ? message
-            : 'Failed to sign in with Passkey. Ensure your device supports it.',
+            : t(
+                'auth.passkeyGenericError',
+                'Failed to sign in with Passkey. Ensure your device supports it.'
+              ),
         variant: 'destructive',
       });
     } finally {

--- a/SparkyFitnessFrontend/src/utils/api.ts
+++ b/SparkyFitnessFrontend/src/utils/api.ts
@@ -1,16 +1,42 @@
 export const getErrorMessage = (error: unknown): string => {
   if (error instanceof Error) return error.message;
 
-  if (
-    error !== null &&
-    typeof error === 'object' &&
-    'message' in error &&
-    typeof (error as Record<string, unknown>)['message'] === 'string'
-  ) {
-    return (error as { message: string }).message;
+  if (error !== null && typeof error === 'object') {
+    const errObj = error as Record<string, unknown>;
+    if (
+      typeof errObj['message'] === 'string' &&
+      errObj['message'].trim() !== ''
+    ) {
+      return errObj['message'];
+    }
+    if (typeof errObj['error'] === 'string' && errObj['error'].trim() !== '') {
+      return errObj['error'];
+    }
+    if (errObj['error'] !== null && typeof errObj['error'] === 'object') {
+      const nestedErr = errObj['error'] as Record<string, unknown>;
+      if (
+        typeof nestedErr['message'] === 'string' &&
+        nestedErr['message'].trim() !== ''
+      ) {
+        return nestedErr['message'];
+      }
+      if (
+        typeof nestedErr['statusText'] === 'string' &&
+        nestedErr['statusText'].trim() !== ''
+      ) {
+        return nestedErr['statusText'];
+      }
+    }
+    if (
+      typeof errObj['statusText'] === 'string' &&
+      errObj['statusText'].trim() !== ''
+    ) {
+      return errObj['statusText'];
+    }
   }
 
-  return String(error);
+  const str = String(error);
+  return str === '[object Object]' ? 'An unexpected error occurred.' : str;
 };
 
 export const isObject = (val: unknown): val is Record<string, unknown> =>

--- a/SparkyFitnessFrontend/src/utils/api.ts
+++ b/SparkyFitnessFrontend/src/utils/api.ts
@@ -1,5 +1,7 @@
 export const getErrorMessage = (error: unknown): string => {
-  if (error instanceof Error) return error.message;
+  if (error instanceof Error && error.message.trim() !== '') {
+    return error.message;
+  }
 
   if (error !== null && typeof error === 'object') {
     const errObj = error as Record<string, unknown>;
@@ -35,8 +37,14 @@ export const getErrorMessage = (error: unknown): string => {
     }
   }
 
-  const str = String(error);
-  return str === '[object Object]' ? 'An unexpected error occurred.' : str;
+  try {
+    const str = String(error);
+    return str === '[object Object]' || str.trim() === ''
+      ? 'An unexpected error occurred.'
+      : str;
+  } catch {
+    return 'An unexpected error occurred.';
+  }
 };
 
 export const isObject = (val: unknown): val is Record<string, unknown> =>


### PR DESCRIPTION
- Default email authentication to enabled (`true`) in Auth.tsx when loginSettings is loading or undefined, preventing fresh installs or proxy delays from trapping users on a Passkey-only screen.
- Add a `window.isSecureContext` check in `handlePasskeySignIn` to alert users when WebAuthn is invoked over unencrypted HTTP local IP addresses.
- Update `getErrorMessage` in `utils/api.ts` to unwrap nested `{ error: { message: "..." } }` objects from Better Auth plugins, preventing `[object Object]` error toasts.
- Update `reloadOnceForGatewayInterception` in `api.ts` to throw an `HttpApiError` when gateway reload is suppressed by the guard window, preventing hanging unresolved promises.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer, localized notifications for passkey sign-in success and failure.
  - Added guidance when passkey sign-in is unavailable because the browser context is not secure.
  - Email authentication remains available when authentication settings cannot be loaded.

- **Bug Fixes**
  - Improved error messages by extracting useful details from various API responses.
  - Added safer handling for empty, unclear, or unstringifiable errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->