### PR TITLE
fix(server): default missing entry_timestamp for non-daily custom measurements

### DIFF
--- a/SparkyFitnessServer/models/measurementRepository.ts
+++ b/SparkyFitnessServer/models/measurementRepository.ts
@@ -2,16 +2,23 @@ import { getClient } from '../db/poolManager.js';
 import { log } from '../config/logging.js';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'pg-f... Remove this comment to see the full error message
 import format from 'pg-format';
-import { CALORIE_CALCULATION_CONSTANTS, isDayString } from '@workspace/shared';
+import {
+  CALORIE_CALCULATION_CONSTANTS,
+  isDayString,
+  isValidTimeZone,
+  todayInZone,
+} from '@workspace/shared';
 
 /**
  * Helper to derive a default UTC entry_timestamp ISO string when omitted or invalid.
  * Avoids timezone jump issues by leveraging isDayString and Date.UTC date construction.
+ * Compares entryDate with todayInZone(userTimezone) to detect if logging for the user's current day.
  */
 function defaultEntryTimestamp(
   entryTimestamp: string | null | undefined,
   entryDate: string | null | undefined,
-  entryHour: number | null | undefined
+  entryHour: number | null | undefined,
+  userTimezone?: string | null
 ): string {
   if (entryTimestamp && entryTimestamp.trim() !== '') {
     return entryTimestamp;
@@ -33,8 +40,10 @@ function defaultEntryTimestamp(
     }
 
     const now = new Date();
-    const nowUtcDay = now.toISOString().split('T')[0];
-    if (entryDate === nowUtcDay) {
+    const tz =
+      userTimezone && isValidTimeZone(userTimezone) ? userTimezone : 'UTC';
+    const currentDayInZone = todayInZone(tz);
+    if (entryDate === currentDayInZone) {
       return now.toISOString();
     }
 
@@ -977,33 +986,25 @@ async function getCustomMeasurementsByDateRange(
   }
 }
 async function upsertCustomMeasurement(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  actingUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  categoryId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  value: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  entryDate: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  entryHour: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  entryTimestamp: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  notes: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  frequency: any,
-  source = 'manual'
+  userId: string,
+  actingUserId: string,
+  categoryId: string,
+  value: string | number | boolean,
+  entryDate: string,
+  entryHour?: number | null,
+  entryTimestamp?: string | null,
+  notes?: string | null,
+  frequency?: string | null,
+  source = 'manual',
+  userTimezone?: string | null
 ) {
   const client = await getClient(actingUserId); // User-specific operation, using actingUserId for RLS context
   try {
     let query;
     let values;
     // Normalize entry_hour and entry_timestamp for 'Daily' frequency to prevent duplicates
-    let normalizedEntryHour = entryHour;
-    let normalizedEntryTimestamp = entryTimestamp;
+    let normalizedEntryHour = entryHour ?? null;
+    let normalizedEntryTimestamp = entryTimestamp ?? null;
     if (frequency === 'Daily') {
       normalizedEntryHour = 0; // Set hour to 0 for daily measurements
       // Normalize timestamp to the beginning of the day
@@ -1029,7 +1030,8 @@ async function upsertCustomMeasurement(
       normalizedEntryTimestamp = defaultEntryTimestamp(
         normalizedEntryTimestamp,
         entryDate,
-        normalizedEntryHour
+        normalizedEntryHour,
+        userTimezone
       );
     }
     // For 'Unlimited' and 'All' frequencies, always insert a new entry.
@@ -1048,7 +1050,7 @@ async function upsertCustomMeasurement(
         entryDate,
         normalizedEntryHour,
         normalizedEntryTimestamp,
-        notes,
+        notes ?? null,
         actingUserId,
         source,
       ];
@@ -1058,7 +1060,12 @@ async function upsertCustomMeasurement(
         SELECT id FROM custom_measurements
         WHERE user_id = $1 AND category_id = $2 AND entry_date = $3 AND source = $4
       `;
-      const existingEntryValues = [userId, categoryId, entryDate, source];
+      const existingEntryValues: unknown[] = [
+        userId,
+        categoryId,
+        entryDate,
+        source,
+      ];
       if (frequency === 'Hourly' && normalizedEntryHour !== null) {
         existingEntryQuery += ` AND entry_hour = $${existingEntryValues.length + 1}`;
         existingEntryValues.push(normalizedEntryHour);
@@ -1083,7 +1090,7 @@ async function upsertCustomMeasurement(
         values = [
           value,
           normalizedEntryTimestamp,
-          notes,
+          notes ?? null,
           actingUserId,
           source,
           id,
@@ -1102,7 +1109,7 @@ async function upsertCustomMeasurement(
           entryDate,
           normalizedEntryHour,
           normalizedEntryTimestamp,
-          notes,
+          notes ?? null,
           actingUserId,
           source,
         ];
@@ -1114,6 +1121,19 @@ async function upsertCustomMeasurement(
     client.release();
   }
 }
+
+export interface BulkCustomMeasurementInputRow {
+  categoryId: string;
+  value: string | number | boolean;
+  entryDate: string;
+  entryHour?: number | null;
+  entryTimestamp?: string | null;
+  notes?: string | null;
+  frequency: string;
+  source?: string | null;
+  userTimezone?: string | null;
+}
+
 /**
  * Batch counterpart of upsertCustomMeasurement for health-data ingestion: one
  * client + one transaction for the whole batch instead of one client per
@@ -1128,28 +1148,10 @@ async function upsertCustomMeasurement(
  * winner's row).
  */
 async function bulkUpsertCustomMeasurements(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  actingUserId: any,
-  rows: Array<{
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    categoryId: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    value: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    entryDate: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    entryHour: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    entryTimestamp: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    notes: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    frequency: any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    source?: any;
-  }>
+  userId: string,
+  actingUserId: string,
+  rows: BulkCustomMeasurementInputRow[],
+  userTimezone?: string | null
 ) {
   if (!rows || rows.length === 0) {
     return [];
@@ -1187,7 +1189,8 @@ async function bulkUpsertCustomMeasurements(
         normalizedEntryTimestamp = defaultEntryTimestamp(
           normalizedEntryTimestamp,
           row.entryDate,
-          normalizedEntryHour
+          normalizedEntryHour,
+          row.userTimezone ?? userTimezone
         );
       }
       return {

--- a/SparkyFitnessServer/models/measurementRepository.ts
+++ b/SparkyFitnessServer/models/measurementRepository.ts
@@ -2,7 +2,47 @@ import { getClient } from '../db/poolManager.js';
 import { log } from '../config/logging.js';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'pg-f... Remove this comment to see the full error message
 import format from 'pg-format';
-import { CALORIE_CALCULATION_CONSTANTS } from '@workspace/shared';
+import { CALORIE_CALCULATION_CONSTANTS, isDayString } from '@workspace/shared';
+
+/**
+ * Helper to derive a default UTC entry_timestamp ISO string when omitted or invalid.
+ * Avoids timezone jump issues by leveraging isDayString and Date.UTC date construction.
+ */
+function defaultEntryTimestamp(
+  entryTimestamp: string | null | undefined,
+  entryDate: string | null | undefined,
+  entryHour: number | null | undefined
+): string {
+  if (entryTimestamp && entryTimestamp.trim() !== '') {
+    return entryTimestamp;
+  }
+  if (entryDate && isDayString(entryDate)) {
+    const parts = entryDate.split('-');
+    const year = Number(parts[0]);
+    const month = Number(parts[1]);
+    const day = Number(parts[2]);
+
+    if (
+      entryHour !== null &&
+      entryHour !== undefined &&
+      !isNaN(Number(entryHour))
+    ) {
+      return new Date(
+        Date.UTC(year, month - 1, day, Number(entryHour), 0, 0, 0)
+      ).toISOString();
+    }
+
+    const now = new Date();
+    const nowUtcDay = now.toISOString().split('T')[0];
+    if (entryDate === nowUtcDay) {
+      return now.toISOString();
+    }
+
+    return new Date(Date.UTC(year, month - 1, day, 0, 0, 0, 0)).toISOString();
+  }
+
+  return new Date().toISOString();
+}
 // SECURITY: Whitelist allowed measurement columns to prevent SQL injection via dynamic keys
 const ALLOWED_CHECK_IN_COLUMNS = [
   'weight',
@@ -967,9 +1007,30 @@ async function upsertCustomMeasurement(
     if (frequency === 'Daily') {
       normalizedEntryHour = 0; // Set hour to 0 for daily measurements
       // Normalize timestamp to the beginning of the day
-      const dateObj = new Date(entryDate);
-      dateObj.setUTCHours(0, 0, 0, 0);
-      normalizedEntryTimestamp = dateObj.toISOString();
+      if (entryDate && isDayString(entryDate)) {
+        const parts = entryDate.split('-');
+        normalizedEntryTimestamp = new Date(
+          Date.UTC(
+            Number(parts[0]),
+            Number(parts[1]) - 1,
+            Number(parts[2]),
+            0,
+            0,
+            0,
+            0
+          )
+        ).toISOString();
+      } else {
+        const dateObj = new Date(entryDate);
+        dateObj.setUTCHours(0, 0, 0, 0);
+        normalizedEntryTimestamp = dateObj.toISOString();
+      }
+    } else {
+      normalizedEntryTimestamp = defaultEntryTimestamp(
+        normalizedEntryTimestamp,
+        entryDate,
+        normalizedEntryHour
+      );
     }
     // For 'Unlimited' and 'All' frequencies, always insert a new entry.
     // For 'Daily' and 'Hourly', check for existing entries to update.
@@ -1104,9 +1165,30 @@ async function bulkUpsertCustomMeasurements(
       if (row.frequency === 'Daily') {
         normalizedEntryHour = 0; // Set hour to 0 for daily measurements
         // Normalize timestamp to the beginning of the day
-        const dateObj = new Date(row.entryDate);
-        dateObj.setUTCHours(0, 0, 0, 0);
-        normalizedEntryTimestamp = dateObj.toISOString();
+        if (row.entryDate && isDayString(row.entryDate)) {
+          const parts = row.entryDate.split('-');
+          normalizedEntryTimestamp = new Date(
+            Date.UTC(
+              Number(parts[0]),
+              Number(parts[1]) - 1,
+              Number(parts[2]),
+              0,
+              0,
+              0,
+              0
+            )
+          ).toISOString();
+        } else {
+          const dateObj = new Date(row.entryDate);
+          dateObj.setUTCHours(0, 0, 0, 0);
+          normalizedEntryTimestamp = dateObj.toISOString();
+        }
+      } else {
+        normalizedEntryTimestamp = defaultEntryTimestamp(
+          normalizedEntryTimestamp,
+          row.entryDate,
+          normalizedEntryHour
+        );
       }
       return {
         ...row,

--- a/SparkyFitnessServer/models/measurementRepository.ts
+++ b/SparkyFitnessServer/models/measurementRepository.ts
@@ -1227,8 +1227,7 @@ async function bulkUpsertCustomMeasurements(
     const keyedWinnerIndexes = [...winnerByKey.values()];
     // One superset SELECT for all keyed rows, then exact per-key matching in
     // JS (mirrors the per-record existence SELECT semantics).
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const existingByKey = new Map<string, any>();
+    const existingByKey = new Map<string, Record<string, unknown>>();
     if (keyedWinnerIndexes.length > 0) {
       const categoryIds = [
         ...new Set(keyedWinnerIndexes.map((i) => prepared[i].categoryId)),
@@ -1246,8 +1245,7 @@ async function bulkUpsertCustomMeasurements(
       );
       for (const index of keyedWinnerIndexes) {
         const row = prepared[index];
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const match = existing.rows.find((dbRow: any) => {
+        const match = existing.rows.find((dbRow: Record<string, unknown>) => {
           if (dbRow.category_id !== row.categoryId) return false;
           // entry_date comes back as a YYYY-MM-DD string (poolManager DATE parser)
           if (String(dbRow.entry_date) !== String(row.entryDate)) return false;
@@ -1265,8 +1263,7 @@ async function bulkUpsertCustomMeasurements(
         }
       }
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const writtenByInput: any[] = new Array(rows.length);
+    const writtenByInput: Record<string, unknown>[] = new Array(rows.length);
     const updateIndexes = keyedWinnerIndexes.filter((i) =>
       existingByKey.has(keyByIndex[i]!)
     );
@@ -1279,21 +1276,27 @@ async function bulkUpsertCustomMeasurements(
          RETURNING cm.*`,
         [
           actingUserId,
-          updateIndexes.map((i) => existingByKey.get(keyByIndex[i]!).id),
+          updateIndexes.map((i) => existingByKey.get(keyByIndex[i]!)!.id),
           updateIndexes.map((i) => prepared[i].value),
           updateIndexes.map((i) => prepared[i].entryTimestamp),
           updateIndexes.map((i) => prepared[i].notes ?? null),
           updateIndexes.map((i) => prepared[i].source),
         ]
       );
-      const updatedById = new Map(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        updateResult.rows.map((row: any) => [row.id, row])
+      const updatedById = new Map<string, Record<string, unknown>>(
+        updateResult.rows.map((row: Record<string, unknown>) => [
+          row.id as string,
+          row,
+        ])
       );
       for (const index of updateIndexes) {
-        writtenByInput[index] = updatedById.get(
-          existingByKey.get(keyByIndex[index]!).id
-        );
+        const existingRow = existingByKey.get(keyByIndex[index]!);
+        if (existingRow && existingRow.id) {
+          const updatedRow = updatedById.get(String(existingRow.id));
+          if (updatedRow) {
+            writtenByInput[index] = updatedRow;
+          }
+        }
       }
     }
     const insertIndexes = [

--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -1622,13 +1622,21 @@ async function updateSleepEntry(
     throw error;
   }
 }
+interface UpsertCustomMeasurementPayload {
+  category_id: string;
+  value: string | number | boolean;
+  entry_date: string;
+  entry_hour?: number | null;
+  entry_timestamp?: string | null;
+  notes?: string | null;
+  source?: string;
+  timezone?: string | null;
+}
+
 async function upsertCustomMeasurementEntry(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authenticatedUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  actingUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  payload: any
+  authenticatedUserId: string,
+  actingUserId: string,
+  payload: UpsertCustomMeasurementPayload
 ) {
   try {
     const {
@@ -1643,13 +1651,16 @@ async function upsertCustomMeasurementEntry(
     // Fetch category details to get the frequency
     const categories =
       await measurementRepository.getCustomCategories(authenticatedUserId);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const category = categories.find((cat: any) => cat.id === category_id);
+    const category = categories.find(
+      (cat: { id: string; frequency: string }) => cat.id === category_id
+    );
     if (!category) {
       throw new Error(`Custom category with ID ${category_id} not found.`);
     }
     const userTimezone =
-      payload.timezone || (await loadUserTimezone(authenticatedUserId));
+      payload.timezone && isValidTimeZone(payload.timezone)
+        ? payload.timezone
+        : await loadUserTimezone(authenticatedUserId);
     const result = await measurementRepository.upsertCustomMeasurement(
       authenticatedUserId,
       actingUserId,

--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -1648,6 +1648,8 @@ async function upsertCustomMeasurementEntry(
     if (!category) {
       throw new Error(`Custom category with ID ${category_id} not found.`);
     }
+    const userTimezone =
+      payload.timezone || (await loadUserTimezone(authenticatedUserId));
     const result = await measurementRepository.upsertCustomMeasurement(
       authenticatedUserId,
       actingUserId,
@@ -1658,7 +1660,8 @@ async function upsertCustomMeasurementEntry(
       entry_timestamp,
       notes,
       category.frequency, // Pass the frequency to the repository
-      source // Pass the source to the repository
+      source, // Pass the source to the repository
+      userTimezone
     );
     return result;
   } catch (error) {

--- a/SparkyFitnessServer/tests/chatbotToolsCheckin.test.ts
+++ b/SparkyFitnessServer/tests/chatbotToolsCheckin.test.ts
@@ -297,6 +297,42 @@ describe('log_custom_metric', () => {
     });
   });
 
+  it('logs custom metric successfully for non-daily frequency category', async () => {
+    vi.mocked(measurementService.getCustomCategories).mockResolvedValue([
+      {
+        id: 'c2',
+        name: 'Blood Pressure Systolic',
+        frequency: 'Unlimited',
+      },
+    ]);
+    vi.mocked(
+      measurementService.upsertCustomMeasurementEntry
+    ).mockResolvedValue({ id: 'm2' });
+
+    const result = await tools.sparky_manage_checkin.execute!(
+      {
+        action: 'log_custom_metric',
+        category_name: 'Blood Pressure Systolic',
+        value: 118,
+        unit: 'mmHg',
+        entry_date: '2026-08-10',
+      },
+      opts
+    );
+
+    expect(result).toBe(
+      '✅ Custom metric "Blood Pressure Systolic" logged: 118 mmHg on 2026-08-10.'
+    );
+    expect(
+      measurementService.upsertCustomMeasurementEntry
+    ).toHaveBeenCalledWith('user-1', 'user-1', {
+      category_id: 'c2',
+      value: '118',
+      entry_date: '2026-08-10',
+      notes: undefined,
+    });
+  });
+
   it('asks for create_category when the category does not exist', async () => {
     vi.mocked(measurementService.getCustomCategories).mockResolvedValue([]);
 

--- a/SparkyFitnessServer/tests/measurementRepository.customMetricTimestamp.test.ts
+++ b/SparkyFitnessServer/tests/measurementRepository.customMetricTimestamp.test.ts
@@ -1,28 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import measurementRepository from '../models/measurementRepository.js';
 import { getClient } from '../db/poolManager.js';
+import {
+  createMockDbClient,
+  type MockDbClient,
+} from './helpers/mockDbClient.js';
+import { todayInZone } from '@workspace/shared';
 
 vi.mock('../db/poolManager.js', () => ({
   getClient: vi.fn(),
 }));
 
+type QueryTuple = [string, unknown[] | undefined];
+
 describe('measurementRepository custom metric entry_timestamp defaulting', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockClient: any;
+  let mockClient: MockDbClient;
 
   beforeEach(() => {
-    mockClient = {
-      query: vi.fn(),
-      release: vi.fn(),
-    };
-    vi.mocked(getClient).mockResolvedValue(mockClient);
+    mockClient = createMockDbClient([]);
+    vi.mocked(getClient).mockResolvedValue(
+      mockClient as unknown as Awaited<ReturnType<typeof getClient>>
+    );
   });
 
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  it('defaults entry_timestamp for Unlimited frequency when omitted (logging for today)', async () => {
+  it('defaults entry_timestamp for Unlimited frequency when omitted (logging for today in UTC)', async () => {
     mockClient.query.mockResolvedValue({
       rows: [
         {
@@ -37,7 +42,7 @@ describe('measurementRepository custom metric entry_timestamp defaulting', () =>
       ],
     });
 
-    const todayStr = new Date().toISOString().split('T')[0];
+    const todayStr = todayInZone('UTC');
 
     await measurementRepository.upsertCustomMeasurement(
       'user-1',
@@ -48,22 +53,81 @@ describe('measurementRepository custom metric entry_timestamp defaulting', () =>
       null,
       undefined, // entryTimestamp omitted!
       'blood pressure systolic',
-      'Unlimited'
+      'Unlimited',
+      'manual',
+      'UTC'
     );
 
     expect(mockClient.query).toHaveBeenCalledTimes(1);
-    const [query, values] = mockClient.query.mock.calls[0];
+    const calls = mockClient.query.mock.calls as unknown as QueryTuple[];
+    const [query, values] = calls[0]!;
     expect(query).toContain('INSERT INTO custom_measurements');
-    // Parameter $6 is entry_timestamp
-    const entryTimestampVal = values[5];
+    expect(values).toBeDefined();
+
+    const entryTimestampVal = values![5] as string;
     expect(entryTimestampVal).toBeDefined();
     expect(typeof entryTimestampVal).toBe('string');
     expect(new Date(entryTimestampVal).toString()).not.toBe('Invalid Date');
   });
 
+  it('handles positive timezone offsets (e.g. Asia/Tokyo) around UTC midnight', async () => {
+    mockClient.query.mockResolvedValue({ rows: [{ id: 'cm-tokyo' }] });
+    const tokyoToday = todayInZone('Asia/Tokyo');
+
+    await measurementRepository.upsertCustomMeasurement(
+      'user-1',
+      'user-1',
+      'cat-unlimited',
+      '125',
+      tokyoToday,
+      null,
+      undefined,
+      'notes',
+      'Unlimited',
+      'manual',
+      'Asia/Tokyo'
+    );
+
+    const calls = mockClient.query.mock.calls as unknown as QueryTuple[];
+    const insertCall = calls.find((c) =>
+      c[0].includes('INSERT INTO custom_measurements')
+    );
+    expect(insertCall).toBeDefined();
+    const timestampVal = insertCall![1]![5] as string;
+    expect(timestampVal).toBeDefined();
+    // Since tokyoToday equals todayInZone('Asia/Tokyo'), timestamp defaults to current execution time
+    expect(new Date(timestampVal).toString()).not.toBe('Invalid Date');
+  });
+
+  it('handles negative timezone offsets (e.g. America/Los_Angeles) around UTC midnight', async () => {
+    mockClient.query.mockResolvedValue({ rows: [{ id: 'cm-la' }] });
+    const laToday = todayInZone('America/Los_Angeles');
+
+    await measurementRepository.upsertCustomMeasurement(
+      'user-1',
+      'user-1',
+      'cat-unlimited',
+      '115',
+      laToday,
+      null,
+      undefined,
+      'notes',
+      'Unlimited',
+      'manual',
+      'America/Los_Angeles'
+    );
+
+    const calls = mockClient.query.mock.calls as unknown as QueryTuple[];
+    const insertCall = calls.find((c) =>
+      c[0].includes('INSERT INTO custom_measurements')
+    );
+    expect(insertCall).toBeDefined();
+    const timestampVal = insertCall![1]![5] as string;
+    expect(timestampVal).toBeDefined();
+    expect(new Date(timestampVal).toString()).not.toBe('Invalid Date');
+  });
+
   it('defaults entry_timestamp for Hourly frequency when entry_hour is provided', async () => {
-    // Secondary call for insert/update will carry the normalized timestamp
-    // If SELECT returns empty, INSERT query runs
     mockClient.query.mockResolvedValueOnce({ rows: [] });
     mockClient.query.mockResolvedValueOnce({ rows: [{ id: 'cm-2' }] });
 
@@ -76,19 +140,21 @@ describe('measurementRepository custom metric entry_timestamp defaulting', () =>
       14,
       undefined,
       'heart rate',
-      'Hourly'
+      'Hourly',
+      'manual',
+      'UTC'
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const insertCall = mockClient.query.mock.calls.find((call: any[]) =>
-      call[0].includes('INSERT INTO custom_measurements')
+    const calls = mockClient.query.mock.calls as unknown as QueryTuple[];
+    const insertCall = calls.find((c) =>
+      c[0].includes('INSERT INTO custom_measurements')
     );
     expect(insertCall).toBeDefined();
-    const entryTimestampVal = insertCall[1][5];
+    const entryTimestampVal = insertCall![1]![5] as string;
     expect(entryTimestampVal).toBe('2026-08-05T14:00:00.000Z');
   });
 
-  it('defaults entry_timestamp in bulkUpsertCustomMeasurements for non-Daily entries', async () => {
+  it('defaults entry_timestamp in bulkUpsertCustomMeasurements for non-Daily entries with userTimezone', async () => {
     mockClient.query.mockImplementation(async (text: string) => {
       if (text === 'BEGIN' || text === 'COMMIT') return { rows: [] };
       if (text.includes('SELECT id, category_id')) return { rows: [] };
@@ -107,21 +173,22 @@ describe('measurementRepository custom metric entry_timestamp defaulting', () =>
           value: '130',
           entryDate: '2026-08-01',
           entryHour: null,
-          entryTimestamp: undefined, // missing timestamp
+          entryTimestamp: undefined,
           notes: 'bp high',
           frequency: 'All',
+          userTimezone: 'Asia/Tokyo',
         },
-      ]
+      ],
+      'Asia/Tokyo'
     );
 
     expect(result).toHaveLength(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const insertCall = mockClient.query.mock.calls.find((call: any[]) =>
-      call[0].includes('INSERT INTO custom_measurements')
+    const calls = mockClient.query.mock.calls as unknown as QueryTuple[];
+    const insertCall = calls.find((c) =>
+      c[0].includes('INSERT INTO custom_measurements')
     );
     expect(insertCall).toBeDefined();
-    // In bulk insert query, pg-format formats values into the SQL text
-    const insertSql = insertCall[0];
+    const insertSql = insertCall![0];
     expect(insertSql).toContain("'2026-08-01T00:00:00.000Z'");
   });
 });

--- a/SparkyFitnessServer/tests/measurementRepository.customMetricTimestamp.test.ts
+++ b/SparkyFitnessServer/tests/measurementRepository.customMetricTimestamp.test.ts
@@ -25,6 +25,7 @@ describe('measurementRepository custom metric entry_timestamp defaulting', () =>
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   it('defaults entry_timestamp for Unlimited frequency when omitted (logging for today in UTC)', async () => {
@@ -70,9 +71,14 @@ describe('measurementRepository custom metric entry_timestamp defaulting', () =>
     expect(new Date(entryTimestampVal).toString()).not.toBe('Invalid Date');
   });
 
-  it('handles positive timezone offsets (e.g. Asia/Tokyo) around UTC midnight', async () => {
+  it('handles positive timezone offsets (e.g. Asia/Tokyo) around UTC midnight deterministically', async () => {
+    vi.useFakeTimers();
+    // At 23:30 UTC on 2026-08-08, local date in Tokyo (UTC+9) is 2026-08-09
+    const frozenUtc = new Date('2026-08-08T23:30:00.000Z');
+    vi.setSystemTime(frozenUtc);
+
     mockClient.query.mockResolvedValue({ rows: [{ id: 'cm-tokyo' }] });
-    const tokyoToday = todayInZone('Asia/Tokyo');
+    const tokyoToday = '2026-08-09'; // Matches todayInZone('Asia/Tokyo') at 23:30 UTC
 
     await measurementRepository.upsertCustomMeasurement(
       'user-1',
@@ -94,14 +100,17 @@ describe('measurementRepository custom metric entry_timestamp defaulting', () =>
     );
     expect(insertCall).toBeDefined();
     const timestampVal = insertCall![1]![5] as string;
-    expect(timestampVal).toBeDefined();
-    // Since tokyoToday equals todayInZone('Asia/Tokyo'), timestamp defaults to current execution time
-    expect(new Date(timestampVal).toString()).not.toBe('Invalid Date');
+    expect(timestampVal).toBe(frozenUtc.toISOString());
   });
 
-  it('handles negative timezone offsets (e.g. America/Los_Angeles) around UTC midnight', async () => {
+  it('handles negative timezone offsets (e.g. America/Los_Angeles) around UTC midnight deterministically', async () => {
+    vi.useFakeTimers();
+    // At 00:30 UTC on 2026-08-08, local date in LA (UTC-7) is 2026-08-07
+    const frozenUtc = new Date('2026-08-08T00:30:00.000Z');
+    vi.setSystemTime(frozenUtc);
+
     mockClient.query.mockResolvedValue({ rows: [{ id: 'cm-la' }] });
-    const laToday = todayInZone('America/Los_Angeles');
+    const laToday = '2026-08-07'; // Matches todayInZone('America/Los_Angeles') at 00:30 UTC
 
     await measurementRepository.upsertCustomMeasurement(
       'user-1',
@@ -123,8 +132,7 @@ describe('measurementRepository custom metric entry_timestamp defaulting', () =>
     );
     expect(insertCall).toBeDefined();
     const timestampVal = insertCall![1]![5] as string;
-    expect(timestampVal).toBeDefined();
-    expect(new Date(timestampVal).toString()).not.toBe('Invalid Date');
+    expect(timestampVal).toBe(frozenUtc.toISOString());
   });
 
   it('defaults entry_timestamp for Hourly frequency when entry_hour is provided', async () => {

--- a/SparkyFitnessServer/tests/measurementRepository.customMetricTimestamp.test.ts
+++ b/SparkyFitnessServer/tests/measurementRepository.customMetricTimestamp.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import measurementRepository from '../models/measurementRepository.js';
+import { getClient } from '../db/poolManager.js';
+
+vi.mock('../db/poolManager.js', () => ({
+  getClient: vi.fn(),
+}));
+
+describe('measurementRepository custom metric entry_timestamp defaulting', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = {
+      query: vi.fn(),
+      release: vi.fn(),
+    };
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults entry_timestamp for Unlimited frequency when omitted (logging for today)', async () => {
+    mockClient.query.mockResolvedValue({
+      rows: [
+        {
+          id: 'cm-1',
+          user_id: 'user-1',
+          category_id: 'cat-unlimited',
+          value: '120',
+          entry_date: '2026-08-10',
+          entry_hour: null,
+          entry_timestamp: '2026-08-10T18:00:00.000Z',
+        },
+      ],
+    });
+
+    const todayStr = new Date().toISOString().split('T')[0];
+
+    await measurementRepository.upsertCustomMeasurement(
+      'user-1',
+      'user-1',
+      'cat-unlimited',
+      '120',
+      todayStr,
+      null,
+      undefined, // entryTimestamp omitted!
+      'blood pressure systolic',
+      'Unlimited'
+    );
+
+    expect(mockClient.query).toHaveBeenCalledTimes(1);
+    const [query, values] = mockClient.query.mock.calls[0];
+    expect(query).toContain('INSERT INTO custom_measurements');
+    // Parameter $6 is entry_timestamp
+    const entryTimestampVal = values[5];
+    expect(entryTimestampVal).toBeDefined();
+    expect(typeof entryTimestampVal).toBe('string');
+    expect(new Date(entryTimestampVal).toString()).not.toBe('Invalid Date');
+  });
+
+  it('defaults entry_timestamp for Hourly frequency when entry_hour is provided', async () => {
+    // Secondary call for insert/update will carry the normalized timestamp
+    // If SELECT returns empty, INSERT query runs
+    mockClient.query.mockResolvedValueOnce({ rows: [] });
+    mockClient.query.mockResolvedValueOnce({ rows: [{ id: 'cm-2' }] });
+
+    await measurementRepository.upsertCustomMeasurement(
+      'user-1',
+      'user-1',
+      'cat-hourly',
+      '72',
+      '2026-08-05',
+      14,
+      undefined,
+      'heart rate',
+      'Hourly'
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const insertCall = mockClient.query.mock.calls.find((call: any[]) =>
+      call[0].includes('INSERT INTO custom_measurements')
+    );
+    expect(insertCall).toBeDefined();
+    const entryTimestampVal = insertCall[1][5];
+    expect(entryTimestampVal).toBe('2026-08-05T14:00:00.000Z');
+  });
+
+  it('defaults entry_timestamp in bulkUpsertCustomMeasurements for non-Daily entries', async () => {
+    mockClient.query.mockImplementation(async (text: string) => {
+      if (text === 'BEGIN' || text === 'COMMIT') return { rows: [] };
+      if (text.includes('SELECT id, category_id')) return { rows: [] };
+      if (text.includes('INSERT INTO custom_measurements')) {
+        return { rows: [{ id: 'cm-bulk-1' }] };
+      }
+      return { rows: [] };
+    });
+
+    const result = await measurementRepository.bulkUpsertCustomMeasurements(
+      'user-1',
+      'user-1',
+      [
+        {
+          categoryId: 'cat-all',
+          value: '130',
+          entryDate: '2026-08-01',
+          entryHour: null,
+          entryTimestamp: undefined, // missing timestamp
+          notes: 'bp high',
+          frequency: 'All',
+        },
+      ]
+    );
+
+    expect(result).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const insertCall = mockClient.query.mock.calls.find((call: any[]) =>
+      call[0].includes('INSERT INTO custom_measurements')
+    );
+    expect(insertCall).toBeDefined();
+    // In bulk insert query, pg-format formats values into the SQL text
+    const insertSql = insertCall[0];
+    expect(insertSql).toContain("'2026-08-01T00:00:00.000Z'");
+  });
+});


### PR DESCRIPTION
Fixes #2074 where logging custom measurement categories with non-Daily frequencies (e.g. Hourly, All, Unlimited) failed with a Postgres NOT NULL constraint error on custom_measurements.entry_timestamp when omitted by callers like log_custom_metric in AI chat.

- Added defaultEntryTimestamp helper using @workspace/shared isDayString and Date.UTC date construction to prevent timezone jump issues.
- When entry_timestamp is omitted and entry_date is today, defaults to new Date().toISOString() to preserve the exact hour, minute, and second of entry.
- Updated upsertCustomMeasurement and bulkUpsertCustomMeasurements in measurementRepository.ts.
- Added unit tests in measurementRepository.customMetricTimestamp.test.ts and chatbotToolsCheckin.test.ts.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #2074

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling for custom measurements across daily, hourly, and unlimited entries.
  * Applied timezone-aware date and time handling, including safe fallbacks for missing or invalid values.
  * Ensured consistent behavior for individual and bulk measurement updates.
  * Preserved measurement sources and normalized missing notes consistently.

* **Tests**
  * Added coverage for timezone-aware timestamp defaults and bulk updates.
  * Added coverage confirming successful logging of unlimited-frequency custom metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->