### PR TITLE
fix(frontend): fit layout and dialogs to the viewport on mobile/PWA

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -1199,8 +1199,8 @@ const EnhancedFoodSearch = ({
         </Button>
       </div>
 
-      <div className="flex space-x-2 items-center">
-        <div className="relative flex-1">
+      <div className="flex flex-wrap gap-2 items-center">
+        <div className="relative flex-1 min-w-[12rem]">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <Input
             placeholder={t(
@@ -1258,7 +1258,7 @@ const EnhancedFoodSearch = ({
               setManualProviderId(value);
             }}
           >
-            <SelectTrigger className="w-[180px]">
+            <SelectTrigger className="w-full sm:w-[180px]">
               <SelectValue
                 placeholder={t(
                   'enhancedFoodSearch.selectProvider',

--- a/SparkyFitnessFrontend/src/components/ui/dialog.tsx
+++ b/SparkyFitnessFrontend/src/components/ui/dialog.tsx
@@ -49,7 +49,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+          'dialog-viewport-fit fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
           className
         )}
         {...props}
@@ -87,7 +87,7 @@ const DialogContent = React.forwardRef<
         <DialogPrimitive.Root open={showConfirm} onOpenChange={setShowConfirm}>
           <DialogPrimitive.Portal>
             <DialogOverlay className="z-60" />
-            <DialogPrimitive.Content className="fixed left-[50%] top-[50%] z-[60] grid w-full max-w-md translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+            <DialogPrimitive.Content className="dialog-viewport-fit fixed left-[50%] top-[50%] z-[60] grid w-full max-w-md translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg sm:rounded-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
               <div className="flex flex-col space-y-1.5 text-center sm:text-left">
                 <DialogPrimitive.Title className="text-lg font-semibold leading-none tracking-tight">
                   Close Window

--- a/SparkyFitnessFrontend/src/index.css
+++ b/SparkyFitnessFrontend/src/index.css
@@ -190,3 +190,32 @@
 .apple-safe-area {
   padding-bottom: env(safe-area-inset-bottom);
 }
+
+/* Mobile viewport fit. Desktop is intentionally untouched. */
+@media (max-width: 767px) {
+  html,
+  body {
+    max-width: 100%;
+    /* `clip`, not `hidden`: `hidden` turns html/body into a scroll container and
+       breaks `position: sticky` and scroll-into-view. */
+    overflow-x: clip;
+    overscroll-behavior-x: none;
+  }
+
+  /* Caps every dialog regardless of its own `max-w-*` utility. Plain CSS declared
+     after `@import 'tailwindcss'`, so it wins on equal specificity without
+     `!important`, and tailwind-merge cannot strip it (it is not a Tailwind class). */
+  .dialog-viewport-fit {
+    width: calc(100vw - 2rem);
+    max-width: calc(100vw - 2rem);
+    max-height: calc(100dvh - 2rem);
+    overflow-y: auto;
+  }
+
+  /* DialogContent is a grid, and grid/flex children default to `min-width: auto`,
+     so a wide child (a search result row, a nutrient grid) can still push past the
+     capped dialog. Allowing them to shrink keeps content inside the box. */
+  .dialog-viewport-fit > * {
+    min-width: 0;
+  }
+}

--- a/SparkyFitnessFrontend/src/pages/Diary/Diary.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/Diary.tsx
@@ -485,8 +485,11 @@ const Diary = () => {
     <div className="space-y-6">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pb-2 border-b">
         <div />
-        <div className="flex items-center gap-2 sm:ml-auto">
-          <div ref={setToolbarContainer} className="flex items-center gap-2" />
+        <div className="flex min-w-0 flex-wrap items-center gap-2 sm:ml-auto">
+          <div
+            ref={setToolbarContainer}
+            className="flex min-w-0 flex-wrap items-center gap-2"
+          />
           <DayNavigator
             selectedDate={selectedDate}
             onDateChange={(dateString) => {


### PR DESCRIPTION
On phones — most visibly in installed PWA mode, where there is no browser chrome to hide it — the app panned horizontally when swiping left-right and dialogs such as "Add Food to <meal>" overflowed both screen edges.

Root causes:
- No horizontal guard on html/body, so any overflowing child made the whole document pannable, dragging the fixed bottom nav along with it.
- DialogContent is `w-full max-w-lg` with no inset, and ~20 dialogs override it upward (the add-food flow uses max-w-6xl / 1152px). Centered via translate-x-[-50%], these overhang both sides on a 360px viewport.
- DialogContent is a grid, and grid children default to `min-width: auto`, so wide inner content pushed past the box even once it was capped.
- The FoodSearch filter row was a non-wrapping flex row holding the search input plus two selects.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #2092

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile responsiveness for food search and diary controls, allowing items to wrap cleanly on smaller screens.
  * Prevented horizontal overflow and unwanted overscrolling on mobile devices.
  * Improved dialog sizing and scrolling so content stays within the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->