### PR TITLE
fix(frontend): stop the widget grid oscillating when a scrollbar toggle flips its breakpoint

### DIFF
--- a/SparkyFitnessFrontend/src/components/widgets/WidgetGrid.tsx
+++ b/SparkyFitnessFrontend/src/components/widgets/WidgetGrid.tsx
@@ -25,12 +25,13 @@ import {
   GRID_ROW_HEIGHT,
   applyAutoHeights,
   areLayoutsEqual,
-  breakpointForWidth,
+  evaluateMeasurement,
   mergePositions,
   pxToRows,
   reconcileLayouts,
   stabilizeGridWidth,
   type DashboardLayouts,
+  type MeasureGuard,
 } from '@/utils/dashboardLayout';
 
 export interface Widget {
@@ -80,13 +81,6 @@ class GridErrorBoundary extends Component<
 // Stable reference so `hidden`/`handleLayoutChange` deps don't churn when no
 // widgets are hidden (a fresh `[]` each render would invalidate them).
 const EMPTY_HIDDEN: string[] = [];
-
-// Ceiling on how many times a single widget's measured height may change before
-// we stop believing it. A settled grid measures each widget a handful of times
-// (mount, data load, font load); anything past this is a feedback loop, and
-// freezing the last height degrades to a slightly-off tile instead of pinning
-// the CPU until React throws "Maximum update depth exceeded".
-const MAX_MEASURE_CHANGES = 20;
 
 const WidgetGridInner = ({
   pageKey,
@@ -151,33 +145,28 @@ const WidgetGridInner = ({
   // content-driven so tiles grow to fit and never show an inner scrollbar.
   const [measuredRows, setMeasuredRows] = useState<Record<string, number>>({});
 
-  // How many times each widget's measured height has actually changed. Reset
-  // whenever the widget set or the grid breakpoint changes -- those legitimately
-  // re-measure everything -- so the cap only ever catches a runaway loop.
-  const measureChangesRef = useRef<Record<string, number>>({});
-  // Mirrors the accepted heights so the counting below can stay outside the
-  // state updater (updaters may run twice under StrictMode and would double-count).
+  // Per-widget rate limiter that keeps a measurement feedback loop from
+  // re-rendering the grid until React throws. Kept in refs (and evaluated
+  // outside the state updater, which may run twice under StrictMode) so a
+  // double-invoked updater cannot double-count.
+  const measureGuardsRef = useRef<Record<string, MeasureGuard>>({});
   const acceptedRowsRef = useRef<Record<string, number>>({});
-
-  const measureEpoch = `${widgetKeys.join(',')}|${breakpointForWidth(width)}`;
-  useEffect(() => {
-    measureChangesRef.current = {};
-    acceptedRowsRef.current = {};
-  }, [measureEpoch]);
 
   const handleMeasure = useCallback((key: string, px: number) => {
     const rows = pxToRows(px);
     if (acceptedRowsRef.current[key] === rows) return;
 
-    const seen = (measureChangesRef.current[key] ?? 0) + 1;
-    measureChangesRef.current[key] = seen;
-    // Past the cap we keep the last accepted height rather than chase a
-    // measure -> layout -> measure oscillation into a render-depth crash.
-    if (seen > MAX_MEASURE_CHANGES) return;
+    const { guard, apply } = evaluateMeasurement(
+      measureGuardsRef.current[key],
+      rows,
+      performance.now()
+    );
+    measureGuardsRef.current[key] = guard;
+    if (apply === null || acceptedRowsRef.current[key] === apply) return;
 
-    acceptedRowsRef.current[key] = rows;
+    acceptedRowsRef.current[key] = apply;
     setMeasuredRows((prev) =>
-      prev[key] === rows ? prev : { ...prev, [key]: rows }
+      prev[key] === apply ? prev : { ...prev, [key]: apply }
     );
   }, []);
 

--- a/SparkyFitnessFrontend/src/components/widgets/WidgetGrid.tsx
+++ b/SparkyFitnessFrontend/src/components/widgets/WidgetGrid.tsx
@@ -25,9 +25,11 @@ import {
   GRID_ROW_HEIGHT,
   applyAutoHeights,
   areLayoutsEqual,
+  breakpointForWidth,
   mergePositions,
   pxToRows,
   reconcileLayouts,
+  stabilizeGridWidth,
   type DashboardLayouts,
 } from '@/utils/dashboardLayout';
 
@@ -79,6 +81,13 @@ class GridErrorBoundary extends Component<
 // widgets are hidden (a fresh `[]` each render would invalidate them).
 const EMPTY_HIDDEN: string[] = [];
 
+// Ceiling on how many times a single widget's measured height may change before
+// we stop believing it. A settled grid measures each widget a handful of times
+// (mount, data load, font load); anything past this is a feedback loop, and
+// freezing the last height degrades to a slightly-off tile instead of pinning
+// the CPU until React throws "Maximum update depth exceeded".
+const MAX_MEASURE_CHANGES = 20;
+
 const WidgetGridInner = ({
   pageKey,
   widgets,
@@ -88,7 +97,16 @@ const WidgetGridInner = ({
   const { t } = useTranslation();
   const { isActingOnBehalf } = useActiveUser();
   const { saved, save, reset, isLoading } = useDashboardLayout(pageKey);
-  const { width, containerRef, mounted } = useContainerWidth();
+  const { width: rawWidth, containerRef, mounted } = useContainerWidth();
+
+  // Content-measured tile heights make the grid's height a function of its
+  // width, and the page's width a function of its height (scrollbar). Feeding
+  // the raw measurement straight to the grid lets a ~15px scrollbar toggle flip
+  // the breakpoint near a threshold and oscillate forever (#2056), so damp it.
+  const [width, setWidth] = useState(rawWidth);
+  useEffect(() => {
+    setWidth((prev) => stabilizeGridWidth(prev, rawWidth));
+  }, [rawWidth]);
 
   // Layout editing is a personal action; when viewing someone else's profile
   // the layout is shown read-only (the server also rejects writes).
@@ -133,8 +151,31 @@ const WidgetGridInner = ({
   // content-driven so tiles grow to fit and never show an inner scrollbar.
   const [measuredRows, setMeasuredRows] = useState<Record<string, number>>({});
 
+  // How many times each widget's measured height has actually changed. Reset
+  // whenever the widget set or the grid breakpoint changes -- those legitimately
+  // re-measure everything -- so the cap only ever catches a runaway loop.
+  const measureChangesRef = useRef<Record<string, number>>({});
+  // Mirrors the accepted heights so the counting below can stay outside the
+  // state updater (updaters may run twice under StrictMode and would double-count).
+  const acceptedRowsRef = useRef<Record<string, number>>({});
+
+  const measureEpoch = `${widgetKeys.join(',')}|${breakpointForWidth(width)}`;
+  useEffect(() => {
+    measureChangesRef.current = {};
+    acceptedRowsRef.current = {};
+  }, [measureEpoch]);
+
   const handleMeasure = useCallback((key: string, px: number) => {
     const rows = pxToRows(px);
+    if (acceptedRowsRef.current[key] === rows) return;
+
+    const seen = (measureChangesRef.current[key] ?? 0) + 1;
+    measureChangesRef.current[key] = seen;
+    // Past the cap we keep the last accepted height rather than chase a
+    // measure -> layout -> measure oscillation into a render-depth crash.
+    if (seen > MAX_MEASURE_CHANGES) return;
+
+    acceptedRowsRef.current[key] = rows;
     setMeasuredRows((prev) =>
       prev[key] === rows ? prev : { ...prev, [key]: rows }
     );

--- a/SparkyFitnessFrontend/src/index.css
+++ b/SparkyFitnessFrontend/src/index.css
@@ -184,6 +184,16 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  /* The customizable widget grid measures its container width and picks a
+     react-grid-layout breakpoint from it, while tile heights are measured from
+     their content. Without a reserved gutter, a scrollbar appearing/disappearing
+     as tiles auto-grow changes that width by ~15px, which can flip the
+     breakpoint, which changes the height again -> endless relayout (#2056).
+     Reserving the gutter breaks that loop at the source. */
+  html {
+    scrollbar-gutter: stable;
+  }
 }
 
 /* Handling apple safe areas at the bottom bar */

--- a/SparkyFitnessFrontend/src/tests/utils/dashboardLayout.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/dashboardLayout.test.ts
@@ -1,9 +1,11 @@
 import {
   applyAutoHeights,
+  breakpointForWidth,
   buildWidgetKeys,
   generateDefaultLayouts,
   mealWidgetKey,
   reconcileLayouts,
+  stabilizeGridWidth,
   type DashboardLayouts,
   type WidgetLayout,
 } from '@/utils/dashboardLayout';
@@ -149,5 +151,50 @@ describe('applyAutoHeights', () => {
     const base = onlyLg([{ i: 'energy', x: 0, y: 0, w: 3, h: 5, minH: 6 }]);
     expect(applyAutoHeights(base, { energy: 2 }).lg[0]!.h).toBe(6); // minH floor
     expect(applyAutoHeights(base, {}).lg[0]!.h).toBe(5); // unmeasured -> base
+  });
+});
+
+describe('breakpointForWidth', () => {
+  it('selects the largest breakpoint the width reaches', () => {
+    expect(breakpointForWidth(1400)).toBe('lg');
+    expect(breakpointForWidth(1200)).toBe('lg');
+    expect(breakpointForWidth(1199)).toBe('md');
+    expect(breakpointForWidth(996)).toBe('md');
+    expect(breakpointForWidth(995)).toBe('sm');
+    expect(breakpointForWidth(768)).toBe('sm');
+    expect(breakpointForWidth(767)).toBe('xs');
+    expect(breakpointForWidth(0)).toBe('xs');
+  });
+});
+
+describe('stabilizeGridWidth', () => {
+  it('ignores a scrollbar-sized change that would flip the breakpoint', () => {
+    // The #2056 loop: a ~15px scrollbar toggle straddling the lg threshold.
+    expect(stabilizeGridWidth(1205, 1190)).toBe(1205);
+    expect(stabilizeGridWidth(1190, 1205)).toBe(1190);
+  });
+
+  it('accepts small changes that stay inside one breakpoint', () => {
+    expect(stabilizeGridWidth(1300, 1285)).toBe(1285);
+    expect(stabilizeGridWidth(900, 890)).toBe(890);
+  });
+
+  it('accepts a real resize even when it crosses a breakpoint', () => {
+    expect(stabilizeGridWidth(1205, 1100)).toBe(1100);
+    expect(stabilizeGridWidth(1100, 1205)).toBe(1205);
+  });
+
+  it('always takes the first real measurement and ignores bogus widths', () => {
+    expect(stabilizeGridWidth(0, 1190)).toBe(1190);
+    expect(stabilizeGridWidth(1205, 0)).toBe(1205);
+    expect(stabilizeGridWidth(1205, Number.NaN)).toBe(1205);
+  });
+
+  it('settles: alternating jitter never oscillates the fed width', () => {
+    let width = 1205;
+    for (const next of [1190, 1205, 1190, 1205, 1190]) {
+      width = stabilizeGridWidth(width, next);
+    }
+    expect(width).toBe(1205);
   });
 });

--- a/SparkyFitnessFrontend/src/tests/utils/dashboardLayout.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/dashboardLayout.test.ts
@@ -221,9 +221,16 @@ describe('evaluateMeasurement', () => {
     expect(run([8, 9, 10], 200)).toEqual([8, 9, 10]);
   });
 
+  // One change past the limit, so the burst keeps exercising the capped path
+  // whatever MAX_MEASURE_CHANGES_PER_WINDOW is tuned to.
+  const burstOverLimit = () =>
+    Array.from({ length: MAX_MEASURE_CHANGES_PER_WINDOW + 1 }, (_, i) =>
+      i % 2 ? 12 : 9
+    );
+
   it('settles on the tallest height once a burst looks like a loop', () => {
-    // 20 alternating changes inside one window: a measure -> layout -> measure cycle.
-    const alternating = Array.from({ length: 20 }, (_, i) => (i % 2 ? 12 : 9));
+    // Alternating changes inside one window: a measure -> layout -> measure cycle.
+    const alternating = burstOverLimit();
     const applied = run(alternating);
     expect(applied.slice(0, MAX_MEASURE_CHANGES_PER_WINDOW)).toEqual(
       alternating.slice(0, MAX_MEASURE_CHANGES_PER_WINDOW)
@@ -236,11 +243,11 @@ describe('evaluateMeasurement', () => {
 
   it('is a rate limit, not a permanent cap: later real changes still apply', () => {
     // Exhaust the window...
-    const burst = Array.from({ length: 20 }, (_, i) => (i % 2 ? 12 : 9));
     let guard: MeasureGuard | undefined;
-    for (const rows of burst) {
+    for (const rows of burstOverLimit()) {
       guard = evaluateMeasurement(guard, rows, 1000).guard;
     }
+    expect(guard?.changes).toBeGreaterThan(MAX_MEASURE_CHANGES_PER_WINDOW);
     // ...then a genuine change well after the window expires.
     const later = evaluateMeasurement(guard, 7, 1000 + MEASURE_WINDOW_MS + 1);
     expect(later.apply).toBe(7);

--- a/SparkyFitnessFrontend/src/tests/utils/dashboardLayout.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/dashboardLayout.test.ts
@@ -2,11 +2,15 @@ import {
   applyAutoHeights,
   breakpointForWidth,
   buildWidgetKeys,
+  evaluateMeasurement,
   generateDefaultLayouts,
+  MAX_MEASURE_CHANGES_PER_WINDOW,
   mealWidgetKey,
+  MEASURE_WINDOW_MS,
   reconcileLayouts,
   stabilizeGridWidth,
   type DashboardLayouts,
+  type MeasureGuard,
   type WidgetLayout,
 } from '@/utils/dashboardLayout';
 
@@ -196,5 +200,55 @@ describe('stabilizeGridWidth', () => {
       width = stabilizeGridWidth(width, next);
     }
     expect(width).toBe(1205);
+  });
+});
+
+describe('evaluateMeasurement', () => {
+  const run = (
+    values: number[],
+    stepMs = 0,
+    start = 1000
+  ): (number | null)[] => {
+    let guard: MeasureGuard | undefined;
+    return values.map((rows, i) => {
+      const out = evaluateMeasurement(guard, rows, start + i * stepMs);
+      guard = out.guard;
+      return out.apply;
+    });
+  };
+
+  it('applies normal measurements', () => {
+    expect(run([8, 9, 10], 200)).toEqual([8, 9, 10]);
+  });
+
+  it('settles on the tallest height once a burst looks like a loop', () => {
+    // 20 alternating changes inside one window: a measure -> layout -> measure cycle.
+    const alternating = Array.from({ length: 20 }, (_, i) => (i % 2 ? 12 : 9));
+    const applied = run(alternating);
+    expect(applied.slice(0, MAX_MEASURE_CHANGES_PER_WINDOW)).toEqual(
+      alternating.slice(0, MAX_MEASURE_CHANGES_PER_WINDOW)
+    );
+    // Everything past the cap settles on the tallest seen, so content is never clipped.
+    for (const value of applied.slice(MAX_MEASURE_CHANGES_PER_WINDOW)) {
+      expect(value).toBe(12);
+    }
+  });
+
+  it('is a rate limit, not a permanent cap: later real changes still apply', () => {
+    // Exhaust the window...
+    const burst = Array.from({ length: 20 }, (_, i) => (i % 2 ? 12 : 9));
+    let guard: MeasureGuard | undefined;
+    for (const rows of burst) {
+      guard = evaluateMeasurement(guard, rows, 1000).guard;
+    }
+    // ...then a genuine change well after the window expires.
+    const later = evaluateMeasurement(guard, 7, 1000 + MEASURE_WINDOW_MS + 1);
+    expect(later.apply).toBe(7);
+    expect(later.guard.changes).toBe(1);
+  });
+
+  it('does not trip when changes are spread across windows', () => {
+    const spread = Array.from({ length: 30 }, (_, i) => i + 1);
+    expect(run(spread, MEASURE_WINDOW_MS + 1)).toEqual(spread);
   });
 });

--- a/SparkyFitnessFrontend/src/utils/dashboardLayout.ts
+++ b/SparkyFitnessFrontend/src/utils/dashboardLayout.ts
@@ -97,6 +97,54 @@ export function stabilizeGridWidth(prev: number, next: number): number {
   return breakpointForWidth(next) === breakpointForWidth(prev) ? next : prev;
 }
 
+/** Rolling window used to tell a measurement feedback loop from real changes. */
+export const MEASURE_WINDOW_MS = 1000;
+
+/**
+ * Height changes allowed per widget per window before we treat it as a loop. A
+ * settled widget changes height a handful of times (mount, data load, font
+ * load) and legitimate later changes are seconds apart, so only a runaway
+ * measure -> layout -> measure cycle can reach this in one second.
+ */
+export const MAX_MEASURE_CHANGES_PER_WINDOW = 12;
+
+export interface MeasureGuard {
+  windowStart: number;
+  changes: number;
+  /** Tallest height seen in this window; what we settle on when thrashing. */
+  maxRows: number;
+}
+
+/**
+ * Decide whether to accept a freshly measured height for one widget.
+ *
+ * Returns the height to apply (`null` to ignore) plus the guard state to carry
+ * forward. Under a loop we settle on the tallest height seen in the window --
+ * never clipping content -- and then stop applying anything, which starves the
+ * cycle of the re-render that keeps it going. The window expires on its own, so
+ * a genuine content change later is picked up normally: this is a rate limit,
+ * not a permanent cap.
+ */
+export function evaluateMeasurement(
+  guard: MeasureGuard | undefined,
+  rows: number,
+  now: number
+): { guard: MeasureGuard; apply: number | null } {
+  const expired = !guard || now - guard.windowStart > MEASURE_WINDOW_MS;
+  const next: MeasureGuard = expired
+    ? { windowStart: now, changes: 1, maxRows: rows }
+    : {
+        windowStart: guard.windowStart,
+        changes: guard.changes + 1,
+        maxRows: Math.max(guard.maxRows, rows),
+      };
+
+  if (next.changes > MAX_MEASURE_CHANGES_PER_WINDOW) {
+    return { guard: next, apply: next.maxRows };
+  }
+  return { guard: next, apply: rows };
+}
+
 /**
  * Value-equality for two layout maps (ignores object identity). Used to avoid
  * the controlled react-grid-layout feedback loop: onLayoutChange -> setState ->

--- a/SparkyFitnessFrontend/src/utils/dashboardLayout.ts
+++ b/SparkyFitnessFrontend/src/utils/dashboardLayout.ts
@@ -56,6 +56,48 @@ export function pxToRows(px: number): number {
 }
 
 /**
+ * Widths below this are treated as jitter rather than a real resize. Comfortably
+ * above any classic scrollbar (~15-17px) so a scrollbar toggle cannot move the
+ * grid, but small enough that a real drag-resize of the window still lands.
+ */
+export const GRID_WIDTH_JITTER_PX = 24;
+
+/**
+ * The breakpoint react-grid-layout selects for a container width: the largest
+ * breakpoint whose threshold the width reaches.
+ */
+export function breakpointForWidth(width: number): Breakpoint {
+  const ordered = (Object.keys(GRID_BREAKPOINTS) as Breakpoint[]).sort(
+    (a, b) => GRID_BREAKPOINTS[b] - GRID_BREAKPOINTS[a]
+  );
+  for (const bp of ordered) {
+    if (width >= GRID_BREAKPOINTS[bp]) return bp;
+  }
+  return ordered[ordered.length - 1] as Breakpoint;
+}
+
+/**
+ * Damp the container width fed to the grid.
+ *
+ * Tile heights are content-measured, so the grid's total height depends on its
+ * width -- and the page's width depends on whether that height summons a
+ * scrollbar. Near a breakpoint threshold the ~15px scrollbar delta alone can
+ * flip lg<->md, swapping in a different saved layout, changing the height, and
+ * oscillating forever (#2056). Ignoring sub-jitter changes that would also flip
+ * the breakpoint gives the loop the hysteresis it needs to settle.
+ *
+ * A change large enough to be a real resize, or one that stays inside the
+ * current breakpoint, is always accepted so normal resizing still tracks.
+ */
+export function stabilizeGridWidth(prev: number, next: number): number {
+  if (!Number.isFinite(next) || next <= 0) return prev;
+  if (!Number.isFinite(prev) || prev <= 0) return next;
+  const delta = Math.abs(next - prev);
+  if (delta >= GRID_WIDTH_JITTER_PX) return next;
+  return breakpointForWidth(next) === breakpointForWidth(prev) ? next : prev;
+}
+
+/**
  * Value-equality for two layout maps (ignores object identity). Used to avoid
  * the controlled react-grid-layout feedback loop: onLayoutChange -> setState ->
  * new prop identity -> onLayoutChange -> ... If the layout did not actually


### PR DESCRIPTION
…

Tile heights are measured from content, so the grid's height depends on its width -- and its width depends on whether that height summons a scrollbar. Layouts are saved per breakpoint, so a custom `lg` taller than the default `md` inverts the coupling into a loop near the 1200px threshold: the cards slide forever and React eventually trips max update depth, surfacing as the "customizable layout hit an error" fallback.

- Reserve the scrollbar gutter on `html`, removing the driver.
- `stabilizeGridWidth`: ignore a sub-24px width change that would flip the breakpoint (covers browsers without `scrollbar-gutter`, and zoom jitter).
- Cap per-widget height re-measures per epoch, so any residual loop degrades to a slightly-off tile instead of a crashed grid.

Also protects the Diary grid, which shares WidgetGrid.

Fixes #2056

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #2056

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard resizing stability by preventing minor width fluctuations from triggering repeated breakpoint changes.
  * Prevented layout feedback loops and rendering failures during widget resizing.
  * Preserved widget heights more reliably during repeated measurements.
  * Reserved scrollbar space to reduce unexpected layout shifts.

* **Tests**
  * Added coverage for breakpoint thresholds, valid resizes, scrollbar-related jitter, invalid measurements, and repeated oscillation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->