### PR TITLE
feat(food): mobile photo support, and freeze diary entry photos

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2881,7 +2881,13 @@
     "calciumLabel": "Calcium (mg)",
     "ironLabel": "Iron (mg)",
     "cancelButton": "Cancel",
-    "saveFoodButton": "Save Food"
+    "saveFoodButton": "Save Food",
+    "syncConfirmationTitle": "Sync Past Entries?",
+    "syncConfirmationDescription": "Do you want to update all your past diary entries for this food with the new nutrition? Entries you don't update keep their original values.",
+    "syncConfirmationDescriptionWithPhotos": "Do you want to update all your past diary entries for this food with the new nutrition and photos? Updating photos replaces photos you set on individual diary entries, and can't be undone.",
+    "syncConfirmationConfirm": "Update",
+    "syncConfirmationConfirmWithPhotos": "Update nutrition & photos",
+    "syncConfirmationNutritionOnly": "Update nutrition only"
   },
   "customMeasurements": {
     "title": "Custom Measurements - {{date}}",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1693,7 +1693,7 @@
     "replaceEntryPhoto": "Replace photo",
     "removeEntryPhoto": "Remove photo",
     "entryPhotoOverrideHint": "These photos apply to this entry only. Drag to reorder.",
-    "entryPhotoInheritedHint": "Showing the food's own images. Add a photo to override them for this entry.",
+    "entryPhotoInheritedHint": "Showing the food's current photo. Add a photo to set one for this entry.",
     "entryImageUploadFailedTitle": "Upload failed",
     "entryImageUploadFailed": "Could not save the photo for this entry.",
     "entryImageRemoveFailedTitle": "Remove failed",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1693,7 +1693,7 @@
     "replaceEntryPhoto": "Replace photo",
     "removeEntryPhoto": "Remove photo",
     "entryPhotoOverrideHint": "These photos apply to this entry only. Drag to reorder.",
-    "entryPhotoInheritedHint": "Showing the food's current photo. Add a photo to set one for this entry.",
+    "entryPhotoInheritedHint": "Showing the current library photos. Add photos to set them for this entry.",
     "entryImageUploadFailedTitle": "Upload failed",
     "entryImageUploadFailed": "Could not save the photo for this entry.",
     "entryImageRemoveFailedTitle": "Remove failed",

--- a/SparkyFitnessFrontend/src/api/Foods/foodService.ts
+++ b/SparkyFitnessFrontend/src/api/Foods/foodService.ts
@@ -116,12 +116,18 @@ export const getFoodById = async (foodId: string): Promise<Food> => {
   });
 };
 
+/**
+ * `syncImages` true forces the food's current photos onto every matching past
+ * entry, replacing photos the user set on individual diary entries; false
+ * rewrites nutrition only and leaves every entry's photo untouched.
+ */
 export const updateFoodEntriesSnapshot = async (
-  foodId: string
+  foodId: string,
+  syncImages: boolean = true
 ): Promise<void> => {
   return apiCall(`/foods/update-snapshot`, {
     method: 'POST',
-    body: { foodId },
+    body: { foodId, syncImages },
   });
 };
 

--- a/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/CustomFoodForm.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
@@ -37,6 +38,7 @@ const CustomFoodForm = ({
   initialVariants,
   visibleNutrients: passedVisibleNutrients,
 }: CustomFoodFormProps) => {
+  const { t } = useTranslation();
   const {
     nutrientDisplayPreferences,
     energyUnit,
@@ -64,6 +66,7 @@ const CustomFoodForm = ({
     variantErrors,
     loading,
     showSyncConfirmation,
+    syncTouchesPhotos,
     loadedVariants,
     conversionBaseVariants,
     hasTrustedCompatibilityBase,
@@ -352,12 +355,58 @@ const CustomFoodForm = ({
           open={showSyncConfirmation}
           onOpenChange={(open) => {
             if (!open) {
-              handleSyncConfirmation(false);
+              handleSyncConfirmation('none');
             }
           }}
-          onConfirm={() => handleSyncConfirmation(true)}
-          title="Sync Past Entries?"
-          description="Do you want to update all your past diary entries for this food with the new nutritional information?"
+          // When this save replaced the food's photos the user gets a third
+          // outcome, because the two photo results genuinely differ: the
+          // confirm action forces the new photo onto every past entry
+          // (replacing photos set on individual diary entries, which are then
+          // deleted), while the secondary action rewrites nutrition only and
+          // leaves every entry's photo alone. With photos untouched there is
+          // nothing to decide, so it stays a plain yes/no about nutrition.
+          onConfirm={() =>
+            handleSyncConfirmation(
+              syncTouchesPhotos ? 'nutrition-and-photos' : 'nutrition'
+            )
+          }
+          variant={syncTouchesPhotos ? 'destructive' : 'default'}
+          secondaryActionLabel={
+            syncTouchesPhotos
+              ? t(
+                  'customFoodForm.syncConfirmationNutritionOnly',
+                  'Update nutrition only'
+                )
+              : undefined
+          }
+          onSecondaryAction={
+            syncTouchesPhotos
+              ? () => handleSyncConfirmation('nutrition')
+              : undefined
+          }
+          title={t(
+            'customFoodForm.syncConfirmationTitle',
+            'Sync Past Entries?'
+          )}
+          description={
+            syncTouchesPhotos
+              ? t(
+                  'customFoodForm.syncConfirmationDescriptionWithPhotos',
+                  "Do you want to update all your past diary entries for this food with the new nutrition and photos? Updating photos replaces photos you set on individual diary entries, and can't be undone."
+                )
+              : t(
+                  'customFoodForm.syncConfirmationDescription',
+                  "Do you want to update all your past diary entries for this food with the new nutrition? Entries you don't update keep their original values."
+                )
+          }
+          confirmLabel={
+            syncTouchesPhotos
+              ? t(
+                  'customFoodForm.syncConfirmationConfirmWithPhotos',
+                  'Update nutrition & photos'
+                )
+              : t('customFoodForm.syncConfirmationConfirm', 'Update')
+          }
         />
       )}
 

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoodForm.tsx
@@ -4,8 +4,15 @@ import { usePreferences } from '@/contexts/PreferencesContext';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { toast } from '@/hooks/use-toast';
 import { useUpdateFoodEntriesSnapshotMutation } from '@/hooks/Foods/useFoods';
+
+/** The three outcomes of the "Sync Past Entries?" prompt. */
+export type SyncPastEntriesChoice =
+  | 'none'
+  | 'nutrition'
+  | 'nutrition-and-photos';
 import { useCustomNutrients } from '@/hooks/Foods/useCustomNutrients';
 import {
+  pickerImagesDiffer,
   splitPickerImages,
   toSavedImages,
   type PickerImage,
@@ -359,6 +366,10 @@ export function useCustomFoodForm({
   const [variantMeta, setVariantMeta] = useState<VariantMeta[]>([]);
   const [showSyncConfirmation, setShowSyncConfirmation] = useState(false);
   const [savedFoodResult, setSavedFoodResult] = useState<Food | null>(null);
+  // Whether the save that triggered the sync prompt also replaced the food's
+  // photos. Captured at save time rather than derived at render: `food` is a
+  // prop and the sync dialog outlives the save that opened it.
+  const [syncTouchesPhotos, setSyncTouchesPhotos] = useState(false);
   const [showBarcodeConflictConfirmation, setShowBarcodeConflictConfirmation] =
     useState(false);
   // One ordered list of saved images and staged files, so the user can drag a
@@ -1193,12 +1204,15 @@ export function useCustomFoodForm({
         imageFiles,
       });
 
+      const photosChanged = pickerImagesDiffer(imageItems, food?.images);
+
       // The save consumed the staged files; the server echoes back the final
       // list including their new upload paths.
       setImageItems(toSavedImages(savedFood.images));
 
       if (food?.id && user?.id === food.user_id) {
         setSavedFoodResult(savedFood);
+        setSyncTouchesPhotos(photosChanged);
         setShowSyncConfirmation(true);
       } else {
         if (!food?.id) resetForm();
@@ -1246,12 +1260,21 @@ export function useCustomFoodForm({
     await persistFood();
   };
 
-  const handleSyncConfirmation = async (sync: boolean) => {
+  /**
+   * 'none' leaves history alone. 'nutrition' rewrites nutrition and leaves
+   * every entry's photo as it is. 'nutrition-and-photos' additionally forces
+   * the food's photos onto every entry, replacing photos the user set on
+   * individual diary entries — the replaced files are unlinked server-side.
+   */
+  const handleSyncConfirmation = async (choice: SyncPastEntriesChoice) => {
     if (!savedFoodResult) return;
 
-    if (sync) {
+    if (choice !== 'none') {
       try {
-        await updateFoodEntriesSnapshot(savedFoodResult.id);
+        await updateFoodEntriesSnapshot({
+          foodId: savedFoodResult.id,
+          syncImages: choice === 'nutrition-and-photos',
+        });
       } catch {
         /* toast handled by QueryClient */
       }
@@ -1285,6 +1308,7 @@ export function useCustomFoodForm({
     loading,
     showSyncConfirmation,
     setShowSyncConfirmation,
+    syncTouchesPhotos,
     loadedVariants,
     conversionBaseVariants: originalVariants,
     hasTrustedCompatibilityBase,

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoods.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoods.ts
@@ -176,7 +176,13 @@ export const useUpdateFoodEntriesSnapshotMutation = () => {
   const invalidate = useFoodEntryInvalidation();
   const { t } = useTranslation();
   return useMutation({
-    mutationFn: (syncFoodId: string) => updateFoodEntriesSnapshot(syncFoodId),
+    mutationFn: ({
+      foodId,
+      syncImages,
+    }: {
+      foodId: string;
+      syncImages: boolean;
+    }) => updateFoodEntriesSnapshot(foodId, syncImages),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: foodKeys.all,

--- a/SparkyFitnessFrontend/src/pages/Diary/FoodEntryImageOverride.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/FoodEntryImageOverride.tsx
@@ -62,7 +62,7 @@ export function FoodEntryImageOverride({
           <p className="text-xs text-muted-foreground">
             {t(
               'diary.entryPhotoInheritedHint',
-              "Showing the food's current photo. Add a photo to set one for this entry."
+              'Showing the current library photos. Add photos to set them for this entry.'
             )}
           </p>
           <div className="flex flex-wrap gap-2">

--- a/SparkyFitnessFrontend/src/pages/Diary/FoodEntryImageOverride.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/FoodEntryImageOverride.tsx
@@ -62,7 +62,7 @@ export function FoodEntryImageOverride({
           <p className="text-xs text-muted-foreground">
             {t(
               'diary.entryPhotoInheritedHint',
-              "Showing the food's own images. Add a photo to override them for this entry."
+              "Showing the food's current photo. Add a photo to set one for this entry."
             )}
           </p>
           <div className="flex flex-wrap gap-2">

--- a/SparkyFitnessFrontend/src/pages/Diary/MealCard.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/MealCard.tsx
@@ -634,7 +634,7 @@ const MealCard = ({
                         <img
                           src={entryImageSrc}
                           alt={entryName ?? ''}
-                          className="w-12 h-12 object-cover rounded-md cursor-zoom-in"
+                          className="w-16 h-16 object-cover rounded-md cursor-zoom-in"
                           loading="lazy"
                           onError={(e) => {
                             // A dead provider link shouldn't leave a broken icon.

--- a/SparkyFitnessMobile/App.tsx
+++ b/SparkyFitnessMobile/App.tsx
@@ -14,6 +14,8 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import { QueryClientProvider } from '@tanstack/react-query';
+import { FoodImageSourceProvider } from './src/components/FoodImageSourceProvider';
+import { LightboxProvider } from './src/components/LightboxProvider';
 import { Uniwind, useUniwind, useCSSVariable } from 'uniwind';
 
 import { queryClient, serverConnectionQueryKey, serverConfigsQueryKey, useSyncHealthData, useCycleMode } from './src/hooks';
@@ -260,6 +262,10 @@ function AppContent() {
       }}
     >
       <SafeAreaProvider>
+        {/* Inside SafeAreaProvider on purpose: the viewer positions its close
+            button against the insets, so mounting it at the app root crashes
+            with "No safe area value available". */}
+        <LightboxProvider>
         <UniwindInsetsBridge />
         <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} translucent backgroundColor="transparent" />
         <Stack.Navigator
@@ -732,6 +738,7 @@ function AppContent() {
         <ActiveWorkoutKeepAwake />
         <MedicationReminderReconciler />
         <SafeAreaToast />
+        </LightboxProvider>
       </SafeAreaProvider>
     </NavigationContainer>
   );
@@ -762,7 +769,12 @@ function App() {
       <KeyboardProvider>
         <GestureHandlerRootView className="flex-1">
           <BottomSheetModalProvider>
-            <AppContent />
+            {/* One resolver for the whole app: food/meal image paths only need
+                the active server's origin and proxy headers, so there is no
+                reason for each screen to own a copy (or its own cache). */}
+            <FoodImageSourceProvider>
+              <AppContent />
+            </FoodImageSourceProvider>
           </BottomSheetModalProvider>
         </GestureHandlerRootView>
       </KeyboardProvider>

--- a/SparkyFitnessMobile/__tests__/components/EntryImageOverride.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/EntryImageOverride.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import EntryImageOverride from '../../src/components/EntryImageOverride';
+
+jest.mock('../../src/components/FoodImageSourceProvider', () => ({
+  useFoodImageSourceContext: () => (path: string) => ({
+    uri: `https://server/api${path}`,
+    headers: {},
+  }),
+}));
+
+describe('EntryImageOverride', () => {
+  const noop = () => {};
+
+  it('shows the inherited food photos when the entry has no override', () => {
+    const { queryAllByTestId, getByText } = render(
+      <EntryImageOverride
+        images={null}
+        inheritedImages={['/uploads/foods/f/1.jpg', '/uploads/foods/f/2.jpg']}
+        onSave={noop}
+        onClear={noop}
+      />,
+    );
+
+    expect(queryAllByTestId('food-thumbnail')).toHaveLength(2);
+    expect(
+      getByText('Add a photo to set one for this entry.'),
+    ).toBeTruthy();
+  });
+
+  it('shows the override instead of the parent photos when one is set', () => {
+    // The inherited tiles must disappear: the entry is no longer displaying
+    // them, and leaving them visible would misrepresent what is saved.
+    const { queryAllByTestId, queryByText, getByTestId } = render(
+      <EntryImageOverride
+        images={['/uploads/food_entries/e/1.jpg']}
+        inheritedImages={['/uploads/foods/f/1.jpg']}
+        onSave={noop}
+        onClear={noop}
+      />,
+    );
+
+    expect(
+      queryByText('Add a photo to set one for this entry.'),
+    ).toBeNull();
+    expect(queryAllByTestId('food-thumbnail')).toHaveLength(0);
+    expect(getByTestId('food-image-tile-0')).toBeTruthy();
+  });
+
+  it('renders a plain picker when neither the entry nor the parent has a photo', () => {
+    const { queryByText, getByTestId } = render(
+      <EntryImageOverride
+        images={null}
+        inheritedImages={null}
+        onSave={noop}
+        onClear={noop}
+      />,
+    );
+
+    expect(
+      queryByText('Add a photo to set one for this entry.'),
+    ).toBeNull();
+    expect(getByTestId('food-image-add')).toBeTruthy();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/components/FoodThumbnail.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/FoodThumbnail.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Image } from 'expo-image';
+import { fireEvent, render } from '@testing-library/react-native';
+import FoodThumbnail from '../../src/components/FoodThumbnail';
+
+const getImageSource = (path: string) => ({
+  uri: `https://server/api${path}`,
+  headers: {},
+});
+
+describe('FoodThumbnail', () => {
+  it('renders the resolved image for a stored path', () => {
+    const { UNSAFE_getByType } = render(
+      <FoodThumbnail
+        image="/uploads/foods/abc/1.jpg"
+        getImageSource={getImageSource}
+      />,
+    );
+
+    expect(UNSAFE_getByType(Image).props.source).toEqual({
+      uri: 'https://server/api/uploads/foods/abc/1.jpg',
+      headers: {},
+    });
+  });
+
+  it('renders a placeholder box when there is no image', () => {
+    const { queryByTestId } = render(
+      <FoodThumbnail image={null} getImageSource={getImageSource} />,
+    );
+
+    expect(queryByTestId('food-thumbnail')).not.toBeNull();
+  });
+
+  it('renders nothing at all when fallbacks are suppressed', () => {
+    // The diary row opts out: reserving a placeholder for every entry would
+    // make a photo-free day taller than it was before images existed.
+    const { queryByTestId } = render(
+      <FoodThumbnail
+        image={null}
+        getImageSource={getImageSource}
+        showFallback={false}
+      />,
+    );
+
+    expect(queryByTestId('food-thumbnail')).toBeNull();
+  });
+
+  it('still renders when an image is present and fallbacks are suppressed', () => {
+    const { queryByTestId } = render(
+      <FoodThumbnail
+        image="/uploads/foods/abc/1.jpg"
+        getImageSource={getImageSource}
+        showFallback={false}
+      />,
+    );
+
+    expect(queryByTestId('food-thumbnail')).not.toBeNull();
+  });
+});
+
+describe('FoodThumbnail interactivity', () => {
+  it('is pressable when a handler is supplied', () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <FoodThumbnail
+        image="/uploads/foods/abc/1.jpg"
+        getImageSource={getImageSource}
+        onPress={onPress}
+      />,
+    );
+
+    fireEvent.press(getByTestId('food-thumbnail'));
+    expect(onPress).toHaveBeenCalled();
+  });
+
+  it('stays inert when no handler is supplied', () => {
+    // Rows without a viewer (e.g. the picker tiles) must not look tappable.
+    const { getByTestId } = render(
+      <FoodThumbnail
+        image="/uploads/foods/abc/1.jpg"
+        getImageSource={getImageSource}
+      />,
+    );
+
+    expect(getByTestId('food-thumbnail').props.accessibilityRole).toBeUndefined();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/hooks/useAddFoodEntry.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useAddFoodEntry.test.ts
@@ -232,16 +232,21 @@ describe('useAddFoodEntry', () => {
       });
     });
 
-    expect(mockSaveFood).toHaveBeenCalledWith({
-      name: 'Protein Bar',
-      brand: 'Remote Brand',
-      serving_size: 1,
-      serving_unit: 'bar',
-      calories: 200,
-      protein: 20,
-      carbs: 22,
-      fat: 7,
-    });
+    // Second argument is the optional image payload — undefined when the
+    // caller attached no photos, which keeps the request plain JSON.
+    expect(mockSaveFood).toHaveBeenCalledWith(
+      {
+        name: 'Protein Bar',
+        brand: 'Remote Brand',
+        serving_size: 1,
+        serving_unit: 'bar',
+        calories: 200,
+        protein: 20,
+        carbs: 22,
+        fat: 7,
+      },
+      undefined,
+    );
     expect(mockCreateFoodVariant).toHaveBeenCalledWith({
       food_id: 'food-1',
       serving_size: 1,

--- a/SparkyFitnessMobile/__tests__/hooks/useFoodImageSource.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useFoodImageSource.test.ts
@@ -1,0 +1,164 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useFoodImageSource } from '../../src/hooks/useFoodImageSource';
+import {
+  getActiveServerConfig,
+  proxyHeadersToRecord,
+} from '../../src/services/storage';
+
+jest.mock('../../src/services/storage', () => ({
+  getActiveServerConfig: jest.fn(),
+  proxyHeadersToRecord: jest.fn(),
+}));
+
+jest.mock('../../src/services/api/apiClient', () => ({
+  normalizeUrl: (url: string) => url.replace(/\/$/, ''),
+}));
+
+// The hook deliberately avoids navigation context, so there is nothing from
+// @react-navigation to mock here — that is the point of the design.
+import { AppState } from 'react-native';
+
+const mockGetActiveServerConfig = getActiveServerConfig as jest.MockedFunction<
+  typeof getActiveServerConfig
+>;
+const mockProxyHeadersToRecord = proxyHeadersToRecord as jest.MockedFunction<
+  typeof proxyHeadersToRecord
+>;
+
+const CONFIG = {
+  id: 'test',
+  url: 'https://example.com',
+  apiKey: 'key',
+};
+
+async function renderResolver() {
+  const { result, rerender } = renderHook(() => useFoodImageSource());
+  await act(async () => {});
+  return { result, rerender };
+}
+
+/** Fires the AppState listeners the hook registered, as a foreground return. */
+async function returnToForeground() {
+  const addEventListener = AppState.addEventListener as jest.MockedFunction<
+    typeof AppState.addEventListener
+  >;
+  const handlers = addEventListener.mock.calls
+    .filter(([event]) => event === 'change')
+    .map(([, handler]) => handler);
+
+  await act(async () => {
+    handlers.forEach((handler) => handler('active'));
+  });
+}
+
+describe('useFoodImageSource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(AppState, 'addEventListener').mockReturnValue({
+      remove: jest.fn(),
+    } as unknown as ReturnType<typeof AppState.addEventListener>);
+    mockProxyHeadersToRecord.mockReturnValue({});
+    mockGetActiveServerConfig.mockResolvedValue(CONFIG);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns null for an empty path', async () => {
+    const { result } = await renderResolver();
+    expect(result.current.getImageSource('')).toBeNull();
+  });
+
+  it('prefixes server-relative upload paths with the API origin', async () => {
+    // Food images are stored already server-relative, unlike exercise images
+    // which are bare filenames — the hook must not double the directory.
+    const { result } = await renderResolver();
+
+    expect(result.current.getImageSource('/uploads/foods/abc/1.jpg')?.uri).toBe(
+      'https://example.com/api/uploads/foods/abc/1.jpg',
+    );
+  });
+
+  it('treats a bare filename as a legacy upload', async () => {
+    const { result } = await renderResolver();
+
+    expect(result.current.getImageSource('1.jpg')?.uri).toBe(
+      'https://example.com/api/uploads/foods/1.jpg',
+    );
+  });
+
+  it('uses an absolute provider URL directly, with no headers', async () => {
+    // A provider image that failed to localize stays hotlinked; sending the
+    // server's proxy headers to a third-party CDN would leak them.
+    const { result } = await renderResolver();
+
+    const source = result.current.getImageSource('https://cdn.example/x.jpg');
+    expect(source).toEqual({ uri: 'https://cdn.example/x.jpg', headers: {} });
+  });
+
+  it('attaches proxy headers to server-hosted images', async () => {
+    mockProxyHeadersToRecord.mockReturnValue({ 'X-Auth': 'token' });
+    const { result } = await renderResolver();
+
+    expect(
+      result.current.getImageSource('/uploads/foods/abc/1.jpg')?.headers,
+    ).toEqual({ 'X-Auth': 'token' });
+  });
+
+  it('returns a referentially stable source for the same path', async () => {
+    // Regression guard: without the cache, every render builds a fresh
+    // { uri, headers } literal, which <SafeImage> reads as a new source — so
+    // every thumbnail in a list reloads and visibly flashes on re-render.
+    const { result } = await renderResolver();
+
+    const first = result.current.getImageSource('/uploads/foods/abc/1.jpg');
+    const second = result.current.getImageSource('/uploads/foods/abc/1.jpg');
+
+    expect(first).toBe(second);
+  });
+
+  it('does not resolve server-relative paths before config loads', async () => {
+    let resolveConfig: (c: typeof CONFIG) => void = () => {};
+    mockGetActiveServerConfig.mockReturnValue(
+      new Promise((resolve) => {
+        resolveConfig = resolve;
+      }) as ReturnType<typeof getActiveServerConfig>,
+    );
+
+    const { result } = renderHook(() => useFoodImageSource());
+
+    // Nothing to build a URL from yet — and crucially this must not be cached,
+    // or the path would stay unresolved after the config arrives.
+    expect(result.current.getImageSource('/uploads/foods/abc/1.jpg')).toBeNull();
+
+    await act(async () => {
+      resolveConfig(CONFIG);
+    });
+
+    expect(result.current.getImageSource('/uploads/foods/abc/1.jpg')?.uri).toBe(
+      'https://example.com/api/uploads/foods/abc/1.jpg',
+    );
+  });
+
+  it('rebuilds sources after the active server changes', async () => {
+    // Switching servers must not leave thumbnails pointing at the old origin.
+    const { result } = await renderResolver();
+
+    expect(result.current.getImageSource('/uploads/foods/abc/1.jpg')?.uri).toBe(
+      'https://example.com/api/uploads/foods/abc/1.jpg',
+    );
+
+    mockGetActiveServerConfig.mockResolvedValue({
+      ...CONFIG,
+      id: 'other',
+      url: 'https://other.example',
+    });
+
+    await returnToForeground();
+
+    expect(result.current.getImageSource('/uploads/foods/abc/1.jpg')?.uri).toBe(
+      'https://other.example/api/uploads/foods/abc/1.jpg',
+    );
+  });
+});

--- a/SparkyFitnessMobile/__tests__/hooks/useImageLightbox.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useImageLightbox.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useImageLightbox } from '../../src/hooks/useImageLightbox';
+
+describe('useImageLightbox', () => {
+  it('starts closed', () => {
+    const { result } = renderHook(() => useImageLightbox());
+    expect(result.current.lightboxProps.visible).toBe(false);
+  });
+
+  it('opens at the tapped index', () => {
+    const { result } = renderHook(() => useImageLightbox());
+
+    act(() => {
+      result.current.openLightbox(['/a.jpg', '/b.jpg', '/c.jpg'], 2, 'Nutella');
+    });
+
+    expect(result.current.lightboxProps).toMatchObject({
+      visible: true,
+      initialIndex: 2,
+      title: 'Nutella',
+    });
+  });
+
+  it('clamps an out-of-range index to the available images', () => {
+    const { result } = renderHook(() => useImageLightbox());
+
+    act(() => {
+      result.current.openLightbox(['/a.jpg'], 7);
+    });
+
+    expect(result.current.lightboxProps.initialIndex).toBe(0);
+  });
+
+  it('ignores an open request with no images', () => {
+    // Nothing to show — opening an empty modal would trap the user behind a
+    // black screen with only a close button.
+    const { result } = renderHook(() => useImageLightbox());
+
+    act(() => {
+      result.current.openLightbox([], 0);
+    });
+
+    expect(result.current.lightboxProps.visible).toBe(false);
+  });
+
+  it('closes without dropping the images mid-animation', () => {
+    const { result } = renderHook(() => useImageLightbox());
+
+    act(() => {
+      result.current.openLightbox(['/a.jpg', '/b.jpg'], 1);
+    });
+    act(() => {
+      result.current.lightboxProps.onClose();
+    });
+
+    expect(result.current.lightboxProps.visible).toBe(false);
+    // Kept so the fade-out renders the image instead of an empty frame.
+    expect(result.current.lightboxProps.images).toEqual(['/a.jpg', '/b.jpg']);
+  });
+});
+
+describe('reopening', () => {
+  it('reports a fresh open even at the same index', () => {
+    // ImageLightbox re-seeds (index + autoplay) off the visible transition.
+    // Every caller opens at index 0, so a reopen must still register as a
+    // change — otherwise autoplay stays off for the rest of the session.
+    const { result } = renderHook(() => useImageLightbox());
+
+    act(() => result.current.openLightbox(['/a.jpg', '/b.jpg'], 0));
+    act(() => result.current.lightboxProps.onClose());
+    expect(result.current.lightboxProps.visible).toBe(false);
+
+    act(() => result.current.openLightbox(['/a.jpg', '/b.jpg'], 0));
+    expect(result.current.lightboxProps.visible).toBe(true);
+    expect(result.current.lightboxProps.initialIndex).toBe(0);
+  });
+});

--- a/SparkyFitnessMobile/__tests__/hooks/useMeals.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useMeals.test.ts
@@ -244,7 +244,13 @@ describe('meal mutations', () => {
       await result.current.updateMealAsync({ name: 'Overnight Oats' });
     });
 
-    expect(mockUpdateMeal).toHaveBeenCalledWith('meal-1', { name: 'Overnight Oats' });
+    // Third argument is the optional image payload — undefined when the caller
+    // is not touching photos, which keeps the request plain JSON.
+    expect(mockUpdateMeal).toHaveBeenCalledWith(
+      'meal-1',
+      { name: 'Overnight Oats' },
+      undefined,
+    );
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: mealDetailQueryKey('meal-1') });
     expect(onSuccess).toHaveBeenCalledWith(mealData);
   });

--- a/SparkyFitnessMobile/__tests__/screens/EditLoggedMealScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/EditLoggedMealScreen.test.tsx
@@ -49,6 +49,15 @@ jest.mock('../../src/hooks/useDeleteFoodEntryMeal', () => ({
 jest.mock('../../src/hooks', () => ({
   useMealTypes: jest.fn(),
   usePreferences: jest.fn(() => ({ preferences: undefined, isLoading: false, isError: false, refetch: jest.fn() })),
+  useSetFoodEntryMealImages: jest.fn(() => ({
+    setImages: jest.fn(),
+    setImagesAsync: jest.fn().mockResolvedValue(undefined),
+    isPending: false,
+  })),
+  useClearFoodEntryMealImage: jest.fn(() => ({
+    clearImage: jest.fn(),
+    isPending: false,
+  })),
 }));
 
 jest.mock('../../src/components/ActiveWorkoutBar', () => ({

--- a/SparkyFitnessMobile/__tests__/screens/FoodEntryViewScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodEntryViewScreen.test.tsx
@@ -30,6 +30,15 @@ jest.mock('../../src/hooks', () => ({
   usePreferences: jest.fn(() => ({ preferences: undefined, isLoading: false, isError: false, refetch: jest.fn() })),
   useServerConnection: jest.fn(() => ({ isConnected: true, isLoading: false })),
   useCustomNutrients: jest.fn(() => ({ customNutrients: [], isLoading: false, isError: false, refetch: jest.fn() })),
+  useSetFoodEntryImages: jest.fn(() => ({
+    setImages: jest.fn(),
+    setImagesAsync: jest.fn().mockResolvedValue(undefined),
+    isPending: false,
+  })),
+  useClearFoodEntryImage: jest.fn(() => ({
+    clearImage: jest.fn(),
+    isPending: false,
+  })),
 }));
 
 jest.mock('../../src/hooks/useFoodVariants', () => ({

--- a/SparkyFitnessMobile/__tests__/screens/FoodFormScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodFormScreen.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Alert } from 'react-native';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import Toast from 'react-native-toast-message';
@@ -11,6 +12,7 @@ import {
   useFoodVariants,
 } from '../../src/hooks/useFoodVariants';
 import { setPendingMealIngredientSelection } from '../../src/services/mealBuilderSelection';
+import { updateFoodEntriesSnapshot } from '../../src/services/api/foodsApi';
 
 const mockPop = jest.fn((count: number) => ({ type: 'POP', payload: { count } }));
 const mockPopToTop = jest.fn(() => ({ type: 'POP_TO_TOP' }));
@@ -55,6 +57,17 @@ jest.mock('../../src/hooks/useFoodVariants', () => ({
 
 jest.mock('../../src/services/mealBuilderSelection', () => ({
   setPendingMealIngredientSelection: jest.fn(),
+}));
+
+// The edit path writes through foodsApi directly (not a hook), so without this
+// the save hits the real client, throws for lack of a server config, and never
+// reaches the post-save prompt.
+jest.mock('../../src/services/api/foodsApi', () => ({
+  createFoodVariant: jest.fn(() => Promise.resolve({ id: 'variant-new' })),
+  deleteFoodVariant: jest.fn(() => Promise.resolve()),
+  updateFoodVariant: jest.fn(() => Promise.resolve({})),
+  updateFood: jest.fn(() => Promise.resolve({})),
+  updateFoodEntriesSnapshot: jest.fn(() => Promise.resolve()),
 }));
 
 jest.mock('@tanstack/react-query', () => ({
@@ -168,6 +181,31 @@ const mockToast = Toast as unknown as { show: jest.Mock };
 const insets = { top: 0, bottom: 0, left: 0, right: 0 };
 const frame = { x: 0, y: 0, width: 390, height: 844 };
 
+// The edit flow can raise two Alerts: "Save nutrition" (overwrite vs new
+// variant) and, after a successful save, "Update past entries?". An
+// unanswered Alert leaves a pending promise and the save never completes, so
+// tests must answer both. Defaults are the non-destructive choices.
+function answerSyncPrompt(choice: 'keep' | 'update' = 'keep') {
+  return jest
+    .spyOn(Alert, 'alert')
+    .mockImplementation((title, _message, buttons) => {
+      const list = (buttons ?? []) as { text?: string; onPress?: () => void }[];
+      const press = (text: string) =>
+        list.find((b) => b.text === text)?.onPress?.();
+
+      if (title === 'Update past entries?') {
+        press(choice === 'update' ? 'Update past entries' : 'Keep past entries');
+        return;
+      }
+      if (title === 'Save nutrition') {
+        press('Update existing');
+        return;
+      }
+      // Anything else: take the first non-cancel action so the flow proceeds.
+      list.find((b) => b.text && b.text !== 'Cancel')?.onPress?.();
+    });
+}
+
 describe('FoodFormScreen', () => {
   const navigation = mockNavigation;
 
@@ -192,6 +230,7 @@ describe('FoodFormScreen', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    answerSyncPrompt('keep');
     mockFoodForm.mockClear();
     mockSubmittedFoodFormData = {
       name: 'Custom Meal Food',
@@ -400,8 +439,11 @@ describe('FoodFormScreen', () => {
     fireEvent.press(screen.getByText('Save'));
 
     await waitFor(() => {
+      // Second argument is the optional image payload — undefined when the
+      // user added no photos, which keeps the request plain JSON.
       expect(mockSaveFoodAsync).toHaveBeenCalledWith(
         expect.objectContaining({ barcode: '0123456789012' }),
+        undefined,
       );
     });
   });
@@ -1256,6 +1298,155 @@ describe('FoodFormScreen', () => {
       );
     });
     expect(mockCreateVariant).not.toHaveBeenCalled();
+  });
+
+  it('asks before touching past diary entries, and leaves them alone by default', async () => {
+    // Diary entries hold a nutrition snapshot from when they were logged, so a
+    // library edit must not silently rewrite history. Prompted on every save,
+    // matching web, because one form saves nutrition, name, brand and photo
+    // together.
+    const alertSpy = answerSyncPrompt('keep');
+    mockUseFoodVariants.mockReturnValue({
+      variants: [
+        {
+          id: 'variant-1',
+          food_id: 'food-1',
+          serving_size: 100,
+          serving_unit: 'g',
+          calories: 120,
+          protein: 10,
+          carbs: 8,
+          fat: 4,
+          is_default: true,
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    } as any);
+    mockSubmittedFoodFormData = {
+      ...mockSubmittedFoodFormData,
+      name: 'Greek Yogurt',
+      brand: 'Brand Co',
+      servingSize: '100',
+      servingUnit: 'g',
+      calories: '999',
+      protein: '10',
+      carbs: '8',
+      fat: '4',
+    };
+
+    const screen = renderScreen({
+      mode: 'edit-food',
+      item: {
+        id: 'food-1',
+        name: 'Greek Yogurt',
+        brand: 'Brand Co',
+        servingSize: 100,
+        servingUnit: 'g',
+        calories: 120,
+        protein: 10,
+        carbs: 8,
+        fat: 4,
+        source: 'local',
+        originalItem: {},
+      },
+      initialValues: {
+        name: 'Greek Yogurt',
+        brand: 'Brand Co',
+        servingSize: '100',
+        servingUnit: 'g',
+        calories: '120',
+        protein: '10',
+        carbs: '8',
+        fat: '4',
+      },
+      returnKey: 'FoodDetail-key',
+      foodId: 'food-1',
+      variantId: 'variant-1',
+    });
+
+    fireEvent.press(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(navigation.goBack).toHaveBeenCalled();
+    });
+
+    expect(alertSpy).toHaveBeenCalledWith(
+      'Update past entries?',
+      expect.any(String),
+      expect.any(Array),
+      expect.any(Object),
+    );
+    // Declining must leave history untouched.
+    expect(updateFoodEntriesSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('syncs past entries only when the user opts in', async () => {
+    answerSyncPrompt('update');
+    mockUseFoodVariants.mockReturnValue({
+      variants: [
+        {
+          id: 'variant-1',
+          food_id: 'food-1',
+          serving_size: 100,
+          serving_unit: 'g',
+          calories: 120,
+          protein: 10,
+          carbs: 8,
+          fat: 4,
+          is_default: true,
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    } as any);
+    mockSubmittedFoodFormData = {
+      ...mockSubmittedFoodFormData,
+      name: 'Greek Yogurt',
+      brand: 'Brand Co',
+      servingSize: '100',
+      servingUnit: 'g',
+      calories: '999',
+      protein: '10',
+      carbs: '8',
+      fat: '4',
+    };
+
+    const screen = renderScreen({
+      mode: 'edit-food',
+      item: {
+        id: 'food-1',
+        name: 'Greek Yogurt',
+        brand: 'Brand Co',
+        servingSize: 100,
+        servingUnit: 'g',
+        calories: 120,
+        protein: 10,
+        carbs: 8,
+        fat: 4,
+        source: 'local',
+        originalItem: {},
+      },
+      initialValues: {
+        name: 'Greek Yogurt',
+        brand: 'Brand Co',
+        servingSize: '100',
+        servingUnit: 'g',
+        calories: '120',
+        protein: '10',
+        carbs: '8',
+        fat: '4',
+      },
+      returnKey: 'FoodDetail-key',
+      foodId: 'food-1',
+      variantId: 'variant-1',
+    });
+
+    fireEvent.press(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(updateFoodEntriesSnapshot).toHaveBeenCalledWith('food-1');
+    });
   });
 
   it('refuses to save edit-food submissions while the variants query is still loading', async () => {

--- a/SparkyFitnessMobile/__tests__/screens/FoodFormScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodFormScreen.test.tsx
@@ -194,7 +194,7 @@ function answerSyncPrompt(choice: 'keep' | 'update' = 'keep') {
         list.find((b) => b.text === text)?.onPress?.();
 
       if (title === 'Update past entries?') {
-        press(choice === 'update' ? 'Update past entries' : 'Keep past entries');
+        press(choice === 'update' ? 'Update' : "Don't Update");
         return;
       }
       if (title === 'Save nutrition') {
@@ -1445,7 +1445,13 @@ describe('FoodFormScreen', () => {
     fireEvent.press(screen.getByText('Save'));
 
     await waitFor(() => {
-      expect(updateFoodEntriesSnapshot).toHaveBeenCalledWith('food-1');
+      // Nutrition-only: this save left the food's photos alone, so the
+      // prompt never offered to touch entry photos and must not sync them.
+      expect(updateFoodEntriesSnapshot).toHaveBeenCalledWith(
+        'food-1',
+        undefined,
+        false,
+      );
     });
   });
 

--- a/SparkyFitnessMobile/__tests__/screens/foodFormPersistence.test.ts
+++ b/SparkyFitnessMobile/__tests__/screens/foodFormPersistence.test.ts
@@ -66,4 +66,13 @@ describe('confirmSyncPastEntries', () => {
     expect(title).toBe('Update past entries?');
     expect(message).toContain('keep their original values');
   });
+
+  it('discloses that photos sync along with nutrition', () => {
+    // The snapshot sync refreshes inherited images too, so a prompt naming
+    // only nutrition would understate what the user is agreeing to.
+    const { spy } = captureAlert();
+    void confirmSyncPastEntries();
+
+    expect(spy.mock.calls[0][1]).toContain('new nutrition and photos');
+  });
 });

--- a/SparkyFitnessMobile/__tests__/screens/foodFormPersistence.test.ts
+++ b/SparkyFitnessMobile/__tests__/screens/foodFormPersistence.test.ts
@@ -12,67 +12,133 @@ describe('confirmSyncPastEntries', () => {
     const spy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
     return {
       spy,
+      title: () => spy.mock.calls[0][0],
+      message: () => spy.mock.calls[0][1],
       buttons: () => (spy.mock.calls[0][2] ?? []) as AlertButton[],
       options: () => spy.mock.calls[0][3] as { onDismiss?: () => void },
     };
   }
 
-  it('offers keeping past entries as the safe default', () => {
-    // Diary entries record what was eaten. Rewriting them is the destructive
-    // choice, so the cancel-styled option must be the one that leaves history
-    // alone.
-    const { spy, buttons } = captureAlert();
-    void confirmSyncPastEntries();
+  describe('when the save did not change the food photos', () => {
+    it('offers keeping past entries as the safe default', () => {
+      // Diary entries record what was eaten. Rewriting them is the destructive
+      // choice, so the cancel-styled option must be the one that leaves
+      // history alone.
+      const { spy, buttons } = captureAlert();
+      void confirmSyncPastEntries();
 
-    expect(spy).toHaveBeenCalled();
-    const keep = buttons().find((b) => b.style === 'cancel');
-    expect(keep?.text).toBe('Keep past entries');
+      expect(spy).toHaveBeenCalled();
+      expect(buttons().find((b) => b.style === 'cancel')?.text).toBe(
+        "Don't Update",
+      );
+    });
+
+    it('stays a two-way choice', () => {
+      // Photos are untouched, so a photo option would only ask the user to
+      // decide something this save does not actually change.
+      const { buttons, message } = captureAlert();
+      void confirmSyncPastEntries();
+
+      expect(buttons()).toHaveLength(2);
+      expect(message()).toContain('with the new nutrition?');
+      expect(message()).not.toContain('photo');
+    });
+
+    it('syncs nutrition only when the user picks update', async () => {
+      // Never 'nutrition-and-photos': that path force-replaces custom diary
+      // photos, which the user was never asked about here.
+      const { buttons } = captureAlert();
+      const result = confirmSyncPastEntries();
+
+      buttons().find((b) => b.text === 'Update')?.onPress?.();
+
+      await expect(result).resolves.toBe('nutrition');
+    });
+
+    it('resolves none when the user keeps past entries', async () => {
+      const { buttons } = captureAlert();
+      const result = confirmSyncPastEntries();
+
+      buttons().find((b) => b.text === "Don't Update")?.onPress?.();
+
+      await expect(result).resolves.toBe('none');
+    });
+
+    it('resolves none when dismissed without choosing', async () => {
+      // An Android back-press or outside tap must not be read as consent to
+      // rewrite history.
+      const { options } = captureAlert();
+      const result = confirmSyncPastEntries();
+
+      options().onDismiss?.();
+
+      await expect(result).resolves.toBe('none');
+    });
+
+    it('states that entries are left alone unless updated', () => {
+      const { title, message } = captureAlert();
+      void confirmSyncPastEntries();
+
+      expect(title()).toBe('Update past entries?');
+      expect(message()).toContain('keep their original values');
+    });
   });
 
-  it('resolves true only when the user picks update', async () => {
-    const { buttons } = captureAlert();
-    const result = confirmSyncPastEntries();
+  describe('when the save replaced the food photos', () => {
+    it('offers all three outcomes', () => {
+      const { buttons } = captureAlert();
+      void confirmSyncPastEntries(true);
 
-    buttons().find((b) => b.text === 'Update past entries')?.onPress?.();
+      expect(buttons().map((b) => b.text)).toEqual([
+        "Don't Update",
+        'Update nutrition only',
+        'Update nutrition & photos',
+      ]);
+    });
 
-    await expect(result).resolves.toBe(true);
-  });
+    it('marks only the photo-replacing option as destructive', () => {
+      // It is the one path that discards a photo the user chose for a specific
+      // diary entry, and the server unlinks the replaced file.
+      const { buttons } = captureAlert();
+      void confirmSyncPastEntries(true);
 
-  it('resolves false when the user keeps past entries', async () => {
-    const { buttons } = captureAlert();
-    const result = confirmSyncPastEntries();
+      expect(
+        buttons()
+          .filter((b) => b.style === 'destructive')
+          .map((b) => b.text),
+      ).toEqual(['Update nutrition & photos']);
+    });
 
-    buttons().find((b) => b.text === 'Keep past entries')?.onPress?.();
+    it('keeps the safe choice cancel-styled and default on dismiss', async () => {
+      const { buttons, options } = captureAlert();
+      const result = confirmSyncPastEntries(true);
 
-    await expect(result).resolves.toBe(false);
-  });
+      expect(buttons().find((b) => b.style === 'cancel')?.text).toBe(
+        "Don't Update",
+      );
+      options().onDismiss?.();
 
-  it('resolves false when dismissed without choosing', async () => {
-    // An Android back-press or outside tap must not be read as consent to
-    // rewrite history.
-    const { options } = captureAlert();
-    const result = confirmSyncPastEntries();
+      await expect(result).resolves.toBe('none');
+    });
 
-    options().onDismiss?.();
+    it('resolves nutrition when photos are declined', async () => {
+      const { buttons } = captureAlert();
+      const result = confirmSyncPastEntries(true);
 
-    await expect(result).resolves.toBe(false);
-  });
+      buttons().find((b) => b.text === 'Update nutrition only')?.onPress?.();
 
-  it('states that entries are left alone unless updated', () => {
-    const { spy } = captureAlert();
-    void confirmSyncPastEntries();
+      await expect(result).resolves.toBe('nutrition');
+    });
 
-    const [title, message] = spy.mock.calls[0];
-    expect(title).toBe('Update past entries?');
-    expect(message).toContain('keep their original values');
-  });
+    it('resolves nutrition-and-photos when photos are accepted', async () => {
+      const { buttons } = captureAlert();
+      const result = confirmSyncPastEntries(true);
 
-  it('discloses that photos sync along with nutrition', () => {
-    // The snapshot sync refreshes inherited images too, so a prompt naming
-    // only nutrition would understate what the user is agreeing to.
-    const { spy } = captureAlert();
-    void confirmSyncPastEntries();
+      buttons()
+        .find((b) => b.text === 'Update nutrition & photos')
+        ?.onPress?.();
 
-    expect(spy.mock.calls[0][1]).toContain('new nutrition and photos');
+      await expect(result).resolves.toBe('nutrition-and-photos');
+    });
   });
 });

--- a/SparkyFitnessMobile/__tests__/screens/foodFormPersistence.test.ts
+++ b/SparkyFitnessMobile/__tests__/screens/foodFormPersistence.test.ts
@@ -1,0 +1,69 @@
+import { Alert } from 'react-native';
+import { confirmSyncPastEntries } from '../../src/screens/foodForm/persistence';
+
+type AlertButton = { text?: string; style?: string; onPress?: () => void };
+
+describe('confirmSyncPastEntries', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function captureAlert() {
+    const spy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    return {
+      spy,
+      buttons: () => (spy.mock.calls[0][2] ?? []) as AlertButton[],
+      options: () => spy.mock.calls[0][3] as { onDismiss?: () => void },
+    };
+  }
+
+  it('offers keeping past entries as the safe default', () => {
+    // Diary entries record what was eaten. Rewriting them is the destructive
+    // choice, so the cancel-styled option must be the one that leaves history
+    // alone.
+    const { spy, buttons } = captureAlert();
+    void confirmSyncPastEntries();
+
+    expect(spy).toHaveBeenCalled();
+    const keep = buttons().find((b) => b.style === 'cancel');
+    expect(keep?.text).toBe('Keep past entries');
+  });
+
+  it('resolves true only when the user picks update', async () => {
+    const { buttons } = captureAlert();
+    const result = confirmSyncPastEntries();
+
+    buttons().find((b) => b.text === 'Update past entries')?.onPress?.();
+
+    await expect(result).resolves.toBe(true);
+  });
+
+  it('resolves false when the user keeps past entries', async () => {
+    const { buttons } = captureAlert();
+    const result = confirmSyncPastEntries();
+
+    buttons().find((b) => b.text === 'Keep past entries')?.onPress?.();
+
+    await expect(result).resolves.toBe(false);
+  });
+
+  it('resolves false when dismissed without choosing', async () => {
+    // An Android back-press or outside tap must not be read as consent to
+    // rewrite history.
+    const { options } = captureAlert();
+    const result = confirmSyncPastEntries();
+
+    options().onDismiss?.();
+
+    await expect(result).resolves.toBe(false);
+  });
+
+  it('states that entries are left alone unless updated', () => {
+    const { spy } = captureAlert();
+    void confirmSyncPastEntries();
+
+    const [title, message] = spy.mock.calls[0];
+    expect(title).toBe('Update past entries?');
+    expect(message).toContain('keep their original values');
+  });
+});

--- a/SparkyFitnessMobile/__tests__/services/externalFoodSearchApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/externalFoodSearchApi.test.ts
@@ -1297,6 +1297,37 @@ describe('externalFoodSearchApi', () => {
     };
 
     describe('transformNormalizedFood', () => {
+      test('carries the provider photo through to the search row', () => {
+        // Regression: provider results rendered a placeholder icon on mobile
+        // while web showed the photo. The server sends image_url, but this
+        // mapper dropped it — a field this function omits is invisible to the
+        // UI no matter what arrived on the wire.
+        const food = {
+          name: 'Sambar Powder',
+          brand: 'MTR',
+          is_custom: false,
+          image_url: 'https://images.openfoodfacts.org/thumb.jpg',
+          image_source_url: 'https://images.openfoodfacts.org/full.jpg',
+          default_variant: {
+            serving_size: 100,
+            serving_unit: 'g',
+            calories: 0,
+            protein: 0,
+            carbs: 0,
+            fat: 0,
+          },
+        };
+
+        const result = transformNormalizedFood(food, 'openfoodfacts');
+
+        expect(result.image_url).toBe(
+          'https://images.openfoodfacts.org/thumb.jpg',
+        );
+        expect(result.image_source_url).toBe(
+          'https://images.openfoodfacts.org/full.jpg',
+        );
+      });
+
       test('flattens default_variant to top-level fields', () => {
         const food = {
           id: 'internal-1',
@@ -1333,6 +1364,9 @@ describe('externalFoodSearchApi', () => {
           id: 'ext-123',
           name: 'Chicken Breast',
           brand: 'Farm Fresh',
+          image_url: null,
+          image_source_url: null,
+          images: undefined,
           barcode: undefined,
           provider_type: 'openfoodfacts',
           provider_external_id: 'ext-123',

--- a/SparkyFitnessMobile/__tests__/services/foodsApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/foodsApi.test.ts
@@ -1,4 +1,11 @@
-import { fetchFoods, searchFoods, fetchFoodVariants, saveFood, deleteFood } from '../../src/services/api/foodsApi';
+import {
+  fetchFoods,
+  searchFoods,
+  fetchFoodVariants,
+  saveFood,
+  deleteFood,
+  updateFoodEntriesSnapshot,
+} from '../../src/services/api/foodsApi';
 import type { SaveFoodPayload } from '../../src/services/api/foodsApi';
 import { getActiveServerConfig, ServerConfig } from '../../src/services/storage';
 
@@ -430,6 +437,56 @@ describe('foodsApi', () => {
       await expect(saveFood(testPayload)).rejects.toThrow(
         'Server configuration not found.'
       );
+    });
+  });
+
+  describe('updateFoodEntriesSnapshot', () => {
+    const testConfig: ServerConfig = {
+      id: 'test-id',
+      url: 'https://example.com',
+      apiKey: 'test-api-key-12345',
+    };
+
+    test('posts the food id to /api/foods/update-snapshot', async () => {
+      // Opt-in only: this is the single endpoint that rewrites the nutrition
+      // snapshot on already-logged diary entries. Nothing else in the food
+      // edit flow touches history.
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+      await updateFoodEntriesSnapshot('food-abc');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://example.com/api/foods/update-snapshot',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ foodId: 'food-abc' }),
+        }),
+      );
+    });
+
+    test('omits variantId entirely when not supplied, so all variants sync', async () => {
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+      await updateFoodEntriesSnapshot('food-abc');
+
+      const body = JSON.parse(
+        (mockFetch.mock.calls[0][1] as { body: string }).body,
+      );
+      expect(body).not.toHaveProperty('variantId');
+    });
+
+    test('scopes to a single variant when one is given', async () => {
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+      await updateFoodEntriesSnapshot('food-abc', 'variant-1');
+
+      const body = JSON.parse(
+        (mockFetch.mock.calls[0][1] as { body: string }).body,
+      );
+      expect(body).toEqual({ foodId: 'food-abc', variantId: 'variant-1' });
     });
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/foodsApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/foodsApi.test.ts
@@ -460,7 +460,7 @@ describe('foodsApi', () => {
         'https://example.com/api/foods/update-snapshot',
         expect.objectContaining({
           method: 'POST',
-          body: JSON.stringify({ foodId: 'food-abc' }),
+          body: JSON.stringify({ foodId: 'food-abc', syncImages: true }),
         }),
       );
     });
@@ -486,7 +486,25 @@ describe('foodsApi', () => {
       const body = JSON.parse(
         (mockFetch.mock.calls[0][1] as { body: string }).body,
       );
-      expect(body).toEqual({ foodId: 'food-abc', variantId: 'variant-1' });
+      expect(body).toEqual({
+        foodId: 'food-abc',
+        variantId: 'variant-1',
+        syncImages: true,
+      });
+    });
+
+    test('sends syncImages false for a nutrition-only sync', async () => {
+      // The "Update nutrition only" choice: past entries get the new numbers
+      // and every entry keeps the photo it is showing, custom or inherited.
+      mockGetActiveServerConfig.mockResolvedValue(testConfig);
+      mockFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+      await updateFoodEntriesSnapshot('food-abc', undefined, false);
+
+      const body = JSON.parse(
+        (mockFetch.mock.calls[0][1] as { body: string }).body,
+      );
+      expect(body).toEqual({ foodId: 'food-abc', syncImages: false });
     });
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/imageUploadClient.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/imageUploadClient.test.ts
@@ -1,0 +1,248 @@
+import {
+  postImageMultipart,
+  postPayloadWithImages,
+} from '../../src/services/api/imageUploadClient';
+import { getActiveServerConfig, proxyHeadersToRecord } from '../../src/services/storage';
+import { getAuthHeaders } from '../../src/services/api/authService';
+import { fetchWithTimeout } from '../../src/utils/concurrency';
+
+jest.mock('../../src/services/storage', () => ({
+  getActiveServerConfig: jest.fn(),
+  proxyHeadersToRecord: jest.fn(),
+}));
+
+jest.mock('../../src/services/api/authService', () => ({
+  getAuthHeaders: jest.fn(),
+  notifySessionExpired: jest.fn(),
+}));
+
+jest.mock('../../src/services/api/apiClient', () => ({
+  normalizeUrl: (url: string) => url.replace(/\/$/, ''),
+}));
+
+jest.mock('../../src/services/LogService', () => ({ addLog: jest.fn() }));
+
+jest.mock('../../src/utils/concurrency', () => ({
+  UPLOAD_TIMEOUT_MS: 30000,
+  fetchWithTimeout: jest.fn(),
+}));
+
+// expo-file-system's File is a Blob; the real one needs a native module, so
+// stand in a marker object that records the uri it was constructed with.
+jest.mock('expo-file-system', () => ({
+  // Must extend Blob: jsdom's FormData stringifies anything that is not a
+  // Blob/File, which would silently turn the upload into a text field — the
+  // same class of failure expo/fetch raises at runtime for RN file parts.
+  File: class extends Blob {
+    uri: string;
+    constructor(uri: string) {
+      super([uri]);
+      this.uri = uri;
+    }
+  },
+}));
+
+const mockFetch = fetchWithTimeout as jest.MockedFunction<typeof fetchWithTimeout>;
+
+function okResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('postImageMultipart', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getActiveServerConfig as jest.Mock).mockResolvedValue({
+      id: 'srv',
+      url: 'https://example.com',
+      apiKey: 'k',
+    });
+    (proxyHeadersToRecord as jest.Mock).mockReturnValue({ 'X-Proxy': 'p' });
+    (getAuthHeaders as jest.Mock).mockReturnValue({ Authorization: 'Bearer k' });
+    mockFetch.mockResolvedValue(okResponse({ id: 'entry-1' }));
+  });
+
+  it('posts the order array and one file part per upload', async () => {
+    await postImageMultipart({
+      endpoint: '/api/food-entries/e1/image',
+      serviceName: 'Test',
+      operation: 'set image',
+      order: ['/uploads/foods/a/1.jpg', '__new__0'],
+      newUris: ['file:///new.jpg'],
+    });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe('https://example.com/api/food-entries/e1/image');
+
+    const form = (init as RequestInit).body as FormData;
+    expect(form.getAll('images')).toHaveLength(2);
+    expect(form.getAll('images')[0]).toBe(
+      JSON.stringify(['/uploads/foods/a/1.jpg', '__new__0']),
+    );
+    // The file part must serialize as a Blob. An RN {uri, name, type} object
+    // would land here as the string "[object Object]" — the same silent
+    // corruption expo/fetch rejects outright at runtime.
+    expect(form.getAll('images')[1]).toBeInstanceOf(Blob);
+    expect(typeof form.getAll('images')[1]).not.toBe('string');
+  });
+
+  it('never sets Content-Type, so multer can supply the boundary', async () => {
+    await postImageMultipart({
+      endpoint: '/api/food-entries/e1/image',
+      serviceName: 'Test',
+      operation: 'set image',
+      order: [],
+      newUris: [],
+    });
+
+    const headers = (mockFetch.mock.calls[0][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(Object.keys(headers).map((k) => k.toLowerCase())).not.toContain(
+      'content-type',
+    );
+  });
+
+  it('sends proxy headers alongside auth', async () => {
+    await postImageMultipart({
+      endpoint: '/api/food-entries/e1/image',
+      serviceName: 'Test',
+      operation: 'set image',
+      order: [],
+      newUris: [],
+    });
+
+    const headers = (mockFetch.mock.calls[0][1] as RequestInit).headers as Record<
+      string,
+      string
+    >;
+    expect(headers['X-Proxy']).toBe('p');
+    expect(headers.Authorization).toBe('Bearer k');
+  });
+
+  it('puts the order INSIDE the wrapper for wrapped routes', async () => {
+    // Regression: the server's parseMultipartBody replaces the body with the
+    // parsed wrapper and discards other text fields. A top-level `images`
+    // field is therefore dropped, and the server reads the uploads as the
+    // complete set — silently unlinking every existing photo on the food.
+    await postImageMultipart({
+      endpoint: '/api/foods',
+      serviceName: 'Test',
+      operation: 'save food',
+      order: ['/uploads/foods/a/1.jpg', '__new__0'],
+      newUris: ['file:///a.jpg'],
+      payload: { name: 'Nutella' },
+      wrapperField: 'foodData',
+    });
+
+    const form = (mockFetch.mock.calls[0][1] as RequestInit).body as FormData;
+    expect(form.get('foodData')).toBe(
+      JSON.stringify({
+        name: 'Nutella',
+        images: ['/uploads/foods/a/1.jpg', '__new__0'],
+      }),
+    );
+    // Only the file part remains under `images`; no stray text field.
+    const imageParts = form.getAll('images');
+    expect(imageParts).toHaveLength(1);
+    expect(imageParts[0]).toBeInstanceOf(Blob);
+  });
+
+  it('keeps the order top-level for unwrapped entry routes', async () => {
+    // The per-entry image endpoints read req.body.images directly — they run
+    // no wrapper parsing, so the field must NOT be nested there.
+    await postImageMultipart({
+      endpoint: '/api/food-entries/e1/image',
+      serviceName: 'Test',
+      operation: 'set image',
+      order: ['__new__0'],
+      newUris: ['file:///a.jpg'],
+    });
+
+    const form = (mockFetch.mock.calls[0][1] as RequestInit).body as FormData;
+    expect(form.getAll('images')[0]).toBe(JSON.stringify(['__new__0']));
+  });
+
+  it('throws an ApiError carrying the status code on a failed response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 413,
+      text: async () => 'File too large',
+    } as unknown as Response);
+
+    // Inspected via catch rather than `.rejects.toMatchObject`, which compares
+    // Errors by message and ignores extra properties like `status`.
+    let caught: unknown;
+    try {
+      await postImageMultipart({
+        endpoint: '/api/foods',
+        serviceName: 'Test',
+        operation: 'save food',
+        order: [],
+        newUris: [],
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect((caught as { statusCode?: number })?.statusCode).toBe(413);
+  });
+});
+
+describe('postPayloadWithImages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getActiveServerConfig as jest.Mock).mockResolvedValue({
+      id: 'srv',
+      url: 'https://example.com',
+      apiKey: 'k',
+    });
+    (proxyHeadersToRecord as jest.Mock).mockReturnValue({});
+    (getAuthHeaders as jest.Mock).mockReturnValue({});
+    mockFetch.mockResolvedValue(okResponse({ id: 'food-1' }));
+  });
+
+  it('stays plain JSON when there are no files to upload', async () => {
+    // Matches web: a save that touches no photos must not become multipart.
+    const sendJson = jest.fn().mockResolvedValue({ id: 'food-1' });
+
+    await postPayloadWithImages({
+      endpoint: '/api/foods',
+      serviceName: 'Test',
+      operation: 'save food',
+      payload: { name: 'Oreo' },
+      wrapperField: 'foodData',
+      order: ['/uploads/foods/a/1.jpg'],
+      newUris: [],
+      sendJson,
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(sendJson).toHaveBeenCalledWith({
+      name: 'Oreo',
+      images: ['/uploads/foods/a/1.jpg'],
+    });
+  });
+
+  it('switches to multipart as soon as a file is present', async () => {
+    const sendJson = jest.fn();
+
+    await postPayloadWithImages({
+      endpoint: '/api/foods',
+      serviceName: 'Test',
+      operation: 'save food',
+      payload: { name: 'Oreo' },
+      wrapperField: 'foodData',
+      order: ['__new__0'],
+      newUris: ['file:///a.jpg'],
+      sendJson,
+    });
+
+    expect(sendJson).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalled();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/utils/foodImages.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/foodImages.test.ts
@@ -1,0 +1,148 @@
+import {
+  normalizeFoodImagePath,
+  usableFoodImages,
+  primaryImageOf,
+  externalFoodImage,
+  diaryEntryImages,
+  diaryEntryImage,
+  loggedMealImages,
+  loggedMealImage,
+} from '../../src/utils/foodImages';
+
+describe('normalizeFoodImagePath', () => {
+  it('keeps server-relative and absolute paths as-is', () => {
+    expect(normalizeFoodImagePath('/uploads/foods/abc/0.jpg')).toBe(
+      '/uploads/foods/abc/0.jpg',
+    );
+    expect(normalizeFoodImagePath('https://cdn.example/x.jpg')).toBe(
+      'https://cdn.example/x.jpg',
+    );
+  });
+
+  it('treats empty-ish values as no image', () => {
+    expect(normalizeFoodImagePath(null)).toBeNull();
+    expect(normalizeFoodImagePath(undefined)).toBeNull();
+    expect(normalizeFoodImagePath('')).toBeNull();
+    expect(normalizeFoodImagePath('   ')).toBeNull();
+  });
+
+  it('treats the legacy "[]" payload as no image', () => {
+    // Older rows serialized an empty image list as the literal string "[]";
+    // rendering it would request /uploads/foods/[] and 404.
+    expect(normalizeFoodImagePath('[]')).toBeNull();
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeFoodImagePath('  /uploads/foods/a/1.png  ')).toBe(
+      '/uploads/foods/a/1.png',
+    );
+  });
+});
+
+describe('usableFoodImages', () => {
+  it('drops unusable entries but keeps order', () => {
+    expect(
+      usableFoodImages(['', '/uploads/foods/a/1.jpg', '[]', 'https://x/2.jpg']),
+    ).toEqual(['/uploads/foods/a/1.jpg', 'https://x/2.jpg']);
+  });
+
+  it('returns an empty array for non-array input', () => {
+    expect(usableFoodImages(null)).toEqual([]);
+    expect(usableFoodImages(undefined)).toEqual([]);
+  });
+});
+
+describe('primaryImageOf', () => {
+  it('returns the first usable image', () => {
+    expect(primaryImageOf({ images: ['[]', '/uploads/foods/a/2.jpg'] })).toBe(
+      '/uploads/foods/a/2.jpg',
+    );
+  });
+
+  it('returns null when there is nothing to show', () => {
+    expect(primaryImageOf({ images: [] })).toBeNull();
+    expect(primaryImageOf(null)).toBeNull();
+  });
+});
+
+describe('externalFoodImage', () => {
+  it('prefers an already-imported images array', () => {
+    expect(
+      externalFoodImage({
+        images: ['/uploads/foods/a/1.jpg'],
+        image_source_url: 'https://x/full.jpg',
+        image_url: 'https://x/thumb.jpg',
+      }),
+    ).toBe('/uploads/foods/a/1.jpg');
+  });
+
+  it('prefers the full-size source over the search thumbnail', () => {
+    expect(
+      externalFoodImage({
+        image_source_url: 'https://x/full.jpg',
+        image_url: 'https://x/thumb.jpg',
+      }),
+    ).toBe('https://x/full.jpg');
+  });
+
+  it('falls back to the thumbnail when there is no full-size variant', () => {
+    expect(externalFoodImage({ image_url: 'https://x/thumb.jpg' })).toBe(
+      'https://x/thumb.jpg',
+    );
+  });
+
+  it('returns null when the provider supplied no photo', () => {
+    expect(externalFoodImage({})).toBeNull();
+    expect(externalFoodImage(null)).toBeNull();
+  });
+});
+
+describe('diaryEntryImages', () => {
+  it('prefers the per-entry override over the parent food', () => {
+    expect(
+      diaryEntryImages({
+        images: ['/uploads/food_entries/e/1.jpg'],
+        food_images: ['/uploads/foods/f/1.jpg'],
+      }),
+    ).toEqual(['/uploads/food_entries/e/1.jpg']);
+  });
+
+  it('falls back to the parent food when there is no override', () => {
+    // The override is never written back to the parent, so this fallback is
+    // what makes an un-overridden entry still show a picture.
+    expect(
+      diaryEntryImages({ images: [], food_images: ['/uploads/foods/f/1.jpg'] }),
+    ).toEqual(['/uploads/foods/f/1.jpg']);
+  });
+
+  it('ignores an override that holds only unusable values', () => {
+    expect(
+      diaryEntryImages({
+        images: ['[]'],
+        food_images: ['/uploads/foods/f/1.jpg'],
+      }),
+    ).toEqual(['/uploads/foods/f/1.jpg']);
+  });
+
+  it('returns nothing when neither side has an image', () => {
+    expect(diaryEntryImages({ images: null, food_images: null })).toEqual([]);
+    expect(diaryEntryImage(null)).toBeNull();
+  });
+});
+
+describe('loggedMealImages', () => {
+  it('prefers the entry override over the meal template', () => {
+    expect(
+      loggedMealImages({
+        images: ['/uploads/food_entry_meals/e/1.jpg'],
+        meal_images: ['/uploads/meals/m/1.jpg'],
+      }),
+    ).toEqual(['/uploads/food_entry_meals/e/1.jpg']);
+  });
+
+  it('falls back to the meal template', () => {
+    expect(
+      loggedMealImage({ images: [], meal_images: ['/uploads/meals/m/1.jpg'] }),
+    ).toBe('/uploads/meals/m/1.jpg');
+  });
+});

--- a/SparkyFitnessMobile/__tests__/utils/pickerImages.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/pickerImages.test.ts
@@ -1,0 +1,128 @@
+import {
+  MAX_IMAGES,
+  toNewImage,
+  toSavedImages,
+  splitPickerImages,
+  pickerImagesDiffer,
+  setAsMain,
+  removeImageAt,
+  pickerImageKey,
+  type PickerImage,
+} from '../../src/utils/pickerImages';
+
+const saved = (path: string): PickerImage => ({ kind: 'saved', path });
+
+describe('toSavedImages', () => {
+  it('drops empty and legacy "[]" entries', () => {
+    expect(toSavedImages(['/a.jpg', '', '[]', '  ', '/b.jpg'])).toEqual([
+      { kind: 'saved', path: '/a.jpg' },
+      { kind: 'saved', path: '/b.jpg' },
+    ]);
+  });
+
+  it('handles null input', () => {
+    expect(toSavedImages(null)).toEqual([]);
+  });
+});
+
+describe('splitPickerImages', () => {
+  it('emits stored paths as-is and placeholders for uploads', () => {
+    const items = [saved('/a.jpg'), toNewImage('file:///new1'), saved('/b.jpg')];
+
+    expect(splitPickerImages(items)).toEqual({
+      order: ['/a.jpg', '__new__0', '/b.jpg'],
+      newUris: ['file:///new1'],
+    });
+  });
+
+  it('numbers placeholders by upload position, not item position', () => {
+    // __new__<n> indexes into the appended files, so the second new image is
+    // __new__1 even though it is the fourth item.
+    const items = [
+      saved('/a.jpg'),
+      toNewImage('file:///x'),
+      saved('/b.jpg'),
+      toNewImage('file:///y'),
+    ];
+
+    expect(splitPickerImages(items)).toEqual({
+      order: ['/a.jpg', '__new__0', '/b.jpg', '__new__1'],
+      newUris: ['file:///x', 'file:///y'],
+    });
+  });
+
+  it('truncates to the server MAX_IMAGE_COUNT', () => {
+    const items = Array.from({ length: MAX_IMAGES + 3 }, (_, i) =>
+      saved(`/img-${i}.jpg`),
+    );
+
+    const { order } = splitPickerImages(items);
+    expect(order).toHaveLength(MAX_IMAGES);
+  });
+});
+
+describe('pickerImagesDiffer', () => {
+  it('is true when a new upload is staged', () => {
+    expect(pickerImagesDiffer([toNewImage('file:///x')], [])).toBe(true);
+  });
+
+  it('is false when nothing changed', () => {
+    expect(
+      pickerImagesDiffer([saved('/a.jpg'), saved('/b.jpg')], ['/a.jpg', '/b.jpg']),
+    ).toBe(false);
+  });
+
+  it('is true when an image was removed', () => {
+    expect(pickerImagesDiffer([saved('/a.jpg')], ['/a.jpg', '/b.jpg'])).toBe(
+      true,
+    );
+  });
+
+  it('is true when only the order changed', () => {
+    // Order is not cosmetic: index 0 is the thumbnail, so a reorder alone is a
+    // real change that must be saved.
+    expect(
+      pickerImagesDiffer([saved('/b.jpg'), saved('/a.jpg')], ['/a.jpg', '/b.jpg']),
+    ).toBe(true);
+  });
+});
+
+describe('setAsMain', () => {
+  it('moves the chosen image to index 0 and keeps the rest in order', () => {
+    const items = [saved('/a.jpg'), saved('/b.jpg'), saved('/c.jpg')];
+
+    expect(setAsMain(items, 2)).toEqual([
+      saved('/c.jpg'),
+      saved('/a.jpg'),
+      saved('/b.jpg'),
+    ]);
+  });
+
+  it('is a no-op for index 0 and out-of-range indices', () => {
+    const items = [saved('/a.jpg'), saved('/b.jpg')];
+    expect(setAsMain(items, 0)).toBe(items);
+    expect(setAsMain(items, 5)).toBe(items);
+  });
+});
+
+describe('removeImageAt', () => {
+  it('removes only the given index', () => {
+    const items = [saved('/a.jpg'), saved('/b.jpg'), saved('/c.jpg')];
+    expect(removeImageAt(items, 1)).toEqual([saved('/a.jpg'), saved('/c.jpg')]);
+  });
+
+  it('is a no-op out of range', () => {
+    const items = [saved('/a.jpg')];
+    expect(removeImageAt(items, 3)).toBe(items);
+  });
+});
+
+describe('pickerImageKey', () => {
+  it('gives new images a stable identity distinct from their uri', () => {
+    const a = toNewImage('file:///same');
+    const b = toNewImage('file:///same');
+    // Two picks of the same file are separate list entries and must not
+    // collide as React keys.
+    expect(pickerImageKey(a)).not.toBe(pickerImageKey(b));
+  });
+});

--- a/SparkyFitnessMobile/app.config.ts
+++ b/SparkyFitnessMobile/app.config.ts
@@ -135,6 +135,14 @@ export default ({ config }: ConfigContext): Partial<ExpoConfig> => {
       infoPlist: {
         NSLocalNetworkUsageDescription:
           'SparkyFitness connects to self-hosted servers on your local network.',
+        // Required by the food/meal photo picker and the label/barcode
+        // scanner. iOS terminates the app on first use without these, and App
+        // Review rejects a binary that requests either without a purpose
+        // string.
+        NSCameraUsageDescription:
+          'SparkyFitness uses the camera to photograph foods and meals, and to scan barcodes and nutrition labels.',
+        NSPhotoLibraryUsageDescription:
+          'SparkyFitness lets you choose photos from your library for your foods, meals, and diary entries.',
         NSAppTransportSecurity: {
           NSAllowsArbitraryLoads: false,
         },

--- a/SparkyFitnessMobile/src/components/EntryImageOverride.tsx
+++ b/SparkyFitnessMobile/src/components/EntryImageOverride.tsx
@@ -55,6 +55,25 @@ const EntryImageOverride: React.FC<EntryImageOverrideProps> = ({
     setItems(toSavedImages(images));
   }
 
+  // `items` is updated optimistically so the picked photo shows while the
+  // upload runs. If the write fails, `images` never changes and the re-seed
+  // above never fires, leaving `items` holding a change that was never
+  // persisted — a later save would then send that list as the complete set and
+  // delete images the server still has. So when a mutation settles and the
+  // saved images did not move, treat it as a failure and drop the optimistic
+  // state. Synced during render for the same reason as the re-seed above.
+  const [wasPending, setWasPending] = useState(isPending);
+  if (wasPending !== isPending) {
+    setWasPending(isPending);
+    if (
+      !isPending &&
+      seededKey === savedKey &&
+      pickerImagesDiffer(items, images)
+    ) {
+      setItems(toSavedImages(images));
+    }
+  }
+
   const hasOverride = usableFoodImages(images).length > 0;
   const inherited = usableFoodImages(inheritedImages);
 

--- a/SparkyFitnessMobile/src/components/EntryImageOverride.tsx
+++ b/SparkyFitnessMobile/src/components/EntryImageOverride.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+import { View, Text } from 'react-native';
+import FoodImagePicker from './FoodImagePicker';
+import FoodThumbnail from './FoodThumbnail';
+import { useFoodImageSourceContext } from './FoodImageSourceProvider';
+import {
+  pickerImagesDiffer,
+  toSavedImages,
+  type PickerImage,
+} from '../utils/pickerImages';
+import { usableFoodImages } from '../utils/foodImages';
+
+interface EntryImageOverrideProps {
+  /** The entry's own override photos. */
+  images: string[] | null | undefined;
+  /** The parent food's or meal's photos, shown when there is no override. */
+  inheritedImages: string[] | null | undefined;
+  onSave: (items: PickerImage[]) => void;
+  onClear: () => void;
+  isPending?: boolean;
+}
+
+/**
+ * Per-entry photo control for the diary.
+ *
+ * With no override, the parent food's photos are shown dimmed and read-only —
+ * the entry really is displaying them, and presenting them as editable would
+ * imply that changing one here edits the food itself. It does not: the server
+ * never writes an entry override back to the parent.
+ */
+const EntryImageOverride: React.FC<EntryImageOverrideProps> = ({
+  images,
+  inheritedImages,
+  onSave,
+  onClear,
+  isPending = false,
+}) => {
+  const getImageSource = useFoodImageSourceContext();
+  const [items, setItems] = useState<PickerImage[]>(() => toSavedImages(images));
+
+  // Re-seed when the saved override changes underneath (after a save settles,
+  // or when the screen is reused for a different entry). Synced during render
+  // rather than in an effect so the tiles never show a stale frame first.
+  const savedKey = (images ?? []).join('|');
+  const [seededKey, setSeededKey] = useState(savedKey);
+  if (seededKey !== savedKey) {
+    setSeededKey(savedKey);
+    setItems(toSavedImages(images));
+  }
+
+  const hasOverride = usableFoodImages(images).length > 0;
+  const inherited = usableFoodImages(inheritedImages);
+
+  const handleChange = (next: PickerImage[]) => {
+    setItems(next);
+    if (!pickerImagesDiffer(next, images)) return;
+    if (next.length === 0) {
+      onClear();
+      return;
+    }
+    onSave(next);
+  };
+
+  if (!hasOverride && inherited.length > 0) {
+    return (
+      <View>
+        <Text className="text-text-secondary text-sm font-medium mb-2">
+          Photo
+        </Text>
+        <View className="flex-row gap-2" style={{ opacity: 0.6 }}>
+          {inherited.slice(0, 4).map((image) => (
+            <FoodThumbnail
+              key={image}
+              image={image}
+              getImageSource={getImageSource}
+              size={56}
+            />
+          ))}
+        </View>
+        <View className="mt-3">
+          <FoodImagePicker
+            items={items}
+            onItemsChange={handleChange}
+            label=""
+            helpText="Add a photo to set one for this entry."
+            disabled={isPending}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <FoodImagePicker
+      items={items}
+      onItemsChange={handleChange}
+      label="Photo"
+      helpText={hasOverride ? 'This photo applies to this entry only.' : undefined}
+      disabled={isPending}
+    />
+  );
+};
+
+export default EntryImageOverride;

--- a/SparkyFitnessMobile/src/components/EntryImageOverride.tsx
+++ b/SparkyFitnessMobile/src/components/EntryImageOverride.tsx
@@ -18,6 +18,12 @@ interface EntryImageOverrideProps {
   onSave: (items: PickerImage[]) => void;
   onClear: () => void;
   isPending?: boolean;
+  /**
+   * False for a non-owner viewing a shared entry: the photos still render, but
+   * every add/remove action is withheld. The server rejects the write with a
+   * 403 anyway, so offering the control would only produce a failed save.
+   */
+  canEdit?: boolean;
 }
 
 /**
@@ -34,6 +40,7 @@ const EntryImageOverride: React.FC<EntryImageOverrideProps> = ({
   onSave,
   onClear,
   isPending = false,
+  canEdit = true,
 }) => {
   const getImageSource = useFoodImageSourceContext();
   const [items, setItems] = useState<PickerImage[]>(() => toSavedImages(images));
@@ -60,6 +67,28 @@ const EntryImageOverride: React.FC<EntryImageOverrideProps> = ({
     }
     onSave(next);
   };
+
+  if (!canEdit) {
+    const shown = hasOverride ? usableFoodImages(images) : inherited;
+    if (shown.length === 0) return null;
+    return (
+      <View>
+        <Text className="text-text-secondary text-sm font-medium mb-2">
+          Photo
+        </Text>
+        <View className="flex-row gap-2">
+          {shown.slice(0, 4).map((image) => (
+            <FoodThumbnail
+              key={image}
+              image={image}
+              getImageSource={getImageSource}
+              size={56}
+            />
+          ))}
+        </View>
+      </View>
+    );
+  }
 
   if (!hasOverride && inherited.length > 0) {
     return (

--- a/SparkyFitnessMobile/src/components/FoodImagePicker.tsx
+++ b/SparkyFitnessMobile/src/components/FoodImagePicker.tsx
@@ -1,0 +1,199 @@
+import React, { useRef, useState } from 'react';
+import { View, Text, ScrollView, Pressable, Alert } from 'react-native';
+import { useCSSVariable } from 'uniwind';
+import Toast from 'react-native-toast-message';
+import SafeImage from './SafeImage';
+import Icon from './Icon';
+import { useFoodImageSourceContext } from './FoodImageSourceProvider';
+import { pickImageFromCamera, pickImagesFromLibrary } from '../utils/pickImage';
+import {
+  MAX_IMAGES,
+  toNewImage,
+  setAsMain,
+  removeImageAt,
+  pickerImageKey,
+  type PickerImage,
+} from '../utils/pickerImages';
+import { addLog } from '../services/LogService';
+
+const TILE = 72;
+
+interface FoodImagePickerProps {
+  items: PickerImage[];
+  onItemsChange: (items: PickerImage[]) => void;
+  label?: string;
+  /** Copy shown under the tiles; callers explain per-entry override semantics. */
+  helpText?: string;
+  maxImages?: number;
+  disabled?: boolean;
+}
+
+/**
+ * Multi-image picker for foods, meals, and diary entries.
+ *
+ * Ordering is expressed by "Set as main" rather than drag-to-reorder: index 0
+ * is the thumbnail, and promoting an image is the only reordering that changes
+ * anything a user can see. Dragging tiles inside a scrolling form is
+ * substantially more machinery for the same outcome.
+ */
+const FoodImagePicker: React.FC<FoodImagePickerProps> = ({
+  items,
+  onItemsChange,
+  label = 'Photos',
+  helpText,
+  maxImages = MAX_IMAGES,
+  disabled = false,
+}) => {
+  const getImageSource = useFoodImageSourceContext();
+  const [textMuted, borderSubtle] = useCSSVariable([
+    '--color-text-muted',
+    '--color-border-subtle',
+  ]) as [string, string];
+
+  // Guards against a double-tap opening two system pickers, which on Android
+  // leaves the second one orphaned. Mirrors FoodPhotoImproveScreen.
+  const pickerLock = useRef(false);
+  const [busy, setBusy] = useState(false);
+
+  const remaining = Math.max(0, maxImages - items.length);
+  const canAdd = !disabled && remaining > 0;
+
+  const runPick = async (pick: () => Promise<{ uri: string }[]>) => {
+    if (pickerLock.current) return;
+    pickerLock.current = true;
+    setBusy(true);
+    try {
+      const picked = await pick();
+      if (picked.length === 0) return;
+      onItemsChange([
+        ...items,
+        ...picked.slice(0, remaining).map((image) => toNewImage(image.uri)),
+      ]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      addLog(`[Food Image Picker] Picking failed: ${message}`, 'ERROR');
+      Toast.show({ type: 'error', text1: 'Could not add photo' });
+    } finally {
+      pickerLock.current = false;
+      setBusy(false);
+    }
+  };
+
+  const addFromCamera = () =>
+    runPick(async () => {
+      const result = await pickImageFromCamera();
+      if (result.status === 'denied') {
+        // A denial is a dead end until the user changes Settings, so say so
+        // rather than letting the tap look like it did nothing.
+        Toast.show({
+          type: 'error',
+          text1: 'Camera permission needed',
+          text2: 'Enable camera access to add a photo.',
+        });
+        return [];
+      }
+      return result.status === 'ok' ? [result.image] : [];
+    });
+
+  const addFromLibrary = () => runPick(() => pickImagesFromLibrary(remaining));
+
+  const promptAdd = () => {
+    Alert.alert('Add photo', undefined, [
+      { text: 'Take Photo', onPress: () => void addFromCamera() },
+      { text: 'Choose from Library', onPress: () => void addFromLibrary() },
+      { text: 'Cancel', style: 'cancel' },
+    ]);
+  };
+
+  const promptTileActions = (index: number) => {
+    if (disabled) return;
+    const buttons: {
+      text: string;
+      style?: 'cancel' | 'destructive';
+      onPress?: () => void;
+    }[] = [];
+    if (index > 0) {
+      buttons.push({
+        text: 'Set as main',
+        onPress: () => onItemsChange(setAsMain(items, index)),
+      });
+    }
+    buttons.push({
+      text: 'Remove',
+      style: 'destructive',
+      onPress: () => onItemsChange(removeImageAt(items, index)),
+    });
+    buttons.push({ text: 'Cancel', style: 'cancel' });
+    Alert.alert('Photo', undefined, buttons);
+  };
+
+  return (
+    <View>
+      <Text className="text-text-secondary text-sm font-medium mb-2">
+        {label}
+      </Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ gap: 8 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        {items.map((item, index) => (
+          <Pressable
+            key={pickerImageKey(item)}
+            onPress={() => promptTileActions(index)}
+            disabled={disabled}
+            testID={`food-image-tile-${index}`}
+            accessibilityLabel={
+              index === 0 ? 'Main photo, edit' : `Photo ${index + 1}, edit`
+            }
+            style={({ pressed }) => (pressed ? { opacity: 0.7 } : null)}
+          >
+            <SafeImage
+              source={
+                item.kind === 'saved'
+                  ? getImageSource(item.path)
+                  : { uri: item.uri, headers: {} }
+              }
+              style={{ width: TILE, height: TILE, borderRadius: 8 }}
+              contentFit="cover"
+            />
+            {index === 0 && items.length > 1 ? (
+              <View className="absolute bottom-0 left-0 right-0 bg-black/60 rounded-b-lg py-0.5">
+                <Text className="text-white text-[10px] text-center font-medium">
+                  Main
+                </Text>
+              </View>
+            ) : null}
+          </Pressable>
+        ))}
+
+        {canAdd ? (
+          <Pressable
+            onPress={promptAdd}
+            disabled={busy}
+            testID="food-image-add"
+            accessibilityLabel="Add photo"
+            className="items-center justify-center bg-raised"
+            style={{
+              width: TILE,
+              height: TILE,
+              borderRadius: 8,
+              borderWidth: 1,
+              borderStyle: 'dashed',
+              borderColor: borderSubtle,
+              opacity: busy ? 0.5 : 1,
+            }}
+          >
+            <Icon name="add" size={24} color={textMuted} />
+          </Pressable>
+        ) : null}
+      </ScrollView>
+      {helpText ? (
+        <Text className="text-text-muted text-xs mt-2">{helpText}</Text>
+      ) : null}
+    </View>
+  );
+};
+
+export default FoodImagePicker;

--- a/SparkyFitnessMobile/src/components/FoodImagePicker.tsx
+++ b/SparkyFitnessMobile/src/components/FoodImagePicker.tsx
@@ -55,6 +55,12 @@ const FoodImagePicker: React.FC<FoodImagePickerProps> = ({
   const pickerLock = useRef(false);
   const [busy, setBusy] = useState(false);
 
+  // The system picker stays open for seconds, so `items` captured by the
+  // handler can be stale by the time it returns — a parent that seeds saved
+  // images meanwhile would be overwritten. Append against the latest list.
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+
   const remaining = Math.max(0, maxImages - items.length);
   const canAdd = !disabled && remaining > 0;
 
@@ -65,9 +71,12 @@ const FoodImagePicker: React.FC<FoodImagePickerProps> = ({
     try {
       const picked = await pick();
       if (picked.length === 0) return;
+      const current = itemsRef.current;
       onItemsChange([
-        ...items,
-        ...picked.slice(0, remaining).map((image) => toNewImage(image.uri)),
+        ...current,
+        ...picked
+          .slice(0, Math.max(0, maxImages - current.length))
+          .map((image) => toNewImage(image.uri)),
       ]);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/SparkyFitnessMobile/src/components/FoodImageSourceProvider.tsx
+++ b/SparkyFitnessMobile/src/components/FoodImageSourceProvider.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import {
+  useFoodImageSource,
+  type GetFoodImageSource,
+} from '../hooks/useFoodImageSource';
+
+const FoodImageSourceContext = createContext<GetFoodImageSource | null>(null);
+
+// Rows reach the resolver through context rather than props: food rows are
+// rendered via a union dispatcher (FoodSearchResultRow) several layers below
+// the screen, and threading a prop through every branch would touch far more
+// code than it earns. Mounted once in App.tsx — the resolver only needs the
+// active server's origin and proxy headers, so one instance (and one path
+// cache) serves every screen.
+export const FoodImageSourceProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const { getImageSource } = useFoodImageSource();
+
+  const value = useMemo(() => getImageSource, [getImageSource]);
+
+  return (
+    <FoodImageSourceContext.Provider value={value}>
+      {children}
+    </FoodImageSourceContext.Provider>
+  );
+};
+
+// A row outside a provider degrades to "no image" (the thumbnail renders its
+// fallback) rather than crashing — a missing provider should never take a
+// screen down over a decoration.
+const NO_IMAGE_SOURCE: GetFoodImageSource = () => null;
+
+export function useFoodImageSourceContext(): GetFoodImageSource {
+  return useContext(FoodImageSourceContext) ?? NO_IMAGE_SOURCE;
+}

--- a/SparkyFitnessMobile/src/components/FoodLibraryRow.tsx
+++ b/SparkyFitnessMobile/src/components/FoodLibraryRow.tsx
@@ -8,6 +8,10 @@ import { deriveShareStatus } from '../utils/shareStatus';
 import ShareStatusBadge from './ShareStatusBadge';
 import Icon from './Icon';
 import VerifiedBadge from './VerifiedBadge';
+import FoodThumbnail from './FoodThumbnail';
+import { useFoodImageSourceContext } from './FoodImageSourceProvider';
+import { primaryImageOf, usableFoodImages } from '../utils/foodImages';
+import { useOpenLightbox } from './LightboxProvider';
 
 interface FoodLibraryRowProps {
   food: FoodItem;
@@ -28,13 +32,33 @@ const FoodLibraryRow: React.FC<FoodLibraryRowProps> = ({
   const status = deriveShareStatus(food.user_id, food.shared_with_public, profile?.id);
   // Gold, not accent: a passive indicator, not a tap target. See MealLibraryRow.
   const [goldColor] = useCSSVariable(['--color-cat-amber']) as [string];
+  const getImageSource = useFoodImageSourceContext();
+  const images = usableFoodImages(food.images);
+  const openLightbox = useOpenLightbox();
+  const openImages =
+    images.length > 0 ? () => openLightbox(images, 0, food.name) : undefined;
+
+  // The thumbnail is a SIBLING of the row's pressable, never nested inside it:
+  // a Pressable within a Pressable leaves both live, so a tap on the photo can
+  // open the detail screen instead of the viewer. Mirrors the exercise rows.
   return (
-    <Pressable
-      onPress={onPress}
-      disabled={!onPress}
-      className={`px-4 py-3 ${showDivider ? 'border-b border-border-subtle' : ''}`}
-      style={({ pressed }) => (pressed && onPress ? { opacity: 0.7 } : null)}
+    <View
+      className={`flex-row items-center ${showDivider ? 'border-b border-border-subtle' : ''}`}
     >
+      <View className="pl-4 py-3">
+        <FoodThumbnail
+          image={primaryImageOf(food)}
+          getImageSource={getImageSource}
+          size={40}
+          onPress={openImages}
+        />
+      </View>
+      <Pressable
+        onPress={onPress}
+        disabled={!onPress}
+        className="flex-1 pr-4 py-3"
+        style={({ pressed }) => (pressed && onPress ? { opacity: 0.7 } : null)}
+      >
       <View className="flex-row justify-between items-center">
         <View className="flex-1 mr-3">
           <View className="flex-row items-center gap-1.5">
@@ -72,7 +96,8 @@ const FoodLibraryRow: React.FC<FoodLibraryRowProps> = ({
           </Text>
         </View>
       </View>
-    </Pressable>
+      </Pressable>
+    </View>
   );
 };
 

--- a/SparkyFitnessMobile/src/components/FoodThumbnail.tsx
+++ b/SparkyFitnessMobile/src/components/FoodThumbnail.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { View, Pressable, type StyleProp, type ViewStyle } from 'react-native';
+import { useCSSVariable } from 'uniwind';
+import SafeImage from './SafeImage';
+import Icon from './Icon';
+import type { GetFoodImageSource } from '../hooks/useFoodImageSource';
+
+interface FoodThumbnailProps {
+  /** Stored image path, or null when the entity has no picture. */
+  image: string | null;
+  /** From `useFoodImageSource()`; hoisted so one cache serves a whole list. */
+  getImageSource: GetFoodImageSource;
+  size?: number;
+  /** Which placeholder glyph to show when there is no image. */
+  variant?: 'food' | 'meal';
+  /**
+   * When false, an entity with no image renders nothing at all rather than a
+   * placeholder box. Dense rows (the diary) use this so a photo-free day keeps
+   * exactly the layout it had before images existed.
+   */
+  showFallback?: boolean;
+  /** Opens the lightbox. Omit to leave the thumbnail non-interactive. */
+  onPress?: () => void;
+  /**
+   * Applied to the outer container. Callers pass spacing here rather than
+   * wrapping the thumbnail, so a collapsed thumbnail leaves no stray margin.
+   */
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+/**
+ * The one food/meal image slot, shared by search, library, and diary rows so
+ * sizing and the empty state stay identical across them.
+ */
+const FoodThumbnail: React.FC<FoodThumbnailProps> = ({
+  image,
+  getImageSource,
+  size = 44,
+  variant = 'food',
+  showFallback = true,
+  onPress,
+  style,
+  testID = 'food-thumbnail',
+}) => {
+  const [textMuted] = useCSSVariable(['--color-text-muted']) as [string];
+
+  const source = image ? getImageSource(image) : null;
+
+  if (!source && !showFallback) {
+    return null;
+  }
+
+  const box = { width: size, height: size, borderRadius: 8 };
+
+  const Container = onPress ? Pressable : View;
+
+  return (
+    <Container
+      testID={testID}
+      style={style}
+      {...(onPress
+        ? {
+            onPress,
+            accessibilityRole: 'imagebutton' as const,
+            accessibilityLabel: 'View photo',
+            // Sibling pressable, never nested inside the row's own — nesting
+            // leaves the inner one live while the parent is disabled. Matches
+            // the exercise thumbnail pattern.
+            hitSlop: 4,
+          }
+        : {})}
+    >
+      <SafeImage
+        source={source}
+        style={box}
+        contentFit="cover"
+        fallback={
+          <View className="bg-raised items-center justify-center" style={box}>
+            <Icon
+              name={variant === 'meal' ? 'meal' : 'food'}
+              size={Math.round(size / 2)}
+              color={textMuted}
+            />
+          </View>
+        }
+      />
+    </Container>
+  );
+};
+
+export default FoodThumbnail;

--- a/SparkyFitnessMobile/src/components/ImageLightbox.tsx
+++ b/SparkyFitnessMobile/src/components/ImageLightbox.tsx
@@ -1,0 +1,175 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  Modal,
+  Pressable,
+  FlatList,
+  useWindowDimensions,
+  AppState,
+  type ViewToken,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import SafeImage from './SafeImage';
+import Icon from './Icon';
+import { useFoodImageSourceContext } from './FoodImageSourceProvider';
+
+const AUTOPLAY_INTERVAL_MS = 3000;
+
+export interface ImageLightboxProps {
+  visible: boolean;
+  images: string[];
+  initialIndex: number;
+  title?: string;
+  onClose: () => void;
+}
+
+/**
+ * Full-screen viewer for a food/meal/entry photo set.
+ *
+ * Multi-image sets auto-advance, matching web. Autoplay stops for good on the
+ * first manual swipe — a slideshow that resumes fights a user who is browsing —
+ * and pauses while the app is backgrounded, which is the React Native
+ * equivalent of the `visibilitychange` handling in the web lightbox.
+ */
+const ImageLightbox: React.FC<ImageLightboxProps> = ({
+  visible,
+  images,
+  initialIndex,
+  title,
+  onClose,
+}) => {
+  const { width, height } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  const getImageSource = useFoodImageSourceContext();
+  const listRef = useRef<FlatList<string>>(null);
+
+  const [index, setIndex] = useState(initialIndex);
+  const [autoplay, setAutoplay] = useState(true);
+
+  // Re-seed on every open, so it starts on the tapped image with autoplay
+  // running rather than wherever the previous session left off. Done during
+  // render (not in an effect) so the first painted frame is the right slide.
+  //
+  // The key has to track `visible` itself, not just the index: every caller
+  // opens at index 0, so keying on the index alone would fire once and never
+  // again — leaving autoplay permanently off after the first manual swipe.
+  const [wasVisible, setWasVisible] = useState(visible);
+  if (visible !== wasVisible) {
+    setWasVisible(visible);
+    if (visible) {
+      setIndex(initialIndex);
+      setAutoplay(true);
+    }
+  }
+
+  useEffect(() => {
+    if (!visible || !autoplay || images.length < 2) return;
+
+    let paused = AppState.currentState !== 'active';
+    const subscription = AppState.addEventListener('change', (state) => {
+      paused = state !== 'active';
+    });
+
+    const timer = setInterval(() => {
+      if (paused) return;
+      setIndex((current) => {
+        const next = (current + 1) % images.length;
+        listRef.current?.scrollToIndex({ index: next, animated: true });
+        return next;
+      });
+    }, AUTOPLAY_INTERVAL_MS);
+
+    return () => {
+      clearInterval(timer);
+      subscription.remove();
+    };
+  }, [visible, autoplay, images.length]);
+
+  // Stable identity via empty deps: FlatList rejects a changing
+  // onViewableItemsChanged, and reading a ref during render is disallowed.
+  const onViewableItemsChanged = useCallback(
+    ({ viewableItems }: { viewableItems: ViewToken[] }) => {
+      const first = viewableItems[0];
+      if (first?.index != null) setIndex(first.index);
+    },
+    [],
+  );
+
+  const stopAutoplay = useCallback(() => setAutoplay(false), []);
+
+  const getItemLayout = useCallback(
+    (_: unknown, i: number) => ({ length: width, offset: width * i, index: i }),
+    [width],
+  );
+
+  if (images.length === 0) return null;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent={false}
+      animationType="fade"
+      onRequestClose={onClose}
+      statusBarTranslucent
+    >
+      <View className="flex-1 bg-black">
+        <FlatList
+          ref={listRef}
+          data={images}
+          horizontal
+          pagingEnabled
+          showsHorizontalScrollIndicator={false}
+          initialScrollIndex={initialIndex}
+          getItemLayout={getItemLayout}
+          keyExtractor={(item, i) => `${i}:${item}`}
+          onScrollBeginDrag={stopAutoplay}
+          onViewableItemsChanged={onViewableItemsChanged}
+          viewabilityConfig={{ itemVisiblePercentThreshold: 60 }}
+          renderItem={({ item }) => (
+            <View style={{ width, height }} className="items-center justify-center">
+              <SafeImage
+                source={getImageSource(item)}
+                style={{ width, height: height * 0.8 }}
+                contentFit="contain"
+                autoplay
+              />
+            </View>
+          )}
+        />
+
+        <Pressable
+          onPress={onClose}
+          accessibilityLabel="Close"
+          testID="lightbox-close"
+          hitSlop={12}
+          className="absolute"
+          style={{ top: insets.top + 8, right: 16 }}
+        >
+          <View className="bg-black/60 rounded-full p-2">
+            <Icon name="close" size={22} color="#fff" />
+          </View>
+        </Pressable>
+
+        <View
+          className="absolute left-0 right-0 items-center"
+          style={{ top: insets.top + 12 }}
+          pointerEvents="none"
+        >
+          {title ? (
+            <Text className="text-white text-base font-medium" numberOfLines={1}>
+              {title}
+            </Text>
+          ) : null}
+          {images.length > 1 ? (
+            <Text className="text-white/70 text-xs mt-0.5">
+              {index + 1} / {images.length}
+            </Text>
+          ) : null}
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+export default ImageLightbox;

--- a/SparkyFitnessMobile/src/components/LightboxProvider.tsx
+++ b/SparkyFitnessMobile/src/components/LightboxProvider.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext } from 'react';
+import ImageLightbox from './ImageLightbox';
+import { useImageLightbox } from '../hooks/useImageLightbox';
+
+type OpenLightbox = (images: string[], index?: number, title?: string) => void;
+
+const LightboxContext = createContext<OpenLightbox | null>(null);
+
+/**
+ * One image viewer for the whole app.
+ *
+ * Mounted once in `App.tsx` rather than per screen: food thumbnails appear in
+ * search, both libraries, the diary, meal-type day views and detail screens,
+ * and wiring an `onImagePress` prop down to each of those (through a union
+ * dispatcher, in the search case) meant a surface was silently left
+ * non-interactive every time a new one appeared. A row now opens the viewer
+ * directly, so adding a thumbnail anywhere is enough to make it tappable.
+ */
+export const LightboxProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { lightboxProps, openLightbox } = useImageLightbox();
+
+  return (
+    <LightboxContext.Provider value={openLightbox}>
+      {children}
+      <ImageLightbox {...lightboxProps} />
+    </LightboxContext.Provider>
+  );
+};
+
+// A row rendered outside the provider simply has a non-interactive thumbnail
+// rather than crashing — a viewer is a nicety, not a reason to take a screen
+// down.
+const NOOP: OpenLightbox = () => {};
+
+export function useOpenLightbox(): OpenLightbox {
+  return useContext(LightboxContext) ?? NOOP;
+}

--- a/SparkyFitnessMobile/src/components/MealLibraryRow.tsx
+++ b/SparkyFitnessMobile/src/components/MealLibraryRow.tsx
@@ -7,6 +7,10 @@ import { useProfile } from '../hooks';
 import { deriveShareStatus } from '../utils/shareStatus';
 import ShareStatusBadge from './ShareStatusBadge';
 import Icon from './Icon';
+import FoodThumbnail from './FoodThumbnail';
+import { useFoodImageSourceContext } from './FoodImageSourceProvider';
+import { primaryImageOf, usableFoodImages } from '../utils/foodImages';
+import { useOpenLightbox } from './LightboxProvider';
 
 interface MealLibraryRowProps {
   meal: Meal;
@@ -39,14 +43,33 @@ const MealLibraryRow: React.FC<MealLibraryRowProps> = ({
   // leaving accent (blue) for tappable things. --color-cat-amber is the closest
   // token to web's yellow-500 and has a dark-mode value, unlike a raw hex.
   const [goldColor] = useCSSVariable(['--color-cat-amber']) as [string];
+  const getImageSource = useFoodImageSourceContext();
+  const images = usableFoodImages(meal.images);
 
+  const openLightbox = useOpenLightbox();
+  const openImages =
+    images.length > 0 ? () => openLightbox(images, 0, meal.name) : undefined;
+
+  // Sibling, not nested — see FoodLibraryRow for why.
   return (
-    <Pressable
-      onPress={onPress}
-      disabled={!onPress}
-      className={`px-4 py-3 ${showDivider ? 'border-b border-border-subtle' : ''}`}
-      style={({ pressed }) => (pressed && onPress ? { opacity: 0.7 } : null)}
+    <View
+      className={`flex-row items-center ${showDivider ? 'border-b border-border-subtle' : ''}`}
     >
+      <View className="pl-4 py-3">
+        <FoodThumbnail
+          image={primaryImageOf(meal)}
+          getImageSource={getImageSource}
+          size={40}
+          onPress={openImages}
+          variant="meal"
+        />
+      </View>
+      <Pressable
+        onPress={onPress}
+        disabled={!onPress}
+        className="flex-1 pr-4 py-3"
+        style={({ pressed }) => (pressed && onPress ? { opacity: 0.7 } : null)}
+      >
       <View className="flex-row justify-between items-center">
         <View className="flex-1 mr-3">
           <View className="flex-row items-center gap-1.5">
@@ -91,7 +114,8 @@ const MealLibraryRow: React.FC<MealLibraryRowProps> = ({
           </Text>
         </View>
       </View>
-    </Pressable>
+      </Pressable>
+    </View>
   );
 };
 

--- a/SparkyFitnessMobile/src/components/SwipeableExerciseRow.tsx
+++ b/SparkyFitnessMobile/src/components/SwipeableExerciseRow.tsx
@@ -106,11 +106,13 @@ const SwipeableExerciseRow: React.FC<SwipeableExerciseRowProps> = ({
       >
         <Pressable className="py-2.5 bg-surface" onPress={onPress} onLongPress={handleLongPress}>
           <View className="flex-row items-center">
-            <View className="mr-3 items-center justify-center" style={{ width: 36, height: 36 }}>
+            {/* Kept in step with the food row's thumbnail so the two diary
+                row types line up rather than differing by a few pixels. */}
+            <View className="mr-3 items-center justify-center" style={{ width: 56, height: 56 }}>
               <SafeImage
                 source={imageSource}
-                style={{ width: 36, height: 36, borderRadius: 8 }}
-                fallback={<Icon name={iconName} size={20} color={accentPrimary} />}
+                style={{ width: 56, height: 56, borderRadius: 8 }}
+                fallback={<Icon name={iconName} size={28} color={accentPrimary} />}
               />
             </View>
             <View className="flex-1">

--- a/SparkyFitnessMobile/src/components/SwipeableFoodRow.tsx
+++ b/SparkyFitnessMobile/src/components/SwipeableFoodRow.tsx
@@ -11,6 +11,10 @@ import { useDeleteFoodEntryMeal } from '../hooks/useDeleteFoodEntryMeal';
 import type { FoodEntry } from '../types/foodEntries';
 import type { EntryNutrition } from '../utils/mealNutrition';
 import { formatTimeLabel } from '../utils/entryTimeDisplay';
+import FoodThumbnail from './FoodThumbnail';
+import { useFoodImageSourceContext } from './FoodImageSourceProvider';
+import { diaryEntryImage, diaryEntryImages } from '../utils/foodImages';
+import { useOpenLightbox } from './LightboxProvider';
 
 interface SwipeableFoodRowProps {
   entry: FoodEntry;
@@ -27,6 +31,9 @@ const SwipeableFoodRow: React.FC<SwipeableFoodRowProps> = ({ entry, nutrition, o
   );
 
   const isMealComponent = !!entry.food_entry_meal_id;
+  const getImageSource = useFoodImageSourceContext();
+  const entryImage = diaryEntryImage(entry);
+  const openLightbox = useOpenLightbox();
 
   const onDeleteSuccess = () => {
     swipeableRef.current?.close();
@@ -95,6 +102,19 @@ const SwipeableFoodRow: React.FC<SwipeableFoodRowProps> = ({ entry, nutrition, o
         rightThreshold={40}
       >
         <View className="py-1.5 flex-row items-center bg-surface">
+          {/* Diary rows are deliberately dense, so this slot collapses to
+              nothing when an entry has no photo — a photo-free day keeps the
+              exact layout it had before images existed. */}
+          {entryImage ? (
+            <FoodThumbnail
+              image={entryImage}
+              getImageSource={getImageSource}
+              size={32}
+              showFallback={false}
+              style={{ marginRight: 8 }}
+              onPress={() => openLightbox(diaryEntryImages(entry), 0, name)}
+            />
+          ) : null}
           <TouchableOpacity
             className="flex-1 mr-2"
             activeOpacity={0.7}

--- a/SparkyFitnessMobile/src/components/SwipeableFoodRow.tsx
+++ b/SparkyFitnessMobile/src/components/SwipeableFoodRow.tsx
@@ -109,7 +109,7 @@ const SwipeableFoodRow: React.FC<SwipeableFoodRowProps> = ({ entry, nutrition, o
             <FoodThumbnail
               image={entryImage}
               getImageSource={getImageSource}
-              size={32}
+              size={56}
               showFallback={false}
               style={{ marginRight: 8 }}
               onPress={() => openLightbox(diaryEntryImages(entry), 0, name)}

--- a/SparkyFitnessMobile/src/components/foodSearch/FoodResultRow.tsx
+++ b/SparkyFitnessMobile/src/components/foodSearch/FoodResultRow.tsx
@@ -6,6 +6,10 @@ import VerifiedBadge from '../VerifiedBadge';
 import { deriveShareStatus } from '../../utils/shareStatus';
 import { formatServingUnit } from '../../utils/foodDetails';
 import { foodItemToFoodInfo } from '../../types/foodInfo';
+import FoodThumbnail from '../FoodThumbnail';
+import { useFoodImageSourceContext } from '../FoodImageSourceProvider';
+import { primaryImageOf, usableFoodImages } from '../../utils/foodImages';
+import { useOpenLightbox } from '../LightboxProvider';
 import type { FoodInfoItem } from '../../types/foodInfo';
 import type { FoodItem, TopFoodItem } from '../../types/foods';
 
@@ -25,6 +29,9 @@ const FoodResultRow: React.FC<FoodResultRowProps> = ({
   onSelect,
 }) => {
   const status = deriveShareStatus(item.user_id, item.shared_with_public, profileId);
+  const getImageSource = useFoodImageSourceContext();
+  const openLightbox = useOpenLightbox();
+  const images = usableFoodImages(item.images);
   return (
     <TouchableOpacity
       className="px-4 py-2 border-b border-border-subtle"
@@ -32,7 +39,17 @@ const FoodResultRow: React.FC<FoodResultRowProps> = ({
       onPress={() => onSelect(foodItemToFoodInfo(item))}
     >
       <View className="flex-row justify-between items-center">
-        <View className="flex-1 mr-3">
+        <FoodThumbnail
+          image={primaryImageOf(item)}
+          getImageSource={getImageSource}
+          size={40}
+          onPress={
+            images.length > 0
+              ? () => openLightbox(images, 0, item.name)
+              : undefined
+          }
+        />
+        <View className="flex-1 mx-3">
           <View className="flex-row items-start gap-1">
             <Text className="text-text-primary text-base font-medium flex-shrink">
               {item.name}

--- a/SparkyFitnessMobile/src/components/foodSearch/FoodResultRow.tsx
+++ b/SparkyFitnessMobile/src/components/foodSearch/FoodResultRow.tsx
@@ -32,13 +32,12 @@ const FoodResultRow: React.FC<FoodResultRowProps> = ({
   const getImageSource = useFoodImageSourceContext();
   const openLightbox = useOpenLightbox();
   const images = usableFoodImages(item.images);
+  // The thumbnail is a SIBLING of the row's pressable, never nested inside it —
+  // nesting leaves the inner one live while the parent is disabled. Matches
+  // FoodLibraryRow.
   return (
-    <TouchableOpacity
-      className="px-4 py-2 border-b border-border-subtle"
-      activeOpacity={0.7}
-      onPress={() => onSelect(foodItemToFoodInfo(item))}
-    >
-      <View className="flex-row justify-between items-center">
+    <View className="flex-row items-center border-b border-border-subtle">
+      <View className="pl-4 py-2">
         <FoodThumbnail
           image={primaryImageOf(item)}
           getImageSource={getImageSource}
@@ -49,6 +48,12 @@ const FoodResultRow: React.FC<FoodResultRowProps> = ({
               : undefined
           }
         />
+      </View>
+      <TouchableOpacity
+        className="flex-1 flex-row justify-between items-center pr-4 py-2"
+        activeOpacity={0.7}
+        onPress={() => onSelect(foodItemToFoodInfo(item))}
+      >
         <View className="flex-1 mx-3">
           <View className="flex-row items-start gap-1">
             <Text className="text-text-primary text-base font-medium flex-shrink">
@@ -78,8 +83,8 @@ const FoodResultRow: React.FC<FoodResultRowProps> = ({
             {`${item.default_variant.serving_size} ${formatServingUnit(item.default_variant.serving_unit)}`}
           </Text>
         </View>
-      </View>
-    </TouchableOpacity>
+      </TouchableOpacity>
+    </View>
   );
 };
 

--- a/SparkyFitnessMobile/src/components/foodSearch/FoodSearchResultRow.tsx
+++ b/SparkyFitnessMobile/src/components/foodSearch/FoodSearchResultRow.tsx
@@ -39,22 +39,25 @@ const OnlineResultRow: React.FC<OnlineResultRowProps> = ({
   const getImageSource = useFoodImageSourceContext();
   const openLightbox = useOpenLightbox();
   const image = externalFoodImage(item);
+  // Sibling thumbnail, not nested in the row's pressable — see FoodResultRow.
   return (
-  <TouchableOpacity
-    className="px-4 py-2 border-b border-border-subtle"
-    activeOpacity={0.7}
-    disabled={loadingFoodId !== null}
-    onPress={() => {
-      void onSelect(item, providerId);
-    }}
-  >
-    <View className="flex-row justify-between items-center">
+  <View className="flex-row items-center border-b border-border-subtle">
+    <View className="pl-4 py-2">
       <FoodThumbnail
         image={image}
         getImageSource={getImageSource}
         size={40}
         onPress={image ? () => openLightbox([image], 0, item.name) : undefined}
       />
+    </View>
+    <TouchableOpacity
+      className="flex-1 flex-row justify-between items-center pr-4 py-2"
+      activeOpacity={0.7}
+      disabled={loadingFoodId !== null}
+      onPress={() => {
+        void onSelect(item, providerId);
+      }}
+    >
       <View className="flex-1 mx-3">
         <View className="flex-row items-start gap-1">
           <Text className="text-text-primary text-base font-medium flex-shrink">
@@ -107,8 +110,8 @@ const OnlineResultRow: React.FC<OnlineResultRowProps> = ({
           </>
         )}
       </View>
-    </View>
-  </TouchableOpacity>
+    </TouchableOpacity>
+  </View>
   );
 };
 

--- a/SparkyFitnessMobile/src/components/foodSearch/FoodSearchResultRow.tsx
+++ b/SparkyFitnessMobile/src/components/foodSearch/FoodSearchResultRow.tsx
@@ -4,6 +4,10 @@ import Button from '../ui/Button';
 import MealLibraryRow from '../MealLibraryRow';
 import VerifiedBadge from '../VerifiedBadge';
 import FoodResultRow from './FoodResultRow';
+import FoodThumbnail from '../FoodThumbnail';
+import { useFoodImageSourceContext } from '../FoodImageSourceProvider';
+import { externalFoodImage } from '../../utils/foodImages';
+import { useOpenLightbox } from '../LightboxProvider';
 import { landingKey } from '../../utils/landingLists';
 import { formatServingDescription, formatServingUnit } from '../../utils/foodDetails';
 import { OWNERSHIP_FILTER_LABELS, type OwnershipFilter } from '../../utils/shareStatus';
@@ -31,7 +35,11 @@ const OnlineResultRow: React.FC<OnlineResultRowProps> = ({
   loadingFoodId,
   getProviderColor,
   onSelect,
-}) => (
+}) => {
+  const getImageSource = useFoodImageSourceContext();
+  const openLightbox = useOpenLightbox();
+  const image = externalFoodImage(item);
+  return (
   <TouchableOpacity
     className="px-4 py-2 border-b border-border-subtle"
     activeOpacity={0.7}
@@ -41,7 +49,13 @@ const OnlineResultRow: React.FC<OnlineResultRowProps> = ({
     }}
   >
     <View className="flex-row justify-between items-center">
-      <View className="flex-1 mr-3">
+      <FoodThumbnail
+        image={image}
+        getImageSource={getImageSource}
+        size={40}
+        onPress={image ? () => openLightbox([image], 0, item.name) : undefined}
+      />
+      <View className="flex-1 mx-3">
         <View className="flex-row items-start gap-1">
           <Text className="text-text-primary text-base font-medium flex-shrink">
             {item.name}
@@ -95,7 +109,8 @@ const OnlineResultRow: React.FC<OnlineResultRowProps> = ({
       </View>
     </View>
   </TouchableOpacity>
-);
+  );
+};
 
 interface ShowAllProviderRowProps {
   provider: ExternalProvider;

--- a/SparkyFitnessMobile/src/hooks/index.ts
+++ b/SparkyFitnessMobile/src/hooks/index.ts
@@ -159,3 +159,10 @@ export {
   useDeleteMedicationEntry,
 } from './useMedications';
 
+
+export {
+  useSetFoodEntryImages,
+  useClearFoodEntryImage,
+  useSetFoodEntryMealImages,
+  useClearFoodEntryMealImage,
+} from './useEntryImages';

--- a/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
+++ b/SparkyFitnessMobile/src/hooks/useAddFoodEntry.ts
@@ -8,6 +8,7 @@ import {
   type SaveFoodPayload,
 } from '../services/api/foodsApi';
 import { createFoodEntry, type CreateFoodEntryPayload } from '../services/api/foodEntriesApi';
+import type { ImageUploadArgs } from '../utils/pickerImages';
 import { dailySummaryQueryKey, foodsQueryKey } from './queryKeys';
 import { invalidateMealUsageCaches } from './useMeals';
 import type { FoodEntry } from '../types/foodEntries';
@@ -22,6 +23,11 @@ import { persistExternalVariants } from '../utils/persistExternalVariants';
 
 export interface AddFoodEntryInput {
   saveFoodPayload?: SaveFoodPayload;
+  /**
+   * Photos to upload with the food being created. Without this, a food created
+   * from the diary saves with no picture even though the user attached one.
+   */
+  saveFoodImages?: ImageUploadArgs;
   saveThenCreateVariantPayload?: Omit<CreateFoodVariantPayload, 'food_id'>;
   /**
    * All external provider variants for the food being added.
@@ -111,7 +117,7 @@ export function useAddFoodEntry(options?: UseAddFoodEntryOptions) {
   const mutation = useMutation({
     mutationFn: async (input: AddFoodEntryInput) => {
       if (input.saveFoodPayload) {
-        const saved = await saveFood(input.saveFoodPayload);
+        const saved = await saveFood(input.saveFoodPayload, input.saveFoodImages);
 
         let variantId = saved.default_variant?.id;
         let unit = input.createEntryPayload.unit;

--- a/SparkyFitnessMobile/src/hooks/useEntryImages.ts
+++ b/SparkyFitnessMobile/src/hooks/useEntryImages.ts
@@ -1,0 +1,135 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import Toast from 'react-native-toast-message';
+import {
+  setFoodEntryImages,
+  clearFoodEntryImage,
+  setFoodEntryMealImages,
+  clearFoodEntryMealImage,
+} from '../services/api/entryImagesApi';
+import { dailySummaryQueryKey, foodEntryMealDetailQueryKey } from './queryKeys';
+import { splitPickerImages, type PickerImage } from '../utils/pickerImages';
+
+/**
+ * Diary per-entry photo mutations.
+ *
+ * The default staleTime is Infinity, so each of these invalidates the day it
+ * changed — the diary will not refetch on its own.
+ */
+
+type EntryImageOptions<TResult> = {
+  entryDate: string;
+  /** Extra keys to invalidate beyond the day summary. */
+  extraKeys?: readonly (readonly unknown[])[];
+  onSuccess?: (result: TResult) => void;
+  errorText: string;
+};
+
+/**
+ * One mutation shape for all four endpoints: set and clear differ only in what
+ * they call and what they take, so the invalidation and error handling live
+ * here once.
+ */
+function useEntryImageMutation<TVariables, TResult>(
+  mutationFn: (variables: TVariables) => Promise<TResult>,
+  options: EntryImageOptions<TResult>,
+) {
+  const queryClient = useQueryClient();
+  const { entryDate, extraKeys, onSuccess, errorText } = options;
+
+  return useMutation({
+    mutationFn,
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({
+        queryKey: dailySummaryQueryKey(entryDate),
+      });
+      for (const queryKey of extraKeys ?? []) {
+        queryClient.invalidateQueries({ queryKey });
+      }
+      onSuccess?.(result);
+    },
+    onError: () => {
+      Toast.show({ type: 'error', text1: errorText, text2: 'Please try again.' });
+    },
+  });
+}
+
+export function useSetFoodEntryImages(
+  entryId: string,
+  entryDate: string,
+  options?: { onSuccess?: (result: Awaited<ReturnType<typeof setFoodEntryImages>>) => void },
+) {
+  const mutation = useEntryImageMutation(
+    (items: PickerImage[]) => {
+      const { order, newUris } = splitPickerImages(items);
+      return setFoodEntryImages(entryId, order, newUris);
+    },
+    {
+      entryDate,
+      onSuccess: options?.onSuccess,
+      errorText: 'Failed to save photo',
+    },
+  );
+
+  return {
+    setImages: mutation.mutate,
+    setImagesAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+  };
+}
+
+export function useClearFoodEntryImage(
+  entryId: string,
+  entryDate: string,
+  options?: { onSuccess?: () => void },
+) {
+  const mutation = useEntryImageMutation<void, void>(() => clearFoodEntryImage(entryId), {
+    entryDate,
+    onSuccess: options?.onSuccess,
+    errorText: 'Failed to remove photo',
+  });
+
+  return { clearImage: () => mutation.mutate(), isPending: mutation.isPending };
+}
+
+export function useSetFoodEntryMealImages(
+  entryId: string,
+  entryDate: string,
+  options?: { onSuccess?: () => void },
+) {
+  const mutation = useEntryImageMutation(
+    (items: PickerImage[]) => {
+      const { order, newUris } = splitPickerImages(items);
+      return setFoodEntryMealImages(entryId, order, newUris);
+    },
+    {
+      entryDate,
+      extraKeys: [foodEntryMealDetailQueryKey(entryId)],
+      onSuccess: options?.onSuccess,
+      errorText: 'Failed to save photo',
+    },
+  );
+
+  return {
+    setImages: mutation.mutate,
+    setImagesAsync: mutation.mutateAsync,
+    isPending: mutation.isPending,
+  };
+}
+
+export function useClearFoodEntryMealImage(
+  entryId: string,
+  entryDate: string,
+  options?: { onSuccess?: () => void },
+) {
+  const mutation = useEntryImageMutation<void, void>(
+    () => clearFoodEntryMealImage(entryId),
+    {
+      entryDate,
+      extraKeys: [foodEntryMealDetailQueryKey(entryId)],
+      onSuccess: options?.onSuccess,
+      errorText: 'Failed to remove photo',
+    },
+  );
+
+  return { clearImage: () => mutation.mutate(), isPending: mutation.isPending };
+}

--- a/SparkyFitnessMobile/src/hooks/useFoodImageSource.ts
+++ b/SparkyFitnessMobile/src/hooks/useFoodImageSource.ts
@@ -2,6 +2,7 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 import { AppState } from 'react-native';
 import { getActiveServerConfig, proxyHeadersToRecord } from '../services/storage';
 import { normalizeUrl } from '../services/api/apiClient';
+import { addLog } from '../services/LogService';
 import type { ServerConfig } from '../services/storage';
 
 type ImageSource = { uri: string; headers: Record<string, string> };
@@ -32,9 +33,18 @@ export function useFoodImageSource() {
   useEffect(() => {
     let cancelled = false;
     const load = () => {
-      getActiveServerConfig().then((next) => {
-        if (!cancelled) setConfig(next);
-      });
+      // getActiveServerConfig rethrows storage failures. This hook backs an
+      // app-root provider, so an uncaught rejection here has nowhere to land —
+      // keep the last good config and log instead.
+      getActiveServerConfig()
+        .then((next) => {
+          if (!cancelled) setConfig(next);
+        })
+        .catch((error) => {
+          addLog('[Food Images] Failed to read active server config', 'ERROR', [
+            String(error),
+          ]);
+        });
     };
 
     load();
@@ -54,19 +64,27 @@ export function useFoodImageSource() {
   // builds a fresh { uri, headers } literal, which makes <Image>/<SafeImage>
   // treat it as a new source and reload — every food thumbnail in a list
   // flashes whenever the list re-renders.
-  const cacheRef = useRef<Map<string, ImageSource>>(new Map());
-
-  // Base URL / proxy headers change with the active server, so drop the cache
-  // when config changes.
-  useEffect(() => {
-    cacheRef.current.clear();
-  }, [config]);
+  //
+  // The map is tagged with the config it was built for and rebuilt on the first
+  // lookup after a server switch, rather than cleared from an effect. An effect
+  // only runs after descendants have already rendered against the new config,
+  // so they would read the previous server's URIs and proxy headers out of the
+  // stale map — and clearing it later triggers no re-render to correct them.
+  const cacheRef = useRef<{
+    config: ServerConfig | null;
+    map: Map<string, ImageSource>;
+  }>({ config, map: new Map() });
 
   const getImageSource = useCallback<GetFoodImageSource>(
     (imagePath: string) => {
       if (!imagePath) return null;
 
-      const cached = cacheRef.current.get(imagePath);
+      if (cacheRef.current.config !== config) {
+        cacheRef.current = { config, map: new Map() };
+      }
+      const sourceCache = cacheRef.current.map;
+
+      const cached = sourceCache.get(imagePath);
       if (cached) return cached;
 
       let source: ImageSource;
@@ -92,7 +110,7 @@ export function useFoodImageSource() {
         };
       }
 
-      cacheRef.current.set(imagePath, source);
+      sourceCache.set(imagePath, source);
       return source;
     },
     [config],

--- a/SparkyFitnessMobile/src/hooks/useFoodImageSource.ts
+++ b/SparkyFitnessMobile/src/hooks/useFoodImageSource.ts
@@ -1,0 +1,102 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
+import { getActiveServerConfig, proxyHeadersToRecord } from '../services/storage';
+import { normalizeUrl } from '../services/api/apiClient';
+import type { ServerConfig } from '../services/storage';
+
+type ImageSource = { uri: string; headers: Record<string, string> };
+
+export type GetFoodImageSource = (imagePath: string) => ImageSource | null;
+
+/**
+ * Resolves stored food/meal image paths to loadable `<Image>` sources.
+ *
+ * Mirrors `useExerciseImageSource`, with one difference: exercises store bare
+ * filenames and the hook supplies the whole directory, whereas food images are
+ * stored already server-relative (`/uploads/foods/<id>/...`) and only need the
+ * server origin. Bare filenames are still handled for legacy rows, matching
+ * web's `resolveFoodImageSrc`.
+ *
+ * No Authorization header is sent — `/uploads` is served statically and the web
+ * app loads the same paths with a plain `<img>`. Proxy headers are still needed
+ * so reverse-proxy-authenticated servers let the request through.
+ */
+export function useFoodImageSource() {
+  const [config, setConfig] = useState<ServerConfig | null>(null);
+
+  // Deliberately not useFocusEffect (which the exercise equivalent uses): it
+  // requires a navigation context, and this hook backs an app-root provider
+  // that sits above the navigator. Re-reading on mount and on foreground
+  // return covers the moments the active server can have changed underneath
+  // us, without coupling an image URL to the navigation tree.
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      getActiveServerConfig().then((next) => {
+        if (!cancelled) setConfig(next);
+      });
+    };
+
+    load();
+
+    const subscription = AppState.addEventListener('change', (state) => {
+      if (state === 'active') load();
+    });
+
+    return () => {
+      cancelled = true;
+      subscription.remove();
+    };
+  }, []);
+
+  // Cache resolved sources by image path so the same path yields a
+  // referentially-stable object across renders. Without this, each render
+  // builds a fresh { uri, headers } literal, which makes <Image>/<SafeImage>
+  // treat it as a new source and reload — every food thumbnail in a list
+  // flashes whenever the list re-renders.
+  const cacheRef = useRef<Map<string, ImageSource>>(new Map());
+
+  // Base URL / proxy headers change with the active server, so drop the cache
+  // when config changes.
+  useEffect(() => {
+    cacheRef.current.clear();
+  }, [config]);
+
+  const getImageSource = useCallback<GetFoodImageSource>(
+    (imagePath: string) => {
+      if (!imagePath) return null;
+
+      const cached = cacheRef.current.get(imagePath);
+      if (cached) return cached;
+
+      let source: ImageSource;
+      // Absolute URLs (provider images that never localized) — use directly.
+      if (
+        imagePath.startsWith('http://') ||
+        imagePath.startsWith('https://')
+      ) {
+        source = { uri: imagePath, headers: {} };
+      } else if (!config) {
+        // Don't cache until config resolves, so the path resolves once ready.
+        return null;
+      } else {
+        const base = normalizeUrl(config.url);
+        // The server mounts uploads at both /uploads and /api/uploads; use the
+        // /api prefix so a single reverse-proxy rule covers every request.
+        const uri = imagePath.startsWith('/uploads/')
+          ? `${base}/api${imagePath}`
+          : `${base}/api/uploads/foods/${imagePath}`;
+        source = {
+          uri,
+          headers: proxyHeadersToRecord(config.proxyHeaders),
+        };
+      }
+
+      cacheRef.current.set(imagePath, source);
+      return source;
+    },
+    [config],
+  );
+
+  return { getImageSource };
+}

--- a/SparkyFitnessMobile/src/hooks/useImageLightbox.ts
+++ b/SparkyFitnessMobile/src/hooks/useImageLightbox.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from 'react';
+import type { ImageLightboxProps } from '../components/ImageLightbox';
+
+type LightboxState = {
+  visible: boolean;
+  images: string[];
+  initialIndex: number;
+  title?: string;
+};
+
+const CLOSED: LightboxState = { visible: false, images: [], initialIndex: 0 };
+
+/**
+ * One lightbox per list rather than one per row.
+ *
+ * Spread `lightboxProps` onto a single `<ImageLightbox />` at the screen level
+ * and call `openLightbox(images, index, title)` from each row. Mounting a modal
+ * per row would multiply an off-screen Modal by the length of the list.
+ */
+export function useImageLightbox(): {
+  lightboxProps: ImageLightboxProps;
+  openLightbox: (images: string[], index?: number, title?: string) => void;
+} {
+  const [state, setState] = useState<LightboxState>(CLOSED);
+
+  const openLightbox = useCallback(
+    (images: string[], index = 0, title?: string) => {
+      if (images.length === 0) return;
+      setState({
+        visible: true,
+        images,
+        initialIndex: Math.min(Math.max(index, 0), images.length - 1),
+        title,
+      });
+    },
+    [],
+  );
+
+  const onClose = useCallback(() => {
+    setState((current) => ({ ...current, visible: false }));
+  }, []);
+
+  return {
+    lightboxProps: { ...state, onClose },
+    openLightbox,
+  };
+}

--- a/SparkyFitnessMobile/src/hooks/useMeals.ts
+++ b/SparkyFitnessMobile/src/hooks/useMeals.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Alert } from 'react-native';
 import Toast from 'react-native-toast-message';
+import type { ImageUploadArgs } from '../utils/pickerImages';
 import {
   createMeal,
   deleteMeal,
@@ -130,11 +131,24 @@ export function useMeal(
   };
 }
 
+export type MealImages = ImageUploadArgs;
+
+type CreateMealVariables = {
+  payload: CreateMealPayload;
+  images?: MealImages;
+};
+
+type UpdateMealVariables = {
+  payload: UpdateMealPayload;
+  images?: MealImages;
+};
+
 export function useCreateMeal() {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: (payload: CreateMealPayload) => createMeal(payload),
+    mutationFn: ({ payload, images }: CreateMealVariables) =>
+      createMeal(payload, images),
     onSuccess: (meal) => {
       invalidateMealCaches(queryClient, meal.id);
     },
@@ -147,9 +161,13 @@ export function useCreateMeal() {
     },
   });
 
+  // Images stay an optional trailing argument so callers that never touch
+  // photos keep their existing single-argument call.
   return {
-    createMeal: mutation.mutate,
-    createMealAsync: mutation.mutateAsync,
+    createMeal: (payload: CreateMealPayload, images?: MealImages) =>
+      mutation.mutate({ payload, images }),
+    createMealAsync: (payload: CreateMealPayload, images?: MealImages) =>
+      mutation.mutateAsync({ payload, images }),
     isPending: mutation.isPending,
   };
 }
@@ -159,11 +177,11 @@ export function useUpdateMeal(options?: { mealId?: string; onSuccess?: (meal: Me
   const { mealId, onSuccess } = options ?? {};
 
   const mutation = useMutation({
-    mutationFn: (payload: UpdateMealPayload) => {
+    mutationFn: ({ payload, images }: UpdateMealVariables) => {
       if (!mealId) {
         throw new Error('Meal ID is required to update a meal.');
       }
-      return updateMeal(mealId, payload);
+      return updateMeal(mealId, payload, images);
     },
     onSuccess: (meal) => {
       invalidateMealCaches(queryClient, meal.id);
@@ -179,8 +197,10 @@ export function useUpdateMeal(options?: { mealId?: string; onSuccess?: (meal: Me
   });
 
   return {
-    updateMeal: mutation.mutate,
-    updateMealAsync: mutation.mutateAsync,
+    updateMeal: (payload: UpdateMealPayload, images?: MealImages) =>
+      mutation.mutate({ payload, images }),
+    updateMealAsync: (payload: UpdateMealPayload, images?: MealImages) =>
+      mutation.mutateAsync({ payload, images }),
     isPending: mutation.isPending,
   };
 }

--- a/SparkyFitnessMobile/src/hooks/useSaveFood.ts
+++ b/SparkyFitnessMobile/src/hooks/useSaveFood.ts
@@ -2,12 +2,21 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Toast from 'react-native-toast-message';
 import { saveFood, type SaveFoodPayload } from '../services/api/foodsApi';
 import { favoritesQueryKey, foodsQueryKey } from './queryKeys';
+import type { ImageUploadArgs } from '../utils/pickerImages';
+
+export type SaveFoodImages = ImageUploadArgs;
+
+type SaveFoodVariables = {
+  payload: SaveFoodPayload;
+  images?: SaveFoodImages;
+};
 
 export function useSaveFood() {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: (payload: SaveFoodPayload) => saveFood(payload),
+    mutationFn: ({ payload, images }: SaveFoodVariables) =>
+      saveFood(payload, images),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...foodsQueryKey] });
       // Keep an edited food's name/nutrition fresh in the Favorites section
@@ -19,9 +28,13 @@ export function useSaveFood() {
     },
   });
 
+  // Images stay an optional trailing argument so the many existing callers
+  // that never touch photos keep their `saveFoodAsync(payload)` call.
   return {
-    saveFood: mutation.mutate,
-    saveFoodAsync: mutation.mutateAsync,
+    saveFood: (payload: SaveFoodPayload, images?: SaveFoodImages) =>
+      mutation.mutate({ payload, images }),
+    saveFoodAsync: (payload: SaveFoodPayload, images?: SaveFoodImages) =>
+      mutation.mutateAsync({ payload, images }),
     isPending: mutation.isPending,
     isSaved: mutation.isSuccess,
   };

--- a/SparkyFitnessMobile/src/screens/DiaryScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DiaryScreen.tsx
@@ -398,11 +398,13 @@ const DiaryScreen: React.FC<DiaryScreenProps> = ({ navigation }) => {
   );
 
   return (
-    <GestureDetector gesture={swipeGesture}>
-      <View className="flex-1 bg-background">
-        {content}
-      </View>
-    </GestureDetector>
+    <>
+      <GestureDetector gesture={swipeGesture}>
+        <View className="flex-1 bg-background">
+          {content}
+        </View>
+      </GestureDetector>
+    </>
   );
 };
 

--- a/SparkyFitnessMobile/src/screens/EditLoggedMealScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/EditLoggedMealScreen.tsx
@@ -6,6 +6,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
 import Button from '../components/ui/Button';
 import FormInput from '../components/FormInput';
+import EntryImageOverride from '../components/EntryImageOverride';
 import Icon from '../components/Icon';
 import { useScreenHeader, SAVE_LABEL, SAVING_LABEL } from '../hooks/useScreenHeader';
 import StepperInput from '../components/StepperInput';
@@ -18,7 +19,12 @@ import NutritionMacroCard from '../components/NutritionMacroCard';
 import StatusView from '../components/StatusView';
 import SwipeableIngredientRow from '../components/SwipeableIngredientRow';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
-import { useMealTypes, usePreferences } from '../hooks';
+import {
+  useMealTypes,
+  usePreferences,
+  useSetFoodEntryMealImages,
+  useClearFoodEntryMealImage,
+} from '../hooks';
 import { useFoodEntryMealDetails } from '../hooks/useFoodEntryMealDetails';
 import { useUpdateFoodEntryMeal } from '../hooks/useUpdateFoodEntryMeal';
 import { useDeleteFoodEntryMeal } from '../hooks/useDeleteFoodEntryMeal';
@@ -81,6 +87,18 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
   const timeSheetRef = useRef<TimeSheetRef>(null);
 
   const { meal, isLoading, isError, error } = useFoodEntryMealDetails(foodEntryMealId, { initialMeal });
+
+  // Per-entry override photo for this logged meal. Never written back to the
+  // meal template, which is what an entry without an override falls back to.
+  const {
+    setImages: setMealEntryImages,
+    isPending: isSettingMealImage,
+  } = useSetFoodEntryMealImages(foodEntryMealId, meal?.entry_date ?? '');
+  const {
+    clearImage: clearMealEntryImage,
+    isPending: isClearingMealImage,
+  } = useClearFoodEntryMealImage(foodEntryMealId, meal?.entry_date ?? '');
+  const isMealImagePending = isSettingMealImage || isClearingMealImage;
   const { mealTypes } = useMealTypes();
   const { preferences } = usePreferences();
   const showNetCarbs = preferences?.show_net_carbs === true;
@@ -366,6 +384,14 @@ const EditLoggedMealScreen: React.FC<EditLoggedMealScreenProps> = ({ navigation,
             autoCapitalize="sentences"
           />
         </View>
+
+        <EntryImageOverride
+          images={meal?.images}
+          inheritedImages={meal?.meal_images}
+          onSave={setMealEntryImages}
+          onClear={clearMealEntryImage}
+          isPending={isMealImagePending}
+        />
 
         {/* Aggregate nutrition */}
         <NutritionMacroCard

--- a/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryAddScreen.tsx
@@ -780,9 +780,16 @@ const FoodEntryAddScreen: React.FC<FoodEntryAddScreenProps> = ({
         cholesterol: saveFoodSourceValues.cholesterol,
         vitamin_a: saveFoodSourceValues.vitaminA,
         vitamin_c: saveFoodSourceValues.vitaminC,
+        // Carry the provider photo through import. The server localizes remote
+        // URLs into /uploads after COMMIT; dropping these here is the exact
+        // hand-enumerated-payload trap called out in the food-provider-images
+        // developer doc.
+        images: activeItem.images ?? undefined,
+        image_url: activeItem.image_url ?? null,
+        image_source_url: activeItem.image_source_url ?? null,
       };
     },
-    [activeItem.barcode, activeItem.brand, activeItem.is_custom, activeItem.name, activeItem.provider_external_id, activeItem.provider_type, activeItem.provider_verified, adjustedValues, saveFoodSourceValues],
+    [activeItem.barcode, activeItem.brand, activeItem.is_custom, activeItem.name, activeItem.provider_external_id, activeItem.provider_type, activeItem.provider_verified, activeItem.images, activeItem.image_url, activeItem.image_source_url, adjustedValues, saveFoodSourceValues],
   );
 
   const {

--- a/SparkyFitnessMobile/src/screens/FoodEntryViewScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryViewScreen.tsx
@@ -19,6 +19,7 @@ import Icon from '../components/Icon';
 import StepperInput from '../components/StepperInput';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import BottomSheetPicker from '../components/BottomSheetPicker';
+import EntryImageOverride from '../components/EntryImageOverride';
 import CalendarSheet, { type CalendarSheetRef } from '../components/CalendarSheet';
 import TimeSheet, { type TimeSheetRef } from '../components/TimeSheet';
 import { toHourMinute } from '@workspace/shared';
@@ -28,7 +29,14 @@ import {
   getFoodEntryMealTypeLabel,
   getMealTypeDisplayLabel,
 } from '../utils/mealNutrition';
-import { useMealTypes, usePreferences, useServerConnection, useCustomNutrients } from '../hooks';
+import {
+  useMealTypes,
+  usePreferences,
+  useServerConnection,
+  useCustomNutrients,
+  useSetFoodEntryImages,
+  useClearFoodEntryImage,
+} from '../hooks';
 import { useFoodVariants } from '../hooks/useFoodVariants';
 import { useDeleteFoodEntry } from '../hooks/useDeleteFoodEntry';
 import { useUpdateFoodEntry } from '../hooks/useUpdateFoodEntry';
@@ -120,6 +128,25 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
   const [entry, setEntry] = useState(route.params.entry);
   const [createdVariantOverride, setCreatedVariantOverride] =
     useState<FoodUnitVariant | null>(null);
+
+  // Per-entry override photo. Writes land on the entry only — the parent food
+  // keeps its own images, which is what an entry without an override falls
+  // back to.
+  // Both paths sync the locally held entry so the control reflects what was
+  // saved without waiting for the diary query to round-trip. The clear path
+  // needs it as much as the save path: leaving a stale `images` behind would
+  // keep the override UI showing instead of falling back to the food's photos.
+  const { setImages: setEntryImages, isPending: isSettingEntryImage } =
+    useSetFoodEntryImages(entry.id, entry.entry_date, {
+      onSuccess: (updated) => {
+        if (updated) setEntry((current) => ({ ...current, ...updated }));
+      },
+    });
+  const { clearImage: clearEntryImage, isPending: isClearingEntryImage } =
+    useClearFoodEntryImage(entry.id, entry.entry_date, {
+      onSuccess: () => setEntry((current) => ({ ...current, images: [] })),
+    });
+  const isEntryImagePending = isSettingEntryImage || isClearingEntryImage;
   const insets = useSafeAreaInsets();
   const usesNativeHeader = useNativeIOSHeadersActive();
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
@@ -799,6 +826,15 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
               {(isEditing && adjustedValues?.brand) || entry.brand_name}
             </Text>
           )}
+          <View className="mt-4">
+            <EntryImageOverride
+              images={entry.images}
+              inheritedImages={entry.food_images}
+              onSave={setEntryImages}
+              onClear={clearEntryImage}
+              isPending={isEntryImagePending}
+            />
+          </View>
           {isEditing ? (
             <FadeView key="edit-serving">
               <View className="mt-3">

--- a/SparkyFitnessMobile/src/screens/FoodEntryViewScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodEntryViewScreen.tsx
@@ -833,6 +833,7 @@ const FoodEntryViewScreen: React.FC<FoodEntryViewScreenProps> = ({
               onSave={setEntryImages}
               onClear={clearEntryImage}
               isPending={isEntryImagePending}
+              canEdit={canEdit}
             />
           </View>
           {isEditing ? (

--- a/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
@@ -237,6 +237,12 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
           variantId: displayVariant.id,
           source: 'external',
           provider_verified: result.food.provider_verified,
+          // Same reason as the local branch above: FoodEntryAddScreen builds its
+          // create payload from these fields, so an external scan without them
+          // imports a food with no picture.
+          images: result.food.images ?? null,
+          image_url: result.food.image_url ?? null,
+          image_source_url: result.food.image_source_url ?? null,
           externalVariants: orderedVariants?.map((v) => ({
             serving_size: v.serving_size,
             serving_unit: v.serving_unit,

--- a/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodScanScreen.tsx
@@ -187,6 +187,12 @@ const FoodScanScreen: React.FC<FoodScanScreenProps> = ({ navigation, route }) =>
           variantId: defaultVariant.id,
           source: 'local',
           provider_verified: result.food.provider_verified,
+          // Carry the scanned product's photo through to the add screen, which
+          // passes it to the create payload. Omitting it here is why a scanned
+          // barcode would save a food with no picture.
+          images: result.food.images ?? null,
+          image_url: result.food.image_url ?? null,
+          image_source_url: result.food.image_source_url ?? null,
           originalItem: result.food,
         };
         navigation.replace('FoodEntryAdd', {

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -490,6 +490,7 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
           showFoodInfo(
             externalFoodItemToFoodInfo({
               ...detailed,
+              images: detailed.images?.length ? detailed.images : item.images,
               image_url: detailed.image_url ?? item.image_url,
               image_source_url:
                 detailed.image_source_url ?? item.image_source_url,

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -484,7 +484,17 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
               serving_description: item.serving_description,
             },
           );
-          showFoodInfo(externalFoodItemToFoodInfo(detailed));
+          // The details endpoint does not always echo the photo the search
+          // result carried, so re-attach it rather than losing the image the
+          // user just saw. Mirrors the web food search.
+          showFoodInfo(
+            externalFoodItemToFoodInfo({
+              ...detailed,
+              image_url: detailed.image_url ?? item.image_url,
+              image_source_url:
+                detailed.image_source_url ?? item.image_source_url,
+            }),
+          );
         } catch (error) {
           const message =
             getApiErrorMessage(error) ?? "Couldn't load full nutrition details.";
@@ -1053,19 +1063,19 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({ navigation, route }
   };
 
   return (
-    <View
-      className="flex-1 bg-background"
-      style={Platform.OS === 'android' ? { paddingTop: insets.top } : undefined}
-    >
-      {renderHeaderBar()}
-      {renderBody()}
-      <AnchoredMenu
-        visible={menuVisible}
-        anchor={menuAnchor}
-        onClose={() => setMenuVisible(false)}
-        items={menuItems}
-      />
-    </View>
+      <View
+        className="flex-1 bg-background"
+        style={Platform.OS === 'android' ? { paddingTop: insets.top } : undefined}
+      >
+        {renderHeaderBar()}
+        {renderBody()}
+        <AnchoredMenu
+          visible={menuVisible}
+          anchor={menuAnchor}
+          onClose={() => setMenuVisible(false)}
+          items={menuItems}
+        />
+      </View>
   );
 };
 

--- a/SparkyFitnessMobile/src/screens/FoodsLibraryScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodsLibraryScreen.tsx
@@ -166,18 +166,18 @@ const FoodsLibraryScreen: React.FC<FoodsLibraryScreenProps> = ({ navigation }) =
   });
 
   return (
-    <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
-      {header}
-      {isConnected ? (
-        <LibrarySearchBar
-          value={searchText}
-          onChangeText={setSearchText}
-          placeholder="Search foods..."
-          isSearching={isSearching}
-        />
-      ) : null}
-      {renderContent()}
-    </View>
+      <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
+        {header}
+        {isConnected ? (
+          <LibrarySearchBar
+            value={searchText}
+            onChangeText={setSearchText}
+            placeholder="Search foods..."
+            isSearching={isSearching}
+          />
+        ) : null}
+        {renderContent()}
+      </View>
   );
 };
 

--- a/SparkyFitnessMobile/src/screens/LibraryScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/LibraryScreen.tsx
@@ -191,7 +191,7 @@ const LibraryScreen: React.FC<LibraryScreenProps> = ({ navigation }) => {
   }
 
   return (
-    <ScrollView
+      <ScrollView
         className="flex-1 bg-background"
         style={[{ flex: 1 }, usesNativeTabs ? undefined : { paddingTop: insets.top }]}
         contentContainerStyle={{

--- a/SparkyFitnessMobile/src/screens/MealAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MealAddScreen.tsx
@@ -20,6 +20,13 @@ import StatusView from '../components/StatusView';
 import { FooterSaveBar } from '../components/FormScreenChrome';
 import Icon from '../components/Icon';
 import { useCreateMeal, useMeal, useUpdateMeal } from '../hooks';
+import FoodImagePicker from '../components/FoodImagePicker';
+import {
+  pickerImagesDiffer,
+  splitPickerImages,
+  toSavedImages,
+  type PickerImage,
+} from '../utils/pickerImages';
 import { consumePendingMealIngredientSelection } from '../services/mealBuilderSelection';
 import { mealIngredientDraftToFoodInfo } from '../types/foodInfo';
 import type { MealFoodPayload, MealIngredientDraft } from '../types/meals';
@@ -115,6 +122,7 @@ const MealAddScreen: React.FC<MealAddScreenProps> = ({ navigation, route }) => {
   // total_servings = totalAmount / servingSize on save.
   const [totalAmountText, setTotalAmountText] = useState('1');
   const [ingredients, setIngredients] = useState<MealIngredientDraft[]>([]);
+  const [pickerImages, setPickerImages] = useState<PickerImage[]>([]);
   const [initializedMealId, setInitializedMealId] = useState<string | null>(null);
 
   const { createMealAsync, isPending } = useCreateMeal();
@@ -145,6 +153,7 @@ const MealAddScreen: React.FC<MealAddScreenProps> = ({ navigation, route }) => {
       )
     );
     setIngredients(editMeal.foods.map(buildMealIngredientDraftFromMealFood));
+    setPickerImages(toSavedImages(editMeal.images));
     setInitializedMealId(editMeal.id);
   }, [editMeal, initializedMealId, isEditMode]);
 
@@ -375,13 +384,27 @@ const MealAddScreen: React.FC<MealAddScreenProps> = ({ navigation, route }) => {
         foods: ingredients.map(mealIngredientToPayload),
       };
 
+      // Only send images on edit when they changed: a supplied `images` array
+      // is authoritative server-side and deletes anything omitted.
+      const imageArgs =
+        isEditMode
+          ? pickerImagesDiffer(pickerImages, editMeal?.images)
+            ? splitPickerImages(pickerImages)
+            : undefined
+          : pickerImages.length > 0
+            ? splitPickerImages(pickerImages)
+            : undefined;
+
       if (isEditMode) {
-        await updateMealAsync(payload);
+        await updateMealAsync(payload, imageArgs);
       } else {
-        await createMealAsync({
-          ...payload,
-          is_public: false,
-        });
+        await createMealAsync(
+          {
+            ...payload,
+            is_public: false,
+          },
+          imageArgs,
+        );
       }
       navigation.goBack();
     } catch {
@@ -455,6 +478,12 @@ const MealAddScreen: React.FC<MealAddScreenProps> = ({ navigation, route }) => {
         keyboardShouldPersistTaps="handled"
       >
         <View className="bg-surface rounded-xl p-4 gap-4 shadow-sm">
+          <FoodImagePicker
+            items={pickerImages}
+            onItemsChange={setPickerImages}
+            disabled={isSaving}
+          />
+
           <View className="gap-1.5">
             <Text className="text-text-secondary text-sm font-medium">Meal Name *</Text>
             <FormInput

--- a/SparkyFitnessMobile/src/screens/MealTypeDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MealTypeDetailScreen.tsx
@@ -213,14 +213,14 @@ const MealTypeDetailScreen: React.FC<MealTypeDetailScreenProps> = ({ navigation,
   });
 
   return (
-    <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
-      {header}
+      <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
+        {header}
 
-      {renderContent()}
+        {renderContent()}
 
-      <ServingAdjustSheet ref={servingSheetRef} onViewEntry={(entry) => navigation.navigate('FoodEntryView', { entry })} />
-      <CopyMealSheet ref={copySheetRef} isPending={isCopying} onCopy={copyMeal} />
-    </View>
+        <ServingAdjustSheet ref={servingSheetRef} onViewEntry={(entry) => navigation.navigate('FoodEntryView', { entry })} />
+        <CopyMealSheet ref={copySheetRef} isPending={isCopying} onCopy={copyMeal} />
+      </View>
   );
 };
 

--- a/SparkyFitnessMobile/src/screens/MealsLibraryScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MealsLibraryScreen.tsx
@@ -175,11 +175,11 @@ const MealsLibraryScreen: React.FC<MealsLibraryScreenProps> = ({ navigation }) =
   });
 
   return (
-    <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
-      {header}
-      {isConnected ? renderSearchBar() : null}
-      {renderContent()}
-    </View>
+      <View className="flex-1 bg-background" style={usesNativeHeader ? undefined : { paddingTop: insets.top }}>
+        {header}
+        {isConnected ? renderSearchBar() : null}
+        {renderContent()}
+      </View>
   );
 };
 

--- a/SparkyFitnessMobile/src/screens/foodForm/CreateFoodMode.tsx
+++ b/SparkyFitnessMobile/src/screens/foodForm/CreateFoodMode.tsx
@@ -7,6 +7,11 @@ import { StackActions } from '@react-navigation/native';
 import Icon from '../../components/Icon';
 import StepperInput from '../../components/StepperInput';
 import FoodForm, { type FoodFormData } from '../../components/FoodForm';
+import FoodImagePicker from '../../components/FoodImagePicker';
+import {
+  splitPickerImages,
+  type PickerImage,
+} from '../../utils/pickerImages';
 import BottomSheetPicker from '../../components/BottomSheetPicker';
 import CalendarSheet, { type CalendarSheetRef } from '../../components/CalendarSheet';
 import Switch from '../../components/ui/Switch';
@@ -181,6 +186,10 @@ export function CreateFoodMode({ params, navigation, routeKey }: { params: Creat
 
   const [customNutrientValues, setCustomNutrientValues] = useState<Record<string, number>>({});
 
+  const [pickerImages, setPickerImages] = useState<PickerImage[]>([]);
+  const imageArgs =
+    pickerImages.length > 0 ? splitPickerImages(pickerImages) : undefined;
+
   const { saveFoodAsync, isPending: isSavePending } = useSaveFood();
   // Holds the equivalent-save function for the current submit so onSuccess can
   // fire it after the food+entry are both confirmed, without a separate pre-save.
@@ -283,7 +292,7 @@ export function CreateFoodMode({ params, navigation, routeKey }: { params: Creat
 
     if (isMealBuilderMode) {
       try {
-        const savedFood = await saveFoodAsync(saveFoodPayload);
+        const savedFood = await saveFoodAsync(saveFoodPayload, imageArgs);
         isSavingRef.current = true;
         saveEquivalentsAsync(savedFood.id);
         setPendingMealIngredientSelection({
@@ -302,7 +311,7 @@ export function CreateFoodMode({ params, navigation, routeKey }: { params: Creat
 
     if (isLibraryMode) {
       try {
-        const savedFood = await saveFoodAsync(saveFoodPayload);
+        const savedFood = await saveFoodAsync(saveFoodPayload, imageArgs);
         isSavingRef.current = true;
         saveEquivalentsAsync(savedFood.id);
         Toast.show({ type: 'success', text1: 'Food saved' });
@@ -328,6 +337,7 @@ export function CreateFoodMode({ params, navigation, routeKey }: { params: Creat
     // isSavingRef is set in onSuccess so it stays false if addEntry fails.
     addEntry({
       saveFoodPayload,
+      saveFoodImages: imageArgs,
       createEntryPayload: {
         meal_type_id: effectiveMealId,
         quantity,
@@ -375,6 +385,15 @@ export function CreateFoodMode({ params, navigation, routeKey }: { params: Creat
         initialValues={initialFood}
         submitLabel={primaryLabel}
         hideSubmitButton={usesNativeHeader}
+        headerChildren={
+          <View className="mb-4">
+            <FoodImagePicker
+              items={pickerImages}
+              onItemsChange={setPickerImages}
+              disabled={isSubmitting}
+            />
+          </View>
+        }
         showAutoScaleNutrition={showAutoScaleNutrition}
         initialAutoScaleNutritionEnabled={initialAutoScaleNutritionEnabled}
         unitSelector={

--- a/SparkyFitnessMobile/src/screens/foodForm/EditFoodMode.tsx
+++ b/SparkyFitnessMobile/src/screens/foodForm/EditFoodMode.tsx
@@ -407,9 +407,14 @@ export function EditFoodMode({ params, navigation }: { params: EditFoodParams; n
 
             // Same prompt as the main path: one rule — every save of a food
             // you own asks before touching diary history.
-            if (await confirmSyncPastEntries()) {
+            const syncChoice = await confirmSyncPastEntries(imagesChanged);
+            if (syncChoice !== 'none') {
               try {
-                await updateFoodEntriesSnapshot(foodId);
+                await updateFoodEntriesSnapshot(
+                  foodId,
+                  undefined,
+                  syncChoice === 'nutrition-and-photos',
+                );
                 invalidateFoodCaches(queryClient, foodId);
                 Toast.show({ type: 'success', text1: 'Past entries updated' });
               } catch {
@@ -483,10 +488,14 @@ export function EditFoodMode({ params, navigation }: { params: EditFoodParams; n
       // web: one form saves nutrition, name, brand and photo together, so
       // gating on "did nutrition change" would make the prompt appear and
       // disappear for what looks to the user like the same action.
-      const shouldSync = await confirmSyncPastEntries();
-      if (shouldSync) {
+      const syncChoice = await confirmSyncPastEntries(imagesChanged);
+      if (syncChoice !== 'none') {
         try {
-          await updateFoodEntriesSnapshot(foodId);
+          await updateFoodEntriesSnapshot(
+            foodId,
+            undefined,
+            syncChoice === 'nutrition-and-photos',
+          );
           invalidateFoodCaches(queryClient, foodId);
           Toast.show({ type: 'success', text1: 'Past entries updated' });
         } catch {

--- a/SparkyFitnessMobile/src/screens/foodForm/EditFoodMode.tsx
+++ b/SparkyFitnessMobile/src/screens/foodForm/EditFoodMode.tsx
@@ -5,6 +5,13 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { CommonActions } from '@react-navigation/native';
 import { useQueryClient } from '@tanstack/react-query';
 import FoodForm, { type FoodFormData } from '../../components/FoodForm';
+import FoodImagePicker from '../../components/FoodImagePicker';
+import {
+  pickerImagesDiffer,
+  splitPickerImages,
+  toSavedImages,
+  type PickerImage,
+} from '../../utils/pickerImages';
 import { useCreateFoodVariant, useFoodVariants } from '../../hooks/useFoodVariants';
 import { parseOptional } from '../../types/foodInfo';
 import {
@@ -12,6 +19,7 @@ import {
   deleteFoodVariant,
   updateFoodVariant,
   updateFood,
+  updateFoodEntriesSnapshot,
   type CreateFoodVariantPayload,
   type UpdateFoodVariantPayload,
 } from '../../services/api/foodsApi';
@@ -38,6 +46,7 @@ import {
   buildVariantFromFormData,
   buildVariantFromInitialValues,
   confirmDiscardEquivalents,
+  confirmSyncPastEntries,
   confirmVariantOverwrite,
   equivalentsDiffer,
   hasFoodFormChanges,
@@ -80,6 +89,10 @@ export function EditFoodMode({ params, navigation }: { params: EditFoodParams; n
   const usesNativeHeader = useNativeIOSHeadersActive();
   const queryClient = useQueryClient();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [pickerImages, setPickerImages] = useState<PickerImage[]>(() =>
+    toSavedImages(item?.images),
+  );
+  const imagesChanged = pickerImagesDiffer(pickerImages, item?.images);
   const { createVariant } = useCreateFoodVariant();
   const { variants } = useFoodVariants(foodId, { enabled: true });
   const savedUnitVariants = useMemo(
@@ -282,7 +295,14 @@ export function EditFoodMode({ params, navigation }: { params: EditFoodParams; n
       const foodPayload: { name?: string; brand?: string } = {};
       if (data.name !== initialValues.name) foodPayload.name = data.name;
       if (data.brand !== initialValues.brand) foodPayload.brand = data.brand || '';
-      const hasFoodMetadataChange = Object.keys(foodPayload).length > 0;
+      // Only send images when they actually changed: the server treats a
+      // supplied `images` array as authoritative and deletes anything omitted,
+      // so an unchanged round-trip is wasted work at best.
+      const imageArgs = imagesChanged
+        ? splitPickerImages(pickerImages)
+        : undefined;
+      const hasFoodMetadataChange =
+        Object.keys(foodPayload).length > 0 || imagesChanged;
 
       let equivalentChangedCount = 0;
 
@@ -305,7 +325,7 @@ export function EditFoodMode({ params, navigation }: { params: EditFoodParams; n
         setCurrentCustomNutrients(nextCustomNutrients);
 
         if (hasFoodMetadataChange) {
-          await updateFood(foodId, foodPayload);
+          await updateFood(foodId, foodPayload, imageArgs);
         }
         invalidateFoodCaches(queryClient, foodId);
       } else {
@@ -378,12 +398,29 @@ export function EditFoodMode({ params, navigation }: { params: EditFoodParams; n
             setVariantBaselineValues(nextVariantBaselineValues);
             setCurrentCustomNutrients(nextCustomNutrients);
             if (hasFoodMetadataChange) {
-              await updateFood(foodId, foodPayload);
+              await updateFood(foodId, foodPayload, imageArgs);
             }
             invalidateFoodCaches(queryClient, foodId);
             // Skip the diff/overwrite path — new variant is already saved.
             setEquivalentBaseline(equivalentDraft);
             Toast.show({ type: 'success', text1: 'Saved as new variant' });
+
+            // Same prompt as the main path: one rule — every save of a food
+            // you own asks before touching diary history.
+            if (await confirmSyncPastEntries()) {
+              try {
+                await updateFoodEntriesSnapshot(foodId);
+                invalidateFoodCaches(queryClient, foodId);
+                Toast.show({ type: 'success', text1: 'Past entries updated' });
+              } catch {
+                Toast.show({
+                  type: 'error',
+                  text1: 'Could not update past entries',
+                  text2: 'Your food was saved.',
+                });
+              }
+            }
+
             isSavingRef.current = true;
             navigation.dispatch({
               ...CommonActions.setParams({
@@ -407,7 +444,7 @@ export function EditFoodMode({ params, navigation }: { params: EditFoodParams; n
         const writes: Promise<unknown>[] = [];
 
         if (hasFoodMetadataChange) {
-          writes.push(updateFood(foodId, foodPayload));
+          writes.push(updateFood(foodId, foodPayload, imageArgs));
         }
 
         for (const row of diff.creates) {
@@ -440,6 +477,28 @@ export function EditFoodMode({ params, navigation }: { params: EditFoodParams; n
             ? `Saved · ${equivalentChangedCount} equivalent unit${equivalentChangedCount === 1 ? '' : 's'} updated`
             : 'Saved',
       });
+
+      // Past diary entries keep the nutrition snapshot they were logged with.
+      // Ask before rewriting that history. Prompted on every save, matching
+      // web: one form saves nutrition, name, brand and photo together, so
+      // gating on "did nutrition change" would make the prompt appear and
+      // disappear for what looks to the user like the same action.
+      const shouldSync = await confirmSyncPastEntries();
+      if (shouldSync) {
+        try {
+          await updateFoodEntriesSnapshot(foodId);
+          invalidateFoodCaches(queryClient, foodId);
+          Toast.show({ type: 'success', text1: 'Past entries updated' });
+        } catch {
+          // The food itself saved fine; only the optional sync failed, so say
+          // so rather than implying the edit was lost.
+          Toast.show({
+            type: 'error',
+            text1: 'Could not update past entries',
+            text2: 'Your food was saved.',
+          });
+        }
+      }
 
       isSavingRef.current = true;
       navigation.dispatch({
@@ -493,6 +552,15 @@ export function EditFoodMode({ params, navigation }: { params: EditFoodParams; n
         submitLabel={SAVE_LABEL}
         isSubmitting={isSubmitting}
         hideSubmitButton={usesNativeHeader}
+        headerChildren={
+          <View className="mb-4">
+            <FoodImagePicker
+              items={pickerImages}
+              onItemsChange={setPickerImages}
+              disabled={isSubmitting}
+            />
+          </View>
+        }
         unitSelector={
           availableUnitVariants.length > 0
             ? {

--- a/SparkyFitnessMobile/src/screens/foodForm/persistence.ts
+++ b/SparkyFitnessMobile/src/screens/foodForm/persistence.ts
@@ -87,7 +87,9 @@ export function confirmDiscardEquivalents(): Promise<boolean> {
 }
 
 /**
- * Asks whether to rewrite past diary entries with the food's new nutrition.
+ * Asks whether to rewrite past diary entries with the food's new nutrition and
+ * photos — the snapshot sync refreshes inherited images alongside nutrition,
+ * so the prompt has to name both for the consent to be informed.
  *
  * Entries store a snapshot from when they were logged, so editing a food
  * leaves history untouched by default — a logged meal records what was eaten.
@@ -98,7 +100,7 @@ export function confirmSyncPastEntries(): Promise<boolean> {
   return new Promise((resolve) => {
     Alert.alert(
       'Update past entries?',
-      'Your library food is saved. Do you also want to update past diary entries for this food with the new nutrition? Existing entries keep their original values unless you update them.',
+      'Your library food is saved. Do you also want to update past diary entries for this food with the new nutrition and photos? Existing entries keep their original values unless you update them.',
       [
         { text: 'Keep past entries', style: 'cancel', onPress: () => resolve(false) },
         { text: 'Update past entries', onPress: () => resolve(true) },

--- a/SparkyFitnessMobile/src/screens/foodForm/persistence.ts
+++ b/SparkyFitnessMobile/src/screens/foodForm/persistence.ts
@@ -86,6 +86,28 @@ export function confirmDiscardEquivalents(): Promise<boolean> {
   });
 }
 
+/**
+ * Asks whether to rewrite past diary entries with the food's new nutrition.
+ *
+ * Entries store a snapshot from when they were logged, so editing a food
+ * leaves history untouched by default — a logged meal records what was eaten.
+ * Mirrors the web "Sync Past Entries?" dialog, including asking only after the
+ * save has succeeded, so the food is saved either way.
+ */
+export function confirmSyncPastEntries(): Promise<boolean> {
+  return new Promise((resolve) => {
+    Alert.alert(
+      'Update past entries?',
+      'Your library food is saved. Do you also want to update past diary entries for this food with the new nutrition? Existing entries keep their original values unless you update them.',
+      [
+        { text: 'Keep past entries', style: 'cancel', onPress: () => resolve(false) },
+        { text: 'Update past entries', onPress: () => resolve(true) },
+      ],
+      { onDismiss: () => resolve(false) },
+    );
+  });
+}
+
 export function confirmVariantOverwrite(unitLabel: string): Promise<'overwrite' | 'new' | 'cancel'> {
   return new Promise((resolve) => {
     Alert.alert(

--- a/SparkyFitnessMobile/src/screens/foodForm/persistence.ts
+++ b/SparkyFitnessMobile/src/screens/foodForm/persistence.ts
@@ -86,26 +86,65 @@ export function confirmDiscardEquivalents(): Promise<boolean> {
   });
 }
 
+export type SyncPastEntriesChoice = 'none' | 'nutrition' | 'nutrition-and-photos';
+
 /**
- * Asks whether to rewrite past diary entries with the food's new nutrition and
- * photos — the snapshot sync refreshes inherited images alongside nutrition,
- * so the prompt has to name both for the consent to be informed.
+ * Asks whether to rewrite past diary entries with the food's new values.
  *
  * Entries store a snapshot from when they were logged, so editing a food
  * leaves history untouched by default — a logged meal records what was eaten.
  * Mirrors the web "Sync Past Entries?" dialog, including asking only after the
  * save has succeeded, so the food is saved either way.
+ *
+ * `photosChanged` splits the prompt in two. When the save left the food's
+ * photos alone there is nothing to decide about them, so the dialog stays a
+ * plain yes/no about nutrition. When photos did change, the user gets the
+ * third option, because the two photo outcomes are genuinely different:
+ *
+ *  - `nutrition-and-photos` forces the new photo onto every past entry,
+ *    INCLUDING entries where the user picked their own photo in the diary.
+ *    Those replaced photos are deleted server-side; this is not reversible.
+ *  - `nutrition` rewrites nutrition only, so every entry keeps the photo it
+ *    is showing today, custom or inherited.
  */
-export function confirmSyncPastEntries(): Promise<boolean> {
+export function confirmSyncPastEntries(
+  photosChanged = false,
+): Promise<SyncPastEntriesChoice> {
+  if (!photosChanged) {
+    return new Promise((resolve) => {
+      Alert.alert(
+        'Update past entries?',
+        "Your library food is saved. Do you also want to update past diary entries for this food with the new nutrition? Entries you don't update keep their original values.",
+        [
+          // "Update"/"Don't Update" rather than two parallel "… past entries"
+          // labels: the negation lands on the first word, so the options are
+          // told apart at a glance instead of by diffing similar phrases.
+          { text: "Don't Update", style: 'cancel', onPress: () => resolve('none') },
+          // Photos did not change, so syncing them would be a no-op — ask for
+          // the nutrition-only sync and leave every entry's photo alone.
+          { text: 'Update', onPress: () => resolve('nutrition') },
+        ],
+        { onDismiss: () => resolve('none') },
+      );
+    });
+  }
+
   return new Promise((resolve) => {
     Alert.alert(
       'Update past entries?',
-      'Your library food is saved. Do you also want to update past diary entries for this food with the new nutrition and photos? Existing entries keep their original values unless you update them.',
+      'Your library food is saved. What should past diary entries for this food use?',
       [
-        { text: 'Keep past entries', style: 'cancel', onPress: () => resolve(false) },
-        { text: 'Update past entries', onPress: () => resolve(true) },
+        { text: "Don't Update", style: 'cancel', onPress: () => resolve('none') },
+        { text: 'Update nutrition only', onPress: () => resolve('nutrition') },
+        // Destructive: this is the one path that discards a photo the user
+        // chose for a specific diary entry, so it is styled as such.
+        {
+          text: 'Update nutrition & photos',
+          style: 'destructive',
+          onPress: () => resolve('nutrition-and-photos'),
+        },
       ],
-      { onDismiss: () => resolve(false) },
+      { onDismiss: () => resolve('none') },
     );
   });
 }

--- a/SparkyFitnessMobile/src/services/api/entryImagesApi.ts
+++ b/SparkyFitnessMobile/src/services/api/entryImagesApi.ts
@@ -1,0 +1,56 @@
+import { apiFetch } from './apiClient';
+import { postImageMultipart } from './imageUploadClient';
+import type { FoodEntry } from '../../types/foodEntries';
+import type { FoodEntryMeal } from '../../types/foodEntryMeals';
+
+/**
+ * Per-entry override photos for the diary.
+ *
+ * These write only to the entry row. The parent food or meal template is never
+ * touched, which is what lets one logged serving carry its own picture while
+ * every other entry of the same food keeps falling back to the library photo.
+ */
+
+export const setFoodEntryImages = async (
+  entryId: string,
+  order: string[],
+  newUris: string[],
+): Promise<FoodEntry> =>
+  postImageMultipart<FoodEntry>({
+    endpoint: `/api/food-entries/${entryId}/image`,
+    serviceName: 'Food Entries API',
+    operation: 'set entry image',
+    order,
+    newUris,
+  });
+
+export const clearFoodEntryImage = async (entryId: string): Promise<void> =>
+  apiFetch<void>({
+    endpoint: `/api/food-entries/${entryId}/image`,
+    serviceName: 'Food Entries API',
+    operation: 'clear entry image',
+    method: 'DELETE',
+  });
+
+export const setFoodEntryMealImages = async (
+  entryId: string,
+  order: string[],
+  newUris: string[],
+): Promise<FoodEntryMeal> =>
+  postImageMultipart<FoodEntryMeal>({
+    endpoint: `/api/food-entry-meals/${entryId}/image`,
+    serviceName: 'Food Entry Meals API',
+    operation: 'set logged meal image',
+    order,
+    newUris,
+  });
+
+export const clearFoodEntryMealImage = async (
+  entryId: string,
+): Promise<void> =>
+  apiFetch<void>({
+    endpoint: `/api/food-entry-meals/${entryId}/image`,
+    serviceName: 'Food Entry Meals API',
+    operation: 'clear logged meal image',
+    method: 'DELETE',
+  });

--- a/SparkyFitnessMobile/src/services/api/externalFoodSearchApi.ts
+++ b/SparkyFitnessMobile/src/services/api/externalFoodSearchApi.ts
@@ -442,6 +442,12 @@ interface NormalizedFood {
   provider_type?: string;
   is_custom: boolean;
   provider_verified?: boolean;
+  // Provider photo. The server's NormalizedFoodSchema declares these, so they
+  // arrive on the wire; they only reach the UI if this interface declares them
+  // AND transformNormalizedFood copies them across.
+  image_url?: string | null;
+  image_source_url?: string | null;
+  images?: string[];
   default_variant: NormalizedFoodVariant;
   variants?: NormalizedFoodVariant[];
 }
@@ -455,6 +461,13 @@ export interface BarcodeFood {
   provider_type?: string;
   is_custom: boolean;
   provider_verified?: boolean;
+  // Provider photo. The server's NormalizedFoodSchema declares these, so they
+  // arrive on the wire; they only reach the UI if this interface declares them
+  // AND transformNormalizedFood copies them across.
+  image_url?: string | null;
+  image_source_url?: string | null;
+  images?: string[];
+
   default_variant: NormalizedFoodVariant;
   variants?: NormalizedFoodVariant[];
 }
@@ -516,6 +529,11 @@ export function transformNormalizedFood(
     source: food.provider_type ?? providerType,
     variants: variants && variants.length > 0 ? variants : undefined,
     provider_verified: food.provider_verified === true,
+    // Carry the provider photo through. Every field this mapper omits is
+    // invisible to the UI no matter what the server sent.
+    image_url: food.image_url ?? null,
+    image_source_url: food.image_source_url ?? null,
+    images: food.images,
   };
 }
 
@@ -599,6 +617,11 @@ export async function lookupBarcodeV2(barcode: string, providerId?: string): Pro
     provider_type: food.provider_type,
     is_custom: food.is_custom,
     provider_verified: food.provider_verified,
+    // Same omission trap as the search mapper: a scanned barcode's photo is
+    // lost unless it is copied here.
+    image_url: food.image_url ?? null,
+    image_source_url: food.image_source_url ?? null,
+    images: food.images,
     default_variant: food.default_variant,
     variants: resolvedVariants,
   };

--- a/SparkyFitnessMobile/src/services/api/foodsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/foodsApi.ts
@@ -313,13 +313,21 @@ export const updateFood = async (
 export const updateFoodEntriesSnapshot = async (
   foodId: string,
   variantId?: string,
+  /**
+   * `true` forces the food's current photos onto every matching entry,
+   * replacing photos the user set on individual diary entries. `false`
+   * rewrites nutrition only and leaves every entry's photo untouched.
+   */
+  syncImages: boolean = true,
 ): Promise<void> => {
   return apiFetch<void>({
     endpoint: '/api/foods/update-snapshot',
     serviceName: 'Foods API',
     operation: 'sync past entries',
     method: 'POST',
-    body: variantId ? { foodId, variantId } : { foodId },
+    body: variantId
+      ? { foodId, variantId, syncImages }
+      : { foodId, syncImages },
   });
 };
 

--- a/SparkyFitnessMobile/src/services/api/foodsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/foodsApi.ts
@@ -1,4 +1,6 @@
 import { apiFetch } from './apiClient';
+import { postPayloadWithImages } from './imageUploadClient';
+import type { ImageUploadArgs } from '../../utils/pickerImages';
 import {
   FoodItem,
   FoodsResponse,
@@ -148,18 +150,49 @@ export interface SaveFoodPayload {
   provider_external_id?: string | null;
   provider_verified?: boolean;
   custom_nutrients?: Record<string, string | number>;
+  // Provider photo carried through import. The server's resolveImageInput
+  // prefers `images`, then `image_source_url`, then `image_url`, and localizes
+  // remote URLs into /uploads after COMMIT. Omitting these is why a provider
+  // food silently saves without its picture.
+  images?: string[];
+  image_url?: string | null;
+  image_source_url?: string | null;
 }
 
 /**
  * Saves a food item to the database.
+ *
+ * `images` carries the ordered image list (`__new__<n>` placeholders for
+ * uploads); `newImageUris` are the local files those placeholders refer to.
+ * With no files the request stays plain JSON, matching web.
  */
-export const saveFood = async (food: SaveFoodPayload): Promise<FoodItem> => {
-  return apiFetch<FoodItem>({
+export const saveFood = async (
+  food: SaveFoodPayload,
+  images?: ImageUploadArgs,
+): Promise<FoodItem> => {
+  const sendJson = (payload: Record<string, unknown>) =>
+    apiFetch<FoodItem>({
+      endpoint: '/api/foods',
+      serviceName: 'Foods API',
+      operation: 'save food',
+      method: 'POST',
+      body: payload,
+    });
+
+  if (!images) {
+    return sendJson(food as unknown as Record<string, unknown>);
+  }
+
+  return postPayloadWithImages<FoodItem>({
     endpoint: '/api/foods',
     serviceName: 'Foods API',
     operation: 'save food',
     method: 'POST',
-    body: food,
+    payload: food as unknown as Record<string, unknown>,
+    wrapperField: 'foodData',
+    order: images.order,
+    newUris: images.newUris,
+    sendJson,
   });
 };
 
@@ -234,15 +267,59 @@ export interface DeleteFoodResponse {
 }
 
 /**
- * Updates a food item's metadata (name, brand).
+ * Updates a food item's metadata (name, brand, images).
  */
-export const updateFood = async (foodId: string, payload: UpdateFoodPayload): Promise<FoodItem> => {
-  return apiFetch<FoodItem>({
+export const updateFood = async (
+  foodId: string,
+  payload: UpdateFoodPayload,
+  images?: ImageUploadArgs,
+): Promise<FoodItem> => {
+  const sendJson = (body: Record<string, unknown>) =>
+    apiFetch<FoodItem>({
+      endpoint: `/api/foods/${foodId}`,
+      serviceName: 'Foods API',
+      operation: 'update food',
+      method: 'PUT',
+      body,
+    });
+
+  if (!images) {
+    return sendJson(payload as unknown as Record<string, unknown>);
+  }
+
+  return postPayloadWithImages<FoodItem>({
     endpoint: `/api/foods/${foodId}`,
     serviceName: 'Foods API',
     operation: 'update food',
     method: 'PUT',
-    body: payload,
+    payload: payload as unknown as Record<string, unknown>,
+    wrapperField: 'foodData',
+    order: images.order,
+    newUris: images.newUris,
+    sendJson,
+  });
+};
+
+/**
+ * Rewrites the stored nutrition snapshot on every past diary entry for this
+ * food, so already-logged servings reflect the food's current values.
+ *
+ * Opt-in only. Diary entries hold a snapshot taken at log time, and editing a
+ * food deliberately leaves them alone — a past meal is a record of what was
+ * eaten, not a live reference. Web asks before calling this; mobile now does
+ * too. Omitting `variantId` updates entries across all of the food's variants,
+ * matching web.
+ */
+export const updateFoodEntriesSnapshot = async (
+  foodId: string,
+  variantId?: string,
+): Promise<void> => {
+  return apiFetch<void>({
+    endpoint: '/api/foods/update-snapshot',
+    serviceName: 'Foods API',
+    operation: 'sync past entries',
+    method: 'POST',
+    body: variantId ? { foodId, variantId } : { foodId },
   });
 };
 

--- a/SparkyFitnessMobile/src/services/api/imageUploadClient.ts
+++ b/SparkyFitnessMobile/src/services/api/imageUploadClient.ts
@@ -48,6 +48,13 @@ export async function postImageMultipart<T>(params: {
   const config = await getActiveServerConfig();
   if (!config) throw new Error('Server configuration not found.');
   const baseUrl = normalizeUrl(config.url);
+  // Same transport guard `apiFetch` applies: these requests carry auth headers
+  // and user photos, so never send them over plaintext in a release build.
+  if (!__DEV__ && baseUrl.toLowerCase().startsWith('http://')) {
+    throw new Error(
+      'HTTPS is required for server connections. Please update your server URL in Settings.',
+    );
+  }
 
   const form = new FormData();
 
@@ -112,8 +119,12 @@ export async function postImageMultipart<T>(params: {
     );
   }
 
-  // 204 has no body; image endpoints otherwise return the updated row.
-  if (response.status === 204) return undefined as T;
+  // 204 has no body; image endpoints otherwise return the updated row. An
+  // empty 200 is treated the same, as apiFetch does — response.json() would
+  // throw on it after an otherwise successful upload.
+  if (response.status === 204 || response.headers?.get('content-length') === '0') {
+    return undefined as T;
+  }
   return (await response.json()) as T;
 }
 

--- a/SparkyFitnessMobile/src/services/api/imageUploadClient.ts
+++ b/SparkyFitnessMobile/src/services/api/imageUploadClient.ts
@@ -1,0 +1,149 @@
+import { File } from 'expo-file-system';
+import { normalizeUrl } from './apiClient';
+import { ApiError } from './errors';
+import { getActiveServerConfig, proxyHeadersToRecord } from '../storage';
+import { getAuthHeaders, notifySessionExpired } from './authService';
+import { addLog } from '../LogService';
+import { UPLOAD_TIMEOUT_MS, fetchWithTimeout } from '../../utils/concurrency';
+
+/**
+ * Shared multipart transport for food/meal/entry images.
+ *
+ * `apiFetch` JSON-encodes its body, so image writes cannot go through it. This
+ * mirrors `pregnancyPhotosApi.uploadPhoto` — the app's one proven multipart
+ * path — and exists so the auth/proxy/timeout/session-expiry handling is not
+ * hand-copied into every image endpoint.
+ *
+ * Two rules are load-bearing and easy to break:
+ *  - Global fetch is Expo's WinterCG `expo/fetch`, which rejects React
+ *    Native's `{uri, name, type}` FormData parts with "Unsupported
+ *    FormDataPart implementation". An `expo-file-system` `File` implements
+ *    Blob and serializes correctly.
+ *  - Content-Type must be left unset so multer receives a boundary.
+ */
+export async function postImageMultipart<T>(params: {
+  endpoint: string;
+  serviceName: string;
+  operation: string;
+  method?: 'POST' | 'PUT';
+  /** Ordered `images` array with `__new__<n>` placeholders for uploads. */
+  order: string[];
+  /** Local URIs to upload, in placeholder order. */
+  newUris: string[];
+  /** Optional JSON payload, sent under `wrapperField` (e.g. `foodData`). */
+  payload?: unknown;
+  wrapperField?: string;
+}): Promise<T> {
+  const {
+    endpoint,
+    serviceName,
+    operation,
+    method = 'POST',
+    order,
+    newUris,
+    payload,
+    wrapperField,
+  } = params;
+
+  const config = await getActiveServerConfig();
+  if (!config) throw new Error('Server configuration not found.');
+  const baseUrl = normalizeUrl(config.url);
+
+  const form = new FormData();
+
+  // Where the order array goes depends on whether the route wraps its body.
+  //
+  // Wrapped routes (foods, meals) run parseMultipartBody, which REPLACES the
+  // body with the parsed wrapper object and discards every other text field —
+  // so a top-level `images` field would be silently dropped, and the server
+  // would treat the request as "these uploads are the complete set" and unlink
+  // the existing photos. It has to travel inside the wrapper, as web does.
+  //
+  // Unwrapped routes (the per-entry image endpoints) read `req.body.images`
+  // directly, so the top-level field is correct there.
+  //
+  // Text fields must precede the file parts either way: multer only reliably
+  // exposes fields that arrive before the files in the multipart stream.
+  if (payload !== undefined && wrapperField) {
+    form.append(wrapperField, JSON.stringify({ ...(payload as object), images: order }));
+  } else {
+    form.append('images', JSON.stringify(order));
+  }
+
+  for (const uri of newUris) {
+    form.append('images', new File(uri));
+  }
+
+  let response: Response;
+  try {
+    response = await fetchWithTimeout(
+      `${baseUrl}${endpoint}`,
+      {
+        method,
+        headers: {
+          ...proxyHeadersToRecord(config.proxyHeaders),
+          ...getAuthHeaders(config),
+          // Multer needs to set the boundary: do NOT set Content-Type here.
+        },
+        body: form,
+      },
+      UPLOAD_TIMEOUT_MS,
+    );
+  } catch (err) {
+    // A throw here means no response ever arrived (dropped connection,
+    // timeout, or a proxy rejecting the body before the app server saw it),
+    // so log it; the response-error path below cannot.
+    addLog(`[${serviceName}] ${operation} failed without a response`, 'ERROR', [
+      String(err),
+    ]);
+    throw err;
+  }
+
+  if (!response.ok) {
+    if (response.status === 401 && config.authType === 'session') {
+      notifySessionExpired(config.id);
+    }
+    const text = await response.text();
+    addLog(`[${serviceName}] Failed to ${operation}`, 'ERROR', [text]);
+    throw new ApiError(
+      `Server error: ${response.status} - ${text}`,
+      response.status,
+      text,
+    );
+  }
+
+  // 204 has no body; image endpoints otherwise return the updated row.
+  if (response.status === 204) return undefined as T;
+  return (await response.json()) as T;
+}
+
+/**
+ * Sends a JSON payload, switching to multipart only when there are files to
+ * upload — matching web's `buildPayloadRequest`, so servers see the same plain
+ * JSON body they always have when a user touches no images.
+ */
+export async function postPayloadWithImages<T>(params: {
+  endpoint: string;
+  serviceName: string;
+  operation: string;
+  method?: 'POST' | 'PUT';
+  payload: Record<string, unknown>;
+  wrapperField: string;
+  order: string[];
+  newUris: string[];
+  /** Used when no files need uploading. */
+  sendJson: (payload: Record<string, unknown>) => Promise<T>;
+}): Promise<T> {
+  const { payload, order, newUris, sendJson, ...rest } = params;
+
+  if (newUris.length === 0) {
+    return sendJson({ ...payload, images: order });
+  }
+
+  return postImageMultipart<T>({
+    ...rest,
+    payload,
+    order,
+    newUris,
+  });
+}

--- a/SparkyFitnessMobile/src/services/api/mealsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/mealsApi.ts
@@ -1,4 +1,6 @@
 import { apiFetch } from './apiClient';
+import { postPayloadWithImages } from './imageUploadClient';
+import type { ImageUploadArgs } from '../../utils/pickerImages';
 import { CreateMealPayload, Meal, MealDeletionImpact, UpdateMealPayload } from '../../types/meals';
 
 /**
@@ -62,27 +64,68 @@ export const searchMeals = async (searchTerm: string): Promise<Meal[]> => {
 /**
  * Creates a meal template for the current user.
  */
-export const createMeal = async (payload: CreateMealPayload): Promise<Meal> => {
-  return apiFetch<Meal>({
+export const createMeal = async (
+  payload: CreateMealPayload,
+  images?: ImageUploadArgs,
+): Promise<Meal> => {
+  const sendJson = (body: Record<string, unknown>) =>
+    apiFetch<Meal>({
+      endpoint: '/api/meals',
+      serviceName: 'Meals API',
+      operation: 'create meal',
+      method: 'POST',
+      body,
+    });
+
+  if (!images) {
+    return sendJson(payload as unknown as Record<string, unknown>);
+  }
+
+  return postPayloadWithImages<Meal>({
     endpoint: '/api/meals',
     serviceName: 'Meals API',
     operation: 'create meal',
     method: 'POST',
-    body: payload,
+    payload: payload as unknown as Record<string, unknown>,
+    wrapperField: 'mealData',
+    order: images.order,
+    newUris: images.newUris,
+    sendJson,
   });
 };
 
 /**
  * Updates a meal template and refetches the expanded meal detail.
  */
-export const updateMeal = async (id: string, payload: UpdateMealPayload): Promise<Meal> => {
-  await apiFetch<Meal>({
-    endpoint: `/api/meals/${id}`,
-    serviceName: 'Meals API',
-    operation: 'update meal',
-    method: 'PUT',
-    body: payload,
-  });
+export const updateMeal = async (
+  id: string,
+  payload: UpdateMealPayload,
+  images?: ImageUploadArgs,
+): Promise<Meal> => {
+  const sendJson = (body: Record<string, unknown>) =>
+    apiFetch<Meal>({
+      endpoint: `/api/meals/${id}`,
+      serviceName: 'Meals API',
+      operation: 'update meal',
+      method: 'PUT',
+      body,
+    });
+
+  if (!images) {
+    await sendJson(payload as unknown as Record<string, unknown>);
+  } else {
+    await postPayloadWithImages<Meal>({
+      endpoint: `/api/meals/${id}`,
+      serviceName: 'Meals API',
+      operation: 'update meal',
+      method: 'PUT',
+      payload: payload as unknown as Record<string, unknown>,
+      wrapperField: 'mealData',
+      order: images.order,
+      newUris: images.newUris,
+      sendJson,
+    });
+  }
 
   return fetchMeal(id);
 };

--- a/SparkyFitnessMobile/src/types/externalFoods.ts
+++ b/SparkyFitnessMobile/src/types/externalFoods.ts
@@ -61,4 +61,10 @@ export interface ExternalFoodItem {
   variants?: ExternalFoodVariant[];
   /** Whether the food is verified by the provider (e.g. Yazio verified foods) */
   provider_verified?: boolean;
+  /** Provider thumbnail URL; absolute, not yet imported into /uploads. */
+  image_url?: string | null;
+  /** Full-size counterpart of `image_url`, preferred when localizing on save. */
+  image_source_url?: string | null;
+  /** Present once the food has been imported and localized server-side. */
+  images?: string[] | null;
 }

--- a/SparkyFitnessMobile/src/types/foodEntries.ts
+++ b/SparkyFitnessMobile/src/types/foodEntries.ts
@@ -49,4 +49,10 @@ export interface FoodEntry {
   // entries that were themselves imported from a provider.
   source?: string | null;
   provider_verified?: boolean;
+
+  // Per-entry override photos. Never written back to the parent food, so an
+  // entry without an override falls back to `food_images`.
+  images?: string[] | null;
+  // The parent food's own images, returned alongside the entry by the server.
+  food_images?: string[] | null;
 }

--- a/SparkyFitnessMobile/src/types/foodEntryMeals.ts
+++ b/SparkyFitnessMobile/src/types/foodEntryMeals.ts
@@ -65,6 +65,12 @@ export interface FoodEntryMeal {
   iron?: number;
   glycemic_index?: string;
   custom_nutrients?: Record<string, string | number>;
+
+  // Per-entry override photos. Never written back to the meal template, so an
+  // entry without an override falls back to `meal_images`.
+  images?: string[] | null;
+  // The parent meal template's own images, returned alongside the entry.
+  meal_images?: string[] | null;
 }
 
 export interface FoodEntryMealCreateData {

--- a/SparkyFitnessMobile/src/types/foodInfo.ts
+++ b/SparkyFitnessMobile/src/types/foodInfo.ts
@@ -125,6 +125,13 @@ export interface FoodInfoItem {
   variantId?: string;
   externalVariants?: ExternalFoodVariant[];
   provider_verified?: boolean;
+  // Photos. `images` is set for already-saved foods and meals; the two URL
+  // fields carry a provider result's photo before it has been imported, and
+  // must survive as far as the create payload or the food is saved without
+  // one. See docs/content/8.developer/12.food-provider-images.md.
+  images?: string[] | null;
+  image_url?: string | null;
+  image_source_url?: string | null;
   // Yield count for meal-source items — surfaces "meal makes N servings"
   // context in the diary-add screen for serving-unit meals where the
   // per-serving size suffix is suppressed.
@@ -168,6 +175,7 @@ export const foodItemToFoodInfo = (item: FoodItem | TopFoodItem ): FoodInfoItem 
   vitaminC: item.default_variant.vitamin_c,
   customNutrients: item.default_variant.custom_nutrients ?? null,
   variantId: item.default_variant.id,
+  images: item.images ?? null,
   source: 'local',
   originalItem: item,
 });
@@ -200,6 +208,9 @@ export const externalFoodItemToFoodInfo = (item: ExternalFoodItem): FoodInfoItem
   vitaminC: item.vitamin_c,
   externalVariants: item.variants,
   provider_verified: item.provider_verified,
+  images: item.images ?? null,
+  image_url: item.image_url ?? null,
+  image_source_url: item.image_source_url ?? null,
   source: 'external',
   originalItem: item,
 });
@@ -252,6 +263,7 @@ export const mealToFoodInfo = (meal: Meal): FoodInfoItem => {
     vitaminA: hasField('vitamin_a') ? Math.round(perServing(sumField('vitamin_a'))) : undefined,
     vitaminC: hasField('vitamin_c') ? Math.round(perServing(sumField('vitamin_c'))) : undefined,
     mealTotalServings: totalServings,
+    images: meal.images ?? null,
     source: 'meal',
     originalItem: meal,
   };

--- a/SparkyFitnessMobile/src/types/foods.ts
+++ b/SparkyFitnessMobile/src/types/foods.ts
@@ -38,6 +38,10 @@ export interface FoodItem {
   is_quick_food?: boolean;
   // Present only on items returned by the favorites endpoint.
   favorited_at?: string;
+  // Ordered image paths; index 0 is the thumbnail. Locally uploaded images are
+  // server-relative (`/uploads/foods/<id>/...`); provider images that could not
+  // be downloaded stay absolute and are hotlinked.
+  images?: string[] | null;
   default_variant: FoodDefaultVariant;
 }
 

--- a/SparkyFitnessMobile/src/types/meals.ts
+++ b/SparkyFitnessMobile/src/types/meals.ts
@@ -121,5 +121,7 @@ export interface Meal {
   updated_at: string;
   // Present only on items returned by the favorites endpoint.
   favorited_at?: string;
+  // Ordered image paths; index 0 is the thumbnail. See FoodItem.images.
+  images?: string[] | null;
   foods: MealFood[];
 }

--- a/SparkyFitnessMobile/src/utils/foodImages.ts
+++ b/SparkyFitnessMobile/src/utils/foodImages.ts
@@ -1,0 +1,127 @@
+import type { FoodItem } from '../types/foods';
+import type { Meal } from '../types/meals';
+import type { FoodEntry } from '../types/foodEntries';
+import type { FoodEntryMeal } from '../types/foodEntryMeals';
+import type { ExternalFoodItem } from '../types/externalFoods';
+
+/**
+ * Food and meal image selection, mirroring the web helpers in
+ * `SparkyFitnessFrontend/src/utils/foodImages.ts` so the two platforms pick the
+ * same picture for the same row.
+ *
+ * These return stored *paths*, not loadable URIs. Turning a path into something
+ * `<Image>` can fetch needs the active server's base URL and proxy headers, so
+ * that step lives in `useFoodImageSource` instead.
+ */
+
+/**
+ * Narrows a stored image reference to a usable path, or null when there is
+ * nothing to show.
+ *
+ * Locally uploaded images arrive server-relative (`/uploads/foods/<id>/...`).
+ * Provider images that could not be downloaded stay absolute and are hotlinked.
+ * A bare filename is a legacy upload stored without its directory prefix.
+ */
+export function normalizeFoodImagePath(
+  image: string | null | undefined,
+): string | null {
+  if (!image) {
+    return null;
+  }
+  const trimmed = image.trim();
+  // Legacy/empty payloads occasionally serialize as a literal "[]".
+  if (trimmed === '' || trimmed === '[]') {
+    return null;
+  }
+  return trimmed;
+}
+
+/** Returns only the entries of `images` that resolve to a usable path. */
+export function usableFoodImages(
+  images: string[] | null | undefined,
+): string[] {
+  if (!Array.isArray(images)) {
+    return [];
+  }
+  return images
+    .map(normalizeFoodImagePath)
+    .filter((path): path is string => path !== null);
+}
+
+/** First usable image for a food or meal, or null when it has none. */
+export function primaryImageOf(
+  entity:
+    | Pick<FoodItem, 'images'>
+    | Pick<Meal, 'images'>
+    | null
+    | undefined,
+): string | null {
+  return usableFoodImages(entity?.images)[0] ?? null;
+}
+
+/**
+ * Picks the image for an external provider result.
+ *
+ * Precedence matches web's `FoodResultCard`: an already-imported `images` array
+ * wins, then the full-size `image_source_url`, then the search thumbnail.
+ */
+export function externalFoodImage(
+  item: Pick<
+    ExternalFoodItem,
+    'images' | 'image_url' | 'image_source_url'
+  > | null | undefined,
+): string | null {
+  if (!item) {
+    return null;
+  }
+  return (
+    usableFoodImages(item.images)[0] ??
+    normalizeFoodImagePath(item.image_source_url) ??
+    normalizeFoodImagePath(item.image_url)
+  );
+}
+
+/**
+ * Picks the images to show for a diary food entry.
+ *
+ * Precedence: the entry's own override photos, then the parent food's images.
+ * The override is never written back to the parent, so this fallback is what
+ * makes an un-overridden entry still show a picture.
+ */
+export function diaryEntryImages(
+  entry: Pick<FoodEntry, 'images' | 'food_images'> | null | undefined,
+): string[] {
+  if (!entry) {
+    return [];
+  }
+  const override = usableFoodImages(entry.images);
+  return override.length > 0 ? override : usableFoodImages(entry.food_images);
+}
+
+/** First image to show for a diary food entry, or null when it has none. */
+export function diaryEntryImage(
+  entry: Pick<FoodEntry, 'images' | 'food_images'> | null | undefined,
+): string | null {
+  return diaryEntryImages(entry)[0] ?? null;
+}
+
+/**
+ * Picks the images to show for a logged meal, with the same override-then-parent
+ * precedence as `diaryEntryImages`.
+ */
+export function loggedMealImages(
+  entry: Pick<FoodEntryMeal, 'images' | 'meal_images'> | null | undefined,
+): string[] {
+  if (!entry) {
+    return [];
+  }
+  const override = usableFoodImages(entry.images);
+  return override.length > 0 ? override : usableFoodImages(entry.meal_images);
+}
+
+/** First image to show for a logged meal, or null when it has none. */
+export function loggedMealImage(
+  entry: Pick<FoodEntryMeal, 'images' | 'meal_images'> | null | undefined,
+): string | null {
+  return loggedMealImages(entry)[0] ?? null;
+}

--- a/SparkyFitnessMobile/src/utils/pickImage.ts
+++ b/SparkyFitnessMobile/src/utils/pickImage.ts
@@ -1,0 +1,121 @@
+import * as ImagePicker from 'expo-image-picker';
+import * as ImageManipulator from 'expo-image-manipulator';
+import { addLog } from '../services/LogService';
+
+/**
+ * Camera / photo-library capture for food and meal photos, downscaled before
+ * upload.
+ *
+ * The server stores what it is given — there is no thumbnail generation and no
+ * `sharp` — and enforces a 10 MB per-file limit. A modern phone camera photo
+ * can approach or exceed that, and a full-resolution shot is wasted on a 40pt
+ * list thumbnail, so every picked image is resized and re-encoded first. This
+ * mirrors what `FoodScanScreen.prepareLabelPhoto` does for label scans.
+ */
+
+// Long-edge cap. Comfortably above what any current display needs for a
+// full-screen lightbox, while cutting a 12MP camera shot by roughly an order
+// of magnitude.
+const MAX_DIMENSION = 1600;
+const COMPRESS_QUALITY = 0.85;
+
+export type PickedImage = { uri: string };
+
+/**
+ * Distinguishes the two "nothing happened" outcomes: a cancel is the user
+ * changing their mind and needs no message, while a denial is a dead end the
+ * caller must explain (the picker will never open until Settings changes).
+ */
+export type CameraPickResult =
+  | { status: 'ok'; image: PickedImage }
+  | { status: 'cancelled' }
+  | { status: 'denied' };
+
+async function downscale(asset: {
+  uri: string;
+  width?: number;
+  height?: number;
+}): Promise<PickedImage> {
+  const { uri, width, height } = asset;
+  const longEdge = Math.max(width ?? 0, height ?? 0);
+
+  const actions: ImageManipulator.Action[] =
+    longEdge > MAX_DIMENSION && width && height
+      ? [
+          {
+            resize:
+              width >= height
+                ? { width: MAX_DIMENSION }
+                : { height: MAX_DIMENSION },
+          },
+        ]
+      : [];
+
+  // Re-encode even when no resize is needed: it normalizes HEIC (the iOS
+  // default) to JPEG, which is on the server's mime allowlist. HEIC is not.
+  const processed = await ImageManipulator.manipulateAsync(uri, actions, {
+    compress: COMPRESS_QUALITY,
+    format: ImageManipulator.SaveFormat.JPEG,
+  });
+
+  return { uri: processed.uri };
+}
+
+/** Takes a photo with the system camera. */
+export async function pickImageFromCamera(): Promise<CameraPickResult> {
+  const permission = await ImagePicker.requestCameraPermissionsAsync();
+  if (!permission.granted) {
+    return { status: 'denied' };
+  }
+
+  const result = await ImagePicker.launchCameraAsync({
+    mediaTypes: 'images',
+    quality: 1,
+  });
+  if (result.canceled) return { status: 'cancelled' };
+
+  const asset = result.assets?.[0];
+  if (!asset?.uri) return { status: 'cancelled' };
+
+  try {
+    return { status: 'ok', image: await downscale(asset) };
+  } catch (error) {
+    // A failed re-encode should not lose the user's photo; the server still
+    // accepts the original when it is within limits.
+    addLog(
+      `[Food Image] Downscale failed, using original: ${String(error)}`,
+      'WARNING',
+    );
+    return { status: 'ok', image: { uri: asset.uri } };
+  }
+}
+
+/**
+ * Picks up to `limit` images from the photo library.
+ */
+export async function pickImagesFromLibrary(
+  limit: number,
+): Promise<PickedImage[]> {
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: 'images',
+    quality: 1,
+    allowsMultipleSelection: limit > 1,
+    selectionLimit: Math.max(1, limit),
+  });
+  if (result.canceled) return [];
+
+  const picked: PickedImage[] = [];
+  for (const asset of result.assets ?? []) {
+    if (!asset?.uri) continue;
+    try {
+      picked.push(await downscale(asset));
+    } catch (error) {
+      addLog(
+        `[Food Image] Downscale failed, using original: ${String(error)}`,
+        'WARNING',
+      );
+      picked.push({ uri: asset.uri });
+    }
+  }
+  return picked;
+}

--- a/SparkyFitnessMobile/src/utils/pickerImages.ts
+++ b/SparkyFitnessMobile/src/utils/pickerImages.ts
@@ -1,0 +1,108 @@
+/**
+ * Client-side model for the server's image ordering protocol, mirroring web's
+ * `SparkyFitnessFrontend/src/utils/imagePickerItems.ts`.
+ *
+ * The server (`middleware/imageUpload.ts`) takes an `images` field holding the
+ * desired final order: existing images appear as their stored path, and each
+ * newly uploaded file is referenced by `__new__<n>` where n is its index among
+ * the appended files. Anything omitted from that array is deleted server-side,
+ * and index 0 is the thumbnail.
+ */
+
+/** Matches the server's MAX_IMAGE_COUNT. */
+export const MAX_IMAGES = 10;
+
+/**
+ * Wire form of a picker's contents: the ordered `images` array (with
+ * `__new__<n>` placeholders) plus the local files those placeholders name.
+ */
+export type ImageUploadArgs = { order: string[]; newUris: string[] };
+
+export type SavedPickerImage = { kind: 'saved'; path: string };
+export type NewPickerImage = { kind: 'new'; uri: string; id: string };
+export type PickerImage = SavedPickerImage | NewPickerImage;
+
+let newImageCounter = 0;
+
+/** Wraps a freshly picked local URI as an unsaved picker item. */
+export function toNewImage(uri: string): PickerImage {
+  newImageCounter += 1;
+  return { kind: 'new', uri, id: `new-${newImageCounter}` };
+}
+
+/** Seeds the picker from an entity's stored image array. */
+export function toSavedImages(
+  images: string[] | null | undefined,
+): SavedPickerImage[] {
+  if (!Array.isArray(images)) return [];
+  return images
+    .map((image) => image?.trim())
+    .filter((image): image is string => !!image && image !== '[]')
+    .map((path) => ({ kind: 'saved', path }));
+}
+
+/**
+ * Splits picker state into the wire representation: the ordered `images` array
+ * (with `__new__<n>` placeholders) and the parallel list of URIs to upload.
+ */
+export function splitPickerImages(items: PickerImage[]): ImageUploadArgs {
+  const order: string[] = [];
+  const newUris: string[] = [];
+
+  for (const item of items.slice(0, MAX_IMAGES)) {
+    if (item.kind === 'saved') {
+      order.push(item.path);
+    } else {
+      order.push(`__new__${newUris.length}`);
+      newUris.push(item.uri);
+    }
+  }
+
+  return { order, newUris };
+}
+
+/**
+ * Whether the picker differs from what is stored, so a caller can skip an
+ * upload round-trip when nothing changed. Order matters: promoting an image to
+ * index 0 changes the thumbnail without adding or removing anything.
+ */
+export function pickerImagesDiffer(
+  items: PickerImage[],
+  stored: string[] | null | undefined,
+): boolean {
+  if (items.some((item) => item.kind === 'new')) return true;
+
+  const current = items.flatMap((item) =>
+    item.kind === 'saved' ? [item.path] : [],
+  );
+  const previous = toSavedImages(stored).map((item) => item.path);
+
+  if (current.length !== previous.length) return true;
+  return current.some((path, index) => path !== previous[index]);
+}
+
+/** Moves an image to index 0, making it the thumbnail. Order is otherwise kept. */
+export function setAsMain(
+  items: PickerImage[],
+  index: number,
+): PickerImage[] {
+  if (index <= 0 || index >= items.length) return items;
+  const next = [...items];
+  const [promoted] = next.splice(index, 1);
+  next.unshift(promoted);
+  return next;
+}
+
+/** Removes the image at `index`. */
+export function removeImageAt(
+  items: PickerImage[],
+  index: number,
+): PickerImage[] {
+  if (index < 0 || index >= items.length) return items;
+  return items.filter((_, i) => i !== index);
+}
+
+/** Identity for React list keys. */
+export function pickerImageKey(item: PickerImage): string {
+  return item.kind === 'saved' ? `saved:${item.path}` : item.id;
+}

--- a/SparkyFitnessServer/db/migrations/20260814000000_backfill_diary_entry_images_from_parent.sql
+++ b/SparkyFitnessServer/db/migrations/20260814000000_backfill_diary_entry_images_from_parent.sql
@@ -1,0 +1,39 @@
+-- Freezes diary entry photos, so editing a food or meal no longer changes what
+-- past entries display.
+--
+-- Until now food_entries.images / food_entry_meals.images held only a per-entry
+-- OVERRIDE, and were empty for an ordinary log. The diary therefore fell back
+-- to the parent's images and rendered them live — so replacing a food's photo
+-- silently changed every past entry of that food. Nutrition never behaved that
+-- way: it is snapshotted onto the entry at log time and only changes when the
+-- user explicitly syncs. This aligns photos with that model.
+--
+-- From here on the application writes the parent's images onto the entry when
+-- it is logged (see models/foodEntry.ts) and updates them on an explicit sync
+-- (see services/foodCoreService.ts). This migration backfills rows that
+-- pre-date that behaviour.
+--
+-- LIMITATION, deliberately accepted: the photo an entry was logged with is not
+-- recoverable — it was never stored. Backfilling necessarily stamps the
+-- parent's CURRENT image onto old entries. This freezes history from today
+-- forward; it does not restore it.
+--
+-- Only rows holding an empty array are touched, so a real user-set override is
+-- always preserved.
+
+UPDATE food_entries fe
+SET images = f.images
+FROM foods f
+WHERE fe.food_id = f.id
+  AND fe.images = '[]'::jsonb
+  AND jsonb_array_length(f.images) > 0;
+
+-- Logged meals inherit from the meal template. meal_template_id is nullable
+-- (ad-hoc logged meals have no template); those rows keep an empty array and
+-- render exactly as they do today.
+UPDATE food_entry_meals fem
+SET images = m.images
+FROM meals m
+WHERE fem.meal_template_id = m.id
+  AND fem.images = '[]'::jsonb
+  AND jsonb_array_length(m.images) > 0;

--- a/SparkyFitnessServer/middleware/imageUpload.ts
+++ b/SparkyFitnessServer/middleware/imageUpload.ts
@@ -6,6 +6,7 @@ import { promises as fsp } from 'fs';
 import { randomUUID } from 'crypto';
 import { fileURLToPath } from 'url';
 import { log } from '../config/logging.js';
+import { getSystemClient } from '../db/poolManager.js';
 import type { ImageDomain } from '../utils/imageDownloader.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -357,6 +358,43 @@ async function cleanupStagedImages(req: unknown): Promise<void> {
  * Deletes local upload files that are present in `previous` but not in `next`.
  * Remote URLs and paths outside the uploads root are ignored.
  */
+/**
+ * True when a diary row still displays this image path.
+ *
+ * Diary entries snapshot their parent's photo at log time, so a path dropped
+ * from a food can still be the picture a past meal shows. Deleting the file
+ * would leave that history rendering a broken image, so the file outlives the
+ * food's own reference to it.
+ */
+async function isImageReferencedByDiary(image: string): Promise<boolean> {
+  const client = await getSystemClient();
+  try {
+    const result = await client.query(
+      `SELECT 1
+         FROM food_entries
+        WHERE images @> $1::jsonb
+        UNION ALL
+       SELECT 1
+         FROM food_entry_meals
+        WHERE images @> $1::jsonb
+        LIMIT 1`,
+      [JSON.stringify([image])]
+    );
+    return result.rows.length > 0;
+  } catch (error) {
+    // A failed check must not delete the file: losing a photo referenced by
+    // history is worse than leaving an unreferenced one on disk.
+    log(
+      'warn',
+      'Could not check diary references for image; keeping it',
+      error
+    );
+    return true;
+  } finally {
+    client.release();
+  }
+}
+
 async function removeOrphanedImages(
   previous: unknown,
   next: unknown
@@ -370,6 +408,9 @@ async function removeOrphanedImages(
     }
     if (!image.startsWith('/uploads/')) {
       continue; // remote URL, nothing local to delete
+    }
+    if (await isImageReferencedByDiary(image)) {
+      continue;
     }
     const absolute = path.resolve(
       baseUploadsDir,

--- a/SparkyFitnessServer/models/foodEntry.ts
+++ b/SparkyFitnessServer/models/foodEntry.ts
@@ -144,7 +144,7 @@ async function createFoodEntry(
     if (entryData.food_id) {
       // This is an individual food entry
       const foodSnapshotQuery = await client.query(
-        `SELECT f.name, f.brand, fv.*
+        `SELECT f.name, f.brand, f.images AS food_images, fv.*
          FROM foods f
          JOIN food_variants fv ON f.id = fv.food_id
          WHERE f.id = $1 AND fv.id = $2`,
@@ -325,7 +325,12 @@ async function createFoodEntry(
         entryData.source ?? null,
         entryData.source_id ?? null,
         entryData.entry_time ?? null,
-        JSON.stringify(toImageArray(entryData.images)),
+        // Photos are snapshotted like nutrition: the entry keeps what the food
+        // looked like when it was logged, so editing the food later does not
+        // rewrite history. An explicit client value still wins (that is the
+        // per-entry photo the user chose), and meal-component entries have no
+        // parent food row to read from, so they fall back to an empty array.
+        JSON.stringify(toImageArray(entryData.images ?? snapshot.food_images)),
       ]
     );
     await client.query('COMMIT');

--- a/SparkyFitnessServer/models/foodEntryMealRepository.ts
+++ b/SparkyFitnessServer/models/foodEntryMealRepository.ts
@@ -47,12 +47,22 @@ async function createFoodEntryMeal(
         throw new Error(`Invalid meal type: ${foodEntryMealData.meal_type}`);
       }
     }
+    // Snapshot the template's photo onto the logged meal, mirroring how the
+    // nutrition of its components is snapshotted: editing the template later
+    // must not rewrite what past entries show. Ad-hoc logged meals have no
+    // template and simply keep an empty array.
     const result = await client.query(
       `INSERT INTO food_entry_meals (
                 user_id, meal_template_id, meal_type_id, entry_date, entry_time, name, description,
                 quantity, unit, legacy_serving_unit_math,
-                created_by_user_id, updated_by_user_id
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                created_by_user_id, updated_by_user_id, images
+            ) VALUES (
+              $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+              COALESCE(
+                (SELECT m.images FROM meals m WHERE m.id = $2),
+                '[]'::jsonb
+              )
+            )
             RETURNING *`,
       [
         foodEntryMealData.user_id,

--- a/SparkyFitnessServer/models/foodMisc.ts
+++ b/SparkyFitnessServer/models/foodMisc.ts
@@ -394,7 +394,21 @@ async function updateFoodEntriesSnapshot(
           calcium = $20,
           iron = $21,
           glycemic_index = $22,
-          custom_nutrients = $23
+          custom_nutrients = $23,
+          -- Refresh the inherited photo, but never a photo the user chose for
+          -- this specific entry. The two are told apart by their upload
+          -- directory: finalizeUploadedImages writes
+          -- /uploads/<domain>/<entityId>/<file>, so a diary-set photo always
+          -- lives under /uploads/food_entries/ while an inherited one points
+          -- at the food's own /uploads/foods/ path (or a remote provider URL).
+          images = CASE
+            WHEN NOT EXISTS (
+              SELECT 1
+                FROM jsonb_array_elements_text(food_entries.images) AS img
+               WHERE img LIKE '/uploads/food_entries/%'
+            ) THEN $27::jsonb
+            ELSE food_entries.images
+          END
        WHERE user_id = $24 AND food_id = $25 AND variant_id = $26
        RETURNING id`,
       [
@@ -424,6 +438,7 @@ async function updateFoodEntriesSnapshot(
         userId,
         foodId,
         variantId,
+        JSON.stringify(newSnapshotData.images ?? []),
       ]
     );
     return result.rowCount;

--- a/SparkyFitnessServer/models/foodMisc.ts
+++ b/SparkyFitnessServer/models/foodMisc.ts
@@ -383,24 +383,37 @@ async function updateFoodEntriesSnapshot(
 ): Promise<{ rowCount: number; replacedEntryImages: string[] }> {
   const client = await getClient(userId); // User-specific operation
   try {
-    // Collected before the UPDATE overwrites them. Scoped to the same rows the
-    // UPDATE touches, and to diary-set paths only — an inherited path points at
-    // the food's own upload directory and must never be unlinked from here.
+    // The read and the overwrite share one transaction, and the read takes row
+    // locks. Without them a diary photo saved between the two statements would
+    // be overwritten by the UPDATE while going unreported here, leaking its
+    // file: nothing would ever reference it again, and nothing would delete it.
+    await client.query('BEGIN');
+
+    // Scoped to the same rows the UPDATE touches, and to diary-set paths only —
+    // an inherited path points at the food's own upload directory and must
+    // never be unlinked from here.
     let replacedEntryImages: string[] = [];
     if (syncImages) {
+      // The whole column, not the unnested paths: FOR UPDATE cannot be applied
+      // to a set-returning function or a DISTINCT query, so the rows are locked
+      // as they are and filtered below.
       const existing = await client.query(
-        `SELECT DISTINCT img
-           FROM food_entries,
-                jsonb_array_elements_text(food_entries.images) AS img
+        `SELECT images
+           FROM food_entries
           WHERE user_id = $1
             AND food_id = $2
             AND variant_id = $3
-            AND img LIKE '/uploads/food_entries/%'`,
+            FOR UPDATE`,
         [userId, foodId, variantId]
       );
-      replacedEntryImages = (existing.rows as { img: string }[]).map((row) =>
-        String(row.img)
-      );
+      const seen = new Set<string>();
+      for (const row of existing.rows as { images: unknown }[]) {
+        for (const image of Array.isArray(row.images) ? row.images : []) {
+          const path = String(image);
+          if (path.startsWith('/uploads/food_entries/')) seen.add(path);
+        }
+      }
+      replacedEntryImages = [...seen];
     }
 
     const result = await client.query(
@@ -466,6 +479,10 @@ async function updateFoodEntriesSnapshot(
         ...(syncImages ? [JSON.stringify(newSnapshotData.images ?? [])] : []),
       ]
     );
+    // Committed before the caller unlinks anything: a file deleted for a
+    // transaction that then rolled back would be gone with its row intact.
+    await client.query('COMMIT');
+
     return {
       rowCount: result.rowCount ?? 0,
       // Only report photos that actually stopped being referenced.
@@ -473,6 +490,11 @@ async function updateFoodEntriesSnapshot(
         (image) => !(newSnapshotData.images ?? []).includes(image)
       ),
     };
+  } catch (error) {
+    // Best-effort: the connection may already be unusable, and the original
+    // error is the one worth surfacing.
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
   } finally {
     client.release();
   }

--- a/SparkyFitnessServer/models/foodMisc.ts
+++ b/SparkyFitnessServer/models/foodMisc.ts
@@ -361,14 +361,48 @@ async function getFoodsNeedingReview(userId: string) {
     client.release();
   }
 }
+/**
+ * Rewrites the snapshot past diary entries were logged with.
+ *
+ * `syncImages` decides what happens to the photo column:
+ *  - `false` - `images` is left out of the UPDATE entirely, so every entry
+ *    keeps whatever photo it is showing today (inherited or diary-set).
+ *  - `true` - every matching entry is forced onto the food's current photos,
+ *    including entries where the user picked their own photo in the diary.
+ *
+ * The diary-set photos that get replaced are returned so the caller can unlink
+ * their files: nothing else references `/uploads/food_entries/<entryId>/...`,
+ * so they would otherwise sit on disk forever.
+ */
 async function updateFoodEntriesSnapshot(
   userId: string,
   foodId: string,
   variantId: string,
-  newSnapshotData: FoodEntrySnapshot
-) {
+  newSnapshotData: FoodEntrySnapshot,
+  syncImages: boolean = true
+): Promise<{ rowCount: number; replacedEntryImages: string[] }> {
   const client = await getClient(userId); // User-specific operation
   try {
+    // Collected before the UPDATE overwrites them. Scoped to the same rows the
+    // UPDATE touches, and to diary-set paths only — an inherited path points at
+    // the food's own upload directory and must never be unlinked from here.
+    let replacedEntryImages: string[] = [];
+    if (syncImages) {
+      const existing = await client.query(
+        `SELECT DISTINCT img
+           FROM food_entries,
+                jsonb_array_elements_text(food_entries.images) AS img
+          WHERE user_id = $1
+            AND food_id = $2
+            AND variant_id = $3
+            AND img LIKE '/uploads/food_entries/%'`,
+        [userId, foodId, variantId]
+      );
+      replacedEntryImages = (existing.rows as { img: string }[]).map((row) =>
+        String(row.img)
+      );
+    }
+
     const result = await client.query(
       `UPDATE food_entries
        SET
@@ -394,21 +428,10 @@ async function updateFoodEntriesSnapshot(
           calcium = $20,
           iron = $21,
           glycemic_index = $22,
-          custom_nutrients = $23,
-          -- Refresh the inherited photo, but never a photo the user chose for
-          -- this specific entry. The two are told apart by their upload
-          -- directory: finalizeUploadedImages writes
-          -- /uploads/<domain>/<entityId>/<file>, so a diary-set photo always
-          -- lives under /uploads/food_entries/ while an inherited one points
-          -- at the food's own /uploads/foods/ path (or a remote provider URL).
-          images = CASE
-            WHEN NOT EXISTS (
-              SELECT 1
-                FROM jsonb_array_elements_text(food_entries.images) AS img
-               WHERE img LIKE '/uploads/food_entries/%'
-            ) THEN $27::jsonb
-            ELSE food_entries.images
-          END
+          custom_nutrients = $23
+          -- The user picked "nutrition only", so the photo column is left out
+          -- of the statement and every entry keeps the photo it shows today.
+          ${syncImages ? ', images = $27::jsonb' : ''}
        WHERE user_id = $24 AND food_id = $25 AND variant_id = $26
        RETURNING id`,
       [
@@ -438,10 +461,18 @@ async function updateFoodEntriesSnapshot(
         userId,
         foodId,
         variantId,
-        JSON.stringify(newSnapshotData.images ?? []),
+        // Postgres rejects a bind with more parameters than the statement
+        // references, so $27 is only supplied when the SET clause uses it.
+        ...(syncImages ? [JSON.stringify(newSnapshotData.images ?? [])] : []),
       ]
     );
-    return result.rowCount;
+    return {
+      rowCount: result.rowCount ?? 0,
+      // Only report photos that actually stopped being referenced.
+      replacedEntryImages: replacedEntryImages.filter(
+        (image) => !(newSnapshotData.images ?? []).includes(image)
+      ),
+    };
   } finally {
     client.release();
   }

--- a/SparkyFitnessServer/routes/foodCrudRoutes.ts
+++ b/SparkyFitnessServer/routes/foodCrudRoutes.ts
@@ -1240,6 +1240,15 @@ router.get('/needs-review', authenticate, async (req, res, next) => {
  *               variantId:
  *                 type: string
  *                 format: uuid
+ *               syncImages:
+ *                 type: boolean
+ *                 default: true
+ *                 description: >
+ *                   When true (the default), past entries are forced onto the
+ *                   food's current photos, replacing photos the user set on
+ *                   individual diary entries; the replaced files are unlinked.
+ *                   When false, nutrition is rewritten and every entry keeps
+ *                   the photo it is showing.
  *     responses:
  *       200:
  *         description: The result of the snapshot update.
@@ -1247,7 +1256,7 @@ router.get('/needs-review', authenticate, async (req, res, next) => {
  *         description: foodId is required.
  */
 router.post('/update-snapshot', authenticate, async (req, res, next) => {
-  const { foodId, variantId } = req.body;
+  const { foodId, variantId, syncImages } = req.body;
   if (!foodId) {
     return res.status(400).json({ error: 'foodId is required.' });
   }
@@ -1255,7 +1264,10 @@ router.post('/update-snapshot', authenticate, async (req, res, next) => {
     const result = await foodService.updateFoodEntriesSnapshot(
       req.userId,
       foodId,
-      variantId
+      variantId,
+      // Defaults to true so a client that predates this flag keeps syncing
+      // photos, which is what it has always done.
+      syncImages !== false
     );
     res.status(200).json(result);
   } catch (error) {

--- a/SparkyFitnessServer/routes/foodCrudRoutes.ts
+++ b/SparkyFitnessServer/routes/foodCrudRoutes.ts
@@ -1260,6 +1260,12 @@ router.post('/update-snapshot', authenticate, async (req, res, next) => {
   if (!foodId) {
     return res.status(400).json({ error: 'foodId is required.' });
   }
+  // Rejected rather than coerced: every non-empty string is truthy, so a
+  // stringly-typed `"false"` would silently select the path that overwrites
+  // and deletes diary-specific photos.
+  if (syncImages !== undefined && typeof syncImages !== 'boolean') {
+    return res.status(400).json({ error: 'syncImages must be a boolean.' });
+  }
   try {
     const result = await foodService.updateFoodEntriesSnapshot(
       req.userId,
@@ -1267,7 +1273,7 @@ router.post('/update-snapshot', authenticate, async (req, res, next) => {
       variantId,
       // Defaults to true so a client that predates this flag keeps syncing
       // photos, which is what it has always done.
-      syncImages !== false
+      syncImages ?? true
     );
     res.status(200).json(result);
   } catch (error) {

--- a/SparkyFitnessServer/services/foodCoreService.ts
+++ b/SparkyFitnessServer/services/foodCoreService.ts
@@ -781,7 +781,8 @@ async function getFoodsNeedingReview(authenticatedUserId: string) {
 async function updateSnapshotForVariant(
   authenticatedUserId: string,
   food: FoodInput,
-  variant: FoodVariantInput
+  variant: FoodVariantInput,
+  syncImages: boolean
 ) {
   const newSnapshotData = {
     food_name: food.name,
@@ -811,21 +812,42 @@ async function updateSnapshotForVariant(
     glycemic_index: variant.glycemic_index,
     custom_nutrients: sanitizeCustomNutrients(variant.custom_nutrients),
   };
-  await foodRepository.updateFoodEntriesSnapshot(
-    authenticatedUserId,
-    String(food.id),
-    String(variant.id),
-    newSnapshotData
-  );
+  const { replacedEntryImages } =
+    await foodRepository.updateFoodEntriesSnapshot(
+      authenticatedUserId,
+      String(food.id),
+      String(variant.id),
+      newSnapshotData,
+      syncImages
+    );
+  // Diary-set photos the sync just overwrote are now referenced by nothing.
+  // removeOrphanedImages re-checks each path against the diary before
+  // unlinking, so a copy still in use elsewhere is left alone.
+  if (replacedEntryImages.length > 0) {
+    await removeOrphanedImages(replacedEntryImages, []).catch((error) => {
+      log(
+        'error',
+        `Error removing replaced diary entry images for food ${food.id}:`,
+        error
+      );
+    });
+  }
   await foodRepository.clearUserIgnoredUpdate(
     authenticatedUserId,
     String(variant.id)
   );
 }
+/**
+ * `syncImages` distinguishes the two "update past entries" choices: `true`
+ * forces the food's current photos onto every matching entry (replacing photos
+ * the user set on individual diary entries), `false` rewrites nutrition only
+ * and leaves every entry's photo exactly as it is.
+ */
 async function updateFoodEntriesSnapshot(
   authenticatedUserId: string,
   foodId: string,
-  variantId: string
+  variantId: string,
+  syncImages: boolean = true
 ) {
   try {
     const food = await foodRepository.getFoodById(foodId, authenticatedUserId);
@@ -841,7 +863,12 @@ async function updateFoodEntriesSnapshot(
       if (!variant) {
         throw new Error('Food variant not found.');
       }
-      await updateSnapshotForVariant(authenticatedUserId, food, variant);
+      await updateSnapshotForVariant(
+        authenticatedUserId,
+        food,
+        variant,
+        syncImages
+      );
     } else {
       // All variants path
       const variants = await foodRepository.getFoodVariantsByFoodId(
@@ -849,7 +876,12 @@ async function updateFoodEntriesSnapshot(
         authenticatedUserId
       );
       for (const variant of variants) {
-        await updateSnapshotForVariant(authenticatedUserId, food, variant);
+        await updateSnapshotForVariant(
+          authenticatedUserId,
+          food,
+          variant,
+          syncImages
+        );
       }
     }
     return { message: 'Food entries updated successfully.' };

--- a/SparkyFitnessServer/services/foodCoreService.ts
+++ b/SparkyFitnessServer/services/foodCoreService.ts
@@ -786,6 +786,9 @@ async function updateSnapshotForVariant(
   const newSnapshotData = {
     food_name: food.name,
     brand_name: food.brand,
+    // Photos are snapshotted onto entries at log time, so an explicit sync is
+    // the only thing that refreshes them — same rule as the nutrition fields.
+    images: toImageArray(food.images),
     serving_size: variant.serving_size,
     serving_unit: variant.serving_unit,
     calories: variant.calories,

--- a/SparkyFitnessServer/tests/foodCoreService.updateSnapshot.test.ts
+++ b/SparkyFitnessServer/tests/foodCoreService.updateSnapshot.test.ts
@@ -1,8 +1,13 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
 import foodRepository from '../models/foodRepository.js';
 import foodCoreService from '../services/foodCoreService.js';
+import { removeOrphanedImages } from '../middleware/imageUpload.js';
 vi.mock('../models/foodRepository');
 vi.mock('../config/logging', () => ({ log: vi.fn() }));
+vi.mock('../middleware/imageUpload', () => ({
+  removeOrphanedImages: vi.fn().mockResolvedValue(undefined),
+  removeEntityImageDir: vi.fn().mockResolvedValue(undefined),
+}));
 const TEST_USER_ID = 'user-123';
 const FOOD_ID = 'food-456';
 const VARIANT_ID = 'variant-789';
@@ -51,7 +56,10 @@ describe('foodCoreService.updateFoodEntriesSnapshot', () => {
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     foodRepository.getFoodVariantById.mockResolvedValue(makeVariant());
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue(2);
+    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue({
+      rowCount: 2,
+      replacedEntryImages: [],
+    });
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     foodRepository.clearUserIgnoredUpdate.mockResolvedValue();
     const result = await foodCoreService.updateFoodEntriesSnapshot(
@@ -82,7 +90,10 @@ describe('foodCoreService.updateFoodEntriesSnapshot', () => {
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     foodRepository.getFoodVariantById.mockResolvedValue(variant);
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue(1);
+    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue({
+      rowCount: 1,
+      replacedEntryImages: [],
+    });
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     foodRepository.clearUserIgnoredUpdate.mockResolvedValue();
     await foodCoreService.updateFoodEntriesSnapshot(
@@ -100,8 +111,8 @@ describe('foodCoreService.updateFoodEntriesSnapshot', () => {
       {
         food_name: food.name,
         brand_name: food.brand,
-        // Photos ride along with the nutrition snapshot; the SQL applies them
-        // only to entries still showing an inherited photo.
+        // Photos ride along with the nutrition snapshot; the trailing
+        // syncImages flag decides whether the SQL applies them.
         images: [],
         serving_size: variant.serving_size,
         serving_unit: variant.serving_unit,
@@ -124,7 +135,9 @@ describe('foodCoreService.updateFoodEntriesSnapshot', () => {
         iron: variant.iron,
         glycemic_index: variant.glycemic_index,
         custom_nutrients: { zinc: '1.3mg' },
-      }
+      },
+      // Defaults to syncing photos, matching the route default.
+      true
     );
   });
   it('should sanitize custom_nutrients by stripping empty and null values', async () => {
@@ -136,7 +149,10 @@ describe('foodCoreService.updateFoodEntriesSnapshot', () => {
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     foodRepository.getFoodVariantById.mockResolvedValue(variant);
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue(1);
+    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue({
+      rowCount: 1,
+      replacedEntryImages: [],
+    });
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     foodRepository.clearUserIgnoredUpdate.mockResolvedValue();
     await foodCoreService.updateFoodEntriesSnapshot(
@@ -148,6 +164,84 @@ describe('foodCoreService.updateFoodEntriesSnapshot', () => {
       // @ts-expect-error TS(2339): Property 'mock' does not exist on type '(userId: a... Remove this comment to see the full error message
       foodRepository.updateFoodEntriesSnapshot.mock.calls[0][3];
     expect(snapshotArg.custom_nutrients).toEqual({ zinc: '1.3mg', ok: '5mg' });
+  });
+  it('forwards the syncImages choice to the repository', async () => {
+    // 'Update nutrition only' must reach the repository as false, or the
+    // sync would silently overwrite photos the user chose to keep.
+    for (const syncImages of [true, false]) {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      foodRepository.getFoodById.mockResolvedValue(makeFood());
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      foodRepository.getFoodVariantById.mockResolvedValue(makeVariant());
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      foodRepository.updateFoodEntriesSnapshot.mockResolvedValue({
+        rowCount: 1,
+        replacedEntryImages: [],
+      });
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      foodRepository.clearUserIgnoredUpdate.mockResolvedValue();
+
+      await foodCoreService.updateFoodEntriesSnapshot(
+        TEST_USER_ID,
+        FOOD_ID,
+        VARIANT_ID,
+        syncImages
+      );
+
+      // @ts-expect-error TS(2339): Property 'mock' does not exist on type '(userId: a... Remove this comment to see the full error message
+      const call = foodRepository.updateFoodEntriesSnapshot.mock.calls[0];
+      expect(call[4]).toBe(syncImages);
+      vi.clearAllMocks();
+    }
+  });
+  it('unlinks the diary photos the sync replaced', async () => {
+    // Nothing else references /uploads/food_entries/<entryId>/..., so leaving
+    // them behind would leak a file per overwritten entry.
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodById.mockResolvedValue(makeFood());
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodVariantById.mockResolvedValue(makeVariant());
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue({
+      rowCount: 1,
+      replacedEntryImages: ['/uploads/food_entries/e1/custom.jpg'],
+    });
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.clearUserIgnoredUpdate.mockResolvedValue();
+
+    await foodCoreService.updateFoodEntriesSnapshot(
+      TEST_USER_ID,
+      FOOD_ID,
+      VARIANT_ID,
+      true
+    );
+
+    expect(removeOrphanedImages).toHaveBeenCalledWith(
+      ['/uploads/food_entries/e1/custom.jpg'],
+      []
+    );
+  });
+  it('does not unlink anything when nothing was replaced', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodById.mockResolvedValue(makeFood());
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.getFoodVariantById.mockResolvedValue(makeVariant());
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue({
+      rowCount: 1,
+      replacedEntryImages: [],
+    });
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodRepository.clearUserIgnoredUpdate.mockResolvedValue();
+
+    await foodCoreService.updateFoodEntriesSnapshot(
+      TEST_USER_ID,
+      FOOD_ID,
+      VARIANT_ID,
+      false
+    );
+
+    expect(removeOrphanedImages).not.toHaveBeenCalled();
   });
   it('should throw "Food not found." when food is null', async () => {
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
@@ -208,7 +302,7 @@ describe('foodCoreService.updateFoodEntriesSnapshot', () => {
     // @ts-expect-error TS(2339): Property 'mockImplementation' does not exist on ty... Remove this comment to see the full error message
     foodRepository.updateFoodEntriesSnapshot.mockImplementation(() => {
       callOrder.push('updateFoodEntriesSnapshot');
-      return Promise.resolve(1);
+      return Promise.resolve({ rowCount: 1, replacedEntryImages: [] });
     });
     // @ts-expect-error TS(2339): Property 'mockImplementation' does not exist on ty... Remove this comment to see the full error message
     foodRepository.clearUserIgnoredUpdate.mockImplementation(() => {
@@ -237,7 +331,10 @@ describe('foodCoreService.updateFoodEntriesSnapshot', () => {
       variantB,
     ]);
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue(1);
+    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue({
+      rowCount: 1,
+      replacedEntryImages: [],
+    });
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     foodRepository.clearUserIgnoredUpdate.mockResolvedValue();
     // @ts-expect-error TS(2554): Expected 3 arguments, but got 2.
@@ -274,7 +371,10 @@ describe('foodCoreService.updateFoodEntriesSnapshot', () => {
       variantB,
     ]);
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue(1);
+    foodRepository.updateFoodEntriesSnapshot.mockResolvedValue({
+      rowCount: 1,
+      replacedEntryImages: [],
+    });
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     foodRepository.clearUserIgnoredUpdate.mockResolvedValue();
     // @ts-expect-error TS(2554): Expected 3 arguments, but got 2.

--- a/SparkyFitnessServer/tests/foodCoreService.updateSnapshot.test.ts
+++ b/SparkyFitnessServer/tests/foodCoreService.updateSnapshot.test.ts
@@ -100,6 +100,9 @@ describe('foodCoreService.updateFoodEntriesSnapshot', () => {
       {
         food_name: food.name,
         brand_name: food.brand,
+        // Photos ride along with the nutrition snapshot; the SQL applies them
+        // only to entries still showing an inherited photo.
+        images: [],
         serving_size: variant.serving_size,
         serving_unit: variant.serving_unit,
         calories: variant.calories,

--- a/SparkyFitnessServer/tests/foodEntrySnapshot.test.ts
+++ b/SparkyFitnessServer/tests/foodEntrySnapshot.test.ts
@@ -50,88 +50,158 @@ describe('foodRepository snapshot functions', () => {
       custom_nutrients: { zinc: '1.3mg' },
       ...overrides,
     });
-    it('should execute UPDATE with all 26 params in correct order and return rowCount', async () => {
+    // With syncImages on, the repository first SELECTs the diary-set photos it
+    // is about to overwrite so the caller can unlink them, then runs the
+    // UPDATE. These helpers keep the two calls straight.
+    const mockSelectThenUpdate = (rowCount = 1, replaced: string[] = []) => {
+      mockClient.query
+        .mockResolvedValueOnce({ rows: replaced.map((img) => ({ img })) })
+        .mockResolvedValueOnce({ rowCount });
+    };
+    const updateCall = () => mockClient.query.mock.calls[1];
+
+    it('should execute UPDATE with all 27 params in correct order and return rowCount', async () => {
       const snapshot = makeSnapshotData();
-      mockClient.query.mockResolvedValue({ rowCount: 3 });
+      mockSelectThenUpdate(3);
       const result = await foodRepository.updateFoodEntriesSnapshot(
         userId,
         foodId,
         variantId,
         snapshot
       );
-      expect(result).toBe(3);
-      expect(mockClient.query).toHaveBeenCalledWith(
-        expect.stringContaining('UPDATE food_entries'),
-        [
-          snapshot.food_name,
-          snapshot.brand_name,
-          snapshot.serving_size,
-          snapshot.serving_unit,
-          snapshot.calories,
-          snapshot.protein,
-          snapshot.carbs,
-          snapshot.fat,
-          snapshot.saturated_fat,
-          snapshot.polyunsaturated_fat,
-          snapshot.monounsaturated_fat,
-          snapshot.trans_fat,
-          snapshot.cholesterol,
-          snapshot.sodium,
-          snapshot.potassium,
-          snapshot.dietary_fiber,
-          snapshot.sugars,
-          snapshot.vitamin_a,
-          snapshot.vitamin_c,
-          snapshot.calcium,
-          snapshot.iron,
-          snapshot.glycemic_index,
-          snapshot.custom_nutrients,
-          userId,
-          foodId,
-          variantId,
-          // Images ride along as the 27th param; the SQL only applies them to
-          // entries still showing an inherited photo.
-          JSON.stringify([]),
-        ]
-      );
+      expect(result.rowCount).toBe(3);
+      expect(updateCall()[0]).toContain('UPDATE food_entries');
+      expect(updateCall()[1]).toEqual([
+        snapshot.food_name,
+        snapshot.brand_name,
+        snapshot.serving_size,
+        snapshot.serving_unit,
+        snapshot.calories,
+        snapshot.protein,
+        snapshot.carbs,
+        snapshot.fat,
+        snapshot.saturated_fat,
+        snapshot.polyunsaturated_fat,
+        snapshot.monounsaturated_fat,
+        snapshot.trans_fat,
+        snapshot.cholesterol,
+        snapshot.sodium,
+        snapshot.potassium,
+        snapshot.dietary_fiber,
+        snapshot.sugars,
+        snapshot.vitamin_a,
+        snapshot.vitamin_c,
+        snapshot.calcium,
+        snapshot.iron,
+        snapshot.glycemic_index,
+        snapshot.custom_nutrients,
+        userId,
+        foodId,
+        variantId,
+        // Images ride along as the 27th param whenever they are being synced.
+        JSON.stringify([]),
+      ]);
     });
 
-    it('refreshes an inherited photo but never a diary-set one', async () => {
-      // The two are told apart by upload directory rather than a flag: a photo
-      // set on the entry itself lives under /uploads/food_entries/, while an
-      // inherited one points at the food's /uploads/foods/ path.
-      mockClient.query.mockResolvedValue({ rowCount: 1 });
+    it('forces the new photo onto every entry when syncing images', async () => {
+      // The "update nutrition & photos" choice deliberately overwrites photos
+      // the user set on individual diary entries, so the statement must carry
+      // no guard exempting them.
+      mockSelectThenUpdate(1);
 
       await foodRepository.updateFoodEntriesSnapshot(
         userId,
         foodId,
         variantId,
-        makeSnapshotData({ images: ['/uploads/foods/f1/new.jpg'] })
+        makeSnapshotData({ images: ['/uploads/foods/f1/new.jpg'] }),
+        true
       );
 
-      const [sql, params] = mockClient.query.mock.calls[0];
-      expect(sql).toContain("img LIKE '/uploads/food_entries/%'");
-      expect(sql).toContain('NOT EXISTS');
+      const [sql, params] = updateCall();
+      expect(sql).toContain('images = $27::jsonb');
+      expect(sql).not.toContain('NOT EXISTS');
       expect(params[26]).toBe(JSON.stringify(['/uploads/foods/f1/new.jpg']));
+    });
+
+    it('returns the diary-set photos it replaced so they can be unlinked', async () => {
+      // Nothing else references /uploads/food_entries/<entryId>/..., so an
+      // unreported path would sit on disk forever.
+      mockSelectThenUpdate(2, [
+        '/uploads/food_entries/e1/custom.jpg',
+        '/uploads/food_entries/e2/custom.jpg',
+      ]);
+
+      const result = await foodRepository.updateFoodEntriesSnapshot(
+        userId,
+        foodId,
+        variantId,
+        makeSnapshotData({ images: ['/uploads/foods/f1/new.jpg'] }),
+        true
+      );
+
+      expect(result.replacedEntryImages).toEqual([
+        '/uploads/food_entries/e1/custom.jpg',
+        '/uploads/food_entries/e2/custom.jpg',
+      ]);
+      // Scoped to diary-set paths: an inherited path belongs to the food and
+      // must never be unlinked from here.
+      expect(mockClient.query.mock.calls[0][0]).toContain(
+        "img LIKE '/uploads/food_entries/%'"
+      );
+    });
+
+    it('never reports a replaced photo that survives in the new list', async () => {
+      mockSelectThenUpdate(1, ['/uploads/food_entries/e1/keep.jpg']);
+
+      const result = await foodRepository.updateFoodEntriesSnapshot(
+        userId,
+        foodId,
+        variantId,
+        makeSnapshotData({ images: ['/uploads/food_entries/e1/keep.jpg'] }),
+        true
+      );
+
+      expect(result.replacedEntryImages).toEqual([]);
+    });
+
+    it('leaves the photo column out entirely for a nutrition-only sync', async () => {
+      // Every entry keeps the photo it is showing, custom or inherited, so the
+      // statement must not bind a 27th parameter either — Postgres rejects a
+      // bind carrying more parameters than the statement references.
+      mockClient.query.mockResolvedValue({ rowCount: 1 });
+
+      const result = await foodRepository.updateFoodEntriesSnapshot(
+        userId,
+        foodId,
+        variantId,
+        makeSnapshotData({ images: ['/uploads/foods/f1/new.jpg'] }),
+        false
+      );
+
+      // No pre-SELECT either: nothing is being replaced.
+      expect(mockClient.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockClient.query.mock.calls[0];
+      expect(sql).not.toContain('images =');
+      expect(params).toHaveLength(26);
+      expect(result.replacedEntryImages).toEqual([]);
     });
 
     it('should default custom_nutrients to {} when null or undefined', async () => {
       for (const falsy of [null, undefined]) {
-        mockClient.query.mockResolvedValue({ rowCount: 1 });
+        mockSelectThenUpdate(1);
         await foodRepository.updateFoodEntriesSnapshot(
           userId,
           foodId,
           variantId,
           makeSnapshotData({ custom_nutrients: falsy })
         );
-        const params = mockClient.query.mock.calls[0][1];
         // custom_nutrients is param index 22 (0-based)
-        expect(params[22]).toEqual({});
+        expect(updateCall()[1][22]).toEqual({});
         mockClient.query.mockClear();
       }
     });
     it('should always release client on success', async () => {
-      mockClient.query.mockResolvedValue({ rowCount: 0 });
+      mockSelectThenUpdate(0);
       await foodRepository.updateFoodEntriesSnapshot(
         userId,
         foodId,

--- a/SparkyFitnessServer/tests/foodEntrySnapshot.test.ts
+++ b/SparkyFitnessServer/tests/foodEntrySnapshot.test.ts
@@ -50,15 +50,26 @@ describe('foodRepository snapshot functions', () => {
       custom_nutrients: { zinc: '1.3mg' },
       ...overrides,
     });
-    // With syncImages on, the repository first SELECTs the diary-set photos it
-    // is about to overwrite so the caller can unlink them, then runs the
-    // UPDATE. These helpers keep the two calls straight.
-    const mockSelectThenUpdate = (rowCount = 1, replaced: string[] = []) => {
+    // With syncImages on the repository runs four statements: BEGIN, a locking
+    // SELECT of the photos it is about to overwrite, the UPDATE, then COMMIT.
+    // These helpers keep them straight.
+    const mockSelectThenUpdate = (
+      rowCount = 1,
+      entryImages: string[][] = []
+    ) => {
       mockClient.query
-        .mockResolvedValueOnce({ rows: replaced.map((img) => ({ img })) })
-        .mockResolvedValueOnce({ rowCount });
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({
+          rows: entryImages.map((images) => ({ images })),
+        })
+        .mockResolvedValueOnce({ rowCount })
+        .mockResolvedValueOnce({}); // COMMIT
     };
-    const updateCall = () => mockClient.query.mock.calls[1];
+    const sqlCalls = () =>
+      mockClient.query.mock.calls.filter(
+        ([sql]: [string]) => !['BEGIN', 'COMMIT', 'ROLLBACK'].includes(sql)
+      );
+    const updateCall = () => sqlCalls()[1];
 
     it('should execute UPDATE with all 27 params in correct order and return rowCount', async () => {
       const snapshot = makeSnapshotData();
@@ -123,12 +134,55 @@ describe('foodRepository snapshot functions', () => {
       expect(params[26]).toBe(JSON.stringify(['/uploads/foods/f1/new.jpg']));
     });
 
+    it('reads and overwrites in one transaction, locking the rows', async () => {
+      // A diary photo saved between the read and the UPDATE would otherwise be
+      // overwritten without being reported, leaking its file forever.
+      mockSelectThenUpdate(1);
+
+      await foodRepository.updateFoodEntriesSnapshot(
+        userId,
+        foodId,
+        variantId,
+        makeSnapshotData({ images: ['/uploads/foods/f1/new.jpg'] }),
+        true
+      );
+
+      const statements = mockClient.query.mock.calls.map(([sql]: [string]) =>
+        sql.trim().split('\n')[0].trim()
+      );
+      expect(statements[0]).toBe('BEGIN');
+      expect(statements[statements.length - 1]).toBe('COMMIT');
+      expect(sqlCalls()[0][0]).toContain('FOR UPDATE');
+    });
+
+    it('rolls back and rethrows when the update fails', async () => {
+      mockClient.query
+        .mockResolvedValue({}) // ROLLBACK and anything after
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockResolvedValueOnce({ rows: [] })
+        .mockRejectedValueOnce(new Error('DB error'));
+
+      await expect(
+        foodRepository.updateFoodEntriesSnapshot(
+          userId,
+          foodId,
+          variantId,
+          makeSnapshotData(),
+          true
+        )
+      ).rejects.toThrow('DB error');
+
+      expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+      expect(mockClient.release).toHaveBeenCalledTimes(1);
+    });
+
     it('returns the diary-set photos it replaced so they can be unlinked', async () => {
       // Nothing else references /uploads/food_entries/<entryId>/..., so an
-      // unreported path would sit on disk forever.
+      // unreported path would sit on disk forever. Inherited paths belong to
+      // the food and must never be unlinked from here.
       mockSelectThenUpdate(2, [
-        '/uploads/food_entries/e1/custom.jpg',
-        '/uploads/food_entries/e2/custom.jpg',
+        ['/uploads/food_entries/e1/custom.jpg', '/uploads/foods/f1/old.jpg'],
+        ['/uploads/food_entries/e2/custom.jpg'],
       ]);
 
       const result = await foodRepository.updateFoodEntriesSnapshot(
@@ -143,15 +197,29 @@ describe('foodRepository snapshot functions', () => {
         '/uploads/food_entries/e1/custom.jpg',
         '/uploads/food_entries/e2/custom.jpg',
       ]);
-      // Scoped to diary-set paths: an inherited path belongs to the food and
-      // must never be unlinked from here.
-      expect(mockClient.query.mock.calls[0][0]).toContain(
-        "img LIKE '/uploads/food_entries/%'"
+    });
+
+    it('reports each replaced photo once even when entries share it', async () => {
+      mockSelectThenUpdate(2, [
+        ['/uploads/food_entries/e1/custom.jpg'],
+        ['/uploads/food_entries/e1/custom.jpg'],
+      ]);
+
+      const result = await foodRepository.updateFoodEntriesSnapshot(
+        userId,
+        foodId,
+        variantId,
+        makeSnapshotData({ images: [] }),
+        true
       );
+
+      expect(result.replacedEntryImages).toEqual([
+        '/uploads/food_entries/e1/custom.jpg',
+      ]);
     });
 
     it('never reports a replaced photo that survives in the new list', async () => {
-      mockSelectThenUpdate(1, ['/uploads/food_entries/e1/keep.jpg']);
+      mockSelectThenUpdate(1, [['/uploads/food_entries/e1/keep.jpg']]);
 
       const result = await foodRepository.updateFoodEntriesSnapshot(
         userId,
@@ -178,9 +246,10 @@ describe('foodRepository snapshot functions', () => {
         false
       );
 
-      // No pre-SELECT either: nothing is being replaced.
-      expect(mockClient.query).toHaveBeenCalledTimes(1);
-      const [sql, params] = mockClient.query.mock.calls[0];
+      // No pre-SELECT either: nothing is being replaced, so there is nothing
+      // to read or lock.
+      expect(sqlCalls()).toHaveLength(1);
+      const [sql, params] = sqlCalls()[0];
       expect(sql).not.toContain('images =');
       expect(params).toHaveLength(26);
       expect(result.replacedEntryImages).toEqual([]);

--- a/SparkyFitnessServer/tests/foodEntrySnapshot.test.ts
+++ b/SparkyFitnessServer/tests/foodEntrySnapshot.test.ts
@@ -89,9 +89,32 @@ describe('foodRepository snapshot functions', () => {
           userId,
           foodId,
           variantId,
+          // Images ride along as the 27th param; the SQL only applies them to
+          // entries still showing an inherited photo.
+          JSON.stringify([]),
         ]
       );
     });
+
+    it('refreshes an inherited photo but never a diary-set one', async () => {
+      // The two are told apart by upload directory rather than a flag: a photo
+      // set on the entry itself lives under /uploads/food_entries/, while an
+      // inherited one points at the food's /uploads/foods/ path.
+      mockClient.query.mockResolvedValue({ rowCount: 1 });
+
+      await foodRepository.updateFoodEntriesSnapshot(
+        userId,
+        foodId,
+        variantId,
+        makeSnapshotData({ images: ['/uploads/foods/f1/new.jpg'] })
+      );
+
+      const [sql, params] = mockClient.query.mock.calls[0];
+      expect(sql).toContain("img LIKE '/uploads/food_entries/%'");
+      expect(sql).toContain('NOT EXISTS');
+      expect(params[26]).toBe(JSON.stringify(['/uploads/foods/f1/new.jpg']));
+    });
+
     it('should default custom_nutrients to {} when null or undefined', async () => {
       for (const falsy of [null, undefined]) {
         mockClient.query.mockResolvedValue({ rowCount: 1 });

--- a/SparkyFitnessServer/tests/foodUpdateSnapshotRoute.test.ts
+++ b/SparkyFitnessServer/tests/foodUpdateSnapshotRoute.test.ts
@@ -1,0 +1,80 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import express from 'express';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supe... Remove this comment to see the full error message
+import request from 'supertest';
+import foodService from '../services/foodService.js';
+import foodCrudRoutes from '../routes/foodCrudRoutes.js';
+
+vi.mock('../middleware/authMiddleware.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = 'user-123';
+    req.authenticatedUserId = 'user-123';
+    next();
+  },
+}));
+vi.mock('../middleware/checkPermissionMiddleware.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  default: vi.fn(() => (_req: any, _res: any, next: any) => next()),
+}));
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+vi.mock('../services/foodService.js', () => ({
+  default: { updateFoodEntriesSnapshot: vi.fn() },
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/foods', foodCrudRoutes);
+
+describe('POST /foods/update-snapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    foodService.updateFoodEntriesSnapshot.mockResolvedValue({ message: 'ok' });
+  });
+
+  const syncImagesArg = () =>
+    // @ts-expect-error TS(2339): Property 'mock' does not exist on type '(userId: a... Remove this comment to see the full error message
+    foodService.updateFoodEntriesSnapshot.mock.calls[0][3];
+
+  it('requires foodId', async () => {
+    const res = await request(app).post('/foods/update-snapshot').send({});
+    expect(res.status).toBe(400);
+    expect(foodService.updateFoodEntriesSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('defaults to syncing photos when the flag is omitted', async () => {
+    // Clients predating the flag always synced photos; that must not change
+    // under them.
+    const res = await request(app)
+      .post('/foods/update-snapshot')
+      .send({ foodId: 'food-1' });
+
+    expect(res.status).toBe(200);
+    expect(syncImagesArg()).toBe(true);
+  });
+
+  it('passes an explicit false through for a nutrition-only sync', async () => {
+    const res = await request(app)
+      .post('/foods/update-snapshot')
+      .send({ foodId: 'food-1', syncImages: false });
+
+    expect(res.status).toBe(200);
+    expect(syncImagesArg()).toBe(false);
+  });
+
+  it.each([['false'], ['true'], [0], [1], [null]])(
+    'rejects a non-boolean syncImages (%p) instead of coercing it',
+    async (syncImages) => {
+      // Every non-empty string is truthy, so coercing "false" would silently
+      // pick the path that overwrites and deletes diary-specific photos.
+      const res = await request(app)
+        .post('/foods/update-snapshot')
+        .send({ foodId: 'food-1', syncImages });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('syncImages must be a boolean.');
+      expect(foodService.updateFoodEntriesSnapshot).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/SparkyFitnessServer/types/nutrition.ts
+++ b/SparkyFitnessServer/types/nutrition.ts
@@ -55,6 +55,11 @@ export interface FoodEntrySnapshot extends NutrientFields {
   serving_unit?: string | null;
   allergens?: string[] | null;
   traces?: string[] | null;
+  /**
+   * The parent food's photos, applied to entries that are still showing what
+   * they inherited at log time. Entries with their own diary-set photo keep it.
+   */
+  images?: string[] | null;
 }
 
 /** A serving option for a food, as stored in `food_variants`. */

--- a/docs/content/8.developer/12.food-provider-images.md
+++ b/docs/content/8.developer/12.food-provider-images.md
@@ -86,6 +86,51 @@ curl -s "https://api.nal.usda.gov/fdc/v1/foods/search?query=cheddar&pageSize=1&a
 
 For an OAuth provider, fetch a token first, then request one known food and grep the raw JSON for `image`. Testing a provider's **own documentation example food id** is the strongest check available: if their docs show images for that id and your call doesn't, the difference is account entitlement, not code.
 
+
+## Diary entries own their photo
+
+A diary entry does not display the food's photo live. It snapshots it, exactly
+as it snapshots nutrition:
+
+- `models/foodEntry.ts` copies the food's `images` onto `food_entries.images`
+  when the entry is logged, and `models/foodEntryMealRepository.ts` does the
+  same from the meal template.
+- Editing the food afterwards therefore does **not** change past entries.
+  `POST /foods/update-snapshot` is the only thing that refreshes them, and it is
+  opt-in — both clients ask "Update past entries?" after a save.
+- Migration `20260814000000_backfill_diary_entry_images_from_parent.sql`
+  backfilled rows logged before this behaviour existed. The photo an old entry
+  was *originally* logged with is unrecoverable — it was never stored — so the
+  backfill stamps the parent's current image. It freezes history going forward
+  rather than restoring it.
+
+### Telling an inherited photo from a diary-set one
+
+Both live in `food_entries.images`, so they are distinguished by upload
+directory rather than a flag. `finalizeUploadedImages` writes
+`/uploads/<domain>/<entityId>/<file>`, so:
+
+- `/uploads/foods/…` (or a remote provider URL) — inherited at log time. A sync
+  may refresh it.
+- `/uploads/food_entries/…` — the user chose this photo for this entry. A sync
+  must never touch it.
+
+`updateFoodEntriesSnapshot` in `models/foodMisc.ts` encodes exactly that with a
+`NOT EXISTS … LIKE '/uploads/food_entries/%'` guard. If upload paths are ever
+restructured, that guard has to move with them.
+
+### Deleting images that history still uses
+
+Because entries store the food's path rather than a copy of the file, dropping
+an image from a food would delete a file past entries still render.
+`removeOrphanedImages` checks `food_entries` / `food_entry_meals` for the path
+first and keeps the file when it is still referenced — and keeps it on any error
+too, since an unreferenced file on disk is cheaper than a broken thumbnail in
+someone's history.
+
+Food *deletion* was already safe: the food is either hard-deleted along with its
+entries, or hidden (`is_quick_food`) with its row and images intact.
+
 ## Gotchas
 
 - **Search a branded product, not a dish.** "chicken pasta" returns generic entries that have no photo on any provider. Use `nutella`, `oreo`, or a specific packaged item to actually exercise the image path. Absent images there mean the food has no photo upstream, not that something is broken.


### PR DESCRIPTION
Brings food and meal photos to mobile, and fixes both platforms silently rewriting history when a food's photo changed.

Mobile: thumbnails in search, both libraries, and the diary; camera and library capture with on-device downscaling; multi-image with "Set as main"; a full-screen viewer; and a per-entry photo override. Editing a food now prompts before touching past entries, matching web.

Server: entries snapshot the parent's photo at log time, the way they already snapshot nutrition, so only an explicit sync updates them. An inherited photo is told apart from a user-set one by its upload directory, and a file is kept while any entry still displays it. A migration backfills existing entries; the photo an old entry was originally logged with is unrecoverable, so this freezes history rather than restoring it.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #628

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)
<img width="417" height="888" alt="image" src="https://github.com/user-attachments/assets/7899c47c-49fb-46ca-9a86-de82dd5dc420" />
<img width="417" height="888" alt="image" src="https://github.com/user-attachments/assets/bc0d79cf-48f6-419f-ac9f-0070463d796f" />
<img width="417" height="888" alt="image" src="https://github.com/user-attachments/assets/dde94595-0e61-4d35-850e-65b785563433" />
<img width="417" height="888" alt="image" src="https://github.com/user-attachments/assets/7422d090-2282-44bc-b07d-788a2eaecdcb" />

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add and manage multiple photos for foods and meals using the camera or photo library.
  * View thumbnails across food libraries, search results, and diary entries.
  * Open photos in a full-screen lightbox with browsing and autoplay.
  * Set diary-entry-specific photos while retaining inherited food or meal images.
  * Choose whether food updates sync nutrition only or also replace past-entry photos.
* **Bug Fixes**
  * Improved preservation of provider images and photos referenced by diary history.
  * Clarified guidance for inherited and entry-specific photos.
* **Documentation**
  * Added guidance covering photo inheritance and synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->