### PR TITLE
fix(api-keys): call better-auth with the shape each endpoint declares

### DIFF
--- a/SparkyFitnessServer/routes/auth/apiKeyRoutes.ts
+++ b/SparkyFitnessServer/routes/auth/apiKeyRoutes.ts
@@ -39,15 +39,23 @@ router.post('/user/generate-api-key', authenticate, async (req, res, next) => {
   try {
     // @ts-expect-error TS(2339): Property 'createApiKey' does not exist on type 'In... Remove this comment to see the full error message
     const result = await auth.api.createApiKey({
-      // Key the credential to the authenticated actor, never the switched
-      // context (req.userId). A family-sharing delegate acting on behalf of
-      // another user must not be able to mint/list/delete that user's API
-      // keys — doing so would let a narrow delegation (e.g. medications)
-      // escalate into full account takeover. Mirrors the isAdmin check in
-      // authMiddleware.ts, which also guards on the authenticated user.
-      userId: req.authenticatedUserId,
-      name,
-      expiresIn: expiresIn || 31536000, // Default 1 year
+      // Better Auth's server API takes endpoint fields under `body`; the
+      // plugin declares /api-key/create with `body: createApiKeyBodySchema`.
+      // Passed flat, every field arrived undefined.
+      body: {
+        // Key the credential to the authenticated actor, never the switched
+        // context (req.userId). A family-sharing delegate acting on behalf of
+        // another user must not be able to mint/list/delete that user's API
+        // keys — doing so would let a narrow delegation (e.g. medications)
+        // escalate into full account takeover. Mirrors the isAdmin check in
+        // authMiddleware.ts, which also guards on the authenticated user.
+        //
+        // `userId` is a server-only field on the create schema, so this stays
+        // an explicit binding rather than a session lookup.
+        userId: req.authenticatedUserId,
+        name,
+        expiresIn: expiresIn || 31536000, // Default 1 year
+      },
     });
     res.status(201).json({
       message: 'API key generated successfully',
@@ -89,10 +97,18 @@ router.delete(
     try {
       // @ts-expect-error TS(2339): Property 'deleteApiKey' does not exist on type 'In... Remove this comment to see the full error message
       await auth.api.deleteApiKey({
-        apiKeyId,
-        // Authenticated actor only — a switched-context delegate must not be
-        // able to delete the account owner's keys.
-        userId: req.authenticatedUserId,
+        // Two corrections beyond the `body` wrapper: the delete schema names
+        // the field `keyId` (not `apiKeyId`), and it has no `userId` field at
+        // all, so the previous binding was silently dropped.
+        body: { keyId: apiKeyId },
+        // /api-key/delete runs behind Better Auth's sessionMiddleware, so the
+        // owner comes from the session rather than a passed id. Forwarding the
+        // request headers preserves the guarantee the removed `userId` was
+        // there for: authMiddleware derives req.authenticatedUserId from
+        // getSession({ headers: req.headers }), so the session resolves to the
+        // authenticated actor — never the switched context — and a delegate
+        // still cannot delete the account owner's keys.
+        headers: req.headers,
       });
       res.status(200).json({ message: 'API key deleted successfully.' });
     } catch (error) {
@@ -118,12 +134,19 @@ router.delete(
 router.get('/user-api-keys', authenticate, async (req, res, next) => {
   try {
     // @ts-expect-error TS(2339): Property 'listApiKeys' does not exist on type 'Inf... Remove this comment to see the full error message
-    const apiKeys = await auth.api.listApiKeys({
-      // Authenticated actor only — do not expose the account owner's key
-      // metadata to a switched-context delegate.
-      userId: req.authenticatedUserId,
+    // /api-key/list is a GET declared with `query`, not `body`, and it takes
+    // no `userId` — so unlike the other two this one is not a missing `body`
+    // wrapper. It runs behind sessionMiddleware, so the owner comes from the
+    // session. Forwarding the headers keeps the same guarantee the removed
+    // `userId` was there for: the session is the authenticated actor's, never
+    // the switched context, so a delegate cannot list the owner's keys.
+    const result = await auth.api.listApiKeys({
+      headers: req.headers,
     });
-    res.status(200).json(apiKeys);
+    // The endpoint returns { apiKeys, total, limit, offset }. The route has
+    // always been documented as returning "a list of API keys", so unwrap to
+    // the array rather than leaking the pagination envelope.
+    res.status(200).json(result?.apiKeys ?? []);
   } catch (error) {
     next(error);
   }

--- a/SparkyFitnessServer/tests/apiKeyRoutes.contextSwitch.test.ts
+++ b/SparkyFitnessServer/tests/apiKeyRoutes.contextSwitch.test.ts
@@ -74,29 +74,61 @@ describe('apiKeyRoutes: credentials target the authenticated actor, not the swit
     // The vulnerability: a medications (or any) delegate switching context and
     // calling this endpoint would otherwise mint a full-access key owned by the
     // victim, enabling account takeover beyond the delegated scope.
-    expect(arg.userId).toBe(DELEGATE_ID);
-    expect(arg.userId).not.toBe(VICTIM_ID);
+    //
+    // `userId` is a real (server-only) field on createApiKeyBodySchema, so
+    // this binding is honoured — it just has to sit under `body`.
+    expect(arg.body.userId).toBe(DELEGATE_ID);
+    expect(arg.body.userId).not.toBe(VICTIM_ID);
   });
 
-  it('delete api-key targets the delegate, not the switched-to victim', async () => {
+  it('delete api-key names the key under body.keyId and never the victim', async () => {
     mockDeleteApiKey.mockResolvedValue(undefined);
 
     const res = await request(app).delete('/api/identity/user/api-key/key-1');
 
     expect(res.status).toBe(200);
     expect(mockDeleteApiKey).toHaveBeenCalledTimes(1);
-    expect(mockDeleteApiKey.mock.calls[0][0].userId).toBe(DELEGATE_ID);
-    expect(mockDeleteApiKey.mock.calls[0][0].userId).not.toBe(VICTIM_ID);
+    const arg = mockDeleteApiKey.mock.calls[0][0];
+    // deleteApiKeyBodySchema is { configId?, keyId } — there is no `userId`
+    // field, so the previous `userId: DELEGATE_ID` would have been stripped by
+    // the zod schema and enforced nothing even had the call been well formed.
+    // Ownership is decided by Better Auth's sessionMiddleware, so what this
+    // route must get right is forwarding the headers: the session belongs to
+    // the authenticated delegate, never to the switched-to victim.
+    expect(arg.body).toEqual({ keyId: 'key-1' });
+    expect(arg.headers).toBeDefined();
+    // Nothing anywhere in the call may name the victim.
+    expect(JSON.stringify(arg)).not.toContain(VICTIM_ID);
   });
 
-  it('list api-keys returns the delegate keys, not the switched-to victim keys', async () => {
-    mockListApiKeys.mockResolvedValue([]);
+  it('list api-keys forwards the session headers and never names the victim', async () => {
+    mockListApiKeys.mockResolvedValue({ apiKeys: [], total: 0 });
 
     const res = await request(app).get('/api/identity/user-api-keys');
 
     expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
     expect(mockListApiKeys).toHaveBeenCalledTimes(1);
-    expect(mockListApiKeys.mock.calls[0][0].userId).toBe(DELEGATE_ID);
-    expect(mockListApiKeys.mock.calls[0][0].userId).not.toBe(VICTIM_ID);
+    const arg = mockListApiKeys.mock.calls[0][0];
+    // /api-key/list is a GET taking `query`, and has no `userId` field either,
+    // so the same reasoning as delete applies.
+    expect(arg.headers).toBeDefined();
+    expect(JSON.stringify(arg)).not.toContain(VICTIM_ID);
+  });
+
+  it('list api-keys unwraps the pagination envelope to a bare array', async () => {
+    mockListApiKeys.mockResolvedValue({
+      apiKeys: [{ id: 'key-1', name: 'mine' }],
+      total: 1,
+      limit: 10,
+      offset: 0,
+    });
+
+    const res = await request(app).get('/api/identity/user-api-keys');
+
+    expect(res.status).toBe(200);
+    // The route is documented as returning "a list of API keys"; Better Auth
+    // returns { apiKeys, total, limit, offset }.
+    expect(res.body).toEqual([{ id: 'key-1', name: 'mine' }]);
   });
 });


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

The three API-key routes passed their fields flat to Better Auth, which takes them under `body`, so every field arrived undefined and all three endpoints failed.

**How did you implement the solution?**

Checking each endpoint declaration in `@better-auth/api-key@1.5.6` against the routes, the three do **not** take the same shape, so the issue's "add a `body` wrapper to all three" is only correct for one:

| Endpoint | Declares | Has `userId`? | Fix |
|---|---|---|---|
| `/api-key/create` | `body: createApiKeyBodySchema` | yes (server-only) | wrap in `body` |
| `/api-key/delete` | `body: deleteApiKeyBodySchema` | **no** | wrap, **and** rename `apiKeyId` → `keyId` |
| `/api-key/list` | `query`, method **GET** | **no** | takes `query`, not `body` — a `body` wrapper would not have fixed it |

`create` keeps its explicit `userId` binding, moved under `body`. `delete` and `list` run behind `sessionMiddleware` and have no `userId` field, so they now forward `req.headers` and ownership comes from the session.

That preserves the guard the `userId` argument was there for: `authMiddleware` derives `req.authenticatedUserId` from `getSession({ headers: req.headers })` — the same resolution `sessionMiddleware` does — so the session is the authenticated actor's, never the switched context, and a family-sharing delegate still cannot reach the owner's keys. Worth flagging since it reads like removing a guard: for those two, the old `userId` **enforced nothing** — the schemas have no such field, so zod would have stripped it regardless.

`list` also returns `{ apiKeys, total, limit, offset }`; the route is documented as returning a list, so it now unwraps to the array.

**One correction to the issue:** Settings is unaffected. `useApiKeys.ts` calls `authClient.apiKey.*` — Better Auth's own client — not these Express routes. What is broken is the Swagger-documented REST surface under `/identity/...`.

The `@ts-expect-error` suppressions stay: `tsc --noEmit` is 0 errors before and after. The suppressed error is `Property 'createApiKey' does not exist` — the plugin is not in the inferred `auth.api` type, so there was no signature to check these arguments against, which is why three malformed calls shipped.

Linked Issue: Closes #2119

## How to Test

1. Check out this branch and run `pnpm run typecheck && pnpm run lint && pnpm run test` in `SparkyFitnessServer/`.
2. `tests/apiKeyRoutes.contextSwitch.test.ts` covers the three call shapes plus the `list` envelope unwrapping.
3. Against a running deployment, exercise `POST /identity/user/generate-api-key`, `GET /identity/user-api-keys`, and `DELETE /identity/user/api-key/{id}` — all three previously failed.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: No new tables — this changes only how existing routes call Better Auth, so `rls_policies.sql` needs no update.

## Test Results

```
tsc --noEmit              0 errors
vitest run                242 passed | 2 skipped (244 files)
                          2995 passed | 216 skipped (3211 tests)
eslint --max-warnings 0   clean
prettier --check          clean
```

The existing context-switch security test asserted `userId` on all three calls. For `delete` and `list` that checked a value the schema discards, so it could pass while nothing was enforced. Those two cases now assert what is load-bearing: the right key id, the session headers forwarded, and the victim id appearing nowhere in the call. A fourth case pins the `list` unwrapping.

No UI or frontend changes, so no screenshots apply.
