### PR TITLE
fix(exercise): widen fractional workout telemetry columns to numeric

### DIFF
--- a/SparkyFitnessServer/db/migrations/20260816000000_widen_fractional_workout_telemetry_to_numeric.sql
+++ b/SparkyFitnessServer/db/migrations/20260816000000_widen_fractional_workout_telemetry_to_numeric.sql
@@ -5,9 +5,10 @@
 -- The values are fractional by design on both ends:
 --   * Health Connect reports cadence and heart rate as averages (Double), and
 --     declares FloorsClimbedRecord.floors as a Double outright.
---   * deriveWorkoutTelemetry()/deriveLaps() in
---     services/workoutTelemetryDerivation.ts emit avg/max cadence rounded to one
---     decimal, which the integer columns could not hold either.
+--   * services/workoutTelemetryDerivation.ts rounds cadence to one decimal on
+--     both paths — deriveWorkoutTelemetry() for avg_cadence and max_cadence,
+--     deriveLaps() for avg_cadence (laps have no max_cadence column) — which the
+--     integer columns could not hold either.
 --
 -- Widening is lossless, matches 20260628000000_convert_exercise_durations_to_numeric.sql,
 -- and is a no-op where the column is already numeric. NUMERIC is parsed back to a

--- a/SparkyFitnessServer/db/migrations/20260816000000_widen_fractional_workout_telemetry_to_numeric.sql
+++ b/SparkyFitnessServer/db/migrations/20260816000000_widen_fractional_workout_telemetry_to_numeric.sql
@@ -5,7 +5,7 @@
 -- The values are fractional by design on both ends:
 --   * Health Connect reports cadence and heart rate as averages (Double), and
 --     declares FloorsClimbedRecord.floors as a Double outright.
---   * deriveWorkoutTelemetry()/deriveLapTelemetry() in
+--   * deriveWorkoutTelemetry()/deriveLaps() in
 --     services/workoutTelemetryDerivation.ts emit avg/max cadence rounded to one
 --     decimal, which the integer columns could not hold either.
 --

--- a/SparkyFitnessServer/db/migrations/20260816000000_widen_fractional_workout_telemetry_to_numeric.sql
+++ b/SparkyFitnessServer/db/migrations/20260816000000_widen_fractional_workout_telemetry_to_numeric.sql
@@ -14,6 +14,8 @@
 -- and is a no-op where the column is already numeric. NUMERIC is parsed back to a
 -- JS number by the parser registered in db/poolManager.ts, so API shapes are unchanged.
 
+BEGIN;
+
 ALTER TABLE exercise_entries
   ALTER COLUMN avg_heart_rate TYPE numeric,
   ALTER COLUMN max_heart_rate TYPE numeric,
@@ -25,3 +27,5 @@ ALTER TABLE exercise_entry_laps
   ALTER COLUMN avg_heart_rate TYPE numeric,
   ALTER COLUMN max_heart_rate TYPE numeric,
   ALTER COLUMN avg_cadence    TYPE numeric;
+
+COMMIT;

--- a/SparkyFitnessServer/db/migrations/20260816000000_widen_fractional_workout_telemetry_to_numeric.sql
+++ b/SparkyFitnessServer/db/migrations/20260816000000_widen_fractional_workout_telemetry_to_numeric.sql
@@ -1,0 +1,26 @@
+-- Workout telemetry that arrives fractional was stored in integer columns, so a
+-- single decimal value aborted the whole insert. On the mobile "Import History"
+-- backfill that rejects the entire chunk, not just the offending session.
+--
+-- The values are fractional by design on both ends:
+--   * Health Connect reports cadence and heart rate as averages (Double), and
+--     declares FloorsClimbedRecord.floors as a Double outright.
+--   * deriveWorkoutTelemetry()/deriveLapTelemetry() in
+--     services/workoutTelemetryDerivation.ts emit avg/max cadence rounded to one
+--     decimal, which the integer columns could not hold either.
+--
+-- Widening is lossless, matches 20260628000000_convert_exercise_durations_to_numeric.sql,
+-- and is a no-op where the column is already numeric. NUMERIC is parsed back to a
+-- JS number by the parser registered in db/poolManager.ts, so API shapes are unchanged.
+
+ALTER TABLE exercise_entries
+  ALTER COLUMN avg_heart_rate TYPE numeric,
+  ALTER COLUMN max_heart_rate TYPE numeric,
+  ALTER COLUMN avg_cadence    TYPE numeric,
+  ALTER COLUMN max_cadence    TYPE numeric,
+  ALTER COLUMN floors_climbed TYPE numeric;
+
+ALTER TABLE exercise_entry_laps
+  ALTER COLUMN avg_heart_rate TYPE numeric,
+  ALTER COLUMN max_heart_rate TYPE numeric,
+  ALTER COLUMN avg_cadence    TYPE numeric;


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Fractional workout telemetry (cadence, heart rate, floors climbed) sits in `integer` columns, so one decimal aborts the insert — and on the mobile Import History backfill the failing row rejects the whole chunk, so a single workout blocks the entire historical import.

**How did you implement the solution?**

One migration widening the affected columns to `numeric`, rather than rounding `avg_cadence` and waiting for the next column to hit the same wall. The values are fractional on both ends: Health Connect reports cadence and HR as averages (`Double`) and declares `FloorsClimbedRecord.floors` as a `Double` by spec, and `deriveWorkoutTelemetry()` / the lap derivation in `services/workoutTelemetryDerivation.ts` emit `avg_cadence`/`max_cadence` as `round(mean(...), 1)` — the same failure reachable with no Health Connect involved.

`integer → numeric` is lossless, the ALTER is a no-op where the column is already `numeric`, and it follows `20260628000000_convert_exercise_durations_to_numeric.sql`. Response shapes are unchanged — `db/poolManager.ts` registers a `NUMERIC` parser returning a JS number.

Widened — `exercise_entries`: `avg_heart_rate`, `max_heart_rate`, `avg_cadence`, `max_cadence`, `floors_climbed`. `exercise_entry_laps`: `avg_heart_rate`, `max_heart_rate`, `avg_cadence`.

**Locking / downtime:** `integer → numeric` is not binary-coercible, so each `ALTER TABLE` rewrites the table under an `ACCESS EXCLUSIVE` lock and rebuilds any index on the touched columns. That happens at boot, before the server starts serving, and the columns of each table are widened in one statement so it is a single rewrite pass per table rather than one per column. On a self-hosted instance it is seconds; on a large `exercise_entries` it is proportional to row count, and the whole thing runs inside one `BEGIN`/`COMMIT` so a failure leaves the schema untouched.

Linked Issue: Closes #2130

## How to Test

**Heads-up: I have not tested this migration file itself.** I ran the equivalent `ALTER TABLE` by hand against my own v1.6.2 instance (Docker Compose, Postgres 18.3, Pixel + OnePlus Watch 3 → Health Connect) and 263 days imported cleanly afterwards, having previously died at 0. The migration here is that same SQL, but it has not been through a real boot-time migration run or a fresh install — please verify before merging.

1. Start the server on this branch; the migration applies on boot.
2. `\d exercise_entries` / `\d exercise_entry_laps` — the columns above should read `numeric`.
3. Run Import History from the Android app over a range with cadence/floors data; it should complete instead of `Chunk 1/3 rejected in full by server`.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests (`243 passed | 2 skipped`). No new files, endpoints or schemas — the change is one SQL migration.
- [x] **[MANDATORY for Backend changes] Database Security**: No new tables, so `rls_policies.sql` needs no change.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

No UI change — schema only.
