### PR TITLE
fix(exercise): Per Preset Assumed Exercise Values

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/ActiveWorkoutExerciseCard.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/ActiveWorkoutExerciseCard.test.tsx
@@ -532,7 +532,7 @@ describe('ActiveWorkoutExerciseCard', () => {
 
     it('skips the exercise stats fetch', () => {
       renderCard(true, { mode: 'view' });
-      expect(mockUseExerciseStats).toHaveBeenCalledWith(null, undefined);
+      expect(mockUseExerciseStats).toHaveBeenCalledWith(null, undefined, undefined);
     });
 
     it('never labels a collapsed exercise as planned', () => {
@@ -620,7 +620,7 @@ describe('ActiveWorkoutExerciseCard', () => {
 
     it('fetches exercise stats so "Last time" works for drafts', () => {
       renderCard(true, { mode: 'edit' });
-      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', undefined);
+      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', undefined, undefined);
     });
 
     describe('calories chip', () => {
@@ -759,7 +759,12 @@ describe('ActiveWorkoutExerciseCard', () => {
 
     it('passes the session id as excludePresetEntryId to the stats query', () => {
       renderCard(true, { mode: 'live', excludePresetEntryId: 'session-1' });
-      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', 'session-1');
+      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', 'session-1', undefined);
+    });
+
+    it('passes sourcePresetId through to the stats query', () => {
+      renderCard(true, { mode: 'live', sourcePresetId: 42 });
+      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', undefined, 42);
     });
 
     it('marks the tap-focused row from focusedSetKey (distinct from the cursor)', () => {
@@ -831,7 +836,7 @@ describe('ActiveWorkoutExerciseCard', () => {
       // Without the viewed session's id to exclude, Best could show the very
       // workout being viewed — the hook stays disabled instead.
       const { queryByTestId } = renderCard(true, { mode: 'view' });
-      expect(mockUseExerciseStats).toHaveBeenCalledWith(null, undefined);
+      expect(mockUseExerciseStats).toHaveBeenCalledWith(null, undefined, undefined);
       expect(mockCapturePrBaseline).not.toHaveBeenCalled();
       expect(queryByTestId('icon-trophy-outline')).toBeNull();
     });
@@ -842,7 +847,7 @@ describe('ActiveWorkoutExerciseCard', () => {
         mode: 'view',
         excludePresetEntryId: 'session-1',
       });
-      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', 'session-1');
+      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', 'session-1', undefined);
       expect(mockCapturePrBaseline).not.toHaveBeenCalled();
       expect(getByTestId('icon-trophy-outline')).toBeTruthy();
       expect(getByText('100 × 5')).toBeTruthy();
@@ -934,7 +939,7 @@ describe('ActiveWorkoutExerciseCard', () => {
         excludePresetEntryId: 'session-9',
       });
 
-      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', 'session-9');
+      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', 'session-9', undefined);
       expect(prevOf(utils, 101)).toBe('prev:60x8');
     });
 

--- a/SparkyFitnessMobile/__tests__/hooks/useExerciseStats.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useExerciseStats.test.ts
@@ -36,7 +36,7 @@ describe('useExerciseStats', () => {
     await waitFor(() => {
       expect(result.current.data).toEqual(data);
     });
-    expect(mockFetchStats).toHaveBeenCalledWith('ex-1', undefined);
+    expect(mockFetchStats).toHaveBeenCalledWith('ex-1', undefined, undefined);
   });
 
   it('passes populated recentSessions through untouched', async () => {
@@ -79,7 +79,50 @@ describe('useExerciseStats', () => {
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
     });
-    expect(mockFetchStats).toHaveBeenCalledWith('ex-1', 'session-1');
+    expect(mockFetchStats).toHaveBeenCalledWith('ex-1', 'session-1', undefined);
+  });
+
+  it('forwards presetId to the fetch and query key', async () => {
+    mockFetchStats.mockResolvedValue({
+      bestSet: null,
+      lastSet: null,
+      recentSessions: [],
+    });
+
+    const { result } = renderHook(
+      () => useExerciseStats('ex-1', 'session-1', 42),
+      { wrapper: createQueryWrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockFetchStats).toHaveBeenCalledWith('ex-1', 'session-1', 42);
+  });
+
+  it('treats different presetId values as distinct query keys', async () => {
+    mockFetchStats.mockResolvedValue({
+      bestSet: null,
+      lastSet: null,
+      recentSessions: [],
+    });
+
+    const { result: resultA } = renderHook(
+      () => useExerciseStats('ex-1', undefined, 1),
+      { wrapper: createQueryWrapper(queryClient) },
+    );
+    const { result: resultB } = renderHook(
+      () => useExerciseStats('ex-1', undefined, 2),
+      { wrapper: createQueryWrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(resultA.current.isSuccess).toBe(true);
+      expect(resultB.current.isSuccess).toBe(true);
+    });
+    expect(mockFetchStats).toHaveBeenCalledWith('ex-1', undefined, 1);
+    expect(mockFetchStats).toHaveBeenCalledWith('ex-1', undefined, 2);
+    expect(mockFetchStats).toHaveBeenCalledTimes(2);
   });
 
   it('does not fire when exerciseId is null/undefined', () => {

--- a/SparkyFitnessMobile/__tests__/hooks/useStartLiveWorkout.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useStartLiveWorkout.test.ts
@@ -221,6 +221,11 @@ describe('useStartLiveWorkout', () => {
     const store = useActiveWorkoutStore.getState();
     expect(store.sourcePresetId).toBe(42);
     expect(store.sourceServerConfigId).toBe('config-1');
+    // Also tags the created session server-side (recentSessions stats
+    // scoping), independent of the client-supplied exercises.
+    expect(mockCreateWorkout).toHaveBeenCalledWith(
+      expect.objectContaining({ workout_preset_id: 42 }),
+    );
   });
 
   it('leaves the source preset link null for starts without a preset', async () => {
@@ -233,6 +238,9 @@ describe('useStartLiveWorkout', () => {
     expect(mockGetActiveServerConfig).not.toHaveBeenCalled();
     expect(useActiveWorkoutStore.getState().sourcePresetId).toBeNull();
     expect(useActiveWorkoutStore.getState().sourceServerConfigId).toBeNull();
+    expect(mockCreateWorkout).toHaveBeenCalledWith(
+      expect.not.objectContaining({ workout_preset_id: expect.anything() }),
+    );
   });
 
   it('defaults the name to the dated workout name when omitted', async () => {

--- a/SparkyFitnessMobile/__tests__/screens/ActiveWorkoutScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ActiveWorkoutScreen.test.tsx
@@ -12,6 +12,14 @@ import {
 import { __resetAppPreferencesStoreForTests } from '../../src/stores/appPreferencesStore';
 import type { ActionSheetItem } from '../../src/components/ActionSheet';
 import type { PresetSessionResponse } from '@workspace/shared';
+import { getActiveServerConfig } from '../../src/services/storage';
+
+jest.mock('../../src/services/storage', () => ({
+  getActiveServerConfig: jest.fn(),
+}));
+const mockGetActiveServerConfig = getActiveServerConfig as jest.MockedFunction<
+  typeof getActiveServerConfig
+>;
 
 jest.mock('../../src/hooks/usePreferences', () => ({
   usePreferences: jest.fn(() => ({ preferences: null })),
@@ -69,7 +77,10 @@ jest.mock('../../src/components/ActiveWorkoutExerciseCard', () => {
   return {
     __esModule: true,
     default: (props: any) => (
-      <View testID={`card-${props.exercise.id}`}>
+      <View
+        testID={`card-${props.exercise.id}`}
+        accessibilityLabel={`sourcePresetId:${String(props.sourcePresetId)}`}
+      >
         <Pressable
           testID={`card-${props.exercise.id}-overflow`}
           onPress={() => props.onPressOverflow?.(props.exercise.id)}
@@ -863,5 +874,76 @@ describe('ActiveWorkoutScreen stale deep link guard', () => {
 
     act(() => finishHydration?.());
     expect(navigation.goBack).toHaveBeenCalled();
+  });
+});
+
+describe('ActiveWorkoutScreen source preset server-config guard', () => {
+  /** Flush the config-check promise chain into the effect's state update. */
+  async function flushConfigCheck() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    __resetActiveWorkoutStoreForTests();
+    __resetAppPreferencesStoreForTests();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('passes sourcePresetId to the stats query when the active server matches', async () => {
+    mockGetActiveServerConfig.mockResolvedValue({
+      id: 'config-1',
+      url: 'https://example.com',
+      apiKey: 'key',
+    });
+    useActiveWorkoutStore.getState().startWorkout(makeSession(), {
+      sourcePresetId: 42,
+      sourceServerConfigId: 'config-1',
+    });
+    const { getByTestId } = renderScreen();
+    await flushConfigCheck();
+
+    expect(getByTestId('card-ex-a').props.accessibilityLabel).toBe(
+      'sourcePresetId:42',
+    );
+  });
+
+  it('withholds sourcePresetId when the active server no longer matches the one the workout started on', async () => {
+    // Preset ids can collide across servers, so a config switched since the
+    // workout started must not scope stats to a same-numbered foreign preset.
+    mockGetActiveServerConfig.mockResolvedValue({
+      id: 'other-config',
+      url: 'https://other.example.com',
+      apiKey: 'key',
+    });
+    useActiveWorkoutStore.getState().startWorkout(makeSession(), {
+      sourcePresetId: 42,
+      sourceServerConfigId: 'config-1',
+    });
+    const { getByTestId } = renderScreen();
+    await flushConfigCheck();
+
+    expect(getByTestId('card-ex-a').props.accessibilityLabel).toBe(
+      'sourcePresetId:undefined',
+    );
+  });
+
+  it('withholds sourcePresetId for a workout that was not started from a preset', async () => {
+    useActiveWorkoutStore.getState().startWorkout(makeSession());
+    const { getByTestId } = renderScreen();
+    await flushConfigCheck();
+
+    expect(getByTestId('card-ex-a').props.accessibilityLabel).toBe(
+      'sourcePresetId:undefined',
+    );
+    expect(mockGetActiveServerConfig).not.toHaveBeenCalled();
   });
 });

--- a/SparkyFitnessMobile/__tests__/screens/ActiveWorkoutScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ActiveWorkoutScreen.test.tsx
@@ -3,6 +3,7 @@ import { Alert } from 'react-native';
 import { fireEvent, render, act } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useIsFocused } from '@react-navigation/native';
 import ActiveWorkoutScreen from '../../src/screens/ActiveWorkoutScreen';
 import { useActiveWorkoutAutosave } from '../../src/hooks/useActiveWorkoutAutosave';
 import {
@@ -20,6 +21,12 @@ jest.mock('../../src/services/storage', () => ({
 const mockGetActiveServerConfig = getActiveServerConfig as jest.MockedFunction<
   typeof getActiveServerConfig
 >;
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useIsFocused: jest.fn(() => true),
+}));
+const mockUseIsFocused = useIsFocused as jest.MockedFunction<typeof useIsFocused>;
 
 jest.mock('../../src/hooks/usePreferences', () => ({
   usePreferences: jest.fn(() => ({ preferences: null })),
@@ -887,9 +894,21 @@ describe('ActiveWorkoutScreen source preset server-config guard', () => {
     });
   }
 
+  /** Re-render with a fresh element so the mocked useIsFocused() is re-read. */
+  function rerenderScreen(rerender: (ui: React.ReactElement) => void) {
+    rerender(
+      <SafeAreaProvider initialMetrics={{ insets, frame }}>
+        <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+          <ActiveWorkoutScreen navigation={navigation} route={route} />
+        </QueryClientProvider>
+      </SafeAreaProvider>,
+    );
+  }
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
+    mockUseIsFocused.mockReturnValue(true);
     __resetActiveWorkoutStoreForTests();
     __resetAppPreferencesStoreForTests();
   });
@@ -945,5 +964,64 @@ describe('ActiveWorkoutScreen source preset server-config guard', () => {
       'sourcePresetId:undefined',
     );
     expect(mockGetActiveServerConfig).not.toHaveBeenCalled();
+  });
+
+  it('re-verifies and clears the stale presetId when the active server changes after an initial successful validation', async () => {
+    mockGetActiveServerConfig.mockResolvedValue({
+      id: 'config-1',
+      url: 'https://example.com',
+      apiKey: 'key',
+    });
+    useActiveWorkoutStore.getState().startWorkout(makeSession(), {
+      sourcePresetId: 42,
+      sourceServerConfigId: 'config-1',
+    });
+    const { getByTestId, rerender } = renderScreen();
+    await flushConfigCheck();
+    expect(getByTestId('card-ex-a').props.accessibilityLabel).toBe(
+      'sourcePresetId:42',
+    );
+
+    // The user backgrounds this screen (e.g. to Server Settings) and switches
+    // the active server. sourcePresetId/sourceServerConfigId are fixed for
+    // the whole session, so only the focus transition can catch this — the
+    // screen never unmounts.
+    mockUseIsFocused.mockReturnValue(false);
+    rerenderScreen(rerender);
+    await flushConfigCheck();
+    // Blurred: the previously-verified id must not linger on screen.
+    expect(getByTestId('card-ex-a').props.accessibilityLabel).toBe(
+      'sourcePresetId:undefined',
+    );
+
+    mockGetActiveServerConfig.mockResolvedValue({
+      id: 'other-config',
+      url: 'https://other.example.com',
+      apiKey: 'key',
+    });
+    mockUseIsFocused.mockReturnValue(true);
+    rerenderScreen(rerender);
+    await flushConfigCheck();
+
+    // Refocused against a different server: re-verification must fail, not
+    // resurrect the stale, now-foreign preset id 42.
+    expect(getByTestId('card-ex-a').props.accessibilityLabel).toBe(
+      'sourcePresetId:undefined',
+    );
+  });
+
+  it('leaves sourcePresetId withheld without throwing when the config lookup rejects', async () => {
+    mockGetActiveServerConfig.mockRejectedValue(new Error('storage unavailable'));
+    useActiveWorkoutStore.getState().startWorkout(makeSession(), {
+      sourcePresetId: 42,
+      sourceServerConfigId: 'config-1',
+    });
+
+    const { getByTestId } = renderScreen();
+    await flushConfigCheck();
+
+    expect(getByTestId('card-ex-a').props.accessibilityLabel).toBe(
+      'sourcePresetId:undefined',
+    );
   });
 });

--- a/SparkyFitnessMobile/__tests__/screens/ActiveWorkoutScreen.workoutPlanEnd.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ActiveWorkoutScreen.workoutPlanEnd.test.tsx
@@ -4,6 +4,17 @@ import { fireEvent, render, act } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ActiveWorkoutScreen from '../../src/screens/ActiveWorkoutScreen';
+
+// ActiveWorkoutScreen's source-preset/server guard calls both of these; this
+// suite doesn't exercise that guard, but useIsFocused requires a real
+// navigation context (absent here) and would throw if left unmocked.
+jest.mock('../../src/services/storage', () => ({
+  getActiveServerConfig: jest.fn(),
+}));
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useIsFocused: jest.fn(() => true),
+}));
 import { ApiError } from '../../src/services/api/errors';
 import {
   __resetActiveWorkoutStoreForTests,

--- a/SparkyFitnessMobile/__tests__/screens/WorkoutDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/WorkoutDetailScreen.test.tsx
@@ -384,7 +384,7 @@ describe('WorkoutDetailScreen', () => {
 
       // View mode: session.id reaches the stats layer so the workout being
       // viewed can't surface as its own Best.
-      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', 'session-1');
+      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', 'session-1', undefined);
       expect(mockUseExerciseStats).not.toHaveBeenCalledWith(null, undefined);
       mockUseExerciseStats.mockClear();
 
@@ -392,7 +392,7 @@ describe('WorkoutDetailScreen', () => {
 
       // Edit mode: same exclusion, so the workout being edited can't pollute
       // its own Last/Best/recent-sessions baseline.
-      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', 'session-1');
+      expect(mockUseExerciseStats).toHaveBeenCalledWith('ex-1', 'session-1', undefined);
     });
 
     it('renders edit cards and saves set_type/rpe edits through the payload', async () => {

--- a/SparkyFitnessMobile/src/components/ActiveWorkoutExerciseCard.tsx
+++ b/SparkyFitnessMobile/src/components/ActiveWorkoutExerciseCard.tsx
@@ -98,6 +98,14 @@ interface ActiveWorkoutExerciseCardProps {
    */
   excludePresetEntryId?: string;
   /**
+   * Live only: the preset this workout was started from, forwarded to the
+   * stats query so recentSessions (the PREVIOUS column / placeholder source)
+   * reflects this preset's own history instead of this exercise's history
+   * from a different preset. Omitted for freeform (non-preset) workouts,
+   * which keeps the exercise-global fallback unchanged.
+   */
+  sourcePresetId?: number;
+  /**
    * Live only: the store's PR stamps. When any of this exercise's set ids is
    * stamped, the Best line goes gold and shows the new record (the server
    * best stays historical by design).
@@ -231,6 +239,7 @@ function ActiveWorkoutExerciseCard({
   getImageSource,
   mode = 'live',
   excludePresetEntryId,
+  sourcePresetId,
   prSetIds,
   showRestChip = true,
   onChangeCalories,
@@ -290,6 +299,7 @@ function ActiveWorkoutExerciseCard({
   const { data: stats } = useExerciseStats(
     readOnly && excludePresetEntryId == null ? null : exercise.exercise_id,
     excludePresetEntryId,
+    sourcePresetId,
   );
   const lastSet = stats?.lastSet ?? null;
   const bestSet = stats?.bestSet ?? null;

--- a/SparkyFitnessMobile/src/hooks/queryKeys.ts
+++ b/SparkyFitnessMobile/src/hooks/queryKeys.ts
@@ -72,8 +72,14 @@ export const exerciseStatsQueryKeyRoot = ['exerciseStats'] as const;
 export const exerciseStatsQueryKey = (
   exerciseId: string,
   excludePresetEntryId?: string,
+  presetId?: number,
 ) =>
-  [...exerciseStatsQueryKeyRoot, exerciseId, excludePresetEntryId ?? null] as const;
+  [
+    ...exerciseStatsQueryKeyRoot,
+    exerciseId,
+    excludePresetEntryId ?? null,
+    presetId ?? null,
+  ] as const;
 
 export const exerciseDetailQueryKey = (exerciseId: string) =>
   ['exerciseDetail', exerciseId] as const;

--- a/SparkyFitnessMobile/src/hooks/useExerciseStats.ts
+++ b/SparkyFitnessMobile/src/hooks/useExerciseStats.ts
@@ -5,10 +5,11 @@ import { exerciseStatsQueryKey } from './queryKeys';
 export function useExerciseStats(
   exerciseId: string | null | undefined,
   excludePresetEntryId?: string,
+  presetId?: number,
 ) {
   return useQuery({
-    queryKey: exerciseStatsQueryKey(exerciseId ?? '', excludePresetEntryId),
-    queryFn: () => fetchExerciseStats(exerciseId!, excludePresetEntryId),
+    queryKey: exerciseStatsQueryKey(exerciseId ?? '', excludePresetEntryId, presetId),
+    queryFn: () => fetchExerciseStats(exerciseId!, excludePresetEntryId, presetId),
     enabled: !!exerciseId,
   });
 }

--- a/SparkyFitnessMobile/src/hooks/useStartLiveWorkout.ts
+++ b/SparkyFitnessMobile/src/hooks/useStartLiveWorkout.ts
@@ -128,6 +128,11 @@ export function useStartLiveWorkout(navigation: StartLiveWorkoutNavigation): {
           entry_date: entryDate,
           source: 'sparky',
           exercises: stripPlannedSetValues(exercises),
+          // Tags the created session to the preset (recentSessions stats
+          // scoping, server-side) without changing how it's built — the
+          // server keeps the client-supplied exercises verbatim when both
+          // fields are present instead of substituting the preset's own.
+          workout_preset_id: sourcePresetId,
         });
         invalidateCache(entryDate);
         // Chained so the exact-alarm prompt never stacks on top of the OS

--- a/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
@@ -18,6 +18,7 @@ import {
   KeyboardStickyView,
   type KeyboardAwareScrollViewRef,
 } from 'react-native-keyboard-controller';
+import { useIsFocused } from '@react-navigation/native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, { LinearTransition } from 'react-native-reanimated';
 import Toast from 'react-native-toast-message';
@@ -189,23 +190,37 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
   const { getImageSource } = useExerciseImageSource();
 
   // Preset ids are per-server; a config switched since the workout started
-  // (such as the user backgrounded this screen, switched servers in settings,
-  // and came back) can resolve the id against the wrong server's preset.
+  // (such as the user backgrounding this screen, switching servers in
+  // settings, and coming back) can resolve the id against the wrong server's
+  // preset. sourcePresetId/sourceServerConfigId are fixed for the whole
+  // session, so a switch that happens without this screen unmounting would
+  // never re-trigger the check on its own — re-verify on every focus regain
+  // instead, and clear immediately so a stale verified id from the old
+  // server can't leak through while the fresh check is in flight.
+  const isFocused = useIsFocused();
   const [verifiedSourcePresetId, setVerifiedSourcePresetId] = useState<
     number | undefined
   >(undefined);
   useEffect(() => {
-    if (sourcePresetId == null) return;
+    if (!isFocused || sourcePresetId == null) {
+      setVerifiedSourcePresetId(undefined);
+      return;
+    }
     let cancelled = false;
+    setVerifiedSourcePresetId(undefined);
     void (async () => {
-      const config = await getActiveServerConfig();
-      if (cancelled || config?.id !== sourceServerConfigId) return;
-      setVerifiedSourcePresetId(sourcePresetId);
+      try {
+        const config = await getActiveServerConfig();
+        if (cancelled || config?.id !== sourceServerConfigId) return;
+        setVerifiedSourcePresetId(sourcePresetId);
+      } catch {
+        // Storage read failed — leave verifiedSourcePresetId cleared.
+      }
     })();
     return () => {
       cancelled = true;
     };
-  }, [sourcePresetId, sourceServerConfigId]);
+  }, [isFocused, sourcePresetId, sourceServerConfigId]);
   const { flush } = useActiveWorkoutAutosave();
   const { runNavigationAction } = useNavigationActionGuard(navigation);
 

--- a/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
@@ -164,6 +164,7 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
   const insets = useSafeAreaInsets();
   const session = useActiveWorkoutStore((s) => s.session);
   const sessionId = useActiveWorkoutStore((s) => s.sessionId);
+  const sourcePresetId = useActiveWorkoutStore((s) => s.sourcePresetId);
   const startedAt = useActiveWorkoutStore((s) => s.startedAt);
   const completedSetIds = useActiveWorkoutStore((s) => s.completedSetIds);
   const prSetIds = useActiveWorkoutStore((s) => s.prSetIds);
@@ -1202,6 +1203,7 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
               completedSetIds={completedSetIds}
               prSetIds={prSetIds}
               excludePresetEntryId={sessionId ?? undefined}
+              sourcePresetId={sourcePresetId ?? undefined}
               activeSetId={activeSetId}
               focusedSetKey={focusedSetKey}
               setRenderKeys={setRenderKeys}

--- a/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ActiveWorkoutScreen.tsx
@@ -65,6 +65,7 @@ import { useSelectedExercise } from '../hooks/useSelectedExercise';
 import { deleteWorkout } from '../services/api/exerciseApi';
 import { addLog } from '../services/LogService';
 import { useNativeIOSTabsActive } from '../services/nativeTabBarPreference';
+import { getActiveServerConfig } from '../services/storage';
 import { useActiveWorkoutStore, type ActiveSetPatch } from '../stores/activeWorkoutStore';
 import { normalizeDate } from '../utils/dateUtils';
 import { runAfterKeyboardSettles } from '../utils/keyboardFocus';
@@ -165,6 +166,7 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
   const session = useActiveWorkoutStore((s) => s.session);
   const sessionId = useActiveWorkoutStore((s) => s.sessionId);
   const sourcePresetId = useActiveWorkoutStore((s) => s.sourcePresetId);
+  const sourceServerConfigId = useActiveWorkoutStore((s) => s.sourceServerConfigId);
   const startedAt = useActiveWorkoutStore((s) => s.startedAt);
   const completedSetIds = useActiveWorkoutStore((s) => s.completedSetIds);
   const prSetIds = useActiveWorkoutStore((s) => s.prSetIds);
@@ -185,6 +187,25 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
   const weightUnit = (preferences?.default_weight_unit ?? 'kg') as 'kg' | 'lbs';
   const distanceUnit = (preferences?.default_distance_unit as 'km' | 'miles') ?? 'km';
   const { getImageSource } = useExerciseImageSource();
+
+  // Preset ids are per-server; a config switched since the workout started
+  // (such as the user backgrounded this screen, switched servers in settings,
+  // and came back) can resolve the id against the wrong server's preset.
+  const [verifiedSourcePresetId, setVerifiedSourcePresetId] = useState<
+    number | undefined
+  >(undefined);
+  useEffect(() => {
+    if (sourcePresetId == null) return;
+    let cancelled = false;
+    void (async () => {
+      const config = await getActiveServerConfig();
+      if (cancelled || config?.id !== sourceServerConfigId) return;
+      setVerifiedSourcePresetId(sourcePresetId);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [sourcePresetId, sourceServerConfigId]);
   const { flush } = useActiveWorkoutAutosave();
   const { runNavigationAction } = useNavigationActionGuard(navigation);
 
@@ -1203,7 +1224,7 @@ function ActiveWorkoutScreen({ navigation, route }: Props) {
               completedSetIds={completedSetIds}
               prSetIds={prSetIds}
               excludePresetEntryId={sessionId ?? undefined}
-              sourcePresetId={sourcePresetId ?? undefined}
+              sourcePresetId={verifiedSourcePresetId}
               activeSetId={activeSetId}
               focusedSetKey={focusedSetKey}
               setRenderKeys={setRenderKeys}

--- a/SparkyFitnessMobile/src/services/api/exerciseApi.ts
+++ b/SparkyFitnessMobile/src/services/api/exerciseApi.ts
@@ -44,12 +44,17 @@ export const fetchExerciseHistory = async (
 export const fetchExerciseStats = async (
   exerciseId: string,
   excludePresetEntryId?: string,
+  presetId?: number,
 ): Promise<ExerciseStatsResponse> => {
   // The live active-workout card passes its session id so today's in-progress
   // (or pre-persisted planned) sets are excluded from the historical baseline.
-  const query = excludePresetEntryId
-    ? `?excludePresetEntryId=${encodeURIComponent(excludePresetEntryId)}`
-    : '';
+  // presetId (when the workout was started from a preset) scopes
+  // recentSessions to that preset's own history instead of this exercise's
+  // history from every preset/freeform workout.
+  const params = new URLSearchParams();
+  if (excludePresetEntryId) params.set('excludePresetEntryId', excludePresetEntryId);
+  if (presetId != null) params.set('presetId', String(presetId));
+  const query = params.toString() ? `?${params.toString()}` : '';
   return apiFetch<ExerciseStatsResponse>({
     endpoint: `/api/v2/exercises/${encodeURIComponent(exerciseId)}/stats${query}`,
     serviceName: 'Exercise API',

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -1440,7 +1440,8 @@ async function getRecentSessionsForExercise(
   userId: string,
   exerciseId: string,
   excludePresetEntryId: string | null = null,
-  limit = 3
+  limit = 3,
+  presetId: number | null = null
 ): Promise<RecentSessionRow[]> {
   const client = await getClient(userId);
   try {
@@ -1459,6 +1460,14 @@ async function getRecentSessionsForExercise(
        WHERE ee.user_id = $1
          AND ee.exercise_id = $2
          AND ($3::uuid IS NULL OR ee.exercise_preset_entry_id IS DISTINCT FROM $3)
+         AND (
+           $5::integer IS NULL
+           OR EXISTS (
+             SELECT 1 FROM exercise_preset_entries epe
+              WHERE epe.id = ee.exercise_preset_entry_id
+                AND epe.workout_preset_id = $5
+           )
+         )
          AND EXISTS (
            SELECT 1 FROM exercise_entry_sets ees
             WHERE ees.exercise_entry_id = ee.id
@@ -1466,7 +1475,7 @@ async function getRecentSessionsForExercise(
          )
        ORDER BY ee.entry_date DESC, ee.created_at DESC, ee.id DESC
        LIMIT $4`,
-      [userId, exerciseId, excludePresetEntryId, limit]
+      [userId, exerciseId, excludePresetEntryId, limit, presetId]
     );
     return result.rows;
   } finally {

--- a/SparkyFitnessServer/routes/exercisePresetEntryRoutes.ts
+++ b/SparkyFitnessServer/routes/exercisePresetEntryRoutes.ts
@@ -53,7 +53,14 @@ function handleRouteError(error: any, res: any, next: any) {
  *   post:
  *     summary: Create a grouped workout session
  *     tags: [Fitness & Workouts]
- *     description: Creates a grouped workout from either a workout preset or an inline exercises array. Returns the full nested grouped session payload used by the mobile client.
+ *     description: |
+ *       Creates a grouped workout from a workout preset, an inline exercises array, or both.
+ *       `workout_preset_id` alone copies that preset's own stored exercise/set structure.
+ *       `exercises` alone creates a freeform session with the given structure.
+ *       Both together (e.g. a live workout started from a preset) tag the session to that
+ *       preset for stats scoping while using the client-supplied exercise/set structure
+ *       verbatim, keeping the session editable like any other client-authored session.
+ *       Returns the full nested grouped session payload used by the mobile client.
  *     security:
  *       - cookieAuth: []
  *     responses:

--- a/SparkyFitnessServer/routes/v2/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/exerciseRoutes.ts
@@ -2,6 +2,7 @@ import express, { RequestHandler } from 'express';
 import { z } from 'zod';
 import {
   exerciseSearchQuerySchema,
+  exerciseStatsQuerySchema,
   exerciseStatsResponseSchema,
   paginatedExercisesResponseSchema,
 } from '@workspace/shared';
@@ -158,6 +159,7 @@ router.get('/search', searchHandler);
  *         required: false
  *         schema:
  *           type: integer
+ *           minimum: 1
  *         description: |
  *           Optional workout preset id to scope recentSessions to. When supplied, only sessions performed as that
  *           preset are considered, so the live "Previous" placeholders reflect this preset's own history instead of
@@ -167,7 +169,7 @@ router.get('/search', searchHandler);
  *       200:
  *         description: Best set + last set stats + recent sessions.
  *       400:
- *         description: Invalid exerciseId or excludePresetEntryId (not a UUID).
+ *         description: Invalid exerciseId, excludePresetEntryId (not a UUID), or presetId (not a positive integer).
  *       401:
  *         description: Unauthenticated.
  *       403:
@@ -187,12 +189,7 @@ const statsHandler: RequestHandler = async (req, res, next) => {
       });
       return;
     }
-    const parsedQuery = z
-      .object({
-        excludePresetEntryId: z.string().uuid().optional(),
-        presetId: z.coerce.number().int().positive().optional(),
-      })
-      .safeParse(req.query);
+    const parsedQuery = exerciseStatsQuerySchema.safeParse(req.query);
     if (!parsedQuery.success) {
       res.status(400).json({
         error: 'Invalid excludePresetEntryId or presetId',

--- a/SparkyFitnessServer/routes/v2/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/exerciseRoutes.ts
@@ -153,6 +153,16 @@ router.get('/search', searchHandler);
  *           Optional preset-entry UUID to exclude from the baseline. Used by the live active-workout card so today's
  *           in-progress (or pre-persisted planned) sets do not pollute the historical best/last baseline, and by the
  *           edit-workout screens to exclude the workout being edited. Also applies to recentSessions.
+ *       - in: query
+ *         name: presetId
+ *         required: false
+ *         schema:
+ *           type: integer
+ *         description: |
+ *           Optional workout preset id to scope recentSessions to. When supplied, only sessions performed as that
+ *           preset are considered, so the live "Previous" placeholders reflect this preset's own history instead of
+ *           this exercise's history from a different preset. Does not affect bestSet/lastSet, which stay
+ *           exercise-global (a PR is a PR regardless of which preset it happened under).
  *     responses:
  *       200:
  *         description: Best set + last set stats + recent sessions.
@@ -178,11 +188,14 @@ const statsHandler: RequestHandler = async (req, res, next) => {
       return;
     }
     const parsedQuery = z
-      .object({ excludePresetEntryId: z.string().uuid().optional() })
+      .object({
+        excludePresetEntryId: z.string().uuid().optional(),
+        presetId: z.coerce.number().int().positive().optional(),
+      })
       .safeParse(req.query);
     if (!parsedQuery.success) {
       res.status(400).json({
-        error: 'Invalid excludePresetEntryId',
+        error: 'Invalid excludePresetEntryId or presetId',
         details: parsedQuery.error.flatten().fieldErrors,
       });
       return;
@@ -190,7 +203,8 @@ const statsHandler: RequestHandler = async (req, res, next) => {
     const stats = await exerciseService.getExerciseStats(
       req.userId,
       parsed.data.exerciseId,
-      parsedQuery.data.excludePresetEntryId ?? null
+      parsedQuery.data.excludePresetEntryId ?? null,
+      parsedQuery.data.presetId ?? null
     );
     const response = exerciseStatsResponseSchema.parse(stats);
     res.status(200).json(response);

--- a/SparkyFitnessServer/services/exerciseService.ts
+++ b/SparkyFitnessServer/services/exerciseService.ts
@@ -1927,9 +1927,19 @@ async function createGroupedWorkoutSession(
           },
           actingUserId
         );
-      exerciseDefinitions = workoutPreset.exercises || [];
-      childEntrySource = 'Workout Preset';
-      preserveLegacyPresetDurationFallback = true;
+      if (exercises !== undefined) {
+        // Client supplied its own exercise/set structure (e.g. a live
+        // workout's Hevy-style placeholders) — use it verbatim. The entry is
+        // still tagged to the preset (for recentSessions stats scoping), but
+        // keeps its own source and stays nested-edit-able like any other
+        // client-authored session, unlike a pure workout_preset_id start
+        // (source 'Workout Preset', not in EDITABLE_SOURCES).
+        exerciseDefinitions = exercises;
+      } else {
+        exerciseDefinitions = workoutPreset.exercises || [];
+        childEntrySource = 'Workout Preset';
+        preserveLegacyPresetDurationFallback = true;
+      }
     } else {
       presetEntry =
         await exercisePresetEntryRepository.createExercisePresetEntryWithClient(

--- a/SparkyFitnessServer/services/exerciseService.ts
+++ b/SparkyFitnessServer/services/exerciseService.ts
@@ -251,9 +251,12 @@ async function getExerciseStats(
   userId: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   exerciseId: any,
-  excludePresetEntryId: string | null = null
+  excludePresetEntryId: string | null = null,
+  presetId: number | null = null
 ) {
   const [bestRow, lastRow, recentRows] = await Promise.all([
+    // Best/last stay exercise-global by design: a heavier lift is a PR
+    // regardless of which preset it was performed under.
     exerciseEntryDb.getBestSetForExercise(
       userId,
       exerciseId,
@@ -264,10 +267,15 @@ async function getExerciseStats(
       exerciseId,
       excludePresetEntryId
     ),
+    // Recent sessions feed the live "Previous" placeholders; scoping to the
+    // preset that started the workout (when supplied) means those placeholders
+    // reflect this preset's own history instead of a different preset's.
     exerciseEntryDb.getRecentSessionsForExercise(
       userId,
       exerciseId,
-      excludePresetEntryId
+      excludePresetEntryId,
+      undefined,
+      presetId
     ),
   ]);
   return {

--- a/SparkyFitnessServer/tests/exerciseEntriesApiSchemas.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntriesApiSchemas.test.ts
@@ -80,7 +80,7 @@ describe('Exercise entry API schemas', () => {
     expect(result.data.exercises).toHaveLength(1);
   });
 
-  it('rejects create payloads that provide both workout sources', () => {
+  it('accepts create payloads that provide both workout sources (preset-tagged, client-supplied exercises)', () => {
     const result = runSchema('createPresetSessionRequestSchema', {
       workout_preset_id: 42,
       name: 'Morning Workout',
@@ -91,7 +91,9 @@ describe('Exercise entry API schemas', () => {
         },
       ],
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    expect(result.data.workout_preset_id).toBe(42);
+    expect(result.data.exercises).toHaveLength(1);
   });
 
   it('rejects create payloads that provide neither workout source', () => {

--- a/SparkyFitnessServer/tests/exerciseEntryStats.integration.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntryStats.integration.test.ts
@@ -62,8 +62,12 @@ const E2 = '00000000-0000-4000-b000-0000000000e2'; // session exclusion
 const E3 = '00000000-0000-4000-b000-0000000000e3'; // null-preset always counted
 const E4 = '00000000-0000-4000-b000-0000000000e4'; // recent sessions: limit + ordering
 const E5 = '00000000-0000-4000-b000-0000000000e5'; // recent sessions: null/set-less filtering
+const E6 = '00000000-0000-4000-b000-0000000000e6'; // recent sessions: workout_preset_id scoping
 const PE_CURRENT = '00000000-0000-4000-b000-0000000000c1';
 const PE_OTHER = '00000000-0000-4000-b000-0000000000c2';
+const PE_PRESET_A_OLD = '00000000-0000-4000-b000-0000000000c3';
+const PE_PRESET_A_NEW = '00000000-0000-4000-b000-0000000000c4';
+const PE_INDIVIDUAL_E6 = '00000000-0000-4000-b000-0000000000c5';
 
 const EN1 = '00000000-0000-4000-b000-000000000101';
 const EN2_INDIV = '00000000-0000-4000-b000-000000000201';
@@ -79,7 +83,9 @@ const EN5_CARDIO = '00000000-0000-4000-b000-000000000501';
 const EN5_NULLSETS = '00000000-0000-4000-b000-000000000502';
 const EN5_MIXED = '00000000-0000-4000-b000-000000000503';
 
-const ALL_EXERCISES = [E1, E2, E3, E4, E5];
+const ALL_EXERCISES = [E1, E2, E3, E4, E5, E6];
+let presetAId: number;
+let presetBId: number;
 
 describe.runIf(RUN)('exercise stats SQL (warmup + session exclusion)', () => {
   beforeAll(async () => {
@@ -110,6 +116,7 @@ describe.runIf(RUN)('exercise stats SQL (warmup + session exclusion)', () => {
         [E3, 'Stats Test Exercise 3'],
         [E4, 'Stats Test Exercise 4'],
         [E5, 'Stats Test Exercise 5'],
+        [E6, 'Stats Test Exercise 6'],
       ] as const) {
         await sys.query(
           'INSERT INTO public.exercises (id, name, source, user_id, is_custom) VALUES ($1, $2, $3, $4, true)',
@@ -125,6 +132,22 @@ describe.runIf(RUN)('exercise stats SQL (warmup + session exclusion)', () => {
           [id, U, name, '2026-07-07', 'manual']
         );
       }
+
+      // Two workout presets for the recentSessions presetId-scoping test:
+      // Preset A has history for E6, Preset B has none.
+      await sys.query('DELETE FROM public.workout_presets WHERE user_id = $1', [
+        U,
+      ]);
+      const presetAResult = await sys.query(
+        'INSERT INTO public.workout_presets (user_id, name) VALUES ($1, $2) RETURNING id',
+        [U, 'Stats Test Preset A']
+      );
+      presetAId = presetAResult.rows[0].id;
+      const presetBResult = await sys.query(
+        'INSERT INTO public.workout_presets (user_id, name) VALUES ($1, $2) RETURNING id',
+        [U, 'Stats Test Preset B']
+      );
+      presetBId = presetBResult.rows[0].id;
 
       const insertEntry = async (
         id: string,
@@ -216,6 +239,48 @@ describe.runIf(RUN)('exercise stats SQL (warmup + session exclusion)', () => {
       await insertEntry(EN5_MIXED, E5, null, '2026-07-04');
       await insertSet(EN5_MIXED, 1, 'Working Set', null, null);
       await insertSet(EN5_MIXED, 2, 'Working Set', 50, 10);
+
+      // E6 — recentSessions presetId scoping: two sessions performed as
+      // Preset A, plus a more recent/heavier individual (non-preset) session
+      // that a Preset-A-scoped query must exclude.
+      await sys.query(
+        `INSERT INTO public.exercise_preset_entries (id, user_id, workout_preset_id, name, entry_date, source)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [
+          PE_PRESET_A_OLD,
+          U,
+          presetAId,
+          'Preset A Session (old)',
+          '2026-07-01',
+          'manual',
+        ]
+      );
+      await sys.query(
+        `INSERT INTO public.exercise_preset_entries (id, user_id, workout_preset_id, name, entry_date, source)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [
+          PE_PRESET_A_NEW,
+          U,
+          presetAId,
+          'Preset A Session (new)',
+          '2026-07-05',
+          'manual',
+        ]
+      );
+      await sys.query(
+        `INSERT INTO public.exercise_preset_entries (id, user_id, name, entry_date, source)
+         VALUES ($1, $2, $3, $4, $5)`,
+        [PE_INDIVIDUAL_E6, U, 'Individual Session', '2026-07-07', 'manual']
+      );
+      const EN6_PRESET_OLD = '00000000-0000-4000-b000-000000000601';
+      const EN6_PRESET_NEW = '00000000-0000-4000-b000-000000000602';
+      const EN6_INDIVIDUAL = '00000000-0000-4000-b000-000000000603';
+      await insertEntry(EN6_PRESET_OLD, E6, PE_PRESET_A_OLD, '2026-07-01');
+      await insertSet(EN6_PRESET_OLD, 1, 'Working Set', 100, 8);
+      await insertEntry(EN6_PRESET_NEW, E6, PE_PRESET_A_NEW, '2026-07-05');
+      await insertSet(EN6_PRESET_NEW, 1, 'Working Set', 120, 6);
+      await insertEntry(EN6_INDIVIDUAL, E6, PE_INDIVIDUAL_E6, '2026-07-07');
+      await insertSet(EN6_INDIVIDUAL, 1, 'Working Set', 200, 4);
     } finally {
       sys.release();
     }
@@ -232,6 +297,9 @@ describe.runIf(RUN)('exercise stats SQL (warmup + session exclusion)', () => {
         'DELETE FROM public.exercise_preset_entries WHERE user_id = $1',
         [U]
       );
+      await sys.query('DELETE FROM public.workout_presets WHERE user_id = $1', [
+        U,
+      ]);
       await sys.query(
         'DELETE FROM public.exercises WHERE id = ANY($1::uuid[])',
         [ALL_EXERCISES]
@@ -324,6 +392,42 @@ describe.runIf(RUN)('exercise stats SQL (warmup + session exclusion)', () => {
     expect(sessions[0].sets?.map((s) => Number(s.weight))).toEqual([
       100, 999, 888, 777,
     ]);
+  });
+
+  it('scopes recent sessions to a workout preset id when supplied', async () => {
+    const scoped = await exerciseEntryDb.getRecentSessionsForExercise(
+      U,
+      E6,
+      null,
+      undefined,
+      presetAId
+    );
+    // Only the two Preset-A sessions, newest first; the heavier/more recent
+    // individual (non-preset) session is excluded even though it would
+    // otherwise be the top result.
+    expect(scoped.map((s) => s.entry_date)).toEqual([
+      '2026-07-05',
+      '2026-07-01',
+    ]);
+    expect(scoped.map((s) => Number(s.sets?.[0]?.weight))).toEqual([120, 100]);
+  });
+
+  it('returns no recent sessions for a preset that was never performed', async () => {
+    const scoped = await exerciseEntryDb.getRecentSessionsForExercise(
+      U,
+      E6,
+      null,
+      undefined,
+      presetBId
+    );
+    expect(scoped).toEqual([]);
+  });
+
+  it('is unaffected by presetId scoping when presetId is omitted', async () => {
+    const all = await exerciseEntryDb.getRecentSessionsForExercise(U, E6);
+    expect(
+      all.map((s) => Number(s.sets?.[0]?.weight)).sort((a, b) => a - b)
+    ).toEqual([100, 120, 200]);
   });
 
   it('omits both-null sets and skips entries with no qualifying sets', async () => {

--- a/SparkyFitnessServer/tests/exercisePresetEntryRoutes.test.ts
+++ b/SparkyFitnessServer/tests/exercisePresetEntryRoutes.test.ts
@@ -15,14 +15,14 @@ vi.mock('@workspace/shared', () => ({
         data.workout_preset_id !== undefined && data.workout_preset_id !== null;
       const hasExercises = data.exercises !== undefined;
 
-      if (hasPresetId === hasExercises) {
+      if (!hasPresetId && !hasExercises) {
         return {
           success: false,
           error: {
             issues: [
               {
                 message:
-                  'Provide exactly one workout source: workout_preset_id or exercises.',
+                  'Provide a workout source: workout_preset_id or exercises.',
               },
             ],
             flatten: () => ({ formErrors: [], fieldErrors: {} }),
@@ -344,17 +344,34 @@ describe('exercisePresetEntryRoutes', () => {
       }
     );
   });
-  it('rejects ambiguous create payloads', async () => {
+  it('accepts create payloads that tag a preset while supplying client exercises', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    exerciseService.createGroupedWorkoutSession.mockResolvedValue(
+      groupedSessionFixture
+    );
+    const body = {
+      workout_preset_id: 42,
+      name: 'Morning Workout',
+      entry_date: '2026-03-12',
+      exercises: [
+        {
+          exercise_id: '11111111-1111-4111-8111-111111111111',
+        },
+      ],
+    };
+    const response = await invokeRoute('post', '/', { body });
+    expect(response.statusCode).toBe(201);
+    expect(exerciseService.createGroupedWorkoutSession).toHaveBeenCalledWith(
+      '99999999-9999-4999-8999-999999999999',
+      '99999999-9999-4999-8999-999999999999',
+      body
+    );
+  });
+  it('rejects create payloads with neither a preset nor exercises', async () => {
     const response = await invokeRoute('post', '/', {
       body: {
-        workout_preset_id: 42,
         name: 'Morning Workout',
         entry_date: '2026-03-12',
-        exercises: [
-          {
-            exercise_id: '11111111-1111-4111-8111-111111111111',
-          },
-        ],
       },
     });
     expect(response.statusCode).toBe(400);

--- a/SparkyFitnessServer/tests/exerciseRoutesV2.test.ts
+++ b/SparkyFitnessServer/tests/exerciseRoutesV2.test.ts
@@ -360,6 +360,7 @@ describe('GET /v2/exercises/:exerciseId/stats', () => {
     expect(exerciseService.getExerciseStats).toHaveBeenCalledWith(
       'user-123',
       EXERCISE_UUID,
+      null,
       null
     );
   });
@@ -431,7 +432,8 @@ describe('GET /v2/exercises/:exerciseId/stats', () => {
     expect(exerciseService.getExerciseStats).toHaveBeenCalledWith(
       'user-123',
       EXERCISE_UUID,
-      excludeId
+      excludeId,
+      null
     );
   });
 
@@ -441,7 +443,38 @@ describe('GET /v2/exercises/:exerciseId/stats', () => {
     );
 
     expect(res.statusCode).toBe(400);
-    expect(res.body.error).toBe('Invalid excludePresetEntryId');
+    expect(res.body.error).toBe('Invalid excludePresetEntryId or presetId');
+    expect(exerciseService.getExerciseStats).not.toHaveBeenCalled();
+  });
+
+  it('forwards a valid presetId query param to the service', async () => {
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseService.getExerciseStats.mockResolvedValue({
+      bestSet: null,
+      lastSet: null,
+      recentSessions: [],
+    });
+
+    const res = await request(app).get(
+      `/v2/exercises/${EXERCISE_UUID}/stats?presetId=42`
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(exerciseService.getExerciseStats).toHaveBeenCalledWith(
+      'user-123',
+      EXERCISE_UUID,
+      null,
+      42
+    );
+  });
+
+  it('returns 400 when presetId is not a positive integer', async () => {
+    const res = await request(app).get(
+      `/v2/exercises/${EXERCISE_UUID}/stats?presetId=not-a-number`
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toBe('Invalid excludePresetEntryId or presetId');
     expect(exerciseService.getExerciseStats).not.toHaveBeenCalled();
   });
 

--- a/SparkyFitnessServer/tests/exerciseService.groupedWorkouts.test.ts
+++ b/SparkyFitnessServer/tests/exerciseService.groupedWorkouts.test.ts
@@ -302,6 +302,88 @@ describe('exerciseService grouped workouts', () => {
     expect(createCalls[1][2]).toMatchObject({ superset_group: null });
     expect(client.query).toHaveBeenCalledWith('COMMIT');
   });
+
+  it('tags the entry to the preset but uses client-supplied exercises when both are given', async () => {
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    workoutPresetRepository.getWorkoutPresetById.mockResolvedValue({
+      id: 42,
+      name: 'Push Day',
+      description: 'Preset',
+      // The preset's own stored structure — must NOT be what gets created.
+      exercises: [
+        {
+          exercise_id: '11111111-1111-4111-8111-111111111111',
+          sort_order: 0,
+          superset_group: 1,
+          sets: [],
+        },
+      ],
+    });
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    exercisePresetEntryRepository.createExercisePresetEntryWithClient.mockResolvedValue(
+      { id: 'preset-entry-1' }
+    );
+    // @ts-expect-error TS(2339): Property 'mockImplementation' does not exist on ty... Remove this comment to see the full error message
+    resolveExerciseIdToUuid.mockImplementation(async (id: string) => id);
+    // @ts-expect-error TS(2339): Property 'mockImplementation' does not exist on ty... Remove this comment to see the full error message
+    exerciseDb.getExerciseById.mockImplementation(async (id: string) => ({
+      id,
+      name: 'Test Exercise',
+      calories_per_hour: 300,
+    }));
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    calorieCalculationService.estimateCaloriesBurnedPerHour.mockResolvedValue(
+      300
+    );
+    // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+    exerciseEntryDb._createExerciseEntryWithClient.mockResolvedValue({
+      entry: { id: 'new-entry' },
+      operation: 'created',
+    });
+
+    // The client (e.g. a live workout) supplies its own single exercise,
+    // distinct from the preset's stored two-exercise structure.
+    await exerciseService.createGroupedWorkoutSession('user-1', 'actor-1', {
+      workout_preset_id: 42,
+      entry_date: '2026-03-12',
+      source: 'sparky',
+      name: 'Live Workout',
+      exercises: [
+        {
+          exercise_id: '33333333-3333-4333-8333-333333333333',
+          sort_order: 0,
+          superset_group: null,
+          duration_minutes: 5,
+          sets: [],
+        },
+      ],
+    });
+
+    // The entry is tagged to the preset for stats scoping...
+    expect(
+      exercisePresetEntryRepository.createExercisePresetEntryWithClient
+    ).toHaveBeenCalledWith(
+      client,
+      'user-1',
+      expect.objectContaining({ workout_preset_id: 42 }),
+      'actor-1'
+    );
+
+    // ...but the created child entry is the client-supplied exercise, not the
+    // preset's stored one, and keeps the client's own source ('sparky', not
+    // 'Workout Preset') so the session stays nested-edit-able afterward.
+    const taggedCreateCalls = vi.mocked(
+      exerciseEntryDb._createExerciseEntryWithClient
+    ).mock.calls;
+    expect(taggedCreateCalls).toHaveLength(1);
+    expect(taggedCreateCalls[0][2]).toMatchObject({
+      exercise_id: '33333333-3333-4333-8333-333333333333',
+      superset_group: null,
+    });
+    expect(taggedCreateCalls[0][4]).toBe('sparky');
+    expect(client.query).toHaveBeenCalledWith('COMMIT');
+  });
+
   it('propagates entry_date changes to existing child entries on header-only updates', async () => {
     getGroupedExerciseSessionByIdWithClient
       // @ts-expect-error TS(2339): Property 'mockResolvedValueOnce' does not exist on... Remove this comment to see the full error message

--- a/SparkyFitnessServer/tests/exerciseService.stats.test.ts
+++ b/SparkyFitnessServer/tests/exerciseService.stats.test.ts
@@ -86,6 +86,8 @@ describe('exerciseService.getExerciseStats', () => {
     expect(exerciseEntryDb.getRecentSessionsForExercise).toHaveBeenCalledWith(
       userId,
       exerciseId,
+      null,
+      undefined,
       null
     );
 
@@ -188,7 +190,37 @@ describe('exerciseService.getExerciseStats', () => {
     expect(exerciseEntryDb.getRecentSessionsForExercise).toHaveBeenCalledWith(
       userId,
       exerciseId,
-      excludePresetEntryId
+      excludePresetEntryId,
+      undefined,
+      null
+    );
+  });
+
+  it('forwards presetId to getRecentSessionsForExercise only', async () => {
+    const presetId = 42;
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseEntryDb.getBestSetForExercise.mockResolvedValue(null);
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseEntryDb.getLastSetForExercise.mockResolvedValue(null);
+
+    await exerciseService.getExerciseStats(userId, exerciseId, null, presetId);
+
+    expect(exerciseEntryDb.getBestSetForExercise).toHaveBeenCalledWith(
+      userId,
+      exerciseId,
+      null
+    );
+    expect(exerciseEntryDb.getLastSetForExercise).toHaveBeenCalledWith(
+      userId,
+      exerciseId,
+      null
+    );
+    expect(exerciseEntryDb.getRecentSessionsForExercise).toHaveBeenCalledWith(
+      userId,
+      exerciseId,
+      null,
+      undefined,
+      presetId
     );
   });
 

--- a/shared/src/schemas/api/ExerciseEntries.api.zod.ts
+++ b/shared/src/schemas/api/ExerciseEntries.api.zod.ts
@@ -29,6 +29,23 @@ export const exerciseHistoryQuerySchema = z
   })
   .strict();
 
+/** Query params for the per-exercise best/last/recent-sessions stats endpoint */
+export const exerciseStatsQuerySchema = z.object({
+  /**
+   * Preset-entry UUID to exclude from the baseline (today's in-progress/
+   * planned sets, or the workout being edited). Applies to bestSet, lastSet,
+   * and recentSessions.
+   */
+  excludePresetEntryId: z.string().uuid().optional(),
+  /**
+   * Workout preset id to scope recentSessions to, so the live "Previous"
+   * placeholders reflect this preset's own history instead of this
+   * exercise's history from a different preset. Does not affect
+   * bestSet/lastSet, which stay exercise-global.
+   */
+  presetId: z.coerce.number().int().positive().optional(),
+});
+
 // --- Building blocks ---
 
 /**
@@ -475,6 +492,7 @@ export const exerciseStatsResponseSchema = z
 // --- Types ---
 
 export type ExerciseHistoryQuery = z.infer<typeof exerciseHistoryQuerySchema>;
+export type ExerciseStatsQuery = z.infer<typeof exerciseStatsQuerySchema>;
 export type ExerciseSnapshotResponse = z.infer<
   typeof exerciseSnapshotResponseSchema
 >;

--- a/shared/src/schemas/api/ExerciseEntries.api.zod.ts
+++ b/shared/src/schemas/api/ExerciseEntries.api.zod.ts
@@ -146,12 +146,16 @@ export const createPresetSessionRequestSchema = z
       data.workout_preset_id !== undefined && data.workout_preset_id !== null;
     const hasExercises = data.exercises !== undefined;
 
-    if (hasPresetId === hasExercises) {
+    // workout_preset_id alone means "copy this preset's own stored
+    // structure"; exercises alone means a freeform/individual session;
+    // both together means "tag this session as started from a preset, but
+    // use the client-supplied (e.g. live-workout) exercise/set structure
+    // instead of the preset's stored one." Only rule out neither.
+    if (!hasPresetId && !hasExercises) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message:
-          "Provide exactly one workout source: workout_preset_id or exercises.",
-        path: hasPresetId ? ["workout_preset_id"] : ["exercises"],
+        message: "Provide a workout source: workout_preset_id or exercises.",
+        path: ["exercises"],
       });
     }
 


### PR DESCRIPTION
## Description

Fix preset workouts assuming set values based on previous completion of an exercise _outside_ of the preset it was completed on.

**What problem does this PR solve?**
Currently, when starting a workout preset, the assumed weight and set values are determined by the _exercise's_ set's previous values. The potentially unintended consequence of this treatment is that when you have the same exercise for a primary workout and a secondary workout, they share the same assumed set value, which makes tracking Primary and Secondary exercises difficult.

**How did you implement the solution?**
AI assisted with user review

Linked Issue: Closes https://github.com/CodeWithCJ/SparkyFitness/issues/2118

## How to Test

1. Update containers and mobile app
2. Create Preset A and Preset B with the same exercise
3. Via mobile app, start workout Preset A with {Exercise 1}
a. Update values and complete a set and finisht the workout
4. Via mobile app, start workout Preset B with {Exercise 1}
a. Note assumed Exercise 1 values are not based on Preset A
b. Update values and complete a set and finisht the workout
5. Via mobile app, start workout Preset A with {Exercise 1}
a. Note assumed values are based on Preset A's previous completion
5. Via mobile app, start workout Preset B with {Exercise 1}
a. Note assumed values are based on Preset B's previous completion

## PR Type

- [X] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [X] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [X] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Table screenshot representation</summary>

### Before

**Preset 1:**
| Exercise | Weight | Reps |
|------|------|------|
| Bench | 100 lbs | 10 reps |
| Squat | 120 lbs | 15 reps |

**Preset 2:**
| Exercise | Weight | Reps |
|------|------|------|
| Squat | 160 lbs | 10 reps
| Bench| 90 lbs | 15 reps


**Assuming you completed **Preset 1** - Preset 2's Assumed values are Preset 1's completed values, whatever they may be:**
| Exercise | Weight | Reps |
|------|------|------|
| Bench | 100 lbs | 10 reps |
| Squat | 120 lbs | 15 reps |

### After

**Preset 1:**
| Exercise | Weight | Reps |
|------|------|------|
| Bench | 100 lbs | 10 reps |
| Squat | 120 lbs | 15 reps |

**Preset 2:**
| Exercise | Weight | Reps |
|------|------|------|
| Squat | 160 lbs | 10 reps
| Bench| 90 lbs | 15 reps


**Assuming you completed **Preset 1** - Preset 2's Assumed values are unchanged or Preset 2's previously completed values:**
| Exercise | Weight | Reps |
|------|------|------|
| Squat | 160 lbs | 10 reps
| Bench| 90 lbs | 15 reps

</details>

## Notes for Reviewers

This updated utilizes `exercise_preset_entries.workout_preset_id`, which was previously not updated to the server, so assumed valued will be empty until a workout is completed _after_ this changed.

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.

Does this logic make sense?

Currently, it is impossible to reliably/accurately track T1, T2, etc. movements if you reuse an exercise, as the whatever the previously completed values are assumed, making it impossible to track.

Alternatively to this change, users can created duplicates of an exercise to label as T1, T2, etc., which seems clunky to me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Recent exercise-session history can be filtered by workout preset.
  - Preset-based workouts preserve custom exercises and link sessions to their source preset.
  - Workout creation supports combining a preset with custom exercises.
  - Preset statistics are shared only when the active server configuration matches.

- **Bug Fixes**
  - Best and latest exercise statistics remain exercise-wide while recent history is preset-specific.
  - Added validation for invalid preset identifiers and incomplete workout requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->