### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,11 @@ For full installation guides, configuration options, and development docs, pleas
 
 ## Star History
 
-<a href="https://star-history.com/#CodeWithCJ/SparkyFitness&Date">
+<a href="https://star-history.dera.page/#CodeWithCJ/SparkyFitness&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=CodeWithCJ/SparkyFitness&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=CodeWithCJ/SparkyFitness&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=CodeWithCJ/SparkyFitness&type=Date" width="100%" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=CodeWithCJ/SparkyFitness&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=CodeWithCJ/SparkyFitness&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=CodeWithCJ/SparkyFitness&type=Date" width="100%" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart shown in the README has been broken, because the underlying GitHub stargazer API restricts how the data can be fetched, leaving the chart blank for visitors.

This change updates the chart to a working alternative so the repository's star history renders correctly again.

No behavior change beyond fixing the chart link and image source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History links and chart image sources in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->