### PR TITLE
Documentation improvements for MCP with Open WebUI

### DIFF
--- a/docs/content/2.features/1.diary/exercise.md
+++ b/docs/content/2.features/1.diary/exercise.md
@@ -1,3 +1,5 @@
 # Exercise Tracking
 
-SparkyFitness allows you to easily track your exercise routines, including details like duration, intensity, and calories burned. Comprehensive guides on logging and managing your workouts will be added in the future.
+SparkyFitness allows you to easily track your exercise routines, including details like duration, intensity, and calories burned. You can also import and sync your exercise routines from Health Connect (Android) or Apple Health using the [Mobile App](mobile-app/mobile-app).
+
+Comprehensive guides on logging and managing your workouts will be added in the future.

--- a/docs/content/2.features/1.diary/exercise.md
+++ b/docs/content/2.features/1.diary/exercise.md
@@ -1,5 +1,5 @@
 # Exercise Tracking
 
-SparkyFitness allows you to easily track your exercise routines, including details like duration, intensity, and calories burned. You can also import and sync your exercise routines from Health Connect (Android) or Apple Health using the [Mobile App](mobile-app/mobile-app).
+SparkyFitness allows you to easily track your exercise routines, including details like duration, intensity, and calories burned. You can also import and sync your exercise routines from Health Connect (Android) or Apple Health using the [Mobile App](/mobile-app/mobile-app).
 
 Comprehensive guides on logging and managing your workouts will be added in the future.

--- a/docs/content/2.features/15.mcp-server.md
+++ b/docs/content/2.features/15.mcp-server.md
@@ -81,7 +81,7 @@ The MCP server is served **in-process** by the main SparkyFitness server at `POS
 
 ### 1. Generate an API Key
 
-Go to **Settings → Developer & Integrations → API Key Management** in the web UI and generate a key (or call `POST /identity/user/generate-api-key`). You'll pass this as a **Bearer Token** in the `Authorization` header.
+Go to **Settings → Developer & Integrations → API Key Management** in the web UI and generate a key. You'll pass this as a **Bearer Token** in the `Authorization` header.
 
 ### 2. Find Your MCP Endpoint
 

--- a/docs/content/2.features/15.mcp-server.md
+++ b/docs/content/2.features/15.mcp-server.md
@@ -77,11 +77,11 @@ Because the AI has access to all these tools, it can do things a standard app ca
 
 ## 🚀 Getting Started
 
-The MCP server is now served **in-process** by the main SparkyFitness server at `POST /mcp`. There is no separate MCP service to run.
+The MCP server is served **in-process** by the main SparkyFitness server at `POST /mcp`. There is no separate MCP service to run.
 
 ### 1. Generate an API Key
 
-Go to **Profile → Personal API Key** in the web UI and generate a key (or call `POST /identity/user/generate-api-key`). You'll pass this as a **Bearer Token** in the `Authorization` header.
+Go to **Settings → Developer & Integrations → API Key Management** in the web UI and generate a key (or call `POST /identity/user/generate-api-key`). You'll pass this as a **Bearer Token** in the `Authorization` header.
 
 ### 2. Find Your MCP Endpoint
 
@@ -116,3 +116,14 @@ Go to **Profile → Personal API Key** in the web UI and generate a key (or call
 ```
 
 _Note: for a local-dev server over plain HTTP, add `--allow-http` to the args and use `http://localhost:8080/mcp` (or `http://localhost:3010/mcp` to hit the server directly) — `mcp-remote` refuses non-HTTPS URLs otherwise._
+
+**Open WebUI client** (e.g. for locally hosted Ollama, Llama.cpp, etc.)
+
+1.  In Open WebUI, click your name in the bottom left and open the **Admin Panel → Settings**.
+2.  Scroll down to the Tools section and select **Integrations**.
+3.  Add a new connection:
+    *  Type: MCP Streamable HTTP (click 'OpenAPI' to change the option)
+    *   URL: The MCP url from above
+    *   Auth: Bearer
+    *   API Key: The API key from above
+4.  Save the options and refresh the web page. You can enable it on new chats through the Integration option.


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Add steps to help new users connect MCP to their Open WebUI instance.
Add a link to the mobile app page from the exercise page since it's relevant.

**How did you implement the solution?**
Doc change only.

Linked Issue: n/a

## How to Test

Doc changes only.

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [x] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

Not needed, doc only 
</details>

## Notes for Reviewers

There are a lot of "This documentation is coming soon" pages in the documentation. There are a few duplicate pages, too. Generally the documentation is quite difficult to follow. Would you be open to re-organising this if I came up with a rough hierarchy which simplifies the pages and splits developer and user content?

Additionally it would be good to block new PRs if they don't have relevant documentation updates (to ensure it's maintained long term).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for importing and syncing exercise routines through Health Connect or Apple Health.
  * Updated API key management instructions with the new location in Settings.
  * Added setup steps for connecting Open WebUI as an MCP Streamable HTTP client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->