### PR TITLE
(fix) Supplements display on Nutrition Summary

### DIFF
--- a/SparkyFitnessFrontend/src/tests/utils/addSupplementTotals.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/addSupplementTotals.test.ts
@@ -1,4 +1,5 @@
 import { addSupplementTotals } from '@/utils/nutritionCalculations';
+import { EMPTY_SUPPLEMENT_TOTALS } from '@workspace/shared';
 import type { MealTotals } from '@/types/meal';
 
 const foodTotals = {
@@ -11,19 +12,18 @@ const foodTotals = {
   sodium: 2000,
   cholesterol: 100,
   saturated_fat: 10,
+  calcium: 256.3,
   custom_nutrients: {},
 } as unknown as MealTotals;
 
 const supplementTotals = {
+  ...EMPTY_SUPPLEMENT_TOTALS,
   calories: 15,
-  protein: 0,
-  carbs: 0,
   fat: 1.5,
-  dietary_fiber: 0,
 };
 
 describe('addSupplementTotals', () => {
-  it('adds the supplement arm to the five rolled-up fields', () => {
+  it('adds the supplement arm to the macro fields', () => {
     const totals = addSupplementTotals(foodTotals, supplementTotals);
 
     expect(totals.calories).toBe(1547);
@@ -31,14 +31,49 @@ describe('addSupplementTotals', () => {
     expect(totals.protein).toBe(120);
   });
 
-  it('leaves fields the server does not roll up for supplements alone', () => {
-    // Sodium is not summed for supplements by the nutrition summary or the chatbot, so
-    // adding it here would make the Diary the only surface that counted it.
+  // The #2145 case: a supplement's calcium reached Reports, which sums all seventeen
+  // fixed columns, but not the Diary card, which summed five. The reporter saw the
+  // food-only 256.3mg against a dose supplying 10000mg.
+  it('adds micronutrients the supplement carries, not just macros', () => {
+    const totals = addSupplementTotals(foodTotals, {
+      ...EMPTY_SUPPLEMENT_TOTALS,
+      calcium: 10000,
+      sodium: 150,
+      iron: 18,
+    });
+
+    expect(totals.calcium).toBe(10256.3);
+    expect(totals.sodium).toBe(2150);
+    expect(totals.iron).toBe(18);
+  });
+
+  it('leaves a fixed field alone when the supplement contributes nothing to it', () => {
     const totals = addSupplementTotals(foodTotals, supplementTotals);
 
     expect(totals.sodium).toBe(2000);
     expect(totals.sugars).toBe(30);
     expect(totals.cholesterol).toBe(100);
+  });
+
+  // A client newer than its server gets only the five macro keys back. Adding
+  // `food[key] + supplements[key]` across all seventeen would write NaN into the other
+  // twelve, which renders as "NaN mg" rather than failing loudly.
+  it('does not produce NaN against a server that reports only the macro fields', () => {
+    const legacyServerResponse = {
+      calories: 15,
+      protein: 0,
+      carbs: 0,
+      fat: 1.5,
+      dietary_fiber: 0,
+    };
+
+    const totals = addSupplementTotals(foodTotals, legacyServerResponse);
+
+    expect(totals.calories).toBe(1547);
+    expect(totals.calcium).toBe(256.3);
+    expect(totals.sodium).toBe(2000);
+    expect(Number.isNaN(totals.calcium as number)).toBe(false);
+    expect(Number.isNaN(totals.potassium as number)).toBe(false);
   });
 
   it('returns the food totals untouched when there is no supplement arm', () => {
@@ -47,15 +82,10 @@ describe('addSupplementTotals', () => {
   });
 
   it('is a no-op for a day with supplements that carry no nutrition', () => {
-    const totals = addSupplementTotals(foodTotals, {
-      calories: 0,
-      protein: 0,
-      carbs: 0,
-      fat: 0,
-      dietary_fiber: 0,
-    });
+    const totals = addSupplementTotals(foodTotals, EMPTY_SUPPLEMENT_TOTALS);
 
     expect(totals.calories).toBe(1532);
     expect(totals.fat).toBe(50);
+    expect(totals.calcium).toBe(256.3);
   });
 });

--- a/SparkyFitnessFrontend/src/tests/utils/addSupplementTotals.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/addSupplementTotals.test.ts
@@ -47,6 +47,59 @@ describe('addSupplementTotals', () => {
     expect(totals.iron).toBe(18);
   });
 
+  // The larger half of #2145. Only six catalog micronutrients have a fixed column, so a
+  // magnesium or vitamin D supplement contributes nothing the fixed loop can reach; those
+  // values live in the snapshot's custom_nutrients and have to be folded separately.
+  it('adds custom nutrients the supplement carries', () => {
+    const totals = addSupplementTotals(
+      {
+        ...foodTotals,
+        custom_nutrients: { Magnesium: 120, Choline: 200 },
+      } as unknown as MealTotals,
+      {
+        ...EMPTY_SUPPLEMENT_TOTALS,
+        custom_nutrients: { Magnesium: 400, 'Vitamin D': 50 },
+      }
+    );
+
+    expect(totals.custom_nutrients).toEqual({
+      Magnesium: 520,
+      Choline: 200,
+      // No food supplied it, which is the ordinary case for a supplement nutrient. Being
+      // dropped for that would leave the row reading zero against a dose that supplied it.
+      'Vitamin D': 50,
+    });
+  });
+
+  it('does not mutate the food custom-nutrient map it was handed', () => {
+    // The caller's own day totals hold this object; folding doses into it in place would
+    // double-count the moment the same day is folded again.
+    const foodCustom = { Magnesium: 120 };
+    const withCustom = {
+      ...foodTotals,
+      custom_nutrients: foodCustom,
+    } as unknown as MealTotals;
+
+    addSupplementTotals(withCustom, {
+      ...EMPTY_SUPPLEMENT_TOTALS,
+      custom_nutrients: { Magnesium: 400 },
+    });
+
+    expect(foodCustom).toEqual({ Magnesium: 120 });
+  });
+
+  it('leaves the custom nutrients alone when the supplement carries none', () => {
+    const totals = addSupplementTotals(
+      {
+        ...foodTotals,
+        custom_nutrients: { Magnesium: 120 },
+      } as unknown as MealTotals,
+      supplementTotals
+    );
+
+    expect(totals.custom_nutrients).toEqual({ Magnesium: 120 });
+  });
+
   it('leaves a fixed field alone when the supplement contributes nothing to it', () => {
     const totals = addSupplementTotals(foodTotals, supplementTotals);
 

--- a/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
+++ b/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
@@ -1,5 +1,8 @@
 import type { SupplementTotals } from '@workspace/shared';
-import { resolveSupplementTotals } from '@workspace/shared';
+import {
+  resolveSupplementTotals,
+  FOOD_VARIANT_NUTRIENT_FIELDS,
+} from '@workspace/shared';
 import { getDietTemplate } from '@/constants/dietTemplates';
 import { EMPTY_MEAL_TOTALS } from '@/constants/nutrients';
 import i18n from '@/i18n';
@@ -313,28 +316,33 @@ export const calculateNutrition = (
 /**
  * Folds a day's logged supplement doses into its food totals.
  *
- * Limited to the five fields the server rolls up for supplements everywhere else
- * (`supplementFixed` in foodMisc). A supplement's sodium is not summed by the nutrition
- * summary or the chatbot either, so adding it here alone would trade one inconsistency for
- * a subtler one: the Diary would be the only surface that counted it.
+ * Covers every field in `FOOD_VARIANT_NUTRIENT_FIELDS`, not just the macros. It added only
+ * the five macro fields until #2145: a supplement carrying 10000mg of calcium showed its
+ * calcium in Reports, which sums all seventeen, and nothing in the Diary summary card
+ * beside it, which is the surface the user was actually looking at.
+ *
+ * The older reasoning for the narrow version was that no other surface summed a
+ * supplement's sodium either, so widening here alone would make the Diary the odd one out.
+ * That was already untrue of the range query in `reportRepository`, and the inconsistency
+ * it was avoiding is the one users hit.
  *
  * Returns the food totals unchanged when there is no supplement arm, so a day with no
  * supplements is byte-for-byte what it was before supplements existed.
  */
 export const addSupplementTotals = <T extends MealTotals>(
   foodTotals: T,
-  supplementTotals: SupplementTotals | undefined | null
+  supplementTotals: Partial<SupplementTotals> | undefined | null
 ): T => {
   if (!supplementTotals) return foodTotals;
+  // Merges against a full-width zero object, so an older server answering with only the
+  // five macro keys yields 0 for the rest rather than `number + undefined` = NaN.
   const supplements = resolveSupplementTotals(supplementTotals);
-  return {
-    ...foodTotals,
-    calories: foodTotals.calories + supplements.calories,
-    protein: foodTotals.protein + supplements.protein,
-    carbs: foodTotals.carbs + supplements.carbs,
-    fat: foodTotals.fat + supplements.fat,
-    dietary_fiber: foodTotals.dietary_fiber + supplements.dietary_fiber,
-  };
+  const combined = { ...foodTotals };
+  for (const field of FOOD_VARIANT_NUTRIENT_FIELDS) {
+    const food = Number(foodTotals[field]) || 0;
+    (combined as MealTotals)[field] = food + supplements[field];
+  }
+  return combined;
 };
 
 export const calculateDayTotals = (

--- a/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
+++ b/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
@@ -333,8 +333,13 @@ export const calculateNutrition = (
  * falls back to `dayTotals.custom_nutrients` for a nutrient with no fixed field, so this
  * needs no display change to become visible.
  *
- * Returns the food totals unchanged when there is no supplement arm, so a day with no
- * supplements is byte-for-byte what it was before supplements existed.
+ * Returns the argument itself when there is no supplement arm at all, which now means an
+ * older server or a failed fetch rather than a day without supplements: this server always
+ * sends the arm, so a supplement-free day arrives present-and-zero and takes the merge
+ * below instead. That path adds nothing to the seventeen, but it does leave a
+ * `custom_nutrients` key on totals that may not have carried one. Downstream reads it as
+ * `custom_nutrients?.[nutrient] ?? 0`, so an empty map and an absent one mean the same
+ * thing there.
  */
 export const addSupplementTotals = <T extends MealTotals>(
   foodTotals: T,

--- a/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
+++ b/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
@@ -1,6 +1,7 @@
 import type { SupplementTotals } from '@workspace/shared';
 import {
   resolveSupplementTotals,
+  addSupplementCustomNutrients,
   FOOD_VARIANT_NUTRIENT_FIELDS,
 } from '@workspace/shared';
 import { getDietTemplate } from '@/constants/dietTemplates';
@@ -326,6 +327,12 @@ export const calculateNutrition = (
  * That was already untrue of the range query in `reportRepository`, and the inconsistency
  * it was avoiding is the one users hit.
  *
+ * Custom nutrients are folded in as well, and they are where most micronutrients actually
+ * live: only six of the catalog's entries have a fixed column, so a magnesium or vitamin D
+ * supplement contributes nothing the loop below can reach. `NutritionSummaryCard` already
+ * falls back to `dayTotals.custom_nutrients` for a nutrient with no fixed field, so this
+ * needs no display change to become visible.
+ *
  * Returns the food totals unchanged when there is no supplement arm, so a day with no
  * supplements is byte-for-byte what it was before supplements existed.
  */
@@ -342,6 +349,13 @@ export const addSupplementTotals = <T extends MealTotals>(
     const food = Number(foodTotals[field]) || 0;
     (combined as MealTotals)[field] = food + supplements[field];
   }
+  // Replaced with a new map rather than mutated: `foodTotals.custom_nutrients` is the
+  // object the caller's food totals hold, and adding doses into it in place would
+  // double-count as soon as anything folds the same day again.
+  combined.custom_nutrients = addSupplementCustomNutrients(
+    foodTotals.custom_nutrients,
+    supplements
+  );
   return combined;
 };
 

--- a/SparkyFitnessMobile/__tests__/hooks/supplementTotals.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/supplementTotals.test.ts
@@ -1,6 +1,7 @@
 import {
   resolveSupplementTotals,
   hasSupplementNutrition,
+  addSupplementCustomNutrients,
   EMPTY_SUPPLEMENT_TOTALS,
   FOOD_VARIANT_NUTRIENT_FIELDS,
 } from '@workspace/shared';
@@ -45,10 +46,62 @@ describe('resolveSupplementTotals', () => {
     // Tied to the shared column list rather than restated, so this cannot drift from the
     // set `reportRepository` sums and the Diary card renders. It listed only the five
     // macro fields until #2145.
-    expect(Object.keys(EMPTY_SUPPLEMENT_TOTALS).sort()).toEqual(
+    const { custom_nutrients, ...fixed } = EMPTY_SUPPLEMENT_TOTALS;
+
+    expect(Object.keys(fixed).sort()).toEqual(
       [...FOOD_VARIANT_NUTRIENT_FIELDS].sort()
     );
-    expect(Object.keys(EMPTY_SUPPLEMENT_TOTALS)).toHaveLength(17);
+    expect(Object.keys(fixed)).toHaveLength(17);
+    // The seventeen fixed columns plus the open-ended map. Only six catalog micronutrients
+    // have a fixed column, so without this arm a magnesium or vitamin D supplement has
+    // nowhere at all to land.
+    expect(custom_nutrients).toEqual({});
+  });
+
+  it('defaults custom nutrients to an empty map, never undefined', () => {
+    // Callers iterate this without checking. A server predating the custom arm, or a day
+    // with no doses, has to read as "contributed nothing" rather than throwing.
+    expect(resolveSupplementTotals(undefined).custom_nutrients).toEqual({});
+    expect(
+      resolveSupplementTotals({ calories: 15 }).custom_nutrients
+    ).toEqual({});
+  });
+
+  it('carries custom nutrient values through', () => {
+    const resolved = resolveSupplementTotals({
+      ...EMPTY_SUPPLEMENT_TOTALS,
+      custom_nutrients: { Magnesium: 400, 'Vitamin D': 50 },
+    });
+
+    expect(resolved.custom_nutrients).toEqual({
+      Magnesium: 400,
+      'Vitamin D': 50,
+    });
+  });
+
+  it('coerces a custom nutrient the server could not total', () => {
+    // sf_try_numeric yields NULL for a value it cannot parse, and a key whose every
+    // contribution is NULL sums to NULL and arrives as JSON null.
+    const resolved = resolveSupplementTotals({
+      custom_nutrients: { Magnesium: null, Zinc: 15 } as unknown as Record<
+        string,
+        number
+      >,
+    });
+
+    expect(resolved.custom_nutrients.Magnesium).toBe(0);
+    expect(resolved.custom_nutrients.Zinc).toBe(15);
+  });
+
+  it('hands back a fresh map rather than the shared constant', () => {
+    // Callers fold their own totals into what they get back. Returning the module-level
+    // EMPTY_SUPPLEMENT_TOTALS for the absent case would let one caller's day leak into
+    // every later caller's in the same process.
+    const first = resolveSupplementTotals(undefined);
+    first.custom_nutrients.Magnesium = 400;
+
+    expect(resolveSupplementTotals(undefined).custom_nutrients).toEqual({});
+    expect(EMPTY_SUPPLEMENT_TOTALS.custom_nutrients).toEqual({});
   });
 
   it('is arithmetically inert for a day with no supplements', () => {
@@ -69,10 +122,88 @@ describe('resolveSupplementTotals', () => {
     ).toBe(true);
   });
 
+  // Most micronutrients are custom nutrients, so a supplement can easily carry nutrition
+  // while every fixed field reads zero. Asking `Object.values(...).some(v => v > 0)` over
+  // the resolved arm compares the custom_nutrients object itself against 0, gets false,
+  // and presents a magnesium-only day as empty under a nonzero total.
+  it('reports nutrition for a supplement carrying only custom nutrients', () => {
+    expect(
+      hasSupplementNutrition({
+        ...EMPTY_SUPPLEMENT_TOTALS,
+        custom_nutrients: { Magnesium: 400 },
+      })
+    ).toBe(true);
+  });
+
   it('reports none for zeros, an absent arm, or an older server', () => {
     // All three must leave the empty state intact rather than defeating it.
     expect(hasSupplementNutrition(EMPTY_SUPPLEMENT_TOTALS)).toBe(false);
     expect(hasSupplementNutrition(undefined)).toBe(false);
     expect(hasSupplementNutrition(null)).toBe(false);
+    expect(
+      hasSupplementNutrition({
+        ...EMPTY_SUPPLEMENT_TOTALS,
+        custom_nutrients: { Magnesium: 0 },
+      })
+    ).toBe(false);
+  });
+});
+
+// Web folds these in `addSupplementTotals` and mobile in `useDailySummary`. Shared so the
+// two cannot produce different magnesium figures for the same day on adjacent screens.
+describe('addSupplementCustomNutrients', () => {
+  it('adds a dose onto the food total for the same nutrient', () => {
+    const combined = addSupplementCustomNutrients(
+      { Magnesium: 120, Choline: 200 },
+      { ...EMPTY_SUPPLEMENT_TOTALS, custom_nutrients: { Magnesium: 400 } }
+    );
+
+    expect(combined.Magnesium).toBe(520);
+    expect(combined.Choline).toBe(200);
+  });
+
+  it('keeps a nutrient no food supplied', () => {
+    // The common case for a supplement: vitamin D has no fixed column and rarely any food
+    // contribution, so dropping unmatched keys would drop the whole reason for the fix.
+    const combined = addSupplementCustomNutrients(
+      { Magnesium: 120 },
+      {
+        ...EMPTY_SUPPLEMENT_TOTALS,
+        custom_nutrients: { 'Vitamin D': 50 },
+      }
+    );
+
+    expect(combined['Vitamin D']).toBe(50);
+    expect(combined.Magnesium).toBe(120);
+  });
+
+  it('does not mutate the food totals it was given', () => {
+    const foodTotals = { Magnesium: 120 };
+
+    addSupplementCustomNutrients(foodTotals, {
+      ...EMPTY_SUPPLEMENT_TOTALS,
+      custom_nutrients: { Magnesium: 400 },
+    });
+
+    expect(foodTotals).toEqual({ Magnesium: 120 });
+  });
+
+  it('is a no-op for an absent or empty supplement arm', () => {
+    expect(addSupplementCustomNutrients({ Magnesium: 120 }, undefined)).toEqual({
+      Magnesium: 120,
+    });
+    expect(
+      addSupplementCustomNutrients({ Magnesium: 120 }, EMPTY_SUPPLEMENT_TOTALS)
+    ).toEqual({ Magnesium: 120 });
+  });
+
+  it('handles an absent food side', () => {
+    // A supplement-only day has no food entries to derive custom totals from.
+    expect(
+      addSupplementCustomNutrients(undefined, {
+        ...EMPTY_SUPPLEMENT_TOTALS,
+        custom_nutrients: { Magnesium: 400 },
+      })
+    ).toEqual({ Magnesium: 400 });
   });
 });

--- a/SparkyFitnessMobile/__tests__/hooks/supplementTotals.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/supplementTotals.test.ts
@@ -2,13 +2,17 @@ import {
   resolveSupplementTotals,
   hasSupplementNutrition,
   EMPTY_SUPPLEMENT_TOTALS,
+  FOOD_VARIANT_NUTRIENT_FIELDS,
 } from '@workspace/shared';
 
 // Mobile derives its macro pills from food entries while the calorie ring comes from the
 // server's calorieBalance, which counts supplements. Without the supplement arm here the
 // ring disagreed with the pills beneath it, and with the nutrition details screen.
 describe('resolveSupplementTotals', () => {
-  it('passes a real arm through untouched', () => {
+  it('preserves the values a real arm carries', () => {
+    // No longer identity-preserving: since #2145 this fills the fixed nutrients an older
+    // server omits, so it must build a new object. What matters is that supplied values
+    // survive and absent ones read as zero rather than undefined.
     const totals = {
       calories: 15,
       protein: 0,
@@ -16,7 +20,18 @@ describe('resolveSupplementTotals', () => {
       fat: 1.5,
       dietary_fiber: 0,
     };
-    expect(resolveSupplementTotals(totals)).toBe(totals);
+    const resolved = resolveSupplementTotals(totals);
+
+    expect(resolved.calories).toBe(15);
+    expect(resolved.fat).toBe(1.5);
+    expect(resolved.calcium).toBe(0);
+    expect(resolved.sodium).toBe(0);
+  });
+
+  it('keeps a full-width arm intact', () => {
+    const totals = { ...EMPTY_SUPPLEMENT_TOTALS, calcium: 10000, iron: 18 };
+
+    expect(resolveSupplementTotals(totals)).toEqual(totals);
   });
 
   it('returns zeros when the server predates supplement totals', () => {
@@ -27,13 +42,13 @@ describe('resolveSupplementTotals', () => {
   });
 
   it('covers exactly the fields both clients add', () => {
-    expect(Object.keys(EMPTY_SUPPLEMENT_TOTALS).sort()).toEqual([
-      'calories',
-      'carbs',
-      'dietary_fiber',
-      'fat',
-      'protein',
-    ]);
+    // Tied to the shared column list rather than restated, so this cannot drift from the
+    // set `reportRepository` sums and the Diary card renders. It listed only the five
+    // macro fields until #2145.
+    expect(Object.keys(EMPTY_SUPPLEMENT_TOTALS).sort()).toEqual(
+      [...FOOD_VARIANT_NUTRIENT_FIELDS].sort()
+    );
+    expect(Object.keys(EMPTY_SUPPLEMENT_TOTALS)).toHaveLength(17);
   });
 
   it('is arithmetically inert for a day with no supplements', () => {

--- a/SparkyFitnessMobile/__tests__/hooks/useDailySummary.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useDailySummary.test.ts
@@ -4,6 +4,7 @@ import { dailySummaryQueryKey } from '../../src/hooks/queryKeys';
 import { fetchDailySummary } from '../../src/services/api/dailySummaryApi';
 import { fetchFoodEntryMealsByDate } from '../../src/services/api/foodEntryMealsApi';
 import { createTestQueryClient, createQueryWrapper, type QueryClient } from './queryTestUtils';
+import { EMPTY_SUPPLEMENT_TOTALS } from '@workspace/shared';
 
 jest.mock('../../src/services/api/dailySummaryApi', () => ({
   fetchDailySummary: jest.fn(),
@@ -75,6 +76,7 @@ const makeSummaryResponse = (overrides: Record<string, unknown> = {}) => ({
   waterIntake: (overrides.waterIntake ?? 0) as number,
   stepCalories: (overrides.stepCalories ?? 0) as number,
   calorieBalance: makeCalorieBalance(overrides.calorieBalance as Record<string, unknown>),
+  ...(overrides.supplementTotals ? { supplementTotals: overrides.supplementTotals } : {}),
 });
 
 describe('useDailySummary', () => {
@@ -345,6 +347,74 @@ describe('useDailySummary', () => {
       expect(result.current.summary?.remainingCalories).toBe(1500);
     });
 
+  });
+
+  // customNutrientTotals is what every screen reads for a nutrient with no fixed column,
+  // and that is most micronutrients: only six catalog entries map to one. Deriving it from
+  // food entries alone left a magnesium or vitamin D supplement contributing nothing
+  // anywhere on mobile, which is the larger half of #2145.
+  describe('supplement custom nutrients', () => {
+    const supplementTotals = {
+      ...EMPTY_SUPPLEMENT_TOTALS,
+      custom_nutrients: { Magnesium: 400, 'Vitamin D': 50 },
+    };
+
+    test('adds the dose onto the food total for the same nutrient', async () => {
+      mockFetchDailySummary.mockResolvedValue(makeSummaryResponse({
+        foodEntries: [
+          { id: '1', calories: 100, quantity: 2, serving_size: 1, meal_type: 'lunch', unit: 'g', entry_date: testDate, custom_nutrients: { Magnesium: 60 } },
+        ],
+        supplementTotals,
+      }));
+
+      const { result } = renderHook(() => useDailySummary({ date: testDate }), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      // 60 * 2 / 1 from food, plus the 400 the dose carried.
+      expect(result.current.summary?.customNutrientTotals.Magnesium).toBe(520);
+      // No food supplied vitamin D, which is the ordinary case for a supplement nutrient.
+      expect(result.current.summary?.customNutrientTotals['Vitamin D']).toBe(50);
+    });
+
+    test('reports the dose on a day with no food entries', async () => {
+      mockFetchDailySummary.mockResolvedValue(makeSummaryResponse({ supplementTotals }));
+
+      const { result } = renderHook(() => useDailySummary({ date: testDate }), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.summary?.customNutrientTotals).toEqual({
+        Magnesium: 400,
+        'Vitamin D': 50,
+      });
+    });
+
+    test('leaves food custom totals alone when the server sends no supplement arm', async () => {
+      mockFetchDailySummary.mockResolvedValue(makeSummaryResponse({
+        foodEntries: [
+          { id: '1', calories: 100, quantity: 1, serving_size: 1, meal_type: 'lunch', unit: 'g', entry_date: testDate, custom_nutrients: { Magnesium: 60 } },
+        ],
+      }));
+
+      const { result } = renderHook(() => useDailySummary({ date: testDate }), {
+        wrapper: createQueryWrapper(queryClient),
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(result.current.summary?.customNutrientTotals).toEqual({ Magnesium: 60 });
+    });
   });
 
   describe('goal fallback defaults', () => {

--- a/SparkyFitnessMobile/__tests__/screens/DiaryScreenSupplementOnlyDay.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/DiaryScreenSupplementOnlyDay.test.tsx
@@ -148,6 +148,21 @@ describe('DiaryScreen on a supplement-only day', () => {
     expect(screen.queryByText('Add Food')).toBeNull();
   });
 
+  // A magnesium or vitamin D supplement carries nothing in any fixed field, because those
+  // nutrients have no fixed column: only six catalog entries do. The whole arm reads zero
+  // and the day presents as empty under a calorie figure that is not (#2145).
+  it('does not call the day empty for a supplement carrying only custom nutrients', () => {
+    mockUseDailySummary.mockReturnValue(
+      summary({
+        ...EMPTY_SUPPLEMENT_TOTALS,
+        custom_nutrients: { Magnesium: 400 },
+      })
+    );
+    renderDiary();
+
+    expect(screen.queryByText('Add Food')).toBeNull();
+  });
+
   it('still shows the empty day when nothing at all was logged', () => {
     // The other half of the rule: zero supplement totals must not defeat the empty state.
     mockUseDailySummary.mockReturnValue(summary(EMPTY_SUPPLEMENT_TOTALS));

--- a/SparkyFitnessMobile/src/hooks/useDailySummary.ts
+++ b/SparkyFitnessMobile/src/hooks/useDailySummary.ts
@@ -14,7 +14,7 @@ import type { DailySummary } from '../types/dailySummary';
 import type { DailyGoals } from '../types/goals';
 import type { FoodEntry } from '../types/foodEntries';
 import type { ExerciseSessionResponse, CalorieBalance, SupplementTotals } from '@workspace/shared';
-import { resolveSupplementTotals } from '@workspace/shared';
+import { resolveSupplementTotals, addSupplementCustomNutrients } from '@workspace/shared';
 import type { WaterIntake } from '../types/measurements';
 
 import { useRefetchOnFocus } from './useRefetchOnFocus';
@@ -122,7 +122,14 @@ export function useDailySummary({ date, enabled = true }: UseDailySummaryOptions
         exerciseEntries,
         calorieBalance: resolvedCalorieBalance,
         goals,
-        customNutrientTotals: calculateCustomNutrientTotals(foodEntries),
+        // Food entries plus the day's doses. Most micronutrients are custom nutrients
+        // rather than fixed columns, so for a magnesium or vitamin D supplement this is
+        // the only place its contribution can land; the fixed-field arm above cannot
+        // carry it (#2145). Every screen reading customNutrientTotals gets it from here.
+        customNutrientTotals: addSupplementCustomNutrients(
+          calculateCustomNutrientTotals(foodEntries),
+          supplements,
+        ),
         // Per-custom-nutrient goals (keyed by name, matching customNutrientTotals).
         // Normalized to numbers; absent/zero goals are simply not tracked.
         customNutrientGoals: goals.custom_nutrients

--- a/SparkyFitnessMobile/src/screens/DailyNutritionDetailsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DailyNutritionDetailsScreen.tsx
@@ -13,6 +13,11 @@ import { NUTRIENT_META } from '../constants/nutrients';
 import NutritionMacroCard from '../components/NutritionMacroCard';
 import StatusView from '../components/StatusView';
 import Icon from '../components/Icon';
+import {
+  resolveSupplementTotals,
+  FOOD_VARIANT_NUTRIENT_FIELDS,
+} from '@workspace/shared';
+import type { FoodVariantNutrientField } from '@workspace/shared';
 import type { RootStackScreenProps } from '../types/navigation';
 import type { FoodEntry } from '../types/foodEntries';
 
@@ -93,6 +98,12 @@ const DailyNutritionDetailsScreen: React.FC<DailyNutritionDetailsScreenProps> = 
       goal?: number;
     }[] = [];
 
+    // Logged supplement doses, full width and zero-filled, so a fixed nutrient computed
+    // from food entries below can have its supplement contribution added back (#2145).
+    const supplements = resolveSupplementTotals(summary.supplementTotals);
+    const isFixedNutrient = (key: string): key is FoodVariantNutrientField =>
+      (FOOD_VARIANT_NUTRIENT_FIELDS as readonly string[]).includes(key);
+
     // Filter and compute standard nutrients in order of visibleKeys
     for (const key of visibleKeys) {
       // Exclude base macros from the detailed breakdown if they are already visible in top card
@@ -124,9 +135,14 @@ const DailyNutritionDetailsScreen: React.FC<DailyNutritionDetailsScreenProps> = 
           fat: summary.fat.consumed,
           dietary_fiber: summary.fiber.consumed,
         };
+        // Anything not already rolled up is derived from food entries here, which is
+        // food-only. Every fixed nutrient a supplement can carry has to have its dose
+        // contribution added back, or this screen shows a smaller calcium than Reports
+        // does for the same day.
         const consumed =
           rolledUp[key] ??
-          calculateNutrientTotal(summary.foodEntries, key as keyof FoodEntry);
+          calculateNutrientTotal(summary.foodEntries, key as keyof FoodEntry) +
+            (isFixedNutrient(key) ? supplements[key] : 0);
         const goal = summary.goals[key as keyof typeof summary.goals] as number | undefined;
 
         standardItems.push({

--- a/SparkyFitnessServer/models/foodMisc.ts
+++ b/SparkyFitnessServer/models/foodMisc.ts
@@ -233,13 +233,37 @@ function supplementFixed(
 ): string {
   return `COALESCE((SELECT SUM(public.sf_try_numeric(me.nutrients_snapshot->>'${key}') * GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)) FROM medication_entries me WHERE me.user_id = ${userExpr} AND me.entry_date = ${dateExpr} AND me.status IN ('taken', 'prn_taken') AND me.nutrients_snapshot IS NOT NULL), 0)`;
 }
-function supplementCustomUnion(userExpr: string, dateExpr: string): string {
+// One scaled row per (custom nutrient, dose) pair. Kept apart from the UNION wrapper below
+// because the daily-summary query needs the supplement contribution on its own, not merged
+// into the food rows, and the two must not drift: a second copy of this SELECT is a second
+// place for the status filter or the dose clamp to be wrong.
+function supplementCustomRows(userExpr: string, dateExpr: string): string {
   return `
-                UNION ALL
                 SELECT key, public.sf_try_numeric(value) * GREATEST(COALESCE(me2.dose_amount_snapshot, 1), 0) AS scaled
                 FROM medication_entries me2
                 CROSS JOIN LATERAL jsonb_each_text(me2.nutrients_snapshot->'custom_nutrients')
                 WHERE me2.user_id = ${userExpr} AND me2.entry_date = ${dateExpr} AND me2.status IN ('taken', 'prn_taken') AND me2.nutrients_snapshot IS NOT NULL`;
+}
+function supplementCustomUnion(userExpr: string, dateExpr: string): string {
+  return `
+                UNION ALL${supplementCustomRows(userExpr, dateExpr)}`;
+}
+// The same rows aggregated by nutrient name and with no food arm, for the supplement-only
+// totals the Diary needs. Empty object rather than NULL on a day with no doses, so callers
+// can iterate unconditionally.
+function supplementCustomTotals(userExpr: string, dateExpr: string): string {
+  return `COALESCE(
+          (
+            SELECT jsonb_object_agg(key, value)
+            FROM (
+              SELECT key, SUM(scaled) AS value
+              FROM (${supplementCustomRows(userExpr, dateExpr)}
+              ) supplement_custom
+              GROUP BY key
+            ) supplement_custom_agg
+          ),
+          '{}'::jsonb
+        )`;
 }
 
 /**
@@ -256,6 +280,12 @@ function supplementCustomUnion(userExpr: string, dateExpr: string): string {
  * card can render. This selected only the five macro fields until #2145, which is how a
  * supplement's calcium reached Reports but not the Diary card beside it. Returns zeros
  * rather than nulls on a day with no supplements, so callers can add unconditionally.
+ *
+ * Custom nutrients come back alongside them, aggregated by name. Most micronutrients are
+ * custom: only six catalog entries have a fixed column, so magnesium, vitamin D, zinc and
+ * the B vitamins reach the client through `custom_nutrients` or not at all. This endpoint
+ * carried none of them until #2145; `getDailyNutritionSummary` already unions them into
+ * its food totals, but the Diary does not call that.
  */
 async function getDailySupplementTotals(userId: string, date: string) {
   const client = await getClient(userId);
@@ -263,17 +293,28 @@ async function getDailySupplementTotals(userId: string, date: string) {
     const selects = FOOD_VARIANT_NUTRIENT_FIELDS.map(
       (field) => `${supplementFixed(field, '$1', '$2')} AS ${field}`
     ).join(',\n        ');
-    const result = await client.query(`SELECT\n        ${selects}`, [
-      userId,
-      date,
-    ]);
+    const result = await client.query(
+      `SELECT\n        ${selects},\n        ${supplementCustomTotals('$1', '$2')} AS custom_nutrients`,
+      [userId, date]
+    );
     const row = result.rows[0] ?? {};
-    return Object.fromEntries(
-      FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [
-        field,
-        Number(row[field]) || 0,
-      ])
-    ) as Record<FoodVariantNutrientField, number>;
+    const customRow = (row.custom_nutrients ?? {}) as Record<string, unknown>;
+    return {
+      ...(Object.fromEntries(
+        FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [
+          field,
+          Number(row[field]) || 0,
+        ])
+      ) as Record<FoodVariantNutrientField, number>),
+      // A key whose every contribution failed `sf_try_numeric` sums to NULL and arrives as
+      // JSON null, so these are coerced the same way the fixed columns are.
+      custom_nutrients: Object.fromEntries(
+        Object.entries(customRow).map(([name, value]) => [
+          name,
+          Number(value) || 0,
+        ])
+      ),
+    };
   } finally {
     client.release();
   }

--- a/SparkyFitnessServer/models/foodMisc.ts
+++ b/SparkyFitnessServer/models/foodMisc.ts
@@ -1,4 +1,6 @@
 import { getClient, getSystemClient } from '../db/poolManager.js';
+import { FOOD_VARIANT_NUTRIENT_FIELDS } from '@workspace/shared';
+import type { FoodVariantNutrientField } from '@workspace/shared';
 import type { FoodEntrySnapshot } from '../types/nutrition.js';
 
 const DEFAULT_VARIANT_JSON_SQL = `
@@ -249,29 +251,29 @@ function supplementCustomUnion(userExpr: string, dateExpr: string): string {
  * and once to show as its own line, so what is displayed still reconciles against the
  * food rows the user can see.
  *
- * Fields are exactly the set `supplementFixed` is applied to elsewhere. Returns zeros
+ * Fields are `FOOD_VARIANT_NUTRIENT_FIELDS`, the same list `reportRepository` applies
+ * `supplementFixed` to for the range query and the same fixed fields the Diary's summary
+ * card can render. This selected only the five macro fields until #2145, which is how a
+ * supplement's calcium reached Reports but not the Diary card beside it. Returns zeros
  * rather than nulls on a day with no supplements, so callers can add unconditionally.
  */
 async function getDailySupplementTotals(userId: string, date: string) {
   const client = await getClient(userId);
   try {
-    const result = await client.query(
-      `SELECT
-        ${supplementFixed('calories', '$1', '$2')} AS calories,
-        ${supplementFixed('protein', '$1', '$2')} AS protein,
-        ${supplementFixed('carbs', '$1', '$2')} AS carbs,
-        ${supplementFixed('fat', '$1', '$2')} AS fat,
-        ${supplementFixed('dietary_fiber', '$1', '$2')} AS dietary_fiber`,
-      [userId, date]
-    );
+    const selects = FOOD_VARIANT_NUTRIENT_FIELDS.map(
+      (field) => `${supplementFixed(field, '$1', '$2')} AS ${field}`
+    ).join(',\n        ');
+    const result = await client.query(`SELECT\n        ${selects}`, [
+      userId,
+      date,
+    ]);
     const row = result.rows[0] ?? {};
-    return {
-      calories: Number(row.calories) || 0,
-      protein: Number(row.protein) || 0,
-      carbs: Number(row.carbs) || 0,
-      fat: Number(row.fat) || 0,
-      dietary_fiber: Number(row.dietary_fiber) || 0,
-    };
+    return Object.fromEntries(
+      FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [
+        field,
+        Number(row[field]) || 0,
+      ])
+    ) as Record<FoodVariantNutrientField, number>;
   } finally {
     client.release();
   }

--- a/SparkyFitnessServer/services/dailySummaryService.ts
+++ b/SparkyFitnessServer/services/dailySummaryService.ts
@@ -20,6 +20,7 @@ import {
   computeCaloriesRemaining,
   computeCalorieProgress,
   computeTdeeAdjustment,
+  EMPTY_SUPPLEMENT_TOTALS,
 } from '@workspace/shared';
 import type { CalorieGoalAdjustmentMode } from '@workspace/shared';
 
@@ -301,7 +302,10 @@ export async function getDailySummary({
           `Supplement totals fetch failed for user ${targetUserId} on ${date}, defaulting to zeros:`,
           error
         );
-        return { calories: 0, protein: 0, carbs: 0, fat: 0, dietary_fiber: 0 };
+        // Must stay the same width as the query's own result. A hardcoded five-key
+        // literal here would reintroduce #2145 on the degraded path alone, which is
+        // the hardest version to notice.
+        return EMPTY_SUPPLEMENT_TOTALS;
       }),
   ]);
 

--- a/SparkyFitnessServer/services/dailySummaryService.ts
+++ b/SparkyFitnessServer/services/dailySummaryService.ts
@@ -20,7 +20,7 @@ import {
   computeCaloriesRemaining,
   computeCalorieProgress,
   computeTdeeAdjustment,
-  EMPTY_SUPPLEMENT_TOTALS,
+  resolveSupplementTotals,
 } from '@workspace/shared';
 import type { CalorieGoalAdjustmentMode } from '@workspace/shared';
 
@@ -305,7 +305,14 @@ export async function getDailySummary({
         // Must stay the same width as the query's own result. A hardcoded five-key
         // literal here would reintroduce #2145 on the degraded path alone, which is
         // the hardest version to notice.
-        return EMPTY_SUPPLEMENT_TOTALS;
+        //
+        // Built fresh rather than handing back `EMPTY_SUPPLEMENT_TOTALS` itself: this
+        // value goes into the response object, so returning the shared constant would
+        // put one process-wide object on every degraded response, and anything that
+        // later folded into it would corrupt the constant for every caller after.
+        // A shallow spread would not be enough either, since `custom_nutrients` would
+        // still alias.
+        return resolveSupplementTotals(null);
       }),
   ]);
 

--- a/SparkyFitnessServer/tests/dailySummaryService.test.ts
+++ b/SparkyFitnessServer/tests/dailySummaryService.test.ts
@@ -623,4 +623,23 @@ describe('dailySummaryService supplement calories', () => {
     expect(summary.calorieBalance.eaten).toBe(500);
     expect(summary.supplementTotals.calories).toBe(0);
   });
+
+  test('degraded path does not hand out the shared empty constant', async () => {
+    vi.mocked(foodRepository.getDailySupplementTotals).mockRejectedValue(
+      new Error('supplement totals unavailable')
+    );
+
+    const first = await run();
+    // A caller folding into what it was given must not reach the constant behind it,
+    // which every later degraded response would otherwise carry.
+    first.supplementTotals.calories = 999;
+    first.supplementTotals.custom_nutrients.Magnesium = 400;
+
+    const second = await run();
+
+    expect(second.supplementTotals.calories).toBe(0);
+    expect(second.supplementTotals.custom_nutrients).toEqual({});
+    expect(EMPTY_SUPPLEMENT_TOTALS.calories).toBe(0);
+    expect(EMPTY_SUPPLEMENT_TOTALS.custom_nutrients).toEqual({});
+  });
 });

--- a/SparkyFitnessServer/tests/dailySummaryService.test.ts
+++ b/SparkyFitnessServer/tests/dailySummaryService.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { ExerciseSessionResponse } from '@workspace/shared';
+import { EMPTY_SUPPLEMENT_TOTALS } from '@workspace/shared';
 import { getDailySummary } from '../services/dailySummaryService.js';
 import goalService from '../services/goalService.js';
 import foodEntryService from '../services/foodEntryService.js';
@@ -125,6 +126,7 @@ describe('dailySummaryService', () => {
       },
     ]);
     vi.mocked(foodRepository.getDailySupplementTotals).mockResolvedValue({
+      ...EMPTY_SUPPLEMENT_TOTALS,
       calories: 0,
       protein: 0,
       carbs: 0,
@@ -527,6 +529,7 @@ describe('dailySummaryService supplement calories', () => {
     vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue(null);
     vi.mocked(bmrService.calculateBmr).mockReturnValue(0);
     vi.mocked(foodRepository.getDailySupplementTotals).mockResolvedValue({
+      ...EMPTY_SUPPLEMENT_TOTALS,
       calories: 0,
       protein: 0,
       carbs: 0,
@@ -549,6 +552,7 @@ describe('dailySummaryService supplement calories', () => {
 
   test('adds logged supplement calories to eaten', async () => {
     vi.mocked(foodRepository.getDailySupplementTotals).mockResolvedValue({
+      ...EMPTY_SUPPLEMENT_TOTALS,
       calories: 15,
       protein: 0,
       carbs: 0,
@@ -571,6 +575,7 @@ describe('dailySummaryService supplement calories', () => {
     const withoutSupplements = (await run()).calorieBalance.remaining;
 
     vi.mocked(foodRepository.getDailySupplementTotals).mockResolvedValue({
+      ...EMPTY_SUPPLEMENT_TOTALS,
       calories: 15,
       protein: 0,
       carbs: 0,
@@ -584,6 +589,7 @@ describe('dailySummaryService supplement calories', () => {
 
   test('returns the supplement totals separately, so the Diary can show what they were', async () => {
     const totals = {
+      ...EMPTY_SUPPLEMENT_TOTALS,
       calories: 15,
       protein: 0,
       carbs: 0,

--- a/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
+++ b/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
@@ -1,5 +1,9 @@
 import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  EMPTY_SUPPLEMENT_TOTALS,
+  FOOD_VARIANT_NUTRIENT_FIELDS,
+} from '@workspace/shared';
+import {
   createMockDbClient,
   type MockDbClient,
 } from './helpers/mockDbClient.js';
@@ -118,13 +122,12 @@ describe('getDailySupplementTotals', () => {
 
     const totals = await getDailySupplementTotals(userId, '2026-08-06');
 
-    expect(totals).toEqual({
-      calories: 0,
-      protein: 0,
-      carbs: 0,
-      fat: 0,
-      dietary_fiber: 0,
-    });
+    expect(totals).toEqual(EMPTY_SUPPLEMENT_TOTALS);
+    // Full width, not just the macros: the Diary card renders whichever fixed nutrients
+    // the user has enabled, so a narrow zero object reintroduces #2145 on an empty day.
+    expect(Object.keys(totals).sort()).toEqual(
+      [...FOOD_VARIANT_NUTRIENT_FIELDS].sort()
+    );
   });
 
   it('coerces numeric strings, which is what pg returns for numeric columns', async () => {

--- a/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
+++ b/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
@@ -114,6 +114,58 @@ describe('getDailySupplementTotals', () => {
     }
   });
 
+  // Only six catalog micronutrients have a fixed column. Magnesium, vitamin D, vitamin K,
+  // zinc and the B vitamins are user-defined nutrients living in the snapshot's
+  // custom_nutrients object, so the fixed columns above cannot carry them at all and the
+  // Diary would still understate the typical multivitamin (#2145).
+  it('aggregates the custom nutrients a dose carries', async () => {
+    mockClient = createMockDbClient([{}]);
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+
+    await getDailySupplementTotals(userId, '2026-08-06');
+
+    const sql = String(mockClient.query.mock.calls[0][0]);
+    expect(sql).toContain("nutrients_snapshot->'custom_nutrients'");
+    expect(sql).toContain('jsonb_object_agg(key, value)');
+    expect(sql).toContain('AS custom_nutrients');
+    // Same status filter and dose clamp as the fixed arm, because the custom rows are the
+    // shared fragment rather than a second copy that could drift from it.
+    expect(sql).toContain("me2.status IN ('taken', 'prn_taken')");
+    expect(sql).toContain('GREATEST(COALESCE(me2.dose_amount_snapshot, 1), 0)');
+    // Supplements alone. Unioning the food rows in here, the way getDailyNutritionSummary
+    // does, would double-count every custom nutrient: callers add this arm onto totals
+    // they have already derived from food entries themselves.
+    expect(sql).not.toContain('food_entries');
+  });
+
+  it('returns the custom nutrient map the query produced', async () => {
+    mockClient = createMockDbClient([
+      { calories: '0', custom_nutrients: { Magnesium: 400, 'Vitamin D': 50 } },
+    ]);
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+
+    const totals = await getDailySupplementTotals(userId, '2026-08-06');
+
+    expect(totals.custom_nutrients).toEqual({
+      Magnesium: 400,
+      'Vitamin D': 50,
+    });
+  });
+
+  it('coerces a custom nutrient that summed to null', async () => {
+    // sf_try_numeric returns NULL for a value it cannot parse; a key whose contributions
+    // are all NULL sums to NULL and jsonb_object_agg emits it as JSON null.
+    mockClient = createMockDbClient([
+      { custom_nutrients: { Magnesium: null, Zinc: '15' } },
+    ]);
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+
+    const totals = await getDailySupplementTotals(userId, '2026-08-06');
+
+    expect(totals.custom_nutrients.Magnesium).toBe(0);
+    expect(totals.custom_nutrients.Zinc).toBe(15);
+  });
+
   it('returns zeros, not nulls, on a day with no supplements', async () => {
     // COALESCE makes the SQL emit 0, but an empty result set must not become NaN either:
     // callers add these to food totals unconditionally.
@@ -125,9 +177,12 @@ describe('getDailySupplementTotals', () => {
     expect(totals).toEqual(EMPTY_SUPPLEMENT_TOTALS);
     // Full width, not just the macros: the Diary card renders whichever fixed nutrients
     // the user has enabled, so a narrow zero object reintroduces #2145 on an empty day.
-    expect(Object.keys(totals).sort()).toEqual(
+    const { custom_nutrients, ...fixed } = totals;
+    expect(Object.keys(fixed).sort()).toEqual(
       [...FOOD_VARIANT_NUTRIENT_FIELDS].sort()
     );
+    // An empty map rather than undefined, so callers can iterate without checking.
+    expect(custom_nutrients).toEqual({});
   });
 
   it('coerces numeric strings, which is what pg returns for numeric columns', async () => {

--- a/shared/src/schemas/api/DailySummary.api.zod.ts
+++ b/shared/src/schemas/api/DailySummary.api.zod.ts
@@ -1,4 +1,8 @@
 import { z } from "zod";
+import {
+  FOOD_VARIANT_NUTRIENT_FIELDS,
+  type FoodVariantNutrientField,
+} from "../../constants/foodVariantNutrients.ts";
 import { dailyGoalsResponseSchema } from "./DailyGoals.api.zod.ts";
 import { foodEntryResponseSchema } from "./FoodEntries.api.zod.ts";
 import { exerciseSessionResponseSchema } from "./ExerciseEntries.api.zod.ts";
@@ -38,14 +42,18 @@ export type AdjustedGoals = z.infer<typeof adjustedGoalsSchema>;
  * dose snapshot. Folded into `calorieBalance.eaten`, and returned separately so the Diary
  * can account for it on screen rather than showing a total the food rows cannot explain.
  * Always present; zeros on a day with no supplements.
+ *
+ * Keyed off `FOOD_VARIANT_NUTRIENT_FIELDS` rather than listing fields, because this arm has
+ * to stay the same width as two things that already use that list: the columns
+ * `reportRepository` sums for the range query, and the fixed fields the Diary's
+ * `NutritionSummaryCard` can render. It carried only the five macro fields until #2145,
+ * which is exactly how a supplement's calcium could reach Reports and not the Diary.
  */
-export const supplementTotalsSchema = z.object({
-  calories: z.number(),
-  protein: z.number(),
-  carbs: z.number(),
-  fat: z.number(),
-  dietary_fiber: z.number(),
-});
+const supplementTotalsShape = Object.fromEntries(
+  FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, z.number()]),
+) as Record<FoodVariantNutrientField, z.ZodNumber>;
+
+export const supplementTotalsSchema = z.object(supplementTotalsShape);
 
 export type SupplementTotals = z.infer<typeof supplementTotalsSchema>;
 
@@ -63,28 +71,37 @@ export const dailySummaryResponseSchema = z.object({
 export type DailySummaryResponse = z.infer<typeof dailySummaryResponseSchema>;
 
 /** Zeros, for a day with no supplements or a server too old to report them. */
-export const EMPTY_SUPPLEMENT_TOTALS: SupplementTotals = {
-  calories: 0,
-  protein: 0,
-  carbs: 0,
-  fat: 0,
-  dietary_fiber: 0,
-};
+export const EMPTY_SUPPLEMENT_TOTALS: SupplementTotals = Object.fromEntries(
+  FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, 0]),
+) as SupplementTotals;
 
 /**
- * Normalises a possibly-absent supplement arm so callers can add it unconditionally.
+ * Normalises a possibly-absent or partial supplement arm so callers can add it
+ * unconditionally.
  *
  * Absent has two causes worth keeping distinct in the mind but not in the code: a day on
  * which nothing was logged, and a client talking to a server that predates supplement
  * totals. Both mean "add nothing", and neither should make a client branch.
+ *
+ * PARTIAL is a third case and the reason this merges rather than returning the argument
+ * unchanged. A server older than #2145 answers with only the five macro fields, so a
+ * caller adding `food[key] + supplements[key]` across all seventeen would land on
+ * `number + undefined` and write NaN into twelve of them. Filling the gaps with zeros
+ * makes an old server read as "contributed nothing to those twelve", which is the honest
+ * reading: it did not report them because it could not.
  *
  * Shared because web and mobile each derive their own day totals. That duplication is why
  * supplement energy reached the mobile calorie ring, which comes from the server, while the
  * macro pills beside it kept counting food alone.
  */
 export const resolveSupplementTotals = (
-  totals: SupplementTotals | null | undefined,
-): SupplementTotals => totals ?? EMPTY_SUPPLEMENT_TOTALS;
+  totals: Partial<SupplementTotals> | null | undefined,
+): SupplementTotals => {
+  if (!totals) return EMPTY_SUPPLEMENT_TOTALS;
+  return Object.fromEntries(
+    FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, totals[field] ?? 0]),
+  ) as SupplementTotals;
+};
 
 /**
  * Whether the day's supplements contributed any nutrition at all.
@@ -95,7 +112,7 @@ export const resolveSupplementTotals = (
  * figure that is not zero. A dose the user logged is not nothing.
  */
 export const hasSupplementNutrition = (
-  totals: SupplementTotals | null | undefined,
+  totals: Partial<SupplementTotals> | null | undefined,
 ): boolean =>
   Object.values(resolveSupplementTotals(totals)).some(
     (value) => (value ?? 0) > 0,

--- a/shared/src/schemas/api/DailySummary.api.zod.ts
+++ b/shared/src/schemas/api/DailySummary.api.zod.ts
@@ -48,12 +48,22 @@ export type AdjustedGoals = z.infer<typeof adjustedGoalsSchema>;
  * `reportRepository` sums for the range query, and the fixed fields the Diary's
  * `NutritionSummaryCard` can render. It carried only the five macro fields until #2145,
  * which is exactly how a supplement's calcium could reach Reports and not the Diary.
+ *
+ * `custom_nutrients` is the other half of that fix and the larger one. Only six of the
+ * micronutrient catalog's entries map to a fixed column (calcium, iron, potassium, sodium,
+ * vitamin_a, vitamin_c); magnesium, vitamin D, vitamin K, zinc and the B vitamins are all
+ * user-defined nutrients living in the snapshot's `custom_nutrients` object. Widening the
+ * fixed fields alone closes the calcium the #2145 reporter happened to log and leaves the
+ * typical multivitamin still understated.
  */
 const supplementTotalsShape = Object.fromEntries(
   FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, z.number()]),
 ) as Record<FoodVariantNutrientField, z.ZodNumber>;
 
-export const supplementTotalsSchema = z.object(supplementTotalsShape);
+export const supplementTotalsSchema = z.object({
+  ...supplementTotalsShape,
+  custom_nutrients: z.record(z.string(), z.number()),
+});
 
 export type SupplementTotals = z.infer<typeof supplementTotalsSchema>;
 
@@ -71,9 +81,28 @@ export const dailySummaryResponseSchema = z.object({
 export type DailySummaryResponse = z.infer<typeof dailySummaryResponseSchema>;
 
 /** Zeros, for a day with no supplements or a server too old to report them. */
-export const EMPTY_SUPPLEMENT_TOTALS: SupplementTotals = Object.fromEntries(
-  FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, 0]),
-) as SupplementTotals;
+export const EMPTY_SUPPLEMENT_TOTALS: SupplementTotals = {
+  ...(Object.fromEntries(
+    FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, 0]),
+  ) as Record<FoodVariantNutrientField, number>),
+  custom_nutrients: {},
+};
+
+/**
+ * Custom-nutrient values arrive as free-form JSON keys rather than typed columns, so
+ * unlike the fixed fields there is nothing behind them guaranteeing a number. The server
+ * aggregates them through `sf_try_numeric`, which yields NULL for a value it cannot parse,
+ * and a key whose every contribution is NULL sums to NULL and reaches the client as JSON
+ * null. Coercing here keeps that out of `food + supplement` arithmetic downstream.
+ */
+const resolveCustomNutrients = (
+  custom: Record<string, number> | null | undefined,
+): Record<string, number> => {
+  if (!custom) return {};
+  return Object.fromEntries(
+    Object.entries(custom).map(([name, value]) => [name, Number(value) || 0]),
+  );
+};
 
 /**
  * Normalises a possibly-absent or partial supplement arm so callers can add it
@@ -93,14 +122,42 @@ export const EMPTY_SUPPLEMENT_TOTALS: SupplementTotals = Object.fromEntries(
  * Shared because web and mobile each derive their own day totals. That duplication is why
  * supplement energy reached the mobile calorie ring, which comes from the server, while the
  * macro pills beside it kept counting food alone.
+ *
+ * Always builds a fresh object, including a fresh `custom_nutrients`. Handing back the
+ * shared `EMPTY_SUPPLEMENT_TOTALS` for the absent case would let one caller that folds
+ * into the returned map poison the constant for every later caller in the process.
  */
 export const resolveSupplementTotals = (
   totals: Partial<SupplementTotals> | null | undefined,
-): SupplementTotals => {
-  if (!totals) return EMPTY_SUPPLEMENT_TOTALS;
-  return Object.fromEntries(
-    FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, totals[field] ?? 0]),
-  ) as SupplementTotals;
+): SupplementTotals => ({
+  ...(Object.fromEntries(
+    FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, totals?.[field] ?? 0]),
+  ) as Record<FoodVariantNutrientField, number>),
+  custom_nutrients: resolveCustomNutrients(totals?.custom_nutrients),
+});
+
+/**
+ * Adds a day's supplement custom nutrients onto the food-derived totals for the same day.
+ *
+ * Shared for the same reason `resolveSupplementTotals` is: web builds its day totals in
+ * `addSupplementTotals` and mobile builds its own in `useDailySummary`, and when those two
+ * disagree the user sees one magnesium figure on the Diary and a different one in the
+ * nutrition details beneath it.
+ *
+ * Keys are user-defined nutrient names, so food and supplements can name the same nutrient
+ * and both contributions belong in one row. Nothing is dropped for having no food side:
+ * a nutrient only a supplement carries is still a nutrient the user consumed.
+ */
+export const addSupplementCustomNutrients = (
+  foodTotals: Record<string, number> | null | undefined,
+  totals: Partial<SupplementTotals> | null | undefined,
+): Record<string, number> => {
+  const combined: Record<string, number> = { ...(foodTotals ?? {}) };
+  const supplements = resolveSupplementTotals(totals).custom_nutrients;
+  for (const [name, value] of Object.entries(supplements)) {
+    combined[name] = (Number(combined[name]) || 0) + value;
+  }
+  return combined;
 };
 
 /**
@@ -110,10 +167,18 @@ export const resolveSupplementTotals = (
  * food entries were the only source of nutrition, so they ask whether any exist; on a day
  * with a logged supplement and no meal, that reads as an empty day sitting under a calorie
  * figure that is not zero. A dose the user logged is not nothing.
+ *
+ * The two arms are asked separately rather than over `Object.values`, which would compare
+ * the `custom_nutrients` object itself against 0 and always get false. A magnesium-only
+ * supplement day would then still present as empty, and magnesium is a custom nutrient for
+ * every user: it has no fixed column.
  */
 export const hasSupplementNutrition = (
   totals: Partial<SupplementTotals> | null | undefined,
-): boolean =>
-  Object.values(resolveSupplementTotals(totals)).some(
-    (value) => (value ?? 0) > 0,
+): boolean => {
+  const resolved = resolveSupplementTotals(totals);
+  return (
+    FOOD_VARIANT_NUTRIENT_FIELDS.some((field) => (resolved[field] ?? 0) > 0) ||
+    Object.values(resolved.custom_nutrients).some((value) => value > 0)
   );
+};


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

A logged supplement dose reaches Reports in full but only partially reached the Diary's Nutrition Summary card. `/api/daily-summary` rolled up five of the seventeen `food_variants` nutrient columns (calories, protein, carbs, fat, dietary fiber) but no custom nutrients, so any other nutrient a supplement carries reads food-only on the Diary while Reports counts the dose. This is a wrong row rather than a missing one: the card already renders every nutrient the user enabled, the number behind it was just short.

**How did you implement the solution?**

Two commits. The first alone leaves the typical supplement understated, because only six of the thirty-two micronutrient catalog entries map to a fixed column (calcium, iron, potassium, sodium, vitamin A, vitamin C); magnesium, D, K, zinc and the B vitamins are all custom nutrients.

1. **Count all fixed supplement nutrients.** Widened the rollup to `FOOD_VARIANT_NUTRIENT_FIELDS`, the list already shared by the report range query and the card's fixed fields, rather than a second hardcoded set that can drift from it. `supplementTotalsSchema`, `EMPTY_SUPPLEMENT_TOTALS`, `getDailySupplementTotals`, the `dailySummaryService` error fallback, web `addSupplementTotals` and mobile `DailyNutritionDetailsScreen` all derive from it.
2. **Count supplement custom nutrients.** `getDailySupplementTotals` now aggregates them by nutrient name (empty map, never null). `supplementCustomRows` is factored out of `supplementCustomUnion` so the supplement-only aggregation and the food union share one SELECT and the status filter and dose clamp cannot drift apart. A shared `addSupplementCustomNutrients` is called by both web and mobile, so one day cannot produce two magnesium figures on adjacent screens.

No migration, no new endpoint, and no display defaults changed: an enabled row simply becomes correct.

Linked Issue: Closes #2145

## How to Test

1. Check out this branch and start the server and frontend as usual.
2. Create a food marked as a supplement carrying a fixed nutrient outside the macros (for example calcium) and a couple of custom nutrients (Magnesium, Vitamin D).
3. Log a dose for today.
4. `GET /api/daily-summary` for that date: `supplementTotals` returns all seventeen fixed keys plus `custom_nutrients` with the dose contribution.
5. On the Diary, enable Calcium in the Summary view, and add Magnesium there as a custom nutrient. Both rows now include the dose and agree with the Reports tab for the same day.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: no locale files are changed by this PR.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: typecheck, lint and tests all run clean. No new endpoints; the existing `/api/daily-summary` Zod schema is widened alongside the change.
- [x] **[MANDATORY for Backend changes] Database Security**: no new tables, so `rls_policies.sql` needs no change.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="549" height="253" alt="2026-08-18 11_33_03-supplements-vitamins - File Explorer" src="https://github.com/user-attachments/assets/38cf163b-03dd-47c9-83ef-fadb2b7c4eea" />

</details>

## Notes for Reviewers

Four behaviour changes worth mentioning:

- **`resolveSupplementTotals` is no longer identity-preserving.** It merges against a full-width zero object, so a client newer than its server still gets seventeen keys. Otherwise `food[key] + supplements[key]` would write `NaN` into the twelve the old server omits.
- **It also always builds a fresh object**, including a fresh `custom_nutrients`. Returning the shared `EMPTY_SUPPLEMENT_TOTALS` would let one caller folding into the result poison the constant process-wide.
- **`hasSupplementNutrition` was silently broken by the widening and is fixed here.** `Object.values(...).some(v => v > 0)` compared the `custom_nutrients` object against `0` and always got false, so a magnesium-only day presented as empty despite a nonzero total. It now checks the two arms separately.
- **Custom values are coerced on both sides**, since `sf_try_numeric` yields NULL for an unparseable value and a key whose every contribution is NULL arrives as JSON null.

Left alone on purpose: the legacy `getDailyNutritionSummary` and its `foodEntryService` fallback, which reports five `total_*` macros plus custom nutrients, has no micronutrient fields to understate, and is not what the Diary calls.

I also considered auto-provisioning supplement nutrients onto the Summary view and decided against it on density grounds: `goal` and `report_*` are scrollable, but the Diary summary is a fixed at-a-glance panel and a multivitamin's many rows would bury the macros. `NutrientDisplaySettings` already offers custom nutrients for the `summary` group, so anyone who wants calcium or D3 there can add it today.

Verification: full gate green on both commits and again after rebasing onto current main (four typechecks, server 3041 pass / 219 skip, frontend 896 pass, mobile 5356 pass, i18n audit clean). Seven mutation controls, each confirmed to land and each killed by a named test, with an unmutated control green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Supplement totals now include all supported vitamins, minerals, and custom nutrients—not just core macros.
  * Daily nutrition summaries and details incorporate custom nutrients from supplements.
  * Partial or incomplete supplement data is normalized safely with zero values.

* **Bug Fixes**
  * Fixed supplement-only days being incorrectly shown as empty.
  * Prevented missing nutrient values from producing invalid totals.
  * Preserved existing custom nutrient data without unintended changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->