### PR TITLE
fix(mcp): tolerate a client sending a newer protocol version than negotiated

### DIFF
--- a/SparkyFitnessServer/routes/mcpRoutes.ts
+++ b/SparkyFitnessServer/routes/mcpRoutes.ts
@@ -5,6 +5,7 @@ import {
   LATEST_PROTOCOL_VERSION,
   SUPPORTED_PROTOCOL_VERSIONS,
 } from '@modelcontextprotocol/sdk/types.js';
+import { isDayString } from '@workspace/shared';
 import { log } from '../config/logging.js';
 import { loadUserTimezone } from '../utils/timezoneLoader.js';
 import {
@@ -33,14 +34,27 @@ const router = express.Router();
  *
  * The spec says the client MUST send the negotiated version, so that is a
  * client-side fault — but 400ing every call is a poor way to meet it, and the
- * request is otherwise perfectly serviceable at our version. Only *newer*
- * versions are clamped: an unrecognised *older* one is left alone so it still
- * fails loudly rather than being silently upgraded.
+ * request is otherwise perfectly serviceable at our version.
+ *
+ * Only a well-formed version that genuinely post-dates this SDK is clamped.
+ * An unrecognised *older* version, and anything that is not a real date, are
+ * both left alone so they still fail loudly rather than being silently
+ * upgraded — the spec requires a 400 for a malformed version.
  */
 export function clampFutureProtocolVersion(req: express.Request): void {
-  const raw = req.headers['mcp-protocol-version'];
-  const version = Array.isArray(raw) ? raw[0] : raw;
-  if (!version || SUPPORTED_PROTOCOL_VERSIONS.includes(version)) return;
+  const version = req.headers['mcp-protocol-version'];
+  // Node collapses a repeated non-`set-cookie` header into a single
+  // comma-joined string, so this is a string or undefined — never an array.
+  // A repeated header therefore arrives as "2026-07-28, 2026-07-28", fails the
+  // date check below, and is left for the transport to reject with the same 400
+  // it already returned before this clamp existed.
+  if (typeof version !== 'string') return;
+  if (SUPPORTED_PROTOCOL_VERSIONS.includes(version)) return;
+  // The comparison below is lexicographic, so it is only a version comparison
+  // for real dates. Without this guard a value like "latest" or "foo" sorts
+  // above LATEST_PROTOCOL_VERSION and would be silently accepted as a future
+  // version instead of being rejected.
+  if (!isDayString(version)) return;
   // Versions are ISO dates, so a lexicographic compare is a date compare.
   if (version <= LATEST_PROTOCOL_VERSION) return;
   log(
@@ -57,6 +71,9 @@ export function clampFutureProtocolVersion(req: express.Request): void {
     for (let i = 0; i < rawHeaders.length; i += 2) {
       if (rawHeaders[i]?.toLowerCase() === 'mcp-protocol-version') {
         rawHeaders[i + 1] = LATEST_PROTOCOL_VERSION;
+        // Exactly one occurrence can reach here: a repeated header would have
+        // been comma-joined and rejected by the date check above.
+        break;
       }
     }
   }

--- a/SparkyFitnessServer/routes/mcpRoutes.ts
+++ b/SparkyFitnessServer/routes/mcpRoutes.ts
@@ -1,6 +1,10 @@
 import express from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from '@modelcontextprotocol/sdk/types.js';
 import { log } from '../config/logging.js';
 import { loadUserTimezone } from '../utils/timezoneLoader.js';
 import {
@@ -13,6 +17,50 @@ import chatService from '../services/chatService.js';
 import { TtlCache } from '../utils/ttlCache.js';
 
 const router = express.Router();
+
+/**
+ * Clamp an unrecognised `MCP-Protocol-Version` header down to the newest version
+ * this SDK understands.
+ *
+ * `initialize` already negotiates correctly — a client asking for a future
+ * version is answered with ours. But some clients (Claude.ai's connector at the
+ * time of writing) then send *their* newest version in the header on every
+ * subsequent request rather than the negotiated one, and the transport rejects
+ * the whole request:
+ *
+ *   Bad Request: Unsupported protocol version: 2026-07-28
+ *   (supported versions: 2025-11-25, 2025-06-18, ...)
+ *
+ * The spec says the client MUST send the negotiated version, so that is a
+ * client-side fault — but 400ing every call is a poor way to meet it, and the
+ * request is otherwise perfectly serviceable at our version. Only *newer*
+ * versions are clamped: an unrecognised *older* one is left alone so it still
+ * fails loudly rather than being silently upgraded.
+ */
+export function clampFutureProtocolVersion(req: express.Request): void {
+  const raw = req.headers['mcp-protocol-version'];
+  const version = Array.isArray(raw) ? raw[0] : raw;
+  if (!version || SUPPORTED_PROTOCOL_VERSIONS.includes(version)) return;
+  // Versions are ISO dates, so a lexicographic compare is a date compare.
+  if (version <= LATEST_PROTOCOL_VERSION) return;
+  log(
+    'warn',
+    `[MCP] Client sent protocol version ${version}, which post-dates this SDK; treating it as ${LATEST_PROTOCOL_VERSION}.`
+  );
+  req.headers['mcp-protocol-version'] = LATEST_PROTOCOL_VERSION;
+  // `req.headers` alone is not enough. The Node transport hands the request to
+  // Hono's getRequestListener, which rebuilds a Web Request from `rawHeaders`,
+  // so a clamp applied only to the parsed headers is silently discarded and the
+  // transport still sees the original version.
+  const rawHeaders = (req as unknown as { rawHeaders?: string[] }).rawHeaders;
+  if (Array.isArray(rawHeaders)) {
+    for (let i = 0; i < rawHeaders.length; i += 2) {
+      if (rawHeaders[i]?.toLowerCase() === 'mcp-protocol-version') {
+        rawHeaders[i + 1] = LATEST_PROTOCOL_VERSION;
+      }
+    }
+  }
+}
 
 // Per-user cache of the two DB lookups at the top of every MCP request (each
 // request builds a fresh McpServer, so tools/list + tools/call each paid a
@@ -66,6 +114,7 @@ function stripNulls(val: unknown): unknown {
  */
 router.post('/', async (req, res) => {
   try {
+    clampFutureProtocolVersion(req);
     const userId = req.authenticatedUserId;
     // The profile is honored verbatim for every service type (unlike chat,
     // which only honors 'core' for self-hosted backends): a user who trimmed

--- a/SparkyFitnessServer/tests/mcpProtocolVersion.test.ts
+++ b/SparkyFitnessServer/tests/mcpProtocolVersion.test.ts
@@ -101,15 +101,60 @@ describe('clampFutureProtocolVersion', () => {
     ).toBeUndefined();
   });
 
-  it('handles a repeated header (array form) without throwing', () => {
+  it.each([
+    'latest',
+    'foo',
+    'invalid-version',
+    'z',
+    '2025-13-01',
+    '2025-02-30',
+  ])(
+    'leaves the malformed version %s alone so the transport can 400 it',
+    (version) => {
+      // These all sort above LATEST_PROTOCOL_VERSION under a lexicographic
+      // compare, so without a date check they would be silently accepted as
+      // "newer" versions. The spec requires a 400 for a malformed version.
+      const req = reqWith(version);
+      clampFutureProtocolVersion(req);
+      expect(
+        (req as unknown as { headers: Record<string, string> }).headers[
+          'mcp-protocol-version'
+        ]
+      ).toBe(version);
+      expect((req as unknown as { rawHeaders: string[] }).rawHeaders[1]).toBe(
+        version
+      );
+      expect(logSpy).not.toHaveBeenCalled();
+    }
+  );
+
+  it('leaves a repeated header alone rather than half-rewriting it', () => {
+    // Node collapses duplicates of a non-set-cookie header into one
+    // comma-joined string, so req.headers never holds an array here. Rewriting
+    // each rawHeaders occurrence would just produce
+    // "2025-11-25, 2025-11-25" — still unsupported — so the clamp declines the
+    // value and leaves the transport to reject it exactly as it did before.
     const req = {
-      headers: { 'mcp-protocol-version': ['2026-07-28', '2026-07-28'] },
+      headers: { 'mcp-protocol-version': '2026-07-28, 2026-07-28' },
+      rawHeaders: [
+        'MCP-Protocol-Version',
+        '2026-07-28',
+        'MCP-Protocol-Version',
+        '2026-07-28',
+      ],
     } as never;
-    expect(() => clampFutureProtocolVersion(req)).not.toThrow();
-    expect(
-      (req as unknown as { headers: Record<string, string> }).headers[
-        'mcp-protocol-version'
-      ]
-    ).toBe(LATEST_PROTOCOL_VERSION);
+    clampFutureProtocolVersion(req);
+    const { headers, rawHeaders } = req as unknown as {
+      headers: Record<string, string>;
+      rawHeaders: string[];
+    };
+    expect(headers['mcp-protocol-version']).toBe('2026-07-28, 2026-07-28');
+    expect(rawHeaders).toEqual([
+      'MCP-Protocol-Version',
+      '2026-07-28',
+      'MCP-Protocol-Version',
+      '2026-07-28',
+    ]);
+    expect(logSpy).not.toHaveBeenCalled();
   });
 });

--- a/SparkyFitnessServer/tests/mcpProtocolVersion.test.ts
+++ b/SparkyFitnessServer/tests/mcpProtocolVersion.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  LATEST_PROTOCOL_VERSION,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const logSpy = vi.fn();
+vi.mock('../config/logging.js', () => ({
+  log: (...a: unknown[]) => logSpy(...a),
+}));
+
+// The route module pulls in the whole tool registry and DB layer; the clamp is
+// pure header logic, so stub the rest out rather than standing up the world.
+vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+  McpServer: class {},
+}));
+vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
+  StreamableHTTPServerTransport: class {},
+}));
+vi.mock('../utils/timezoneLoader.js', () => ({ loadUserTimezone: vi.fn() }));
+vi.mock('../ai/mcp/mcpAdapter.js', () => ({
+  registerRegistryTools: vi.fn(),
+  registerDevTools: vi.fn(),
+}));
+vi.mock('../utils/adminCheck.js', () => ({ resolveIsAdmin: vi.fn() }));
+vi.mock('../services/versionService.js', () => ({
+  default: { getAppVersion: () => '0.0.0-test' },
+}));
+vi.mock('../services/chatService.js', () => ({
+  default: { getActiveAiServiceSetting: vi.fn() },
+}));
+
+const { clampFutureProtocolVersion } = await import('../routes/mcpRoutes.js');
+
+const reqWith = (version?: string) =>
+  ({
+    headers: version === undefined ? {} : { 'mcp-protocol-version': version },
+    // The transport reads rawHeaders, not the parsed headers, so the fixture
+    // has to carry both for the test to mean anything.
+    rawHeaders: version === undefined ? [] : ['MCP-Protocol-Version', version],
+  }) as never;
+
+describe('clampFutureProtocolVersion', () => {
+  beforeEach(() => logSpy.mockClear());
+
+  it('rewrites a version newer than this SDK to the latest supported one', () => {
+    // Claude.ai's connector negotiates 2025-11-25 at initialize and then sends
+    // its own newest version on every later request; the transport used to 400
+    // the whole call.
+    const req = reqWith('2026-07-28');
+    clampFutureProtocolVersion(req);
+    expect(
+      (req as unknown as { headers: Record<string, string> }).headers[
+        'mcp-protocol-version'
+      ]
+    ).toBe(LATEST_PROTOCOL_VERSION);
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('also rewrites rawHeaders, which is what the transport actually reads', () => {
+    // The Node transport rebuilds a Web Request from rawHeaders via Hono, so a
+    // clamp applied only to req.headers is discarded and the 400 persists.
+    const req = reqWith('2026-07-28');
+    clampFutureProtocolVersion(req);
+    const raw = (req as unknown as { rawHeaders: string[] }).rawHeaders;
+    expect(raw[1]).toBe(LATEST_PROTOCOL_VERSION);
+  });
+
+  it('leaves every supported version untouched', () => {
+    for (const version of SUPPORTED_PROTOCOL_VERSIONS) {
+      const req = reqWith(version);
+      clampFutureProtocolVersion(req);
+      expect(
+        (req as unknown as { headers: Record<string, string> }).headers[
+          'mcp-protocol-version'
+        ]
+      ).toBe(version);
+    }
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('leaves an unrecognised OLDER version alone so it still fails loudly', () => {
+    // Silently upgrading a client that asked for something ancient would hide a
+    // real incompatibility.
+    const req = reqWith('2023-01-01');
+    clampFutureProtocolVersion(req);
+    expect(
+      (req as unknown as { headers: Record<string, string> }).headers[
+        'mcp-protocol-version'
+      ]
+    ).toBe('2023-01-01');
+  });
+
+  it('does nothing when the header is absent', () => {
+    const req = reqWith();
+    clampFutureProtocolVersion(req);
+    expect(
+      (req as unknown as { headers: Record<string, string> }).headers[
+        'mcp-protocol-version'
+      ]
+    ).toBeUndefined();
+  });
+
+  it('handles a repeated header (array form) without throwing', () => {
+    const req = {
+      headers: { 'mcp-protocol-version': ['2026-07-28', '2026-07-28'] },
+    } as never;
+    expect(() => clampFutureProtocolVersion(req)).not.toThrow();
+    expect(
+      (req as unknown as { headers: Record<string, string> }).headers[
+        'mcp-protocol-version'
+      ]
+    ).toBe(LATEST_PROTOCOL_VERSION);
+  });
+});


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Claude.ai's connector negotiates fine at `initialize` but then sends its own newest protocol version (`2026-07-28`) in the `MCP-Protocol-Version` header on every subsequent request, so the transport 400s every tool call against an otherwise healthy server.

**How did you implement the solution?**
Clamp a header version that post-dates this SDK down to `LATEST_PROTOCOL_VERSION` before the transport sees it. An unrecognised *older* version is left untouched, so a genuine incompatibility still fails loudly instead of being silently upgraded.

One subtlety: rewriting `req.headers` alone does nothing. The Node transport hands the request to Hono's `getRequestListener`, which rebuilds a Web Request from `rawHeaders` — so the clamp writes to both. Without that it logs success while the transport carries on rejecting.

This is a stopgap, not a substitute for the SDK v2 migration you mentioned in #2155 — it just stops the header alone from breaking clients while there is no SDK release to move to (`@modelcontextprotocol/sdk` is at 1.30.0 and its `LATEST_PROTOCOL_VERSION` is still `2025-11-25`, and no 2.x is published).

Linked Issue: Closes #2155

## How to Test

Against a running server, with an API key:

```bash
# Before this change: 400 "Unsupported protocol version: 2026-07-28"
# After: normal tool list
curl -s -X POST https://<host>/mcp \
  -H "Authorization: Bearer <API_KEY>" \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -H 'MCP-Protocol-Version: 2026-07-28' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
```

A real `tools/call` at the same header version works too. Sending a supported version (e.g. `2025-11-25`) behaves exactly as before.

Unit tests: `pnpm exec vitest run tests/mcpProtocolVersion.test.ts` — 6 cases covering the clamp, every supported version left untouched, an older unknown version left alone, the header absent, a repeated header, and the `rawHeaders` rewrite.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. *(No new tables in this PR.)*

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

No UI changes — this is server-side header handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer MCP protocol versions by automatically using the latest supported version when needed.
  * Preserved recognized, older, missing, and malformed protocol versions without changing them.
  * Improved handling of repeated protocol headers, ensuring they remain unchanged for proper validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->