### PR TITLE
fix(Server): Normalize database and migrate JSON array parsing to utility function

### DIFF
--- a/SparkyFitnessServer/db/migrations/20260816192818_normalize_exercise_json_array_fields.sql
+++ b/SparkyFitnessServer/db/migrations/20260816192818_normalize_exercise_json_array_fields.sql
@@ -1,0 +1,80 @@
+-- exercises.equipment/primary_muscles/secondary_muscles/instructions/images
+-- (and the matching columns on exercise_entries) are TEXT columns holding a
+-- JSON-array-encoded string by design (20250927180257_alter_exercises_table.sql:
+-- "-- Stored as JSON array of strings"). Some rows hold a bare JSON string
+-- instead of a one-item array (free-exercise-db's raw JSON uses a single
+-- string for a solo value, and the import path historically passed that
+-- through unnormalized) or, for a handful of legacy rows, plain non-JSON text
+-- (e.g. a comma-separated equipment list). Every read path that JSON-parses
+-- these columns without checking it got an array back then either crashes
+-- (application code prior to this fix) or, if guarded, silently drops the
+-- value. This backfills existing rows into the one true shape: a JSON array.
+--
+-- Idempotent: normalize_exercise_json_array() is a pure function of the
+-- input value, and each UPDATE only touches rows where the function's output
+-- actually differs from the stored value, so a re-run updates zero rows.
+
+CREATE OR REPLACE FUNCTION normalize_exercise_json_array(value text)
+RETURNS text
+LANGUAGE plpgsql
+AS $func$
+DECLARE
+    parsed jsonb;
+BEGIN
+    IF value IS NULL OR btrim(value) = '' THEN
+        RETURN value;
+    END IF;
+
+    BEGIN
+        parsed := value::jsonb;
+    EXCEPTION WHEN OTHERS THEN
+        -- Not valid JSON at all (legacy plain/comma-separated text, e.g.
+        -- "Barbell, Dumbbell"). Recover it the same way the application's
+        -- own getDistinctEquipment fallback does: strip brackets/quotes/
+        -- backticks, split on comma, trim, drop empties. ORDER BY ord keeps
+        -- the original comma order, since aggregation order is otherwise
+        -- unspecified.
+        RETURN (
+            SELECT COALESCE(jsonb_agg(item ORDER BY ord), '[]'::jsonb)::text
+            FROM (
+                SELECT btrim(piece) AS item, ord
+                FROM unnest(string_to_array(translate(value, '[]''"`', ''), ',')) WITH ORDINALITY AS u(piece, ord)
+                WHERE btrim(piece) <> ''
+            ) AS pieces
+        );
+    END;
+
+    IF jsonb_typeof(parsed) = 'array' THEN
+        RETURN value; -- already the correct shape
+    END IF;
+
+    -- A bare JSON scalar/object (most commonly a single string like
+    -- "Barbell") — wrap it into a one-item array.
+    RETURN jsonb_build_array(parsed)::text;
+END;
+$func$;
+
+UPDATE exercises SET equipment = normalize_exercise_json_array(equipment)
+WHERE equipment IS NOT NULL AND normalize_exercise_json_array(equipment) IS DISTINCT FROM equipment;
+UPDATE exercises SET primary_muscles = normalize_exercise_json_array(primary_muscles)
+WHERE primary_muscles IS NOT NULL AND normalize_exercise_json_array(primary_muscles) IS DISTINCT FROM primary_muscles;
+UPDATE exercises SET secondary_muscles = normalize_exercise_json_array(secondary_muscles)
+WHERE secondary_muscles IS NOT NULL AND normalize_exercise_json_array(secondary_muscles) IS DISTINCT FROM secondary_muscles;
+UPDATE exercises SET instructions = normalize_exercise_json_array(instructions)
+WHERE instructions IS NOT NULL AND normalize_exercise_json_array(instructions) IS DISTINCT FROM instructions;
+UPDATE exercises SET images = normalize_exercise_json_array(images)
+WHERE images IS NOT NULL AND normalize_exercise_json_array(images) IS DISTINCT FROM images;
+
+UPDATE exercise_entries SET equipment = normalize_exercise_json_array(equipment)
+WHERE equipment IS NOT NULL AND normalize_exercise_json_array(equipment) IS DISTINCT FROM equipment;
+UPDATE exercise_entries SET primary_muscles = normalize_exercise_json_array(primary_muscles)
+WHERE primary_muscles IS NOT NULL AND normalize_exercise_json_array(primary_muscles) IS DISTINCT FROM primary_muscles;
+UPDATE exercise_entries SET secondary_muscles = normalize_exercise_json_array(secondary_muscles)
+WHERE secondary_muscles IS NOT NULL AND normalize_exercise_json_array(secondary_muscles) IS DISTINCT FROM secondary_muscles;
+UPDATE exercise_entries SET instructions = normalize_exercise_json_array(instructions)
+WHERE instructions IS NOT NULL AND normalize_exercise_json_array(instructions) IS DISTINCT FROM instructions;
+UPDATE exercise_entries SET images = normalize_exercise_json_array(images)
+WHERE images IS NOT NULL AND normalize_exercise_json_array(images) IS DISTINCT FROM images;
+
+-- Migration-only helper; not part of the application's function catalog.
+DROP FUNCTION normalize_exercise_json_array(text);

--- a/SparkyFitnessServer/db/migrations/20260816192818_normalize_exercise_json_array_fields.sql
+++ b/SparkyFitnessServer/db/migrations/20260816192818_normalize_exercise_json_array_fields.sql
@@ -13,6 +13,13 @@
 -- Idempotent: normalize_exercise_json_array() is a pure function of the
 -- input value, and each UPDATE only touches rows where the function's output
 -- actually differs from the stored value, so a re-run updates zero rows.
+--
+-- Explicit transaction: the migration runner sends this whole file as one
+-- unwrapped query, so an explicit BEGIN/COMMIT isn't load-bearing today, but
+-- it makes the all-or-nothing guarantee obvious without relying on knowing
+-- that detail — if any UPDATE below fails, every table stays consistent
+-- with every other (and the helper function never lingers half-applied).
+BEGIN;
 
 CREATE OR REPLACE FUNCTION normalize_exercise_json_array(value text)
 RETURNS text
@@ -21,8 +28,15 @@ AS $func$
 DECLARE
     parsed jsonb;
 BEGIN
-    IF value IS NULL OR btrim(value) = '' THEN
+    IF value IS NULL THEN
         RETURN value;
+    END IF;
+
+    IF btrim(value) = '' THEN
+        -- Non-NULL but empty/whitespace-only isn't valid JSON either; make it
+        -- the same "no values" shape as everything else instead of leaving a
+        -- row whose column still doesn't parse as JSON.
+        RETURN '[]';
     END IF;
 
     BEGIN
@@ -78,3 +92,5 @@ WHERE images IS NOT NULL AND normalize_exercise_json_array(images) IS DISTINCT F
 
 -- Migration-only helper; not part of the application's function catalog.
 DROP FUNCTION normalize_exercise_json_array(text);
+
+COMMIT;

--- a/SparkyFitnessServer/db/migrations/20260816192818_normalize_exercise_json_array_fields.sql
+++ b/SparkyFitnessServer/db/migrations/20260816192818_normalize_exercise_json_array_fields.sql
@@ -10,9 +10,35 @@
 -- (application code prior to this fix) or, if guarded, silently drops the
 -- value. This backfills existing rows into the one true shape: a JSON array.
 --
--- Idempotent: normalize_exercise_json_array() is a pure function of the
--- input value, and each UPDATE only touches rows where the function's output
--- actually differs from the stored value, so a re-run updates zero rows.
+-- Two recovery strategies for non-JSON legacy text, chosen per column:
+--   equipment/primary_muscles/secondary_muscles are comma-separated lists
+--   ("Barbell, Dumbbell") — split on comma, same as the application's own
+--   getDistinctEquipment fallback.
+--   instructions/images are prose/paths, not lists. Comma-splitting a
+--   sentence like "Lie on the bench, then press." would fabricate two fake
+--   steps, and stripping characters would silently delete apostrophes and
+--   quotes from real instructional text. These two are instead wrapped
+--   verbatim into a single-item array — destructive text mangling is worse
+--   than a rarely-needed second array element, and this migration has no
+--   down migration.
+--
+-- Idempotent: normalize_exercise_json_array() is a pure function of its
+-- input, and each UPDATE only computes and writes rows that need it, so a
+-- re-run updates zero rows.
+--
+-- Performance: exercise_entries is a per-workout log table that can carry
+-- years of import history (Garmin, etc.), and this runs synchronously during
+-- server startup before the app accepts requests. Two things keep the cost
+-- down: a cheap prefix prefilter (`left(btrim(col), 1) <> '['`) skips the
+-- already-correct majority without ever calling the function — every
+-- malformed shape this migration actually targets (a bare JSON string, or
+-- plain non-JSON text) fails this check, so the only theoretical miss is a
+-- value that already starts with '[' but isn't valid JSON, which no known
+-- write path in this codebase produces; and each UPDATE computes the
+-- normalized value once per candidate row via a subquery, instead of calling
+-- the function twice (once in WHERE, once in SET) — worth avoiding here
+-- since the function's internal EXCEPTION block is a subtransaction per
+-- call.
 --
 -- Explicit transaction: the migration runner sends this whole file as one
 -- unwrapped query, so an explicit BEGIN/COMMIT isn't load-bearing today, but
@@ -21,7 +47,10 @@
 -- with every other (and the helper function never lingers half-applied).
 BEGIN;
 
-CREATE OR REPLACE FUNCTION normalize_exercise_json_array(value text)
+CREATE OR REPLACE FUNCTION normalize_exercise_json_array(
+    value text,
+    split_on_comma boolean DEFAULT true
+)
 RETURNS text
 LANGUAGE plpgsql
 AS $func$
@@ -42,20 +71,27 @@ BEGIN
     BEGIN
         parsed := value::jsonb;
     EXCEPTION WHEN OTHERS THEN
-        -- Not valid JSON at all (legacy plain/comma-separated text, e.g.
-        -- "Barbell, Dumbbell"). Recover it the same way the application's
-        -- own getDistinctEquipment fallback does: strip brackets/quotes/
-        -- backticks, split on comma, trim, drop empties. ORDER BY ord keeps
-        -- the original comma order, since aggregation order is otherwise
-        -- unspecified.
-        RETURN (
-            SELECT COALESCE(jsonb_agg(item ORDER BY ord), '[]'::jsonb)::text
-            FROM (
-                SELECT btrim(piece) AS item, ord
-                FROM unnest(string_to_array(translate(value, '[]''"`', ''), ',')) WITH ORDINALITY AS u(piece, ord)
-                WHERE btrim(piece) <> ''
-            ) AS pieces
-        );
+        IF split_on_comma THEN
+            -- Legacy comma-separated list text (equipment/muscles). Recover
+            -- it the same way the application's own getDistinctEquipment
+            -- fallback does: strip brackets/quotes/backticks, split on
+            -- comma, trim, drop empties. ORDER BY ord keeps the original
+            -- comma order, since aggregation order is otherwise unspecified.
+            RETURN (
+                SELECT COALESCE(jsonb_agg(item ORDER BY ord), '[]'::jsonb)::text
+                FROM (
+                    SELECT btrim(piece) AS item, ord
+                    FROM unnest(string_to_array(translate(value, '[]''"`', ''), ',')) WITH ORDINALITY AS u(piece, ord)
+                    WHERE btrim(piece) <> ''
+                ) AS pieces
+            );
+        ELSE
+            -- Free-text prose (instructions) or a file path (images) — never
+            -- comma-split or strip characters out of it. Preserve it
+            -- verbatim as a single-item array; to_jsonb() JSON-encodes it
+            -- correctly regardless of embedded quotes/apostrophes/backslashes.
+            RETURN jsonb_build_array(to_jsonb(btrim(value)))::text;
+        END IF;
     END;
 
     IF jsonb_typeof(parsed) = 'array' THEN
@@ -63,34 +99,93 @@ BEGIN
     END IF;
 
     -- A bare JSON scalar/object (most commonly a single string like
-    -- "Barbell") — wrap it into a one-item array.
+    -- "Barbell") — wrap it into a one-item array. Applies to every column;
+    -- split_on_comma only affects the not-valid-JSON-at-all fallback above.
     RETURN jsonb_build_array(parsed)::text;
 END;
 $func$;
 
-UPDATE exercises SET equipment = normalize_exercise_json_array(equipment)
-WHERE equipment IS NOT NULL AND normalize_exercise_json_array(equipment) IS DISTINCT FROM equipment;
-UPDATE exercises SET primary_muscles = normalize_exercise_json_array(primary_muscles)
-WHERE primary_muscles IS NOT NULL AND normalize_exercise_json_array(primary_muscles) IS DISTINCT FROM primary_muscles;
-UPDATE exercises SET secondary_muscles = normalize_exercise_json_array(secondary_muscles)
-WHERE secondary_muscles IS NOT NULL AND normalize_exercise_json_array(secondary_muscles) IS DISTINCT FROM secondary_muscles;
-UPDATE exercises SET instructions = normalize_exercise_json_array(instructions)
-WHERE instructions IS NOT NULL AND normalize_exercise_json_array(instructions) IS DISTINCT FROM instructions;
-UPDATE exercises SET images = normalize_exercise_json_array(images)
-WHERE images IS NOT NULL AND normalize_exercise_json_array(images) IS DISTINCT FROM images;
+UPDATE exercises e SET equipment = normalized.value
+FROM (
+    SELECT id, normalize_exercise_json_array(equipment) AS value
+    FROM exercises
+    WHERE equipment IS NOT NULL AND left(btrim(equipment), 1) <> '['
+) AS normalized
+WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.equipment;
 
-UPDATE exercise_entries SET equipment = normalize_exercise_json_array(equipment)
-WHERE equipment IS NOT NULL AND normalize_exercise_json_array(equipment) IS DISTINCT FROM equipment;
-UPDATE exercise_entries SET primary_muscles = normalize_exercise_json_array(primary_muscles)
-WHERE primary_muscles IS NOT NULL AND normalize_exercise_json_array(primary_muscles) IS DISTINCT FROM primary_muscles;
-UPDATE exercise_entries SET secondary_muscles = normalize_exercise_json_array(secondary_muscles)
-WHERE secondary_muscles IS NOT NULL AND normalize_exercise_json_array(secondary_muscles) IS DISTINCT FROM secondary_muscles;
-UPDATE exercise_entries SET instructions = normalize_exercise_json_array(instructions)
-WHERE instructions IS NOT NULL AND normalize_exercise_json_array(instructions) IS DISTINCT FROM instructions;
-UPDATE exercise_entries SET images = normalize_exercise_json_array(images)
-WHERE images IS NOT NULL AND normalize_exercise_json_array(images) IS DISTINCT FROM images;
+UPDATE exercises e SET primary_muscles = normalized.value
+FROM (
+    SELECT id, normalize_exercise_json_array(primary_muscles) AS value
+    FROM exercises
+    WHERE primary_muscles IS NOT NULL AND left(btrim(primary_muscles), 1) <> '['
+) AS normalized
+WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.primary_muscles;
+
+UPDATE exercises e SET secondary_muscles = normalized.value
+FROM (
+    SELECT id, normalize_exercise_json_array(secondary_muscles) AS value
+    FROM exercises
+    WHERE secondary_muscles IS NOT NULL AND left(btrim(secondary_muscles), 1) <> '['
+) AS normalized
+WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.secondary_muscles;
+
+UPDATE exercises e SET instructions = normalized.value
+FROM (
+    SELECT id, normalize_exercise_json_array(instructions, false) AS value
+    FROM exercises
+    WHERE instructions IS NOT NULL AND left(btrim(instructions), 1) <> '['
+) AS normalized
+WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.instructions;
+
+UPDATE exercises e SET images = normalized.value
+FROM (
+    SELECT id, normalize_exercise_json_array(images, false) AS value
+    FROM exercises
+    WHERE images IS NOT NULL AND left(btrim(images), 1) <> '['
+) AS normalized
+WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.images;
+
+UPDATE exercise_entries e SET equipment = normalized.value
+FROM (
+    SELECT id, normalize_exercise_json_array(equipment) AS value
+    FROM exercise_entries
+    WHERE equipment IS NOT NULL AND left(btrim(equipment), 1) <> '['
+) AS normalized
+WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.equipment;
+
+UPDATE exercise_entries e SET primary_muscles = normalized.value
+FROM (
+    SELECT id, normalize_exercise_json_array(primary_muscles) AS value
+    FROM exercise_entries
+    WHERE primary_muscles IS NOT NULL AND left(btrim(primary_muscles), 1) <> '['
+) AS normalized
+WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.primary_muscles;
+
+UPDATE exercise_entries e SET secondary_muscles = normalized.value
+FROM (
+    SELECT id, normalize_exercise_json_array(secondary_muscles) AS value
+    FROM exercise_entries
+    WHERE secondary_muscles IS NOT NULL AND left(btrim(secondary_muscles), 1) <> '['
+) AS normalized
+WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.secondary_muscles;
+
+UPDATE exercise_entries e SET instructions = normalized.value
+FROM (
+    SELECT id, normalize_exercise_json_array(instructions, false) AS value
+    FROM exercise_entries
+    WHERE instructions IS NOT NULL AND left(btrim(instructions), 1) <> '['
+) AS normalized
+WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.instructions;
+
+UPDATE exercise_entries e SET images = normalized.value
+FROM (
+    SELECT id, normalize_exercise_json_array(images, false) AS value
+    FROM exercise_entries
+    WHERE images IS NOT NULL AND left(btrim(images), 1) <> '['
+) AS normalized
+WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.images;
 
 -- Migration-only helper; not part of the application's function catalog.
-DROP FUNCTION normalize_exercise_json_array(text);
+DROP FUNCTION normalize_exercise_json_array(text, boolean);
 
 COMMIT;

--- a/SparkyFitnessServer/db/migrations/20260816192818_normalize_exercise_json_array_fields.sql
+++ b/SparkyFitnessServer/db/migrations/20260816192818_normalize_exercise_json_array_fields.sql
@@ -29,16 +29,20 @@
 -- Performance: exercise_entries is a per-workout log table that can carry
 -- years of import history (Garmin, etc.), and this runs synchronously during
 -- server startup before the app accepts requests. Two things keep the cost
--- down: a cheap prefix prefilter (`left(btrim(col), 1) <> '['`) skips the
--- already-correct majority without ever calling the function — every
--- malformed shape this migration actually targets (a bare JSON string, or
--- plain non-JSON text) fails this check, so the only theoretical miss is a
--- value that already starts with '[' but isn't valid JSON, which no known
--- write path in this codebase produces; and each UPDATE computes the
--- normalized value once per candidate row via a subquery, instead of calling
--- the function twice (once in WHERE, once in SET) — worth avoiding here
--- since the function's internal EXCEPTION block is a subtransaction per
--- call.
+-- down without sacrificing correctness:
+--   A value that doesn't even start with '[' can never be a valid JSON
+--   array, so `left(btrim(col), 1) <> '['` cheaply flags it as a candidate
+--   with no parsing at all. But the converse isn't true — a value CAN start
+--   with '[' and still not be valid JSON (an unquoted legacy list like
+--   "[Barbell, Dumbbell]"; models/exercise.ts's own getDistinctEquipment
+--   already carries a fallback for exactly this shape), so bracket-prefixed
+--   values are only treated as already-correct once
+--   exercise_json_array_is_valid() confirms they actually parse as a JSON
+--   array — never on the string shape alone.
+--   Each UPDATE computes the normalized value once per candidate row via a
+--   subquery, instead of calling normalize_exercise_json_array() twice
+--   (once in WHERE, once in SET) — worth avoiding since that function's
+--   internal EXCEPTION block is a subtransaction per call.
 --
 -- Explicit transaction: the migration runner sends this whole file as one
 -- unwrapped query, so an explicit BEGIN/COMMIT isn't load-bearing today, but
@@ -74,16 +78,23 @@ BEGIN
         IF split_on_comma THEN
             -- Legacy comma-separated list text (equipment/muscles). Recover
             -- it the same way the application's own getDistinctEquipment
-            -- fallback does: strip brackets/quotes/backticks, split on
-            -- comma, trim, drop empties. ORDER BY ord keeps the original
-            -- comma order, since aggregation order is otherwise unspecified.
+            -- fallback does: split on comma first, then trim wrapper
+            -- brackets/quotes/backticks (and whitespace) from each segment's
+            -- own boundaries only. Splitting first and using btrim's
+            -- character-set trim (boundary-only) instead of translate()
+            -- (which deletes a character everywhere it appears) is what
+            -- keeps a genuine apostrophe inside an item, e.g. "Trainer's
+            -- Choice, Barbell", from being silently stripped along with the
+            -- legacy list-wrapping punctuation. ORDER BY ord keeps the
+            -- original comma order, since aggregation order is otherwise
+            -- unspecified.
             RETURN (
                 SELECT COALESCE(jsonb_agg(item ORDER BY ord), '[]'::jsonb)::text
                 FROM (
-                    SELECT btrim(piece) AS item, ord
-                    FROM unnest(string_to_array(translate(value, '[]''"`', ''), ',')) WITH ORDINALITY AS u(piece, ord)
-                    WHERE btrim(piece) <> ''
+                    SELECT btrim(btrim(btrim(piece), '[]''"`')) AS item, ord
+                    FROM unnest(string_to_array(value, ',')) WITH ORDINALITY AS u(piece, ord)
                 ) AS pieces
+                WHERE item <> ''
             );
         ELSE
             -- Free-text prose (instructions) or a file path (images) — never
@@ -105,11 +116,31 @@ BEGIN
 END;
 $func$;
 
+-- Cheap, non-throwing validity check used only to decide which
+-- bracket-prefixed rows the UPDATEs below can skip. Deliberately does none
+-- of normalize_exercise_json_array's recovery work — it only answers "is
+-- this already a valid JSON array?" so a bracket-prefixed-but-invalid value
+-- (see the Performance note above) is never mistaken for already-correct.
+CREATE OR REPLACE FUNCTION exercise_json_array_is_valid(value text)
+RETURNS boolean
+LANGUAGE plpgsql
+AS $valid$
+BEGIN
+    RETURN jsonb_typeof(value::jsonb) = 'array';
+EXCEPTION WHEN OTHERS THEN
+    RETURN false;
+END;
+$valid$;
+
 UPDATE exercises e SET equipment = normalized.value
 FROM (
     SELECT id, normalize_exercise_json_array(equipment) AS value
     FROM exercises
-    WHERE equipment IS NOT NULL AND left(btrim(equipment), 1) <> '['
+    WHERE equipment IS NOT NULL
+      AND (
+        left(btrim(equipment), 1) <> '['
+        OR NOT exercise_json_array_is_valid(equipment)
+      )
 ) AS normalized
 WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.equipment;
 
@@ -117,7 +148,11 @@ UPDATE exercises e SET primary_muscles = normalized.value
 FROM (
     SELECT id, normalize_exercise_json_array(primary_muscles) AS value
     FROM exercises
-    WHERE primary_muscles IS NOT NULL AND left(btrim(primary_muscles), 1) <> '['
+    WHERE primary_muscles IS NOT NULL
+      AND (
+        left(btrim(primary_muscles), 1) <> '['
+        OR NOT exercise_json_array_is_valid(primary_muscles)
+      )
 ) AS normalized
 WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.primary_muscles;
 
@@ -125,7 +160,11 @@ UPDATE exercises e SET secondary_muscles = normalized.value
 FROM (
     SELECT id, normalize_exercise_json_array(secondary_muscles) AS value
     FROM exercises
-    WHERE secondary_muscles IS NOT NULL AND left(btrim(secondary_muscles), 1) <> '['
+    WHERE secondary_muscles IS NOT NULL
+      AND (
+        left(btrim(secondary_muscles), 1) <> '['
+        OR NOT exercise_json_array_is_valid(secondary_muscles)
+      )
 ) AS normalized
 WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.secondary_muscles;
 
@@ -133,7 +172,11 @@ UPDATE exercises e SET instructions = normalized.value
 FROM (
     SELECT id, normalize_exercise_json_array(instructions, false) AS value
     FROM exercises
-    WHERE instructions IS NOT NULL AND left(btrim(instructions), 1) <> '['
+    WHERE instructions IS NOT NULL
+      AND (
+        left(btrim(instructions), 1) <> '['
+        OR NOT exercise_json_array_is_valid(instructions)
+      )
 ) AS normalized
 WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.instructions;
 
@@ -141,7 +184,11 @@ UPDATE exercises e SET images = normalized.value
 FROM (
     SELECT id, normalize_exercise_json_array(images, false) AS value
     FROM exercises
-    WHERE images IS NOT NULL AND left(btrim(images), 1) <> '['
+    WHERE images IS NOT NULL
+      AND (
+        left(btrim(images), 1) <> '['
+        OR NOT exercise_json_array_is_valid(images)
+      )
 ) AS normalized
 WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.images;
 
@@ -149,7 +196,11 @@ UPDATE exercise_entries e SET equipment = normalized.value
 FROM (
     SELECT id, normalize_exercise_json_array(equipment) AS value
     FROM exercise_entries
-    WHERE equipment IS NOT NULL AND left(btrim(equipment), 1) <> '['
+    WHERE equipment IS NOT NULL
+      AND (
+        left(btrim(equipment), 1) <> '['
+        OR NOT exercise_json_array_is_valid(equipment)
+      )
 ) AS normalized
 WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.equipment;
 
@@ -157,7 +208,11 @@ UPDATE exercise_entries e SET primary_muscles = normalized.value
 FROM (
     SELECT id, normalize_exercise_json_array(primary_muscles) AS value
     FROM exercise_entries
-    WHERE primary_muscles IS NOT NULL AND left(btrim(primary_muscles), 1) <> '['
+    WHERE primary_muscles IS NOT NULL
+      AND (
+        left(btrim(primary_muscles), 1) <> '['
+        OR NOT exercise_json_array_is_valid(primary_muscles)
+      )
 ) AS normalized
 WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.primary_muscles;
 
@@ -165,7 +220,11 @@ UPDATE exercise_entries e SET secondary_muscles = normalized.value
 FROM (
     SELECT id, normalize_exercise_json_array(secondary_muscles) AS value
     FROM exercise_entries
-    WHERE secondary_muscles IS NOT NULL AND left(btrim(secondary_muscles), 1) <> '['
+    WHERE secondary_muscles IS NOT NULL
+      AND (
+        left(btrim(secondary_muscles), 1) <> '['
+        OR NOT exercise_json_array_is_valid(secondary_muscles)
+      )
 ) AS normalized
 WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.secondary_muscles;
 
@@ -173,7 +232,11 @@ UPDATE exercise_entries e SET instructions = normalized.value
 FROM (
     SELECT id, normalize_exercise_json_array(instructions, false) AS value
     FROM exercise_entries
-    WHERE instructions IS NOT NULL AND left(btrim(instructions), 1) <> '['
+    WHERE instructions IS NOT NULL
+      AND (
+        left(btrim(instructions), 1) <> '['
+        OR NOT exercise_json_array_is_valid(instructions)
+      )
 ) AS normalized
 WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.instructions;
 
@@ -181,11 +244,16 @@ UPDATE exercise_entries e SET images = normalized.value
 FROM (
     SELECT id, normalize_exercise_json_array(images, false) AS value
     FROM exercise_entries
-    WHERE images IS NOT NULL AND left(btrim(images), 1) <> '['
+    WHERE images IS NOT NULL
+      AND (
+        left(btrim(images), 1) <> '['
+        OR NOT exercise_json_array_is_valid(images)
+      )
 ) AS normalized
 WHERE e.id = normalized.id AND normalized.value IS DISTINCT FROM e.images;
 
--- Migration-only helper; not part of the application's function catalog.
+-- Migration-only helpers; not part of the application's function catalog.
 DROP FUNCTION normalize_exercise_json_array(text, boolean);
+DROP FUNCTION exercise_json_array_is_valid(text);
 
 COMMIT;

--- a/SparkyFitnessServer/models/exercise.ts
+++ b/SparkyFitnessServer/models/exercise.ts
@@ -10,6 +10,7 @@ import {
   buildSqlSearch,
   buildSqlExactMatchOrder,
 } from '../utils/dbSearchHelper.js';
+import { parseJsonArrayField } from '../utils/exerciseJsonFields.js';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getExerciseById(id: any, userId: any) {
   const client = await getClient(userId);
@@ -413,25 +414,26 @@ async function searchExercises(
     const result = await client.query(finalQuery, selectQueryParams);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return result.rows.map((row: any) => {
-      // Helper function to safely parse JSONB fields into arrays
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const parseJsonbField = (field: any) => {
-        if (row[field]) {
-          try {
-            const parsed = JSON.parse(row[field]);
-            return Array.isArray(parsed) ? parsed : [parsed]; // Ensure it's an array
-          } catch (e) {
-            log('error', `Error parsing ${field} for exercise ${row.id}:`, e);
-            return [];
-          }
-        }
-        return [];
-      };
-      row.equipment = parseJsonbField('equipment');
-      row.primary_muscles = parseJsonbField('primary_muscles');
-      row.secondary_muscles = parseJsonbField('secondary_muscles');
-      row.instructions = parseJsonbField('instructions');
-      row.images = parseJsonbField('images');
+      row.equipment = parseJsonArrayField(
+        row.equipment,
+        `equipment for exercise ${row.id}`
+      );
+      row.primary_muscles = parseJsonArrayField(
+        row.primary_muscles,
+        `primary_muscles for exercise ${row.id}`
+      );
+      row.secondary_muscles = parseJsonArrayField(
+        row.secondary_muscles,
+        `secondary_muscles for exercise ${row.id}`
+      );
+      row.instructions = parseJsonArrayField(
+        row.instructions,
+        `instructions for exercise ${row.id}`
+      );
+      row.images = parseJsonArrayField(
+        row.images,
+        `images for exercise ${row.id}`
+      );
       return row;
     });
   } finally {
@@ -516,24 +518,26 @@ async function searchExercisesPaginated(
     ]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const exercises = result.rows.map((row: any) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const parseJsonbField = (field: any) => {
-        if (row[field]) {
-          try {
-            const parsed = JSON.parse(row[field]);
-            return Array.isArray(parsed) ? parsed : [parsed];
-          } catch (e) {
-            log('error', `Error parsing ${field} for exercise ${row.id}:`, e);
-            return [];
-          }
-        }
-        return [];
-      };
-      row.equipment = parseJsonbField('equipment');
-      row.primary_muscles = parseJsonbField('primary_muscles');
-      row.secondary_muscles = parseJsonbField('secondary_muscles');
-      row.instructions = parseJsonbField('instructions');
-      row.images = parseJsonbField('images');
+      row.equipment = parseJsonArrayField(
+        row.equipment,
+        `equipment for exercise ${row.id}`
+      );
+      row.primary_muscles = parseJsonArrayField(
+        row.primary_muscles,
+        `primary_muscles for exercise ${row.id}`
+      );
+      row.secondary_muscles = parseJsonArrayField(
+        row.secondary_muscles,
+        `secondary_muscles for exercise ${row.id}`
+      );
+      row.instructions = parseJsonArrayField(
+        row.instructions,
+        `instructions for exercise ${row.id}`
+      );
+      row.images = parseJsonArrayField(
+        row.images,
+        `images for exercise ${row.id}`
+      );
       return row;
     });
     return { exercises, totalCount };
@@ -689,25 +693,26 @@ async function getRecentExercises(userId: any, limit: any) {
     );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return result.rows.map((row: any) => {
-      // Helper function to safely parse JSONB fields into arrays
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const parseJsonbField = (field: any) => {
-        if (row[field]) {
-          try {
-            const parsed = JSON.parse(row[field]);
-            return Array.isArray(parsed) ? parsed : [parsed]; // Ensure it's an array
-          } catch (e) {
-            log('error', `Error parsing ${field} for exercise ${row.id}:`, e);
-            return [];
-          }
-        }
-        return [];
-      };
-      row.equipment = parseJsonbField('equipment');
-      row.primary_muscles = parseJsonbField('primary_muscles');
-      row.secondary_muscles = parseJsonbField('secondary_muscles');
-      row.instructions = parseJsonbField('instructions');
-      row.images = parseJsonbField('images');
+      row.equipment = parseJsonArrayField(
+        row.equipment,
+        `equipment for exercise ${row.id}`
+      );
+      row.primary_muscles = parseJsonArrayField(
+        row.primary_muscles,
+        `primary_muscles for exercise ${row.id}`
+      );
+      row.secondary_muscles = parseJsonArrayField(
+        row.secondary_muscles,
+        `secondary_muscles for exercise ${row.id}`
+      );
+      row.instructions = parseJsonArrayField(
+        row.instructions,
+        `instructions for exercise ${row.id}`
+      );
+      row.images = parseJsonArrayField(
+        row.images,
+        `images for exercise ${row.id}`
+      );
       return row;
     });
   } finally {
@@ -739,25 +744,26 @@ async function getTopExercises(userId: any, limit: any) {
     );
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return result.rows.map((row: any) => {
-      // Helper function to safely parse JSONB fields into arrays
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const parseJsonbField = (field: any) => {
-        if (row[field]) {
-          try {
-            const parsed = JSON.parse(row[field]);
-            return Array.isArray(parsed) ? parsed : [parsed]; // Ensure it's an array
-          } catch (e) {
-            log('error', `Error parsing ${field} for exercise ${row.id}:`, e);
-            return [];
-          }
-        }
-        return [];
-      };
-      row.equipment = parseJsonbField('equipment');
-      row.primary_muscles = parseJsonbField('primary_muscles');
-      row.secondary_muscles = parseJsonbField('secondary_muscles');
-      row.instructions = parseJsonbField('instructions');
-      row.images = parseJsonbField('images');
+      row.equipment = parseJsonArrayField(
+        row.equipment,
+        `equipment for exercise ${row.id}`
+      );
+      row.primary_muscles = parseJsonArrayField(
+        row.primary_muscles,
+        `primary_muscles for exercise ${row.id}`
+      );
+      row.secondary_muscles = parseJsonArrayField(
+        row.secondary_muscles,
+        `secondary_muscles for exercise ${row.id}`
+      );
+      row.instructions = parseJsonArrayField(
+        row.instructions,
+        `instructions for exercise ${row.id}`
+      );
+      row.images = parseJsonArrayField(
+        row.images,
+        `images for exercise ${row.id}`
+      );
       return row;
     });
   } finally {

--- a/SparkyFitnessServer/models/exercise.ts
+++ b/SparkyFitnessServer/models/exercise.ts
@@ -10,7 +10,10 @@ import {
   buildSqlSearch,
   buildSqlExactMatchOrder,
 } from '../utils/dbSearchHelper.js';
-import { parseJsonArrayField } from '../utils/exerciseJsonFields.js';
+import {
+  parseJsonArrayField,
+  normalizeToStringArray,
+} from '../utils/exerciseJsonFields.js';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getExerciseById(id: any, userId: any) {
   const client = await getClient(userId);
@@ -569,18 +572,28 @@ async function createExercise(exerciseData: any) {
         exerciseData.force,
         exerciseData.level,
         exerciseData.mechanic,
-        exerciseData.equipment ? JSON.stringify(exerciseData.equipment) : null,
+        // normalizeToStringArray is applied here, right before encoding,
+        // so every write path (route JSON body, CSV import, external
+        // provider import) lands on the same JSON-array-of-strings shape
+        // regardless of whether the caller already normalized it.
+        exerciseData.equipment
+          ? JSON.stringify(normalizeToStringArray(exerciseData.equipment))
+          : null,
         exerciseData.primary_muscles
-          ? JSON.stringify(exerciseData.primary_muscles)
+          ? JSON.stringify(normalizeToStringArray(exerciseData.primary_muscles))
           : null,
         exerciseData.secondary_muscles
-          ? JSON.stringify(exerciseData.secondary_muscles)
+          ? JSON.stringify(
+              normalizeToStringArray(exerciseData.secondary_muscles)
+            )
           : null,
         exerciseData.instructions
-          ? JSON.stringify(exerciseData.instructions)
+          ? JSON.stringify(normalizeToStringArray(exerciseData.instructions))
           : null,
         exerciseData.category,
-        exerciseData.images ? JSON.stringify(exerciseData.images) : null,
+        exerciseData.images
+          ? JSON.stringify(normalizeToStringArray(exerciseData.images))
+          : null,
         exerciseData.calories_per_hour || 0, // Ensure calories_per_hour is a number, default to 0
         exerciseData.description,
         exerciseData.is_custom,
@@ -631,17 +644,23 @@ async function updateExercise(id: any, userId: any, updateData: any) {
         updateData.force,
         updateData.level,
         updateData.mechanic,
-        updateData.equipment ? JSON.stringify(updateData.equipment) : null,
+        // See createExercise: normalize right before encoding so this
+        // chokepoint holds the invariant regardless of caller.
+        updateData.equipment
+          ? JSON.stringify(normalizeToStringArray(updateData.equipment))
+          : null,
         updateData.primary_muscles
-          ? JSON.stringify(updateData.primary_muscles)
+          ? JSON.stringify(normalizeToStringArray(updateData.primary_muscles))
           : null,
         updateData.secondary_muscles
-          ? JSON.stringify(updateData.secondary_muscles)
+          ? JSON.stringify(normalizeToStringArray(updateData.secondary_muscles))
           : null,
         updateData.instructions
-          ? JSON.stringify(updateData.instructions)
+          ? JSON.stringify(normalizeToStringArray(updateData.instructions))
           : null,
-        updateData.images ? JSON.stringify(updateData.images) : null,
+        updateData.images
+          ? JSON.stringify(normalizeToStringArray(updateData.images))
+          : null,
         typeof updateData.is_quick_exercise === 'boolean'
           ? updateData.is_quick_exercise
           : null,

--- a/SparkyFitnessServer/routes/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/exerciseRoutes.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import type { Response } from 'express';
 import { authenticate } from '../middleware/authMiddleware.js';
 import exerciseService from '../services/exerciseService.js';
 import reportRepository from '../models/reportRepository.js';
@@ -8,7 +9,10 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { ExternalProviderType } from 'types/externalProvider.ts';
-import { exerciseWriteArrayFieldsSchema } from '@workspace/shared';
+import {
+  exerciseWriteArrayFieldsSchema,
+  type ExerciseWriteArrayFields,
+} from '@workspace/shared';
 
 import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
@@ -40,6 +44,36 @@ const storage = multer.diskStorage({
   },
 });
 const upload = multer({ storage: storage });
+
+/**
+ * Parses the multipart `exerciseData` JSON field and validates it against
+ * exerciseWriteArrayFieldsSchema, or writes the standard 400 response and
+ * returns null. Malformed/missing JSON gets the same clean 400 a shape
+ * validation failure does, instead of falling through to the generic error
+ * handler.
+ */
+function parseExerciseData(
+  raw: unknown,
+  res: Response
+): ExerciseWriteArrayFields | null {
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(String(raw));
+  } catch {
+    res.status(400).json({ error: 'Invalid exercise payload.' });
+    return null;
+  }
+  const result = exerciseWriteArrayFieldsSchema.safeParse(parsedJson);
+  if (!result.success) {
+    res.status(400).json({
+      error: 'Invalid exercise payload.',
+      details: result.error.flatten(),
+    });
+    return null;
+  }
+  return result.data;
+}
+
 /**
  * @swagger
  * tags:
@@ -926,16 +960,8 @@ router.post(
   upload.array('images', 10),
   async (req, res, next) => {
     try {
-      const parsedExerciseData = exerciseWriteArrayFieldsSchema.safeParse(
-        JSON.parse(req.body.exerciseData)
-      );
-      if (!parsedExerciseData.success) {
-        return res.status(400).json({
-          error: 'Invalid exercise payload.',
-          details: parsedExerciseData.error.flatten(),
-        });
-      }
-      const exerciseData = parsedExerciseData.data;
+      const exerciseData = parseExerciseData(req.body?.exerciseData, res);
+      if (!exerciseData) return;
       // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
       const imagePaths = req.files
         ? // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
@@ -1153,16 +1179,8 @@ router.put(
         .json({ error: 'Exercise ID is required and must be a valid UUID.' });
     }
     try {
-      const parsedExerciseData = exerciseWriteArrayFieldsSchema.safeParse(
-        JSON.parse(req.body.exerciseData)
-      );
-      if (!parsedExerciseData.success) {
-        return res.status(400).json({
-          error: 'Invalid exercise payload.',
-          details: parsedExerciseData.error.flatten(),
-        });
-      }
-      const exerciseData = parsedExerciseData.data;
+      const exerciseData = parseExerciseData(req.body?.exerciseData, res);
+      if (!exerciseData) return;
       // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
       const newImagePaths = req.files
         ? // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message

--- a/SparkyFitnessServer/routes/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/exerciseRoutes.ts
@@ -1241,8 +1241,12 @@ router.put(
               `${exerciseData.name.replace(/[^a-zA-Z0-9]/g, '_')}/${file.filename}`
           )
         : [];
-      // Combine existing images with new images
-      const existingImages = (exerciseData.images ?? []) as string[];
+      // Combine existing images with new images. exerciseData.images is a
+      // real string[] here (exerciseWriteArrayFieldsSchema normalizes it),
+      // not a cast-away lie — a client-sent bare string is coerced to a
+      // one-item array before this point instead of spreading into one
+      // "image path" per character.
+      const existingImages = exerciseData.images ?? [];
       const allImages = [...existingImages, ...newImagePaths];
       const updatedExercise = await exerciseService.updateExercise(
         req.userId,

--- a/SparkyFitnessServer/routes/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/exerciseRoutes.ts
@@ -13,6 +13,7 @@ import {
   exerciseWriteArrayFieldsSchema,
   type ExerciseWriteArrayFields,
 } from '@workspace/shared';
+import { log } from '../config/logging.js';
 
 import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
@@ -27,9 +28,25 @@ const baseUploadsDir = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
 const storage = multer.diskStorage({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   destination: (req: any, file: any, cb: any) => {
-    const exerciseName = req.body.exerciseData
-      ? JSON.parse(req.body.exerciseData).name
-      : 'unknown-exercise';
+    // Runs per-file, before the route handler (and its exerciseData
+    // validation) ever executes — malformed/wrongly-shaped exerciseData must
+    // not throw here, or the request fails uncontrolled instead of getting
+    // the route handler's clean 400. Same 'unknown-exercise' fallback
+    // already used when exerciseData is absent; parseExerciseData in the
+    // route handler is what actually rejects the request, regardless of
+    // which folder this file landed in.
+    let exerciseName = 'unknown-exercise';
+    try {
+      if (req.body.exerciseData) {
+        const name = JSON.parse(req.body.exerciseData).name;
+        if (typeof name === 'string' && name.length > 0) {
+          exerciseName = name;
+        }
+      }
+    } catch {
+      // Malformed JSON, or .name isn't the shape expected, keep the
+      // fallback name.
+    }
     const uploadPath = path.join(
       baseUploadsDir,
       'exercises',
@@ -72,6 +89,31 @@ function parseExerciseData(
     return null;
   }
   return result.data;
+}
+
+/**
+ * multer has already written any uploaded files to disk by the time
+ * parseExerciseData can reject the request (validation runs in the route
+ * handler, after the upload middleware). Delete them so a rejected request
+ * doesn't leave orphaned files under uploads/exercises/. Awaited by callers,
+ * but doesn't delay the client's response: parseExerciseData has already
+ * sent it before cleanup runs. Best-effort: a failed delete is logged, not
+ * surfaced to the client.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function cleanupUploadedFiles(files: any): Promise<void> {
+  if (!Array.isArray(files)) return;
+  await Promise.all(
+    files.map(async (file) => {
+      const filePath = file?.path;
+      if (typeof filePath !== 'string') return;
+      try {
+        await fs.promises.unlink(filePath);
+      } catch (err) {
+        log('warn', `Failed to clean up rejected upload ${filePath}:`, err);
+      }
+    })
+  );
 }
 
 /**
@@ -961,7 +1003,11 @@ router.post(
   async (req, res, next) => {
     try {
       const exerciseData = parseExerciseData(req.body?.exerciseData, res);
-      if (!exerciseData) return;
+      if (!exerciseData) {
+        // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
+        await cleanupUploadedFiles(req.files);
+        return;
+      }
       // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
       const imagePaths = req.files
         ? // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
@@ -1180,7 +1226,11 @@ router.put(
     }
     try {
       const exerciseData = parseExerciseData(req.body?.exerciseData, res);
-      if (!exerciseData) return;
+      if (!exerciseData) {
+        // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
+        await cleanupUploadedFiles(req.files);
+        return;
+      }
       // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
       const newImagePaths = req.files
         ? // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message

--- a/SparkyFitnessServer/routes/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/exerciseRoutes.ts
@@ -8,6 +8,7 @@ import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
 import { ExternalProviderType } from 'types/externalProvider.ts';
+import { exerciseWriteArrayFieldsSchema } from '@workspace/shared';
 
 import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
@@ -925,13 +926,23 @@ router.post(
   upload.array('images', 10),
   async (req, res, next) => {
     try {
-      const exerciseData = JSON.parse(req.body.exerciseData);
+      const parsedExerciseData = exerciseWriteArrayFieldsSchema.safeParse(
+        JSON.parse(req.body.exerciseData)
+      );
+      if (!parsedExerciseData.success) {
+        return res.status(400).json({
+          error: 'Invalid exercise payload.',
+          details: parsedExerciseData.error.flatten(),
+        });
+      }
+      const exerciseData = parsedExerciseData.data;
       // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
       const imagePaths = req.files
         ? // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
           req.files.map(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (file: any) =>
+              // @ts-expect-error TS(18046): 'exerciseData.name' is of type 'unknown' (passthrough field, not part of exerciseWriteArrayFieldsSchema).
               `${exerciseData.name.replace(/[^a-zA-Z0-9]/g, '_')}/${file.filename}`
           )
         : [];
@@ -1142,18 +1153,29 @@ router.put(
         .json({ error: 'Exercise ID is required and must be a valid UUID.' });
     }
     try {
-      const exerciseData = JSON.parse(req.body.exerciseData);
+      const parsedExerciseData = exerciseWriteArrayFieldsSchema.safeParse(
+        JSON.parse(req.body.exerciseData)
+      );
+      if (!parsedExerciseData.success) {
+        return res.status(400).json({
+          error: 'Invalid exercise payload.',
+          details: parsedExerciseData.error.flatten(),
+        });
+      }
+      const exerciseData = parsedExerciseData.data;
       // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
       const newImagePaths = req.files
         ? // @ts-expect-error TS(2339): Property 'files' does not exist on type 'Request<{... Remove this comment to see the full error message
           req.files.map(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (file: any) =>
+              // @ts-expect-error TS(18046): 'exerciseData.name' is of type 'unknown' (passthrough field, not part of exerciseWriteArrayFieldsSchema).
               `${exerciseData.name.replace(/[^a-zA-Z0-9]/g, '_')}/${file.filename}`
           )
         : [];
       // Combine existing images with new images
-      const allImages = [...(exerciseData.images || []), ...newImagePaths];
+      const existingImages = (exerciseData.images ?? []) as string[];
+      const allImages = [...existingImages, ...newImagePaths];
       const updatedExercise = await exerciseService.updateExercise(
         req.userId,
         id,

--- a/SparkyFitnessServer/services/exerciseService.ts
+++ b/SparkyFitnessServer/services/exerciseService.ts
@@ -18,6 +18,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { resolveExerciseIdToUuid } from '../utils/uuidUtils.js';
+import { normalizeToStringArray } from '../utils/exerciseJsonFields.js';
 import {
   deriveExerciseModality,
   canEditGroupedWorkout,
@@ -982,21 +983,6 @@ interface FreeExerciseDBResult {
 }
 
 /**
- * free-exercise-db's raw JSON stores equipment/muscles/instructions as
- * either a string array or a single bare string (never an empty string for
- * "none" — that's `null`/absent). Anything reaching `createExercise` un-
- * normalized gets JSON.stringify'd as-is, so a bare string round-trips as a
- * JSON-encoded string instead of a one-item array, and every downstream
- * `.join()`/`.map()` consumer of the parsed field then crashes.
- */
-function normalizeToStringArray(
-  value: string | string[] | null | undefined
-): string[] {
-  if (Array.isArray(value)) return value;
-  return value ? [value] : [];
-}
-
-/**
  * wger descriptions are HTML (often a <ol>/<li> list). Normalize to the same
  * plain-text step array free-exercise-db exercises use.
  */
@@ -1375,6 +1361,10 @@ async function addFreeExerciseDBExerciseToUserExercises(
       })
     );
     // Map free-exercise-db data to our generic Exercise model
+    const instructions = normalizeToStringArray(
+      // @ts-expect-error TS(2571): Object is of type 'unknown'.
+      exerciseDetails.instructions
+    );
     const exerciseData = {
       id: uuidv4(), // Generate a new UUID for the local exercise
       source: 'free-exercise-db',
@@ -1397,8 +1387,7 @@ async function addFreeExerciseDBExerciseToUserExercises(
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
         exerciseDetails.secondaryMuscles
       ),
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      instructions: normalizeToStringArray(exerciseDetails.instructions),
+      instructions,
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
       category: exerciseDetails.category,
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
@@ -1409,8 +1398,11 @@ async function addFreeExerciseDBExerciseToUserExercises(
           exerciseDetails,
           authenticatedUserId
         ), // Calculate calories
+      // Same normalized array the instructions field uses, not the raw
+      // (possibly bare-string) value — indexing a bare string here would
+      // silently take its first character instead of the first instruction.
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      description: exerciseDetails.instructions[0] || exerciseDetails.name, // Use first instruction as description or name
+      description: instructions[0] ?? exerciseDetails.name,
       user_id: authenticatedUserId,
       is_custom: true, // Imported exercises are custom to the user
       shared_with_public: false, // Imported exercises are private by default

--- a/SparkyFitnessServer/services/exerciseService.ts
+++ b/SparkyFitnessServer/services/exerciseService.ts
@@ -308,10 +308,10 @@ async function createExercise(authenticatedUserId: any, exerciseData: any) {
   try {
     // Ensure the exercise is created for the authenticated user
     exerciseData.user_id = authenticatedUserId;
-    // If images are provided, ensure they are stored as JSON string in the database
-    if (exerciseData.images && Array.isArray(exerciseData.images)) {
-      exerciseData.images = JSON.stringify(exerciseData.images);
-    }
+    // exerciseDb.createExercise (models/exercise.ts) is the single
+    // persistence chokepoint for JSON-encoding equipment/muscles/
+    // instructions/images — encoding images here too would double-encode it
+    // into a JSON string containing a JSON string.
     const newExercise = await exerciseDb.createExercise(exerciseData);
     return newExercise;
   } catch (error) {
@@ -737,10 +737,10 @@ async function updateExercise(
     if (!exerciseOwnerId) {
       throw new Error('Exercise not found.');
     }
-    // If images are provided, ensure they are stored as JSON string in the database
-    if (updateData.images && Array.isArray(updateData.images)) {
-      updateData.images = JSON.stringify(updateData.images);
-    }
+    // exerciseDb.updateExercise (models/exercise.ts) is the single
+    // persistence chokepoint for JSON-encoding equipment/muscles/
+    // instructions/images — encoding images here too would double-encode it
+    // into a JSON string containing a JSON string.
     const updatedExercise = await exerciseDb.updateExercise(
       id,
       authenticatedUserId,

--- a/SparkyFitnessServer/services/exerciseService.ts
+++ b/SparkyFitnessServer/services/exerciseService.ts
@@ -1393,8 +1393,8 @@ async function addFreeExerciseDBExerciseToUserExercises(
       equipment: normalizeToStringArray(exerciseDetails.equipment),
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
       primary_muscles: normalizeToStringArray(exerciseDetails.primaryMuscles),
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
       secondary_muscles: normalizeToStringArray(
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
         exerciseDetails.secondaryMuscles
       ),
       // @ts-expect-error TS(2571): Object is of type 'unknown'.

--- a/SparkyFitnessServer/services/exerciseService.ts
+++ b/SparkyFitnessServer/services/exerciseService.ts
@@ -982,6 +982,21 @@ interface FreeExerciseDBResult {
 }
 
 /**
+ * free-exercise-db's raw JSON stores equipment/muscles/instructions as
+ * either a string array or a single bare string (never an empty string for
+ * "none" — that's `null`/absent). Anything reaching `createExercise` un-
+ * normalized gets JSON.stringify'd as-is, so a bare string round-trips as a
+ * JSON-encoded string instead of a one-item array, and every downstream
+ * `.join()`/`.map()` consumer of the parsed field then crashes.
+ */
+function normalizeToStringArray(
+  value: string | string[] | null | undefined
+): string[] {
+  if (Array.isArray(value)) return value;
+  return value ? [value] : [];
+}
+
+/**
  * wger descriptions are HTML (often a <ol>/<li> list). Normalize to the same
  * plain-text step array free-exercise-db exercises use.
  */
@@ -1121,26 +1136,10 @@ async function searchExternalExercises(
         force: exercise.force,
         level: exercise.level,
         mechanic: exercise.mechanic,
-        equipment: Array.isArray(exercise.equipment)
-          ? exercise.equipment
-          : exercise.equipment
-            ? [exercise.equipment]
-            : [],
-        primary_muscles: Array.isArray(exercise.primaryMuscles)
-          ? exercise.primaryMuscles
-          : exercise.primaryMuscles
-            ? [exercise.primaryMuscles]
-            : [],
-        secondary_muscles: Array.isArray(exercise.secondaryMuscles)
-          ? exercise.secondaryMuscles
-          : exercise.secondaryMuscles
-            ? [exercise.secondaryMuscles]
-            : [],
-        instructions: Array.isArray(exercise.instructions)
-          ? exercise.instructions
-          : exercise.instructions
-            ? [exercise.instructions]
-            : [],
+        equipment: normalizeToStringArray(exercise.equipment),
+        primary_muscles: normalizeToStringArray(exercise.primaryMuscles),
+        secondary_muscles: normalizeToStringArray(exercise.secondaryMuscles),
+        instructions: normalizeToStringArray(exercise.instructions),
         images: exercise.images.map((img: string) =>
           freeExerciseDBService.getExerciseImageUrl(img)
         ),
@@ -1391,13 +1390,15 @@ async function addFreeExerciseDBExerciseToUserExercises(
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
       mechanic: exerciseDetails.mechanic,
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      equipment: exerciseDetails.equipment,
+      equipment: normalizeToStringArray(exerciseDetails.equipment),
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      primary_muscles: exerciseDetails.primaryMuscles,
+      primary_muscles: normalizeToStringArray(exerciseDetails.primaryMuscles),
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      secondary_muscles: exerciseDetails.secondaryMuscles,
+      secondary_muscles: normalizeToStringArray(
+        exerciseDetails.secondaryMuscles
+      ),
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      instructions: exerciseDetails.instructions,
+      instructions: normalizeToStringArray(exerciseDetails.instructions),
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
       category: exerciseDetails.category,
       // @ts-expect-error TS(2571): Object is of type 'unknown'.

--- a/SparkyFitnessServer/services/reportService.ts
+++ b/SparkyFitnessServer/services/reportService.ts
@@ -20,6 +20,7 @@ import {
 } from '@workspace/shared';
 import { userAge } from '../utils/dateHelpers.js';
 import { loadUserTimezone } from '../utils/timezoneLoader.js';
+import { parseJsonArrayField } from '../utils/exerciseJsonFields.js';
 
 interface CustomNutrientDefinition {
   id: string;
@@ -335,11 +336,13 @@ async function getReportsData(
         name: entry.exercise_name,
         category: entry.exercise_category,
         calories_per_hour: entry.exercise_calories_per_hour,
-        equipment: JSON.parse(entry.exercise_equipment || '[]'),
-        primary_muscles: JSON.parse(entry.exercise_primary_muscles || '[]'),
-        secondary_muscles: JSON.parse(entry.exercise_secondary_muscles || '[]'),
-        instructions: JSON.parse(entry.exercise_instructions || '[]'),
-        images: JSON.parse(entry.exercise_images || '[]'),
+        equipment: parseJsonArrayField(entry.exercise_equipment),
+        primary_muscles: parseJsonArrayField(entry.exercise_primary_muscles),
+        secondary_muscles: parseJsonArrayField(
+          entry.exercise_secondary_muscles
+        ),
+        instructions: parseJsonArrayField(entry.exercise_instructions),
+        images: parseJsonArrayField(entry.exercise_images),
         source: entry.exercise_source,
         source_id: entry.exercise_source_id,
         user_id: entry.exercise_user_id,

--- a/SparkyFitnessServer/tests/exerciseImportDedup.test.ts
+++ b/SparkyFitnessServer/tests/exerciseImportDedup.test.ts
@@ -179,6 +179,10 @@ describe('external exercise import dedup', () => {
           equipment: [],
           secondary_muscles: [],
           instructions: ['Lie flat on the floor.'],
+          // Must be the whole first instruction, not
+          // exerciseDetails.instructions[0] indexing the raw bare string
+          // (which would silently give just its first character, 'L').
+          description: 'Lie flat on the floor.',
         })
       );
     });

--- a/SparkyFitnessServer/tests/exerciseImportDedup.test.ts
+++ b/SparkyFitnessServer/tests/exerciseImportDedup.test.ts
@@ -127,6 +127,58 @@ describe('external exercise import dedup', () => {
           source: 'free-exercise-db',
           source_id: 'Barbell_Bench_Press',
           user_id: userId,
+          // free-exercise-db's raw equipment is a bare string, not a
+          // one-item array; passing it through unwrapped means createExercise
+          // JSON.stringify's it into a JSON-encoded string that every later
+          // reader's `.join()`/`.map()` then crashes on (#reports export).
+          equipment: ['barbell'],
+          // Fields free-exercise-db already returns as arrays must round-trip
+          // unchanged, not get double-wrapped.
+          primary_muscles: ['chest'],
+          secondary_muscles: ['triceps'],
+          instructions: ['Lie on the bench.'],
+        })
+      );
+    });
+
+    it('wraps a bare instructions string into a one-item array', async () => {
+      // @ts-expect-error TS(2339): mock method not on typed function.
+      exerciseDb.getExerciseBySourceAndSourceId.mockResolvedValueOnce(
+        undefined
+      );
+      // @ts-expect-error TS(2339): mock method not on typed function.
+      freeExerciseDBService.getExerciseById.mockResolvedValueOnce({
+        id: 'Air_Bike',
+        name: 'Air Bike',
+        force: null,
+        level: 'beginner',
+        mechanic: null,
+        equipment: null,
+        primaryMuscles: ['abdominals'],
+        secondaryMuscles: [],
+        // A single-step exercise from the raw source: a bare string, not
+        // a one-item array.
+        instructions: 'Lie flat on the floor.',
+        category: 'strength',
+        images: [],
+      });
+      // @ts-expect-error TS(2339): mock method not on typed function.
+      calorieCalculationService.estimateCaloriesBurnedPerHour.mockResolvedValueOnce(
+        200
+      );
+      // @ts-expect-error TS(2339): mock method not on typed function.
+      exerciseDb.createExercise.mockResolvedValueOnce({ id: 'created-uuid-2' });
+
+      await exerciseService.addFreeExerciseDBExerciseToUserExercises(
+        userId,
+        'Air_Bike'
+      );
+
+      expect(exerciseDb.createExercise).toHaveBeenCalledWith(
+        expect.objectContaining({
+          equipment: [],
+          secondary_muscles: [],
+          instructions: ['Lie flat on the floor.'],
         })
       );
     });

--- a/SparkyFitnessServer/tests/exerciseJsonFields.test.ts
+++ b/SparkyFitnessServer/tests/exerciseJsonFields.test.ts
@@ -1,0 +1,48 @@
+import { vi, describe, expect, it } from 'vitest';
+
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+import { parseJsonArrayField } from '../utils/exerciseJsonFields.js';
+import { log } from '../config/logging.js';
+
+describe('parseJsonArrayField', () => {
+  it('returns [] for null, undefined, and empty string', () => {
+    expect(parseJsonArrayField(null)).toEqual([]);
+    expect(parseJsonArrayField(undefined)).toEqual([]);
+    expect(parseJsonArrayField('')).toEqual([]);
+  });
+
+  it('parses a proper JSON array as-is', () => {
+    expect(parseJsonArrayField('["Barbell","Dumbbell"]')).toEqual([
+      'Barbell',
+      'Dumbbell',
+    ]);
+  });
+
+  it('wraps a bare JSON-encoded string into a single-item array', () => {
+    // The exact shape that crashed the CSV export: a legacy row stored a
+    // single equipment value as a JSON string instead of a one-item array,
+    // so JSON.parse succeeded but returned a string, and .join() downstream
+    // threw "equipment.join is not a function".
+    expect(parseJsonArrayField('"Barbell"')).toEqual(['Barbell']);
+  });
+
+  it('wraps a bare JSON number or object the same way', () => {
+    expect(parseJsonArrayField('5')).toEqual([5]);
+    expect(parseJsonArrayField('{"a":1}')).toEqual([{ a: 1 }]);
+  });
+
+  it('returns [] and logs with the given context for invalid JSON', () => {
+    expect(
+      parseJsonArrayField('Barbell', 'equipment for exercise ex-1')
+    ).toEqual([]);
+    expect(parseJsonArrayField('[Barbell, Dumbbell]')).toEqual([]);
+    expect(log).toHaveBeenCalledWith(
+      'error',
+      expect.stringContaining('(equipment for exercise ex-1)'),
+      expect.any(Error)
+    );
+  });
+});

--- a/SparkyFitnessServer/tests/exerciseJsonFields.test.ts
+++ b/SparkyFitnessServer/tests/exerciseJsonFields.test.ts
@@ -75,4 +75,19 @@ describe('normalizeToStringArray', () => {
   it('returns [] for an empty array unchanged', () => {
     expect(normalizeToStringArray([])).toEqual([]);
   });
+
+  it('drops non-string elements instead of persisting them as valid-but-wrong-shape JSON', () => {
+    // Callers into this (CSV import, external-provider responses) are
+    // untyped at runtime despite the string[] signature; a stray number or
+    // object must not silently ride through to JSON.stringify.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(
+      normalizeToStringArray(['Barbell', 5, null, { a: 1 }] as any)
+    ).toEqual(['Barbell']);
+  });
+
+  it('returns [] for a non-string, non-array value rather than wrapping it', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(normalizeToStringArray(5 as any)).toEqual([]);
+  });
 });

--- a/SparkyFitnessServer/tests/exerciseJsonFields.test.ts
+++ b/SparkyFitnessServer/tests/exerciseJsonFields.test.ts
@@ -1,10 +1,13 @@
 import { vi, describe, expect, it } from 'vitest';
 
-vi.mock('../config/logging', () => ({
+vi.mock('../config/logging.js', () => ({
   log: vi.fn(),
 }));
 
-import { parseJsonArrayField } from '../utils/exerciseJsonFields.js';
+import {
+  parseJsonArrayField,
+  normalizeToStringArray,
+} from '../utils/exerciseJsonFields.js';
 import { log } from '../config/logging.js';
 
 describe('parseJsonArrayField', () => {
@@ -44,5 +47,32 @@ describe('parseJsonArrayField', () => {
       expect.stringContaining('(equipment for exercise ex-1)'),
       expect.any(Error)
     );
+  });
+});
+
+describe('normalizeToStringArray', () => {
+  it('returns an already-correct array unchanged', () => {
+    expect(normalizeToStringArray(['Barbell', 'Dumbbell'])).toEqual([
+      'Barbell',
+      'Dumbbell',
+    ]);
+  });
+
+  it('wraps a single string into a one-item array', () => {
+    // The exact shape free-exercise-db's raw JSON sends for a solo value.
+    expect(normalizeToStringArray('Barbell')).toEqual(['Barbell']);
+  });
+
+  it('returns [] for null and undefined', () => {
+    expect(normalizeToStringArray(null)).toEqual([]);
+    expect(normalizeToStringArray(undefined)).toEqual([]);
+  });
+
+  it('returns [] for an empty string rather than a one-item array of ""', () => {
+    expect(normalizeToStringArray('')).toEqual([]);
+  });
+
+  it('returns [] for an empty array unchanged', () => {
+    expect(normalizeToStringArray([])).toEqual([]);
   });
 });

--- a/SparkyFitnessServer/tests/exerciseJsonFields.test.ts
+++ b/SparkyFitnessServer/tests/exerciseJsonFields.test.ts
@@ -78,16 +78,14 @@ describe('normalizeToStringArray', () => {
 
   it('drops non-string elements instead of persisting them as valid-but-wrong-shape JSON', () => {
     // Callers into this (CSV import, external-provider responses) are
-    // untyped at runtime despite the string[] signature; a stray number or
-    // object must not silently ride through to JSON.stringify.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(
-      normalizeToStringArray(['Barbell', 5, null, { a: 1 }] as any)
-    ).toEqual(['Barbell']);
+    // untyped at runtime despite the unknown-accepting signature; a stray
+    // number or object must not silently ride through to JSON.stringify.
+    expect(normalizeToStringArray(['Barbell', 5, null, { a: 1 }])).toEqual([
+      'Barbell',
+    ]);
   });
 
   it('returns [] for a non-string, non-array value rather than wrapping it', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(normalizeToStringArray(5 as any)).toEqual([]);
+    expect(normalizeToStringArray(5)).toEqual([]);
   });
 });

--- a/SparkyFitnessServer/tests/exerciseRepository.arrayFieldNormalization.test.ts
+++ b/SparkyFitnessServer/tests/exerciseRepository.arrayFieldNormalization.test.ts
@@ -12,6 +12,10 @@ import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { v4 as uuidv4 } from 'uuid';
 import exerciseDb from '../models/exercise.js';
 import { getClient } from '../db/poolManager.js';
+import {
+  createMockDbClient,
+  type MockDbClient,
+} from './helpers/mockDbClient.js';
 
 vi.mock('../db/poolManager', () => ({
   getClient: vi.fn(),
@@ -38,19 +42,17 @@ const UPDATE_PARAM = {
   images: 13,
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function lastQuery(mockClient: any): [string, unknown[]] {
-  return mockClient.query.mock.calls[mockClient.query.mock.calls.length - 1];
+function lastQuery(mockClient: MockDbClient): [string, unknown[]] {
+  const calls = mockClient.query.mock.calls;
+  return calls[calls.length - 1] as [string, unknown[]];
 }
 
 describe('exercise array-field normalization at the write chokepoint', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockClient: any;
+  let mockClient: MockDbClient;
 
   beforeEach(() => {
-    mockClient = { query: vi.fn(), release: vi.fn() };
-    // @ts-expect-error mock typing
-    getClient.mockResolvedValue(mockClient);
+    mockClient = createMockDbClient();
+    vi.mocked(getClient).mockResolvedValue(mockClient);
   });
 
   afterEach(() => {

--- a/SparkyFitnessServer/tests/exerciseRepository.arrayFieldNormalization.test.ts
+++ b/SparkyFitnessServer/tests/exerciseRepository.arrayFieldNormalization.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression coverage for the models/exercise.ts write chokepoint: every
+ * caller of createExercise/updateExercise (route JSON body, CSV import via
+ * exerciseEntryService.ts, external-provider import) must land on the same
+ * JSON-array-of-strings shape in the database, even when a caller sends a
+ * bare string instead of an array (e.g. exerciseEntryService.ts's CSV import
+ * passes entryGroup.exercise_equipment straight through with only a truthy
+ * check, no shape normalization). normalizeToStringArray is applied right
+ * before JSON.stringify so this holds regardless of caller.
+ */
+import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import exerciseDb from '../models/exercise.js';
+import { getClient } from '../db/poolManager.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+// Bind positions of the array fields in the two writer statements.
+const CREATE_PARAM = {
+  equipment: 6,
+  primary_muscles: 7,
+  secondary_muscles: 8,
+  instructions: 9,
+  images: 11,
+};
+const UPDATE_PARAM = {
+  equipment: 9,
+  primary_muscles: 10,
+  secondary_muscles: 11,
+  instructions: 12,
+  images: 13,
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function lastQuery(mockClient: any): [string, unknown[]] {
+  return mockClient.query.mock.calls[mockClient.query.mock.calls.length - 1];
+}
+
+describe('exercise array-field normalization at the write chokepoint', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = { query: vi.fn(), release: vi.fn() };
+    // @ts-expect-error mock typing
+    getClient.mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createExercise', () => {
+    it('wraps a bare string (e.g. from CSV import) into a one-item JSON array instead of a JSON-encoded bare string', async () => {
+      mockClient.query.mockResolvedValueOnce({ rows: [{ id: uuidv4() }] });
+
+      await exerciseDb.createExercise({
+        user_id: uuidv4(),
+        name: 'Test Exercise',
+        equipment: 'Barbell, Dumbbell',
+        primary_muscles: 'chest',
+        secondary_muscles: 'triceps',
+        instructions: 'Lie on the bench, then press.',
+        images: 'exercises/test.jpg',
+      });
+
+      const params = lastQuery(mockClient)[1];
+      expect(params[CREATE_PARAM.equipment]).toBe(
+        JSON.stringify(['Barbell, Dumbbell'])
+      );
+      expect(params[CREATE_PARAM.primary_muscles]).toBe(
+        JSON.stringify(['chest'])
+      );
+      expect(params[CREATE_PARAM.secondary_muscles]).toBe(
+        JSON.stringify(['triceps'])
+      );
+      expect(params[CREATE_PARAM.instructions]).toBe(
+        JSON.stringify(['Lie on the bench, then press.'])
+      );
+      expect(params[CREATE_PARAM.images]).toBe(
+        JSON.stringify(['exercises/test.jpg'])
+      );
+    });
+
+    it('passes an already-correct array through unchanged', async () => {
+      mockClient.query.mockResolvedValueOnce({ rows: [{ id: uuidv4() }] });
+
+      await exerciseDb.createExercise({
+        user_id: uuidv4(),
+        name: 'Test Exercise',
+        equipment: ['Barbell', 'Dumbbell'],
+      });
+
+      expect(lastQuery(mockClient)[1][CREATE_PARAM.equipment]).toBe(
+        JSON.stringify(['Barbell', 'Dumbbell'])
+      );
+    });
+
+    it('binds null for an omitted array field', async () => {
+      mockClient.query.mockResolvedValueOnce({ rows: [{ id: uuidv4() }] });
+
+      await exerciseDb.createExercise({
+        user_id: uuidv4(),
+        name: 'Test Exercise',
+      });
+
+      expect(lastQuery(mockClient)[1][CREATE_PARAM.equipment]).toBeNull();
+    });
+  });
+
+  describe('updateExercise', () => {
+    it('wraps a bare string into a one-item JSON array instead of a JSON-encoded bare string', async () => {
+      mockClient.query.mockResolvedValueOnce({ rows: [{ id: uuidv4() }] });
+
+      await exerciseDb.updateExercise(uuidv4(), uuidv4(), {
+        equipment: 'Barbell, Dumbbell',
+        instructions: "Don't lock your elbows.",
+      });
+
+      const params = lastQuery(mockClient)[1];
+      expect(params[UPDATE_PARAM.equipment]).toBe(
+        JSON.stringify(['Barbell, Dumbbell'])
+      );
+      expect(params[UPDATE_PARAM.instructions]).toBe(
+        JSON.stringify(["Don't lock your elbows."])
+      );
+    });
+
+    // COALESCE($N, column) keeps the stored value when the bind is null.
+    it('binds null for an omitted array field so the existing column value is preserved', async () => {
+      mockClient.query.mockResolvedValueOnce({ rows: [{ id: uuidv4() }] });
+
+      await exerciseDb.updateExercise(uuidv4(), uuidv4(), {
+        name: 'Renamed',
+      });
+
+      expect(lastQuery(mockClient)[1][UPDATE_PARAM.equipment]).toBeNull();
+    });
+  });
+});

--- a/SparkyFitnessServer/tests/exerciseRoutes.write.test.ts
+++ b/SparkyFitnessServer/tests/exerciseRoutes.write.test.ts
@@ -1,0 +1,183 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'
+import request from 'supertest';
+import express from 'express';
+import exerciseService from '../services/exerciseService.js';
+import exerciseRoutes from '../routes/exerciseRoutes.js';
+
+vi.mock('../middleware/authMiddleware.js', () => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authenticate: (req: any, _res: any, next: any) => {
+    req.userId = 'test-user-id';
+    req.authenticatedUserId = 'test-user-id';
+    next();
+  },
+}));
+
+vi.mock('../services/exerciseService.js', () => ({
+  default: {
+    createExercise: vi.fn(),
+    updateExercise: vi.fn(),
+  },
+}));
+
+vi.mock('../models/reportRepository.js', () => ({ default: {} }));
+vi.mock('../integrations/wger/wgerService.js', () => ({ default: {} }));
+
+vi.mock('../config/logging.js', () => ({
+  log: vi.fn(),
+}));
+
+const app = express();
+app.use('/exercises', exerciseRoutes);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+app.use((err: any, _req: any, res: any, _next: any) => {
+  res.status(err.status || 500).json({ error: err.message });
+});
+
+describe('exercise create/update array-field normalization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseService.createExercise.mockResolvedValue({ id: 'created-id' });
+    // @ts-expect-error TS(2339): mockResolvedValue not on typed function.
+    exerciseService.updateExercise.mockResolvedValue({ id: 'updated-id' });
+  });
+
+  describe('POST /exercises', () => {
+    it('passes an already-correct array through unchanged', async () => {
+      const res = await request(app)
+        .post('/exercises')
+        .field(
+          'exerciseData',
+          JSON.stringify({ name: 'Bench Press', equipment: ['Barbell'] })
+        );
+
+      expect(res.statusCode).toBe(201);
+      expect(exerciseService.createExercise).toHaveBeenCalledWith(
+        'test-user-id',
+        expect.objectContaining({ equipment: ['Barbell'] })
+      );
+    });
+
+    it('normalizes a bare string into a one-item array instead of rejecting it', async () => {
+      // The exact shape free-exercise-db's raw JSON sends for a single
+      // value — the client contract must tolerate it, not 400 it.
+      const res = await request(app)
+        .post('/exercises')
+        .field(
+          'exerciseData',
+          JSON.stringify({
+            name: 'Bench Press',
+            equipment: 'Barbell',
+            primary_muscles: 'chest',
+            secondary_muscles: ['triceps'],
+            instructions: 'Lie on the bench.',
+          })
+        );
+
+      expect(res.statusCode).toBe(201);
+      expect(exerciseService.createExercise).toHaveBeenCalledWith(
+        'test-user-id',
+        expect.objectContaining({
+          equipment: ['Barbell'],
+          primary_muscles: ['chest'],
+          secondary_muscles: ['triceps'],
+          instructions: ['Lie on the bench.'],
+        })
+      );
+    });
+
+    it('leaves null and omitted array fields alone', async () => {
+      const res = await request(app)
+        .post('/exercises')
+        .field(
+          'exerciseData',
+          JSON.stringify({ name: 'Bench Press', equipment: null })
+        );
+
+      expect(res.statusCode).toBe(201);
+      expect(exerciseService.createExercise).toHaveBeenCalledWith(
+        'test-user-id',
+        expect.objectContaining({ equipment: null })
+      );
+      const [, payload] = (
+        exerciseService.createExercise as unknown as {
+          mock: { calls: unknown[][] };
+        }
+      ).mock.calls[0];
+      expect(payload).not.toHaveProperty('primary_muscles');
+    });
+
+    it('rejects a genuinely wrong type (not a string/array formatting quirk)', async () => {
+      const res = await request(app)
+        .post('/exercises')
+        .field(
+          'exerciseData',
+          JSON.stringify({ name: 'Bench Press', equipment: 5 })
+        );
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('Invalid exercise payload.');
+      expect(exerciseService.createExercise).not.toHaveBeenCalled();
+    });
+
+    it('keeps unrelated fields untouched via passthrough', async () => {
+      const res = await request(app)
+        .post('/exercises')
+        .field(
+          'exerciseData',
+          JSON.stringify({
+            name: 'Bench Press',
+            category: 'Strength',
+            modality: 'weight_reps',
+            is_public: true,
+          })
+        );
+
+      expect(res.statusCode).toBe(201);
+      expect(exerciseService.createExercise).toHaveBeenCalledWith(
+        'test-user-id',
+        expect.objectContaining({
+          name: 'Bench Press',
+          category: 'Strength',
+          modality: 'weight_reps',
+          is_public: true,
+        })
+      );
+    });
+  });
+
+  describe('PUT /exercises/:id', () => {
+    const VALID_UUID = '11111111-1111-4111-8111-111111111111';
+
+    it('normalizes a bare string into a one-item array instead of rejecting it', async () => {
+      const res = await request(app)
+        .put(`/exercises/${VALID_UUID}`)
+        .field(
+          'exerciseData',
+          JSON.stringify({ name: 'Bench Press', equipment: 'Barbell' })
+        );
+
+      expect(res.statusCode).toBe(200);
+      expect(exerciseService.updateExercise).toHaveBeenCalledWith(
+        'test-user-id',
+        VALID_UUID,
+        expect.objectContaining({ equipment: ['Barbell'] })
+      );
+    });
+
+    it('rejects a genuinely wrong type', async () => {
+      const res = await request(app)
+        .put(`/exercises/${VALID_UUID}`)
+        .field(
+          'exerciseData',
+          JSON.stringify({ name: 'Bench Press', equipment: true })
+        );
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('Invalid exercise payload.');
+      expect(exerciseService.updateExercise).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/SparkyFitnessServer/tests/exerciseRoutes.write.test.ts
+++ b/SparkyFitnessServer/tests/exerciseRoutes.write.test.ts
@@ -2,8 +2,22 @@ import { vi, beforeEach, describe, expect, it } from 'vitest';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'
 import request from 'supertest';
 import express from 'express';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import exerciseService from '../services/exerciseService.js';
 import exerciseRoutes from '../routes/exerciseRoutes.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+// Matches exerciseRoutes.ts's own baseUploadsDir resolution (no
+// SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY set in this test environment) and
+// its destination() sanitization, which turns the fallback name's hyphen
+// into an underscore (exerciseName.replace(/[^a-zA-Z0-9]/g, '_')).
+const unknownExerciseUploadDir = path.join(
+  __dirname,
+  '../uploads/exercises/unknown_exercise'
+);
 
 vi.mock('../middleware/authMiddleware.js', () => ({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -140,6 +154,28 @@ describe('exercise create/update array-field normalization', () => {
       expect(exerciseService.createExercise).not.toHaveBeenCalled();
     });
 
+    it('does not crash and cleans up the upload when malformed JSON arrives alongside an attached file', async () => {
+      // multer's storage.destination JSON.parses exerciseData itself, before
+      // the route handler's own validation ever runs, and only runs at all
+      // when a file is actually attached — the earlier malformed-JSON tests
+      // never exercised that path.
+      const res = await request(app)
+        .post('/exercises')
+        .field('exerciseData', '{not valid json')
+        .attach('images', Buffer.from('fake image bytes'), 'test.jpg');
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('Invalid exercise payload.');
+      expect(exerciseService.createExercise).not.toHaveBeenCalled();
+
+      // The rejected upload must not be left behind under the fallback
+      // 'unknown-exercise' folder multer used before validation ran.
+      const leftoverFiles = fs.existsSync(unknownExerciseUploadDir)
+        ? fs.readdirSync(unknownExerciseUploadDir)
+        : [];
+      expect(leftoverFiles).toEqual([]);
+    });
+
     it('keeps unrelated fields untouched via passthrough', async () => {
       const res = await request(app)
         .post('/exercises')
@@ -206,6 +242,22 @@ describe('exercise create/update array-field normalization', () => {
       expect(res.statusCode).toBe(400);
       expect(res.body.error).toBe('Invalid exercise payload.');
       expect(exerciseService.updateExercise).not.toHaveBeenCalled();
+    });
+
+    it('does not crash and cleans up the upload when malformed JSON arrives alongside an attached file', async () => {
+      const res = await request(app)
+        .put(`/exercises/${VALID_UUID}`)
+        .field('exerciseData', '{not valid json')
+        .attach('images', Buffer.from('fake image bytes'), 'test.jpg');
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('Invalid exercise payload.');
+      expect(exerciseService.updateExercise).not.toHaveBeenCalled();
+
+      const leftoverFiles = fs.existsSync(unknownExerciseUploadDir)
+        ? fs.readdirSync(unknownExerciseUploadDir)
+        : [];
+      expect(leftoverFiles).toEqual([]);
     });
   });
 });

--- a/SparkyFitnessServer/tests/exerciseRoutes.write.test.ts
+++ b/SparkyFitnessServer/tests/exerciseRoutes.write.test.ts
@@ -122,6 +122,24 @@ describe('exercise create/update array-field normalization', () => {
       expect(exerciseService.createExercise).not.toHaveBeenCalled();
     });
 
+    it('returns the standard 400 for malformed JSON instead of a generic 500', async () => {
+      const res = await request(app)
+        .post('/exercises')
+        .field('exerciseData', '{not valid json');
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('Invalid exercise payload.');
+      expect(exerciseService.createExercise).not.toHaveBeenCalled();
+    });
+
+    it('returns the standard 400 when the exerciseData field is missing', async () => {
+      const res = await request(app).post('/exercises');
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('Invalid exercise payload.');
+      expect(exerciseService.createExercise).not.toHaveBeenCalled();
+    });
+
     it('keeps unrelated fields untouched via passthrough', async () => {
       const res = await request(app)
         .post('/exercises')
@@ -174,6 +192,16 @@ describe('exercise create/update array-field normalization', () => {
           'exerciseData',
           JSON.stringify({ name: 'Bench Press', equipment: true })
         );
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.error).toBe('Invalid exercise payload.');
+      expect(exerciseService.updateExercise).not.toHaveBeenCalled();
+    });
+
+    it('returns the standard 400 for malformed JSON instead of a generic 500', async () => {
+      const res = await request(app)
+        .put(`/exercises/${VALID_UUID}`)
+        .field('exerciseData', '{not valid json');
 
       expect(res.statusCode).toBe(400);
       expect(res.body.error).toBe('Invalid exercise payload.');

--- a/SparkyFitnessServer/tests/exerciseService.imagesEncoding.test.ts
+++ b/SparkyFitnessServer/tests/exerciseService.imagesEncoding.test.ts
@@ -13,13 +13,17 @@ import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { v4 as uuidv4 } from 'uuid';
 import exerciseService from '../services/exerciseService.js';
 import { getClient } from '../db/poolManager.js';
+import {
+  createMockDbClient,
+  type MockDbClient,
+} from './helpers/mockDbClient.js';
 
-vi.mock('../db/poolManager', () => ({
+vi.mock('../db/poolManager.js', () => ({
   getClient: vi.fn(),
   getSystemClient: vi.fn(),
 }));
 
-vi.mock('../config/logging', () => ({
+vi.mock('../config/logging.js', () => ({
   log: vi.fn(),
 }));
 
@@ -28,19 +32,17 @@ vi.mock('../config/logging', () => ({
 const CREATE_IMAGES_PARAM = 11;
 const UPDATE_IMAGES_PARAM = 13;
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function lastQuery(mockClient: any): [string, unknown[]] {
-  return mockClient.query.mock.calls[mockClient.query.mock.calls.length - 1];
+function lastQuery(mockClient: MockDbClient): [string, unknown[]] {
+  const calls = mockClient.query.mock.calls;
+  return calls[calls.length - 1] as [string, unknown[]];
 }
 
 describe('exercise images are JSON-encoded exactly once', () => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let mockClient: any;
+  let mockClient: MockDbClient;
 
   beforeEach(() => {
-    mockClient = { query: vi.fn(), release: vi.fn() };
-    // @ts-expect-error mock typing
-    getClient.mockResolvedValue(mockClient);
+    mockClient = createMockDbClient();
+    vi.mocked(getClient).mockResolvedValue(mockClient);
   });
 
   afterEach(() => {

--- a/SparkyFitnessServer/tests/exerciseService.imagesEncoding.test.ts
+++ b/SparkyFitnessServer/tests/exerciseService.imagesEncoding.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Regression test: exerciseService.ts used to pre-JSON.stringify `images`
+ * before handing off to models/exercise.ts's createExercise/updateExercise.
+ * Once that DB-layer chokepoint started JSON.stringify-ing images itself
+ * (so CSV import and other untyped write paths get the same normalization),
+ * the service-level pre-encoding double-encoded it: a real image-path array
+ * became a JSON string, and that string then got wrapped into a one-item
+ * array and re-stringified — corrupting every normal image upload. This
+ * drives exerciseService.createExercise/updateExercise (real functions,
+ * only the DB client mocked) and asserts `images` is encoded exactly once.
+ */
+import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import exerciseService from '../services/exerciseService.js';
+import { getClient } from '../db/poolManager.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+
+vi.mock('../config/logging', () => ({
+  log: vi.fn(),
+}));
+
+// Bind positions of `images` in the two writer statements
+// (models/exercise.ts's createExercise/updateExercise).
+const CREATE_IMAGES_PARAM = 11;
+const UPDATE_IMAGES_PARAM = 13;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function lastQuery(mockClient: any): [string, unknown[]] {
+  return mockClient.query.mock.calls[mockClient.query.mock.calls.length - 1];
+}
+
+describe('exercise images are JSON-encoded exactly once', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mockClient: any;
+
+  beforeEach(() => {
+    mockClient = { query: vi.fn(), release: vi.fn() };
+    // @ts-expect-error mock typing
+    getClient.mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('createExercise stores images as a single JSON array, not a nested encoded string', async () => {
+    mockClient.query.mockResolvedValueOnce({ rows: [{ id: uuidv4() }] });
+
+    await exerciseService.createExercise(uuidv4(), {
+      name: 'Bench Press',
+      images: ['exercises/bench_press/0.jpg', 'exercises/bench_press/1.jpg'],
+    });
+
+    const params = lastQuery(mockClient)[1];
+    expect(params[CREATE_IMAGES_PARAM]).toBe(
+      JSON.stringify([
+        'exercises/bench_press/0.jpg',
+        'exercises/bench_press/1.jpg',
+      ])
+    );
+    // The regression: images ends up double-encoded, e.g.
+    // '["[\\"exercises/bench_press/0.jpg\\",...]"]'.
+    expect(params[CREATE_IMAGES_PARAM]).not.toContain('\\"');
+  });
+
+  it('updateExercise stores images as a single JSON array, not a nested encoded string', async () => {
+    const exerciseId = uuidv4();
+    const userId = uuidv4();
+    // getExerciseOwnerId's query, then the UPDATE itself.
+    mockClient.query
+      .mockResolvedValueOnce({ rows: [{ user_id: userId }] })
+      .mockResolvedValueOnce({ rows: [{ id: exerciseId }] });
+
+    await exerciseService.updateExercise(userId, exerciseId, {
+      images: ['exercises/bench_press/0.jpg'],
+    });
+
+    const params = lastQuery(mockClient)[1];
+    expect(params[UPDATE_IMAGES_PARAM]).toBe(
+      JSON.stringify(['exercises/bench_press/0.jpg'])
+    );
+    expect(params[UPDATE_IMAGES_PARAM]).not.toContain('\\"');
+  });
+});

--- a/SparkyFitnessServer/tests/exercisesApiSchemas.test.ts
+++ b/SparkyFitnessServer/tests/exercisesApiSchemas.test.ts
@@ -155,6 +155,78 @@ describe('Exercises API schemas', () => {
     expect(result.success).toBe(false);
   });
 
+  describe('exerciseWriteArrayFieldsSchema', () => {
+    it('passes an already-correct array through unchanged', () => {
+      const result = runSchema('exerciseWriteArrayFieldsSchema', {
+        equipment: ['Barbell', 'Dumbbell'],
+      });
+      expect(result).toEqual({
+        success: true,
+        data: { equipment: ['Barbell', 'Dumbbell'] },
+      });
+    });
+
+    // Normalization
+    it('wraps a bare string into a one-item array instead of rejecting it', () => {
+      const result = runSchema('exerciseWriteArrayFieldsSchema', {
+        equipment: 'Barbell',
+        primary_muscles: 'chest',
+        secondary_muscles: ['triceps'],
+        instructions: 'Lie on the bench.',
+      });
+      expect(result).toEqual({
+        success: true,
+        data: {
+          equipment: ['Barbell'],
+          primary_muscles: ['chest'],
+          secondary_muscles: ['triceps'],
+          instructions: ['Lie on the bench.'],
+        },
+      });
+    });
+
+    it('leaves null and missing fields alone rather than coercing to []', () => {
+      const result = runSchema('exerciseWriteArrayFieldsSchema', {
+        equipment: null,
+      });
+      expect(result).toEqual({ success: true, data: { equipment: null } });
+      expect(result.data).not.toHaveProperty('primary_muscles');
+    });
+
+    it('rejects a genuinely wrong type (not a string/array formatting quirk)', () => {
+      expect(
+        runSchema('exerciseWriteArrayFieldsSchema', { equipment: 5 }).success
+      ).toBe(false);
+      expect(
+        runSchema('exerciseWriteArrayFieldsSchema', { equipment: true }).success
+      ).toBe(false);
+      expect(
+        runSchema('exerciseWriteArrayFieldsSchema', {
+          equipment: { not: 'valid' },
+        }).success
+      ).toBe(false);
+    });
+
+    it('rejects an array containing a non-string element', () => {
+      const result = runSchema('exerciseWriteArrayFieldsSchema', {
+        equipment: ['Barbell', 5],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('lets unrelated fields through via passthrough', () => {
+      const result = runSchema('exerciseWriteArrayFieldsSchema', {
+        name: 'Bench Press',
+        category: 'Strength',
+        is_public: true,
+      });
+      expect(result).toEqual({
+        success: true,
+        data: { name: 'Bench Press', category: 'Strength', is_public: true },
+      });
+    });
+  });
+
   it('round-trips the paginated response envelope', () => {
     const payload = {
       exercises: [],

--- a/SparkyFitnessServer/tests/normalizeExerciseJsonArrayFields.integration.test.ts
+++ b/SparkyFitnessServer/tests/normalizeExerciseJsonArrayFields.integration.test.ts
@@ -10,9 +10,14 @@
  * left them, then asserts the backfilled shape and that a second run of the
  * same file is a true no-op (idempotency the migration comment promises).
  *
- * It seeds and deletes only its own synthetic `@example.test` rows. The gate
- * does a short-timeout connection probe, so it SKIPS cleanly when no
- * database is reachable (mirrors exerciseEntryStats.integration.test.ts).
+ * It seeds and deletes only its own synthetic `@example.test` rows, but the
+ * migration SQL itself runs unscoped UPDATEs across every matching row in
+ * exercises/exercise_entries (a real backfill, not a test fixture) — so
+ * unlike exerciseEntryStats.integration.test.ts, a reachability probe alone
+ * isn't a safe enough gate. The database name must also look disposable
+ * (contain "test", matching CI's sparky_test) before this runs at all, so a
+ * developer's local `.env` pointed at their normal working database can
+ * never have this silently rewrite real exercise data via `pnpm test`.
  */
 import fs from 'fs';
 import path from 'path';
@@ -40,6 +45,18 @@ async function dbReachable(): Promise<boolean> {
   ) {
     return false;
   }
+  // Unlike exerciseEntryStats.integration.test.ts (only ever touches its own
+  // synthetic rows, safe regardless of which database it's pointed at), this
+  // test executes the real migration SQL, which runs unscoped UPDATEs across
+  // every matching row in exercises/exercise_entries — by design, since it's
+  // a real backfill, not a test fixture. A reachability probe alone isn't
+  // enough of a gate: a developer's local `.env` commonly points `pnpm test`
+  // at their normal working database. Require the database to be clearly
+  // disposable (CI's is named sparky_test) before ever running it, as an
+  // explicit opt-in — a developer has to deliberately point at a database
+  // named like a test database for this to run at all.
+  const dbName = process.env.SPARKY_FITNESS_DB_NAME ?? '';
+  if (!/test/i.test(dbName)) return false;
   const probe = new pg.Client({
     host: process.env.SPARKY_FITNESS_DB_HOST,
     port: Number(process.env.SPARKY_FITNESS_DB_PORT) || 5432,
@@ -101,9 +118,16 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
       );
       await sys.query(
         `INSERT INTO public.exercise_entries
-           (id, user_id, exercise_id, duration_minutes, calories_burned, entry_date, exercise_name, equipment)
-         VALUES ($1, $2, $3, 0, 0, '2026-08-16', 'Migration Test Exercise', $4)`,
-        [ENTRY_MALFORMED, U, EX_MALFORMED, '"Dumbbell"']
+           (id, user_id, exercise_id, duration_minutes, calories_burned, entry_date, exercise_name, equipment, primary_muscles, secondary_muscles)
+         VALUES ($1, $2, $3, 0, 0, '2026-08-16', 'Migration Test Exercise', $4, $5, $6)`,
+        [
+          ENTRY_MALFORMED,
+          U,
+          EX_MALFORMED,
+          '"Dumbbell"',
+          '', // empty string -> should become '[]', not stay ''
+          '   ', // whitespace-only -> should also become '[]'
+        ]
       );
     } finally {
       sys.release();
@@ -138,7 +162,7 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
       ).rows[0];
       const entry = (
         await sys.query(
-          'SELECT equipment FROM public.exercise_entries WHERE id = $1',
+          'SELECT equipment, primary_muscles, secondary_muscles FROM public.exercise_entries WHERE id = $1',
           [ENTRY_MALFORMED]
         )
       ).rows[0];
@@ -167,6 +191,10 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
     expect(exercise.instructions).toBeNull();
     expect(JSON.parse(exercise.images)).toEqual([]);
     expect(JSON.parse(entry.equipment)).toEqual(['Dumbbell']);
+    // Empty string and whitespace-only are non-NULL but still not valid
+    // JSON; both must become the literal '[]', not stay as-is.
+    expect(entry.primary_muscles).toBe('[]');
+    expect(entry.secondary_muscles).toBe('[]');
   });
 
   it('is idempotent: a second run changes nothing', async () => {

--- a/SparkyFitnessServer/tests/normalizeExerciseJsonArrayFields.integration.test.ts
+++ b/SparkyFitnessServer/tests/normalizeExerciseJsonArrayFields.integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Real-DB integration test for db/migrations/20260816192818_normalize_exercise_json_array_fields.sql.
+ *
+ * WHY THIS EXISTS
+ * ----------------
+ * The migration wraps a PL/pgSQL function (JSON parsing, casting, exception
+ * handling, dynamic SQL fallback) that a mocked pool can't meaningfully
+ * exercise. This drives the exact migration file's SQL against a real
+ * Postgres instance, seeding malformed rows the way legacy imports actually
+ * left them, then asserts the backfilled shape and that a second run of the
+ * same file is a true no-op (idempotency the migration comment promises).
+ *
+ * It seeds and deletes only its own synthetic `@example.test` rows. The gate
+ * does a short-timeout connection probe, so it SKIPS cleanly when no
+ * database is reachable (mirrors exerciseEntryStats.integration.test.ts).
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import pg from 'pg';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { getSystemClient, endPool } from '../db/poolManager.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const MIGRATION_SQL = fs.readFileSync(
+  path.join(
+    __dirname,
+    '../db/migrations/20260816192818_normalize_exercise_json_array_fields.sql'
+  ),
+  'utf8'
+);
+
+async function dbReachable(): Promise<boolean> {
+  if (process.env.SKIP_RLS_MATRIX === '1') return false;
+  if (
+    !process.env.SPARKY_FITNESS_APP_DB_USER ||
+    !process.env.SPARKY_FITNESS_DB_HOST
+  ) {
+    return false;
+  }
+  const probe = new pg.Client({
+    host: process.env.SPARKY_FITNESS_DB_HOST,
+    port: Number(process.env.SPARKY_FITNESS_DB_PORT) || 5432,
+    database: process.env.SPARKY_FITNESS_DB_NAME,
+    user: process.env.SPARKY_FITNESS_APP_DB_USER,
+    password: process.env.SPARKY_FITNESS_APP_DB_PASSWORD,
+    connectionTimeoutMillis: 2000,
+  });
+  try {
+    await probe.connect();
+    await probe.query('SELECT 1');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await probe.end().catch(() => {});
+  }
+}
+
+const RUN = await dbReachable();
+
+const U = '00000000-0000-4000-b000-0000000000bb';
+const EX_MALFORMED = '00000000-0000-4000-b000-0000000000f1';
+const ENTRY_MALFORMED = '00000000-0000-4000-b000-000000000601';
+
+describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
+  beforeAll(async () => {
+    const sys = await getSystemClient();
+    try {
+      await sys.query(
+        'DELETE FROM public.exercise_entries WHERE user_id = $1',
+        [U]
+      );
+      await sys.query('DELETE FROM public.exercises WHERE id = $1', [
+        EX_MALFORMED,
+      ]);
+      await sys.query('DELETE FROM public."user" WHERE id = $1', [U]);
+      await sys.query(
+        'INSERT INTO public."user" (id, email, email_verified) VALUES ($1, $2, true) ON CONFLICT (id) DO NOTHING',
+        [U, `normalize-exercise-json-${U}@example.test`]
+      );
+
+      // Every malformed shape the application's own read paths have to
+      // tolerate today, on both tables the migration must cover.
+      await sys.query(
+        `INSERT INTO public.exercises
+           (id, name, source, user_id, is_custom, modality, equipment, primary_muscles, secondary_muscles, instructions, images)
+         VALUES ($1, $2, 'test', $3, true, 'weight_reps', $4, $5, $6, $7, $8)`,
+        [
+          EX_MALFORMED,
+          'Migration Test Exercise',
+          U,
+          '"Barbell"', // bare JSON string -> should wrap to ["Barbell"]
+          '["chest"]', // already correct -> must round-trip unchanged
+          'triceps, shoulders', // not valid JSON -> comma-split fallback
+          null, // NULL -> must stay NULL
+          '[]', // already an empty array -> must round-trip unchanged
+        ]
+      );
+      await sys.query(
+        `INSERT INTO public.exercise_entries
+           (id, user_id, exercise_id, duration_minutes, calories_burned, entry_date, exercise_name, equipment)
+         VALUES ($1, $2, $3, 0, 0, '2026-08-16', 'Migration Test Exercise', $4)`,
+        [ENTRY_MALFORMED, U, EX_MALFORMED, '"Dumbbell"']
+      );
+    } finally {
+      sys.release();
+    }
+  });
+
+  afterAll(async () => {
+    const sys = await getSystemClient();
+    try {
+      await sys.query(
+        'DELETE FROM public.exercise_entries WHERE user_id = $1',
+        [U]
+      );
+      await sys.query('DELETE FROM public.exercises WHERE id = $1', [
+        EX_MALFORMED,
+      ]);
+      await sys.query('DELETE FROM public."user" WHERE id = $1', [U]);
+    } finally {
+      sys.release();
+    }
+    await endPool();
+  });
+
+  async function readRows() {
+    const sys = await getSystemClient();
+    try {
+      const exercise = (
+        await sys.query(
+          'SELECT equipment, primary_muscles, secondary_muscles, instructions, images FROM public.exercises WHERE id = $1',
+          [EX_MALFORMED]
+        )
+      ).rows[0];
+      const entry = (
+        await sys.query(
+          'SELECT equipment FROM public.exercise_entries WHERE id = $1',
+          [ENTRY_MALFORMED]
+        )
+      ).rows[0];
+      return { exercise, entry };
+    } finally {
+      sys.release();
+    }
+  }
+
+  it('normalizes malformed values and leaves correct/NULL values untouched, on both tables', async () => {
+    const sys = await getSystemClient();
+    try {
+      await sys.query(MIGRATION_SQL);
+    } finally {
+      sys.release();
+    }
+
+    const { exercise, entry } = await readRows();
+
+    expect(JSON.parse(exercise.equipment)).toEqual(['Barbell']);
+    expect(JSON.parse(exercise.primary_muscles)).toEqual(['chest']);
+    expect(JSON.parse(exercise.secondary_muscles)).toEqual([
+      'triceps',
+      'shoulders',
+    ]);
+    expect(exercise.instructions).toBeNull();
+    expect(JSON.parse(exercise.images)).toEqual([]);
+    expect(JSON.parse(entry.equipment)).toEqual(['Dumbbell']);
+  });
+
+  it('is idempotent: a second run changes nothing', async () => {
+    const before = await readRows();
+
+    const sys = await getSystemClient();
+    try {
+      await sys.query(MIGRATION_SQL);
+    } finally {
+      sys.release();
+    }
+
+    const after = await readRows();
+    expect(after).toEqual(before);
+  });
+});

--- a/SparkyFitnessServer/tests/normalizeExerciseJsonArrayFields.integration.test.ts
+++ b/SparkyFitnessServer/tests/normalizeExerciseJsonArrayFields.integration.test.ts
@@ -112,14 +112,17 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
           '"Barbell"', // bare JSON string -> should wrap to ["Barbell"]
           '["chest"]', // already correct -> must round-trip unchanged
           'triceps, shoulders', // not valid JSON -> comma-split fallback
-          null, // NULL -> must stay NULL
+          // Not valid JSON, but prose, not a list: a comma AND an apostrophe
+          // inside. Must become ONE element with the text untouched, not two
+          // fake steps with the apostrophe stripped.
+          "Lie on the bench, then press. Don't lock your elbows.",
           '[]', // already an empty array -> must round-trip unchanged
         ]
       );
       await sys.query(
         `INSERT INTO public.exercise_entries
-           (id, user_id, exercise_id, duration_minutes, calories_burned, entry_date, exercise_name, equipment, primary_muscles, secondary_muscles)
-         VALUES ($1, $2, $3, 0, 0, '2026-08-16', 'Migration Test Exercise', $4, $5, $6)`,
+           (id, user_id, exercise_id, duration_minutes, calories_burned, entry_date, exercise_name, equipment, primary_muscles, secondary_muscles, instructions, images)
+         VALUES ($1, $2, $3, 0, 0, '2026-08-16', 'Migration Test Exercise', $4, $5, $6, $7, $8)`,
         [
           ENTRY_MALFORMED,
           U,
@@ -127,6 +130,8 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
           '"Dumbbell"',
           '', // empty string -> should become '[]', not stay ''
           '   ', // whitespace-only -> should also become '[]'
+          'Lie flat, then curl up.', // prose with a comma -> one element, not two
+          'exercises/dumbbell-curl, 0.jpg', // path-like text with a comma -> one element, not split
         ]
       );
     } finally {
@@ -162,7 +167,7 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
       ).rows[0];
       const entry = (
         await sys.query(
-          'SELECT equipment, primary_muscles, secondary_muscles FROM public.exercise_entries WHERE id = $1',
+          'SELECT equipment, primary_muscles, secondary_muscles, instructions, images FROM public.exercise_entries WHERE id = $1',
           [ENTRY_MALFORMED]
         )
       ).rows[0];
@@ -188,13 +193,21 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
       'triceps',
       'shoulders',
     ]);
-    expect(exercise.instructions).toBeNull();
+    expect(JSON.parse(exercise.instructions)).toEqual([
+      "Lie on the bench, then press. Don't lock your elbows.",
+    ]);
     expect(JSON.parse(exercise.images)).toEqual([]);
     expect(JSON.parse(entry.equipment)).toEqual(['Dumbbell']);
     // Empty string and whitespace-only are non-NULL but still not valid
     // JSON; both must become the literal '[]', not stay as-is.
     expect(entry.primary_muscles).toBe('[]');
     expect(entry.secondary_muscles).toBe('[]');
+    // Prose and a path, each with an embedded comma: one element, verbatim,
+    // not comma-split into fake extra entries.
+    expect(JSON.parse(entry.instructions)).toEqual(['Lie flat, then curl up.']);
+    expect(JSON.parse(entry.images)).toEqual([
+      'exercises/dumbbell-curl, 0.jpg',
+    ]);
   });
 
   it('is idempotent: a second run changes nothing', async () => {

--- a/SparkyFitnessServer/tests/normalizeExerciseJsonArrayFields.integration.test.ts
+++ b/SparkyFitnessServer/tests/normalizeExerciseJsonArrayFields.integration.test.ts
@@ -81,6 +81,13 @@ const RUN = await dbReachable();
 const U = '00000000-0000-4000-b000-0000000000bb';
 const EX_MALFORMED = '00000000-0000-4000-b000-0000000000f1';
 const ENTRY_MALFORMED = '00000000-0000-4000-b000-000000000601';
+// Bracket-prefixed text that is NOT valid JSON (unquoted list items, or
+// prose that happens to be wrapped in brackets). The naive "starts with '['
+// means already correct" heuristic would wrongly skip these rows forever;
+// exercise_json_array_is_valid() in the migration must catch it and still
+// route them through normalize_exercise_json_array().
+const EX_BRACKET_INVALID = '00000000-0000-4000-b000-0000000000f2';
+const ENTRY_BRACKET_INVALID = '00000000-0000-4000-b000-000000000602';
 
 describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
   beforeAll(async () => {
@@ -90,8 +97,8 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
         'DELETE FROM public.exercise_entries WHERE user_id = $1',
         [U]
       );
-      await sys.query('DELETE FROM public.exercises WHERE id = $1', [
-        EX_MALFORMED,
+      await sys.query('DELETE FROM public.exercises WHERE id = ANY($1)', [
+        [EX_MALFORMED, EX_BRACKET_INVALID],
       ]);
       await sys.query('DELETE FROM public."user" WHERE id = $1', [U]);
       await sys.query(
@@ -111,7 +118,10 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
           U,
           '"Barbell"', // bare JSON string -> should wrap to ["Barbell"]
           '["chest"]', // already correct -> must round-trip unchanged
-          'triceps, shoulders', // not valid JSON -> comma-split fallback
+          // Not valid JSON -> comma-split fallback. One item carries an
+          // apostrophe that must survive the split, not be stripped along
+          // with legacy list-wrapping punctuation.
+          "Trainer's Choice, shoulders",
           // Not valid JSON, but prose, not a list: a comma AND an apostrophe
           // inside. Must become ONE element with the text untouched, not two
           // fake steps with the apostrophe stripped.
@@ -134,6 +144,34 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
           'exercises/dumbbell-curl, 0.jpg', // path-like text with a comma -> one element, not split
         ]
       );
+
+      // Bracket-prefixed but NOT valid JSON: an unquoted legacy list
+      // ("[Barbell, Dumbbell]") and prose that happens to start/end with
+      // brackets. A naive "starts with '[' -> already correct" prefilter
+      // would leave these rows broken forever.
+      await sys.query(
+        `INSERT INTO public.exercises
+           (id, name, source, user_id, is_custom, modality, equipment, instructions)
+         VALUES ($1, $2, 'test', $3, true, 'weight_reps', $4, $5)`,
+        [
+          EX_BRACKET_INVALID,
+          'Migration Test Exercise (bracket-invalid)',
+          U,
+          '[Barbell, Dumbbell]', // looks like an array, unquoted items -> not valid JSON
+          '[Lie on the bench, then press]', // prose wrapped in brackets -> not valid JSON
+        ]
+      );
+      await sys.query(
+        `INSERT INTO public.exercise_entries
+           (id, user_id, exercise_id, duration_minutes, calories_burned, entry_date, exercise_name, equipment)
+         VALUES ($1, $2, $3, 0, 0, '2026-08-16', 'Migration Test Exercise', $4)`,
+        [
+          ENTRY_BRACKET_INVALID,
+          U,
+          EX_MALFORMED,
+          '[Kettlebell, Bands]', // looks like an array, unquoted items -> not valid JSON
+        ]
+      );
     } finally {
       sys.release();
     }
@@ -146,8 +184,8 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
         'DELETE FROM public.exercise_entries WHERE user_id = $1',
         [U]
       );
-      await sys.query('DELETE FROM public.exercises WHERE id = $1', [
-        EX_MALFORMED,
+      await sys.query('DELETE FROM public.exercises WHERE id = ANY($1)', [
+        [EX_MALFORMED, EX_BRACKET_INVALID],
       ]);
       await sys.query('DELETE FROM public."user" WHERE id = $1', [U]);
     } finally {
@@ -171,7 +209,19 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
           [ENTRY_MALFORMED]
         )
       ).rows[0];
-      return { exercise, entry };
+      const exerciseBracketInvalid = (
+        await sys.query(
+          'SELECT equipment, instructions FROM public.exercises WHERE id = $1',
+          [EX_BRACKET_INVALID]
+        )
+      ).rows[0];
+      const entryBracketInvalid = (
+        await sys.query(
+          'SELECT equipment FROM public.exercise_entries WHERE id = $1',
+          [ENTRY_BRACKET_INVALID]
+        )
+      ).rows[0];
+      return { exercise, entry, exerciseBracketInvalid, entryBracketInvalid };
     } finally {
       sys.release();
     }
@@ -185,12 +235,13 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
       sys.release();
     }
 
-    const { exercise, entry } = await readRows();
+    const { exercise, entry, exerciseBracketInvalid, entryBracketInvalid } =
+      await readRows();
 
     expect(JSON.parse(exercise.equipment)).toEqual(['Barbell']);
     expect(JSON.parse(exercise.primary_muscles)).toEqual(['chest']);
     expect(JSON.parse(exercise.secondary_muscles)).toEqual([
-      'triceps',
+      "Trainer's Choice",
       'shoulders',
     ]);
     expect(JSON.parse(exercise.instructions)).toEqual([
@@ -207,6 +258,23 @@ describe.runIf(RUN)('normalize_exercise_json_array_fields migration', () => {
     expect(JSON.parse(entry.instructions)).toEqual(['Lie flat, then curl up.']);
     expect(JSON.parse(entry.images)).toEqual([
       'exercises/dumbbell-curl, 0.jpg',
+    ]);
+
+    // Bracket-prefixed but not valid JSON must NOT be skipped by the
+    // "starts with '[' -> already correct" prefilter — it still has to go
+    // through normalize_exercise_json_array().
+    expect(JSON.parse(exerciseBracketInvalid.equipment)).toEqual([
+      'Barbell',
+      'Dumbbell',
+    ]);
+    // instructions never comma-splits or strips characters, so the whole
+    // bracket-wrapped sentence is preserved verbatim as one element.
+    expect(JSON.parse(exerciseBracketInvalid.instructions)).toEqual([
+      '[Lie on the bench, then press]',
+    ]);
+    expect(JSON.parse(entryBracketInvalid.equipment)).toEqual([
+      'Kettlebell',
+      'Bands',
     ]);
   });
 

--- a/SparkyFitnessServer/utils/exerciseJsonFields.ts
+++ b/SparkyFitnessServer/utils/exerciseJsonFields.ts
@@ -43,14 +43,14 @@ export function parseJsonArrayField(
  * Callers into this (models/exercise.ts's createExercise/updateExercise,
  * reached by untyped import paths like CSV import and external-provider
  * responses) aren't statically guaranteed to hand this a real string or
- * string[] despite the signature below, so non-string elements are dropped
- * at runtime rather than trusted through to JSON.stringify — a stray number
- * or object in the array would otherwise persist as valid JSON that isn't a
+ * string[] — the parameter is typed `unknown` rather than `string |
+ * string[] | null | undefined` so the signature doesn't claim a guarantee
+ * the caller can't actually provide. Non-string elements are dropped at
+ * runtime rather than trusted through to JSON.stringify — a stray number or
+ * object in the array would otherwise persist as valid JSON that isn't a
  * string array, silently violating the column's documented shape.
  */
-export function normalizeToStringArray(
-  value: string | string[] | null | undefined
-): string[] {
+export function normalizeToStringArray(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value.filter((item): item is string => typeof item === 'string');
   }

--- a/SparkyFitnessServer/utils/exerciseJsonFields.ts
+++ b/SparkyFitnessServer/utils/exerciseJsonFields.ts
@@ -39,10 +39,20 @@ export function parseJsonArrayField(
  * JSON.stringify'd as-is, so a bare string round-trips as a JSON-encoded
  * string instead of a one-item array, and every downstream `.join()`/`.map()`
  * consumer of the parsed field then crashes.
+ *
+ * Callers into this (models/exercise.ts's createExercise/updateExercise,
+ * reached by untyped import paths like CSV import and external-provider
+ * responses) aren't statically guaranteed to hand this a real string or
+ * string[] despite the signature below, so non-string elements are dropped
+ * at runtime rather than trusted through to JSON.stringify — a stray number
+ * or object in the array would otherwise persist as valid JSON that isn't a
+ * string array, silently violating the column's documented shape.
  */
 export function normalizeToStringArray(
   value: string | string[] | null | undefined
 ): string[] {
-  if (Array.isArray(value)) return value;
-  return value ? [value] : [];
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+  return typeof value === 'string' && value ? [value] : [];
 }

--- a/SparkyFitnessServer/utils/exerciseJsonFields.ts
+++ b/SparkyFitnessServer/utils/exerciseJsonFields.ts
@@ -1,0 +1,30 @@
+import { log } from '../config/logging.js';
+
+/**
+ * exercises.equipment/primary_muscles/secondary_muscles/instructions/images
+ * (and the matching columns on exercise_entries) are TEXT columns holding a
+ * JSON-array-encoded string by design (see
+ * db/migrations/20250927180257_alter_exercises_table.sql). Some rows hold a
+ * bare JSON string instead of a one-item array (free-exercise-db's raw JSON
+ * uses a single string for a solo value, and imports have historically
+ * passed that through unnormalized), and a JSON.parse of those returns a
+ * non-array. Wrap it into a one-item array instead of returning it as-is, so
+ * every caller can rely on the result always being an array.
+ */
+export function parseJsonArrayField(
+  value: string | null | undefined,
+  context?: string
+): unknown[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch (error) {
+    log(
+      'error',
+      `Error parsing exercise JSON array field${context ? ` (${context})` : ''}:`,
+      error
+    );
+    return [];
+  }
+}

--- a/SparkyFitnessServer/utils/exerciseJsonFields.ts
+++ b/SparkyFitnessServer/utils/exerciseJsonFields.ts
@@ -28,3 +28,21 @@ export function parseJsonArrayField(
     return [];
   }
 }
+
+/**
+ * Same "always an array" guarantee as parseJsonArrayField, but for a value
+ * that's already been JSON-decoded (e.g. an external API response body)
+ * rather than a raw TEXT column needing JSON.parse. free-exercise-db's raw
+ * JSON stores equipment/muscles/instructions as either a string array or a
+ * single bare string (never an empty string for "none" — that's
+ * `null`/absent). Anything reaching a persistence call un-normalized gets
+ * JSON.stringify'd as-is, so a bare string round-trips as a JSON-encoded
+ * string instead of a one-item array, and every downstream `.join()`/`.map()`
+ * consumer of the parsed field then crashes.
+ */
+export function normalizeToStringArray(
+  value: string | string[] | null | undefined
+): string[] {
+  if (Array.isArray(value)) return value;
+  return value ? [value] : [];
+}

--- a/shared/src/schemas/api/Exercises.api.zod.ts
+++ b/shared/src/schemas/api/Exercises.api.zod.ts
@@ -25,6 +25,39 @@ export const exerciseSearchQuerySchema = z
   })
   .strict();
 
+// --- Request contracts ---
+
+/**
+ * equipment/primary_muscles/secondary_muscles/instructions are stored as a
+ * JSON array of strings (db/migrations/20250927180257_alter_exercises_table.sql).
+ * free-exercise-db's raw JSON (and some legacy imports) uses a bare string
+ * for a single value, so accept either shape and normalize to an array
+ * rather than rejecting — rejecting would break imports over upstream
+ * formatting this app doesn't control. Mirrors the read-side
+ * parseJsonArrayField normalization in utils/exerciseJsonFields.ts.
+ */
+const exerciseStringArrayFieldSchema = z
+  .union([z.array(z.string()), z.string()])
+  .nullable()
+  .optional()
+  .transform((value) => (value == null || Array.isArray(value) ? value : [value]));
+
+/**
+ * The subset of the create/update exercise payload (`POST /exercises`,
+ * `PUT /exercises/:id`) that needs shape normalization before it reaches
+ * the database. `.passthrough()` so the rest of the payload (name, category,
+ * modality, force, level, mechanic, description, is_public, ...) rides
+ * through untouched. This schema only owns the array-shaped fields.
+ */
+export const exerciseWriteArrayFieldsSchema = z
+  .object({
+    equipment: exerciseStringArrayFieldSchema,
+    primary_muscles: exerciseStringArrayFieldSchema,
+    secondary_muscles: exerciseStringArrayFieldSchema,
+    instructions: exerciseStringArrayFieldSchema,
+  })
+  .passthrough();
+
 // --- Response contracts ---
 
 /**
@@ -104,6 +137,9 @@ export const paginatedExternalExerciseSearchResultSchema = z
 // --- Types ---
 
 export type ExerciseSearchQuery = z.infer<typeof exerciseSearchQuerySchema>;
+export type ExerciseWriteArrayFields = z.infer<
+  typeof exerciseWriteArrayFieldsSchema
+>;
 export type ExerciseLibraryItem = z.infer<typeof exerciseLibraryItemSchema>;
 export type PaginatedExercisesResponse = z.infer<
   typeof paginatedExercisesResponseSchema

--- a/shared/src/schemas/api/Exercises.api.zod.ts
+++ b/shared/src/schemas/api/Exercises.api.zod.ts
@@ -28,8 +28,8 @@ export const exerciseSearchQuerySchema = z
 // --- Request contracts ---
 
 /**
- * equipment/primary_muscles/secondary_muscles/instructions are stored as a
- * JSON array of strings (db/migrations/20250927180257_alter_exercises_table.sql).
+ * equipment/primary_muscles/secondary_muscles/instructions/images are stored
+ * as a JSON array of strings (db/migrations/20250927180257_alter_exercises_table.sql).
  * free-exercise-db's raw JSON (and some legacy imports) uses a bare string
  * for a single value, so accept either shape and normalize to an array
  * rather than rejecting — rejecting would break imports over upstream
@@ -48,6 +48,11 @@ const exerciseStringArrayFieldSchema = z
  * the database. `.passthrough()` so the rest of the payload (name, category,
  * modality, force, level, mechanic, description, is_public, ...) rides
  * through untouched. This schema only owns the array-shaped fields.
+ *
+ * The PUT handler merges this field's *existing*
+ * images with new uploads (`[...(exerciseData.images ?? []), ...newPaths]`).
+ * Left unnormalized, a client-sent bare string would silently spread into
+ * one "image path" per character instead of one path.
  */
 export const exerciseWriteArrayFieldsSchema = z
   .object({
@@ -55,6 +60,7 @@ export const exerciseWriteArrayFieldsSchema = z
     primary_muscles: exerciseStringArrayFieldSchema,
     secondary_muscles: exerciseStringArrayFieldSchema,
     instructions: exerciseStringArrayFieldSchema,
+    images: exerciseStringArrayFieldSchema,
   })
   .passthrough();
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Fixed unwrapped exercise TEXT fields that were expected to be stored JSON array of strings.

**How did you implement the solution?**
AI assisted with user review.

Linked Issue: Closes https://github.com/CodeWithCJ/SparkyFitness/issues/2142

## How to Test

1. Check out this branch and run a successful exercise report export
2. View DB content to verify migration of exercise text fields that were not JSON arrays are now JSON arrays

## PR Type

- [X] Issue (bug fix)
- [ ] New Feature
- [X] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [X] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before API example:

```
        {
            "id": "34a5a7e4-0851-4929-a38c-dce8bd89b83e",
            "source": "free-exercise-db",
            "source_id": "Bench_Press_-_Powerlifting",
            "name": "Bench Press - Powerlifting",
            "force": "push",
            "level": "intermediate",
            "mechanic": "compound",
            "equipment": "\"barbell\"",
            "primary_muscles": "[\"triceps\"]",
            "secondary_muscles": "[\"chest\",\"forearms\",\"lats\",\"shoulders\"]",
            "instructions": "[\"Begin by lying on the bench, getting your head beyond the bar if possible. Tuck your feet underneath you and arch your back. Using the bar to help support your weight, lift your shoulder off the bench and retract them, squeezing the shoulder blades together. Use your feet to drive your traps into the bench. Maintain this tight body position throughout the movement.\",\"However wide your grip, it should cover the ring on the bar. Pull the bar out of the rack without protracting your shoulders. Focus on squeezing the bar and trying to pull it apart.\",\"Lower the bar to your lower chest or upper stomach. The bar, wrist, and elbow should stay in line at all times.\",\"Pause when the barbell touches your torso, and then drive the bar up with as much force as possible. The elbows should be tucked in until lockout.\"]",
            "category": "powerlifting",
            "images": [
                "Bench_Press_-_Powerlifting/0.jpg",
                "Bench_Press_-_Powerlifting/1.jpg"
            ],
            "calories_per_hour": 498,
            "description": "Begin by lying on the bench, getting your head beyond the bar if possible. Tuck your feet underneath you and arch your back. Using the bar to help support your weight, lift your shoulder off the bench and retract them, squeezing the shoulder blades together. Use your feet to drive your traps into the bench. Maintain this tight body position throughout the movement.",
            "user_id": "559c9574-61ca-4293-a543-4a8a2d453896",
            "is_custom": true,
            "shared_with_public": false,
            "modality": "weight_reps",
            "created_at": "2026-07-29T02:18:00.847Z",
            "updated_at": "2026-07-29T02:18:00.847Z",
            "tags": [
                "private"
            ]
        },
```

### After API example:

Note `"equipment"` is now properly wrapped as a json array in the text field.

```
            "id": "34a5a7e4-0851-4929-a38c-dce8bd89b83e",
            "source": "free-exercise-db",
            "source_id": "Bench_Press_-_Powerlifting",
            "name": "Bench Press - Powerlifting",
            "force": "push",
            "level": "intermediate",
            "mechanic": "compound",
            "equipment": "[\"barbell\"]",
            "primary_muscles": "[\"triceps\"]",
            "secondary_muscles": "[\"chest\",\"forearms\",\"lats\",\"shoulders\"]",
            "instructions": "[\"Begin by lying on the bench, getting your head beyond the bar if possible. Tuck your feet underneath you and arch your back. Using the bar to help support your weight, lift your shoulder off the bench and retract them, squeezing the shoulder blades together. Use your feet to drive your traps into the bench. Maintain this tight body position throughout the movement.\",\"However wide your grip, it should cover the ring on the bar. Pull the bar out of the rack without protracting your shoulders. Focus on squeezing the bar and trying to pull it apart.\",\"Lower the bar to your lower chest or upper stomach. The bar, wrist, and elbow should stay in line at all times.\",\"Pause when the barbell touches your torso, and then drive the bar up with as much force as possible. The elbows should be tucked in until lockout.\"]",
            "category": "powerlifting",
            "images": [
                "Bench_Press_-_Powerlifting/0.jpg",
                "Bench_Press_-_Powerlifting/1.jpg"
            ],
            "calories_per_hour": 498,
            "description": "Begin by lying on the bench, getting your head beyond the bar if possible. Tuck your feet underneath you and arch your back. Using the bar to help support your weight, lift your shoulder off the bench and retract them, squeezing the shoulder blades together. Use your feet to drive your traps into the bench. Maintain this tight body position throughout the movement.",
            "user_id": "559c9574-61ca-4293-a543-4a8a2d453896",
            "is_custom": true,
            "shared_with_public": false,
            "modality": "weight_reps",
            "created_at": "2026-07-29T02:18:00.847Z",
            "updated_at": "2026-07-29T02:18:00.847Z",
            "tags": [
                "private"
            ]
        }
```


</details>

## Notes for Reviewers

> I have not converted the TEXT fields. It is too much of a lift for me.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exercise equipment, muscle groups, instructions, and images are consistently handled as arrays.
  - Single text values are converted into one-item arrays during creation, updates, and imports.
  - Existing arrays, blank values, and optional fields are preserved.

- **Bug Fixes**
  - Improved compatibility with legacy or malformed exercise data.
  - Invalid exercise submissions now receive clear validation errors.
  - Reports and imported descriptions display normalized data correctly.
  - Failed uploads are cleaned up automatically.

- **Tests**
  - Added coverage for normalization, validation, imports, reporting, and database migration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->