### PR TITLE
fix(exercises): show thumbnails for saved sourced exercises

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearchListItem.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearchListItem.tsx
@@ -4,6 +4,7 @@ import { EXERCISE_CATEGORY_META } from '@/constants/exercises';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { Exercise } from '@/types/exercises';
 import { getEnergyUnitString } from '@/utils/nutritionCalculations';
+import { resolveExerciseImageSrc } from '@/utils/exercises';
 import {
   Share2,
   Users,
@@ -99,11 +100,7 @@ export const ExerciseSearchListItem = ({
       {hasImage && !showFallback ? (
         <div className="relative flex-shrink-0 w-12 h-12 rounded-lg overflow-hidden ring-1 ring-gray-200 dark:ring-gray-700 bg-gray-50 dark:bg-gray-800">
           <img
-            src={
-              exercise.source
-                ? exercise.images![currentImageIndex]
-                : '/uploads/exercises/' + exercise.images![currentImageIndex]
-            }
+            src={resolveExerciseImageSrc(exercise.images![currentImageIndex])}
             alt={exercise.name}
             className="w-full h-full object-contain"
             onError={() => setImageError(true)}

--- a/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearchListItem.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/ExerciseSearchListItem.tsx
@@ -4,7 +4,10 @@ import { EXERCISE_CATEGORY_META } from '@/constants/exercises';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { Exercise } from '@/types/exercises';
 import { getEnergyUnitString } from '@/utils/nutritionCalculations';
-import { resolveExerciseImageSrc } from '@/utils/exercises';
+import {
+  resolveExerciseImageSrc,
+  filterValidExerciseImages,
+} from '@/utils/exercises';
 import {
   Share2,
   Users,
@@ -51,13 +54,13 @@ export const ExerciseSearchListItem = ({
   const [isActioning, setIsActioning] = useState(false);
   const { energyUnit, convertEnergy } = usePreferences();
   const [imageError, setImageError] = useState(false);
+  const validImages = filterValidExerciseImages(exercise.images);
+  const imageCount = validImages.length;
   const handleNextImage = () =>
-    setCurrentImageIndex((prev) => (prev + 1) % (exercise.images?.length || 1));
+    setCurrentImageIndex((prev) => (prev + 1) % (imageCount || 1));
   const handlePrevImage = () =>
     setCurrentImageIndex(
-      (prev) =>
-        (prev - 1 + (exercise.images?.length || 1)) %
-        (exercise.images?.length || 1)
+      (prev) => (prev - 1 + (imageCount || 1)) % (imageCount || 1)
     );
 
   const handleSpeak = () => {
@@ -90,9 +93,9 @@ export const ExerciseSearchListItem = ({
   if (exercise.force) metaPills.push(exercise.force);
   if (exercise.mechanic) metaPills.push(exercise.mechanic);
 
-  const hasImage =
-    exercise.images && exercise.images.some((img) => img.trim() !== '[]');
+  const hasImage = imageCount > 0;
   const showFallback = !hasImage || imageError;
+  const safeImageIndex = imageCount > 0 ? currentImageIndex % imageCount : 0;
 
   return (
     <div className="group flex gap-3 p-3 rounded-lg bg-white dark:bg-gray-800/80 border border-gray-100 dark:border-gray-700/60 hover:border-blue-200 dark:hover:border-blue-800 hover:shadow-sm transition-all duration-150">
@@ -100,12 +103,12 @@ export const ExerciseSearchListItem = ({
       {hasImage && !showFallback ? (
         <div className="relative flex-shrink-0 w-12 h-12 rounded-lg overflow-hidden ring-1 ring-gray-200 dark:ring-gray-700 bg-gray-50 dark:bg-gray-800">
           <img
-            src={resolveExerciseImageSrc(exercise.images![currentImageIndex])}
+            src={resolveExerciseImageSrc(validImages[safeImageIndex])}
             alt={exercise.name}
             className="w-full h-full object-contain"
             onError={() => setImageError(true)}
           />
-          {exercise.images!.length > 1 && (
+          {imageCount > 1 && (
             <div className="absolute inset-x-0 bottom-0 flex justify-between px-0.5">
               <button
                 onClick={handlePrevImage}

--- a/SparkyFitnessFrontend/src/tests/utils/resolveExerciseImageSrc.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/resolveExerciseImageSrc.test.ts
@@ -1,4 +1,7 @@
-import { resolveExerciseImageSrc } from '@/utils/exercises';
+import {
+  resolveExerciseImageSrc,
+  filterValidExerciseImages,
+} from '@/utils/exercises';
 
 describe('resolveExerciseImageSrc', () => {
   it('prefixes relative upload paths with /uploads/exercises/', () => {
@@ -30,5 +33,31 @@ describe('resolveExerciseImageSrc', () => {
   it('returns an empty string for missing values', () => {
     expect(resolveExerciseImageSrc(undefined)).toBe('');
     expect(resolveExerciseImageSrc('')).toBe('');
+  });
+});
+
+describe('filterValidExerciseImages', () => {
+  it('drops empty, whitespace, and "[]" sentinel entries', () => {
+    expect(
+      filterValidExerciseImages(['', '  ', '[]', 'Machine_Bicep_Curl/0.jpg'])
+    ).toEqual(['Machine_Bicep_Curl/0.jpg']);
+  });
+
+  it('keeps the order of valid entries in a mixed array', () => {
+    expect(
+      filterValidExerciseImages([
+        '[]',
+        'A/0.jpg',
+        '',
+        'https://example.com/b.png',
+      ])
+    ).toEqual(['A/0.jpg', 'https://example.com/b.png']);
+  });
+
+  it('returns an empty array for missing or non-array input', () => {
+    expect(filterValidExerciseImages(undefined)).toEqual([]);
+    expect(filterValidExerciseImages(null)).toEqual([]);
+    expect(filterValidExerciseImages([])).toEqual([]);
+    expect(filterValidExerciseImages(['[]'])).toEqual([]);
   });
 });

--- a/SparkyFitnessFrontend/src/tests/utils/resolveExerciseImageSrc.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/resolveExerciseImageSrc.test.ts
@@ -1,0 +1,34 @@
+import { resolveExerciseImageSrc } from '@/utils/exercises';
+
+describe('resolveExerciseImageSrc', () => {
+  it('prefixes relative upload paths with /uploads/exercises/', () => {
+    // Saved wger / free-exercise-db exercises persist a relative path whose
+    // files are served from the uploads directory.
+    expect(
+      resolveExerciseImageSrc('Biceps_Curls_With_SZ_bar/abc_123.png')
+    ).toBe('/uploads/exercises/Biceps_Curls_With_SZ_bar/abc_123.png');
+    expect(resolveExerciseImageSrc('Machine_Bicep_Curl/0.jpg')).toBe(
+      '/uploads/exercises/Machine_Bicep_Curl/0.jpg'
+    );
+  });
+
+  it('uses absolute http(s) URLs as-is', () => {
+    const httpsUrl =
+      'https://raw.githubusercontent.com/yuhonas/free-exercise-db/main/exercises/Bench/0.jpg';
+    expect(resolveExerciseImageSrc(httpsUrl)).toBe(httpsUrl);
+    expect(resolveExerciseImageSrc('http://example.com/a.png')).toBe(
+      'http://example.com/a.png'
+    );
+  });
+
+  it('is case-insensitive about the URL scheme', () => {
+    expect(resolveExerciseImageSrc('HTTPS://example.com/a.png')).toBe(
+      'HTTPS://example.com/a.png'
+    );
+  });
+
+  it('returns an empty string for missing values', () => {
+    expect(resolveExerciseImageSrc(undefined)).toBe('');
+    expect(resolveExerciseImageSrc('')).toBe('');
+  });
+});

--- a/SparkyFitnessFrontend/src/utils/exercises.ts
+++ b/SparkyFitnessFrontend/src/utils/exercises.ts
@@ -90,6 +90,25 @@ export function resolveExerciseImageSrc(image: string | undefined): string {
   return `/uploads/exercises/${image}`;
 }
 
+/**
+ * Return only the usable image entries from an exercise's `images` array.
+ *
+ * Persisted `images` can contain unusable entries: empty strings, whitespace,
+ * or the `'[]'` sentinel produced when an exercise has no images. Callers must
+ * drive presence checks, `<img>` sources, and gallery navigation off the same
+ * filtered list so they never disagree and render a broken thumbnail.
+ */
+export function filterValidExerciseImages(
+  images: string[] | undefined | null
+): string[] {
+  if (!Array.isArray(images)) return [];
+  return images.filter((img) => {
+    if (typeof img !== 'string') return false;
+    const trimmed = img.trim();
+    return trimmed !== '' && trimmed !== '[]';
+  });
+}
+
 export function calcExerciseStatsFlat(entries: DailyExerciseEntry[]) {
   return {
     otherCalories: entries.reduce(

--- a/SparkyFitnessFrontend/src/utils/exercises.ts
+++ b/SparkyFitnessFrontend/src/utils/exercises.ts
@@ -69,6 +69,27 @@ export const parseCSV = (
 export const generateUniqueId = () =>
   `temp_${Math.random().toString(36).slice(2, 11)}`;
 
+/**
+ * Resolve an exercise `images` entry to a usable <img> src.
+ *
+ * Exercise image values come from two shapes:
+ * - Absolute URLs (e.g. external provider search results) — used as-is.
+ * - Relative paths for images stored under the server's uploads directory
+ *   (e.g. imported wger / free-exercise-db exercises persist the relative
+ *   path and the files are served from `/uploads/exercises/`).
+ *
+ * The saved-exercise listing previously keyed this decision off
+ * `exercise.source` being truthy, which skipped the `/uploads/exercises/`
+ * prefix for every sourced exercise (wger, free-exercise-db, ...) and left
+ * their thumbnails broken. Detecting an absolute URL instead is correct for
+ * both search results and saved exercises regardless of source.
+ */
+export function resolveExerciseImageSrc(image: string | undefined): string {
+  if (!image) return '';
+  if (/^https?:\/\//i.test(image)) return image;
+  return `/uploads/exercises/${image}`;
+}
+
 export function calcExerciseStatsFlat(entries: DailyExerciseEntry[]) {
   return {
     otherCalories: entries.reduce(


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Thumbnails never render for saved exercises that came from a provider (wger, free-exercise-db, …) — the exercise library shows the category-icon fallback instead of the exercise image.

**How did you implement the solution?**
The listing picked the `<img src>` based on `exercise.source` being truthy: sourced exercises used the raw stored value while only source-less exercises got the `/uploads/exercises/` prefix. Imported exercises persist a **relative** path (their images are downloaded into the uploads dir), so every sourced exercise requested a bare path that the SPA served as `index.html` (`Content-Type: text/html`), leaving the thumbnail broken.

The src is now resolved by detecting an absolute `http(s)` URL (used as-is) and otherwise prefixing `/uploads/exercises/` — the same logic already used in `ExercisePlaybackModal`. This is correct for both saved exercises and external search results regardless of source. Extracted as `resolveExerciseImageSrc` in `utils/exercises.ts` with unit tests.

Linked Issue: N/A (small bug fix)

## How to Test

1. Check out this branch, `cd SparkyFitnessFrontend && pnpm install`.
2. Import an exercise that has an image from an external provider (e.g. wger) so it is saved to your exercise library.
3. Open the Exercises list and find the saved exercise.
4. Verify its thumbnail now renders (previously it fell back to the category icon).
5. `pnpm run validate` and `pnpm exec jest src/tests/utils/resolveExerciseImageSrc.test.ts` both pass.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the License terms.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: No translation files were changed.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: See note below.

## Notes for Reviewers

This changes how an existing `<img src>` is computed (no visual/layout change), so there is no meaningful "before/after" styling screenshot — the observable difference is a broken image vs. a rendered thumbnail for provider-sourced saved exercises. Verified at the network level: the old code requested the bare relative path which the SPA answered with `text/html` (index.html), whereas `/uploads/exercises/<path>` returns the real `image/png`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exercise thumbnail handling for uploaded images.
  - Preserved absolute HTTP(S) image URLs correctly, including uppercase schemes.
  - Filtered out empty, whitespace-only, and invalid image entries.
  - Prevented broken image paths and out-of-range navigation when images are unavailable.

- **Tests**
  - Added coverage for relative paths, absolute URLs, missing values, invalid entries, and mixed image collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->