### PR TITLE
fix(food-search): "All Providers" option

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -78,6 +78,7 @@ import { interleaveTopMatches } from '@/utils/topMatches.ts';
 import { makeProviderColorResolver } from '@/utils/providerColor.ts';
 import { DataProvider } from '@/types/settings.ts';
 import {
+  ALL_PROVIDERS_VALUE,
   getProviderCategory,
   resolveFoodProviderId,
 } from '@/utils/settings.ts';
@@ -86,9 +87,9 @@ import {
 // (an inline [] default would re-run the online search effect during loading).
 const EMPTY_PROVIDERS: DataProvider[] = [];
 
-// Sentinel provider id for the aggregated "All Providers" mode (offered only
-// when more than one food provider is active).
-const ALL_PROVIDERS_VALUE = '__all__';
+// ALL_PROVIDERS_VALUE (the sentinel provider id for the aggregated "All
+// Providers" mode, offered only when more than one food provider is active) is
+// imported from utils/settings so it stays in step with resolveFoodProviderId.
 
 // One page of provider results plus whether the provider reports more pages
 // behind it, so the caller can offer a "Load more" affordance.

--- a/SparkyFitnessFrontend/src/tests/utils/resolveFoodProviderId.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/resolveFoodProviderId.test.ts
@@ -1,7 +1,32 @@
-import { resolveFoodProviderId } from '@/utils/settings';
+import { ALL_PROVIDERS_VALUE, resolveFoodProviderId } from '@/utils/settings';
 
 describe('resolveFoodProviderId', () => {
   const options = [{ id: 'usda' }, { id: 'openfoodfacts' }];
+
+  it('passes the All Providers sentinel through instead of resolving a single provider', () => {
+    // Regression (#2132): the sentinel is not a real provider id, so the
+    // option-list validation used to reject it and fall through to the
+    // persisted default. The dropdown then snapped back to that provider and
+    // the aggregated search never ran.
+    expect(resolveFoodProviderId(ALL_PROVIDERS_VALUE, 'usda', options)).toBe(
+      ALL_PROVIDERS_VALUE
+    );
+  });
+
+  it('passes the sentinel through even when it is not in the option list', () => {
+    // The sentinel never appears in foodProviderOptions (that list holds real
+    // active food providers), so it must not be validated against it.
+    expect(options.map((o) => o.id)).not.toContain(ALL_PROVIDERS_VALUE);
+    expect(resolveFoodProviderId(ALL_PROVIDERS_VALUE, null, options)).toBe(
+      ALL_PROVIDERS_VALUE
+    );
+  });
+
+  it('does not invent the sentinel when it was not selected', () => {
+    expect(resolveFoodProviderId(null, null, options)).not.toBe(
+      ALL_PROVIDERS_VALUE
+    );
+  });
 
   it('prefers a valid explicit manual selection above everything else', () => {
     expect(resolveFoodProviderId('openfoodfacts', 'usda', options)).toBe(

--- a/SparkyFitnessFrontend/src/utils/settings.ts
+++ b/SparkyFitnessFrontend/src/utils/settings.ts
@@ -211,9 +211,18 @@ export const getProviderCategory = (
 };
 
 /**
- * Resolve the food-search provider to select. Precedence: an explicit manual
- * choice, then the user's persisted default, then the first available option.
- * Every returned id is validated against the rendered option list (active
+ * Sentinel provider id for the aggregated "All Providers" food search. It is
+ * not a real provider, so it must be defined alongside the resolver below that
+ * has to let it through; a second copy in the consuming component is how the
+ * two drifted apart in the first place.
+ */
+export const ALL_PROVIDERS_VALUE = '__all__';
+
+/**
+ * Resolve the food-search provider to select. Precedence: the aggregated
+ * "All Providers" sentinel, then an explicit manual choice, then the user's
+ * persisted default, then the first available option.
+ * Every returned real id is validated against the rendered option list (active
  * food-category providers); a manual pick or persisted default that points at a
  * now-inactive/non-food provider is ignored rather than returned, since an id
  * with no matching SelectItem makes the dropdown render blank.
@@ -224,6 +233,12 @@ export const resolveFoodProviderId = (
   foodProviderOptions: { id: string }[]
 ): string | null => {
   const optionIds = foodProviderOptions.map((o) => o.id);
+  // The sentinel has a rendered SelectItem but no matching provider id, so it
+  // has to bypass the option-list validation below or the dropdown snaps back
+  // to a single provider and the aggregated search never runs.
+  if (manualProviderId === ALL_PROVIDERS_VALUE) {
+    return manualProviderId;
+  }
   if (manualProviderId && optionIds.includes(manualProviderId)) {
     return manualProviderId;
   }


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Selecting "All Providers" in the web food search didn't function as expected: the dropdown snapped back to the previously selected provider and the aggregated search never ran. Reported in #2132, present in v1.6.1, v1.6.2 and current `main`.

**How did you implement the solution?**

`resolveFoodProviderId()` validates every candidate provider id against the rendered option list, which only holds real active food-category providers. The aggregated-search sentinel `'__all__'` is not one of them, so it was rejected and resolution fell through to the persisted default, leaving `isAllProviders` permanently false. The sentinel now bypasses that validation ahead of the option-list check. The constant moved from `FoodSearch.tsx` into `utils/settings.ts` next to the resolver, so the two share one definition instead of the separate copies that drifted apart. No behaviour change for real provider ids, and no server change: the fan-out is client side in `useAllProvidersFoodSearch`.

Linked Issue: Closes #2132

## How to Test

1. Check out this branch, then `cd SparkyFitnessFrontend && pnpm install && pnpm test -- src/tests/utils/resolveFoodProviderId.test.ts`. 9 tests pass.
2. Configure at least two active food-category providers under Settings, External Providers.
3. Open the food search dialog from a diary entry and open the provider dropdown.
4. Select "All Providers". The dropdown should now hold that selection instead of reverting.
5. Type a query and verify the aggregated view renders: a Top Matches list with colour-coded source badges, and one collapsible By Source section per provider.
6. Switch back to a single provider and confirm the single-provider view still works unchanged.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the License terms.

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="930" height="495" alt="2026-08-19 14_05_08-RustDesk" src="https://github.com/user-attachments/assets/c72238ae-1af9-4693-b567-74803a8105a1" />

</details>

## Notes for Reviewers

The regression came from two PRs that merged 33 seconds apart on 2 July. #1695 added the sentinel against a permissive `manualProviderId || defaultId || first` chain, and #1697 replaced that chain with the validating `resolveFoodProviderId()`. Neither branch contained the other's code, so git merged both cleanly and each was correct in isolation. The new tests cover the sentinel path directly, which the original resolver suite did not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an “All Providers” food search selection.
  * The selection remains available even when it is not listed among individual provider options.

* **Bug Fixes**
  * Preserved the “All Providers” choice during provider resolution instead of treating it as an invalid provider.
  * Ensured provider selection continues to fall back correctly when no provider is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->