### PR TITLE
refactor(supplements): dedupe the supplement SQL and collapse its subqueries

### DIFF
--- a/SparkyFitnessServer/models/foodMisc.ts
+++ b/SparkyFitnessServer/models/foodMisc.ts
@@ -2,6 +2,14 @@ import { getClient, getSystemClient } from '../db/poolManager.js';
 import { FOOD_VARIANT_NUTRIENT_FIELDS } from '@workspace/shared';
 import type { FoodVariantNutrientField } from '@workspace/shared';
 import type { FoodEntrySnapshot } from '../types/nutrition.js';
+import {
+  supplementScanWhere,
+  supplementFixedSum,
+  supplementCountable,
+  supplementFixed,
+  supplementCustomUnion,
+  supplementCustomTotals,
+} from './supplementSql.js';
 
 const DEFAULT_VARIANT_JSON_SQL = `
   json_build_object(
@@ -220,52 +228,6 @@ async function removeFoodFavorite(userId: string, foodId: string) {
     client.release();
   }
 }
-// A logged supplement contributes its per-dose snapshot, scaled by the dose count taken
-// (GREATEST-clamped so a non-positive value can't subtract). These fragments let the diary
-// daily-summary aggregations count supplements exactly the way the report already does, so
-// they show against goals. userExpr/dateExpr are the SQL expressions to correlate on: bind
-// params ($1/$2) for the single-date query, or the grouped columns (fe.user_id/fe.entry_date)
-// for the per-date query.
-function supplementFixed(
-  key: string,
-  userExpr: string,
-  dateExpr: string
-): string {
-  return `COALESCE((SELECT SUM(public.sf_try_numeric(me.nutrients_snapshot->>'${key}') * GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)) FROM medication_entries me WHERE me.user_id = ${userExpr} AND me.entry_date = ${dateExpr} AND me.status IN ('taken', 'prn_taken') AND me.nutrients_snapshot IS NOT NULL), 0)`;
-}
-// One scaled row per (custom nutrient, dose) pair. Kept apart from the UNION wrapper below
-// because the daily-summary query needs the supplement contribution on its own, not merged
-// into the food rows, and the two must not drift: a second copy of this SELECT is a second
-// place for the status filter or the dose clamp to be wrong.
-function supplementCustomRows(userExpr: string, dateExpr: string): string {
-  return `
-                SELECT key, public.sf_try_numeric(value) * GREATEST(COALESCE(me2.dose_amount_snapshot, 1), 0) AS scaled
-                FROM medication_entries me2
-                CROSS JOIN LATERAL jsonb_each_text(me2.nutrients_snapshot->'custom_nutrients')
-                WHERE me2.user_id = ${userExpr} AND me2.entry_date = ${dateExpr} AND me2.status IN ('taken', 'prn_taken') AND me2.nutrients_snapshot IS NOT NULL`;
-}
-function supplementCustomUnion(userExpr: string, dateExpr: string): string {
-  return `
-                UNION ALL${supplementCustomRows(userExpr, dateExpr)}`;
-}
-// The same rows aggregated by nutrient name and with no food arm, for the supplement-only
-// totals the Diary needs. Empty object rather than NULL on a day with no doses, so callers
-// can iterate unconditionally.
-function supplementCustomTotals(userExpr: string, dateExpr: string): string {
-  return `COALESCE(
-          (
-            SELECT jsonb_object_agg(key, value)
-            FROM (
-              SELECT key, SUM(scaled) AS value
-              FROM (${supplementCustomRows(userExpr, dateExpr)}
-              ) supplement_custom
-              GROUP BY key
-            ) supplement_custom_agg
-          ),
-          '{}'::jsonb
-        )`;
-}
-
 /**
  * The supplement arm of a day's intake, on its own.
  *
@@ -286,15 +248,32 @@ function supplementCustomTotals(userExpr: string, dateExpr: string): string {
  * the B vitamins reach the client through `custom_nutrients` or not at all. This endpoint
  * carried none of them until #2145; `getDailyNutritionSummary` already unions them into
  * its food totals, but the Diary does not call that.
+ *
+ * Unlike the callers that add a supplement total onto a food SUM, this one has no food arm
+ * to correlate against, so the seventeen fields are summed in a single pass over the day's
+ * doses rather than as seventeen scalar subqueries that each rescan the same rows. The
+ * outer COALESCE is what the per-subquery COALESCE used to do: with no GROUP BY the inner
+ * aggregate still yields exactly one row on a day with no doses, but a row of NULLs.
  */
 async function getDailySupplementTotals(userId: string, date: string) {
   const client = await getClient(userId);
   try {
+    const sums = FOOD_VARIANT_NUTRIENT_FIELDS.map(
+      (field) => `${supplementFixedSum(field, 'me')} AS ${field}`
+    ).join(',\n          ');
     const selects = FOOD_VARIANT_NUTRIENT_FIELDS.map(
-      (field) => `${supplementFixed(field, '$1', '$2')} AS ${field}`
+      (field) => `COALESCE(supplement_fixed.${field}, 0) AS ${field}`
     ).join(',\n        ');
     const result = await client.query(
-      `SELECT\n        ${selects},\n        ${supplementCustomTotals('$1', '$2')} AS custom_nutrients`,
+      `SELECT
+        ${selects},
+        ${supplementCustomTotals('$1', '$2')} AS custom_nutrients
+      FROM (
+        SELECT
+          ${sums}
+        FROM medication_entries me
+        WHERE ${supplementScanWhere('me', '$1', '$2')}
+      ) supplement_fixed`,
       [userId, date]
     );
     const row = result.rows[0] ?? {};
@@ -398,8 +377,7 @@ async function getDailyNutritionSummariesByDates(
          SELECT DISTINCT user_id, entry_date
            FROM medication_entries
           WHERE user_id = $1 AND entry_date = ANY($2::date[])
-            AND status IN ('taken', 'prn_taken')
-            AND nutrients_snapshot IS NOT NULL
+            AND ${supplementCountable('')}
        ) d
        LEFT JOIN food_entries fe
               ON fe.user_id = d.user_id AND fe.entry_date = d.entry_date

--- a/SparkyFitnessServer/models/foodMisc.ts
+++ b/SparkyFitnessServer/models/foodMisc.ts
@@ -4,9 +4,9 @@ import type { FoodVariantNutrientField } from '@workspace/shared';
 import type { FoodEntrySnapshot } from '../types/nutrition.js';
 import {
   supplementScanWhere,
-  supplementFixedSum,
+  supplementFixedAgg,
   supplementCountable,
-  supplementFixed,
+  supplementFixedSubquery,
   supplementCustomUnion,
   supplementCustomTotals,
 } from './supplementSql.js';
@@ -238,7 +238,7 @@ async function removeFoodFavorite(userId: string, foodId: string) {
  * food rows the user can see.
  *
  * Fields are `FOOD_VARIANT_NUTRIENT_FIELDS`, the same list `reportRepository` applies
- * `supplementFixed` to for the range query and the same fixed fields the Diary's summary
+ * `supplementFixedSubquery` to for the range query and the same fixed fields the Diary's summary
  * card can render. This selected only the five macro fields until #2145, which is how a
  * supplement's calcium reached Reports but not the Diary card beside it. Returns zeros
  * rather than nulls on a day with no supplements, so callers can add unconditionally.
@@ -259,7 +259,7 @@ async function getDailySupplementTotals(userId: string, date: string) {
   const client = await getClient(userId);
   try {
     const sums = FOOD_VARIANT_NUTRIENT_FIELDS.map(
-      (field) => `${supplementFixedSum(field, 'me')} AS ${field}`
+      (field) => `${supplementFixedAgg(field, 'me')} AS ${field}`
     ).join(',\n          ');
     const selects = FOOD_VARIANT_NUTRIENT_FIELDS.map(
       (field) => `COALESCE(supplement_fixed.${field}, 0) AS ${field}`
@@ -304,11 +304,11 @@ async function getDailyNutritionSummary(userId: string, date: string) {
   try {
     const result = await client.query(
       `SELECT
-        COALESCE(SUM(fe.calories * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed('calories', '$1', '$2')} AS total_calories,
-        COALESCE(SUM(fe.protein * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed('protein', '$1', '$2')} AS total_protein,
-        COALESCE(SUM(fe.carbs * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed('carbs', '$1', '$2')} AS total_carbs,
-        COALESCE(SUM(fe.fat * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed('fat', '$1', '$2')} AS total_fat,
-        COALESCE(SUM(fe.dietary_fiber * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed('dietary_fiber', '$1', '$2')} AS total_dietary_fiber,
+        COALESCE(SUM(fe.calories * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery('calories', '$1', '$2')} AS total_calories,
+        COALESCE(SUM(fe.protein * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery('protein', '$1', '$2')} AS total_protein,
+        COALESCE(SUM(fe.carbs * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery('carbs', '$1', '$2')} AS total_carbs,
+        COALESCE(SUM(fe.fat * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery('fat', '$1', '$2')} AS total_fat,
+        COALESCE(SUM(fe.dietary_fiber * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery('dietary_fiber', '$1', '$2')} AS total_dietary_fiber,
         COALESCE(
           (
             SELECT jsonb_object_agg(key, value)
@@ -348,11 +348,11 @@ async function getDailyNutritionSummariesByDates(
     const result = await client.query(
       `SELECT
         d.entry_date,
-        COALESCE(SUM(fe.calories * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed('calories', 'd.user_id', 'd.entry_date')} AS total_calories,
-        COALESCE(SUM(fe.protein * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed('protein', 'd.user_id', 'd.entry_date')} AS total_protein,
-        COALESCE(SUM(fe.carbs * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed('carbs', 'd.user_id', 'd.entry_date')} AS total_carbs,
-        COALESCE(SUM(fe.fat * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed('fat', 'd.user_id', 'd.entry_date')} AS total_fat,
-        COALESCE(SUM(fe.dietary_fiber * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed('dietary_fiber', 'd.user_id', 'd.entry_date')} AS total_dietary_fiber,
+        COALESCE(SUM(fe.calories * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery('calories', 'd.user_id', 'd.entry_date')} AS total_calories,
+        COALESCE(SUM(fe.protein * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery('protein', 'd.user_id', 'd.entry_date')} AS total_protein,
+        COALESCE(SUM(fe.carbs * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery('carbs', 'd.user_id', 'd.entry_date')} AS total_carbs,
+        COALESCE(SUM(fe.fat * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery('fat', 'd.user_id', 'd.entry_date')} AS total_fat,
+        COALESCE(SUM(fe.dietary_fiber * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery('dietary_fiber', 'd.user_id', 'd.entry_date')} AS total_dietary_fiber,
         COALESCE(
           (
             SELECT jsonb_object_agg(key, value)
@@ -374,10 +374,10 @@ async function getDailyNutritionSummariesByDates(
            FROM food_entries
           WHERE user_id = $1 AND entry_date = ANY($2::date[])
          UNION
-         SELECT DISTINCT user_id, entry_date
-           FROM medication_entries
-          WHERE user_id = $1 AND entry_date = ANY($2::date[])
-            AND ${supplementCountable('')}
+         SELECT DISTINCT me.user_id, me.entry_date
+           FROM medication_entries me
+          WHERE me.user_id = $1 AND me.entry_date = ANY($2::date[])
+            AND ${supplementCountable('me')}
        ) d
        LEFT JOIN food_entries fe
               ON fe.user_id = d.user_id AND fe.entry_date = d.entry_date

--- a/SparkyFitnessServer/models/reportRepository.ts
+++ b/SparkyFitnessServer/models/reportRepository.ts
@@ -4,7 +4,7 @@ import { getClient } from '../db/poolManager.js';
 import {
   doseScale,
   supplementCountable,
-  supplementFixed,
+  supplementFixedSubquery,
 } from './supplementSql.js';
 async function getNutritionData(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -650,7 +650,7 @@ async function getDailyNutritionTotalsRange(
     // disappearing from the range.
     const rangeSelects = RANGE_COLS.map(
       ([col, alias]) =>
-        `COALESCE(SUM(fe.${col} * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed(col, '$1', 'd.entry_date')} as ${alias}`
+        `COALESCE(SUM(fe.${col} * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixedSubquery(col, '$1', 'd.entry_date')} as ${alias}`
     ).join(',\n              ');
     const result = await client.query(
       `SELECT d.entry_date,
@@ -660,10 +660,10 @@ async function getDailyNutritionTotalsRange(
            FROM food_entries
           WHERE user_id = $1 AND entry_date BETWEEN $2 AND $3
          UNION
-         SELECT DISTINCT entry_date
-           FROM medication_entries
-          WHERE user_id = $1 AND entry_date BETWEEN $2 AND $3
-            AND ${supplementCountable('')}
+         SELECT DISTINCT me.entry_date
+           FROM medication_entries me
+          WHERE me.user_id = $1 AND me.entry_date BETWEEN $2 AND $3
+            AND ${supplementCountable('me')}
        ) d
        LEFT JOIN food_entries fe
               ON fe.user_id = $1 AND fe.entry_date = d.entry_date

--- a/SparkyFitnessServer/models/reportRepository.ts
+++ b/SparkyFitnessServer/models/reportRepository.ts
@@ -1,4 +1,5 @@
 import { FOOD_VARIANT_NUTRIENT_FIELDS } from '@workspace/shared';
+import type { FoodVariantNutrientField } from '@workspace/shared';
 import { getClient } from '../db/poolManager.js';
 async function getNutritionData(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -612,6 +613,22 @@ async function getExerciseNames(userId: any, muscle: any, equipment: any) {
     client.release();
   }
 }
+// The range query's output names differ from the column names for exactly two fields, and
+// its consumers read the aliases (foodTools reads row.fiber and row.sugar). Anything without
+// an entry here is aliased to itself.
+const RANGE_COL_ALIASES: Partial<Record<FoodVariantNutrientField, string>> = {
+  dietary_fiber: 'fiber',
+  sugars: 'sugar',
+};
+// Derived rather than hand-listed: this was a second copy of the seventeen fields with
+// nothing enforcing that it stayed in step, so a field added to the shared list would have
+// silently dropped out of trends and the chatbot's nutrition rows.
+const RANGE_COLS: [FoodVariantNutrientField, string][] =
+  FOOD_VARIANT_NUTRIENT_FIELDS.map((col) => [
+    col,
+    RANGE_COL_ALIASES[col] ?? col,
+  ]);
+
 // Per-day nutrition totals (macros + micros) over a date range, scaled by
 // quantity / serving_size since food_entries snapshots store unscaled
 // per-serving values. Backs the chatbot get_nutritional_summary action and
@@ -623,38 +640,16 @@ async function getDailyNutritionTotalsRange(
 ) {
   const client = await getClient(userId);
   try {
-    // Same fixed nutrient columns the query already reports, paired with the output alias
-    // (dietary_fiber -> fiber, sugars -> sugar). Each food SUM gets its dose-scaled
-    // supplement contribution for that date added, so trends include supplements too.
-    // The date set is the UNION of food and taken-supplement dates, so a day with only
-    // supplements logged still yields a row rather than disappearing from the range.
-    const rangeCols: [string, string][] = [
-      ['calories', 'calories'],
-      ['protein', 'protein'],
-      ['carbs', 'carbs'],
-      ['fat', 'fat'],
-      ['saturated_fat', 'saturated_fat'],
-      ['polyunsaturated_fat', 'polyunsaturated_fat'],
-      ['monounsaturated_fat', 'monounsaturated_fat'],
-      ['trans_fat', 'trans_fat'],
-      ['cholesterol', 'cholesterol'],
-      ['sodium', 'sodium'],
-      ['potassium', 'potassium'],
-      ['dietary_fiber', 'fiber'],
-      ['sugars', 'sugar'],
-      ['vitamin_a', 'vitamin_a'],
-      ['vitamin_c', 'vitamin_c'],
-      ['calcium', 'calcium'],
-      ['iron', 'iron'],
-    ];
+    // Each food SUM gets its dose-scaled supplement contribution for that date added, so
+    // trends include supplements too. The date set is the UNION of food and taken-supplement
+    // dates, so a day with only supplements logged still yields a row rather than
+    // disappearing from the range.
     const supplementFixed = (key: string) =>
       `COALESCE((SELECT SUM(public.sf_try_numeric(me.nutrients_snapshot->>'${key}') * GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)) FROM medication_entries me WHERE me.user_id = $1 AND me.entry_date = d.entry_date AND me.status IN ('taken', 'prn_taken') AND me.nutrients_snapshot IS NOT NULL), 0)`;
-    const rangeSelects = rangeCols
-      .map(
-        ([col, alias]) =>
-          `COALESCE(SUM(fe.${col} * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed(col)} as ${alias}`
-      )
-      .join(',\n              ');
+    const rangeSelects = RANGE_COLS.map(
+      ([col, alias]) =>
+        `COALESCE(SUM(fe.${col} * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed(col)} as ${alias}`
+    ).join(',\n              ');
     const result = await client.query(
       `SELECT d.entry_date,
               ${rangeSelects}

--- a/SparkyFitnessServer/models/reportRepository.ts
+++ b/SparkyFitnessServer/models/reportRepository.ts
@@ -1,6 +1,11 @@
 import { FOOD_VARIANT_NUTRIENT_FIELDS } from '@workspace/shared';
 import type { FoodVariantNutrientField } from '@workspace/shared';
 import { getClient } from '../db/poolManager.js';
+import {
+  doseScale,
+  supplementCountable,
+  supplementFixed,
+} from './supplementSql.js';
 async function getNutritionData(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   userId: any,
@@ -57,13 +62,13 @@ async function getNutritionData(
     // malformed JSONB value can't error the whole query.
     const standardNutrientsSelectSupplement = FOOD_VARIANT_NUTRIENT_FIELDS.map(
       (nutrient) =>
-        `(COALESCE(public.sf_try_numeric(me.nutrients_snapshot->>'${nutrient}'), 0) * GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)) AS ${nutrient}`
+        `(COALESCE(public.sf_try_numeric(me.nutrients_snapshot->>'${nutrient}'), 0) * ${doseScale('me')}) AS ${nutrient}`
     ).join(',\n           ');
     const customNutrientsSelectSupplement = customNutrients
       .map((cn) => {
         const ident = cn.name.replace(/"/g, '""');
         const lit = cn.name.replace(/'/g, "''");
-        return `(COALESCE(public.sf_try_numeric(me.nutrients_snapshot->'custom_nutrients'->>'${lit}'), 0) * GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)) AS "${ident}"`;
+        return `(COALESCE(public.sf_try_numeric(me.nutrients_snapshot->'custom_nutrients'->>'${lit}'), 0) * ${doseScale('me')}) AS "${ident}"`;
       })
       .join(',\n           ');
     const result = await client.query(
@@ -112,8 +117,7 @@ async function getNutritionData(
          FROM medication_entries me
          WHERE me.user_id = $1
            AND me.entry_date BETWEEN $2 AND $3
-           AND me.status IN ('taken', 'prn_taken')
-           AND me.nutrients_snapshot IS NOT NULL
+           AND ${supplementCountable('me')}
        ) AS combined_nutrition
        GROUP BY entry_date
        ORDER BY entry_date`,
@@ -644,11 +648,9 @@ async function getDailyNutritionTotalsRange(
     // trends include supplements too. The date set is the UNION of food and taken-supplement
     // dates, so a day with only supplements logged still yields a row rather than
     // disappearing from the range.
-    const supplementFixed = (key: string) =>
-      `COALESCE((SELECT SUM(public.sf_try_numeric(me.nutrients_snapshot->>'${key}') * GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)) FROM medication_entries me WHERE me.user_id = $1 AND me.entry_date = d.entry_date AND me.status IN ('taken', 'prn_taken') AND me.nutrients_snapshot IS NOT NULL), 0)`;
     const rangeSelects = RANGE_COLS.map(
       ([col, alias]) =>
-        `COALESCE(SUM(fe.${col} * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed(col)} as ${alias}`
+        `COALESCE(SUM(fe.${col} * fe.quantity / NULLIF(fe.serving_size, 0)), 0) + ${supplementFixed(col, '$1', 'd.entry_date')} as ${alias}`
     ).join(',\n              ');
     const result = await client.query(
       `SELECT d.entry_date,
@@ -661,8 +663,7 @@ async function getDailyNutritionTotalsRange(
          SELECT DISTINCT entry_date
            FROM medication_entries
           WHERE user_id = $1 AND entry_date BETWEEN $2 AND $3
-            AND status IN ('taken', 'prn_taken')
-            AND nutrients_snapshot IS NOT NULL
+            AND ${supplementCountable('')}
        ) d
        LEFT JOIN food_entries fe
               ON fe.user_id = $1 AND fe.entry_date = d.entry_date

--- a/SparkyFitnessServer/models/supplementSql.ts
+++ b/SparkyFitnessServer/models/supplementSql.ts
@@ -1,3 +1,5 @@
+import type { FoodVariantNutrientField } from '@workspace/shared';
+
 /**
  * SQL fragments for the supplement arm of a day's nutrition.
  *
@@ -49,7 +51,10 @@ function doseScale(alias: string): string {
  * total that is quietly low rather than as an error.
  */
 function supplementCountable(alias: string): string {
-  return `${alias}.status IN ('taken', 'prn_taken') AND ${alias}.nutrients_snapshot IS NOT NULL`;
+  // Parenthesised so the fragment means the same thing wherever it lands. Every caller
+  // today drops it into a flat AND chain, where bare `A AND B` is fine, but the first one
+  // to put it in an OR arm would get `x OR A AND B` and silently lose the second half.
+  return `(${alias}.status IN ('taken', 'prn_taken') AND ${alias}.nutrients_snapshot IS NOT NULL)`;
 }
 
 /** The full row filter for a single-date read: this user, this date, and countable. */
@@ -65,7 +70,10 @@ function supplementScanWhere(
  * The dose-scaled sum of one fixed nutrient field as a bare aggregate, for a caller that
  * supplies its own single `FROM medication_entries` scan and its own WHERE.
  */
-function supplementFixedAgg(key: string, alias: string): string {
+function supplementFixedAgg(
+  key: FoodVariantNutrientField,
+  alias: string
+): string {
   return `SUM(public.sf_try_numeric(${alias}.nutrients_snapshot->>'${key}') * ${doseScale(alias)})`;
 }
 
@@ -76,7 +84,7 @@ function supplementFixedAgg(key: string, alias: string): string {
  * unconditionally.
  */
 function supplementFixedSubquery(
-  key: string,
+  key: FoodVariantNutrientField,
   userExpr: string,
   dateExpr: string
 ): string {

--- a/SparkyFitnessServer/models/supplementSql.ts
+++ b/SparkyFitnessServer/models/supplementSql.ts
@@ -2,25 +2,25 @@
  * SQL fragments for the supplement arm of a day's nutrition.
  *
  * A logged supplement contributes its immutable per-entry `nutrients_snapshot`, scaled by
- * the dose count taken. Three model queries need that contribution — the Diary's
+ * the dose count taken. Several model queries need that contribution — the Diary's
  * supplement-only totals and its combined food+supplement summary (both `foodMisc.ts`),
- * and the range query behind trends and the chatbot (`reportRepository.ts`) — and until
- * this module they each spelled it out. Two copies had already drifted in shape while
- * agreeing in meaning, which is one edit away from disagreeing in meaning: the status
- * filter and the dose clamp are the parts that must never differ between them, since
- * either one being wrong in one place shows up as a plausible number rather than an error.
+ * and the reports and range queries (`reportRepository.ts`) — and until this module they
+ * each spelled it out. The copies had already drifted in shape while agreeing in meaning,
+ * which is one edit away from disagreeing in meaning: the status filter and the dose clamp
+ * are the parts that must never differ, since either one being wrong in one place shows up
+ * as a plausible number rather than an error.
  *
  * `userExpr` / `dateExpr` are the SQL expressions to correlate on, so a caller can bind
  * params ($1/$2) for a single-date query or reference grouped columns (`d.user_id`,
- * `d.entry_date`) for a per-date one. `alias` is the `medication_entries` alias in scope;
- * the fixed and custom fragments appear in the same statement and so cannot share one. Pass
- * an empty alias where the query selects from the bare table.
+ * `d.entry_date`) for a per-date one.
+ *
+ * `alias` is the `medication_entries` alias in the caller's own scope, and it is required:
+ * the fixed and custom fragments can appear in one statement and so cannot share an alias.
+ * Fragments that open their own scan use `sup_me` / `sup_me2` rather than the conventional
+ * `me`, so that a caller correlating on its own `me` cannot have the inner alias shadow the
+ * outer one. That shadowing would turn the correlation into `me.user_id = me.user_id`: a
+ * tautology that runs clean and silently sums the user's entire history.
  */
-
-/** `me.entry_date`, or plain `entry_date` when no alias is in scope. */
-function col(alias: string, name: string): string {
-  return alias ? `${alias}.${name}` : name;
-}
 
 /**
  * How many doses a `medication_entries` row counts for. Missing means one; non-positive
@@ -28,10 +28,10 @@ function col(alias: string, name: string): string {
  *
  * Exported on its own because `getNutritionData` scales per row before summing while the
  * daily aggregations sum the scaled products, so those two cannot share a whole expression
- * — but they must not disagree about what a dose count means.
+ * but must not disagree about what a dose count means.
  */
 function doseScale(alias: string): string {
-  return `GREATEST(COALESCE(${col(alias, 'dose_amount_snapshot')}, 1), 0)`;
+  return `GREATEST(COALESCE(${alias}.dose_amount_snapshot, 1), 0)`;
 }
 
 /**
@@ -40,58 +40,55 @@ function doseScale(alias: string): string {
  * differs between them (one day, or a range), which is why it is not folded in here.
  *
  * Shared rather than repeated because adding a status that should count is otherwise a
- * five-site edit with nothing to catch the site you miss — and missing one shows up as a
- * total that is quietly low, not as an error.
+ * five-site edit with nothing to catch the site you miss, and missing one shows up as a
+ * total that is quietly low rather than as an error.
  */
 function supplementCountable(alias: string): string {
-  return `${col(alias, 'status')} IN ('taken', 'prn_taken') AND ${col(alias, 'nutrients_snapshot')} IS NOT NULL`;
+  return `${alias}.status IN ('taken', 'prn_taken') AND ${alias}.nutrients_snapshot IS NOT NULL`;
 }
 
-/**
- * The full row filter for a single-date read: this user, this date, and countable.
- */
+/** The full row filter for a single-date read: this user, this date, and countable. */
 function supplementScanWhere(
   alias: string,
   userExpr: string,
   dateExpr: string
 ): string {
-  return `${col(alias, 'user_id')} = ${userExpr} AND ${col(alias, 'entry_date')} = ${dateExpr} AND ${supplementCountable(alias)}`;
+  return `${alias}.user_id = ${userExpr} AND ${alias}.entry_date = ${dateExpr} AND ${supplementCountable(alias)}`;
 }
 
 /**
- * The dose-scaled sum of one fixed nutrient field, as an aggregate over rows already
- * filtered by `supplementScanWhere`. Use this when the caller supplies its own single
- * `FROM medication_entries` scan; use `supplementFixed` when it needs a self-contained
- * scalar expression.
+ * The dose-scaled sum of one fixed nutrient field as a bare aggregate, for a caller that
+ * supplies its own single `FROM medication_entries` scan and its own WHERE.
  */
-function supplementFixedSum(key: string, alias: string): string {
+function supplementFixedAgg(key: string, alias: string): string {
   return `SUM(public.sf_try_numeric(${alias}.nutrients_snapshot->>'${key}') * ${doseScale(alias)})`;
 }
 
 /**
  * The dose-scaled total of one fixed nutrient field as a self-contained scalar subquery,
- * for callers adding it onto a food SUM in a grouped query. Zero rather than NULL on a day
- * with no doses, so it can be added unconditionally.
+ * for callers adding it onto a food SUM in a grouped query. Opens its own scan, so it needs
+ * no scan from the caller. Zero rather than NULL on a day with no doses, so it can be added
+ * unconditionally.
  */
-function supplementFixed(
+function supplementFixedSubquery(
   key: string,
   userExpr: string,
   dateExpr: string
 ): string {
-  return `COALESCE((SELECT ${supplementFixedSum(key, 'me')} FROM medication_entries me WHERE ${supplementScanWhere('me', userExpr, dateExpr)}), 0)`;
+  return `COALESCE((SELECT ${supplementFixedAgg(key, 'sup_me')} FROM medication_entries sup_me WHERE ${supplementScanWhere('sup_me', userExpr, dateExpr)}), 0)`;
 }
 
 /**
  * One scaled row per (custom nutrient, dose) pair. Kept apart from the UNION wrapper below
  * because the daily-summary query needs the supplement contribution on its own, not merged
- * into the food rows.
+ * into the food rows. Opens its own scan, hence its own unshadowable alias.
  */
 function supplementCustomRows(userExpr: string, dateExpr: string): string {
   return `
-                SELECT key, public.sf_try_numeric(value) * ${doseScale('me2')} AS scaled
-                FROM medication_entries me2
-                CROSS JOIN LATERAL jsonb_each_text(me2.nutrients_snapshot->'custom_nutrients')
-                WHERE ${supplementScanWhere('me2', userExpr, dateExpr)}`;
+                SELECT key, public.sf_try_numeric(value) * ${doseScale('sup_me2')} AS scaled
+                FROM medication_entries sup_me2
+                CROSS JOIN LATERAL jsonb_each_text(sup_me2.nutrients_snapshot->'custom_nutrients')
+                WHERE ${supplementScanWhere('sup_me2', userExpr, dateExpr)}`;
 }
 
 /** The same rows as an arm of a food query's custom-nutrient UNION. */
@@ -124,9 +121,8 @@ export {
   doseScale,
   supplementCountable,
   supplementScanWhere,
-  supplementFixedSum,
-  supplementFixed,
-  supplementCustomRows,
+  supplementFixedAgg,
+  supplementFixedSubquery,
   supplementCustomUnion,
   supplementCustomTotals,
 };

--- a/SparkyFitnessServer/models/supplementSql.ts
+++ b/SparkyFitnessServer/models/supplementSql.ts
@@ -1,0 +1,132 @@
+/**
+ * SQL fragments for the supplement arm of a day's nutrition.
+ *
+ * A logged supplement contributes its immutable per-entry `nutrients_snapshot`, scaled by
+ * the dose count taken. Three model queries need that contribution — the Diary's
+ * supplement-only totals and its combined food+supplement summary (both `foodMisc.ts`),
+ * and the range query behind trends and the chatbot (`reportRepository.ts`) — and until
+ * this module they each spelled it out. Two copies had already drifted in shape while
+ * agreeing in meaning, which is one edit away from disagreeing in meaning: the status
+ * filter and the dose clamp are the parts that must never differ between them, since
+ * either one being wrong in one place shows up as a plausible number rather than an error.
+ *
+ * `userExpr` / `dateExpr` are the SQL expressions to correlate on, so a caller can bind
+ * params ($1/$2) for a single-date query or reference grouped columns (`d.user_id`,
+ * `d.entry_date`) for a per-date one. `alias` is the `medication_entries` alias in scope;
+ * the fixed and custom fragments appear in the same statement and so cannot share one. Pass
+ * an empty alias where the query selects from the bare table.
+ */
+
+/** `me.entry_date`, or plain `entry_date` when no alias is in scope. */
+function col(alias: string, name: string): string {
+  return alias ? `${alias}.${name}` : name;
+}
+
+/**
+ * How many doses a `medication_entries` row counts for. Missing means one; non-positive
+ * clamps to zero so a bad snapshot can only fail to add, never subtract from a total.
+ *
+ * Exported on its own because `getNutritionData` scales per row before summing while the
+ * daily aggregations sum the scaled products, so those two cannot share a whole expression
+ * — but they must not disagree about what a dose count means.
+ */
+function doseScale(alias: string): string {
+  return `GREATEST(COALESCE(${col(alias, 'dose_amount_snapshot')}, 1), 0)`;
+}
+
+/**
+ * Which `medication_entries` rows count toward nutrition at all: a dose the user actually
+ * took, carrying a snapshot to read. Every read applies this; only the date predicate
+ * differs between them (one day, or a range), which is why it is not folded in here.
+ *
+ * Shared rather than repeated because adding a status that should count is otherwise a
+ * five-site edit with nothing to catch the site you miss — and missing one shows up as a
+ * total that is quietly low, not as an error.
+ */
+function supplementCountable(alias: string): string {
+  return `${col(alias, 'status')} IN ('taken', 'prn_taken') AND ${col(alias, 'nutrients_snapshot')} IS NOT NULL`;
+}
+
+/**
+ * The full row filter for a single-date read: this user, this date, and countable.
+ */
+function supplementScanWhere(
+  alias: string,
+  userExpr: string,
+  dateExpr: string
+): string {
+  return `${col(alias, 'user_id')} = ${userExpr} AND ${col(alias, 'entry_date')} = ${dateExpr} AND ${supplementCountable(alias)}`;
+}
+
+/**
+ * The dose-scaled sum of one fixed nutrient field, as an aggregate over rows already
+ * filtered by `supplementScanWhere`. Use this when the caller supplies its own single
+ * `FROM medication_entries` scan; use `supplementFixed` when it needs a self-contained
+ * scalar expression.
+ */
+function supplementFixedSum(key: string, alias: string): string {
+  return `SUM(public.sf_try_numeric(${alias}.nutrients_snapshot->>'${key}') * ${doseScale(alias)})`;
+}
+
+/**
+ * The dose-scaled total of one fixed nutrient field as a self-contained scalar subquery,
+ * for callers adding it onto a food SUM in a grouped query. Zero rather than NULL on a day
+ * with no doses, so it can be added unconditionally.
+ */
+function supplementFixed(
+  key: string,
+  userExpr: string,
+  dateExpr: string
+): string {
+  return `COALESCE((SELECT ${supplementFixedSum(key, 'me')} FROM medication_entries me WHERE ${supplementScanWhere('me', userExpr, dateExpr)}), 0)`;
+}
+
+/**
+ * One scaled row per (custom nutrient, dose) pair. Kept apart from the UNION wrapper below
+ * because the daily-summary query needs the supplement contribution on its own, not merged
+ * into the food rows.
+ */
+function supplementCustomRows(userExpr: string, dateExpr: string): string {
+  return `
+                SELECT key, public.sf_try_numeric(value) * ${doseScale('me2')} AS scaled
+                FROM medication_entries me2
+                CROSS JOIN LATERAL jsonb_each_text(me2.nutrients_snapshot->'custom_nutrients')
+                WHERE ${supplementScanWhere('me2', userExpr, dateExpr)}`;
+}
+
+/** The same rows as an arm of a food query's custom-nutrient UNION. */
+function supplementCustomUnion(userExpr: string, dateExpr: string): string {
+  return `
+                UNION ALL${supplementCustomRows(userExpr, dateExpr)}`;
+}
+
+/**
+ * The same rows aggregated by nutrient name and with no food arm, for the supplement-only
+ * totals the Diary needs. Empty object rather than NULL on a day with no doses, so callers
+ * can iterate unconditionally.
+ */
+function supplementCustomTotals(userExpr: string, dateExpr: string): string {
+  return `COALESCE(
+          (
+            SELECT jsonb_object_agg(key, value)
+            FROM (
+              SELECT key, SUM(scaled) AS value
+              FROM (${supplementCustomRows(userExpr, dateExpr)}
+              ) supplement_custom
+              GROUP BY key
+            ) supplement_custom_agg
+          ),
+          '{}'::jsonb
+        )`;
+}
+
+export {
+  doseScale,
+  supplementCountable,
+  supplementScanWhere,
+  supplementFixedSum,
+  supplementFixed,
+  supplementCustomRows,
+  supplementCustomUnion,
+  supplementCustomTotals,
+};

--- a/SparkyFitnessServer/models/supplementSql.ts
+++ b/SparkyFitnessServer/models/supplementSql.ts
@@ -20,6 +20,11 @@
  * `me`, so that a caller correlating on its own `me` cannot have the inner alias shadow the
  * outer one. That shadowing would turn the correlation into `me.user_id = me.user_id`: a
  * tautology that runs clean and silently sums the user's entire history.
+ *
+ * `sup_me` and `sup_me2` are therefore RESERVED. A caller must not alias its own table with
+ * either, and must not pass a `userExpr` / `dateExpr` qualified by one, since the same
+ * shadowing returns. Nothing in the type system prevents it; the names are deliberately
+ * unlike anything a caller would reach for.
  */
 
 /**

--- a/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
+++ b/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
@@ -136,9 +136,18 @@ describe('getDailySupplementTotals', () => {
     expect(sql).toContain('AS custom_nutrients');
     // Same status filter and dose clamp as the fixed arm, because the custom rows are the
     // shared fragment rather than a second copy that could drift from it.
-    expect(sql).toMatch(/\w+\.status IN \('taken', 'prn_taken'\)/);
-    expect(sql).toMatch(
-      /GREATEST\(COALESCE\(\w+\.dose_amount_snapshot, 1\), 0\)/
+    //
+    // Asserted against the CUSTOM scan's own alias, derived from the query. This statement
+    // holds two scans, so a bare /\w+\.status IN .../ is satisfied by the fixed one and
+    // stays green even when the custom fragment loses its filter entirely. Deriving the
+    // alias keeps the assertion pinned to the right scan without hardcoding its name.
+    const customAlias = sql.match(
+      /FROM medication_entries (\w+)\s+CROSS JOIN LATERAL jsonb_each_text/
+    )?.[1];
+    expect(customAlias, 'could not find the custom-nutrient scan').toBeTruthy();
+    expect(sql).toContain(`${customAlias}.status IN ('taken', 'prn_taken')`);
+    expect(sql).toContain(
+      `GREATEST(COALESCE(${customAlias}.dose_amount_snapshot, 1), 0)`
     );
     // Supplements alone. Unioning the food rows in here, the way getDailyNutritionSummary
     // does, would double-count every custom nutrient: callers add this arm onto totals

--- a/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
+++ b/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
@@ -39,8 +39,10 @@ describe('daily-total aggregations include supplement snapshots', () => {
     // Reads the immutable per-entry snapshot, restricted to taken/prn_taken entries, and
     // scales by the dose count (GREATEST-clamped so a non-positive value can't subtract).
     expect(sql).toContain('medication_entries');
-    expect(sql).toContain("me.status IN ('taken', 'prn_taken')");
-    expect(sql).toContain('GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)');
+    expect(sql).toMatch(/\w+\.status IN \('taken', 'prn_taken'\)/);
+    expect(sql).toMatch(
+      /GREATEST\(COALESCE\(\w+\.dose_amount_snapshot, 1\), 0\)/
+    );
     // Both the fixed macros and the custom-nutrient aggregation pull from the snapshot.
     expect(sql).toContain("nutrients_snapshot->>'calories'");
     expect(sql).toContain("nutrients_snapshot->'custom_nutrients'");
@@ -80,7 +82,9 @@ describe('daily-total aggregations include supplement snapshots', () => {
     const sql = sqlOf();
     expect(sql).toContain('medication_entries');
     expect(sql).toContain("nutrients_snapshot->>'calories'");
-    expect(sql).toContain('GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)');
+    expect(sql).toMatch(
+      /GREATEST\(COALESCE\(\w+\.dose_amount_snapshot, 1\), 0\)/
+    );
   });
 });
 
@@ -99,8 +103,10 @@ describe('getDailySupplementTotals', () => {
     await getDailySupplementTotals(userId, '2026-08-06');
 
     const sql = String(mockClient.query.mock.calls[0][0]);
-    expect(sql).toContain("me.status IN ('taken', 'prn_taken')");
-    expect(sql).toContain('GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)');
+    expect(sql).toMatch(/\w+\.status IN \('taken', 'prn_taken'\)/);
+    expect(sql).toMatch(
+      /GREATEST\(COALESCE\(\w+\.dose_amount_snapshot, 1\), 0\)/
+    );
     // Exactly the fields the nutrition summary sums for supplements. Offering the picker
     // a field this query does not read would let a user enter a number that goes nowhere.
     for (const key of [
@@ -130,8 +136,10 @@ describe('getDailySupplementTotals', () => {
     expect(sql).toContain('AS custom_nutrients');
     // Same status filter and dose clamp as the fixed arm, because the custom rows are the
     // shared fragment rather than a second copy that could drift from it.
-    expect(sql).toContain("me2.status IN ('taken', 'prn_taken')");
-    expect(sql).toContain('GREATEST(COALESCE(me2.dose_amount_snapshot, 1), 0)');
+    expect(sql).toMatch(/\w+\.status IN \('taken', 'prn_taken'\)/);
+    expect(sql).toMatch(
+      /GREATEST\(COALESCE\(\w+\.dose_amount_snapshot, 1\), 0\)/
+    );
     // Supplements alone. Unioning the food rows in here, the way getDailyNutritionSummary
     // does, would double-count every custom nutrient: callers add this arm onto totals
     // they have already derived from food entries themselves.

--- a/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
+++ b/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
@@ -35,14 +35,41 @@ describe('daily-total aggregations include supplement snapshots', () => {
   afterEach(() => vi.clearAllMocks());
 
   const sqlOf = () => String(mockClient.query.mock.calls[0][0]);
+
+  // These statements contain MANY medication_entries scans: seventeen fixed-nutrient
+  // subqueries, a custom-nutrient scan, and the date-set arm. Asserting that the filter or
+  // the clamp appears *somewhere* in the string therefore proves almost nothing, because any
+  // one of the other scans satisfies it. Dropping the status predicate from a single
+  // nutrient leaves the other sixteen to keep such an assertion green while a skipped dose
+  // starts contributing that nutrient. So: split the statement into its scans and check
+  // every one of them.
+  // Matched as a UNIT, not by splitting on `FROM medication_entries`. The clamp and the
+  // snapshot read sit BEFORE the FROM, so a split would test each chunk against the NEXT
+  // subquery's expressions, and since the fixed subqueries all share one alias, a subquery
+  // that had lost its filter would be covered by its neighbour. The backreference (\1) also
+  // pins the read, the clamp and the scan to one alias.
+  const FIXED_SUBQUERY =
+    /\(SELECT SUM\(public\.sf_try_numeric\((\w+)\.nutrients_snapshot->>'(\w+)'\) \* GREATEST\(COALESCE\(\1\.dose_amount_snapshot, 1\), 0\)\) FROM medication_entries \1 WHERE (.+?)\), 0\)/g;
+
+  const expectEveryScanFiltered = (sql: string) => {
+    const matches = [...sql.matchAll(FIXED_SUBQUERY)];
+    // Every fixed snapshot read must belong to a subquery this regex actually matched,
+    // or one could slip past the loop below and be silently unchecked.
+    const reads = (sql.match(/nutrients_snapshot->>'/g) ?? []).length;
+    expect(matches.length, 'a fixed subquery escaped the check').toBe(reads);
+    expect(matches.length).toBeGreaterThan(0);
+    for (const [, alias, key, where] of matches) {
+      expect(where, `the ${key} subquery lost the status filter`).toContain(
+        `${alias}.status IN ('taken', 'prn_taken')`
+      );
+    }
+  };
+
   const expectSupplementArm = (sql: string) => {
     // Reads the immutable per-entry snapshot, restricted to taken/prn_taken entries, and
     // scales by the dose count (GREATEST-clamped so a non-positive value can't subtract).
     expect(sql).toContain('medication_entries');
-    expect(sql).toMatch(/\w+\.status IN \('taken', 'prn_taken'\)/);
-    expect(sql).toMatch(
-      /GREATEST\(COALESCE\(\w+\.dose_amount_snapshot, 1\), 0\)/
-    );
+    expectEveryScanFiltered(sql);
     // Both the fixed macros and the custom-nutrient aggregation pull from the snapshot.
     expect(sql).toContain("nutrients_snapshot->>'calories'");
     expect(sql).toContain("nutrients_snapshot->'custom_nutrients'");
@@ -51,9 +78,15 @@ describe('daily-total aggregations include supplement snapshots', () => {
   // A day on which the user logged only supplements must still produce a row. Both
   // queries therefore drive from the UNION of food and taken-supplement dates rather
   // than letting food_entries select the date set.
+  //
+  // Pinned to the driving arm specifically. Bare `toContain('UNION')` plus
+  // `toContain('FROM medication_entries')` is satisfied by the custom-nutrient subquery,
+  // which supplies its own UNION ALL and its own scan, so deleting the date-set arm
+  // outright left this green while a supplement-only day silently returned no row at all.
   const expectUnionDrivenDates = (sql: string) => {
-    expect(sql).toContain('UNION');
-    expect(sql).toContain('FROM medication_entries');
+    expect(sql).toMatch(
+      /\bUNION\s+SELECT DISTINCT[\s\S]{0,200}?FROM medication_entries/
+    );
     expect(sql).toContain('LEFT JOIN food_entries');
   };
 

--- a/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
+++ b/SparkyFitnessServer/tests/dailySummarySupplements.test.ts
@@ -83,9 +83,18 @@ describe('daily-total aggregations include supplement snapshots', () => {
   // `toContain('FROM medication_entries')` is satisfied by the custom-nutrient subquery,
   // which supplies its own UNION ALL and its own scan, so deleting the date-set arm
   // outright left this green while a supplement-only day silently returned no row at all.
+  //
+  // The arm must also select the date the dose was LOGGED FOR. Accepting any date
+  // expression lets `me.created_at::date AS entry_date` through, which groups a dose
+  // logged for the 19th but entered on the 20th under the wrong day, or drops it from a
+  // request for the 19th alone.
   const expectUnionDrivenDates = (sql: string) => {
-    expect(sql).toMatch(
-      /\bUNION\s+SELECT DISTINCT[\s\S]{0,200}?FROM medication_entries/
+    const arm = sql.match(
+      /\bUNION\s+(SELECT DISTINCT[\s\S]{0,200}?FROM medication_entries\s+\w+)/
+    )?.[1];
+    expect(arm, 'no supplement date arm drives the date set').toBeTruthy();
+    expect(arm).toMatch(
+      /SELECT DISTINCT (?:\w+\.user_id, )?\w+\.entry_date\s+FROM medication_entries/
     );
     expect(sql).toContain('LEFT JOIN food_entries');
   };
@@ -167,6 +176,13 @@ describe('getDailySupplementTotals', () => {
     expect(sql).toContain("nutrients_snapshot->'custom_nutrients'");
     expect(sql).toContain('jsonb_object_agg(key, value)');
     expect(sql).toContain('AS custom_nutrients');
+    // The aggregate this test is NAMED for. Asserting only that a JSON aggregation exists
+    // leaves the aggregation itself unchecked: swapping SUM(scaled) for MAX(scaled) keeps
+    // every other assertion green, and two magnesium doses of 100mg and 200mg would then
+    // report 200 instead of 300. The mock hands back an already-aggregated row, so no
+    // downstream test notices either.
+    expect(sql).toMatch(/SELECT key, SUM\(scaled\) AS value/);
+    expect(sql).toContain('GROUP BY key');
     // Same status filter and dose clamp as the fixed arm, because the custom rows are the
     // shared fragment rather than a second copy that could drift from it.
     //

--- a/SparkyFitnessServer/tests/reportRangeCols.test.ts
+++ b/SparkyFitnessServer/tests/reportRangeCols.test.ts
@@ -45,7 +45,15 @@ describe('getDailyNutritionTotalsRange select list', () => {
   it('emits one output column per shared nutrient field and no others', async () => {
     const sql = await sqlOf();
     const aliases = [...sql.matchAll(/\bas (\w+),?$/gim)].map((m) => m[1]);
-    expect(aliases).toHaveLength(FOOD_VARIANT_NUTRIENT_FIELDS.length);
+    // The NAMES, not just the count. Counting and de-duplicating alone accepts any renaming
+    // of any field: pointing `calories` at some other alias still leaves seventeen unique
+    // names, so the query would publish that name and no `calories` at all with this test
+    // green. Expected names are spelled out here rather than derived from the alias map
+    // under test, because a guard that imports the thing it guards proves nothing.
+    const expected = FOOD_VARIANT_NUTRIENT_FIELDS.map((field) =>
+      field === 'dietary_fiber' ? 'fiber' : field === 'sugars' ? 'sugar' : field
+    );
+    expect(aliases).toEqual(expected);
     expect(new Set(aliases).size).toBe(aliases.length);
   });
 

--- a/SparkyFitnessServer/tests/reportRangeCols.test.ts
+++ b/SparkyFitnessServer/tests/reportRangeCols.test.ts
@@ -1,0 +1,62 @@
+import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FOOD_VARIANT_NUTRIENT_FIELDS } from '@workspace/shared';
+import {
+  createMockDbClient,
+  type MockDbClient,
+} from './helpers/mockDbClient.js';
+import { v4 as uuidv4 } from 'uuid';
+import { getClient } from '../db/poolManager.js';
+import { getDailyNutritionTotalsRange } from '../models/reportRepository.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+}));
+
+// The range query's select list used to be a hand-written second copy of the shared nutrient
+// list. Nothing enforced that the two stayed in step, and the failure mode is silent: a field
+// added to FOOD_VARIANT_NUTRIENT_FIELDS but not to the copy just stops appearing in trends
+// and in the chatbot's nutrition rows, with no type error and no failing query.
+describe('getDailyNutritionTotalsRange select list', () => {
+  let mockClient: MockDbClient;
+  const userId = uuidv4();
+
+  beforeEach(() => {
+    mockClient = createMockDbClient([{}]);
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  const sqlOf = async () => {
+    await getDailyNutritionTotalsRange(userId, '2026-07-01', '2026-07-21');
+    return String(mockClient.query.mock.calls[0][0]);
+  };
+
+  it('selects every shared nutrient field, on both the food and supplement arms', async () => {
+    const sql = await sqlOf();
+    for (const field of FOOD_VARIANT_NUTRIENT_FIELDS) {
+      expect(sql, `food arm missing ${field}`).toContain(`SUM(fe.${field} *`);
+      expect(sql, `supplement arm missing ${field}`).toContain(
+        `nutrients_snapshot->>'${field}'`
+      );
+    }
+  });
+
+  it('emits one output column per shared nutrient field and no others', async () => {
+    const sql = await sqlOf();
+    const aliases = [...sql.matchAll(/\bas (\w+),?$/gm)].map((m) => m[1]);
+    expect(aliases).toHaveLength(FOOD_VARIANT_NUTRIENT_FIELDS.length);
+    expect(new Set(aliases).size).toBe(aliases.length);
+  });
+
+  // Two fields are published under a different name than their column, and the consumers read
+  // the alias: foodTools maps row.fiber and row.sugar. Renaming a column without carrying the
+  // alias would hand those consumers undefined, which they coerce to 0.
+  it('publishes dietary_fiber as fiber and sugars as sugar', async () => {
+    const sql = await sqlOf();
+    expect(sql).toMatch(/\bas fiber,?$/m);
+    expect(sql).toMatch(/\bas sugar,?$/m);
+    expect(sql).not.toMatch(/\bas dietary_fiber,?$/m);
+    expect(sql).not.toMatch(/\bas sugars,?$/m);
+  });
+});

--- a/SparkyFitnessServer/tests/reportRangeCols.test.ts
+++ b/SparkyFitnessServer/tests/reportRangeCols.test.ts
@@ -42,6 +42,35 @@ describe('getDailyNutritionTotalsRange select list', () => {
     }
   });
 
+  // Each output column must carry the nutrient it is NAMED for. Asserting the set of source
+  // expressions and the set of output names separately leaves them unbound: swapping the
+  // source columns of two fields while keeping their aliases preserves every token and every
+  // alias, so set-wise assertions all pass while `row.calories` returns protein grams and
+  // `row.protein` returns calories. Nothing downstream would notice; the numbers are just
+  // wrong. So pair them off the same line.
+  it('binds each source column to the output name it is published under', async () => {
+    const sql = await sqlOf();
+    const pairs = sql
+      .split('\n')
+      .filter((line) => /SUM\(fe\.\w+ \*/.test(line))
+      .map((line) => [
+        line.match(/SUM\(fe\.(\w+) \*/)?.[1],
+        line.match(/\bas (\w+),?\s*$/i)?.[1],
+        line.match(/nutrients_snapshot->>'(\w+)'/)?.[1],
+      ]);
+    expect(pairs).toEqual(
+      FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [
+        field,
+        field === 'dietary_fiber'
+          ? 'fiber'
+          : field === 'sugars'
+            ? 'sugar'
+            : field,
+        field,
+      ])
+    );
+  });
+
   it('emits one output column per shared nutrient field and no others', async () => {
     const sql = await sqlOf();
     const aliases = [...sql.matchAll(/\bas (\w+),?$/gim)].map((m) => m[1]);

--- a/SparkyFitnessServer/tests/reportRangeCols.test.ts
+++ b/SparkyFitnessServer/tests/reportRangeCols.test.ts
@@ -44,7 +44,7 @@ describe('getDailyNutritionTotalsRange select list', () => {
 
   it('emits one output column per shared nutrient field and no others', async () => {
     const sql = await sqlOf();
-    const aliases = [...sql.matchAll(/\bas (\w+),?$/gm)].map((m) => m[1]);
+    const aliases = [...sql.matchAll(/\bas (\w+),?$/gim)].map((m) => m[1]);
     expect(aliases).toHaveLength(FOOD_VARIANT_NUTRIENT_FIELDS.length);
     expect(new Set(aliases).size).toBe(aliases.length);
   });

--- a/SparkyFitnessServer/tests/reportRangeCols.test.ts
+++ b/SparkyFitnessServer/tests/reportRangeCols.test.ts
@@ -93,7 +93,7 @@ describe('getDailyNutritionTotalsRange select list', () => {
     const sql = await sqlOf();
     expect(sql).toMatch(/\bas fiber,?$/m);
     expect(sql).toMatch(/\bas sugar,?$/m);
-    expect(sql).not.toMatch(/\bas dietary_fiber,?$/m);
-    expect(sql).not.toMatch(/\bas sugars,?$/m);
+    expect(sql).not.toMatch(/\bas dietary_fiber,?$/im);
+    expect(sql).not.toMatch(/\bas sugars,?$/im);
   });
 });

--- a/SparkyFitnessServer/tests/supplementSqlDedup.test.ts
+++ b/SparkyFitnessServer/tests/supplementSqlDedup.test.ts
@@ -32,14 +32,18 @@ describe('the shared fragments correlate on what the caller passes', () => {
   // than one day. The alias is the only thing preventing it, so assert on it directly.
   it('does not shadow a caller that correlates on its own me', () => {
     const sql = supplementFixedSubquery('iron', 'me.user_id', 'me.entry_date');
-    expect(sql).toContain('FROM medication_entries sup_me');
-    expect(sql).toContain('sup_me.user_id = me.user_id');
-    expect(sql).toContain('sup_me.entry_date = me.entry_date');
+    // Derived, not hardcoded: the property that matters is that the inner alias differs
+    // from the caller's, not that it is spelled `sup_me`. Pinning the literal would reject
+    // a future rename that is equally safe while proving nothing extra.
+    const innerAlias = sql.match(/FROM medication_entries (\w+)/)?.[1];
+    expect(innerAlias, 'no inner scan found').toBeTruthy();
+    expect(innerAlias).not.toBe('me');
+    expect(sql).toContain(`${innerAlias}.user_id = me.user_id`);
+    expect(sql).toContain(`${innerAlias}.entry_date = me.entry_date`);
     // Boundary-anchored: a plain substring check would pass on `sup_me.user_id = me.user_id`
     // and assert nothing, since the correct string ends with the wrong one.
     expect(sql).not.toMatch(/(?<![\w.])me\.user_id = me\.user_id/);
     expect(sql).not.toMatch(/(?<![\w.])me\.entry_date = me\.entry_date/);
-    expect(sql).not.toMatch(/FROM medication_entries me(?![\w])/);
   });
 });
 

--- a/SparkyFitnessServer/tests/supplementSqlDedup.test.ts
+++ b/SparkyFitnessServer/tests/supplementSqlDedup.test.ts
@@ -1,5 +1,3 @@
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { FOOD_VARIANT_NUTRIENT_FIELDS } from '@workspace/shared';
 import {
@@ -10,52 +8,38 @@ import { v4 as uuidv4 } from 'uuid';
 import { getClient } from '../db/poolManager.js';
 import { getDailySupplementTotals } from '../models/foodMisc.js';
 import { getDailyNutritionTotalsRange } from '../models/reportRepository.js';
-import { supplementFixed } from '../models/supplementSql.js';
+import { supplementFixedSubquery } from '../models/supplementSql.js';
 
 vi.mock('../db/poolManager', () => ({
   getClient: vi.fn(),
 }));
 
-const sourceOf = (relative: string) =>
-  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8');
-
-// The status filter and the dose clamp decide what a supplement contributes to every total
-// the app shows. Both used to be written out separately in foodMisc and reportRepository,
-// which agreed by inspection and nothing else: either copy could have been edited alone and
-// the result would have been a plausible number on one screen and a different plausible
-// number on another, with no test and no type failing.
-describe('supplement SQL has a single definition', () => {
-  const models = ['../models/foodMisc.ts', '../models/reportRepository.ts'];
-
-  it.each(models)(
-    '%s builds no supplement snapshot SQL of its own',
-    (relative) => {
-      const source = sourceOf(relative);
-      // Constructs, not identifiers: these files legitimately discuss the snapshot and the
-      // dose count in prose, but neither may spell out the clamp or the correlated read.
-      expect(source).not.toContain('GREATEST(COALESCE(');
-      expect(source).not.toContain(
-        'FROM medication_entries me WHERE me.user_id ='
-      );
-      expect(source).not.toContain("me.status IN ('taken', 'prn_taken')");
-    }
-  );
-
-  it('both models correlate through the shared helper', () => {
-    for (const relative of models) {
-      expect(sourceOf(relative)).toContain("from './supplementSql.js'");
-    }
+describe('the shared fragments correlate on what the caller passes', () => {
+  // The helper takes the correlation expressions as arguments precisely so the callers'
+  // different date predicates ($2 vs a grouped column) do not justify a second copy.
+  it('emits the caller-supplied correlation, not a baked-in one', () => {
+    expect(supplementFixedSubquery('calcium', '$1', '$2')).toContain(
+      'sup_me.entry_date = $2'
+    );
+    expect(supplementFixedSubquery('calcium', '$1', 'd.entry_date')).toContain(
+      'sup_me.entry_date = d.entry_date'
+    );
   });
 
-  // The shared helper takes the correlation expressions as arguments precisely so the two
-  // callers' different date predicates ($2 vs the grouped column) do not justify a copy.
-  it('emits the caller-supplied correlation, not a baked-in one', () => {
-    expect(supplementFixed('calcium', '$1', '$2')).toContain(
-      'me.entry_date = $2'
-    );
-    expect(supplementFixed('calcium', '$1', 'd.entry_date')).toContain(
-      'me.entry_date = d.entry_date'
-    );
+  // A fragment that opens its own scan must not use the alias its callers use. With `me`
+  // inside, a caller correlating on its own `me` would emit `me.user_id = me.user_id`: a
+  // self-join tautology that runs clean and silently sums the user's whole history rather
+  // than one day. The alias is the only thing preventing it, so assert on it directly.
+  it('does not shadow a caller that correlates on its own me', () => {
+    const sql = supplementFixedSubquery('iron', 'me.user_id', 'me.entry_date');
+    expect(sql).toContain('FROM medication_entries sup_me');
+    expect(sql).toContain('sup_me.user_id = me.user_id');
+    expect(sql).toContain('sup_me.entry_date = me.entry_date');
+    // Boundary-anchored: a plain substring check would pass on `sup_me.user_id = me.user_id`
+    // and assert nothing, since the correct string ends with the wrong one.
+    expect(sql).not.toMatch(/(?<![\w.])me\.user_id = me\.user_id/);
+    expect(sql).not.toMatch(/(?<![\w.])me\.entry_date = me\.entry_date/);
+    expect(sql).not.toMatch(/FROM medication_entries me(?![\w])/);
   });
 });
 
@@ -96,10 +80,13 @@ describe('getDailySupplementTotals reads the day in one pass', () => {
     }
   });
 
-  // The per-subquery COALESCE used to guarantee this. An un-grouped aggregate over zero
-  // rows still returns one row, but every column in it is NULL, so the zeroing had to move
-  // outward with the collapse or a supplement-free day would have gone out as nulls.
-  it('returns zeros, not nulls, on a day with no doses', async () => {
+  // NOTE: this covers the JS coercion only, not the SQL. It feeds an all-NULL row through
+  // the mock, and `Number(null) || 0` is 0 regardless of what the query said, so it passes
+  // with or without the outer COALESCE. The SQL-level zeroing is asserted as a string by
+  // 'still selects every shared nutrient field' above; that is the assertion a mutation
+  // kills. Kept because the coercion is a real contract (callers add these unconditionally),
+  // but do not read it as a guard on the query.
+  it('coerces a NULL row to zeros, not nulls', async () => {
     const nullRow = Object.fromEntries(
       FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, null])
     );
@@ -138,9 +125,11 @@ describe('the range query keeps its supplement arm', () => {
   it('correlates supplements on the grouped date', async () => {
     await getDailyNutritionTotalsRange(userId, '2026-08-01', '2026-08-19');
     const sql = String(mockClient.query.mock.calls[0][0]);
-    expect(sql).toContain('me.entry_date = d.entry_date');
-    expect(sql).not.toContain('me.entry_date = $2');
-    expect(sql).toContain("me.status IN ('taken', 'prn_taken')");
-    expect(sql).toContain('GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)');
+    expect(sql).toContain('sup_me.entry_date = d.entry_date');
+    expect(sql).not.toContain('sup_me.entry_date = $2');
+    expect(sql).toContain("sup_me.status IN ('taken', 'prn_taken')");
+    expect(sql).toContain(
+      'GREATEST(COALESCE(sup_me.dose_amount_snapshot, 1), 0)'
+    );
   });
 });

--- a/SparkyFitnessServer/tests/supplementSqlDedup.test.ts
+++ b/SparkyFitnessServer/tests/supplementSqlDedup.test.ts
@@ -84,6 +84,25 @@ describe('getDailySupplementTotals reads the day in one pass', () => {
     }
   });
 
+  // Each inner aggregate must be published under the name of the nutrient it reads.
+  // Asserting the snapshot keys and the outer aliases separately leaves them unbound:
+  // swapping just the two inner `AS` names preserves every key and every outer alias, so a
+  // dose of 100 calories and 5g protein comes back as 5 calories and 100g protein with the
+  // assertions above still green. Pair them off the line that generates both.
+  it('publishes each inner aggregate under the nutrient it reads', async () => {
+    await getDailySupplementTotals(userId, '2026-08-19');
+    const pairs = sqlOf()
+      .split('\n')
+      .filter((line) => /nutrients_snapshot->>'/.test(line))
+      .map((line) => [
+        line.match(/nutrients_snapshot->>'(\w+)'/)?.[1],
+        line.match(/\bAS (\w+),?\s*$/)?.[1],
+      ]);
+    expect(pairs).toEqual(
+      FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, field])
+    );
+  });
+
   // NOTE: this covers the JS coercion only, not the SQL. It feeds an all-NULL row through
   // the mock, and `Number(null) || 0` is 0 regardless of what the query said, so it passes
   // with or without the outer COALESCE. The SQL-level zeroing is asserted as a string by

--- a/SparkyFitnessServer/tests/supplementSqlDedup.test.ts
+++ b/SparkyFitnessServer/tests/supplementSqlDedup.test.ts
@@ -1,0 +1,146 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FOOD_VARIANT_NUTRIENT_FIELDS } from '@workspace/shared';
+import {
+  createMockDbClient,
+  type MockDbClient,
+} from './helpers/mockDbClient.js';
+import { v4 as uuidv4 } from 'uuid';
+import { getClient } from '../db/poolManager.js';
+import { getDailySupplementTotals } from '../models/foodMisc.js';
+import { getDailyNutritionTotalsRange } from '../models/reportRepository.js';
+import { supplementFixed } from '../models/supplementSql.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+}));
+
+const sourceOf = (relative: string) =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), 'utf8');
+
+// The status filter and the dose clamp decide what a supplement contributes to every total
+// the app shows. Both used to be written out separately in foodMisc and reportRepository,
+// which agreed by inspection and nothing else: either copy could have been edited alone and
+// the result would have been a plausible number on one screen and a different plausible
+// number on another, with no test and no type failing.
+describe('supplement SQL has a single definition', () => {
+  const models = ['../models/foodMisc.ts', '../models/reportRepository.ts'];
+
+  it.each(models)(
+    '%s builds no supplement snapshot SQL of its own',
+    (relative) => {
+      const source = sourceOf(relative);
+      // Constructs, not identifiers: these files legitimately discuss the snapshot and the
+      // dose count in prose, but neither may spell out the clamp or the correlated read.
+      expect(source).not.toContain('GREATEST(COALESCE(');
+      expect(source).not.toContain(
+        'FROM medication_entries me WHERE me.user_id ='
+      );
+      expect(source).not.toContain("me.status IN ('taken', 'prn_taken')");
+    }
+  );
+
+  it('both models correlate through the shared helper', () => {
+    for (const relative of models) {
+      expect(sourceOf(relative)).toContain("from './supplementSql.js'");
+    }
+  });
+
+  // The shared helper takes the correlation expressions as arguments precisely so the two
+  // callers' different date predicates ($2 vs the grouped column) do not justify a copy.
+  it('emits the caller-supplied correlation, not a baked-in one', () => {
+    expect(supplementFixed('calcium', '$1', '$2')).toContain(
+      'me.entry_date = $2'
+    );
+    expect(supplementFixed('calcium', '$1', 'd.entry_date')).toContain(
+      'me.entry_date = d.entry_date'
+    );
+  });
+});
+
+describe('getDailySupplementTotals reads the day in one pass', () => {
+  let mockClient: MockDbClient;
+  const userId = uuidv4();
+
+  beforeEach(() => {
+    mockClient = createMockDbClient([{}]);
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  const sqlOf = () => String(mockClient.query.mock.calls[0][0]);
+
+  // This query has no food arm to correlate against, so seventeen scalar subqueries each
+  // rescanning the same handful of rows bought nothing. One scan for the fixed fields and
+  // one for the custom aggregation is the whole query.
+  it('scans medication_entries twice, not once per nutrient', async () => {
+    await getDailySupplementTotals(userId, '2026-08-19');
+    const sql = sqlOf();
+    const scans = sql.match(/FROM medication_entries/g) ?? [];
+    expect(scans).toHaveLength(2);
+    expect(FOOD_VARIANT_NUTRIENT_FIELDS.length).toBeGreaterThan(scans.length);
+  });
+
+  it('still selects every shared nutrient field', async () => {
+    await getDailySupplementTotals(userId, '2026-08-19');
+    const sql = sqlOf();
+    for (const field of FOOD_VARIANT_NUTRIENT_FIELDS) {
+      expect(sql, `missing ${field}`).toContain(
+        `nutrients_snapshot->>'${field}'`
+      );
+      expect(sql, `missing alias for ${field}`).toContain(
+        `COALESCE(supplement_fixed.${field}, 0) AS ${field}`
+      );
+    }
+  });
+
+  // The per-subquery COALESCE used to guarantee this. An un-grouped aggregate over zero
+  // rows still returns one row, but every column in it is NULL, so the zeroing had to move
+  // outward with the collapse or a supplement-free day would have gone out as nulls.
+  it('returns zeros, not nulls, on a day with no doses', async () => {
+    const nullRow = Object.fromEntries(
+      FOOD_VARIANT_NUTRIENT_FIELDS.map((field) => [field, null])
+    );
+    mockClient = createMockDbClient([{ ...nullRow, custom_nutrients: {} }]);
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+
+    const totals = await getDailySupplementTotals(userId, '2026-08-19');
+    for (const field of FOOD_VARIANT_NUTRIENT_FIELDS) {
+      expect(totals[field], `${field} came back non-zero`).toBe(0);
+    }
+    expect(totals.custom_nutrients).toEqual({});
+  });
+
+  it('keeps the status filter and the dose clamp on the single scan', async () => {
+    await getDailySupplementTotals(userId, '2026-08-19');
+    const sql = sqlOf();
+    expect(sql).toContain("me.status IN ('taken', 'prn_taken')");
+    expect(sql).toContain('GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)');
+    expect(sql).toContain('me.nutrients_snapshot IS NOT NULL');
+  });
+});
+
+describe('the range query keeps its supplement arm', () => {
+  let mockClient: MockDbClient;
+  const userId = uuidv4();
+
+  beforeEach(() => {
+    mockClient = createMockDbClient([{}]);
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  // reportRepository's copy is gone, so this asserts the shared helper reaches it with the
+  // per-date correlation it needs rather than the bind param the diary query uses.
+  it('correlates supplements on the grouped date', async () => {
+    await getDailyNutritionTotalsRange(userId, '2026-08-01', '2026-08-19');
+    const sql = String(mockClient.query.mock.calls[0][0]);
+    expect(sql).toContain('me.entry_date = d.entry_date');
+    expect(sql).not.toContain('me.entry_date = $2');
+    expect(sql).toContain("me.status IN ('taken', 'prn_taken')");
+    expect(sql).toContain('GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)');
+  });
+});


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Five queries read a logged supplement's nutrient snapshot, and each one spelled out the two things that decide what a dose contributes: the `taken`/`prn_taken` status filter and the dose-count clamp. They agreed by inspection and nothing else, so editing one alone would have left one screen's totals right and another's quietly wrong, with no test and no type failing.

**How did you implement the solution?**

The fragments move into `SparkyFitnessServer/models/supplementSql.ts` and every caller imports them. The correlation expressions stay arguments, so single-date queries bind `$1`/`$2` while the range query references its grouped columns; that difference is what made a copy look justified. Fragments that open their own scan use `sup_me` rather than the conventional `me`, so a caller correlating on its own `me` cannot have the inner alias shadow the outer one and turn the correlation into a tautology. The emitted SQL is therefore not byte-identical to before: the alias renames, plus a table alias added to two `SELECT DISTINCT` arms. Behaviour is unchanged, and the equivalence run below is what checks that.

`getDailySupplementTotals` also collapses from eighteen subqueries to two. It has no food arm to correlate against, so seventeen scalar subqueries each rescanning the same few rows bought nothing. The per-subquery `COALESCE` had to move outward with the collapse: an un-grouped aggregate over zero rows still returns a row, but a row of NULLs, so a supplement-free day would otherwise have started returning nulls where it returned zeros.

Finally, the range query's nutrient list is derived from `FOOD_VARIANT_NUTRIENT_FIELDS` rather than hand-listed, with an explicit alias map for the two output renames (`dietary_fiber` to `fiber`, `sugars` to `sugar`). It matched the shared list exactly, but nothing enforced that, so a field added to the constant would have silently dropped out of trends and the chatbot's nutrition rows.

Behaviour-preserving throughout. No endpoint returns anything different.

Linked Issue: none. This is the follow-up for points 2 and 3 here: https://github.com/CodeWithCJ/SparkyFitness/pull/2161#issuecomment-5334912498

## How to Test

1. `cd SparkyFitnessServer && pnpm run validate`, then `npx vitest run`.
2. The cases worth exercising are a day with food plus a multi-unit dose, a day with only a dose logged, and a day with nothing logged. On the last, `GET /api/daily-summary` returns zeros for all seventeen fixed fields. The outer `COALESCE` in the collapsed query is belt-and-braces rather than load-bearing: the JS layer already coerces a NULL row to zeros, so it is not observable at the API surface either way.
3. `getDailyNutritionTotalsRange` has no REST route, so it is reached through the AI/MCP tools (`get_nutritional_summary`) rather than by calling an endpoint.

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [x] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: typecheck, lint and tests all run and pass. The new file is TypeScript. No new endpoints, so no new Zod schemas; the changed queries are covered by new and existing tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

Not applicable. Server-only change with no UI difference.

## Notes for Reviewers

- Full server suite green, 3136 passed / 221 skipped.
- Four mutation controls, each confirmed to land and to kill a test by name: dropping the status filter, neutering the dose clamp, removing the outer zeroing, and renaming the inner scan alias back to the one callers use. A further seven test-only fixes came out of adversarial review passes over the fix commits themselves, each verified by the mutation that motivated it.
- The clamp mutation is a single edit in the shared module, and it kills tests in `getNutritionData`, `getDailyNutritionTotalsRange`, `getDailyNutritionSummary` and `getDailySupplementTotals`. That list is the evidence the callers genuinely share the fragment rather than merely compiling against it.
- A before/after equivalence run on a dev stack, seeded once and read by both sides: four `/api/daily-summary` days, `/api/reports`, and the range function probed in-container. All six captured surfaces byte-identical.

Two additional notes:

- The review named two duplicate sites - there were actually five: `getNutritionData` held a third copy of the dose clamp, and two `SELECT DISTINCT entry_date` arms held further copies of the status filter. I pulled all of them in, which makes the diff slightly wider than asked for. Happy to split the extra sites out if you would rather keep this tight.
- Points 2 and 3 of the review pull in opposite directions, so they are done together here. Sharing the fragment more widely and then removing it from the one caller that has an alternative would otherwise mean undoing part of the first change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency of daily and date-range nutrition and supplement totals.
  * Preserved correct nutrient labels, date handling, filtering, dose validation, and zero values for empty days.
  * Improved reporting consistency across food and supplement entries.

* **Tests**
  * Expanded coverage for nutrient reporting, supplement aggregation, aliases, filtering, date handling, and empty-day results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
