### PR TITLE
fix: allow shared users with can_manage_diary to INSERT foods

### DIFF
--- a/SparkyFitnessServer/db/migrations/20260820000000_fix_foods_rls_manage_diary_insert.sql
+++ b/SparkyFitnessServer/db/migrations/20260820000000_fix_foods_rls_manage_diary_insert.sql
@@ -1,0 +1,22 @@
+-- Fix: Allow shared users with can_manage_diary permission to INSERT foods
+-- Issue: https://github.com/CodeWithCJ/SparkyFitness/issues/2182
+--
+-- The create_library_policy function in rls_policies.sql has been updated to:
+-- 1. Drop existing policies before creating (idempotent — safe for server boot)
+-- 2. Split the FOR ALL modify_policy into separate INSERT/UPDATE/DELETE policies
+-- 3. Allow can_manage_diary holders to INSERT (but not UPDATE/DELETE)
+--
+-- This migration handles the transition: the server boot (applyRlsPolicies)
+-- will recreate the correct policies via the updated function. This file
+-- exists to document the fix and to drop any stale policy names from older
+-- schema states.
+
+-- Clean up any leftover policies from previous manual fixes
+DROP POLICY IF EXISTS modify_policy ON public.foods;
+DROP POLICY IF EXISTS foods_insert_policy ON public.foods;
+DROP POLICY IF EXISTS foods_update_policy ON public.foods;
+DROP POLICY IF EXISTS foods_delete_policy ON public.foods;
+
+-- The correct policies are created by create_library_policy('foods', ...)
+-- which is applied on every server boot via rls_policies.sql.
+-- No further SQL needed here — the boot process handles it.

--- a/SparkyFitnessServer/db/rls_policies.sql
+++ b/SparkyFitnessServer/db/rls_policies.sql
@@ -471,6 +471,7 @@ AS $_$
 DECLARE
   quoted_permissions text;
   shared_expression text;
+  has_manage boolean;
 BEGIN
   -- Quote each permission name to ensure valid ARRAY syntax
   SELECT array_to_string(ARRAY(
@@ -483,14 +484,50 @@ BEGIN
   ELSE
     shared_expression := quote_ident(shared_column);
   END IF;
-  
+
+  -- Check whether 'can_manage_diary' is among the requested permissions.
+  -- If so, shared users with that permission may INSERT (but not UPDATE/DELETE).
+  has_manage := 'can_manage_diary' = ANY(permissions);
+
+  -- Drop existing policies to make this idempotent (the server re-applies
+  -- rls_policies.sql on every boot).
+  EXECUTE format('DROP POLICY IF EXISTS select_policy ON public.%I;', table_name);
+  EXECUTE format('DROP POLICY IF EXISTS modify_policy ON public.%I;', table_name);
+  EXECUTE format('DROP POLICY IF EXISTS insert_policy ON public.%I;', table_name);
+  EXECUTE format('DROP POLICY IF EXISTS update_policy ON public.%I;', table_name);
+  EXECUTE format('DROP POLICY IF EXISTS delete_policy ON public.%I;', table_name);
+
+  -- SELECT: owner, publicly shared, or granted via family_access
   EXECUTE format('
     CREATE POLICY select_policy ON public.%I FOR SELECT TO PUBLIC
     USING (has_library_access_with_public(user_id, %s, ARRAY[%s]));
-    CREATE POLICY modify_policy ON public.%I FOR ALL TO PUBLIC
+  ', table_name, shared_expression, quoted_permissions);
+
+  IF has_manage THEN
+    -- INSERT: owner OR shared user with can_manage_diary (see issue #2182)
+    EXECUTE format('
+      CREATE POLICY insert_policy ON public.%I FOR INSERT TO PUBLIC
+      WITH CHECK (
+        authenticated_user_id() = user_id
+        OR has_family_access(user_id, ''can_manage_diary'')
+      );
+    ', table_name);
+  ELSE
+    -- INSERT: owner only
+    EXECUTE format('
+      CREATE POLICY insert_policy ON public.%I FOR INSERT TO PUBLIC
+      WITH CHECK (authenticated_user_id() = user_id);
+    ', table_name);
+  END IF;
+
+  -- UPDATE / DELETE: owner only (shared users must not alter or remove entries)
+  EXECUTE format('
+    CREATE POLICY update_policy ON public.%I FOR UPDATE TO PUBLIC
     USING (authenticated_user_id() = user_id)
     WITH CHECK (authenticated_user_id() = user_id);
-  ', table_name, shared_expression, quoted_permissions, table_name);
+    CREATE POLICY delete_policy ON public.%I FOR DELETE TO PUBLIC
+    USING (authenticated_user_id() = user_id);
+  ', table_name, table_name);
 END;
 $_$;
 


### PR DESCRIPTION
## Summary

Fixes #2182 — shared users with "Manages Food Library" (`can_manage_diary`) permission can now INSERT custom food items.

## Problem

The `create_library_policy` function created a single `FOR ALL` modify policy restricted to the owner (`authenticated_user_id = user_id`). This meant shared users with `can_manage_diary` could SELECT foods but got a 403 when trying to INSERT a custom food item while logging a meal.

## Root cause

`rls_policies.sql:490` — the `modify_policy` used `FOR ALL` with `USING/WITH CHECK (authenticated_user_id() = user_id)`, blocking all writes from shared users regardless of their permissions.

## Fix

Split the single `FOR ALL` policy into separate INSERT/UPDATE/DELETE policies:

- **INSERT**: owner OR shared user with `can_manage_diary` via `family_access`
- **UPDATE**: owner only
- **DELETE**: owner only

The `create_library_policy` function is now idempotent (drops existing policies before creating), so it's safe for the server-boot `applyRlsPolicies` flow.

Also applies to `meals` and `workout_presets` (any library table with `can_manage_diary` in its permissions array), since they share the same function.

## Files changed

- `SparkyFitnessServer/db/rls_policies.sql` — updated `create_library_policy` function
- `SparkyFitnessServer/db/migrations/20260820000000_fix_foods_rls_manage_diary_insert.sql` — migration + documentation

## Testing

Existing integration tests (`rlsPermissionMatrix.integration.test.ts`) are unaffected:
- `food_variants` uses its own policy (not `create_library_policy`) with `write: []`
- `goal_presets` uses `create_diary_policy` (unchanged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access control for food library entries.
  - Authorized family members with diary-management permissions can now add entries where permitted.
  - Owners retain control over updating and deleting their entries.
  - Resolved stale permission settings that could prevent valid diary inserts or apply outdated access rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- restored-checklist -->
---
## ✅ Required Checklist (restored automatically)

> The mandatory checklist from our PR template is missing from this description, so it
> has been added back below. **Please tick each box and do not delete this section** —
> these checked boxes are how we record your agreement. Edit the description in place;
> no new commit is needed.

- [ ] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).
- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.
