### PR TITLE
feat/bug(frontend/mobile) - Workout Preset Duplication, Exercise Duplication and Replace, and Preset Name Fix

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1075,6 +1075,8 @@
     "logError": "Failed to log workout preset \"{{presetName}}\" to diary.",
     "exercises": "Exercises",
     "logToDiary": "Log to Diary",
+    "duplicate": "Duplicate",
+    "duplicateNameSuffix": "{{name}} (Copy)",
     "name": "Name",
     "presets": "presets",
     "startWorkout": "Start Workout",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2949,6 +2949,8 @@
     "shareWithPublicLabel": "Share with Public",
     "exercisesLabel": "Exercises",
     "addExerciseButton": "Add Exercise",
+    "replaceExerciseButton": "Replace exercise",
+    "duplicateExerciseButton": "Duplicate exercise",
     "addSetButton": "Add Set",
     "createPresetButton": "Create Preset",
     "validationErrorTitle": "Validation Error",

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPresetForm.ts
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPresetForm.ts
@@ -56,6 +56,13 @@ export function useWorkoutPresetForm({
     );
   });
   const [isAddExerciseDialogOpen, setIsAddExerciseDialogOpen] = useState(false);
+  // While set, the next AddExerciseDialog selection swaps this entry's
+  // exercise identity in place instead of appending a new one. Cleared on
+  // every plain "Add Exercise" open so a cancelled replace can't misroute a
+  // later add; overwritten (not accumulated) by opening Replace on another row.
+  const [replaceTargetIndex, setReplaceTargetIndex] = useState<number | null>(
+    null
+  );
 
   const handleAddExercise = (exercise: Exercise | undefined) => {
     if (exercise) {
@@ -63,27 +70,84 @@ export function useWorkoutPresetForm({
         exercise.modality,
         exercise.category
       );
-      const newExercise: WorkoutPresetExercise = {
-        id: generateClientId(), // Stable ID for DND
-        exercise_id: exercise.id,
-        exercise_name: exercise.name,
-        image_url:
-          exercise.images && exercise.images.length > 0
-            ? exercise.images[0]
-            : '',
-        exercise: exercise,
-        sets: [{ ...defaultSetForModality(modality), id: generateClientId() }],
-        category: exercise.category ?? '',
-        modality,
-      };
-      setExercises((prev) => [...prev, newExercise]);
+      const imageUrl =
+        exercise.images && exercise.images.length > 0 ? exercise.images[0] : '';
+      if (replaceTargetIndex !== null) {
+        // Swap the exercise identity in place, keeping the entry's already
+        // configured sets — the whole point of replace over remove-then-add.
+        setExercises((prev) =>
+          prev.map((ex, index) => {
+            if (index !== replaceTargetIndex) {
+              return ex;
+            }
+            return {
+              ...ex,
+              exercise_id: exercise.id,
+              exercise_name: exercise.name,
+              image_url: imageUrl,
+              exercise,
+              category: exercise.category ?? '',
+              modality,
+            };
+          })
+        );
+      } else {
+        const newExercise: WorkoutPresetExercise = {
+          id: generateClientId(), // Stable ID for DND
+          exercise_id: exercise.id,
+          exercise_name: exercise.name,
+          image_url: imageUrl,
+          exercise: exercise,
+          sets: [
+            { ...defaultSetForModality(modality), id: generateClientId() },
+          ],
+          category: exercise.category ?? '',
+          modality,
+        };
+        setExercises((prev) => [...prev, newExercise]);
+      }
     }
+    setReplaceTargetIndex(null);
     setIsAddExerciseDialogOpen(false);
+  };
+
+  const handleOpenAddExercise = () => {
+    setReplaceTargetIndex(null);
+    setIsAddExerciseDialogOpen(true);
+  };
+
+  const handleOpenReplaceExercise = (exerciseIndex: number) => {
+    setReplaceTargetIndex(exerciseIndex);
+    setIsAddExerciseDialogOpen(true);
   };
 
   const handleRemoveExercise = (index: number) => {
     setExercises((prev) => prev.filter((_, i) => i !== index));
   };
+
+  const handleDuplicateExercise = useCallback((exerciseIndex: number) => {
+    setExercises((prev) => {
+      const exerciseToDuplicate = prev[exerciseIndex];
+      if (!exerciseToDuplicate) {
+        return prev;
+      }
+      const duplicate: WorkoutPresetExercise = {
+        ...exerciseToDuplicate,
+        id: generateClientId(),
+        sets: exerciseToDuplicate.sets.map((set) => ({
+          ...set,
+          id: generateClientId(),
+          completed_at: null,
+          is_pr: false,
+        })),
+      };
+      return [
+        ...prev.slice(0, exerciseIndex + 1),
+        duplicate,
+        ...prev.slice(exerciseIndex + 1),
+      ];
+    });
+  }, []);
 
   const handleSetChange = useCallback(
     (
@@ -324,7 +388,10 @@ export function useWorkoutPresetForm({
     setExercises,
     setIsAddExerciseDialogOpen,
     handleAddExercise,
+    handleOpenAddExercise,
+    handleOpenReplaceExercise,
     handleRemoveExercise,
+    handleDuplicateExercise,
     handleSetChange,
     handleAddSet,
     handleDuplicateSet,

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPresetForm.ts
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPresetForm.ts
@@ -75,11 +75,19 @@ export function useWorkoutPresetForm({
       if (replaceTargetIndex !== null) {
         // Swap the exercise identity in place, keeping the entry's already
         // configured sets — the whole point of replace over remove-then-add.
+        // Only safe when the modality is unchanged, but a duration-only
+        // set carries `reps: null`, and a weight_reps set carries a
+        // `duration`/no `reps` default, reusing those fields across a
+        // modality change would either show a blank reps column instead of
+        // the default, or silently keep a stale field the new modality's UI
+        // hides, but the server still persists. On a modality change, reset
+        // to a fresh default set for the new modality instead.
         setExercises((prev) =>
           prev.map((ex, index) => {
             if (index !== replaceTargetIndex) {
               return ex;
             }
+            const modalityChanged = modality !== ex.modality;
             return {
               ...ex,
               exercise_id: exercise.id,
@@ -88,6 +96,14 @@ export function useWorkoutPresetForm({
               exercise,
               category: exercise.category ?? '',
               modality,
+              sets: modalityChanged
+                ? [
+                    {
+                      ...defaultSetForModality(modality),
+                      id: generateClientId(),
+                    },
+                  ]
+                : ex.sets,
             };
           })
         );
@@ -134,6 +150,12 @@ export function useWorkoutPresetForm({
       const duplicate: WorkoutPresetExercise = {
         ...exerciseToDuplicate,
         id: generateClientId(),
+        // The web editor has no superset UI, so silently carrying the
+        // original's superset_group forward would join the copy to the same
+        // superset with no way for the user to see or intend that (mobile
+        // clears it for the same reason, inserting the copy after the whole
+        // run instead).
+        superset_group: null,
         sets: exerciseToDuplicate.sets.map((set) => ({
           ...set,
           id: generateClientId(),

--- a/SparkyFitnessFrontend/src/pages/Exercises/SortableExerciseItem.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/SortableExerciseItem.tsx
@@ -7,6 +7,8 @@ import {
   ChevronDown,
   ChevronUp,
   Copy,
+  CopyPlus,
+  Repeat,
   Book,
   Dumbbell,
   HeartPulse,
@@ -59,6 +61,10 @@ interface SortableExerciseItemProps {
   onRemoveSet: (exerciseIndex: number, setIndex: number) => void;
   onAddSet?: (exerciseIndex: number) => void;
   onCopyExercise?: (ex: SortableExerciseItemData) => void;
+  /** Swap which exercise this entry points to, keeping its configured sets. */
+  onReplaceExercise?: (exerciseIndex: number) => void;
+  /** Add an independent copy of this entry (same sets) right after it. */
+  onDuplicateExercise?: (exerciseIndex: number) => void;
   onReorderSets?: (
     exerciseIndex: number,
     oldIndex: number,
@@ -78,6 +84,8 @@ export const SortableExerciseItem = ({
   onRemoveSet,
   onAddSet,
   onCopyExercise,
+  onReplaceExercise,
+  onDuplicateExercise,
   onReorderSets,
   weightUnit,
   workoutPresets,
@@ -227,6 +235,28 @@ export const SortableExerciseItem = ({
               ) : (
                 <ChevronDown className="h-4 w-4" />
               )}
+            </Button>
+          )}
+          {onReplaceExercise && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              title="Replace exercise"
+              onClick={() => onReplaceExercise(exerciseIndex)}
+            >
+              <Repeat className="h-4 w-4" />
+            </Button>
+          )}
+          {onDuplicateExercise && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              title="Duplicate exercise"
+              onClick={() => onDuplicateExercise(exerciseIndex)}
+            >
+              <CopyPlus className="h-4 w-4" />
             </Button>
           )}
           {onCopyExercise && (

--- a/SparkyFitnessFrontend/src/pages/Exercises/SortableExerciseItem.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/SortableExerciseItem.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import {
   GripVertical,
@@ -91,6 +92,7 @@ export const SortableExerciseItem = ({
   workoutPresets,
   simplified = false,
 }: SortableExerciseItemProps) => {
+  const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(true);
   const { distanceUnit } = usePreferences();
 
@@ -242,7 +244,14 @@ export const SortableExerciseItem = ({
               variant="ghost"
               size="icon"
               className="h-8 w-8"
-              title="Replace exercise"
+              title={t(
+                'workoutPresetForm.replaceExerciseButton',
+                'Replace exercise'
+              )}
+              aria-label={t(
+                'workoutPresetForm.replaceExerciseButton',
+                'Replace exercise'
+              )}
               onClick={() => onReplaceExercise(exerciseIndex)}
             >
               <Repeat className="h-4 w-4" />
@@ -253,7 +262,14 @@ export const SortableExerciseItem = ({
               variant="ghost"
               size="icon"
               className="h-8 w-8"
-              title="Duplicate exercise"
+              title={t(
+                'workoutPresetForm.duplicateExerciseButton',
+                'Duplicate exercise'
+              )}
+              aria-label={t(
+                'workoutPresetForm.duplicateExerciseButton',
+                'Duplicate exercise'
+              )}
               onClick={() => onDuplicateExercise(exerciseIndex)}
             >
               <CopyPlus className="h-4 w-4" />

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetForm.tsx
@@ -51,7 +51,10 @@ const WorkoutPresetForm: React.FC<WorkoutPresetFormProps> = ({
     setIsPublic,
     setIsAddExerciseDialogOpen,
     handleAddExercise,
+    handleOpenAddExercise,
+    handleOpenReplaceExercise,
     handleRemoveExercise,
+    handleDuplicateExercise,
     handleSetChange,
     handleAddSet,
     handleDuplicateSet,
@@ -118,11 +121,7 @@ const WorkoutPresetForm: React.FC<WorkoutPresetFormProps> = ({
               <h3 className="text-lg font-semibold">
                 {t('workoutPresetForm.exercisesLabel', 'Exercises')}
               </h3>
-              <Button
-                type="button"
-                size="sm"
-                onClick={() => setIsAddExerciseDialogOpen(true)}
-              >
+              <Button type="button" size="sm" onClick={handleOpenAddExercise}>
                 <Plus className="h-4 w-4 mr-2" />
                 {t('workoutPresetForm.addExerciseButton', 'Add Exercise')}
               </Button>
@@ -166,6 +165,8 @@ const WorkoutPresetForm: React.FC<WorkoutPresetFormProps> = ({
                         exerciseIndex={exerciseIndex}
                         weightUnit={weightUnit}
                         onRemoveExercise={handleRemoveExercise}
+                        onReplaceExercise={handleOpenReplaceExercise}
+                        onDuplicateExercise={handleDuplicateExercise}
                         onSetChange={handleSetChange}
                         onDuplicateSet={handleDuplicateSet}
                         onRemoveSet={handleRemoveSet}

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
@@ -57,6 +57,9 @@ import { ColumnDef, RowSelectionState } from '@tanstack/react-table';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Badge } from '@/components/ui/badge';
 
+// Matches workout_presets.name VARCHAR(255) in the database.
+const MAX_PRESET_NAME_LENGTH = 255;
+
 const WorkoutPresetsManager = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -147,10 +150,25 @@ const WorkoutPresetsManager = () => {
       // the same value, relying on id-ASC as a display-order tiebreak.
       // preset.exercises already arrives in display order (server sorts by
       // sort_order then id), so the array index is the real sort_order.
+      // workout_presets.name is VARCHAR(255) with no client-side length cap on
+      // creation, so a max-length preset name must be truncated here to leave
+      // room for the localized suffix — otherwise the duplicate insert fails.
+      const suffixOnly = t('workoutPresetsManager.duplicateNameSuffix', {
+        name: '',
+      });
+      const availableNameLength = Math.max(
+        0,
+        MAX_PRESET_NAME_LENGTH - suffixOnly.length
+      );
+      const truncatedName =
+        preset.name.length > availableNameLength
+          ? preset.name.slice(0, availableNameLength)
+          : preset.name;
+
       await createPreset({
         user_id: user.id,
         name: t('workoutPresetsManager.duplicateNameSuffix', {
-          name: preset.name,
+          name: truncatedName,
         }),
         description: preset.description,
         is_public: false,

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
@@ -141,6 +141,12 @@ const WorkoutPresetsManager = () => {
       // so the original's exercises/sets can be sent as-is. Defaults to
       // private regardless of the source's visibility — duplicating someone
       // else's public preset shouldn't silently re-share it under this user.
+      // sort_order is the one field that can't be sent as-is: the read
+      // queries never select wpe.sort_order, so preset.exercises[].sort_order
+      // is always undefined here and every duplicated row would insert with
+      // the same value, relying on id-ASC as a display-order tiebreak.
+      // preset.exercises already arrives in display order (server sorts by
+      // sort_order then id), so the array index is the real sort_order.
       await createPreset({
         user_id: user.id,
         name: t('workoutPresetsManager.duplicateNameSuffix', {
@@ -148,7 +154,10 @@ const WorkoutPresetsManager = () => {
         }),
         description: preset.description,
         is_public: false,
-        exercises: preset.exercises,
+        exercises: preset.exercises.map((exercise, index) => ({
+          ...exercise,
+          sort_order: index,
+        })),
       });
     },
     [createPreset, user?.id, t]

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
@@ -22,6 +22,7 @@ import {
   Play,
   X,
   MoreHorizontal,
+  CopyPlus,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -131,6 +132,27 @@ const WorkoutPresetsManager = () => {
     await createPreset({ ...newPresetData, user_id: user.id });
     setIsAddPresetDialogOpen(false);
   };
+
+  const handleDuplicatePreset = React.useCallback(
+    async (preset: WorkoutPreset) => {
+      if (!user?.id) return;
+      // The server always inserts fresh rows for exercises/sets on create and
+      // ignores any incoming id (see workoutPresetRepository.createWorkoutPreset),
+      // so the original's exercises/sets can be sent as-is. Defaults to
+      // private regardless of the source's visibility — duplicating someone
+      // else's public preset shouldn't silently re-share it under this user.
+      await createPreset({
+        user_id: user.id,
+        name: t('workoutPresetsManager.duplicateNameSuffix', {
+          name: preset.name,
+        }),
+        description: preset.description,
+        is_public: false,
+        exercises: preset.exercises,
+      });
+    },
+    [createPreset, user?.id, t]
+  );
 
   const handleUpdatePreset = async (
     presetId: string,
@@ -305,6 +327,10 @@ const WorkoutPresetsManager = () => {
                   <CalendarPlus className="mr-2 h-4 w-4" />
                   {t('workoutPresetsManager.logToDiary', 'Log to Diary')}
                 </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleDuplicatePreset(preset)}>
+                  <CopyPlus className="mr-2 h-4 w-4" />
+                  {t('workoutPresetsManager.duplicate', 'Duplicate')}
+                </DropdownMenuItem>
                 <DropdownMenuItem
                   disabled={!isOwned}
                   onClick={() => {
@@ -335,6 +361,7 @@ const WorkoutPresetsManager = () => {
       user?.id,
       weightUnit,
       handleLogPresetToDiary,
+      handleDuplicatePreset,
       handleDeletePreset,
       handleStartWorkoutPlayback,
     ]

--- a/SparkyFitnessFrontend/src/tests/components/SortableExerciseItem.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/SortableExerciseItem.test.tsx
@@ -154,3 +154,46 @@ describe('SortableExerciseItem set table columns', () => {
     expect(container.querySelector('input[step="1"]')).toHaveValue(45);
   });
 });
+
+describe('SortableExerciseItem replace/duplicate exercise actions', () => {
+  it('fires the replace and duplicate handlers with the entry index when clicked', () => {
+    const onReplaceExercise = jest.fn();
+    const onDuplicateExercise = jest.fn();
+    render(
+      <SortableExerciseItem
+        ex={createExercise({
+          category: 'strength',
+          modality: 'weight_reps',
+          sets: [{ set_number: 1, reps: 10, weight: 60 }],
+        })}
+        exerciseIndex={2}
+        onRemoveExercise={() => {}}
+        onSetChange={() => {}}
+        onDuplicateSet={() => {}}
+        onRemoveSet={() => {}}
+        onReplaceExercise={onReplaceExercise}
+        onDuplicateExercise={onDuplicateExercise}
+        weightUnit="kg"
+      />
+    );
+
+    fireEvent.click(screen.getByTitle('Replace exercise'));
+    fireEvent.click(screen.getByTitle('Duplicate exercise'));
+
+    expect(onReplaceExercise).toHaveBeenCalledWith(2);
+    expect(onDuplicateExercise).toHaveBeenCalledWith(2);
+  });
+
+  it('omits the replace and duplicate buttons when their handlers are not provided', () => {
+    renderItem(
+      createExercise({
+        category: 'strength',
+        modality: 'weight_reps',
+        sets: [{ set_number: 1, reps: 10, weight: 60 }],
+      })
+    );
+
+    expect(screen.queryByTitle('Replace exercise')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Duplicate exercise')).not.toBeInTheDocument();
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/components/SortableExerciseItem.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/SortableExerciseItem.test.tsx
@@ -177,8 +177,8 @@ describe('SortableExerciseItem replace/duplicate exercise actions', () => {
       />
     );
 
-    fireEvent.click(screen.getByTitle('Replace exercise'));
-    fireEvent.click(screen.getByTitle('Duplicate exercise'));
+    fireEvent.click(screen.getByRole('button', { name: 'Replace exercise' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate exercise' }));
 
     expect(onReplaceExercise).toHaveBeenCalledWith(2);
     expect(onDuplicateExercise).toHaveBeenCalledWith(2);
@@ -193,7 +193,11 @@ describe('SortableExerciseItem replace/duplicate exercise actions', () => {
       })
     );
 
-    expect(screen.queryByTitle('Replace exercise')).not.toBeInTheDocument();
-    expect(screen.queryByTitle('Duplicate exercise')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Replace exercise' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Duplicate exercise' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/SparkyFitnessFrontend/src/tests/components/WorkoutPresetsManager.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/WorkoutPresetsManager.test.tsx
@@ -10,6 +10,15 @@ jest.mock('react-i18next', () => ({
     t: (key: string, defaultOrValues?: string | Record<string, unknown>) => {
       if (typeof defaultOrValues === 'string') return defaultOrValues;
       if (defaultOrValues && typeof defaultOrValues === 'object') {
+        // Real interpolation only for the key exercised in these tests
+        // (matches en/translation.json's "{{name}} (Copy)"), so the
+        // duplicate-name truncation tests assert on the actual rendered
+        // string rather than a synthetic JSON blob. Other keyed
+        // interpolations fall back to the JSON-stringified form.
+        if (key === 'workoutPresetsManager.duplicateNameSuffix') {
+          const { name } = defaultOrValues as { name: string };
+          return `${name} (Copy)`;
+        }
         return `${key}:${JSON.stringify(defaultOrValues)}`;
       }
       return key;
@@ -87,7 +96,7 @@ describe('WorkoutPresetsManager duplicate preset', () => {
     await waitFor(() => expect(mockCreatePreset).toHaveBeenCalledTimes(1));
     expect(mockCreatePreset).toHaveBeenCalledWith({
       user_id: 'user-1',
-      name: 'workoutPresetsManager.duplicateNameSuffix:{"name":"Upper Body"}',
+      name: 'Upper Body (Copy)',
       description: 'Push + Pull',
       is_public: false,
       exercises: presetFixture.exercises.map((exercise, index) => ({
@@ -95,5 +104,34 @@ describe('WorkoutPresetsManager duplicate preset', () => {
         sort_order: index,
       })),
     });
+  });
+
+  it('truncates a max-length preset name so the duplicate stays within 255 characters', async () => {
+    const originalName = presetFixture.name;
+    presetFixture.name = 'A'.repeat(255);
+
+    try {
+      render(<WorkoutPresetsManager />);
+
+      const trigger = screen.getAllByRole('button', { name: /open menu/i })[0]!;
+      fireEvent.pointerDown(trigger, {
+        button: 0,
+        ctrlKey: false,
+        pointerId: 1,
+      });
+      fireEvent.click(trigger);
+      fireEvent.click((await screen.findAllByText('Duplicate'))[0]!);
+
+      await waitFor(() => expect(mockCreatePreset).toHaveBeenCalledTimes(1));
+      const duplicateName = (
+        mockCreatePreset.mock.calls[0]![0] as { name: string }
+      ).name;
+      // 248-char truncated name + " (Copy)" (7 chars) = 255, the
+      // workout_presets.name VARCHAR(255) limit.
+      expect(duplicateName).toBe(`${'A'.repeat(248)} (Copy)`);
+      expect(duplicateName.length).toBe(255);
+    } finally {
+      presetFixture.name = originalName;
+    }
   });
 });

--- a/SparkyFitnessFrontend/src/tests/components/WorkoutPresetsManager.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/WorkoutPresetsManager.test.tsx
@@ -90,7 +90,10 @@ describe('WorkoutPresetsManager duplicate preset', () => {
       name: 'workoutPresetsManager.duplicateNameSuffix:{"name":"Upper Body"}',
       description: 'Push + Pull',
       is_public: false,
-      exercises: presetFixture.exercises,
+      exercises: presetFixture.exercises.map((exercise, index) => ({
+        ...exercise,
+        sort_order: index,
+      })),
     });
   });
 });

--- a/SparkyFitnessFrontend/src/tests/components/WorkoutPresetsManager.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/WorkoutPresetsManager.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import WorkoutPresetsManager from '@/pages/Exercises/WorkoutPresetsManager';
+import type { WorkoutPreset } from '@/types/workout';
+
+const mockCreatePreset = jest.fn();
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultOrValues?: string | Record<string, unknown>) => {
+      if (typeof defaultOrValues === 'string') return defaultOrValues;
+      if (defaultOrValues && typeof defaultOrValues === 'object') {
+        return `${key}:${JSON.stringify(defaultOrValues)}`;
+      }
+      return key;
+    },
+  }),
+  initReactI18next: {
+    type: '3rdParty',
+    init: () => {},
+  },
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn(),
+  useLocation: () => ({ pathname: '/exercises', search: '' }),
+}));
+
+jest.mock('@/contexts/PreferencesContext', () => ({
+  usePreferences: () => ({ weightUnit: 'kg' }),
+}));
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+jest.mock('@/hooks/Exercises/useExerciseEntries', () => ({
+  useLogWorkoutPresetMutation: () => ({ mutateAsync: jest.fn() }),
+}));
+
+const presetFixture: WorkoutPreset = {
+  id: 'preset-1',
+  user_id: 'user-1',
+  name: 'Upper Body',
+  description: 'Push + Pull',
+  exercises: [
+    {
+      exercise_id: 'exercise-1',
+      exercise_name: 'Bench Press',
+      sets: [{ set_number: 1, reps: 8, weight: 80, rest_time: 90 }],
+    },
+  ],
+} as unknown as WorkoutPreset;
+
+jest.mock('@/hooks/Exercises/useWorkoutPresets', () => ({
+  useWorkoutPresets: () => ({
+    data: { pages: [{ presets: [presetFixture], total: 1 }] },
+    fetchNextPage: jest.fn(),
+    hasNextPage: false,
+    isLoading: false,
+    isFetchingNextPage: false,
+  }),
+  useCreateWorkoutPresetMutation: () => ({
+    mutateAsync: (...args: unknown[]) => mockCreatePreset(...args),
+  }),
+  useUpdateWorkoutPresetMutation: () => ({ mutateAsync: jest.fn() }),
+  useDeleteWorkoutPresetMutation: () => ({ mutateAsync: jest.fn() }),
+}));
+
+describe('WorkoutPresetsManager duplicate preset', () => {
+  beforeEach(() => {
+    mockCreatePreset.mockReset();
+  });
+
+  it('creates a private copy with the original exercises/sets and a "(Copy)" name, regardless of the source visibility', async () => {
+    render(<WorkoutPresetsManager />);
+
+    // DataTable renders both a desktop table and a mobile card list at once
+    // (toggled with CSS media queries jsdom doesn't apply), so each row's
+    // menu trigger appears twice; only one needs to be exercised here.
+    // Radix's dropdown trigger opens on pointerDown, not click.
+    const trigger = screen.getAllByRole('button', { name: /open menu/i })[0]!;
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false, pointerId: 1 });
+    fireEvent.click(trigger);
+    fireEvent.click((await screen.findAllByText('Duplicate'))[0]!);
+
+    await waitFor(() => expect(mockCreatePreset).toHaveBeenCalledTimes(1));
+    expect(mockCreatePreset).toHaveBeenCalledWith({
+      user_id: 'user-1',
+      name: 'workoutPresetsManager.duplicateNameSuffix:{"name":"Upper Body"}',
+      description: 'Push + Pull',
+      is_public: false,
+      exercises: presetFixture.exercises,
+    });
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPresetForm.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPresetForm.test.tsx
@@ -136,16 +136,54 @@ describe('useWorkoutPresetForm modality seeding', () => {
 });
 
 describe('useWorkoutPresetForm replace exercise', () => {
-  it('preserves the existing sets and swaps the exercise identity in place', () => {
+  const presetWithWeightRepsSet = {
+    id: 1,
+    name: 'Push',
+    description: '',
+    is_public: false,
+    exercises: [
+      {
+        id: 7,
+        exercise_id: 'exercise-1',
+        exercise_name: 'Bench Press',
+        modality: 'weight_reps',
+        sets: [
+          {
+            id: 1,
+            set_number: 1,
+            set_type: 'Working Set',
+            reps: 8,
+            weight: 60,
+            duration: null,
+            rest_time: null,
+            notes: null,
+          },
+          {
+            id: 2,
+            set_number: 2,
+            set_type: 'Working Set',
+            reps: 6,
+            weight: 70,
+            duration: null,
+            rest_time: null,
+            notes: null,
+          },
+        ],
+      },
+    ],
+  } as unknown as WorkoutPreset;
+
+  it('preserves the existing sets when the replacement has the same modality', () => {
     const onSave = jest.fn();
     const { result } = renderHook(() =>
-      useWorkoutPresetForm({ initialPreset: presetWithTimedSet, onSave })
+      useWorkoutPresetForm({ initialPreset: presetWithWeightRepsSet, onSave })
     );
 
     act(() => {
       result.current.handleOpenReplaceExercise(0);
     });
     act(() => {
+      // Same 'strength' -> 'weight_reps' modality as the entry being replaced.
       result.current.handleAddExercise({
         id: 'exercise-2',
         name: 'Squat',
@@ -159,15 +197,51 @@ describe('useWorkoutPresetForm replace exercise', () => {
     const replaced = result.current.exercises[0]!;
     expect(replaced.exercise_id).toBe('exercise-2');
     expect(replaced.exercise_name).toBe('Squat');
+    expect(replaced.modality).toBe('weight_reps');
     // The already-entered sets must survive the swap — the whole point of
     // replace over remove-then-re-add.
     expect(replaced.sets).toHaveLength(2);
     expect(replaced.sets[0]).toEqual(
-      expect.objectContaining({ duration: 355, weight: null })
+      expect.objectContaining({ reps: 8, weight: 60 })
     );
     expect(replaced.sets[1]).toEqual(
-      expect.objectContaining({ reps: 5, weight: 0 })
+      expect.objectContaining({ reps: 6, weight: 70 })
     );
+  });
+
+  it('resets to a fresh default set when the replacement changes modality', () => {
+    const onSave = jest.fn();
+    const { result } = renderHook(() =>
+      useWorkoutPresetForm({ initialPreset: presetWithWeightRepsSet, onSave })
+    );
+
+    act(() => {
+      result.current.handleOpenReplaceExercise(0);
+    });
+    act(() => {
+      // 'isometric' -> 'duration' differs from the original 'weight_reps':
+      // reusing the old reps:8/weight:60 sets would show a blank reps column
+      // instead of the duration default, and silently keep weight/reps
+      // values the new UI hides but the server would still persist.
+      result.current.handleAddExercise({
+        id: 'exercise-3',
+        name: 'Plank',
+        category: 'isometric',
+        images: [],
+      } as unknown as Exercise);
+    });
+
+    expect(result.current.exercises).toHaveLength(1);
+    const replaced = result.current.exercises[0]!;
+    expect(replaced.exercise_id).toBe('exercise-3');
+    expect(replaced.modality).toBe('duration');
+    expect(replaced.sets).toHaveLength(1);
+    expect(replaced.sets[0]).toEqual(
+      expect.objectContaining({ reps: null, weight: null, duration: null })
+    );
+    // A fresh id, not one of the original two sets.
+    expect(replaced.sets[0]?.id).not.toBe('1');
+    expect(replaced.sets[0]?.id).not.toBe('2');
   });
 
   it('does not misroute a plain Add Exercise after a replace was opened then cancelled', () => {
@@ -224,5 +298,23 @@ describe('useWorkoutPresetForm duplicate exercise', () => {
     // Independent identity: editing one must never touch the other.
     expect(duplicate.id).not.toBe(original.id);
     expect(duplicate.sets[0]?.id).not.toBe(original.sets[0]?.id);
+  });
+
+  it("does not silently join the original exercise's superset (the web editor has no superset UI)", () => {
+    const onSave = jest.fn();
+    const presetInSuperset = {
+      ...presetWithTimedSet,
+      exercises: [{ ...presetWithTimedSet.exercises[0], superset_group: 3 }],
+    } as unknown as WorkoutPreset;
+    const { result } = renderHook(() =>
+      useWorkoutPresetForm({ initialPreset: presetInSuperset, onSave })
+    );
+
+    act(() => {
+      result.current.handleDuplicateExercise(0);
+    });
+
+    expect(result.current.exercises[0]?.superset_group).toBe(3);
+    expect(result.current.exercises[1]?.superset_group).toBeNull();
   });
 });

--- a/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPresetForm.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPresetForm.test.tsx
@@ -134,3 +134,95 @@ describe('useWorkoutPresetForm modality seeding', () => {
     );
   });
 });
+
+describe('useWorkoutPresetForm replace exercise', () => {
+  it('preserves the existing sets and swaps the exercise identity in place', () => {
+    const onSave = jest.fn();
+    const { result } = renderHook(() =>
+      useWorkoutPresetForm({ initialPreset: presetWithTimedSet, onSave })
+    );
+
+    act(() => {
+      result.current.handleOpenReplaceExercise(0);
+    });
+    act(() => {
+      result.current.handleAddExercise({
+        id: 'exercise-2',
+        name: 'Squat',
+        category: 'strength',
+        images: [],
+      } as unknown as Exercise);
+    });
+
+    // Swapped in place, not appended.
+    expect(result.current.exercises).toHaveLength(1);
+    const replaced = result.current.exercises[0]!;
+    expect(replaced.exercise_id).toBe('exercise-2');
+    expect(replaced.exercise_name).toBe('Squat');
+    // The already-entered sets must survive the swap — the whole point of
+    // replace over remove-then-re-add.
+    expect(replaced.sets).toHaveLength(2);
+    expect(replaced.sets[0]).toEqual(
+      expect.objectContaining({ duration: 355, weight: null })
+    );
+    expect(replaced.sets[1]).toEqual(
+      expect.objectContaining({ reps: 5, weight: 0 })
+    );
+  });
+
+  it('does not misroute a plain Add Exercise after a replace was opened then cancelled', () => {
+    const onSave = jest.fn();
+    const { result } = renderHook(() =>
+      useWorkoutPresetForm({ initialPreset: presetWithTimedSet, onSave })
+    );
+
+    act(() => {
+      result.current.handleOpenReplaceExercise(0);
+    });
+    // Cancel the replace: opening plain Add must drop the pending target.
+    act(() => {
+      result.current.handleOpenAddExercise();
+    });
+    act(() => {
+      result.current.handleAddExercise({
+        id: 'exercise-2',
+        name: 'Squat',
+        category: 'strength',
+        images: [],
+      } as unknown as Exercise);
+    });
+
+    expect(result.current.exercises).toHaveLength(2);
+    expect(result.current.exercises[0]?.exercise_id).toBe('exercise-1');
+    expect(result.current.exercises[1]?.exercise_id).toBe('exercise-2');
+  });
+});
+
+describe('useWorkoutPresetForm duplicate exercise', () => {
+  it('adds an independent copy of the exercise, with the same sets, right after it', () => {
+    const onSave = jest.fn();
+    const { result } = renderHook(() =>
+      useWorkoutPresetForm({ initialPreset: presetWithTimedSet, onSave })
+    );
+
+    act(() => {
+      result.current.handleDuplicateExercise(0);
+    });
+
+    expect(result.current.exercises).toHaveLength(2);
+    const original = result.current.exercises[0]!;
+    const duplicate = result.current.exercises[1]!;
+    expect(duplicate.exercise_id).toBe(original.exercise_id);
+    expect(duplicate.exercise_name).toBe(original.exercise_name);
+    expect(duplicate.sets).toHaveLength(2);
+    expect(duplicate.sets[0]).toEqual(
+      expect.objectContaining({ duration: 355, weight: null })
+    );
+    expect(duplicate.sets[1]).toEqual(
+      expect.objectContaining({ reps: 5, weight: 0 })
+    );
+    // Independent identity: editing one must never touch the other.
+    expect(duplicate.id).not.toBe(original.id);
+    expect(duplicate.sets[0]?.id).not.toBe(original.sets[0]?.id);
+  });
+});

--- a/SparkyFitnessFrontend/src/types/workout.ts
+++ b/SparkyFitnessFrontend/src/types/workout.ts
@@ -27,6 +27,7 @@ export interface WorkoutPresetExercise {
   sets: WorkoutPresetSet[];
   category?: string;
   modality?: ExerciseModality | null; // Populated from backend join
+  superset_group?: number | null;
 }
 
 export interface WorkoutPreset {

--- a/SparkyFitnessMobile/__tests__/hooks/draftExercisesSlice.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/draftExercisesSlice.test.ts
@@ -1,0 +1,80 @@
+import { draftExercisesReducer } from '../../src/hooks/draftExercisesSlice';
+import { getDefaultRestSec } from '../../src/stores/appPreferencesStore';
+import type { WorkoutDraftExercise } from '../../src/types/drafts';
+import type { Exercise } from '../../src/types/exercise';
+
+function buildWeightRepsExercise(): WorkoutDraftExercise {
+  return {
+    clientId: 'ex-1',
+    exerciseId: 'exercise-1',
+    exerciseName: 'Bench Press',
+    exerciseCategory: 'strength',
+    exerciseModality: 'weight_reps',
+    images: [],
+    sets: [
+      { clientId: 'set-1', weight: '60', reps: '8', distance: '' },
+      { clientId: 'set-2', weight: '70', reps: '6', distance: '' },
+    ],
+  } as unknown as WorkoutDraftExercise;
+}
+
+describe('draftExercisesReducer REPLACE_EXERCISE', () => {
+  it('preserves the existing sets when the replacement has the same effective modality', () => {
+    const exercises = [buildWeightRepsExercise()];
+
+    const next = draftExercisesReducer(exercises, {
+      type: 'REPLACE_EXERCISE',
+      clientId: 'ex-1',
+      exercise: { id: 'exercise-2', name: 'Squat', category: 'strength' } as Exercise,
+      setClientId: 'new-set',
+      preserveSets: true,
+    });
+
+    expect(next[0].exerciseId).toBe('exercise-2');
+    expect(next[0].sets).toHaveLength(2);
+    expect(next[0].sets[0]).toEqual(
+      expect.objectContaining({ clientId: 'set-1', weight: '60', reps: '8' }),
+    );
+    expect(next[0].sets[1]).toEqual(
+      expect.objectContaining({ clientId: 'set-2', weight: '70', reps: '6' }),
+    );
+  });
+
+  it('resets to a fresh default set when the replacement changes modality', () => {
+    const exercises = [buildWeightRepsExercise()];
+
+    const next = draftExercisesReducer(exercises, {
+      type: 'REPLACE_EXERCISE',
+      clientId: 'ex-1',
+      exercise: { id: 'exercise-3', name: 'Plank', category: 'isometric' } as Exercise,
+      setClientId: 'new-set',
+      preserveSets: true,
+    });
+
+    expect(next[0].exerciseId).toBe('exercise-3');
+    expect(next[0].sets).toEqual([
+      {
+        clientId: 'new-set',
+        weight: '',
+        reps: '',
+        distance: '',
+        restTime: getDefaultRestSec(),
+      },
+    ]);
+  });
+
+  it('still resets when preserveSets is not requested, regardless of modality', () => {
+    const exercises = [buildWeightRepsExercise()];
+
+    const next = draftExercisesReducer(exercises, {
+      type: 'REPLACE_EXERCISE',
+      clientId: 'ex-1',
+      exercise: { id: 'exercise-2', name: 'Squat', category: 'strength' } as Exercise,
+      setClientId: 'new-set',
+      preserveSets: false,
+    });
+
+    expect(next[0].sets).toHaveLength(1);
+    expect(next[0].sets[0]?.clientId).toBe('new-set');
+  });
+});

--- a/SparkyFitnessMobile/__tests__/hooks/useScreenHeader.test.tsx
+++ b/SparkyFitnessMobile/__tests__/hooks/useScreenHeader.test.tsx
@@ -141,23 +141,26 @@ describe('useScreenHeader custom bar title layout', () => {
   // (flexBasis: auto/content) title gets ZERO share of both the shrink
   // distribution (scaled shrink factor = flexShrink × flexBasis = 0 for
   // basis:0% items) and the growth (growth doesn't apply during overflow) —
-  // a long title claims the entire row and the side cells vanish. The side
-  // cells must be content-sized (no flex-grow/shrink) and the title must be
-  // the one flexible cell, with flexBasis: 0 like CSS's `flex: 1 1 0%`, so
-  // it's on equal footing in that algorithm instead of starting from an
-  // unbounded content-based size. Asserts the inline `style` (not a
-  // className string) since Uniwind's classes are processed at build time
+  // a long title claims the entire row and the side cells vanish. Fixed via
+  // an absolutely-positioned title layer (decoupled from the side cells'
+  // flex layout entirely, so it can never compete with them for space) plus
+  // content-sized (flexShrink: 0) side cells, so neither a long title nor
+  // wide side content can squeeze the other. Asserts the inline `style` (not
+  // a className string) since Uniwind's classes are processed at build time
   // and are opaque to this test either way — the inline style is what
   // actually guarantees the behavior at runtime.
-  it('makes the title cell the flexible one (flexGrow/flexShrink, flexBasis: 0) and the side cells content-sized, so a long title cannot squeeze them to zero', () => {
+  it('renders the title as an untouchable absolute layer and keeps the side cells content-sized, so a long title cannot squeeze them to zero', () => {
     const { UNSAFE_getAllByType } = render(
       <TestScreen title={'A very long preset name that would otherwise overflow the header bar'} />,
     );
 
     const views = UNSAFE_getAllByType(View);
-    const titleContainer = views.find((view) => view.props.className === 'px-2');
-    expect(titleContainer?.props.style).toEqual(
-      expect.objectContaining({ flexGrow: 1, flexShrink: 1, flexBasis: 0, minWidth: 0 }),
+    const titleLayer = views.find((view) => view.props.pointerEvents === 'box-none');
+    expect(titleLayer?.props.style).toEqual(
+      expect.objectContaining({ position: 'absolute', left: 16, right: 16 }),
+    );
+    expect(titleLayer?.props.children.props.children).toBe(
+      'A very long preset name that would otherwise overflow the header bar',
     );
 
     const leftContainer = views.find(

--- a/SparkyFitnessMobile/__tests__/hooks/useScreenHeader.test.tsx
+++ b/SparkyFitnessMobile/__tests__/hooks/useScreenHeader.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Platform } from 'react-native';
+import { Platform, View } from 'react-native';
 import { render } from '@testing-library/react-native';
 
 import { useScreenHeader } from '../../src/hooks/useScreenHeader';
@@ -117,6 +117,58 @@ describe('useScreenHeader accessibility label (custom path)', () => {
     const { getByRole } = render(<TestScreen right={primaryExplicitA11y} />);
 
     expect(getByRole('button').props.accessibilityLabel).toBe('Save meal');
+  });
+});
+
+describe('useScreenHeader custom bar title layout', () => {
+  let osSpy: jest.SpyInstance | null = null;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    __resetAppPreferencesStoreForTests();
+    mockUsesNativeHeader = false;
+    osSpy = jest.replaceProperty(Platform, 'OS', 'android');
+    await initializeI18n('en');
+    await i18n.changeLanguage('en');
+  });
+
+  afterEach(() => {
+    if (osSpy) osSpy.restore();
+  });
+
+  // Confirmed via onLayout measurement on a real device (row:411 L:0 T:379
+  // R:0): a `flex-1` (flexBasis: 0%) side cell next to a flexShrink-only
+  // (flexBasis: auto/content) title gets ZERO share of both the shrink
+  // distribution (scaled shrink factor = flexShrink × flexBasis = 0 for
+  // basis:0% items) and the growth (growth doesn't apply during overflow) —
+  // a long title claims the entire row and the side cells vanish. The side
+  // cells must be content-sized (no flex-grow/shrink) and the title must be
+  // the one flexible cell, with flexBasis: 0 like CSS's `flex: 1 1 0%`, so
+  // it's on equal footing in that algorithm instead of starting from an
+  // unbounded content-based size. Asserts the inline `style` (not a
+  // className string) since Uniwind's classes are processed at build time
+  // and are opaque to this test either way — the inline style is what
+  // actually guarantees the behavior at runtime.
+  it('makes the title cell the flexible one (flexGrow/flexShrink, flexBasis: 0) and the side cells content-sized, so a long title cannot squeeze them to zero', () => {
+    const { UNSAFE_getAllByType } = render(
+      <TestScreen title={'A very long preset name that would otherwise overflow the header bar'} />,
+    );
+
+    const views = UNSAFE_getAllByType(View);
+    const titleContainer = views.find((view) => view.props.className === 'px-2');
+    expect(titleContainer?.props.style).toEqual(
+      expect.objectContaining({ flexGrow: 1, flexShrink: 1, flexBasis: 0, minWidth: 0 }),
+    );
+
+    const leftContainer = views.find(
+      (view) => view.props.className === 'flex-row items-center gap-4',
+    );
+    expect(leftContainer?.props.style).toEqual(expect.objectContaining({ flexShrink: 0 }));
+
+    const rightContainer = views.find(
+      (view) => view.props.className === 'flex-row items-center justify-end gap-4',
+    );
+    expect(rightContainer?.props.style).toEqual(expect.objectContaining({ flexShrink: 0 }));
   });
 });
 

--- a/SparkyFitnessMobile/__tests__/screens/WorkoutPresetDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/WorkoutPresetDetailScreen.test.tsx
@@ -47,6 +47,7 @@ jest.mock('../../src/services/workoutDraftService', () => ({
 const mockNavigation = {
   setOptions: jest.fn(),
   navigate: jest.fn(),
+  push: jest.fn(),
   goBack: jest.fn(),
 } as any;
 jest.mock('@react-navigation/native', () => ({
@@ -189,7 +190,7 @@ describe('WorkoutPresetDetailScreen', () => {
         {
           exercise_id: 'ex-1',
           image_url: null,
-          sort_order: undefined,
+          sort_order: 0,
           superset_group: undefined,
           sets: [
             {
@@ -207,10 +208,46 @@ describe('WorkoutPresetDetailScreen', () => {
       ],
     });
     await waitFor(() => {
-      expect(navigation.navigate).toHaveBeenCalledWith('WorkoutPresetDetail', {
+      // push, not navigate: this runs from WorkoutPresetDetail itself, and
+      // navigate() to the already-focused route would replace its params
+      // instead of pushing a new screen, silently turning the original
+      // detail screen into the copy.
+      expect(navigation.push).toHaveBeenCalledWith('WorkoutPresetDetail', {
         preset: created,
       });
     });
+    expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it('re-indexes sort_order from array position on duplicate (the read query never returns it)', async () => {
+    const createPresetAsync = jest.fn().mockResolvedValue(buildPreset({ id: 8 }));
+    mockUseCreateWorkoutPreset.mockReturnValue({ createPresetAsync, isPending: false });
+
+    const preset = buildPreset({
+      exercises: [
+        {
+          id: 'pe-1',
+          exercise_id: 'ex-1',
+          exercise_name: 'Bench Press',
+          image_url: null,
+          sets: [buildSet()],
+        },
+        {
+          id: 'pe-2',
+          exercise_id: 'ex-2',
+          exercise_name: 'Squat',
+          image_url: null,
+          sets: [buildSet()],
+        },
+      ],
+    });
+    const screen = renderScreen(preset);
+
+    fireEvent.press(screen.getByLabelText('Duplicate workout preset'));
+
+    await waitFor(() => expect(createPresetAsync).toHaveBeenCalledTimes(1));
+    const sentExercises = createPresetAsync.mock.calls[0][0].exercises;
+    expect(sentExercises.map((e: { sort_order: number }) => e.sort_order)).toEqual([0, 1]);
   });
 
   it('navigates to WorkoutAdd with the preset and popCount=2 on Log past workout', async () => {

--- a/SparkyFitnessMobile/__tests__/screens/WorkoutPresetDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/WorkoutPresetDetailScreen.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import WorkoutPresetDetailScreen from '../../src/screens/WorkoutPresetDetailScreen';
-import { usePreferences } from '../../src/hooks';
+import { usePreferences, useCreateWorkoutPreset } from '../../src/hooks';
 import { useStartLiveWorkout } from '../../src/hooks/useStartLiveWorkout';
 import { loadActiveDraft } from '../../src/services/workoutDraftService';
 import { buildPresetStartExercisesPayload } from '../../src/utils/workoutSession';
@@ -20,10 +20,19 @@ jest.mock('../../src/hooks', () => ({
   useServerConnection: jest.fn(() => ({ isConnected: true, isLoading: false })),
   useDeleteWorkoutPreset: jest.fn(() => ({ confirmAndDelete: jest.fn(), isPending: false })),
   useUpdateWorkoutPreset: jest.fn(() => ({ updateWorkoutPreset: jest.fn(), isPending: false })),
+  useCreateWorkoutPreset: jest.fn(() => ({ createPresetAsync: jest.fn(), isPending: false })),
 }));
 
 jest.mock('../../src/hooks/useStartLiveWorkout', () => ({
   useStartLiveWorkout: jest.fn(),
+}));
+
+// Force the custom (non-native) header path so header action buttons render
+// as pressable React elements instead of being handed off to
+// unstable_header*Items, which the test renderer can't press.
+jest.mock('../../src/services/nativeTabBarPreference', () => ({
+  useNativeIOSTabsActive: jest.fn(() => false),
+  useNativeIOSHeadersActive: jest.fn(() => false),
 }));
 
 jest.mock('../../src/components/ActiveWorkoutBar', () => ({
@@ -52,6 +61,9 @@ const mockUsePreferences = usePreferences as jest.MockedFunction<typeof usePrefe
 const mockLoadActiveDraft = loadActiveDraft as jest.MockedFunction<typeof loadActiveDraft>;
 const mockUseStartLiveWorkout = useStartLiveWorkout as jest.MockedFunction<
   typeof useStartLiveWorkout
+>;
+const mockUseCreateWorkoutPreset = useCreateWorkoutPreset as jest.MockedFunction<
+  typeof useCreateWorkoutPreset
 >;
 
 const insets = { top: 0, bottom: 0, left: 0, right: 0 };
@@ -118,6 +130,10 @@ describe('WorkoutPresetDetailScreen', () => {
     } as any);
     mockLoadActiveDraft.mockResolvedValue(null);
     mockUseStartLiveWorkout.mockReturnValue({ startLiveWorkout, isStarting: false });
+    mockUseCreateWorkoutPreset.mockReturnValue({
+      createPresetAsync: jest.fn(),
+      isPending: false,
+    });
   });
 
   it('starts a live workout with the preset-built payload on Start workout', () => {
@@ -142,6 +158,59 @@ describe('WorkoutPresetDetailScreen', () => {
       sourcePresetId: 7,
     });
     expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  it('duplicates the preset (available even though the fixture profile does not own it) into a private copy with the original exercises/sets', async () => {
+    const created = buildPreset({ id: 8, name: 'Push Day (Copy)' });
+    const createPresetAsync = jest.fn().mockResolvedValue(created);
+    mockUseCreateWorkoutPreset.mockReturnValue({ createPresetAsync, isPending: false });
+
+    const preset = buildPreset({
+      exercises: [
+        {
+          id: 'pe-1',
+          exercise_id: 'ex-1',
+          exercise_name: 'Bench Press',
+          image_url: null,
+          sets: [buildSet({ id: 's-1', set_number: 1, reps: 5, weight: 100 })],
+        },
+      ],
+    });
+    const screen = renderScreen(preset);
+
+    fireEvent.press(screen.getByLabelText('Duplicate workout preset'));
+
+    await waitFor(() => expect(createPresetAsync).toHaveBeenCalledTimes(1));
+    expect(createPresetAsync).toHaveBeenCalledWith({
+      name: 'Push Day (Copy)',
+      description: 'Chest, shoulders, triceps',
+      is_public: false,
+      exercises: [
+        {
+          exercise_id: 'ex-1',
+          image_url: null,
+          sort_order: undefined,
+          superset_group: undefined,
+          sets: [
+            {
+              set_number: 1,
+              set_type: 'normal',
+              reps: 5,
+              weight: 100,
+              duration: null,
+              distance: undefined,
+              rest_time: 60,
+              notes: null,
+            },
+          ],
+        },
+      ],
+    });
+    await waitFor(() => {
+      expect(navigation.navigate).toHaveBeenCalledWith('WorkoutPresetDetail', {
+        preset: created,
+      });
+    });
   });
 
   it('navigates to WorkoutAdd with the preset and popCount=2 on Log past workout', async () => {
@@ -215,11 +284,10 @@ describe('WorkoutPresetDetailScreen', () => {
     });
     const screen = renderScreen(preset);
 
-    // The name lives in the header title; the body keeps the description,
+    // The name lives in the header title (rendered as plain text on this
+    // file's forced custom header path); the body keeps the description,
     // exercise count, and the exercise card.
-    expect(navigation.setOptions).toHaveBeenCalledWith(
-      expect.objectContaining({ title: 'Push Day' }),
-    );
+    expect(screen.getByText('Push Day')).toBeTruthy();
     expect(screen.getByText('Chest, shoulders, triceps')).toBeTruthy();
     expect(screen.getByText('1 exercise')).toBeTruthy();
     expect(screen.getByText('Bench Press')).toBeTruthy();

--- a/SparkyFitnessMobile/__tests__/screens/WorkoutPresetDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/WorkoutPresetDetailScreen.test.tsx
@@ -13,6 +13,9 @@ import {
   __resetAppPreferencesStoreForTests,
 } from '../../src/stores/appPreferencesStore';
 import type { WorkoutPreset, WorkoutPresetSet } from '../../src/types/workoutPresets';
+import type { RootStackScreenProps } from '../../src/types/navigation';
+
+type ScreenProps = RootStackScreenProps<'WorkoutPresetDetail'>;
 
 jest.mock('../../src/hooks', () => ({
   usePreferences: jest.fn(),
@@ -49,7 +52,7 @@ const mockNavigation = {
   navigate: jest.fn(),
   push: jest.fn(),
   goBack: jest.fn(),
-} as any;
+} as unknown as ScreenProps['navigation'];
 jest.mock('@react-navigation/native', () => ({
   ...jest.requireActual('@react-navigation/native'),
   useNavigation: () => mockNavigation,

--- a/SparkyFitnessMobile/src/components/WorkoutFormExerciseList.tsx
+++ b/SparkyFitnessMobile/src/components/WorkoutFormExerciseList.tsx
@@ -95,6 +95,12 @@ interface WorkoutFormExerciseListProps {
    */
   onReplaceExercise?: (clientId: string) => void;
   /**
+   * Enables the ⋮ "Duplicate exercise" item: adds an independent copy of the
+   * entry (same sets, notes, calories) right after it, ungrouped even if the
+   * original is in a superset. Preset form only.
+   */
+  onDuplicateExercise?: (clientId: string) => void;
+  /**
    * Enables the ⋮ "Clear logged sets" item, shown only when the exercise has
    * a completed set and renders a set table — cardio-effort-form exercises
    * hide it (workout edit). Absent for forms whose drafts never carry
@@ -166,6 +172,7 @@ const WorkoutFormExerciseList = forwardRef<
     setExerciseCalories,
     setExerciseNotes,
     onReplaceExercise,
+    onDuplicateExercise,
     clearExerciseCompletions,
     supersetWith,
     ungroupExercise,
@@ -540,6 +547,13 @@ const WorkoutFormExerciseList = forwardRef<
         onPress: () => onReplaceExercise(clientId),
       });
     }
+    if (onDuplicateExercise) {
+      items.push({
+        key: 'duplicate',
+        label: 'Duplicate exercise',
+        onPress: () => onDuplicateExercise(clientId),
+      });
+    }
     if (clearExerciseCompletions) {
       const target = exercises.find(e => e.clientId === clientId);
       // The cardio effort form shows no completion state in the forms, so a
@@ -577,6 +591,7 @@ const WorkoutFormExerciseList = forwardRef<
     supersetWith,
     ungroupExercise,
     onReplaceExercise,
+    onDuplicateExercise,
     clearExerciseCompletions,
     onRemoveExercise,
     onViewExercise,

--- a/SparkyFitnessMobile/src/hooks/draftExercisesSlice.ts
+++ b/SparkyFitnessMobile/src/hooks/draftExercisesSlice.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import type { Dispatch, MutableRefObject } from 'react';
 import {
   getDefaultRestSec,
@@ -28,7 +28,26 @@ export function generateClientId(): string {
 export type DraftExercisesAction =
   | { type: 'ADD_EXERCISE'; exercise: Exercise; exerciseClientId: string; setClientId: string }
   | { type: 'REMOVE_EXERCISE'; clientId: string }
-  | { type: 'REPLACE_EXERCISE'; clientId: string; exercise: Exercise; setClientId: string }
+  | {
+      type: 'REPLACE_EXERCISE';
+      clientId: string;
+      exercise: Exercise;
+      setClientId: string;
+      /**
+       * Keep the entry's already-entered sets instead of resetting to one
+       * empty set. Opt-in (preset form only) — the workout form still wants
+       * a fresh set, since replacing a logged exercise's identity while
+       * keeping its recorded numbers would misrepresent what was actually
+       * performed.
+       */
+      preserveSets?: boolean;
+    }
+  | {
+      type: 'DUPLICATE_EXERCISE';
+      clientId: string;
+      newExerciseClientId: string;
+      setClientIds: string[];
+    }
   | { type: 'CLEAR_EXERCISE_COMPLETIONS'; clientId: string }
   | { type: 'ADD_SET'; exerciseClientId: string; setClientId: string }
   | { type: 'REMOVE_SET'; exerciseClientId: string; setClientId: string }
@@ -80,13 +99,26 @@ export function draftExercisesReducer(
       );
 
     // Mirrors the live store's replaceExercise: swap the exercise identity in
-    // place (keeping clientId, position, and superset grouping) and reset to
-    // one default set — the old sets no longer describe the new movement.
-    // Dropping serverId sends the whole session down the server's
-    // delete-and-recreate path (mixed old/new exercise ids aren't allowed).
+    // place (keeping clientId, position, and superset grouping). Dropping
+    // serverId sends the whole session down the server's delete-and-recreate
+    // path (mixed old/new exercise ids aren't allowed). When preserveSets
+    // isn't requested (or there's nothing to preserve), reset to one default
+    // set — the old sets no longer describe the new movement.
     case 'REPLACE_EXERCISE':
       return exercises.map(exercise => {
         if (exercise.clientId !== action.clientId) return exercise;
+        const sets =
+          action.preserveSets && exercise.sets.length > 0
+            ? exercise.sets
+            : [
+                {
+                  clientId: action.setClientId,
+                  weight: '',
+                  reps: '',
+                  distance: '',
+                  restTime: getDefaultRestSec(),
+                },
+              ];
         return {
           ...exercise,
           serverId: undefined,
@@ -96,17 +128,45 @@ export function draftExercisesReducer(
           exerciseCategory: action.exercise.category,
           exerciseModality: action.exercise.modality ?? null,
           images: action.exercise.images ?? [],
-          sets: [
-            {
-              clientId: action.setClientId,
-              weight: '',
-              reps: '',
-              distance: '',
-              restTime: getDefaultRestSec(),
-            },
-          ],
+          sets,
         };
       });
+
+    // Adds an independent copy of the exercise (same sets, notes, calories)
+    // right after its own run so a duplicate can never visually split an
+    // existing superset's border. The copy starts ungrouped — silently
+    // joining the original's superset would change the original's structure.
+    case 'DUPLICATE_EXERCISE': {
+      const index = exercises.findIndex(e => e.clientId === action.clientId);
+      if (index === -1) return exercises;
+      const original = exercises[index];
+      const duplicate: WorkoutDraftExercise = {
+        ...original,
+        clientId: action.newExerciseClientId,
+        serverId: undefined,
+        snapshot: null,
+        supersetGroup: null,
+        sets: original.sets.map((set, i) => ({
+          ...set,
+          clientId: action.setClientIds[i],
+          completedAt: null,
+          isPr: false,
+        })),
+      };
+      let insertAt = index + 1;
+      const groupId = original.supersetGroup ?? null;
+      if (groupId != null) {
+        while (
+          insertAt < exercises.length &&
+          (exercises[insertAt].supersetGroup ?? null) === groupId
+        ) {
+          insertAt++;
+        }
+      }
+      const next = [...exercises];
+      next.splice(insertAt, 0, duplicate);
+      return next;
+    }
 
     // Mirrors the live store's clearExerciseCompletions: un-log every set,
     // dropping the stale PR flags with the completions. Identity return when
@@ -235,6 +295,11 @@ export function draftExercisesReducer(
  */
 export function useDraftExerciseActions(
   dispatch: Dispatch<DraftExercisesAction>,
+  exercises: WorkoutDraftExercise[],
+  options?: {
+    /** See REPLACE_EXERCISE's `preserveSets`. Off by default (workout form). */
+    preserveSetsOnReplace?: boolean;
+  },
 ): {
   exercisesModifiedRef: MutableRefObject<boolean>;
   addExercise: (exercise: Exercise) => { exerciseClientId: string; setClientId: string };
@@ -242,7 +307,8 @@ export function useDraftExerciseActions(
   replaceExercise: (
     clientId: string,
     exercise: Exercise,
-  ) => { exerciseClientId: string; setClientId: string };
+  ) => { exerciseClientId: string; setClientId: string | null };
+  duplicateExercise: (clientId: string) => { exerciseClientId: string };
   clearExerciseCompletions: (clientId: string) => void;
   addSet: (exerciseClientId: string) => string;
   removeSet: (exerciseClientId: string, setClientId: string) => void;
@@ -265,6 +331,18 @@ export function useDraftExerciseActions(
   reorderExercises: (fromItemIndex: number, toItemIndex: number) => void;
 } {
   const exercisesModifiedRef = useRef(false);
+  // Read inside the memoized wrappers below without joining the useMemo deps
+  // (which would churn every wrapper's identity on every draft edit) — only
+  // replaceExercise/duplicateExercise need the current array, to look up a
+  // target's existing sets synchronously before dispatch. Synced in an
+  // effect (not inline) since writing a ref during render is disallowed; by
+  // the time a user action calls replaceExercise/duplicateExercise, the
+  // effect from the latest render has already run.
+  const exercisesRef = useRef(exercises);
+  useEffect(() => {
+    exercisesRef.current = exercises;
+  });
+  const preserveSetsOnReplace = options?.preserveSetsOnReplace ?? false;
   return useMemo(
     () => ({
       exercisesModifiedRef,
@@ -282,8 +360,31 @@ export function useDraftExerciseActions(
       replaceExercise: (clientId: string, exercise: Exercise) => {
         exercisesModifiedRef.current = true;
         const setClientId = generateClientId();
-        dispatch({ type: 'REPLACE_EXERCISE', clientId, exercise, setClientId });
-        return { exerciseClientId: clientId, setClientId };
+        dispatch({
+          type: 'REPLACE_EXERCISE',
+          clientId,
+          exercise,
+          setClientId,
+          preserveSets: preserveSetsOnReplace,
+        });
+        // Sets got preserved (nothing new was created) — there's nothing to
+        // focus. Otherwise a fresh single set was created (either replace
+        // never preserves here, or there was nothing to preserve); focus it,
+        // same as before.
+        const hadExistingSets =
+          (exercisesRef.current.find(e => e.clientId === clientId)?.sets.length ?? 0) > 0;
+        return {
+          exerciseClientId: clientId,
+          setClientId: preserveSetsOnReplace && hadExistingSets ? null : setClientId,
+        };
+      },
+      duplicateExercise: (clientId: string) => {
+        exercisesModifiedRef.current = true;
+        const newExerciseClientId = generateClientId();
+        const target = exercisesRef.current.find(e => e.clientId === clientId);
+        const setClientIds = (target?.sets ?? []).map(() => generateClientId());
+        dispatch({ type: 'DUPLICATE_EXERCISE', clientId, newExerciseClientId, setClientIds });
+        return { exerciseClientId: newExerciseClientId };
       },
       clearExerciseCompletions: (clientId: string) => {
         exercisesModifiedRef.current = true;
@@ -341,6 +442,6 @@ export function useDraftExerciseActions(
         dispatch({ type: 'REORDER_EXERCISES', fromItemIndex, toItemIndex });
       },
     }),
-    [dispatch],
+    [dispatch, preserveSetsOnReplace],
   );
 }

--- a/SparkyFitnessMobile/src/hooks/draftExercisesSlice.ts
+++ b/SparkyFitnessMobile/src/hooks/draftExercisesSlice.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import type { Dispatch, MutableRefObject } from 'react';
+import { resolveExerciseModality } from '@workspace/shared';
 import {
   getDefaultRestSec,
   moveDraftExerciseItem,
@@ -101,14 +102,21 @@ export function draftExercisesReducer(
     // Mirrors the live store's replaceExercise: swap the exercise identity in
     // place (keeping clientId, position, and superset grouping). Dropping
     // serverId sends the whole session down the server's delete-and-recreate
-    // path (mixed old/new exercise ids aren't allowed). When preserveSets
-    // isn't requested (or there's nothing to preserve), reset to one default
-    // set — the old sets no longer describe the new movement.
+    // path (mixed old/new exercise ids aren't allowed). Sets are only
+    // preserved when the replacement's effective modality matches the
+    // original's — otherwise a duration set's null reps, or a weight_reps
+    // set's stale duration, would carry into a UI that hides those fields
+    // but the server would still persist them. When preserveSets isn't
+    // requested, there's nothing to preserve, or the modality changed, reset
+    // to one default set — the old sets no longer describe the new movement.
     case 'REPLACE_EXERCISE':
       return exercises.map(exercise => {
         if (exercise.clientId !== action.clientId) return exercise;
+        const modalityUnchanged =
+          resolveExerciseModality(exercise.exerciseModality, exercise.exerciseCategory) ===
+          resolveExerciseModality(action.exercise.modality, action.exercise.category);
         const sets =
-          action.preserveSets && exercise.sets.length > 0
+          action.preserveSets && exercise.sets.length > 0 && modalityUnchanged
             ? exercise.sets
             : [
                 {
@@ -148,7 +156,10 @@ export function draftExercisesReducer(
         supersetGroup: null,
         sets: original.sets.map((set, i) => ({
           ...set,
-          clientId: action.setClientIds[i],
+          // setClientIds is precomputed against exercisesRef before dispatch
+          // (see useDraftExerciseActions); fall back to a deterministic id if
+          // it and the live reducer state ever desync on set count.
+          clientId: action.setClientIds[i] ?? `${action.newExerciseClientId}-${i}`,
           completedAt: null,
           isPr: false,
         })),
@@ -367,15 +378,20 @@ export function useDraftExerciseActions(
           setClientId,
           preserveSets: preserveSetsOnReplace,
         });
-        // Sets got preserved (nothing new was created) — there's nothing to
-        // focus. Otherwise a fresh single set was created (either replace
-        // never preserves here, or there was nothing to preserve); focus it,
-        // same as before.
-        const hadExistingSets =
-          (exercisesRef.current.find(e => e.clientId === clientId)?.sets.length ?? 0) > 0;
+        // Mirrors REPLACE_EXERCISE's own preserve/reset decision: sets are
+        // preserved (nothing new to focus) only when preserving was
+        // requested, there was something to preserve, and the modality is
+        // unchanged. Otherwise a fresh single set was created; focus it.
+        const target = exercisesRef.current.find(e => e.clientId === clientId);
+        const hadExistingSets = (target?.sets.length ?? 0) > 0;
+        const modalityUnchanged =
+          target != null &&
+          resolveExerciseModality(target.exerciseModality, target.exerciseCategory) ===
+            resolveExerciseModality(exercise.modality, exercise.category);
+        const setsWerePreserved = preserveSetsOnReplace && hadExistingSets && modalityUnchanged;
         return {
           exerciseClientId: clientId,
-          setClientId: preserveSetsOnReplace && hadExistingSets ? null : setClientId,
+          setClientId: setsWerePreserved ? null : setClientId,
         };
       },
       duplicateExercise: (clientId: string) => {

--- a/SparkyFitnessMobile/src/hooks/useExerciseSetEditing.ts
+++ b/SparkyFitnessMobile/src/hooks/useExerciseSetEditing.ts
@@ -57,10 +57,11 @@ export function useExerciseSetEditing(actions: ExerciseSetEditingActions) {
       replaceTarget != null && actions.replaceExercise
         ? actions.replaceExercise(replaceTarget, exercise)
         : actions.addExercise(exercise);
-    // null means a replace preserved the existing sets — nothing new to focus.
-    if (setClientId != null) {
-      pendingActivationRef.current = `${exerciseClientId}:${setClientId}`;
-    }
+    // null means a replace preserved the existing sets — nothing new to
+    // focus. Clear (not just skip) so a stale pending activation from an
+    // earlier action can't fire on a later transitionEnd.
+    pendingActivationRef.current =
+      setClientId != null ? `${exerciseClientId}:${setClientId}` : null;
   // eslint-disable-next-line react-hooks/exhaustive-deps -- using stable sub-properties; spreading `actions` would break memoization
   }, [actions.addExercise, actions.replaceExercise]);
 

--- a/SparkyFitnessMobile/src/hooks/useExerciseSetEditing.ts
+++ b/SparkyFitnessMobile/src/hooks/useExerciseSetEditing.ts
@@ -11,11 +11,12 @@ interface ExerciseSetEditingActions {
   removeExercise: (clientId: string) => void;
   addSet: (exerciseClientId: string) => string;
   /** Enables replace routing: while a replace target is set, the next selected
-   *  exercise swaps in place instead of appending. */
+   *  exercise swaps in place instead of appending. A null setClientId means
+   *  the replace preserved the existing sets, so there's nothing new to focus. */
   replaceExercise?: (
     clientId: string,
     exercise: Exercise,
-  ) => { exerciseClientId: string; setClientId: string };
+  ) => { exerciseClientId: string; setClientId: string | null };
 }
 
 export function useExerciseSetEditing(actions: ExerciseSetEditingActions) {
@@ -56,7 +57,10 @@ export function useExerciseSetEditing(actions: ExerciseSetEditingActions) {
       replaceTarget != null && actions.replaceExercise
         ? actions.replaceExercise(replaceTarget, exercise)
         : actions.addExercise(exercise);
-    pendingActivationRef.current = `${exerciseClientId}:${setClientId}`;
+    // null means a replace preserved the existing sets — nothing new to focus.
+    if (setClientId != null) {
+      pendingActivationRef.current = `${exerciseClientId}:${setClientId}`;
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps -- using stable sub-properties; spreading `actions` would break memoization
   }, [actions.addExercise, actions.replaceExercise]);
 

--- a/SparkyFitnessMobile/src/hooks/useScreenHeader.tsx
+++ b/SparkyFitnessMobile/src/hooks/useScreenHeader.tsx
@@ -723,12 +723,26 @@ export function useScreenHeader(config: ScreenHeaderConfig): React.ReactNode {
     <View
       className={`flex-row items-center px-4 py-3 ${borderless ? '' : 'border-b border-border-subtle'}`}
     >
-      {/* Equal-width side cells keep the title cell geometrically centered in
-          the bar even when the left/right actions have different widths; the
-          title stays content-sized (shrinking to truncate) so it can use more
-          than a third of the width when the sides are light. */}
-      <View className="flex-1 flex-row items-center gap-4">{leftCustom}</View>
-      <View className="shrink px-2">
+      {/* The side cells are content-sized (no flex-grow/shrink) and the title
+          is the one flexible cell (flexGrow/flexShrink with flexBasis: 0,
+          matching CSS's `flex: 1 1 0%`). A `flex-1` (flexBasis: 0%) side cell
+          next to a flexShrink-only (flexBasis: auto/content) title starves
+          under CSS/Yoga's shrink algorithm: each sibling's share of shrinkage
+          is scaled by `flexShrink × flexBasis`, and flexBasis: 0% siblings
+          always compute a scaled shrink factor of 0 — so a long title claims
+          the entire row and the side cells render at 0 width (confirmed via
+          on-device onLayout measurement). Giving every cell in this row the
+          same flexBasis: 0 floor puts them on equal footing. Centering is
+          relative to the leftover space between the two content-sized side
+          cells rather than screen-true-center when their widths differ — an
+          accepted trade-off for buttons that are never hidden. */}
+      <View className="flex-row items-center gap-4" style={{ flexShrink: 0 }}>
+        {leftCustom}
+      </View>
+      <View
+        className="px-2"
+        style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0, minWidth: 0, overflow: 'hidden' }}
+      >
         {center ?? (
           <Text
             numberOfLines={1}
@@ -738,7 +752,9 @@ export function useScreenHeader(config: ScreenHeaderConfig): React.ReactNode {
           </Text>
         )}
       </View>
-      <View className="flex-1 flex-row items-center justify-end gap-4">{rightCustom}</View>
+      <View className="flex-row items-center justify-end gap-4" style={{ flexShrink: 0 }}>
+        {rightCustom}
+      </View>
     </View>
   );
 

--- a/SparkyFitnessMobile/src/hooks/useScreenHeader.tsx
+++ b/SparkyFitnessMobile/src/hooks/useScreenHeader.tsx
@@ -721,27 +721,35 @@ export function useScreenHeader(config: ScreenHeaderConfig): React.ReactNode {
 
   const bar = (
     <View
-      className={`flex-row items-center px-4 py-3 ${borderless ? '' : 'border-b border-border-subtle'}`}
+      className={`px-4 py-3 ${borderless ? '' : 'border-b border-border-subtle'}`}
+      style={{ position: 'relative', flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}
     >
-      {/* The side cells are content-sized (no flex-grow/shrink) and the title
-          is the one flexible cell (flexGrow/flexShrink with flexBasis: 0,
-          matching CSS's `flex: 1 1 0%`). A `flex-1` (flexBasis: 0%) side cell
-          next to a flexShrink-only (flexBasis: auto/content) title starves
-          under CSS/Yoga's shrink algorithm: each sibling's share of shrinkage
-          is scaled by `flexShrink × flexBasis`, and flexBasis: 0% siblings
-          always compute a scaled shrink factor of 0 — so a long title claims
-          the entire row and the side cells render at 0 width (confirmed via
-          on-device onLayout measurement). Giving every cell in this row the
-          same flexBasis: 0 floor puts them on equal footing. Centering is
-          relative to the leftover space between the two content-sized side
-          cells rather than screen-true-center when their widths differ — an
-          accepted trade-off for buttons that are never hidden. */}
-      <View className="flex-row items-center gap-4" style={{ flexShrink: 0 }}>
-        {leftCustom}
-      </View>
+      {/* The title is a separate, absolutely-positioned layer centered on the
+          bar's full width, independent of the side cells' own flex layout —
+          the same technique native iOS/Android headers use. Centering the
+          title by giving the side cells equal flex-grow instead (so an empty
+          side matched the populated one) is what let a long title squeeze
+          both side cells to zero width in the first place: under CSS/Yoga's
+          shrink algorithm, a `flexBasis: 0%` sibling always computes a scaled
+          shrink factor of 0, so once the title overflowed the row it claimed
+          100% of the space and the side cells rendered at 0 width (confirmed
+          via on-device onLayout measurement). Decoupling the title from that
+          layout means it can never compete with the side cells for space, so
+          it can never squeeze them — and it still lands on the bar's true
+          center regardless of how the left/right content widths differ.
+          pointerEvents="box-none" keeps the title layer itself untouchable so
+          it can never sit "on top of" a button for hit-testing purposes. */}
       <View
-        className="px-2"
-        style={{ flexGrow: 1, flexShrink: 1, flexBasis: 0, minWidth: 0, overflow: 'hidden' }}
+        pointerEvents="box-none"
+        style={{
+          position: 'absolute',
+          left: 16,
+          right: 16,
+          top: 0,
+          bottom: 0,
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
       >
         {center ?? (
           <Text
@@ -751,6 +759,13 @@ export function useScreenHeader(config: ScreenHeaderConfig): React.ReactNode {
             {title ?? ''}
           </Text>
         )}
+      </View>
+      {/* flexShrink: 0 (content-sized) rather than flex-1: these cells can
+          never be squeezed by the title, at the cost of no longer truncating
+          if their own content ever got wide enough to overflow — a non-issue
+          for the icon/short-text buttons this bar renders. */}
+      <View className="flex-row items-center gap-4" style={{ flexShrink: 0 }}>
+        {leftCustom}
       </View>
       <View className="flex-row items-center justify-end gap-4" style={{ flexShrink: 0 }}>
         {rightCustom}

--- a/SparkyFitnessMobile/src/hooks/useWorkoutForm.ts
+++ b/SparkyFitnessMobile/src/hooks/useWorkoutForm.ts
@@ -230,7 +230,7 @@ export function useWorkoutForm(options?: UseWorkoutFormOptions) {
     supersetWith,
     ungroupExercise,
     reorderExercises,
-  } = useDraftExerciseActions(dispatch);
+  } = useDraftExerciseActions(dispatch, state.exercises);
 
   const { clearPersistedDraft } = useDraftPersistence({
     state,

--- a/SparkyFitnessMobile/src/hooks/useWorkoutPresetForm.ts
+++ b/SparkyFitnessMobile/src/hooks/useWorkoutPresetForm.ts
@@ -137,6 +137,7 @@ export function useWorkoutPresetForm() {
     addExercise,
     removeExercise,
     replaceExercise,
+    duplicateExercise,
     addSet,
     removeSet,
     updateSetField,
@@ -145,7 +146,7 @@ export function useWorkoutPresetForm() {
     supersetWith,
     ungroupExercise,
     reorderExercises,
-  } = useDraftExerciseActions(dispatch);
+  } = useDraftExerciseActions(dispatch, state.exercises, { preserveSetsOnReplace: true });
 
   const setName = useCallback((name: string) => {
     dispatch({ type: 'SET_NAME', name });
@@ -196,6 +197,7 @@ export function useWorkoutPresetForm() {
     addExercise,
     removeExercise,
     replaceExercise,
+    duplicateExercise,
     addSet,
     removeSet,
     updateSetField,

--- a/SparkyFitnessMobile/src/screens/WorkoutPresetDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutPresetDetailScreen.tsx
@@ -10,6 +10,7 @@ import { type AnchorRect } from '../components/AnchoredMenu';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { clearDraft, loadActiveDraft } from '../services/workoutDraftService';
 import {
+  useCreateWorkoutPreset,
   useDeleteWorkoutPreset,
   usePreferences,
   useProfile,
@@ -211,6 +212,40 @@ const WorkoutPresetDetailScreen: React.FC<WorkoutPresetDetailScreenProps> = ({
     });
   }, [navigation, preset, route.key]);
 
+  // Available regardless of ownership (unlike Share/Edit below) — duplicating
+  // someone else's public preset is exactly how you'd fork it into your own
+  // library.
+  const { createPresetAsync, isPending: isDuplicatePending } = useCreateWorkoutPreset();
+  const handleDuplicatePreset = useCallback(async () => {
+    try {
+      const created = await createPresetAsync({
+        name: `${preset.name} (Copy)`,
+        description: preset.description,
+        is_public: false,
+        exercises: preset.exercises.map(exercise => ({
+          exercise_id: exercise.exercise_id,
+          image_url: exercise.image_url,
+          sort_order: exercise.sort_order ?? undefined,
+          superset_group: exercise.superset_group,
+          sets: exercise.sets.map(set => ({
+            set_number: set.set_number,
+            set_type: set.set_type,
+            reps: set.reps,
+            weight: set.weight,
+            duration: set.duration,
+            distance: set.distance,
+            rest_time: set.rest_time,
+            notes: set.notes,
+          })),
+        })),
+      });
+      Toast.show({ type: 'success', text1: 'Workout preset duplicated' });
+      navigation.navigate('WorkoutPresetDetail', { preset: created });
+    } catch {
+      // useCreateWorkoutPreset already shows an error Toast on failure.
+    }
+  }, [createPresetAsync, preset, navigation]);
+
   const rightItems: HeaderItem[] = [
     ...(canManagePreset
       ? [
@@ -235,6 +270,16 @@ const WorkoutPresetDetailScreen: React.FC<WorkoutPresetDetailScreenProps> = ({
           } as const,
         ]
       : []),
+    {
+      kind: 'icon',
+      sfSymbol: 'doc.on.doc',
+      ionicon: 'copy-outline',
+      role: 'secondary',
+      disabled: isDuplicatePending,
+      onPress: () => void handleDuplicatePreset(),
+      accessibilityLabel: 'Duplicate workout preset',
+      identifier: 'workout-preset-detail-duplicate',
+    } as const,
   ];
 
   const header = useScreenHeader({

--- a/SparkyFitnessMobile/src/screens/WorkoutPresetDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutPresetDetailScreen.tsx
@@ -246,41 +246,29 @@ const WorkoutPresetDetailScreen: React.FC<WorkoutPresetDetailScreenProps> = ({
     }
   }, [createPresetAsync, preset, navigation]);
 
-  const rightItems: HeaderItem[] = [
-    ...(canManagePreset
-      ? [
-          {
-            kind: 'icon',
-            sfSymbol: isPublic ? 'lock.fill' : 'square.and.arrow.up',
-            ionicon: isPublic ? 'lock-closed-outline' : 'share-social-outline',
-            role: 'secondary',
-            useIoniconOnIOS: !isPublic,
-            disabled: isSharePending,
-            onPress: handleToggleShare,
-            accessibilityLabel: isPublic ? 'Make private' : 'Share with public',
-            identifier: 'workout-preset-detail-share',
-          } as const,
-          {
-            kind: 'text',
-            label: 'Edit',
-            role: 'secondary',
-            onPress: handleEdit,
-            accessibilityLabel: 'Edit workout preset',
-            identifier: 'workout-preset-detail-edit',
-          } as const,
-        ]
-      : []),
-    {
-      kind: 'icon',
-      sfSymbol: 'doc.on.doc',
-      ionicon: 'copy-outline',
-      role: 'secondary',
-      disabled: isDuplicatePending,
-      onPress: () => void handleDuplicatePreset(),
-      accessibilityLabel: 'Duplicate workout preset',
-      identifier: 'workout-preset-detail-duplicate',
-    } as const,
-  ];
+  const rightItems: HeaderItem[] = canManagePreset
+    ? [
+        {
+          kind: 'icon',
+          sfSymbol: isPublic ? 'lock.fill' : 'square.and.arrow.up',
+          ionicon: isPublic ? 'lock-closed-outline' : 'share-social-outline',
+          role: 'secondary',
+          useIoniconOnIOS: !isPublic,
+          disabled: isSharePending,
+          onPress: handleToggleShare,
+          accessibilityLabel: isPublic ? 'Make private' : 'Share with public',
+          identifier: 'workout-preset-detail-share',
+        } as const,
+        {
+          kind: 'text',
+          label: 'Edit',
+          role: 'secondary',
+          onPress: handleEdit,
+          accessibilityLabel: 'Edit workout preset',
+          identifier: 'workout-preset-detail-edit',
+        } as const,
+      ]
+    : [];
 
   const header = useScreenHeader({
     title: preset.name,
@@ -376,6 +364,17 @@ const WorkoutPresetDetailScreen: React.FC<WorkoutPresetDetailScreenProps> = ({
           textClassName="text-text-secondary font-medium"
         >
           Log past workout
+        </Button>
+
+        <Button
+          variant="ghost"
+          onPress={() => void handleDuplicatePreset()}
+          disabled={isDuplicatePending}
+          className="mt-3"
+          textClassName="text-text-secondary font-medium"
+          accessibilityLabel="Duplicate workout preset"
+        >
+          {isDuplicatePending ? 'Duplicating...' : 'Duplicate preset'}
         </Button>
 
         {canManagePreset && (

--- a/SparkyFitnessMobile/src/screens/WorkoutPresetDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutPresetDetailScreen.tsx
@@ -222,10 +222,16 @@ const WorkoutPresetDetailScreen: React.FC<WorkoutPresetDetailScreenProps> = ({
         name: `${preset.name} (Copy)`,
         description: preset.description,
         is_public: false,
-        exercises: preset.exercises.map(exercise => ({
+        // The list/detail read queries never select wpe.sort_order (see
+        // workoutPresetRepository), so exercise.sort_order is always
+        // undefined here — every duplicated row would otherwise insert with
+        // the same sort_order and rely on id-ASC as a display-order tiebreak.
+        // preset.exercises already arrives in display order (server sorts by
+        // sort_order then id), so the array index is the real sort_order.
+        exercises: preset.exercises.map((exercise, index) => ({
           exercise_id: exercise.exercise_id,
           image_url: exercise.image_url,
-          sort_order: exercise.sort_order ?? undefined,
+          sort_order: index,
           superset_group: exercise.superset_group,
           sets: exercise.sets.map(set => ({
             set_number: set.set_number,
@@ -240,7 +246,11 @@ const WorkoutPresetDetailScreen: React.FC<WorkoutPresetDetailScreenProps> = ({
         })),
       });
       Toast.show({ type: 'success', text1: 'Workout preset duplicated' });
-      navigation.navigate('WorkoutPresetDetail', { preset: created });
+      // navigate() to the route already focused replaces its params instead of
+      // pushing a new screen (React Navigation 7) — push so Back still returns
+      // to the original preset instead of the fresh copy. Same fix as
+      // MealDetailScreen's MealDetail -> MealDetail link.
+      navigation.push('WorkoutPresetDetail', { preset: created });
     } catch {
       // useCreateWorkoutPreset already shows an error Toast on failure.
     }

--- a/SparkyFitnessMobile/src/screens/WorkoutPresetFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutPresetFormScreen.tsx
@@ -64,6 +64,7 @@ interface PresetFormBodyProps {
   isEligibleForPrefill: (clientId: string) => boolean;
   onAddExercisePress: () => void;
   onReplaceExercise: (clientId: string) => void;
+  onDuplicateExercise: (clientId: string) => void;
   onRegisterAccessoryHandle: (key: string, handle: SetRowAccessoryHandle | null) => void;
   onViewExercise: (exercise: Exercise) => void;
   listRef: React.Ref<WorkoutFormExerciseListHandle>;
@@ -86,6 +87,7 @@ const PresetFormBody: React.FC<PresetFormBodyProps> = ({
   isEligibleForPrefill,
   onAddExercisePress,
   onReplaceExercise,
+  onDuplicateExercise,
   onRegisterAccessoryHandle,
   onViewExercise,
   listRef,
@@ -140,6 +142,7 @@ const PresetFormBody: React.FC<PresetFormBodyProps> = ({
           onRemoveExercise={exerciseSetEditing.handleRemoveExercise}
           setExerciseRest={setExerciseRest}
           onReplaceExercise={onReplaceExercise}
+          onDuplicateExercise={onDuplicateExercise}
           supersetWith={supersetWith}
           ungroupExercise={ungroupExercise}
           onReorderExercises={reorderExercises}
@@ -178,6 +181,7 @@ const CreatePresetMode: React.FC<CreatePresetModeProps> = ({ navigation, route, 
     addExercise,
     removeExercise,
     replaceExercise,
+    duplicateExercise,
     addSet,
     removeSet,
     updateSetField,
@@ -342,6 +346,7 @@ const CreatePresetMode: React.FC<CreatePresetModeProps> = ({ navigation, route, 
         isEligibleForPrefill={isEligibleForPrefill}
         onAddExercisePress={openExerciseSearch}
         onReplaceExercise={handleReplaceExercise}
+        onDuplicateExercise={duplicateExercise}
         onRegisterAccessoryHandle={onRegisterAccessoryHandle}
         onViewExercise={(exercise) =>
           navigation.navigate('ExerciseDetail', { item: exercise, hideWorkoutActions: true })
@@ -403,6 +408,7 @@ const EditPresetMode: React.FC<EditPresetModeProps> = ({ navigation, route, para
     addExercise,
     removeExercise,
     replaceExercise,
+    duplicateExercise,
     addSet,
     removeSet,
     updateSetField,
@@ -571,6 +577,7 @@ const EditPresetMode: React.FC<EditPresetModeProps> = ({ navigation, route, para
         isEligibleForPrefill={isEligibleForPrefill}
         onAddExercisePress={openExerciseSearch}
         onReplaceExercise={handleReplaceExercise}
+        onDuplicateExercise={duplicateExercise}
         onRegisterAccessoryHandle={onRegisterAccessoryHandle}
         onViewExercise={(exercise) =>
           navigation.navigate('ExerciseDetail', { item: exercise, hideWorkoutActions: true })


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Editing a workout preset had no way to swap or clone a single exercise, and there was no way to duplicate an entire preset. Additionally, a long preset name on mobile caused the detail screen's header buttons to be hidden/squeezed.

**How did you implement the solution?**
* Added the ability to replace exercises while editing a workout preset
* Added the ability to clone an exercise while editing a workout preset
* Added the ability to clone an entire workout preset
* Added a fix to reformat the screen header to fix title overlfows

Linked Issue: Closes #2185 and #2186

## How to Test

1. Check out this branch
2. Via web, navigate to Workouts/Workout preset and utilize the new duplicate or replace functions.
a. Confirm operation completed
3. Via mobile, navigate to Workouts/Workout preset and utilize the new duplicate or replace functions. Duplicate is at the bottom of the page above the "Delete preset" option
a. Confirm operation completed
b. Verify long preset title still shows back button, share, and edit button.

## PR Type

- [X] Issue (bug fix)
- [X] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [X] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [X] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [X] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="721" height="427" alt="Screenshot 2026-08-20 000546" src="https://github.com/user-attachments/assets/ed4a2da2-aa0b-45e4-9f5b-69f25d01a198" />

<img width="287" height="207" alt="Screenshot 2026-08-20 122143" src="https://github.com/user-attachments/assets/0f860539-d394-4188-b9dc-87e9aa0993bf" />

### After

<img width="600" height="267" alt="Screenshot 2026-08-20 014642" src="https://github.com/user-attachments/assets/be0b29f5-796d-4f28-b529-3bad19ecd210" />

<img width="711" height="267" alt="Screenshot 2026-08-20 014729" src="https://github.com/user-attachments/assets/963e065c-b013-4709-84a1-de60d1abfa63" />

<img width="424" height="214" alt="image" src="https://github.com/user-attachments/assets/e048d11a-3360-4e9e-a768-61cd1c5ca88e" />

<img width="421" height="281" alt="Screenshot 2026-08-20 152214" src="https://github.com/user-attachments/assets/a20c71cd-8523-40d5-bdd4-9abc20eab8ce" />

<img width="421" height="393" alt="Screenshot 2026-08-20 152331" src="https://github.com/user-attachments/assets/761b2799-6e44-4b3d-84b2-6840c70e0667" />



</details>

## Notes for Reviewers

- I am sorry for a feature and bug fix in the same PR, but I only noticed the bug now when reviewing the title header.
- Workout Preset title overflow issue has not been tested or fixed for iOS devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate workout presets on web and mobile, creating private copies with exercises, sets, and details preserved.
  * Duplicate exercises within workout presets with fresh identifiers and reset completion metadata.
  * Replace exercises while preserving compatible sets; incompatible replacements receive default sets.
  * Added translated labels, success feedback, and navigation for duplication actions.
* **Bug Fixes**
  * Improved mobile header layout so long titles no longer compress action buttons.
* **Tests**
  * Added coverage for duplication, replacement, and header layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->