### PR TITLE
fix(exercises): pass through absolute app paths in resolveExerciseImageSrc

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Diary/EditExerciseDatabaseDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/EditExerciseDatabaseDialog.tsx
@@ -29,6 +29,7 @@ import {
   EXERCISE_MODALITY_OPTIONS,
 } from '@/constants/exercises';
 import { isExerciseModality, resolveExerciseModality } from '@workspace/shared';
+import { resolveExerciseImageSrc } from '@/utils/exercises';
 
 interface EditExerciseDatabaseDialogProps {
   open: boolean;
@@ -398,11 +399,7 @@ const EditExerciseDatabaseDialog: React.FC<EditExerciseDatabaseDialogProps> = ({
                 {(formData.images || []).map((url, index) => (
                   <div key={`existing-${index}`} className="relative w-20 h-20">
                     <img
-                      src={
-                        url.startsWith('http')
-                          ? url
-                          : `/uploads/exercises/${url}`
-                      }
+                      src={resolveExerciseImageSrc(url)}
                       className="w-full h-full object-cover rounded"
                       alt=""
                     />

--- a/SparkyFitnessFrontend/src/pages/Diary/ExerciseEntryDisplay.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/ExerciseEntryDisplay.tsx
@@ -29,6 +29,7 @@ import {
   setsDurationMinutes,
 } from '@workspace/shared';
 import { formatTimeOfDayString } from '@/utils/timeFormatters';
+import { resolveExerciseImageSrc } from '@/utils/exercises';
 
 interface ExerciseEntryDisplayProps {
   exerciseEntry: ExerciseEntry;
@@ -120,9 +121,7 @@ const ExerciseEntryDisplay: React.FC<ExerciseEntryDisplayProps> = ({
   const imageUrl = exerciseEntry.image_url
     ? exerciseEntry.image_url
     : snapshot?.images && snapshot.images.length > 0
-      ? exerciseEntry.source
-        ? `/uploads/exercises/${snapshot.images[0]}`
-        : snapshot.images[0]
+      ? resolveExerciseImageSrc(snapshot.images[0])
       : null;
 
   const metaPills: string[] = [];

--- a/SparkyFitnessFrontend/src/pages/Diary/ExercisePlaybackModal.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/ExercisePlaybackModal.tsx
@@ -28,6 +28,7 @@ import { Label } from '@/components/ui/label';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { debug, info, warn } from '@/utils/logging';
 import { Exercise } from '@/types/exercises';
+import { resolveExerciseImageSrc } from '@/utils/exercises';
 
 interface ExercisePlaybackModalProps {
   isOpen: boolean;
@@ -415,11 +416,7 @@ const ExercisePlaybackModal: React.FC<ExercisePlaybackModalProps> = ({
     const img = images[currentImageIndex];
     if (!img) return null;
 
-    // If it's already a full URL (starts with http), use it as is
-    if (img.startsWith('http')) return img;
-
-    // Otherwise, it's a local upload, so we MUST prefix it
-    return `/uploads/exercises/${img}`;
+    return resolveExerciseImageSrc(img);
   }, [images, currentImageIndex]);
 
   useEffect(() => {

--- a/SparkyFitnessFrontend/src/pages/Exercises/EditExerciseDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/EditExerciseDialog.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/constants/exercises';
 import { useEditExerciseForm } from '@/hooks/Exercises/useEditExerciseForm';
 import { isExerciseModality } from '@workspace/shared';
+import { resolveExerciseImageSrc } from '@/utils/exercises';
 
 interface EditExerciseDialogProps {
   form: ReturnType<typeof useEditExerciseForm>;
@@ -357,11 +358,7 @@ export default function EditExerciseDialog({ form }: EditExerciseDialogProps) {
                       className="relative w-24 h-24 cursor-grab"
                     >
                       <img
-                        src={
-                          url.startsWith('http')
-                            ? url
-                            : `/uploads/exercises/${url}`
-                        }
+                        src={resolveExerciseImageSrc(url)}
                         alt={`existing ${index}`}
                         className="w-full h-full object-cover rounded"
                       />

--- a/SparkyFitnessFrontend/src/tests/utils/resolveExerciseImageSrc.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/resolveExerciseImageSrc.test.ts
@@ -24,6 +24,17 @@ describe('resolveExerciseImageSrc', () => {
     );
   });
 
+  it('uses absolute app paths (already rooted at /) as-is', () => {
+    // CSV imports persist the full app path; prefixing again would produce
+    // /uploads/exercises//uploads/exercises/... and 404.
+    expect(
+      resolveExerciseImageSrc('/uploads/exercises/Bench_Press/0_abc123.jpg')
+    ).toBe('/uploads/exercises/Bench_Press/0_abc123.jpg');
+    expect(resolveExerciseImageSrc('/static/img/a.png')).toBe(
+      '/static/img/a.png'
+    );
+  });
+
   it('is case-insensitive about the URL scheme', () => {
     expect(resolveExerciseImageSrc('HTTPS://example.com/a.png')).toBe(
       'HTTPS://example.com/a.png'

--- a/SparkyFitnessFrontend/src/utils/exercises.ts
+++ b/SparkyFitnessFrontend/src/utils/exercises.ts
@@ -72,8 +72,11 @@ export const generateUniqueId = () =>
 /**
  * Resolve an exercise `images` entry to a usable <img> src.
  *
- * Exercise image values come from two shapes:
+ * Exercise image values come from three shapes:
  * - Absolute URLs (e.g. external provider search results) — used as-is.
+ * - Absolute app paths already rooted at `/` (e.g. CSV imports persist the
+ *   full `/uploads/exercises/Name/0_hash.jpg`) — used as-is; prefixing them
+ *   again would produce `/uploads/exercises//uploads/exercises/...` and 404.
  * - Relative paths for images stored under the server's uploads directory
  *   (e.g. imported wger / free-exercise-db exercises persist the relative
  *   path and the files are served from `/uploads/exercises/`).
@@ -87,6 +90,7 @@ export const generateUniqueId = () =>
 export function resolveExerciseImageSrc(image: string | undefined): string {
   if (!image) return '';
   if (/^https?:\/\//i.test(image)) return image;
+  if (image.startsWith('/')) return image;
   return `/uploads/exercises/${image}`;
 }
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Follow-up to #2169. Saved/imported exercise images 404 because `resolveExerciseImageSrc` double-prefixed full app paths (CSV imports persist `/uploads/exercises/Name/0_hash.jpg`, which got prefixed again into `/uploads/exercises//uploads/exercises/...`).

**How did you implement the solution?**
`resolveExerciseImageSrc` now passes through any value already rooted at `/` (in addition to `http(s)` URLs). The four remaining duplicated inline prefix sites were routed through the helper, which also fixes a reversed condition in `ExerciseEntryDisplay` that only prefixed when a `source` was present.

Linked Issue: N/A (client-side follow-up to review feedback on #2169; server-side import mismatch and mobile changes left to the maintainer per the note there)

## How to Test

1. Check out this branch and run `pnpm run validate` in `SparkyFitnessFrontend/`.
2. Import exercises via CSV (images stored as absolute app paths, e.g. `/uploads/exercises/Bench_Press/0_hash.jpg`).
3. Open the diary / exercise search / playback views and verify the saved image thumbnails render (previously 404 due to the doubled `/uploads/exercises/` prefix).

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. (No translation files were touched.)

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: Before — saved exercise images rendered broken (request to `/uploads/exercises//uploads/exercises/Name/0_hash.jpg` → 404). After — the same images load (request to `/uploads/exercises/Name/0_hash.jpg`). This is a pure path-resolution fix with no visual/layout change beyond the images now loading; regression test `resolveExerciseImageSrc.test.ts` covers the absolute-app-path passthrough.

## Testing

- `pnpm run validate` (tsc -b + eslint --max-warnings 0 + prettier --check) passes.
- `pnpm exec jest` — 100 suites / 946 tests pass.
