### PR TITLE
feat(medications): support away-from-meals food relation

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -249,7 +249,7 @@
     },
     "scheduleDesc": {
       "atTime": " at {{time}}",
-      "mealSuffix": " ({{meal}})",
+      "mealRelationSuffix": " ({{meal}})",
       "daily": "Daily",
       "weeklyOn": "Weekly on {{days}}",
       "everyNDays": "Every {{n}} days",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -249,7 +249,7 @@
     },
     "scheduleDesc": {
       "atTime": " at {{time}}",
-      "mealSuffix": " ({{meal}} meal)",
+      "mealSuffix": " ({{meal}})",
       "daily": "Daily",
       "weeklyOn": "Weekly on {{days}}",
       "everyNDays": "Every {{n}} days",
@@ -542,6 +542,7 @@
     },
     "mealRelation": {
       "after": "After meal",
+      "awayFromMeals": "Away from meals",
       "before": "Before meal",
       "none": "No specific food relation",
       "with": "With meal"

--- a/SparkyFitnessFrontend/src/pages/Medications/ScheduleManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Medications/ScheduleManager.tsx
@@ -274,6 +274,12 @@ export default function ScheduleManager({ med }: { med: MedicationDetail }) {
                     <SelectItem value="after">
                       {t('medications.mealRelation.after', 'After meal')}
                     </SelectItem>
+                    <SelectItem value="away_from_meals">
+                      {t(
+                        'medications.mealRelation.awayFromMeals',
+                        'Away from meals'
+                      )}
+                    </SelectItem>
                   </SelectContent>
                 </Select>
               </div>

--- a/SparkyFitnessFrontend/src/pages/Medications/ScheduleManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Medications/ScheduleManager.tsx
@@ -3,7 +3,11 @@ import { useTranslation } from 'react-i18next';
 import { Settings, Clock, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { usePreferences } from '@/contexts/PreferencesContext';
-import { todayInZone, formatDose } from '@workspace/shared';
+import {
+  todayInZone,
+  formatDose,
+  type MedicationWithMeal,
+} from '@workspace/shared';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -45,7 +49,7 @@ export default function ScheduleManager({ med }: { med: MedicationDetail }) {
   const [scheduleTypeId, setScheduleTypeId] = useState('daily');
   const [timeOfDay, setTimeOfDay] = useState('09:00');
   const [doseAmount, setDoseAmount] = useState('');
-  const [withMeal, setWithMeal] = useState<string | null>(null);
+  const [withMeal, setWithMeal] = useState<MedicationWithMeal | null>(null);
   const [daysOfWeek, setDaysOfWeek] = useState<number[]>([]);
   const [intervalDays, setIntervalDays] = useState('1');
   const [dayOfMonth, setDayOfMonth] = useState('1');
@@ -253,7 +257,9 @@ export default function ScheduleManager({ med }: { med: MedicationDetail }) {
                 </Label>
                 <Select
                   value={withMeal || 'none'}
-                  onValueChange={(v) => setWithMeal(v === 'none' ? null : v)}
+                  onValueChange={(v) =>
+                    setWithMeal(v === 'none' ? null : (v as MedicationWithMeal))
+                  }
                 >
                   <SelectTrigger>
                     <SelectValue />

--- a/SparkyFitnessFrontend/src/pages/Medications/medicationUtils.ts
+++ b/SparkyFitnessFrontend/src/pages/Medications/medicationUtils.ts
@@ -266,8 +266,11 @@ export const formatScheduleDescription = (
       })
     : '';
   const mealStr = sched.with_meal
-    ? i18n.t('medications.scheduleDesc.mealSuffix', ' ({{meal}} meal)', {
-        meal: sched.with_meal,
+    ? i18n.t('medications.scheduleDesc.mealSuffix', ' ({{meal}})', {
+        meal:
+          sched.with_meal === 'away_from_meals'
+            ? 'away from meals'
+            : `${sched.with_meal} meal`,
       })
     : '';
 

--- a/SparkyFitnessFrontend/src/pages/Medications/medicationUtils.ts
+++ b/SparkyFitnessFrontend/src/pages/Medications/medicationUtils.ts
@@ -4,6 +4,7 @@ import {
   MACRO_PICKER_FIELDS,
   getMicronutrientById,
   normalizeNutrientName,
+  type MedicationWithMeal,
 } from '@workspace/shared';
 import type { UserCustomNutrient } from '@/types/customNutrient';
 import type { MedicationNutrients } from '@/types/medications';
@@ -256,6 +257,22 @@ export const formatDaysOfWeek = (days: number[] | null) => {
   return days.map((d) => names[d] ?? '').join(', ');
 };
 
+const translateMealRelation = (withMeal: MedicationWithMeal): string => {
+  switch (withMeal) {
+    case 'before':
+      return i18n.t('medications.mealRelation.before', 'Before meal');
+    case 'with':
+      return i18n.t('medications.mealRelation.with', 'With meal');
+    case 'after':
+      return i18n.t('medications.mealRelation.after', 'After meal');
+    case 'away_from_meals':
+      return i18n.t(
+        'medications.mealRelation.awayFromMeals',
+        'Away from meals'
+      );
+  }
+};
+
 export const formatScheduleDescription = (
   sched: MedicationSchedule,
   timeFormat: string
@@ -266,11 +283,8 @@ export const formatScheduleDescription = (
       })
     : '';
   const mealStr = sched.with_meal
-    ? i18n.t('medications.scheduleDesc.mealSuffix', ' ({{meal}})', {
-        meal:
-          sched.with_meal === 'away_from_meals'
-            ? 'away from meals'
-            : `${sched.with_meal} meal`,
+    ? i18n.t('medications.scheduleDesc.mealRelationSuffix', ' ({{meal}})', {
+        meal: translateMealRelation(sched.with_meal),
       })
     : '';
 

--- a/SparkyFitnessFrontend/src/types/medications.ts
+++ b/SparkyFitnessFrontend/src/types/medications.ts
@@ -2,7 +2,10 @@
 // api service (src/api) and page components can import them (page components are
 // not allowed to import from src/api directly — see eslint no-restricted-imports).
 
-import type { FoodVariantNutrientField } from '@workspace/shared';
+import type {
+  FoodVariantNutrientField,
+  MedicationWithMeal,
+} from '@workspace/shared';
 
 /**
  * A supplement's per-dose payload: the fixed food-variant nutrient columns plus the
@@ -58,7 +61,7 @@ export interface MedicationSchedule {
   cycle_off_days: number | null;
   prn_reason: string | null;
   prn_max_per_day: number | null;
-  with_meal: string | null;
+  with_meal: MedicationWithMeal | null;
   start_date: string | null;
   end_date: string | null;
   active: boolean;

--- a/SparkyFitnessMobile/__tests__/utils/medicationFormat.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/medicationFormat.test.ts
@@ -119,6 +119,7 @@ describe('formatWithMeal', () => {
     ['before', 'Before meal'],
     ['with', 'With meal'],
     ['after', 'After meal'],
+    ['away_from_meals', 'Away from meals'],
   ])('formats %s as %s', (value, expected) => {
     expect(formatWithMeal(value)).toBe(expected);
   });

--- a/SparkyFitnessMobile/src/screens/MedicationScheduleFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationScheduleFormScreen.tsx
@@ -378,6 +378,7 @@ const MedicationScheduleFormScreen: React.FC<MedicationScheduleFormScreenProps> 
       { label: formatWithMeal('before'), value: 'before' },
       { label: formatWithMeal('with'), value: 'with' },
       { label: formatWithMeal('after'), value: 'after' },
+      { label: formatWithMeal('away_from_meals'), value: 'away_from_meals' },
     ],
     [],
   );

--- a/SparkyFitnessServer/schemas/medicationSchemas.ts
+++ b/SparkyFitnessServer/schemas/medicationSchemas.ts
@@ -93,7 +93,10 @@ export const CreateScheduleBodySchema = z
     day_of_month: z.number().int().min(1).max(31).nullable().optional(),
     cycle_on_days: optionalNullableInt,
     cycle_off_days: optionalNullableInt,
-    with_meal: z.enum(['before', 'with', 'after']).nullable().optional(),
+    with_meal: z
+      .enum(['before', 'with', 'after', 'away_from_meals'])
+      .nullable()
+      .optional(),
     prn_reason: optionalNullableString,
     prn_max_per_day: optionalNullableInt,
     start_date: optionalDateString,

--- a/SparkyFitnessServer/tests/medicationRoutes.test.ts
+++ b/SparkyFitnessServer/tests/medicationRoutes.test.ts
@@ -631,6 +631,30 @@ describe('Medication Routes V2', () => {
       );
     });
 
+    it('accepts away_from_meals as a with_meal value', async () => {
+      const schedule = { id: 'sched-2', schedule_type_id: 'daily' };
+      vi.mocked(medicationRepository.addSchedule).mockResolvedValue(schedule);
+      const res = await request(app)
+        .post(`/api/v2/medications/${UID}/schedules`)
+        .set('Cookie', cookie)
+        .send({ schedule_type_id: 'daily', with_meal: 'away_from_meals' });
+      expect(res.statusCode).toBe(201);
+      expect(medicationRepository.addSchedule).toHaveBeenCalledWith(
+        'testUser',
+        UID,
+        expect.objectContaining({ with_meal: 'away_from_meals' })
+      );
+    });
+
+    it('rejects an invalid with_meal value', async () => {
+      const res = await request(app)
+        .post(`/api/v2/medications/${UID}/schedules`)
+        .set('Cookie', cookie)
+        .send({ schedule_type_id: 'daily', with_meal: 'bedtime' });
+      expect(res.statusCode).toBe(400);
+      expect(medicationRepository.addSchedule).not.toHaveBeenCalled();
+    });
+
     it('returns 400 when schedule_type_id is missing on create', async () => {
       const res = await request(app)
         .post(`/api/v2/medications/${UID}/schedules`)

--- a/shared/src/medications/contracts.ts
+++ b/shared/src/medications/contracts.ts
@@ -7,7 +7,7 @@ import type { SharedScheduleRule } from './schedules.ts';
 export type MedicationEntryStatus = 'taken' | 'skipped' | 'snoozed' | 'prn_taken';
 
 /** Meal timing for a scheduled dose, relative to the nearest meal. */
-export type MedicationWithMeal = 'before' | 'with' | 'after';
+export type MedicationWithMeal = 'before' | 'with' | 'after' | 'away_from_meals';
 
 export interface Medication {
   id: string;

--- a/shared/src/medications/format.ts
+++ b/shared/src/medications/format.ts
@@ -117,11 +117,12 @@ export function formatTimeOfDay(timeOfDay: string): string {
   });
 }
 
-/** Formats a schedule's meal-timing value ('before' | 'with' | 'after') for display. */
+/** Formats a schedule's meal-timing value ('before' | 'with' | 'after' | 'away_from_meals') for display. */
 export function formatWithMeal(withMeal: string): string {
   if (withMeal === "before") return "Before meal";
   if (withMeal === "with") return "With meal";
   if (withMeal === "after") return "After meal";
+  if (withMeal === "away_from_meals") return "Away from meals";
   return withMeal;
 }
 


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

*This is my first-ever contribution to an open source project — thanks in advance for the review!*

**What problem does this PR solve?**
Medication schedules only supported "Before/With/After meal" for food timing, but some medications need to be taken "away from meals" (i.e. on an empty stomach, away from any meal) — a real, common instruction that had no accurate option.

**How did you implement the solution?**
Added `'away_from_meals'` as a fourth `with_meal` value end-to-end: the shared `MedicationWithMeal` type, the server's Zod schema for `CreateScheduleBodySchema`/`UpdateScheduleBodySchema`, the web "Food Relation" dropdown (`ScheduleManager.tsx` + `en/translation.json`), and the mobile schedule form's picker options. Also updated `formatWithMeal` (shared) and the web's compact schedule-description suffix (`medicationUtils.ts`) to render it as "Away from meals" / "(away from meals)" instead of the previous naive `"{{value}} meal"` template, which would have rendered the new value as the ungrammatical `"(away_from_meals meal)"` — confirmed this bug existed by reverting the fix locally and reproducing it (see before/after screenshots).

No database migration was needed — `with_meal` is already `VARCHAR(20)`, wide enough for the new value, so this is purely a validation/UI change.

Linked Issue: Closes #1985

## How to Test

1. Check out this branch, run `pnpm install`, and start the stack (`pnpm start` in `SparkyFitnessServer/`, `pnpm dev` in `SparkyFitnessFrontend/`).
2. Go to **Medications → Cabinet**, select a medication, and click **Add Rule**.
3. Open the **With Meal** dropdown — verify **Away from meals** now appears as a fifth option, alongside No specific relation / Before / With / After.
4. Select it and save — verify the schedule row renders as `"... (away from meals)"`, not `"... (away_from_meals meal)"`.
5. On mobile, open a medication's schedule form — verify the same option appears in the meal-timing picker.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. (Issue #1985 is labeled `good first issue` by a maintainer.)

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests. (Added two new test cases to `tests/medicationRoutes.test.ts` covering acceptance of `away_from_meals` and rejection of an invalid value; all 64 tests in that file pass.)
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. (N/A — no new table; `with_meal` already exists as `VARCHAR(20)`, so this is a validation-only change.)

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. (Not tested on an actual device/emulator — no iOS/Android hardware or emulator available in this environment. The mobile change is a one-line addition mirroring three existing lines in the same array, and is covered by an updated Jest test in `medicationFormat.test.ts` plus the existing `MedicationScheduleFormScreen` test suite, all passing. Happy to have a maintainer confirm on-device before merge.)

## Screenshots

<details>
<summary>Click to expand</summary>

### Before
Only 4 options, and an existing "away from meals" schedule mis-rendering as "(away_from_meals meal)":

<img width="1280" height="900" alt="before" src="https://github.com/user-attachments/assets/37317f04-e394-487b-b82f-c77157bf757e" />

### After
The new 5th option, and correct "(away from meals)" rendering:

<img width="1280" height="900" alt="after" src="https://github.com/user-attachments/assets/fc67631b-92da-40f4-b39a-3ccff8683854" />

</details>

## Notes for Reviewers

Thanks for maintaining such a well-documented codebase to work in — it made ramping up on a new project genuinely easy. A few notes:

- I validated the full round trip live (signed up a test account, created a medication, added a schedule with `with_meal: away_from_meals`, confirmed the `201` response and correct persisted value, and confirmed the UI renders it correctly) before and after this change, by temporarily stashing the frontend commit to compare — the before/after screenshots above are from that comparison.
- The mobile "tested on device" checkbox is honestly left unchecked per the note above; I don't have a way to run an emulator/simulator in this environment, but the change is trivial and test-covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an “Away from meals” option when creating or editing medication schedules.
- Available across web and mobile experiences.

## Improvements
- Updated schedule descriptions to display meal timing more clearly with localized labels.

## Bug Fixes
- Ensured the new meal-timing option is validated, saved, and displayed consistently.
- Prevented unsupported meal-timing values from being accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
