### PR TITLE
fix(ai): support models that reject the temperature parameter

### DIFF
--- a/SparkyFitnessFrontend/src/utils/aiServiceUtils.ts
+++ b/SparkyFitnessFrontend/src/utils/aiServiceUtils.ts
@@ -41,8 +41,14 @@ export const requiresApiKey = (serviceType: string | undefined): boolean =>
 export const getModelOptions = (serviceType: string): string[] => {
   switch (serviceType) {
     case 'openai':
+      // The gpt-5.x families accept only the default temperature; the server
+      // detects that and omits the parameter (ai/modelCapabilities.ts), so
+      // they are safe to offer here.
       return [
         'gpt-4o-mini',
+        'gpt-5.6-luna',
+        'gpt-5.6-terra',
+        'gpt-5.6-sol',
         'gpt-5.4-mini',
         'gpt-5.4-nano',
         'gpt-4.1-mini',

--- a/SparkyFitnessServer/ai/modelCapabilities.ts
+++ b/SparkyFitnessServer/ai/modelCapabilities.ts
@@ -1,0 +1,251 @@
+import { log } from '../config/logging.js';
+
+/**
+ * Per-model sampling-parameter capabilities.
+ *
+ * Providers keep shipping models that reject parameters their predecessors
+ * accepted — OpenAI's reasoning families (gpt-5.x, o-series) allow only the
+ * default `temperature`, and Claude Opus 4.7+ / Sonnet 5 reject it outright.
+ * Sending one of those fails the whole request before any work happens.
+ *
+ * Chasing that with a hardcoded model list alone is a treadmill: every new
+ * model family needs a release. So this module has two layers.
+ *
+ *  1. A static gate for families we already know about. Costs nothing and
+ *     avoids a wasted round-trip. Kept deliberately conservative — a missing
+ *     entry is caught free by layer 2, whereas a wrong entry silently loses
+ *     temperature control.
+ *  2. A dynamic gate: when a provider rejects a parameter with a 400, the
+ *     caller drops that parameter, retries once, and records the rejection
+ *     here. Every later request for that model skips the parameter with no
+ *     retry cost, so an unknown future model works on first use without a
+ *     code change.
+ *
+ * Used by both request paths — the raw-fetch dispatcher (providerDispatch.ts)
+ * and the AI SDK chat path (chatService.ts).
+ */
+
+/**
+ * Parameters we are willing to silently drop and retry without.
+ *
+ * Strictly limited to sampling hints whose absence changes *nothing* about the
+ * shape of the response — the model just uses its default. Deliberately
+ * excludes `max_tokens` (required by Anthropic; dropping it trades one failure
+ * for another) and anything that governs output format such as
+ * `response_format`, where a silent drop would return a different shape than
+ * the caller parsed for. Those fail loudly instead.
+ */
+export const DROPPABLE_PARAMS: ReadonlySet<string> = new Set([
+  'temperature',
+  'top_p',
+]);
+
+// Literal patterns for the prose fallback below, kept in step with
+// DROPPABLE_PARAMS. Written out rather than built from the set so the
+// expressions stay static and auditable.
+const DROPPABLE_PARAM_PATTERNS: ReadonlyArray<readonly [string, RegExp]> = [
+  ['temperature', /\btemperature\b/],
+  ['top_p', /\btop_p\b/],
+];
+
+// Claude Opus 4.7 and later reject `temperature` outright with a 400, and
+// Sonnet 5 rejects non-default values. Older models (Sonnet 4.6, Haiku 4.5,
+// and earlier) still honor it.
+const ANTHROPIC_MODELS_REJECTING_TEMPERATURE =
+  /^claude-(opus-(4-7|4-8|5)|sonnet-5|fable-5|mythos-5)/;
+
+// OpenAI reasoning families support only the default temperature of 1.
+// Matches gpt-5, gpt-5.6-luna, o1-mini, o3, o4-mini, and so on.
+//
+// Applied to the canonical 'openai' service type only. An openai_compatible /
+// custom / openrouter gateway may serve a same-looking model id through a shim
+// that does accept temperature, so those are left to layer 2 rather than
+// assumed broken.
+const OPENAI_MODELS_REJECTING_TEMPERATURE = /^(gpt-5|o[1-9](-|$))/;
+
+const STATIC_TEMPERATURE_REJECTIONS: Record<string, RegExp> = {
+  anthropic: ANTHROPIC_MODELS_REJECTING_TEMPERATURE,
+  openai: OPENAI_MODELS_REJECTING_TEMPERATURE,
+};
+
+// ---------------------------------------------------------------------------
+// Layer 2: learned rejections
+// ---------------------------------------------------------------------------
+
+// Model names reach us from user-editable provider settings, so the cache is
+// capped and evicts in insertion order — an unbounded Map keyed by arbitrary
+// strings would be a slow memory leak.
+const MAX_LEARNED_MODELS = 500;
+
+const learnedRejections = new Map<string, Set<string>>();
+
+function cacheKey(serviceType: string, model: string): string {
+  return `${serviceType}:${model}`;
+}
+
+/**
+ * Records that `model` on `serviceType` rejected `param`, so later requests
+ * skip it without paying another failed round-trip.
+ *
+ * Process-local by design: it re-learns cheaply after a restart, needs no
+ * migration, and cannot go stale if a provider reverses the behavior.
+ */
+export function recordRejectedParam(
+  serviceType: string,
+  model: string,
+  param: string
+): void {
+  const key = cacheKey(serviceType, model);
+  const existing = learnedRejections.get(key);
+  if (existing) {
+    existing.add(param);
+    return;
+  }
+  if (learnedRejections.size >= MAX_LEARNED_MODELS) {
+    const oldest = learnedRejections.keys().next();
+    if (!oldest.done) {
+      learnedRejections.delete(oldest.value);
+    }
+  }
+  learnedRejections.set(key, new Set([param]));
+  log(
+    'info',
+    `[modelCapabilities] '${model}' on '${serviceType}' rejected '${param}'; omitting it from future requests.`
+  );
+}
+
+export function isParamRejected(
+  serviceType: string,
+  model: string,
+  param: string
+): boolean {
+  return (
+    learnedRejections.get(cacheKey(serviceType, model))?.has(param) ?? false
+  );
+}
+
+/** Test-only: drops everything layer 2 has learned. */
+export function resetLearnedRejections(): void {
+  learnedRejections.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Combined gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether `temperature` may be sent to this model. False when either the
+ * static family gate matches or the provider has already rejected it once.
+ */
+export function supportsTemperature(
+  serviceType: string,
+  model: string
+): boolean {
+  if (isParamRejected(serviceType, model, 'temperature')) return false;
+  const pattern = STATIC_TEMPERATURE_REJECTIONS[serviceType];
+  return !(pattern && pattern.test(model));
+}
+
+// ---------------------------------------------------------------------------
+// Rejection detection
+// ---------------------------------------------------------------------------
+
+// OpenAI-style machine-readable codes for "this parameter/value isn't allowed".
+const REJECTION_CODES = new Set([
+  'unsupported_value',
+  'unsupported_parameter',
+  'invalid_value',
+]);
+
+// Fallback for providers that return prose without a `param` field.
+const REJECTION_PHRASES =
+  /does not support|unsupported value|unsupported parameter|not supported|only the default|extra inputs are not permitted|not permitted/i;
+
+// A body big enough to be a payload rather than an error isn't worth scanning.
+const MAX_SCANNED_BODY_CHARS = 8_000;
+
+interface ProviderErrorShape {
+  message?: unknown;
+  param?: unknown;
+  code?: unknown;
+  type?: unknown;
+}
+
+function parseProviderError(rawBody: string): ProviderErrorShape | null {
+  try {
+    const parsed: unknown = JSON.parse(rawBody);
+    if (!parsed || typeof parsed !== 'object') return null;
+    // Most providers nest under `error`; a few return the fields at top level.
+    const error = (parsed as { error?: unknown }).error;
+    const candidate =
+      error && typeof error === 'object' ? error : (parsed as object);
+    return candidate as ProviderErrorShape;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Identifies which request parameter a provider's 400 is complaining about, or
+ * null when the error is something else (bad key, unknown model, rate limit).
+ *
+ * Only ever names a parameter in `DROPPABLE_PARAMS`; a rejection of anything
+ * else returns null so the caller surfaces the failure instead of silently
+ * changing the request.
+ */
+export function detectRejectedParam(
+  status: number,
+  rawBody: string
+): string | null {
+  if (status !== 400) return null;
+  if (!rawBody || rawBody.length > MAX_SCANNED_BODY_CHARS) return null;
+
+  const error = parseProviderError(rawBody);
+  const message = typeof error?.message === 'string' ? error.message : rawBody;
+
+  // Preferred path: the provider names the parameter outright.
+  if (typeof error?.param === 'string' && error.param) {
+    const named = error.param;
+    if (!DROPPABLE_PARAMS.has(named)) return null;
+    const code = typeof error.code === 'string' ? error.code : '';
+    if (REJECTION_CODES.has(code) || REJECTION_PHRASES.test(message)) {
+      return named;
+    }
+    return null;
+  }
+
+  // Fallback: no `param` field (Anthropic and some gateways), so look for a
+  // droppable parameter named in prose that reads like a rejection.
+  if (!REJECTION_PHRASES.test(message)) return null;
+  for (const [param, pattern] of DROPPABLE_PARAM_PATTERNS) {
+    if (pattern.test(message)) return param;
+  }
+  return null;
+}
+
+/**
+ * The parameter a 400 is complaining about even when we cannot safely drop it
+ * — used only to turn a raw JSON body into a readable message for the user.
+ */
+export function describeRejectedParam(
+  status: number,
+  rawBody: string
+): string | null {
+  if (status !== 400) return null;
+  if (!rawBody || rawBody.length > MAX_SCANNED_BODY_CHARS) return null;
+  const error = parseProviderError(rawBody);
+  const message = typeof error?.message === 'string' ? error.message : '';
+  if (!message || !REJECTION_PHRASES.test(message)) return null;
+  const named = typeof error?.param === 'string' ? error.param : null;
+  return named || null;
+}
+
+export default {
+  DROPPABLE_PARAMS,
+  supportsTemperature,
+  recordRejectedParam,
+  isParamRejected,
+  resetLearnedRejections,
+  detectRejectedParam,
+  describeRejectedParam,
+};

--- a/SparkyFitnessServer/ai/providerDispatch.ts
+++ b/SparkyFitnessServer/ai/providerDispatch.ts
@@ -16,6 +16,12 @@ import {
   requiresUserSuppliedAiUrl,
   type AiNetworkPolicy,
 } from '../utils/outboundUrlPolicy.js';
+import {
+  describeRejectedParam,
+  detectRejectedParam,
+  recordRejectedParam,
+  supportsTemperature,
+} from './modelCapabilities.js';
 
 const { Agent } = undici;
 
@@ -105,16 +111,6 @@ const OLLAMA_DEFAULT_TIMEOUT_MS = 120_000;
 const ANTHROPIC_MAX_TOKENS = 8192;
 const ANTHROPIC_VERSION = '2023-06-01';
 
-// Claude Opus 4.7 and later reject `temperature` outright with a 400, and
-// Sonnet 5 rejects non-default values. Sending it to those models fails the
-// request before any work happens, so it is dropped rather than forwarded.
-// Older models (Sonnet 4.6, Haiku 4.5, and earlier) still honor it.
-const ANTHROPIC_MODELS_REJECTING_TEMPERATURE =
-  /^claude-(opus-(4-7|4-8|5)|sonnet-5|fable-5|mythos-5)/;
-
-function anthropicAcceptsTemperature(model: string): boolean {
-  return !ANTHROPIC_MODELS_REJECTING_TEMPERATURE.test(model);
-}
 const DEFAULT_SCHEMA_NAME = 'structured_output';
 const MAX_DETAIL_BODY_CHARS = 500;
 
@@ -566,7 +562,7 @@ function buildAnthropicRequest(ctx: BuildContext): BuiltRequest {
     max_tokens: ANTHROPIC_MAX_TOKENS,
     messages: [{ role: 'user', content }],
   };
-  if (ctx.temperature !== undefined && anthropicAcceptsTemperature(ctx.model)) {
+  if (ctx.temperature !== undefined) {
     body.temperature = ctx.temperature;
   }
   if (ctx.jsonSchema) {
@@ -805,9 +801,15 @@ function extractResponse(
   }
 }
 
-type HttpOutcome = { data: unknown } | { error: DispatchResult };
+// `rawBody` carries the provider's untruncated error body for callers that
+// need to interpret it (parameter-rejection detection). It stays internal —
+// `DispatchResult` is unchanged, so nothing extra reaches the API surface.
+type DispatchFailure = Extract<DispatchResult, { ok: false }>;
+type HttpOutcome =
+  | { data: unknown }
+  | { error: DispatchFailure; rawBody?: string };
 
-function timeoutError(): DispatchResult {
+function timeoutError(): DispatchFailure {
   return {
     ok: false,
     category: 'timeout',
@@ -823,15 +825,22 @@ async function readResponse(response: Response): Promise<HttpOutcome> {
     } catch {
       // best-effort; body stays empty
     }
+    // A 400 naming a request parameter is otherwise surfaced as raw JSON the
+    // user has to decode; say it in a sentence instead.
+    const rejected = describeRejectedParam(response.status, body);
+    const detail = rejected
+      ? `The AI service rejected the '${rejected}' parameter for this model. ${truncateBody(body)}`
+      : `AI service returned status ${response.status}${
+          body ? `: ${truncateBody(body)}` : ''
+        }`;
     return {
       error: {
         ok: false,
         category: 'upstream_error',
         status: response.status,
-        detail: `AI service returned status ${response.status}${
-          body ? `: ${truncateBody(body)}` : ''
-        }`,
+        detail,
       },
+      rawBody: body,
     };
   }
   try {
@@ -1076,25 +1085,47 @@ export async function dispatchAiRequest(
       : getDefaultModel(serviceType));
 
   const toolName = schemaName ?? DEFAULT_SCHEMA_NAME;
-  const built = buildRequest(
-    family,
-    {
-      provider,
-      model,
-      prompt,
-      images,
-      jsonSchema,
-      toolName,
-      temperature: req.temperature,
-    },
-    Boolean(parseJson)
-  );
+
+  // One central gate for every family: known-rejecting models (and any model
+  // that has already rejected it once at runtime) never see `temperature`, so
+  // each builder's `!== undefined` guard does the rest.
+  const buildCtx = (temperature: number | undefined) => ({
+    provider,
+    model,
+    prompt,
+    images,
+    jsonSchema,
+    toolName,
+    temperature,
+  });
+  const temperature = supportsTemperature(serviceType, model)
+    ? req.temperature
+    : undefined;
+  let built = buildRequest(family, buildCtx(temperature), Boolean(parseJson));
 
   const timeoutMs = resolveTimeout(req, family);
-  const outcome =
+  const send = () =>
     family === 'ollama'
-      ? await performOllama(built, timeoutMs, networkPolicy)
-      : await performFetch(built, timeoutMs, networkPolicy);
+      ? performOllama(built, timeoutMs, networkPolicy)
+      : performFetch(built, timeoutMs, networkPolicy);
+
+  let outcome = await send();
+
+  // Self-heal: if the provider rejected a sampling parameter we sent, drop it,
+  // remember the rejection, and retry exactly once. This is what lets a model
+  // family we have never heard of work on first use. Bounded to a single extra
+  // attempt, and independent of the 429 backoff loop inside performFetch.
+  if ('error' in outcome && temperature !== undefined && outcome.rawBody) {
+    const rejected = detectRejectedParam(
+      outcome.error.status ?? 0,
+      outcome.rawBody
+    );
+    if (rejected === 'temperature') {
+      recordRejectedParam(serviceType, model, rejected);
+      built = buildRequest(family, buildCtx(undefined), Boolean(parseJson));
+      outcome = await send();
+    }
+  }
 
   if ('error' in outcome) {
     return outcome.error;

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -996,6 +996,35 @@ async function runWithTemperatureFallback<T>(
   }
 }
 
+// Provider error text is safe to surface (providerDispatch already truncates it
+// into user-facing detail), but bounded so a verbose provider cannot flood the
+// log.
+const MAX_LOGGED_ERROR_CHARS = 300;
+
+/**
+ * Renders a provider error as a log-safe one-liner.
+ *
+ * Never log the error object itself: `APICallError` carries
+ * `requestBodyValues`, which for a chat call is the entire request — the user's
+ * messages, the system prompt, and tool arguments. The logger hands objects to
+ * `console.error`, so that would put health data into ERROR-level logs, which
+ * are on by default (see config/logging.ts, where full-payload logging is
+ * deliberately gated behind an explicit DEBUG opt-in).
+ */
+function describeProviderError(error: unknown): string {
+  const truncate = (text: string) =>
+    text.length > MAX_LOGGED_ERROR_CHARS
+      ? `${text.slice(0, MAX_LOGGED_ERROR_CHARS)}…`
+      : text;
+  if (APICallError.isInstance(error)) {
+    return `APICallError status=${error.statusCode ?? 'none'}: ${truncate(error.message)}`;
+  }
+  if (error instanceof Error) {
+    return `${error.name}: ${truncate(error.message)}`;
+  }
+  return 'unknown error';
+}
+
 /**
  * Records a parameter rejection reported through a stream rather than thrown.
  *
@@ -2071,7 +2100,10 @@ async function processChatMessageStream(
         // categories manually, so this path can be the first request a model
         // ever sees.
         noteStreamParameterRejection(aiService.service_type, modelName, error);
-        log('error', `[chat] stream error for user ${userId}:`, error);
+        log(
+          'error',
+          `[chat] stream error for user ${userId}: ${describeProviderError(error)}`
+        );
       },
       // Tighter retry ceiling for cache-less core-profile backends, where every
       // retry re-processes the full prefix.

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -755,14 +755,24 @@ export function getSystemPrompt(
     .replace(/\${customCategories}/g, customCategoriesList);
 }
 
-// OpenAI's 24h extended retention is only supported on the gpt-5.1+ families
-// (per @ai-sdk/openai), and the adapter forwards the field without gating, so
-// other models may reject it. Mirror the adapter's own family check.
+// OpenAI's 24h extended retention is supported on gpt-5.1 through gpt-5.5 only.
+// The adapter forwards `prompt_cache_retention` unchanged with no model gating,
+// so this list is the only thing standing between us and a rejected request.
 //
-// Matched as a family rather than enumerated point releases: an explicit list
-// silently drops each new model off the end (gpt-5.6 did exactly that), and a
-// missing retention hint is invisible — it just costs cache hits.
-const RETENTION_24H_MODEL_PATTERN = /^gpt-5\.[1-9]/;
+// Enumerated on purpose rather than matched as a family. Retention support is
+// shrinking, not growing: gpt-5.6 deprecated `prompt_cache_retention` in favor
+// of `prompt_cache_options.ttl`, so a `/^gpt-5\.[1-9]/`-style pattern would send
+// the field to exactly the models that reject it. The failure modes are not
+// symmetric — omitting the hint for a model that would have accepted it only
+// costs cache hits, while sending it to one that refuses breaks the chat turn.
+// New entries belong here only once that model is known to accept the field.
+const RETENTION_24H_MODEL_PREFIXES = [
+  'gpt-5.1',
+  'gpt-5.2',
+  'gpt-5.3',
+  'gpt-5.4',
+  'gpt-5.5',
+];
 
 // Only the canonical 'openai' service type receives prompt-cache options.
 // OpenAI-compatible services still need the SDK-only systemMessageMode override:
@@ -781,7 +791,7 @@ export function buildChatProviderOptions(
   const openai: Record<string, JSONValue> = {
     promptCacheKey: `sparky-chat-${userId}`,
   };
-  if (RETENTION_24H_MODEL_PATTERN.test(modelName)) {
+  if (RETENTION_24H_MODEL_PREFIXES.some((p) => modelName.startsWith(p))) {
     openai.promptCacheRetention = '24h';
   }
   return { openai };
@@ -983,6 +993,25 @@ async function runWithTemperatureFallback<T>(
     if (rejected !== 'temperature') throw error;
     recordRejectedParam(serviceType, modelName, rejected);
     return await run(false);
+  }
+}
+
+/**
+ * Records a parameter rejection reported through a stream rather than thrown.
+ *
+ * `streamText` cannot be retried in place — by the time the provider's 400
+ * arrives the call has already returned its stream — so the best available
+ * outcome is to remember the rejection and get the next turn right.
+ */
+function noteStreamParameterRejection(
+  serviceType: string,
+  modelName: string,
+  error: unknown
+): void {
+  if (!APICallError.isInstance(error) || error.statusCode !== 400) return;
+  const rejected = detectRejectedParam(400, error.responseBody ?? '');
+  if (rejected) {
+    recordRejectedParam(serviceType, modelName, rejected);
   }
 }
 
@@ -2027,15 +2056,23 @@ async function processChatMessageStream(
       // full-profile Ollama keep provider defaults, and models that reject the
       // parameter get none.
       //
-      // No retry wrapper here: streamText returns the stream synchronously and
-      // surfaces provider errors inside it, so a 400 cannot be caught and
-      // replayed. It does not need one — the intent classifier above runs
-      // against this same model first and records any rejection, so
-      // supportsTemperature is already correct by the time we get here.
+      // No retry wrapper here: streamText returns its stream synchronously and
+      // reports provider errors inside it, so a 400 is never thrown where we
+      // could catch and replay it. onError below records the rejection instead,
+      // which costs this turn but fixes every turn after it.
       ...(toolProfile === 'core' &&
         supportsTemperature(aiService.service_type, modelName) && {
           temperature: CORE_PROFILE_CHAT_TEMPERATURE,
         }),
+      onError({ error }) {
+        // The one place a stream-time parameter rejection can be learned. The
+        // intent classifier is not a reliable canary: it returns early on any
+        // keyword match, and is skipped entirely when the user picks tool
+        // categories manually, so this path can be the first request a model
+        // ever sees.
+        noteStreamParameterRejection(aiService.service_type, modelName, error);
+        log('error', `[chat] stream error for user ${userId}:`, error);
+      },
       // Tighter retry ceiling for cache-less core-profile backends, where every
       // retry re-processes the full prefix.
       stopWhen: buildChatStopConditions(toolProfile),

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -9,6 +9,11 @@ import {
   type DispatchErrorCategory,
   type ProviderConfig,
 } from '../ai/providerDispatch.js';
+import {
+  detectRejectedParam,
+  recordRejectedParam,
+  supportsTemperature,
+} from '../ai/modelCapabilities.js';
 import { loadUserTimezone } from '../utils/timezoneLoader.js';
 import { TtlCache } from '../utils/ttlCache.js';
 import {
@@ -57,7 +62,13 @@ interface ChatMessage {
   parts?: ChatMessagePart[];
 }
 
-import { generateText, streamText, stepCountIs, hasToolCall } from 'ai';
+import {
+  APICallError,
+  generateText,
+  streamText,
+  stepCountIs,
+  hasToolCall,
+} from 'ai';
 import type { JSONValue, LanguageModelUsage, UIMessageChunk } from 'ai';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createAnthropic } from '@ai-sdk/anthropic';
@@ -747,13 +758,11 @@ export function getSystemPrompt(
 // OpenAI's 24h extended retention is only supported on the gpt-5.1+ families
 // (per @ai-sdk/openai), and the adapter forwards the field without gating, so
 // other models may reject it. Mirror the adapter's own family check.
-const RETENTION_24H_MODEL_PREFIXES = [
-  'gpt-5.1',
-  'gpt-5.2',
-  'gpt-5.3',
-  'gpt-5.4',
-  'gpt-5.5',
-];
+//
+// Matched as a family rather than enumerated point releases: an explicit list
+// silently drops each new model off the end (gpt-5.6 did exactly that), and a
+// missing retention hint is invisible — it just costs cache hits.
+const RETENTION_24H_MODEL_PATTERN = /^gpt-5\.[1-9]/;
 
 // Only the canonical 'openai' service type receives prompt-cache options.
 // OpenAI-compatible services still need the SDK-only systemMessageMode override:
@@ -772,7 +781,7 @@ export function buildChatProviderOptions(
   const openai: Record<string, JSONValue> = {
     promptCacheKey: `sparky-chat-${userId}`,
   };
-  if (RETENTION_24H_MODEL_PREFIXES.some((p) => modelName.startsWith(p))) {
+  if (RETENTION_24H_MODEL_PATTERN.test(modelName)) {
     openai.promptCacheRetention = '24h';
   }
   return { openai };
@@ -939,6 +948,42 @@ function createChatModelInstance(
     return createOpenAI(providerOptions).chat(modelName);
   }
   throw new Error(`Unsupported service type: ${aiService.service_type}`);
+}
+
+/**
+ * Runs an AI SDK call, and if the provider rejects `temperature` with a 400,
+ * re-runs it once without one.
+ *
+ * The static gate in `supportsTemperature` covers model families we already
+ * know about; this covers the ones we don't, so a future model that drops the
+ * parameter starts working on first use instead of after a release. The
+ * rejection is recorded, so only the first call for a given model pays the
+ * extra round-trip.
+ *
+ * `run` receives whether to send a temperature this attempt.
+ *
+ * Only for awaited calls (`generateText`). `streamText` returns its stream
+ * synchronously and reports provider errors inside it, so nothing is thrown
+ * here to catch — that path relies on the gate alone, seeded by the intent
+ * classifier which runs against the same model first.
+ */
+async function runWithTemperatureFallback<T>(
+  serviceType: string,
+  modelName: string,
+  run: (sendTemperature: boolean) => Promise<T>
+): Promise<T> {
+  const allowed = supportsTemperature(serviceType, modelName);
+  try {
+    return await run(allowed);
+  } catch (error) {
+    if (!allowed) throw error;
+    if (!APICallError.isInstance(error) || error.statusCode !== 400)
+      throw error;
+    const rejected = detectRejectedParam(400, error.responseBody ?? '');
+    if (rejected !== 'temperature') throw error;
+    recordRejectedParam(serviceType, modelName, rejected);
+    return await run(false);
+  }
 }
 
 // The AI SDK part type for a sparky_ask_user tool call, as it comes back from
@@ -1216,6 +1261,8 @@ export function classifyByKeywords(text: string): ChatToolCategorySlug[] {
 async function classifyUserIntent(
   messages: ChatMessage[],
   modelInstance: Parameters<typeof generateText>[0]['model'],
+  serviceType: string,
+  modelName: string,
   providerOptions?: Record<string, Record<string, JSONValue>>
 ): Promise<ChatToolCategorySlug[]> {
   const lastUserMessage = [...messages]
@@ -1266,15 +1313,21 @@ Available domains:
 
 Your response must contain ONLY the matched domain names as a comma-separated list (e.g., "exercise, food" or "checkin" or "none"). Do not include any other text.`;
 
-    const { text: resultText } = await generateText({
-      model: modelInstance,
-      system: classificationPrompt,
-      messages: contextMessages,
-      providerOptions,
-      temperature: 0,
-      maxRetries: 0,
-      abortSignal: AbortSignal.timeout(10000), // 10s timeout to prevent hanging the chat turn
-    });
+    const { text: resultText } = await runWithTemperatureFallback(
+      serviceType,
+      modelName,
+      (sendTemperature) =>
+        generateText({
+          model: modelInstance,
+          system: classificationPrompt,
+          messages: contextMessages,
+          providerOptions,
+          // Reasoning models (gpt-5.x, o-series) accept only the default.
+          ...(sendTemperature && { temperature: 0 }),
+          maxRetries: 0,
+          abortSignal: AbortSignal.timeout(10000), // 10s timeout to prevent hanging the chat turn
+        })
+    );
 
     log(
       'info',
@@ -1373,6 +1426,8 @@ async function processChatMessage(
       activeCategories = await classifyUserIntent(
         messages,
         modelInstance,
+        aiService.service_type,
+        modelName,
         buildChatProviderOptions(
           aiService.service_type,
           authenticatedUserId,
@@ -1413,58 +1468,65 @@ async function processChatMessage(
     }> = [];
     const toolOutputs: string[] = [];
 
-    const result = await generateText({
-      model: modelInstance,
-      system: systemPromptContent,
-      messages: llmMessages as NonNullable<
-        Parameters<typeof generateText>[0]['messages']
-      >,
-      tools,
-      // Narrows the published/sent tool schemas to this turn's classified
-      // categories; sparky_enable_tools lets the model escalate mid-request
-      // via prepareStep if it turns out to need a dormant category.
-      activeTools: activeToolNames,
-      prepareStep,
-      providerOptions: chatProviderOptions,
-      // Low temperature only for small local models (core profile); cloud and
-      // full-profile Ollama keep provider defaults.
-      ...(toolProfile === 'core' && {
-        temperature: CORE_PROFILE_CHAT_TEMPERATURE,
-      }),
-      // Tighter retry ceiling for cache-less core-profile backends, where every
-      // retry re-processes the full prefix.
-      stopWhen: buildChatStopConditions(toolProfile),
-      maxRetries:
-        toolProfile === 'core'
-          ? CORE_PROFILE_MAX_PROVIDER_RETRIES
-          : MAX_PROVIDER_RETRIES,
-      abortSignal: AbortSignal.timeout(CHAT_REQUEST_TIMEOUT_MS),
-      onStepFinish({ toolCalls, toolResults }) {
-        if (toolCalls && toolCalls.length > 0) {
-          toolCalls.forEach((call) => {
-            log(
-              'info',
-              `Agent executed tool call: ${call.toolName} with args: ${JSON.stringify(call.input)}`
-            );
-            executedToolsList.push({
-              name: call.toolName,
-              args: call.input as Record<string, unknown>,
-            });
-          });
-        }
-        if (toolResults && toolResults.length > 0) {
-          toolResults.forEach((r) => {
-            if (r.output && typeof r.output === 'string') {
-              toolOutputs.push(r.output);
+    const result = await runWithTemperatureFallback(
+      aiService.service_type,
+      modelName,
+      (sendTemperature) =>
+        generateText({
+          model: modelInstance,
+          system: systemPromptContent,
+          messages: llmMessages as NonNullable<
+            Parameters<typeof generateText>[0]['messages']
+          >,
+          tools,
+          // Narrows the published/sent tool schemas to this turn's classified
+          // categories; sparky_enable_tools lets the model escalate mid-request
+          // via prepareStep if it turns out to need a dormant category.
+          activeTools: activeToolNames,
+          prepareStep,
+          providerOptions: chatProviderOptions,
+          // Low temperature only for small local models (core profile); cloud and
+          // full-profile Ollama keep provider defaults. Skipped entirely for
+          // models that reject the parameter (see runWithTemperatureFallback).
+          ...(toolProfile === 'core' &&
+            sendTemperature && {
+              temperature: CORE_PROFILE_CHAT_TEMPERATURE,
+            }),
+          // Tighter retry ceiling for cache-less core-profile backends, where every
+          // retry re-processes the full prefix.
+          stopWhen: buildChatStopConditions(toolProfile),
+          maxRetries:
+            toolProfile === 'core'
+              ? CORE_PROFILE_MAX_PROVIDER_RETRIES
+              : MAX_PROVIDER_RETRIES,
+          abortSignal: AbortSignal.timeout(CHAT_REQUEST_TIMEOUT_MS),
+          onStepFinish({ toolCalls, toolResults }) {
+            if (toolCalls && toolCalls.length > 0) {
+              toolCalls.forEach((call) => {
+                log(
+                  'info',
+                  `Agent executed tool call: ${call.toolName} with args: ${JSON.stringify(call.input)}`
+                );
+                executedToolsList.push({
+                  name: call.toolName,
+                  args: call.input as Record<string, unknown>,
+                });
+              });
             }
-          });
-          const sizes = toolResults
-            .map((r) => `${r.toolName}=${String(r.output ?? '').length}c`)
-            .join(' ');
-          log('info', `[chat] tool result sizes: ${sizes}`);
-        }
-      },
-    });
+            if (toolResults && toolResults.length > 0) {
+              toolResults.forEach((r) => {
+                if (r.output && typeof r.output === 'string') {
+                  toolOutputs.push(r.output);
+                }
+              });
+              const sizes = toolResults
+                .map((r) => `${r.toolName}=${String(r.output ?? '').length}c`)
+                .join(' ');
+              log('info', `[chat] tool result sizes: ${sizes}`);
+            }
+          },
+        })
+    );
 
     const usage = result.totalUsage ?? result.usage;
     log(
@@ -1903,6 +1965,8 @@ async function processChatMessageStream(
       activeCategories = await classifyUserIntent(
         messages,
         modelInstance,
+        aiService.service_type,
+        modelName,
         buildChatProviderOptions(
           aiService.service_type,
           authenticatedUserId,
@@ -1960,10 +2024,18 @@ async function processChatMessageStream(
       prepareStep,
       providerOptions: chatProviderOptions,
       // Low temperature only for small local models (core profile); cloud and
-      // full-profile Ollama keep provider defaults.
-      ...(toolProfile === 'core' && {
-        temperature: CORE_PROFILE_CHAT_TEMPERATURE,
-      }),
+      // full-profile Ollama keep provider defaults, and models that reject the
+      // parameter get none.
+      //
+      // No retry wrapper here: streamText returns the stream synchronously and
+      // surfaces provider errors inside it, so a 400 cannot be caught and
+      // replayed. It does not need one — the intent classifier above runs
+      // against this same model first and records any rejection, so
+      // supportsTemperature is already correct by the time we get here.
+      ...(toolProfile === 'core' &&
+        supportsTemperature(aiService.service_type, modelName) && {
+          temperature: CORE_PROFILE_CHAT_TEMPERATURE,
+        }),
       // Tighter retry ceiling for cache-less core-profile backends, where every
       // retry re-processes the full prefix.
       stopWhen: buildChatStopConditions(toolProfile),

--- a/SparkyFitnessServer/tests/chatProviderOptions.test.ts
+++ b/SparkyFitnessServer/tests/chatProviderOptions.test.ts
@@ -96,28 +96,24 @@ describe('buildChatProviderOptions', () => {
     });
   });
 
-  // Regression for issue #2165: the gate used to enumerate gpt-5.1..gpt-5.5, so
-  // each new point release silently dropped off the end and lost cache hits.
-  it.each(['gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.9'])(
-    'adds 24h retention for %s',
-    (model) => {
-      expect(buildChatProviderOptions('openai', 'user-1', model)).toEqual({
-        openai: {
-          promptCacheKey: 'sparky-chat-user-1',
-          promptCacheRetention: '24h',
-        },
-      });
-    }
-  );
-
-  it.each(['gpt-5', 'gpt-5.0', 'gpt-4o', 'gpt-4o-mini'])(
-    'withholds 24h retention from %s',
-    (model) => {
-      expect(buildChatProviderOptions('openai', 'user-1', model)).toEqual({
-        openai: { promptCacheKey: 'sparky-chat-user-1' },
-      });
-    }
-  );
+  // gpt-5.6 deprecated `prompt_cache_retention` in favor of
+  // `prompt_cache_options.ttl`, and the adapter forwards the field ungated, so
+  // sending it to 5.6+ risks a rejected chat turn. Omitting it only costs cache
+  // hits, so newer models must stay off the list until they're known to take it.
+  it.each([
+    'gpt-5.6-luna',
+    'gpt-5.6-terra',
+    'gpt-5.6-sol',
+    'gpt-5.9',
+    'gpt-5',
+    'gpt-5.0',
+    'gpt-4o',
+    'gpt-4o-mini',
+  ])('withholds 24h retention from %s', (model) => {
+    expect(buildChatProviderOptions('openai', 'user-1', model)).toEqual({
+      openai: { promptCacheKey: 'sparky-chat-user-1' },
+    });
+  });
 
   it('keeps system instructions as the system role for OpenAI-compatible backends', () => {
     expect(

--- a/SparkyFitnessServer/tests/chatProviderOptions.test.ts
+++ b/SparkyFitnessServer/tests/chatProviderOptions.test.ts
@@ -96,6 +96,29 @@ describe('buildChatProviderOptions', () => {
     });
   });
 
+  // Regression for issue #2165: the gate used to enumerate gpt-5.1..gpt-5.5, so
+  // each new point release silently dropped off the end and lost cache hits.
+  it.each(['gpt-5.6-luna', 'gpt-5.6-terra', 'gpt-5.6-sol', 'gpt-5.9'])(
+    'adds 24h retention for %s',
+    (model) => {
+      expect(buildChatProviderOptions('openai', 'user-1', model)).toEqual({
+        openai: {
+          promptCacheKey: 'sparky-chat-user-1',
+          promptCacheRetention: '24h',
+        },
+      });
+    }
+  );
+
+  it.each(['gpt-5', 'gpt-5.0', 'gpt-4o', 'gpt-4o-mini'])(
+    'withholds 24h retention from %s',
+    (model) => {
+      expect(buildChatProviderOptions('openai', 'user-1', model)).toEqual({
+        openai: { promptCacheKey: 'sparky-chat-user-1' },
+      });
+    }
+  );
+
   it('keeps system instructions as the system role for OpenAI-compatible backends', () => {
     expect(
       buildChatProviderOptions('openai_compatible', 'user-1', 'gpt-5.6-sol')

--- a/SparkyFitnessServer/tests/chatService.test.ts
+++ b/SparkyFitnessServer/tests/chatService.test.ts
@@ -1183,6 +1183,58 @@ describe('chatService', () => {
       );
     });
 
+    // APICallError.requestBodyValues holds the whole request — the user's chat
+    // messages, the system prompt, tool args. It must never reach the logger,
+    // which forwards objects to console.error at a level that is on by default.
+    it('never logs the provider error object or the request body it carries', async () => {
+      const SENTINEL = 'SENSITIVE-CHAT-CONTENT-b7f3';
+      vi.mocked(chatRepository.getAiServiceSettingForBackend).mockResolvedValue(
+        {
+          ...aiServiceSetting,
+          service_type: 'openai_compatible',
+          custom_url: 'http://localhost:1234/v1',
+          model_name: 'reasoning-1',
+          chat_tool_profile: 'core',
+        }
+      );
+      const model = new MockLanguageModelV3({
+        doStream: async () => {
+          throw new APICallError({
+            message: 'Provider rejected the request',
+            url: 'http://localhost:1234/v1/chat/completions',
+            requestBodyValues: {
+              messages: [{ role: 'user', content: SENTINEL }],
+              system: SENTINEL,
+            },
+            statusCode: 400,
+            responseBody: JSON.stringify({ error: { message: 'bad request' } }),
+          });
+        },
+      });
+      mockModelHolder.current = model;
+
+      const { stream } = await chatService.processChatMessageStream(
+        [{ role: 'user', content: 'hello' }],
+        'svc-1',
+        activeUserId,
+        actorUserId
+      );
+      await drainStream(stream);
+
+      const logged = vi.mocked(log).mock.calls.flat();
+      expect(logged.length).toBeGreaterThan(0);
+      for (const arg of logged) {
+        // No raw Error objects, and no sentinel anywhere in the rendered args.
+        expect(arg).not.toBeInstanceOf(Error);
+        expect(JSON.stringify(arg) ?? '').not.toContain(SENTINEL);
+      }
+      // The failure is still reported, just redacted.
+      expect(log).toHaveBeenCalledWith(
+        'error',
+        expect.stringContaining('stream error')
+      );
+    });
+
     it('injects an error chunk and skips the assistant save when the model errors out with an empty completion', async () => {
       // Gemini's MALFORMED_FUNCTION_CALL surfaces as finishReason 'error' with
       // no content instead of a thrown error.

--- a/SparkyFitnessServer/tests/chatService.test.ts
+++ b/SparkyFitnessServer/tests/chatService.test.ts
@@ -8,6 +8,10 @@ import chatService, {
 } from '../services/chatService.js';
 import { ASK_USER_TOOL_NAME } from '@workspace/shared';
 import chatRepository from '../models/chatRepository.js';
+import {
+  recordRejectedParam,
+  resetLearnedRejections,
+} from '../ai/modelCapabilities.js';
 import measurementRepository from '../models/measurementRepository.js';
 import preferenceRepository from '../models/preferenceRepository.js';
 import foodRepository from '../models/foodRepository.js';
@@ -76,6 +80,9 @@ describe('chatService', () => {
   const mockTargetUserId = 'user-456';
   beforeEach(() => {
     vi.clearAllMocks();
+    // Learned parameter rejections are module-level; keep them from leaking
+    // between tests.
+    resetLearnedRejections();
   });
   describe('handleAiServiceSettings', () => {
     it('should save AI service settings', async () => {
@@ -652,6 +659,55 @@ describe('chatService', () => {
         expect.stringMatching(/default 4096-token context/)
       );
       // Small local models get a low temperature for steadier tool JSON.
+      expect(model.doGenerateCalls[0].temperature).toBe(0.2);
+    });
+
+    // Regression for issue #2165: some models accept only the default
+    // temperature, so sending the core-profile 0.2 would 400 the turn. The core
+    // profile is honored only for self-hosted service types, so the rejection
+    // reaches this path through the learned gate rather than the static one.
+    it('withholds the core-profile temperature from a model that rejects it', async () => {
+      recordRejectedParam('openai_compatible', 'reasoning-1', 'temperature');
+      vi.mocked(chatRepository.getAiServiceSettingForBackend).mockResolvedValue(
+        {
+          ...aiServiceSetting,
+          service_type: 'openai_compatible',
+          custom_url: 'http://localhost:1234/v1',
+          model_name: 'reasoning-1',
+          chat_tool_profile: 'core',
+        }
+      );
+      const model = scriptModel([textStep('Hi there!')]);
+
+      await chatService.processChatMessage(
+        [{ role: 'user', content: 'hello' }],
+        'svc-1',
+        activeUserId,
+        actorUserId
+      );
+
+      expect(model.doGenerateCalls[0].temperature).toBeUndefined();
+    });
+
+    it('still applies the core-profile temperature to a model that accepts it', async () => {
+      vi.mocked(chatRepository.getAiServiceSettingForBackend).mockResolvedValue(
+        {
+          ...aiServiceSetting,
+          service_type: 'openai_compatible',
+          custom_url: 'http://localhost:1234/v1',
+          model_name: 'reasoning-1',
+          chat_tool_profile: 'core',
+        }
+      );
+      const model = scriptModel([textStep('Hi there!')]);
+
+      await chatService.processChatMessage(
+        [{ role: 'user', content: 'hello' }],
+        'svc-1',
+        activeUserId,
+        actorUserId
+      );
+
       expect(model.doGenerateCalls[0].temperature).toBe(0.2);
     });
 

--- a/SparkyFitnessServer/tests/chatService.test.ts
+++ b/SparkyFitnessServer/tests/chatService.test.ts
@@ -1,5 +1,6 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
 import { MockLanguageModelV3 } from 'ai/test';
+import { APICallError } from 'ai';
 import { simulateReadableStream } from 'ai';
 import type { UIMessageChunk } from 'ai';
 import chatService, {
@@ -11,6 +12,7 @@ import chatRepository from '../models/chatRepository.js';
 import {
   recordRejectedParam,
   resetLearnedRejections,
+  supportsTemperature,
 } from '../ai/modelCapabilities.js';
 import measurementRepository from '../models/measurementRepository.js';
 import preferenceRepository from '../models/preferenceRepository.js';
@@ -1125,6 +1127,59 @@ describe('chatService', () => {
       vi.mocked(chatRepository.saveChatHistory).mockResolvedValue(true);
       vi.mocked(measurementRepository.getCustomCategories).mockResolvedValue(
         []
+      );
+    });
+
+    // The streaming path cannot retry a rejected parameter in place, so the
+    // rejection has to be learned for the next turn. It is the first request a
+    // model sees more often than not: the intent classifier returns early on
+    // any keyword match and is skipped entirely for manual tool selection.
+    it('records a stream-time temperature rejection so later turns omit it', async () => {
+      vi.mocked(chatRepository.getAiServiceSettingForBackend).mockResolvedValue(
+        {
+          ...aiServiceSetting,
+          service_type: 'openai_compatible',
+          custom_url: 'http://localhost:1234/v1',
+          model_name: 'reasoning-1',
+          chat_tool_profile: 'core',
+        }
+      );
+      const model = new MockLanguageModelV3({
+        doStream: async () => {
+          throw new APICallError({
+            message: 'Unsupported value: temperature',
+            url: 'http://localhost:1234/v1/chat/completions',
+            requestBodyValues: {},
+            statusCode: 400,
+            responseBody: JSON.stringify({
+              error: {
+                message:
+                  "Unsupported value: 'temperature' does not support 0.2 with this model. Only the default (1) value is supported.",
+                type: 'invalid_request_error',
+                param: 'temperature',
+                code: 'unsupported_value',
+              },
+            }),
+          });
+        },
+      });
+      mockModelHolder.current = model;
+
+      expect(supportsTemperature('openai_compatible', 'reasoning-1')).toBe(
+        true
+      );
+
+      const { stream } = await chatService.processChatMessageStream(
+        [{ role: 'user', content: 'hello' }],
+        'svc-1',
+        activeUserId,
+        actorUserId
+      );
+      await drainStream(stream);
+
+      // Learned, so the next turn builds the request without it.
+      expect(supportsTemperature('openai_compatible', 'reasoning-1')).toBe(
+        false
       );
     });
 

--- a/SparkyFitnessServer/tests/modelCapabilities.test.ts
+++ b/SparkyFitnessServer/tests/modelCapabilities.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  detectRejectedParam,
+  describeRejectedParam,
+  isParamRejected,
+  recordRejectedParam,
+  resetLearnedRejections,
+  supportsTemperature,
+} from '../ai/modelCapabilities.js';
+
+// The exact body OpenAI returns for a gpt-5.6 model, from issue #2165.
+const ISSUE_2165_BODY = JSON.stringify({
+  error: {
+    message:
+      "Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.",
+    type: 'invalid_request_error',
+    param: 'temperature',
+    code: 'unsupported_value',
+  },
+});
+
+beforeEach(() => {
+  resetLearnedRejections();
+});
+
+describe('detectRejectedParam', () => {
+  it('names temperature from the issue #2165 body', () => {
+    expect(detectRejectedParam(400, ISSUE_2165_BODY)).toBe('temperature');
+  });
+
+  it('names temperature from an Anthropic-style body with no param field', () => {
+    const body = JSON.stringify({
+      type: 'error',
+      error: {
+        type: 'invalid_request_error',
+        message: 'temperature: Extra inputs are not permitted',
+      },
+    });
+    expect(detectRejectedParam(400, body)).toBe('temperature');
+  });
+
+  it('names top_p, the other droppable sampling hint', () => {
+    const body = JSON.stringify({
+      error: {
+        message: "Unsupported value: 'top_p' is not supported with this model.",
+        param: 'top_p',
+        code: 'unsupported_value',
+      },
+    });
+    expect(detectRejectedParam(400, body)).toBe('top_p');
+  });
+
+  // Dropping max_tokens would trade one failure for another (Anthropic
+  // requires it), so it must never be self-healed away.
+  it('refuses to name max_tokens even when the provider rejects it', () => {
+    const body = JSON.stringify({
+      error: {
+        message: "Unsupported parameter: 'max_tokens' is not supported.",
+        param: 'max_tokens',
+        code: 'unsupported_parameter',
+      },
+    });
+    expect(detectRejectedParam(400, body)).toBeNull();
+  });
+
+  it('ignores a 400 that is not a parameter rejection', () => {
+    const body = JSON.stringify({
+      error: {
+        message: 'The model `gpt-9` does not exist.',
+        type: 'invalid_request_error',
+        code: 'model_not_found',
+      },
+    });
+    expect(detectRejectedParam(400, body)).toBeNull();
+  });
+
+  it('ignores non-400 statuses and unparseable bodies', () => {
+    expect(detectRejectedParam(401, ISSUE_2165_BODY)).toBeNull();
+    expect(detectRejectedParam(500, ISSUE_2165_BODY)).toBeNull();
+    expect(detectRejectedParam(400, '<html>Bad Gateway</html>')).toBeNull();
+    expect(detectRejectedParam(400, '')).toBeNull();
+  });
+
+  it('skips a body too large to be an error payload', () => {
+    expect(detectRejectedParam(400, 'x'.repeat(9000))).toBeNull();
+  });
+});
+
+describe('describeRejectedParam', () => {
+  it('names the parameter for a readable error message', () => {
+    expect(describeRejectedParam(400, ISSUE_2165_BODY)).toBe('temperature');
+  });
+
+  it('returns null for an unrelated 400', () => {
+    const body = JSON.stringify({ error: { message: 'Invalid API key.' } });
+    expect(describeRejectedParam(400, body)).toBeNull();
+  });
+});
+
+describe('supportsTemperature — static gate', () => {
+  it.each([
+    ['gpt-5.6-luna', false],
+    ['gpt-5.6-terra', false],
+    ['gpt-5.6-sol', false],
+    ['gpt-5.4-mini', false],
+    ['o1-mini', false],
+    ['o3', false],
+    ['o4-mini', false],
+    ['gpt-4o-mini', true],
+    ['gpt-4.1-mini', true],
+    ['gpt-4o', true],
+  ])('openai %s -> %s', (model, expected) => {
+    expect(supportsTemperature('openai', model)).toBe(expected);
+  });
+
+  it.each([
+    ['claude-opus-5', false],
+    ['claude-opus-4-7', false],
+    ['claude-opus-4-8', false],
+    ['claude-sonnet-5', false],
+    ['claude-fable-5', false],
+    ['claude-mythos-5', false],
+    ['claude-sonnet-4-6', true],
+    ['claude-haiku-4-5', true],
+  ])('anthropic %s -> %s', (model, expected) => {
+    expect(supportsTemperature('anthropic', model)).toBe(expected);
+  });
+
+  // A gateway may serve an OpenAI-looking id through a shim that does accept
+  // temperature, so compatible types are left to the runtime gate instead.
+  it('does not statically block gpt-5 ids on gateway service types', () => {
+    expect(supportsTemperature('openai_compatible', 'gpt-5.6-luna')).toBe(true);
+    expect(supportsTemperature('custom', 'gpt-5.6-luna')).toBe(true);
+    expect(supportsTemperature('openrouter', 'openai/gpt-5.6-luna')).toBe(true);
+  });
+
+  it('leaves unknown providers and models alone', () => {
+    expect(supportsTemperature('ollama', 'llama3.2')).toBe(true);
+    expect(supportsTemperature('google', 'gemini-2.5-flash')).toBe(true);
+  });
+});
+
+describe('supportsTemperature — learned gate', () => {
+  it('blocks a model after it has rejected temperature once', () => {
+    expect(supportsTemperature('openai_compatible', 'mystery-1')).toBe(true);
+    recordRejectedParam('openai_compatible', 'mystery-1', 'temperature');
+    expect(supportsTemperature('openai_compatible', 'mystery-1')).toBe(false);
+    expect(
+      isParamRejected('openai_compatible', 'mystery-1', 'temperature')
+    ).toBe(true);
+  });
+
+  it('scopes the rejection to that service type and model', () => {
+    recordRejectedParam('openai_compatible', 'mystery-1', 'temperature');
+    expect(supportsTemperature('openai_compatible', 'mystery-2')).toBe(true);
+    expect(supportsTemperature('custom', 'mystery-1')).toBe(true);
+  });
+
+  it('records multiple params for the same model', () => {
+    recordRejectedParam('custom', 'm', 'temperature');
+    recordRejectedParam('custom', 'm', 'top_p');
+    expect(isParamRejected('custom', 'm', 'temperature')).toBe(true);
+    expect(isParamRejected('custom', 'm', 'top_p')).toBe(true);
+  });
+
+  // Model names come from user-editable settings, so the cache must be bounded.
+  it('evicts the oldest entry past the cap instead of growing forever', () => {
+    for (let i = 0; i < 505; i++) {
+      recordRejectedParam('custom', `model-${i}`, 'temperature');
+    }
+    expect(isParamRejected('custom', 'model-0', 'temperature')).toBe(false);
+    expect(isParamRejected('custom', 'model-504', 'temperature')).toBe(true);
+  });
+});

--- a/SparkyFitnessServer/tests/providerDispatch.test.ts
+++ b/SparkyFitnessServer/tests/providerDispatch.test.ts
@@ -7,6 +7,7 @@ import {
   type ProviderConfig,
 } from '../ai/providerDispatch.js';
 import { OutboundUrlBlockedError } from '../utils/outboundUrlPolicy.js';
+import { resetLearnedRejections } from '../ai/modelCapabilities.js';
 import convert from 'heic-convert';
 
 // Fixed "JPEG" bytes returned by the mocked transcoder. Declared via vi.hoisted
@@ -1239,6 +1240,144 @@ describe('dispatchAiRequest — model defaulting', () => {
       })
     );
     expect(captured(m).body.model).toBe('llama3.2');
+  });
+});
+
+describe('dispatchAiRequest — models that reject temperature', () => {
+  // The exact body OpenAI returns for gpt-5.6, from issue #2165.
+  const REJECTION_BODY = JSON.stringify({
+    error: {
+      message:
+        "Unsupported value: 'temperature' does not support 0 with this model. Only the default (1) value is supported.",
+      type: 'invalid_request_error',
+      param: 'temperature',
+      code: 'unsupported_value',
+    },
+  });
+
+  function mockSequence(...responses: Array<Record<string, unknown>>) {
+    const m = vi.fn();
+    for (const r of responses) {
+      m.mockResolvedValueOnce({
+        ok: r.ok ?? true,
+        status: r.status ?? 200,
+        text: async () => (typeof r.body === 'string' ? r.body : ''),
+        json: async () => r.body,
+      });
+    }
+    global.fetch = m as typeof global.fetch;
+    return m;
+  }
+
+  function bodyOfCall(m: ReturnType<typeof vi.fn>, i: number) {
+    const init = m.mock.calls[i][1] as { body: string };
+    return JSON.parse(init.body) as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    resetLearnedRejections();
+  });
+
+  // Static gate: no wasted round-trip for a family we already know about.
+  it('omits temperature on the first request for a known gpt-5 model', async () => {
+    const m = mockFetch(openAiBody(JSON.stringify(SAMPLE)));
+    const result = await dispatchAiRequest(
+      baseRequest({
+        provider: makeProvider({ model_name: 'gpt-5.6-luna' }),
+        temperature: 0,
+      })
+    );
+    expect(result.ok).toBe(true);
+    expect(m).toHaveBeenCalledTimes(1);
+    expect(captured(m).body.temperature).toBeUndefined();
+  });
+
+  it('still sends temperature to a model outside the known families', async () => {
+    const m = mockFetch(openAiBody(JSON.stringify(SAMPLE)));
+    await dispatchAiRequest(baseRequest({ temperature: 0 }));
+    expect(captured(m).body.temperature).toBe(0);
+  });
+
+  // Dynamic gate: this is what makes an unknown future model work on first use.
+  it('drops temperature and retries once when the provider rejects it', async () => {
+    const m = mockSequence(
+      { ok: false, status: 400, body: REJECTION_BODY },
+      { body: openAiBody(JSON.stringify(SAMPLE)) }
+    );
+    const result = await dispatchAiRequest(
+      baseRequest({
+        provider: makeProvider({
+          service_type: 'openai_compatible',
+          custom_url: 'https://gateway.example.com/v1',
+          model_name: 'mystery-1',
+        }),
+        temperature: 0,
+      })
+    );
+    expect(result.ok).toBe(true);
+    expect(m).toHaveBeenCalledTimes(2);
+    expect(bodyOfCall(m, 0).temperature).toBe(0);
+    expect(bodyOfCall(m, 1).temperature).toBeUndefined();
+  });
+
+  it('remembers the rejection so later requests cost no retry', async () => {
+    mockSequence(
+      { ok: false, status: 400, body: REJECTION_BODY },
+      { body: openAiBody(JSON.stringify(SAMPLE)) }
+    );
+    const req = () =>
+      dispatchAiRequest(
+        baseRequest({
+          provider: makeProvider({
+            service_type: 'openai_compatible',
+            custom_url: 'https://gateway.example.com/v1',
+            model_name: 'mystery-1',
+          }),
+          temperature: 0,
+        })
+      );
+    await req();
+
+    const second = mockFetch(openAiBody(JSON.stringify(SAMPLE)));
+    const result = await req();
+    expect(result.ok).toBe(true);
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(captured(second).body.temperature).toBeUndefined();
+  });
+
+  it('does not retry a 400 that is not a parameter rejection', async () => {
+    const body = JSON.stringify({
+      error: { message: 'Invalid API key.', code: 'invalid_api_key' },
+    });
+    const m = mockFetch(body, { ok: false, status: 400 });
+    const result = await dispatchAiRequest(baseRequest({ temperature: 0 }));
+    expect(result.ok).toBe(false);
+    expect(m).toHaveBeenCalledTimes(1);
+    if (!result.ok) expect(result.category).toBe('upstream_error');
+  });
+
+  it('does not retry when no temperature was sent in the first place', async () => {
+    const m = mockFetch(REJECTION_BODY, { ok: false, status: 400 });
+    const result = await dispatchAiRequest(baseRequest());
+    expect(result.ok).toBe(false);
+    expect(m).toHaveBeenCalledTimes(1);
+  });
+
+  // A parameter we refuse to drop must fail loudly, but readably.
+  it('explains an unsupported parameter instead of dumping raw JSON', async () => {
+    const body = JSON.stringify({
+      error: {
+        message: "Unsupported parameter: 'max_tokens' is not supported.",
+        param: 'max_tokens',
+        code: 'unsupported_parameter',
+      },
+    });
+    mockFetch(body, { ok: false, status: 400 });
+    const result = await dispatchAiRequest(baseRequest({ temperature: 0 }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.detail).toContain("rejected the 'max_tokens' parameter");
+    }
   });
 });
 


### PR DESCRIPTION
OpenAI's gpt-5.x and o-series accept only the default temperature, so every call that set one failed with a 400 — the connection test, food options, label scan, unit conversion, and the intent classifier that runs on each chat turn.

Gate temperature on a per-model capability check covering the known OpenAI and Anthropic families, and drop-and-retry once when a provider rejects it anyway, caching the rejection so later requests skip it. New model families then work on first use without a code change.

Also match the 24h prompt-cache retention gate as a gpt-5.x family instead of enumerating point releases, which had silently excluded gpt-5.6, surface an unsupported parameter as a readable message rather than raw JSON, and add the gpt-5.6 variants to the model picker.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #2165

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for GPT-5.6 Luna, Terra, and Sol models.
  * Improved compatibility with AI models that restrict sampling options.
  * Requests can automatically retry with supported settings when a provider rejects an option.

* **Bug Fixes**
  * Reduced failures caused by unsupported temperature settings.
  * Improved error messages for rejected request parameters.
  * Preserved temperature customization for compatible models.
  * Limited extended prompt-cache retention to supported GPT-5 models.
  * Improved handling of streaming errors without exposing sensitive request details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->