### PR TITLE
fix(mobile): request both health directions together when both are enabled

### DIFF
--- a/SparkyFitnessMobile/AGENTS.md
+++ b/SparkyFitnessMobile/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-*Last updated: 2026-08-06*
+*Last updated: 2026-08-21*
 
 SparkyFitness Mobile is a React Native 0.85 + Expo SDK 56 app for syncing Apple Health / Health Connect data with the SparkyFitness backend, tracking nutrition, hydration, fasting, measurements, exercise, saved foods, meal templates, custom exercises, workout presets, iOS / Android widgets, the active workout HUD, and the Sparky AI chat.
 
@@ -134,6 +134,8 @@ npx expo prebuild --clean
 - Platform split: `services/writeback.ios.ts` re-exports `healthkit/writeback.ts`; `services/writeback.ts` re-exports `healthconnect/writeback.ts`.
 - `runWriteback()` runs after inbound sync in its own try/catch. Writeback failures must not block inbound sync results.
 - Writeback is opt-in per metric and gated on write permissions. Android production permissions include `WRITE_NUTRITION` and `WRITE_HYDRATION`; other write permissions are dev-only.
+- Read sync and writeback are independent opt-ins with independent prefs; nothing writes the other direction's `preferenceKey`. But the OS authorization sheet is authoritative for every row it shows, so a request carrying only one direction can commit an omitted-but-enabled direction back to off (issue #2160). **Whenever both directions of a record type are enabled, request them together** — `services/shared/healthPermissionSets.ts` builds the counterpart set, and every request path uses it: both `SyncScreen` toggles, "Enable All", and `refreshEnabledMetricPermissions` (which must never issue a read-only request while writeback is on). `buildAuthDataTypes` in `healthkit/index.ts` still keeps `toRead`/`toShare` in separate Sets, and a direction that is switched off is never requested for.
+- `REQUIRED_HEALTH_PERMISSION_VERSION` in `shared/healthPermissionMigration.ts` is 4; bump it when an existing install needs its enabled permissions re-requested.
 - Imported health entries are skipped to avoid echo loops. iOS sets the app bundle id as the own-source guard; Android relies on source metadata.
 - Per-day content-signature hashing skips unchanged days. Each run deletes prior tracked UUIDs then saves fresh records; failed deletes are retried next run.
 - `HealthDataWriteback` on `SyncScreen` owns the remove flow. `BottomSheetPicker` offers all-time purge or date range through `DateRangeSheet`; both call `removeWrittenData(range)` and clear tracking.

--- a/SparkyFitnessMobile/__tests__/services/healthkit/workoutPermissions.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthkit/workoutPermissions.test.ts
@@ -121,3 +121,73 @@ describe('exerciseSession metric permissions', () => {
     }
   });
 });
+
+// Regression guard for issue #2160 at the expansion layer: each direction lands in its
+// own array and neither leaks into the other. Whether a *caller* bundles the enabled
+// counterpart into one request is a separate decision, made in SyncScreen — see
+// services/shared/healthPermissionSets.ts.
+describe('read/write direction independence', () => {
+  it.each(['Nutrition', 'Hydration'])(
+    'requests %s write without touching read',
+    async (recordType) => {
+      const { toRead, toShare } = await authorizeWith([{ accessType: 'write', recordType }]);
+      expect(toRead).toEqual([]);
+      expect(toShare.length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(['Nutrition', 'Hydration'])(
+    'requests %s read without touching write',
+    async (recordType) => {
+      const { toRead, toShare } = await authorizeWith([{ accessType: 'read', recordType }]);
+      expect(toShare).toEqual([]);
+      expect(toRead.length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(['Nutrition', 'Hydration'])(
+    'keeps both directions when %s is requested both ways at once',
+    async (recordType) => {
+      const { toRead, toShare } = await authorizeWith([
+        { accessType: 'read', recordType },
+        { accessType: 'write', recordType },
+      ]);
+      expect(toRead.length).toBeGreaterThan(0);
+      expect(toShare).toEqual(toRead);
+    },
+  );
+});
+
+describe('authorization request logging', () => {
+  const { addLog } = jest.requireMock('../../../src/services/LogService');
+
+  it('records exactly what was handed to HealthKit, per direction', async () => {
+    (addLog as jest.Mock).mockClear();
+    await authorizeWith([{ accessType: 'write', recordType: 'Hydration' }]);
+
+    const [message, , details] = (addLog as jest.Mock).mock.calls.find(
+      ([m]: [string]) => m.includes('Requesting HealthKit authorization'),
+    );
+    expect(message).toBeTruthy();
+    expect(details).toEqual([
+      'toRead (0): (none)',
+      'toShare (1): HKQuantityTypeIdentifierDietaryWater',
+    ]);
+  });
+
+  it('warns instead of silently succeeding when nothing maps to a HealthKit type', async () => {
+    (addLog as jest.Mock).mockClear();
+    (requestAuthorization as jest.Mock).mockClear();
+
+    await requestHealthPermissions([
+      { accessType: 'write', recordType: 'NotARealRecordType' },
+    ] as Parameters<typeof requestHealthPermissions>[0]);
+
+    expect(requestAuthorization).not.toHaveBeenCalled();
+    expect(addLog).toHaveBeenCalledWith(
+      expect.stringContaining('expanded to zero HealthKit types'),
+      'WARNING',
+      ['unmapped: write NotARealRecordType'],
+    );
+  });
+});

--- a/SparkyFitnessMobile/__tests__/services/shared/healthPermissionMigration.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/shared/healthPermissionMigration.test.ts
@@ -32,7 +32,7 @@ describe('migrateEnabledMetricPermissionsIfNeeded', () => {
   });
 
   test('skips migration when the stored version is current', async () => {
-    loadHealthPreference.mockResolvedValue(3);
+    loadHealthPreference.mockResolvedValue(4);
 
     const result = await migrateEnabledMetricPermissionsIfNeeded({
       healthMetricStates: { isExerciseSessionSyncEnabled: true },
@@ -62,7 +62,7 @@ describe('migrateEnabledMetricPermissionsIfNeeded', () => {
 
     expect(result).toBe(true);
     expect(requestHealthPermissions).not.toHaveBeenCalled();
-    expect(saveHealthPreference).toHaveBeenCalledWith('healthPermissionsVersion', 3);
+    expect(saveHealthPreference).toHaveBeenCalledWith('healthPermissionsVersion', 4);
   });
 
   test('persists the new version after all enabled permissions are granted', async () => {
@@ -83,7 +83,7 @@ describe('migrateEnabledMetricPermissionsIfNeeded', () => {
 
     expect(result).toBe(true);
     expect(requestHealthPermissions).toHaveBeenCalledWith(metrics[0].permissions);
-    expect(saveHealthPreference).toHaveBeenCalledWith('healthPermissionsVersion', 3);
+    expect(saveHealthPreference).toHaveBeenCalledWith('healthPermissionsVersion', 4);
   });
 
   test('does not persist the new version when permissions are only partially granted', async () => {
@@ -119,5 +119,51 @@ describe('migrateEnabledMetricPermissionsIfNeeded', () => {
 
     expect(result).toBe(false);
     expect(saveHealthPreference).not.toHaveBeenCalled();
+  });
+});
+
+describe('writeback directions in the refresh pass', () => {
+  const baseArgs = {
+    healthMetricStates: { isHydrationSyncEnabled: true },
+    metrics: [
+      {
+        stateKey: 'isHydrationSyncEnabled',
+        permissions: [{ accessType: 'read' as const, recordType: 'Hydration' }],
+      },
+    ],
+    logTag: '[Test]',
+  };
+
+  it('sends read and write in ONE request, never a read-only one', async () => {
+    const requestHealthPermissions = jest.fn().mockResolvedValue(true);
+    const saveHealthPreference = jest.fn().mockResolvedValue(undefined);
+
+    await migrateEnabledMetricPermissionsIfNeeded({
+      ...baseArgs,
+      loadHealthPreference: jest.fn().mockResolvedValue(null),
+      saveHealthPreference,
+      requestHealthPermissions,
+      extraPermissions: [{ accessType: 'write', recordType: 'Hydration' }],
+    });
+
+    expect(requestHealthPermissions).toHaveBeenCalledTimes(1);
+    expect(requestHealthPermissions).toHaveBeenCalledWith([
+      { accessType: 'read', recordType: 'Hydration' },
+      { accessType: 'write', recordType: 'Hydration' },
+    ]);
+  });
+
+  it('re-runs for installs stamped at the previous version', async () => {
+    const requestHealthPermissions = jest.fn().mockResolvedValue(true);
+
+    await migrateEnabledMetricPermissionsIfNeeded({
+      ...baseArgs,
+      loadHealthPreference: jest.fn().mockResolvedValue(3),
+      saveHealthPreference: jest.fn().mockResolvedValue(undefined),
+      requestHealthPermissions,
+      extraPermissions: [{ accessType: 'write', recordType: 'Hydration' }],
+    });
+
+    expect(requestHealthPermissions).toHaveBeenCalledTimes(1);
   });
 });

--- a/SparkyFitnessMobile/__tests__/services/shared/healthPermissionSets.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/shared/healthPermissionSets.test.ts
@@ -1,0 +1,48 @@
+import {
+  enabledWritebackPermissions,
+  enabledReadPermissionsForRecordType,
+} from '../../../src/services/shared/healthPermissionSets';
+
+describe('healthPermissionSets', () => {
+  describe('enabledWritebackPermissions', () => {
+    it('returns the write direction only for writeback metrics that are on', () => {
+      const perms = enabledWritebackPermissions({ hydration: true, nutrition: false });
+      expect(perms).toEqual([{ accessType: 'write', recordType: 'Hydration' }]);
+    });
+
+    it('returns nothing when no writeback metric is on', () => {
+      expect(enabledWritebackPermissions({})).toEqual([]);
+      expect(enabledWritebackPermissions({ hydration: false })).toEqual([]);
+    });
+
+    it('scopes to the requested record types', () => {
+      const perms = enabledWritebackPermissions(
+        { hydration: true, nutrition: true },
+        new Set(['Hydration']),
+      );
+      expect(perms).toEqual([{ accessType: 'write', recordType: 'Hydration' }]);
+    });
+  });
+
+  describe('enabledReadPermissionsForRecordType', () => {
+    it('returns the read direction when that metric is on', () => {
+      const perms = enabledReadPermissionsForRecordType(
+        { isHydrationSyncEnabled: true },
+        'Hydration',
+      );
+      expect(perms).toEqual([{ accessType: 'read', recordType: 'Hydration' }]);
+    });
+
+    it('returns nothing when the read metric is off — an off direction is never requested', () => {
+      expect(
+        enabledReadPermissionsForRecordType({ isHydrationSyncEnabled: false }, 'Hydration'),
+      ).toEqual([]);
+    });
+
+    it('ignores metrics for other record types', () => {
+      expect(
+        enabledReadPermissionsForRecordType({ isHydrationSyncEnabled: true }, 'Nutrition'),
+      ).toEqual([]);
+    });
+  });
+});

--- a/SparkyFitnessMobile/src/screens/SyncScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SyncScreen.tsx
@@ -9,6 +9,10 @@ import SyncOnOpen from '../components/SyncOnOpen';
 import HealthDataSync from '../components/HealthDataSync';
 import HealthDataWriteback from '../components/HealthDataWriteback';
 import { WRITEBACK_METRICS, type WritebackMetric, type WritebackDateRange } from '../WritebackMetrics';
+import {
+  enabledWritebackPermissions,
+  enabledReadPermissionsForRecordType,
+} from '../services/shared/healthPermissionSets';
 import HealthSourceLabel from '../components/HealthSourceLabel';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
@@ -141,7 +145,7 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
     setWritebackStates(newWritebackStates);
 
     if (initialized) {
-      await refreshEnabledMetricPermissions(newHealthMetricStates);
+      await refreshEnabledMetricPermissions(newHealthMetricStates, newWritebackStates);
     }
 
     const bgSyncEnabled = await loadBackgroundSyncEnabled();
@@ -254,7 +258,12 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
     }
     if (newValue) {
       try {
-        const granted = await requestHealthPermissions(metric.permissions);
+        // Carry the write direction too when writeback for this record type is already
+        // on, so the sheet cannot commit it back to off. See healthPermissionSets.ts.
+        const granted = await requestHealthPermissions([
+          ...metric.permissions,
+          ...enabledWritebackPermissions(writebackStates, new Set([metric.recordType])),
+        ]);
         if (!granted) {
           Alert.alert('Permission Denied', `Please grant ${metric.label.toLowerCase()} permission in ${healthSettingsName}.`);
           setHealthMetricStates(prevStates => ({
@@ -293,7 +302,10 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
     }
     // Enabling: request the write permission; revert the toggle if denied.
     try {
-      const granted = await requestHealthPermissions([metric.permission]);
+      const granted = await requestHealthPermissions([
+        metric.permission,
+        ...enabledReadPermissionsForRecordType(healthMetricStates, metric.permission.recordType),
+      ]);
       if (!granted) {
         Alert.alert(
           'Permission Denied',
@@ -378,7 +390,10 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
     });
 
     if (newValue) {
-      const allPermissions = HEALTH_METRICS.flatMap(metric => metric.permissions);
+      const allPermissions = [
+        ...HEALTH_METRICS.flatMap(metric => metric.permissions),
+        ...enabledWritebackPermissions(writebackStates),
+      ];
       addLog(`[SyncScreen] Requesting permissions for all ${HEALTH_METRICS.length} metrics`, 'DEBUG');
 
       try {

--- a/SparkyFitnessMobile/src/services/healthConnectService.ios.ts
+++ b/SparkyFitnessMobile/src/services/healthConnectService.ios.ts
@@ -12,6 +12,7 @@ import {
 } from '../types/healthRecords';
 import { SyncDuration } from './healthkit/preferences';
 import { migrateEnabledMetricPermissionsIfNeeded } from './shared/healthPermissionMigration';
+import { enabledWritebackPermissions } from './shared/healthPermissionSets';
 
 // Tell the read transformers which bundle id is "us" so they skip HealthKit records
 // this app wrote (hydration writeback feedback-loop guard). Parallels Android's
@@ -74,9 +75,11 @@ export const saveSyncDuration = HealthKitPreferences.saveSyncDuration;
 export const loadSyncDuration = HealthKitPreferences.loadSyncDuration;
 export const refreshEnabledMetricPermissions = async (
   healthMetricStates: HealthMetricStates,
+  writebackStates: Record<string, boolean> = {},
 ): Promise<boolean> =>
   migrateEnabledMetricPermissionsIfNeeded({
     healthMetricStates,
+    extraPermissions: enabledWritebackPermissions(writebackStates),
     metrics: HEALTH_METRICS,
     loadHealthPreference,
     saveHealthPreference,

--- a/SparkyFitnessMobile/src/services/healthConnectService.ts
+++ b/SparkyFitnessMobile/src/services/healthConnectService.ts
@@ -14,6 +14,7 @@ import {
 } from '../types/healthRecords';
 import { SyncDuration } from './healthconnect/preferences';
 import { migrateEnabledMetricPermissionsIfNeeded } from './shared/healthPermissionMigration';
+import { enabledWritebackPermissions } from './shared/healthPermissionSets';
 import * as Application from 'expo-application';
 
 // Tell the read transformers which package is "us" so they skip Health Connect
@@ -74,9 +75,11 @@ export const saveSyncDuration = HealthConnectPreferences.saveSyncDuration;
 export const loadSyncDuration = HealthConnectPreferences.loadSyncDuration;
 export const refreshEnabledMetricPermissions = async (
   healthMetricStates: HealthMetricStates,
+  writebackStates: Record<string, boolean> = {},
 ): Promise<boolean> =>
   migrateEnabledMetricPermissionsIfNeeded({
     healthMetricStates,
+    extraPermissions: enabledWritebackPermissions(writebackStates),
     metrics: HEALTH_METRICS,
     loadHealthPreference,
     saveHealthPreference,

--- a/SparkyFitnessMobile/src/services/healthkit/index.ts
+++ b/SparkyFitnessMobile/src/services/healthkit/index.ts
@@ -268,6 +268,13 @@ export const requestHealthPermissions = async (
 
   const isSimulator = Platform.OS === 'ios' && (Platform.constants as { simulator?: boolean })?.simulator === true;
   if (isSimulator && !(globalThis as Record<string, unknown>).FORCE_HEALTHKIT_ON_SIM) {
+    // Returning true here is a convenience for simulator runs, but callers log it as
+    // "permission granted" — say plainly that nothing was requested so the log is not
+    // read as evidence that HealthKit was asked.
+    addLog(
+      '[HealthKitService] Simulator: skipped the authorization request entirely (no sheet, no grant). Set FORCE_HEALTHKIT_ON_SIM to exercise the real path.',
+      'WARNING',
+    );
     return true;
   }
 
@@ -346,8 +353,23 @@ export const requestHealthPermissions = async (
   const toShare = Array.from(writePermissionsSet);
 
   if (toRead.length === 0 && toShare.length === 0) {
+    // Every requested record type expanded to nothing — an unmapped record type, or one
+    // missing from SUPPORTED_HK_TYPES. Nothing reaches HealthKit, so no sheet appears and
+    // the type never shows up in the Health app, yet callers see success. Say so loudly.
+    addLog(
+      '[HealthKitService] Authorization request expanded to zero HealthKit types — nothing was requested.',
+      'WARNING',
+      permissionsToRequest.map(p => `unmapped: ${p.accessType} ${p.recordType}`),
+    );
     return true;
   }
+
+  // Exactly what we hand HealthKit, per direction. This is the record that separates
+  // "the request never reached HealthKit" from "it did and the grant did not stick".
+  addLog('[HealthKitService] Requesting HealthKit authorization', 'INFO', [
+    `toRead (${toRead.length}): ${toRead.join(', ') || '(none)'}`,
+    `toShare (${toShare.length}): ${toShare.join(', ') || '(none)'}`,
+  ]);
 
   try {
     // HealthKit library expects 'toRead' and 'toShare' arrays

--- a/SparkyFitnessMobile/src/services/shared/healthPermissionMigration.ts
+++ b/SparkyFitnessMobile/src/services/shared/healthPermissionMigration.ts
@@ -1,7 +1,7 @@
 import { addLog } from '../LogService';
 import type { PermissionRequest, HealthMetricStates } from '../../types/healthRecords';
 
-const REQUIRED_HEALTH_PERMISSION_VERSION = 3;
+const REQUIRED_HEALTH_PERMISSION_VERSION = 4;
 const REQUIRED_HEALTH_PERMISSION_VERSION_KEY = 'healthPermissionsVersion';
 
 type PermissionedMetric = {
@@ -16,6 +16,16 @@ interface MigrateEnabledMetricPermissionsParams {
   saveHealthPreference: <T>(key: string, value: T) => Promise<void>;
   requestHealthPermissions: (permissions: PermissionRequest[]) => Promise<boolean>;
   logTag: string;
+  /**
+   * Permissions for directions that are enabled but not covered by `metrics` — in
+   * practice the write side of enabled writeback metrics.
+   *
+   * This pass re-requests permissions for everything already enabled. Issuing it with
+   * the read direction alone would hand the authorization sheet a partial picture, and
+   * the sheet is authoritative for every row it shows, so an omitted-but-enabled write
+   * direction can be committed back to off. Both directions go in one request.
+   */
+  extraPermissions?: PermissionRequest[];
 }
 
 export const migrateEnabledMetricPermissionsIfNeeded = async ({
@@ -25,15 +35,17 @@ export const migrateEnabledMetricPermissionsIfNeeded = async ({
   saveHealthPreference,
   requestHealthPermissions,
   logTag,
+  extraPermissions = [],
 }: MigrateEnabledMetricPermissionsParams): Promise<boolean> => {
   const storedVersion = await loadHealthPreference<number>(REQUIRED_HEALTH_PERMISSION_VERSION_KEY);
   if (storedVersion === REQUIRED_HEALTH_PERMISSION_VERSION) {
     return true;
   }
 
-  const enabledPermissions = metrics
-    .filter(metric => healthMetricStates[metric.stateKey])
-    .flatMap(metric => metric.permissions);
+  const enabledPermissions = [
+    ...metrics.filter(metric => healthMetricStates[metric.stateKey]).flatMap(m => m.permissions),
+    ...extraPermissions,
+  ];
 
   if (enabledPermissions.length === 0) {
     await saveHealthPreference(REQUIRED_HEALTH_PERMISSION_VERSION_KEY, REQUIRED_HEALTH_PERMISSION_VERSION);

--- a/SparkyFitnessMobile/src/services/shared/healthPermissionSets.ts
+++ b/SparkyFitnessMobile/src/services/shared/healthPermissionSets.ts
@@ -1,0 +1,38 @@
+import { HEALTH_METRICS } from '../../HealthMetrics';
+import { WRITEBACK_METRICS } from '../../WritebackMetrics';
+import type { PermissionRequest, HealthMetricStates } from '../../types/healthRecords';
+
+/**
+ * Why a request may carry a direction the caller did not ask about.
+ *
+ * The platform authorization sheet is authoritative for every row it displays:
+ * confirming it commits the state of each visible toggle. Asking for one direction
+ * while the other is already enabled can therefore leave the omitted direction sitting
+ * at its default (off) state — which is how enabling read ends up switching write back
+ * off, and vice versa.
+ *
+ * So whenever both directions of a record type are enabled, they are requested together.
+ * This changes only what a single request *contains*. The two toggles remain independent
+ * opt-ins with independent prefs, the sheet still exposes a per-row toggle, and a
+ * direction that is switched off is never requested for.
+ */
+
+/** Write permissions for writeback metrics that are enabled, optionally scoped to record types. */
+export const enabledWritebackPermissions = (
+  writebackStates: Record<string, boolean>,
+  recordTypes?: ReadonlySet<string>,
+): PermissionRequest[] =>
+  WRITEBACK_METRICS.filter(
+    metric =>
+      writebackStates[metric.id] === true &&
+      (!recordTypes || recordTypes.has(metric.permission.recordType)),
+  ).map(metric => metric.permission);
+
+/** Read permissions for enabled read metrics covering a record type. */
+export const enabledReadPermissionsForRecordType = (
+  healthMetricStates: HealthMetricStates,
+  recordType: string,
+): PermissionRequest[] =>
+  HEALTH_METRICS.filter(
+    metric => metric.recordType === recordType && healthMetricStates[metric.stateKey] === true,
+  ).flatMap(metric => metric.permissions);


### PR DESCRIPTION

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)
Enabling read sync for nutrition or hydration switched write-back off in Apple Health (and vice versa), leaving the type authorized in one direction only. Data other apps wrote stopped importing until the user re-granted access by hand.

Read and write have always been independent opt-ins with independent preferences, and nothing in the app writes the other direction's key. The loss happened at the OS grant level: the authorization sheet is authoritative for every row it displays, so a request carrying a single direction can commit an omitted-but-enabled direction back to off. The worst offender was refreshEnabledMetricPermissions, which fires on Sync screen focus with no toggle involved and issued a read-only request for every enabled metric.

Add services/shared/healthPermissionSets.ts to build the enabled counterpart direction, and use it on every request path: both Sync screen toggles, "Enable All", and the permission refresh. Bump REQUIRED_HEALTH_PERMISSION_VERSION to 4 so existing installs re-request both directions once on upgrade.

Independence is preserved where it matters: the preferences stay separate, a direction that is switched off is never requested for, and the sheet still exposes a per-row toggle.

Also log what is actually handed to HealthKit per direction, warn when a request expands to zero types instead of returning success silently, and say plainly when the simulator short-circuit skips the request. All three masked this bug while diagnosing it.

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #2160

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Health synchronization now requests compatible read and write permissions together.
  * Permission refresh, individual metric, writeback, and “Enable All” flows preserve existing permissions.
  * Improved handling for permission migrations and unmapped health data types.
* **Diagnostics**
  * Added clearer authorization logging, including requested permissions and skipped simulator requests.
* **Tests**
  * Expanded coverage for permission combinations, migrations, writeback settings, and record-type filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->