### PR TITLE
refactor(calories): collapse the adaptive safety floor to two formula-derived modes

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1856,15 +1856,12 @@
       "projectedWeeklyGain": "Projected weekly gain:",
       "projectedWeeklyLoss": "Projected weekly loss:",
       "raisedToFloorTitle": "Target raised to your safety minimum",
-      "safetyFloorCustom": "Custom minimum",
-      "safetyFloorCustomHint": "Replaces the standard floor with your chosen minimum. Health recommendations remain visible.",
-      "safetyFloorDisabled": "Disabled",
-      "safetyFloorDisabledHint": "Stops automatic target clamping. Health warnings remain visible; consider medical guidance for very low targets.",
       "safetyFloorModeLabel": "Adaptive Safety Floor",
-      "safetyFloorStandard": "Standard (RMR / clinical minimum)",
-      "safetyFloorStandardHint": "Uses the higher of your estimated RMR and the clinical minimum (1,200 kcal for females, 1,500 kcal for males).",
-      "safetyFloorValueLabel": "Custom minimum",
-      "awaitingCalibrationTitle": "Awaiting Adaptive TDEE Calibration"
+      "safetyFloorStandard": "Standard (RMR or clinical minimum)",
+      "safetyFloorStandardHint": "Uses the higher of your estimated RMR and the clinical minimum (1,200 kcal for females, 1,500 kcal for males). At lower activity levels the RMR half can make deeper goal modes unreachable.",
+      "awaitingCalibrationTitle": "Awaiting Adaptive TDEE Calibration",
+      "safetyFloorClinicalMinimum": "Clinical minimum only",
+      "safetyFloorClinicalMinimumHint": "Clamps only at the clinical minimum (1,200 kcal for females, 1,500 kcal for males), allowing targets below your estimated RMR. Low-target warnings remain visible."
     },
     "mfa": {
       "confirmPassword": "Confirm Password to Continue",
@@ -1924,10 +1921,8 @@
       "bodyFatMissing": "{{algorithm}} uses body fat, but no measurement is logged — log one for an accurate target.",
       "bodyFatUnused": "Shown for reference only — {{algorithm}} does not take body fat as an input.",
       "belowRecommendedFloor": "⚠️ Warning: Calorie budget is below the recommended safety floor ({{floor}} {{unit}}).",
-      "customFloorDescription": "configured custom safety floor",
-      "customFloorActive": "A custom safety floor is active; recommended limits are still shown above.",
       "raisedToSafetyFloor": "⚠️ Daily budget was automatically raised to the safety-floor limit.",
-      "safetyFloorDisabled": "Automatic safety-floor clamping is disabled; recommended limits are still shown above."
+      "clinicalMinimumFloorActive": "Clamping only at the clinical minimum; the recommended floor is still shown above."
     }
   },
   "admin": {

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1861,7 +1861,9 @@
       "safetyFloorStandardHint": "Uses the higher of your estimated RMR and the clinical minimum (1,200 kcal for females, 1,500 kcal for males). At lower activity levels the RMR half can make deeper goal modes unreachable.",
       "awaitingCalibrationTitle": "Awaiting Adaptive TDEE Calibration",
       "safetyFloorClinicalMinimum": "Clinical minimum only",
-      "safetyFloorClinicalMinimumHint": "Clamps only at the clinical minimum (1,200 kcal for females, 1,500 kcal for males), allowing targets below your estimated RMR. Low-target warnings remain visible."
+      "safetyFloorClinicalMinimumHint": "Clamps only at the clinical minimum (1,200 kcal for females, 1,500 kcal for males), allowing targets below your estimated RMR. Low-target warnings remain visible.",
+      "belowRmrWarning": "Your calorie target is below your estimated minimum metabolism (RMR). This may not be sustainable long-term. Consider selecting a less aggressive Goal Mode, raising your activity level, or switching the safety floor back to Standard.",
+      "maxFeasibleDeficitHint": "The largest deficit that fits above your minimum is about {{percent}}%. To lose faster than that, raise your expenditure through activity, correct your activity level if it is understated, or switch the safety floor to Clinical minimum only."
     },
     "mfa": {
       "confirmPassword": "Confirm Password to Continue",
@@ -1922,7 +1924,9 @@
       "bodyFatUnused": "Shown for reference only — {{algorithm}} does not take body fat as an input.",
       "belowRecommendedFloor": "⚠️ Warning: Calorie budget is below the recommended safety floor ({{floor}} {{unit}}).",
       "raisedToSafetyFloor": "⚠️ Daily budget was automatically raised to the safety-floor limit.",
-      "clinicalMinimumFloorActive": "Clamping only at the clinical minimum; the recommended floor is still shown above."
+      "clinicalMinimumFloorActive": "Clamping only at the clinical minimum; the recommended floor is still shown above.",
+      "rmrFloorDescription": "estimated resting metabolism (RMR)",
+      "clinicalMinimumDescription": "clinical minimum"
     }
   },
   "admin": {

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -655,16 +655,10 @@ Calculated: ${bfp.toFixed(1)}%`;
               </li>
               <li>
                 Effective Safety Floor:{' '}
-                {effectiveSafetyFloor === null ? (
-                  t('settings.goalMode.safetyFloorDisabled', 'Disabled')
-                ) : (
-                  <>
-                    {Math.round(
-                      convertEnergy(effectiveSafetyFloor, 'kcal', energyUnit)
-                    )}{' '}
-                    {getEnergyUnitString(energyUnit)}
-                  </>
-                )}
+                {Math.round(
+                  convertEnergy(effectiveSafetyFloor, 'kcal', energyUnit)
+                )}{' '}
+                {getEnergyUnitString(energyUnit)}
               </li>
             </ul>
           </div>
@@ -672,14 +666,7 @@ Calculated: ${bfp.toFixed(1)}%`;
             <div className="text-sm text-gray-500 italic mt-0.5">
               {/* computeCalorieTarget already decided this; re-deriving it here
                   drifts if the rounding or floor rules change. */}
-              {effectiveSafetyFloor === null ? (
-                <span className="text-amber-600 dark:text-amber-400 font-medium">
-                  {t(
-                    'settings.calorieBreakdown.safetyFloorDisabled',
-                    'Automatic safety-floor clamping is disabled; recommended limits are still shown above.'
-                  )}
-                </span>
-              ) : previewResult.wasClampedToFloor ? (
+              {previewResult.wasClampedToFloor ? (
                 <span className="text-amber-600 dark:text-amber-400 font-medium">
                   {t(
                     'settings.calorieBreakdown.raisedToSafetyFloor',
@@ -689,8 +676,8 @@ Calculated: ${bfp.toFixed(1)}%`;
               ) : effectiveSafetyFloor < recommendedSafetyFloor ? (
                 <span className="text-amber-600 dark:text-amber-400 font-medium">
                   {t(
-                    'settings.calorieBreakdown.customFloorActive',
-                    'A custom safety floor is active; recommended limits are still shown above.'
+                    'settings.calorieBreakdown.clinicalMinimumFloorActive',
+                    'Clamping only at the clinical minimum; the recommended floor is still shown above.'
                   )}
                 </span>
               ) : (

--- a/SparkyFitnessFrontend/src/components/Onboarding/PersonalPlan.tsx
+++ b/SparkyFitnessFrontend/src/components/Onboarding/PersonalPlan.tsx
@@ -71,7 +71,6 @@ const PersonalPlan = ({
     sugarCalculationAlgorithm,
     energyUnit,
     calorieSafetyFloorMode,
-    calorieSafetyFloorValue,
   } = usePreferences();
   const { t } = useTranslation();
   const { user } = useAuth();
@@ -117,7 +116,7 @@ const PersonalPlan = ({
       localVitaminAlgorithm,
       localSugarAlgorithm,
       convertEnergy,
-      { calorieSafetyFloorMode, calorieSafetyFloorValue }
+      calorieSafetyFloorMode
     );
   });
 
@@ -143,7 +142,7 @@ const PersonalPlan = ({
       localVitaminAlgorithm,
       localSugarAlgorithm,
       convertEnergy,
-      { calorieSafetyFloorMode, calorieSafetyFloorValue }
+      calorieSafetyFloorMode
     );
 
     setEditedPlan((prev) => {
@@ -159,17 +158,13 @@ const PersonalPlan = ({
   };
 
   const plan = useMemo(() => {
-    return calculateBasePlan(formData, localSelectedDiet, customPercentages, {
-      calorieSafetyFloorMode,
-      calorieSafetyFloorValue,
-    });
-  }, [
-    formData,
-    localSelectedDiet,
-    customPercentages,
-    calorieSafetyFloorMode,
-    calorieSafetyFloorValue,
-  ]);
+    return calculateBasePlan(
+      formData,
+      localSelectedDiet,
+      customPercentages,
+      calorieSafetyFloorMode
+    );
+  }, [formData, localSelectedDiet, customPercentages, calorieSafetyFloorMode]);
 
   const handleMacroValueChange = (
     changedMacro: keyof typeof customPercentages,
@@ -246,7 +241,7 @@ const PersonalPlan = ({
       localVitaminAlgorithm,
       localSugarAlgorithm,
       convertEnergy,
-      { calorieSafetyFloorMode, calorieSafetyFloorValue }
+      calorieSafetyFloorMode
     );
     setEditedPlan(updatedPlan);
   };

--- a/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
@@ -35,7 +35,7 @@ import {
   GoalMode,
   GoalModeCalculationMethod,
   CalorieSafetyFloorMode,
-  DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+  DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
   type UserPreferences as SharedUserPreferences,
 } from '@workspace/shared';
 
@@ -125,7 +125,6 @@ interface PreferencesContextType {
   goalModeCalculationMethod: GoalModeCalculationMethod;
   goalModeCustomPercentage: number;
   calorieSafetyFloorMode: CalorieSafetyFloorMode;
-  calorieSafetyFloorValue: number;
   setMeasurementDecimalPlaces: (places: number) => void;
   setGoalMode: (mode: GoalMode) => void;
   setGoalModeCalculationMethod: (method: GoalModeCalculationMethod) => void;
@@ -240,7 +239,6 @@ export interface DefaultPreferences {
   goal_mode_calculation_method: GoalModeCalculationMethod;
   goal_mode_custom_percentage: number;
   calorie_safety_floor_mode: SharedUserPreferences['calorie_safety_floor_mode'];
-  calorie_safety_floor_value: SharedUserPreferences['calorie_safety_floor_value'];
 }
 
 const PreferencesContext = createContext<PreferencesContextType | undefined>(
@@ -349,9 +347,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
   const [goalModeCustomPercentage, setGoalModeCustomPercentageState] =
     useState<number>(0);
   const [calorieSafetyFloorMode, setCalorieSafetyFloorModeState] =
-    useState<CalorieSafetyFloorMode>('standard');
-  const [calorieSafetyFloorValue, setCalorieSafetyFloorValueState] =
-    useState<number>(DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR);
+    useState<CalorieSafetyFloorMode>(DEFAULT_CALORIE_SAFETY_FLOOR_MODE);
 
   const fetchUserPreferences = useCallback(async () => {
     try {
@@ -621,8 +617,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         first_day_of_week: 0,
         show_net_carbs: false,
         ai_assisted_conversions: true,
-        calorie_safety_floor_mode: 'standard',
-        calorie_safety_floor_value: DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+        calorie_safety_floor_mode: DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
       };
       await upsertUserPreferences(defaultPrefs);
     } catch (err) {
@@ -745,10 +740,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         );
         setGoalModeCustomPercentageState(data.goal_mode_custom_percentage ?? 0);
         setCalorieSafetyFloorModeState(
-          data.calorie_safety_floor_mode ?? 'standard'
-        );
-        setCalorieSafetyFloorValueState(
-          data.calorie_safety_floor_value ?? DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR
+          data.calorie_safety_floor_mode ?? DEFAULT_CALORIE_SAFETY_FLOOR_MODE
         );
       } else {
         await createDefaultPreferences();
@@ -923,8 +915,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
           newPrefs?.goalModeCustomPercentage ?? goalModeCustomPercentage,
         calorie_safety_floor_mode:
           newPrefs?.calorieSafetyFloorMode ?? calorieSafetyFloorMode,
-        calorie_safety_floor_value:
-          newPrefs?.calorieSafetyFloorValue ?? calorieSafetyFloorValue,
       };
 
       try {
@@ -984,7 +974,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       goalModeCalculationMethod,
       goalModeCustomPercentage,
       calorieSafetyFloorMode,
-      calorieSafetyFloorValue,
       updatePreferences,
       loadPreferences,
     ]
@@ -1232,7 +1221,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       goalModeCalculationMethod,
       goalModeCustomPercentage,
       calorieSafetyFloorMode,
-      calorieSafetyFloorValue,
       setMeasurementDecimalPlaces: setMeasurementDecimalPlacesState,
       setGoalMode,
       setGoalModeCalculationMethod,
@@ -1327,7 +1315,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       goalModeCalculationMethod,
       goalModeCustomPercentage,
       calorieSafetyFloorMode,
-      calorieSafetyFloorValue,
       setGoalMode,
       setGoalModeCalculationMethod,
       setGoalModeCustomPercentage,

--- a/SparkyFitnessFrontend/src/pages/Diary/DailyProgress.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/DailyProgress.tsx
@@ -47,8 +47,6 @@ import {
   calculateBmr,
   computeExerciseCredited,
   normalizeCalorieGoalAdjustmentMode,
-  resolveCalorieSafetyFloor,
-  DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
 } from '@workspace/shared';
 import { CalorieTargetBreakdown } from '@/components/CalorieTargetBreakdown';
 import { useNutrientGoalPreferences } from '@/hooks/Settings/useNutrientGoalPreferences';
@@ -68,7 +66,6 @@ const DailyProgress = ({ selectedDate }: { selectedDate: string }) => {
     goalModeCalculationMethod,
     goalModeCustomPercentage,
     calorieSafetyFloorMode,
-    calorieSafetyFloorValue,
     activityLevel,
     timezone,
   } = usePreferences();
@@ -226,16 +223,11 @@ const DailyProgress = ({ selectedDate }: { selectedDate: string }) => {
 
   let adjustedManualGoal = rawManualGoal;
   if (calorieGoalAdjustmentMode === 'adaptive' && adaptiveTdeeData && bmr > 0) {
-    const adaptiveGoal = Math.round(adaptiveTdeeData.tdee + calorieGoalOffset);
-    const adaptiveGoalFloor = resolveCalorieSafetyFloor(
-      calorieSafetyFloorMode,
-      calorieSafetyFloorValue,
-      DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR
+    // Predates the safety-floor preference; mirrors goalService deliberately.
+    adjustedManualGoal = Math.max(
+      1200,
+      Math.round(adaptiveTdeeData.tdee + calorieGoalOffset)
     );
-    adjustedManualGoal =
-      adaptiveGoalFloor === null
-        ? adaptiveGoal
-        : Math.max(adaptiveGoalFloor, adaptiveGoal);
   }
 
   const previewResult = computeCalorieTarget({
@@ -258,7 +250,6 @@ const DailyProgress = ({ selectedDate }: { selectedDate: string }) => {
     currentGoalCalories: adjustedManualGoal,
     calculateBmrFn: calculateBmr,
     calorieSafetyFloorMode,
-    calorieSafetyFloorValue,
   });
 
   debug(loggingLevel, 'DailyProgress: Calculated values', {

--- a/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
@@ -1486,11 +1486,10 @@ const CalculationSettings = () => {
                     Safety Alert: Calorie target below minimum metabolism
                   </p>
                   <p className="text-sm text-amber-700 dark:text-amber-400/80 leading-relaxed">
-                    Your calorie target is below your estimated minimum
-                    metabolism (RMR). This may not be sustainable long-term.
-                    Consider selecting a less aggressive Goal Mode, raising your
-                    activity level, or switching the safety floor back to
-                    Standard.
+                    {t(
+                      'settings.goalMode.belowRmrWarning',
+                      'Your calorie target is below your estimated minimum metabolism (RMR). This may not be sustainable long-term. Consider selecting a less aggressive Goal Mode, raising your activity level, or switching the safety floor back to Standard.'
+                    )}
                   </p>
                 </div>
               </div>
@@ -1536,8 +1535,14 @@ const CalculationSettings = () => {
                   )}{' '}
                   {getEnergyUnitString(energyUnit)}, which is below your{' '}
                   {previewResult.clampedFloorSource === 'rmr'
-                    ? 'estimated resting metabolism (RMR)'
-                    : 'clinical minimum'}{' '}
+                    ? t(
+                        'settings.calorieBreakdown.rmrFloorDescription',
+                        'estimated resting metabolism (RMR)'
+                      )
+                    : t(
+                        'settings.calorieBreakdown.clinicalMinimumDescription',
+                        'clinical minimum'
+                      )}{' '}
                   of{' '}
                   {Math.round(
                     convertEnergy(previewResult.finalTarget, 'kcal', energyUnit)
@@ -1547,14 +1552,14 @@ const CalculationSettings = () => {
                   {previewResult.maxFeasibleDeficitPercent != null && (
                     <>
                       {' '}
-                      The largest deficit that fits above your minimum is about{' '}
-                      <span className="font-semibold">
-                        {previewResult.maxFeasibleDeficitPercent.toFixed(0)}%
-                      </span>
-                      . To lose faster than that, raise your expenditure through
-                      activity, correct your activity level if it is
-                      understated, or switch the safety floor to Clinical
-                      minimum only.
+                      {t(
+                        'settings.goalMode.maxFeasibleDeficitHint',
+                        'The largest deficit that fits above your minimum is about {{percent}}%. To lose faster than that, raise your expenditure through activity, correct your activity level if it is understated, or switch the safety floor to Clinical minimum only.',
+                        {
+                          percent:
+                            previewResult.maxFeasibleDeficitPercent.toFixed(0),
+                        }
+                      )}
                     </>
                   )}
                 </p>

--- a/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
@@ -68,10 +68,7 @@ import {
   calculateAge,
   CalorieGoalAdjustmentMode,
   CalorieSafetyFloorMode,
-  MIN_CALORIE_SAFETY_FLOOR,
-  MAX_CALORIE_SAFETY_FLOOR,
-  resolveCalorieSafetyFloor,
-  DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+  DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
   shouldShowCalorieSafetyWarning,
   normalizeCalorieGoalAdjustmentMode,
 } from '@workspace/shared';
@@ -122,7 +119,6 @@ const CalculationSettings = () => {
     goalModeCalculationMethod: contextGoalModeCalculationMethod,
     goalModeCustomPercentage: contextGoalModeCustomPercentage,
     calorieSafetyFloorMode: contextCalorieSafetyFloorMode,
-    calorieSafetyFloorValue: contextCalorieSafetyFloorValue,
     weightUnit,
     timezone,
     convertWeight,
@@ -158,24 +154,7 @@ const CalculationSettings = () => {
   );
   const [calorieSafetyFloorMode, setCalorieSafetyFloorMode] =
     useState<CalorieSafetyFloorMode>(
-      contextCalorieSafetyFloorMode ?? 'standard'
-    );
-  const [calorieSafetyFloorValue, setCalorieSafetyFloorValue] =
-    useState<number>(
-      contextCalorieSafetyFloorValue ?? DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR
-    );
-  const [calorieSafetyFloorInput, setCalorieSafetyFloorInput] =
-    useState<string>(
-      String(
-        Math.round(
-          convertEnergy(
-            contextCalorieSafetyFloorValue ??
-              DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
-            'kcal',
-            energyUnit
-          )
-        )
-      )
+      contextCalorieSafetyFloorMode ?? DEFAULT_CALORIE_SAFETY_FLOOR_MODE
     );
 
   const [bmrAlgorithm, setBmrAlgorithm] = useState<BmrAlgorithm>(
@@ -272,16 +251,6 @@ const CalculationSettings = () => {
     if (contextCalorieSafetyFloorMode !== undefined) {
       setCalorieSafetyFloorMode(contextCalorieSafetyFloorMode);
     }
-    if (contextCalorieSafetyFloorValue !== undefined) {
-      setCalorieSafetyFloorValue(contextCalorieSafetyFloorValue);
-      setCalorieSafetyFloorInput(
-        String(
-          Math.round(
-            convertEnergy(contextCalorieSafetyFloorValue, 'kcal', energyUnit)
-          )
-        )
-      );
-    }
     // Since preferences are loaded by the PreferencesProvider at a higher level,
     // we can assume they are available by the time this component renders.
     // Set isLoading to false after initial render with context values.
@@ -304,7 +273,6 @@ const CalculationSettings = () => {
     contextGoalModeCalculationMethod,
     contextGoalModeCustomPercentage,
     contextCalorieSafetyFloorMode,
-    contextCalorieSafetyFloorValue,
     convertEnergy,
     energyUnit,
   ]);
@@ -331,7 +299,6 @@ const CalculationSettings = () => {
         goalModeCalculationMethod: goalModeCalculationMethod,
         goalModeCustomPercentage: goalModeCustomPercentage,
         calorieSafetyFloorMode,
-        calorieSafetyFloorValue,
       });
       invalidateDiary();
       invalidateDailyProgress();
@@ -417,15 +384,8 @@ const CalculationSettings = () => {
     const adaptiveGoal = Math.round(
       (adaptiveTdeeData.tdee ?? 0) + calorieGoalOffset
     );
-    const adaptiveGoalFloor = resolveCalorieSafetyFloor(
-      calorieSafetyFloorMode,
-      calorieSafetyFloorValue,
-      DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR
-    );
-    currentGoalBase =
-      adaptiveGoalFloor === null
-        ? adaptiveGoal
-        : Math.max(adaptiveGoalFloor, adaptiveGoal);
+    // Predates the safety-floor preference; mirrors goalService deliberately.
+    currentGoalBase = Math.max(1200, adaptiveGoal);
   }
 
   const previewResult = computeCalorieTarget({
@@ -448,7 +408,6 @@ const CalculationSettings = () => {
     currentGoalCalories: currentGoalBase,
     calculateBmrFn: calculateBmr,
     calorieSafetyFloorMode,
-    calorieSafetyFloorValue,
   });
 
   const deficitPct = getGoalModeAdjustment(goalMode, goalModeCustomPercentage);
@@ -1289,83 +1248,29 @@ const CalculationSettings = () => {
                   <SelectItem value="standard">
                     {t(
                       'settings.goalMode.safetyFloorStandard',
-                      'Standard (RMR / clinical minimum)'
+                      'Standard (RMR or clinical minimum)'
                     )}
                   </SelectItem>
-                  <SelectItem value="custom">
-                    {t('settings.goalMode.safetyFloorCustom', 'Custom minimum')}
-                  </SelectItem>
-                  <SelectItem value="disabled">
-                    {t('settings.goalMode.safetyFloorDisabled', 'Disabled')}
+                  <SelectItem value="clinical_minimum">
+                    {t(
+                      'settings.goalMode.safetyFloorClinicalMinimum',
+                      'Clinical minimum only'
+                    )}
                   </SelectItem>
                 </SelectContent>
               </Select>
             </div>
-
-            {calorieSafetyFloorMode === 'custom' && (
-              <div>
-                <Label htmlFor="calorie-safety-floor-value">
-                  {t(
-                    'settings.goalMode.safetyFloorValueLabel',
-                    'Custom minimum'
-                  )}{' '}
-                  ({getEnergyUnitString(energyUnit)})
-                </Label>
-                <Input
-                  id="calorie-safety-floor-value"
-                  type="number"
-                  step="1"
-                  min={Math.round(
-                    convertEnergy(MIN_CALORIE_SAFETY_FLOOR, 'kcal', energyUnit)
-                  )}
-                  max={Math.round(
-                    convertEnergy(MAX_CALORIE_SAFETY_FLOOR, 'kcal', energyUnit)
-                  )}
-                  value={calorieSafetyFloorInput}
-                  onChange={(event) => {
-                    const raw = event.target.value;
-                    setCalorieSafetyFloorInput(raw);
-                    if (raw.trim() === '') return;
-                    const parsed = Number(raw);
-                    if (!Number.isFinite(parsed)) return;
-                    setCalorieSafetyFloorValue(
-                      Math.round(convertEnergy(parsed, energyUnit, 'kcal'))
-                    );
-                  }}
-                  onBlur={() => {
-                    const clamped = Math.min(
-                      MAX_CALORIE_SAFETY_FLOOR,
-                      Math.max(
-                        MIN_CALORIE_SAFETY_FLOOR,
-                        calorieSafetyFloorValue
-                      )
-                    );
-                    setCalorieSafetyFloorValue(clamped);
-                    setCalorieSafetyFloorInput(
-                      String(
-                        Math.round(convertEnergy(clamped, 'kcal', energyUnit))
-                      )
-                    );
-                  }}
-                />
-              </div>
-            )}
           </div>
           <p className="text-sm text-muted-foreground">
             {calorieSafetyFloorMode === 'standard'
               ? t(
                   'settings.goalMode.safetyFloorStandardHint',
-                  'Uses the higher of your estimated RMR and the clinical minimum (1,200 kcal for females, 1,500 kcal for males).'
+                  'Uses the higher of your estimated RMR and the clinical minimum (1,200 kcal for females, 1,500 kcal for males). At lower activity levels the RMR half can make deeper goal modes unreachable.'
                 )
-              : calorieSafetyFloorMode === 'custom'
-                ? t(
-                    'settings.goalMode.safetyFloorCustomHint',
-                    'Replaces the standard floor with your chosen minimum. Health recommendations remain visible.'
-                  )
-                : t(
-                    'settings.goalMode.safetyFloorDisabledHint',
-                    'Stops automatic target clamping. Health warnings remain visible; consider medical guidance for very low targets.'
-                  )}
+              : t(
+                  'settings.goalMode.safetyFloorClinicalMinimumHint',
+                  'Clamps only at the clinical minimum (1,200 kcal for females, 1,500 kcal for males), allowing targets below your estimated RMR. Low-target warnings remain visible.'
+                )}
           </p>
         </div>
 
@@ -1571,10 +1476,7 @@ const CalculationSettings = () => {
           )}
 
           {/* Warning callouts */}
-          {shouldShowCalorieSafetyWarning(
-            goalMode,
-            goalModeCalculationMethod
-          ) &&
+          {shouldShowCalorieSafetyWarning(goalMode) &&
             previewResult.finalTarget < previewResult.rmr &&
             previewResult.finalTarget >= previewResult.absoluteFloorValue && (
               <div className="p-4 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-900/50 rounded-xl flex gap-3 text-sm text-amber-800 dark:text-amber-300">
@@ -1586,18 +1488,16 @@ const CalculationSettings = () => {
                   <p className="text-sm text-amber-700 dark:text-amber-400/80 leading-relaxed">
                     Your calorie target is below your estimated minimum
                     metabolism (RMR). This may not be sustainable long-term.
-                    Consider selecting a less aggressive Goal Mode or enabling a
-                    Standard or Custom safety floor.
+                    Consider selecting a less aggressive Goal Mode, raising your
+                    activity level, or switching the safety floor back to
+                    Standard.
                   </p>
                 </div>
               </div>
             )}
 
           {/* Absolute Floor Danger Callout */}
-          {shouldShowCalorieSafetyWarning(
-            goalMode,
-            goalModeCalculationMethod
-          ) &&
+          {shouldShowCalorieSafetyWarning(goalMode) &&
             previewResult.finalTarget < previewResult.absoluteFloorValue && (
               <div className="p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-900/50 rounded-xl flex gap-3 text-sm text-red-800 dark:text-red-300">
                 <ShieldAlert className="w-5 h-5 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />
@@ -1637,12 +1537,7 @@ const CalculationSettings = () => {
                   {getEnergyUnitString(energyUnit)}, which is below your{' '}
                   {previewResult.clampedFloorSource === 'rmr'
                     ? 'estimated resting metabolism (RMR)'
-                    : previewResult.clampedFloorSource === 'custom'
-                      ? t(
-                          'settings.calorieBreakdown.customFloorDescription',
-                          'configured custom safety floor'
-                        )
-                      : 'absolute safety floor'}{' '}
+                    : 'clinical minimum'}{' '}
                   of{' '}
                   {Math.round(
                     convertEnergy(previewResult.finalTarget, 'kcal', energyUnit)
@@ -1657,7 +1552,9 @@ const CalculationSettings = () => {
                         {previewResult.maxFeasibleDeficitPercent.toFixed(0)}%
                       </span>
                       . To lose faster than that, raise your expenditure through
-                      activity rather than cutting intake further.
+                      activity, correct your activity level if it is
+                      understated, or switch the safety floor to Clinical
+                      minimum only.
                     </>
                   )}
                 </p>

--- a/SparkyFitnessFrontend/src/services/preferenceService.ts
+++ b/SparkyFitnessFrontend/src/services/preferenceService.ts
@@ -42,7 +42,6 @@ export interface UserPreferences {
   goal_mode_calculation_method?: 'adaptive' | 'manual' | string;
   goal_mode_custom_percentage?: number;
   calorie_safety_floor_mode?: SharedUserPreferences['calorie_safety_floor_mode'];
-  calorie_safety_floor_value?: SharedUserPreferences['calorie_safety_floor_value'];
   calorie_goal_adjustment_mode:
     | 'dynamic'
     | 'fixed'

--- a/SparkyFitnessFrontend/src/tests/components/CalorieTargetBreakdown.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/CalorieTargetBreakdown.test.tsx
@@ -306,7 +306,7 @@ describe('CalorieTargetBreakdown shown working', () => {
 });
 
 describe('CalorieTargetBreakdown configured safety floor', () => {
-  it('shows a custom floor as the effective limit', () => {
+  it('shows the resolved floor as the effective limit', () => {
     render(
       <CalorieTargetBreakdown
         {...defaultProps}
@@ -322,24 +322,7 @@ describe('CalorieTargetBreakdown configured safety floor', () => {
     );
   });
 
-  it('shows that automatic clamping is disabled without hiding recommendations', () => {
-    render(
-      <CalorieTargetBreakdown
-        {...defaultProps}
-        previewResult={{
-          ...defaultProps.previewResult,
-          effectiveSafetyFloor: null,
-        }}
-      />
-    );
-
-    expect(screen.getByText(/Effective Safety Floor:/)).toHaveTextContent(
-      'Disabled'
-    );
-    expect(screen.getByText(/Clinical Absolute Floor:/)).toBeInTheDocument();
-  });
-
-  it('warns when a custom adaptive target remains below the recommendation', () => {
+  it('warns when a relaxed adaptive target remains below the recommendation', () => {
     render(
       <CalorieTargetBreakdown
         {...defaultProps}

--- a/SparkyFitnessFrontend/src/tests/utils/calculateBasePlan.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/calculateBasePlan.test.ts
@@ -117,7 +117,7 @@ describe('calculateBasePlan goal handling', () => {
     expect(plan!.finalDailyCalories).toBeGreaterThanOrEqual(1200);
   });
 
-  it('uses the configured custom floor when calculating a small weight-loss plan', () => {
+  it('clamps a very small weight-loss plan to the clinical minimum', () => {
     const plan = calculateBasePlan(
       {
         ...baseForm,
@@ -129,34 +129,44 @@ describe('calculateBasePlan goal handling', () => {
       },
       'balanced',
       NO_CUSTOM,
-      {
-        calorieSafetyFloorMode: 'custom',
-        calorieSafetyFloorValue: 1000,
-      }
+      'clinical_minimum'
     );
 
-    expect(plan!.finalDailyCalories).toBe(1000);
+    // Rounded to the nearest 10 by calculateBasePlan, so 1200 exactly.
+    expect(plan!.finalDailyCalories).toBe(1200);
   });
 
-  it('does not clamp a small weight-loss plan when the floor is disabled', () => {
-    const plan = calculateBasePlan(
+  it('keeps the RMR floor on the standard mode', () => {
+    const standard = calculateBasePlan(
       {
         ...baseForm,
         primaryGoal: 'lose_weight',
         sex: 'female',
-        currentWeight: 40,
-        height: 145,
+        currentWeight: 90,
+        height: 155,
         activityLevel: 'not_much',
       },
       'balanced',
       NO_CUSTOM,
+      'standard'
+    );
+    const relaxed = calculateBasePlan(
       {
-        calorieSafetyFloorMode: 'disabled',
-        calorieSafetyFloorValue: 1200,
-      }
+        ...baseForm,
+        primaryGoal: 'lose_weight',
+        sex: 'female',
+        currentWeight: 90,
+        height: 155,
+        activityLevel: 'not_much',
+      },
+      'balanced',
+      NO_CUSTOM,
+      'clinical_minimum'
     );
 
-    expect(plan!.finalDailyCalories).toBe(990);
+    expect(standard!.finalDailyCalories).toBeGreaterThanOrEqual(
+      relaxed!.finalDailyCalories
+    );
   });
 
   // Regression: onboarding persists goalMode, and the goal it saves is this

--- a/SparkyFitnessFrontend/src/tests/utils/calorieCalculations.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/calorieCalculations.test.ts
@@ -568,7 +568,7 @@ describe('computeCalorieTarget safety floor reporting', () => {
     expect(result.isBelowAbsoluteFloor).toBe(true);
   });
 
-  it('uses a custom floor instead of forcing the higher calculated RMR (issue #2124)', () => {
+  it('lets the measured target through below RMR on clinical_minimum (issue #2124)', () => {
     const result = computeCalorieTarget({
       ...smallBase,
       weightKg: 88,
@@ -578,8 +578,7 @@ describe('computeCalorieTarget safety floor reporting', () => {
       currentGoalCalories: 1606,
       goalMode: 'maintain',
       calculationMethod: 'adaptive',
-      calorieSafetyFloorMode: 'custom',
-      calorieSafetyFloorValue: 1200,
+      calorieSafetyFloorMode: 'clinical_minimum',
     });
 
     expect(result.rmr).toBeGreaterThan(1606);
@@ -588,49 +587,87 @@ describe('computeCalorieTarget safety floor reporting', () => {
     expect(result.wasClampedToFloor).toBe(false);
   });
 
-  it('clamps to the configured custom floor and identifies it as the source', () => {
+  it('still clamps at the clinical minimum on clinical_minimum', () => {
     const result = computeCalorieTarget({
       ...smallBase,
       adaptiveTdee: 1300,
       currentGoalCalories: 1300,
       goalMode: 'high_cut',
       calculationMethod: 'adaptive',
-      calorieSafetyFloorMode: 'custom',
-      calorieSafetyFloorValue: 1100,
+      calorieSafetyFloorMode: 'clinical_minimum',
     });
 
     expect(result.target).toBe(1040);
-    expect(result.finalTarget).toBe(1100);
-    expect(result.effectiveSafetyFloor).toBe(1100);
-    expect(result.clampedFloorSource).toBe('custom');
+    expect(result.finalTarget).toBe(1200);
+    expect(result.effectiveSafetyFloor).toBe(1200);
+    expect(result.clampedFloorSource).toBe('absolute');
   });
 
-  it('does not clamp an adaptive target when the floor is disabled', () => {
+  it('uses the male clinical minimum for men', () => {
     const result = computeCalorieTarget({
       ...smallBase,
-      goalMode: 'cut',
+      gender: 'male',
+      weightKg: 90,
+      heightCm: 178,
+      adaptiveTdee: 1700,
+      currentGoalCalories: 1700,
+      goalMode: 'high_cut',
       calculationMethod: 'adaptive',
-      calorieSafetyFloorMode: 'disabled',
-      calorieSafetyFloorValue: 1200,
+      calorieSafetyFloorMode: 'clinical_minimum',
     });
 
-    expect(result.finalTarget).toBe(1190);
-    expect(result.effectiveSafetyFloor).toBeNull();
-    expect(result.wasClampedToFloor).toBe(false);
-    expect(result.clampedFloorSource).toBeNull();
+    expect(result.effectiveSafetyFloor).toBe(1500);
+    expect(result.finalTarget).toBe(1500);
+  });
+
+  // The escape hatch relaxes the RMR half only; the clinical minimum is not opt-out.
+  it('never drops below the clinical minimum in either mode', () => {
+    for (const mode of ['standard', 'clinical_minimum'] as const) {
+      const result = computeCalorieTarget({
+        ...smallBase,
+        adaptiveTdee: 900,
+        currentGoalCalories: 900,
+        goalMode: 'high_cut',
+        calculationMethod: 'adaptive',
+        calorieSafetyFloorMode: mode,
+      });
+      expect(result.finalTarget).toBeGreaterThanOrEqual(1200);
+    }
+  });
+
+  // The reporter is sedentary, not small: the ceiling is 1 - 1/activityMultiplier,
+  // so a 20% cut is unreachable at 1.2 regardless of body size or sex.
+  it('reports the same deficit ceiling for a man and a woman at the same activity level', () => {
+    const ceiling = (gender: 'male' | 'female', bmr: number) =>
+      computeCalorieTarget({
+        ...smallBase,
+        gender,
+        bmr,
+        weightKg: gender === 'male' ? 90 : 100,
+        heightCm: gender === 'male' ? 178 : 155,
+        adaptiveTdee: Math.round(bmr * 1.2),
+        currentGoalCalories: Math.round(bmr * 1.2),
+        goalMode: 'high_cut',
+        calculationMethod: 'adaptive',
+      }).maxFeasibleDeficitPercent;
+
+    expect(ceiling('female', 1633)).toBeCloseTo(16.7, 1);
+    expect(ceiling('male', 1843)).toBeCloseTo(16.7, 1);
   });
 });
 
 describe('shouldShowCalorieSafetyWarning', () => {
   it('does not warn while maintaining weight', () => {
-    expect(shouldShowCalorieSafetyWarning('maintain', 'manual')).toBe(false);
+    expect(shouldShowCalorieSafetyWarning('maintain')).toBe(false);
   });
 
+  // Previously gated on `manual`, which silenced the warning under `adaptive` —
+  // the only method the floor clamps, and so the only one that can now land
+  // below RMR once the user relaxes it.
   it.each(['recomp', 'cut', 'high_cut', 'lean_bulk', 'bulk', 'manual'])(
-    'warns for a manually configured non-maintenance %s goal',
+    'warns for a non-maintenance %s goal regardless of method',
     (goalMode) => {
-      expect(shouldShowCalorieSafetyWarning(goalMode, 'manual')).toBe(true);
-      expect(shouldShowCalorieSafetyWarning(goalMode, 'adaptive')).toBe(false);
+      expect(shouldShowCalorieSafetyWarning(goalMode)).toBe(true);
     }
   );
 });

--- a/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
+++ b/SparkyFitnessFrontend/src/utils/nutritionCalculations.ts
@@ -11,7 +11,7 @@ import type { FoodEntry, FoodVariant } from '@/types/food';
 import { FoodEntryMeal, MealTotals } from '@/types/meal';
 import {
   ACTIVITY_MULTIPLIERS,
-  DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+  DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
   calculateBmr,
   computeCalorieTarget,
   goalModeFromPrimaryGoal,
@@ -625,13 +625,7 @@ export const calculateBasePlan = (
   formData: CalculatorFormData,
   localSelectedDiet: string,
   customPercentages: { carbs: number; protein: number; fat: number },
-  safetyFloor: {
-    calorieSafetyFloorMode: CalorieSafetyFloorMode;
-    calorieSafetyFloorValue: number;
-  } = {
-    calorieSafetyFloorMode: 'standard',
-    calorieSafetyFloorValue: DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
-  }
+  calorieSafetyFloorMode: CalorieSafetyFloorMode = DEFAULT_CALORIE_SAFETY_FLOOR_MODE
 ): BasePlan | null => {
   // formData values are already in Metric (kg/cm) because they come from UnitInput or normalized state
   const weightKg = Number(formData.currentWeight) || 0;
@@ -675,8 +669,7 @@ export const calculateBasePlan = (
     gender,
     currentGoalCalories: 0,
     calculateBmrFn: calculateBmr,
-    calorieSafetyFloorMode: safetyFloor.calorieSafetyFloorMode,
-    calorieSafetyFloorValue: safetyFloor.calorieSafetyFloorValue,
+    calorieSafetyFloorMode,
   });
 
   const finalDailyCalories = Math.round(targetResult.finalTarget / 10) * 10;

--- a/SparkyFitnessFrontend/src/utils/onboarding.ts
+++ b/SparkyFitnessFrontend/src/utils/onboarding.ts
@@ -27,10 +27,7 @@ export const createInitialPlan = (
     fromUnit: EnergyUnit,
     toUnit: EnergyUnit
   ) => number,
-  safetyFloor: {
-    calorieSafetyFloorMode: CalorieSafetyFloorMode;
-    calorieSafetyFloorValue: number;
-  }
+  calorieSafetyFloorMode: CalorieSafetyFloorMode
 ): ExpandedGoals | null => {
   // 1. Basis Plan berechnen
   // formData is already in Metric (kg/cm) from UnitInput
@@ -38,7 +35,7 @@ export const createInitialPlan = (
     formData,
     localSelectedDiet,
     customPercentages,
-    safetyFloor
+    calorieSafetyFloorMode
   );
 
   if (!plan) return null;

--- a/SparkyFitnessMobile/__tests__/screens/CalorieSettingsScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/CalorieSettingsScreen.test.tsx
@@ -80,19 +80,20 @@ describe('CalorieSettingsScreen safety floor', () => {
     mockPreferences = {
       calorie_goal_adjustment_mode: 'adaptive',
       calorie_safety_floor_mode: 'standard',
-      calorie_safety_floor_value: 1200,
     };
   });
 
-  it('offers standard, custom, and disabled safety floor modes', () => {
-    const { getByText } = render(
+  it('offers the standard and clinical-minimum safety floor modes', () => {
+    const { getByText, queryByText } = render(
       <CalorieSettingsScreen navigation={navigation} route={route} />,
     );
 
     expect(getByText('Safety Floor')).toBeTruthy();
     expect(getByText('Standard')).toBeTruthy();
-    expect(getByText('Custom')).toBeTruthy();
-    expect(getByText('Disabled')).toBeTruthy();
+    expect(getByText('Clinical minimum only')).toBeTruthy();
+    // The retired modes must not come back: the clinical minimum is not opt-out.
+    expect(queryByText('Custom')).toBeNull();
+    expect(queryByText('Disabled')).toBeNull();
   });
 
   it('saves a selected safety floor mode', () => {
@@ -100,56 +101,19 @@ describe('CalorieSettingsScreen safety floor', () => {
       <CalorieSettingsScreen navigation={navigation} route={route} />,
     );
 
-    fireEvent.press(getByText('Disabled'));
+    fireEvent.press(getByText('Clinical minimum only'));
     expect(mockMutate).toHaveBeenCalledWith({
-      calorie_safety_floor_mode: 'disabled',
+      calorie_safety_floor_mode: 'clinical_minimum',
     });
   });
 
-  it('saves a custom safety floor value', () => {
-    mockPreferences.calorie_safety_floor_mode = 'custom';
-    const { getByDisplayValue } = render(
+  it('explains what each mode clamps at', () => {
+    const { getByText } = render(
       <CalorieSettingsScreen navigation={navigation} route={route} />,
     );
-    const input = getByDisplayValue('1200');
 
-    fireEvent.changeText(input, '1150');
-    fireEvent(input, 'blur');
-
-    expect(mockMutate).toHaveBeenCalledWith({
-      calorie_safety_floor_value: 1150,
-    });
-  });
-
-  it('restores the saved value without persisting when the custom input is blank', () => {
-    mockPreferences.calorie_safety_floor_mode = 'custom';
-    const { getByDisplayValue } = render(
-      <CalorieSettingsScreen navigation={navigation} route={route} />,
-    );
-    const input = getByDisplayValue('1200');
-
-    fireEvent.changeText(input, '');
-    fireEvent(input, 'blur');
-
-    expect(getByDisplayValue('1200')).toBeTruthy();
-    expect(mockMutate).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    ['799', 800],
-    ['5001', 5000],
-  ])('clamps custom floor %s to %s kcal', (inputValue, expectedValue) => {
-    mockPreferences.calorie_safety_floor_mode = 'custom';
-    const { getByDisplayValue } = render(
-      <CalorieSettingsScreen navigation={navigation} route={route} />,
-    );
-    const input = getByDisplayValue('1200');
-
-    fireEvent.changeText(input, inputValue);
-    fireEvent(input, 'blur');
-
-    expect(mockMutate).toHaveBeenCalledWith({
-      calorie_safety_floor_value: expectedValue,
-    });
+    expect(
+      getByText(/higher of your estimated RMR and the clinical minimum/),
+    ).toBeTruthy();
   });
 });

--- a/SparkyFitnessMobile/src/screens/CalorieSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/CalorieSettingsScreen.tsx
@@ -20,10 +20,7 @@ import { preferencesQueryKey } from '../hooks/queryKeys';
 import type { UserPreferences } from '../types/preferences';
 import type { RootStackScreenProps } from '../types/navigation';
 import {
-  DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
-  MAX_CALORIE_SAFETY_FLOOR,
-  MIN_CALORIE_SAFETY_FLOOR,
-  convertEnergyValue,
+  DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
   type CalorieSafetyFloorMode,
 } from '@workspace/shared';
 
@@ -47,8 +44,7 @@ const activityLevelOptions = [
 
 const safetyFloorOptions = [
   { label: 'Standard', value: 'standard' },
-  { label: 'Custom', value: 'custom' },
-  { label: 'Disabled', value: 'disabled' },
+  { label: 'Clinical minimum only', value: 'clinical_minimum' },
 ];
 
 // Apple Health and Health Connect use different terms for the same baseline-energy value.
@@ -63,19 +59,11 @@ function normalizePreferences(prefs: UserPreferences | undefined) {
     includeBmrInNetCalories: prefs?.include_bmr_in_net_calories ?? false,
     tdeeAllowNegativeAdjustment: prefs?.tdee_allow_negative_adjustment ?? false,
     useExternalBmr: prefs?.use_external_bmr ?? false,
-    calorieSafetyFloorMode: prefs?.calorie_safety_floor_mode ?? 'standard',
-    calorieSafetyFloorValue:
-      prefs?.calorie_safety_floor_value ??
-      DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+    calorieSafetyFloorMode:
+      prefs?.calorie_safety_floor_mode ?? DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
     energyUnit: prefs?.energy_unit ?? 'kcal',
   };
 }
-
-const displayEnergy = (kcal: number, unit: 'kcal' | 'kJ') =>
-  Math.round(convertEnergyValue(kcal, 'kcal', unit));
-
-const toKcal = (value: number, unit: 'kcal' | 'kJ') =>
-  Math.round(convertEnergyValue(value, unit, 'kcal'));
 
 const CalorieSettingsScreen: React.FC<CalorieSettingsScreenProps> = () => {
   const insets = useSafeAreaInsets();
@@ -90,12 +78,6 @@ const CalorieSettingsScreen: React.FC<CalorieSettingsScreenProps> = () => {
   const [percentageText, setPercentageText] = useState(
     () => String(normalized.exerciseCaloriePercentage),
   );
-  const [safetyFloorText, setSafetyFloorText] = useState(() =>
-    String(
-      displayEnergy(normalized.calorieSafetyFloorValue, normalized.energyUnit),
-    ),
-  );
-
   // Re-sync the input text when the saved percentage changes (e.g. a background
   // refetch). Done during render (instead of in an effect) so the field shows
   // the latest saved value on the first render after it changes.
@@ -106,22 +88,6 @@ const CalorieSettingsScreen: React.FC<CalorieSettingsScreenProps> = () => {
     setSyncedPercentage(normalized.exerciseCaloriePercentage);
     setPercentageText(String(normalized.exerciseCaloriePercentage));
   }
-  const [syncedSafetyFloor, setSyncedSafetyFloor] = useState(
-    `${normalized.calorieSafetyFloorValue}:${normalized.energyUnit}`,
-  );
-  const safetyFloorSyncKey = `${normalized.calorieSafetyFloorValue}:${normalized.energyUnit}`;
-  if (syncedSafetyFloor !== safetyFloorSyncKey) {
-    setSyncedSafetyFloor(safetyFloorSyncKey);
-    setSafetyFloorText(
-      String(
-        displayEnergy(
-          normalized.calorieSafetyFloorValue,
-          normalized.energyUnit,
-        ),
-      ),
-    );
-  }
-
   const mutation = useMutation({
     mutationFn: (data: Partial<UserPreferences>) => updatePreferences(data),
     onMutate: async (data) => {
@@ -174,38 +140,6 @@ const CalorieSettingsScreen: React.FC<CalorieSettingsScreenProps> = () => {
     },
     [mutation],
   );
-
-  const handleSafetyFloorBlur = useCallback(() => {
-    const trimmedValue = safetyFloorText.trim();
-    if (trimmedValue === '') {
-      setSafetyFloorText(
-        String(
-          displayEnergy(
-            normalized.calorieSafetyFloorValue,
-            normalized.energyUnit,
-          ),
-        ),
-      );
-      return;
-    }
-    const parsed = Number(trimmedValue);
-    const kcal = Number.isFinite(parsed)
-      ? toKcal(parsed, normalized.energyUnit)
-      : normalized.calorieSafetyFloorValue;
-    const clamped = Math.max(
-      MIN_CALORIE_SAFETY_FLOOR,
-      Math.min(MAX_CALORIE_SAFETY_FLOOR, kcal),
-    );
-    setSafetyFloorText(String(displayEnergy(clamped, normalized.energyUnit)));
-    if (clamped !== normalized.calorieSafetyFloorValue) {
-      mutation.mutate({ calorie_safety_floor_value: clamped });
-    }
-  }, [
-    mutation,
-    normalized.calorieSafetyFloorValue,
-    normalized.energyUnit,
-    safetyFloorText,
-  ]);
 
   const handlePercentageBlur = useCallback(() => {
     const parsed = parseInt(percentageText, 10);
@@ -387,27 +321,10 @@ const CalorieSettingsScreen: React.FC<CalorieSettingsScreenProps> = () => {
               containerStyle={{ flex: 1, maxWidth: 200, marginLeft: 16 }}
             />
           </View>
-          {normalized.calorieSafetyFloorMode === 'custom' && (
-            <View className="mt-4">
-              <Text className="text-sm font-semibold text-text-primary mb-2">
-                Custom minimum ({normalized.energyUnit})
-              </Text>
-              <FormInput
-                value={safetyFloorText}
-                onChangeText={setSafetyFloorText}
-                onBlur={handleSafetyFloorBlur}
-                keyboardType="number-pad"
-                maxLength={5}
-                returnKeyType="done"
-              />
-            </View>
-          )}
           <Text className="text-text-secondary text-sm mt-3">
             {normalized.calorieSafetyFloorMode === 'standard'
-              ? 'Uses the higher of your estimated RMR and the clinical minimum.'
-              : normalized.calorieSafetyFloorMode === 'custom'
-                ? 'Replaces the standard floor with your chosen minimum. Health recommendations remain visible.'
-                : 'Stops automatic target clamping. Health warnings remain visible.'}
+              ? 'Uses the higher of your estimated RMR and the clinical minimum. At lower activity levels this can make deeper goal modes unreachable.'
+              : 'Clamps only at the clinical minimum, allowing targets below your estimated RMR. Low-target warnings remain visible.'}
           </Text>
         </Animated.View>
 

--- a/SparkyFitnessServer/config/swagger.ts
+++ b/SparkyFitnessServer/config/swagger.ts
@@ -2,10 +2,7 @@
 import swaggerJsdoc from 'swagger-jsdoc';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import {
-  MAX_CALORIE_SAFETY_FLOOR,
-  MIN_CALORIE_SAFETY_FLOOR,
-} from '@workspace/shared';
+import { CALORIE_SAFETY_FLOOR_MODES } from '@workspace/shared';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const swaggerScanPaths = [
@@ -1160,16 +1157,9 @@ const options = {
             meal_calorie_distribution: { type: 'object' },
             calorie_safety_floor_mode: {
               type: 'string',
-              enum: ['standard', 'custom', 'disabled'],
+              enum: CALORIE_SAFETY_FLOOR_MODES,
               description:
-                'Controls adaptive calorie-target clamping. Standard uses the recommended RMR/clinical floor, custom uses calorie_safety_floor_value, and disabled only reports health warnings.',
-            },
-            calorie_safety_floor_value: {
-              type: 'integer',
-              minimum: MIN_CALORIE_SAFETY_FLOOR,
-              maximum: MAX_CALORIE_SAFETY_FLOOR,
-              description:
-                'Custom calorie safety floor in kcal/day. Used when calorie_safety_floor_mode is custom.',
+                'Controls adaptive calorie-target clamping. `standard` clamps at the higher of estimated RMR and the sex-specific clinical minimum; `clinical_minimum` clamps only at the clinical minimum, allowing targets below RMR.',
             },
           },
         },

--- a/SparkyFitnessServer/db/migrations/20260822150000_collapse_calorie_safety_floor_modes.sql
+++ b/SparkyFitnessServer/db/migrations/20260822150000_collapse_calorie_safety_floor_modes.sql
@@ -1,0 +1,26 @@
+-- Collapse the calorie safety floor to two formula-derived modes.
+--
+-- `standard` keeps the historical floor, max(RMR, clinical minimum). The escape
+-- hatch is now `clinical_minimum`, which drops only the RMR half. The RMR half is
+-- what makes deeper goal modes unreachable at low activity levels (the bound is
+-- 1 - 1/activityMultiplier, ~17% for a sedentary user), and it is the half without
+-- clinical backing. The clinical minimum itself is not opt-out.
+--
+-- Existing rows: `custom` and `disabled` both map to `clinical_minimum`, the closest
+-- surviving behaviour. A stored custom value is dropped along with the column, since
+-- a static number does not track weight change the way the formula does.
+
+ALTER TABLE public.user_preferences
+  DROP CONSTRAINT IF EXISTS user_preferences_calorie_safety_floor_mode_check;
+
+UPDATE public.user_preferences
+  SET calorie_safety_floor_mode = 'clinical_minimum'
+  WHERE calorie_safety_floor_mode IN ('custom', 'disabled');
+
+ALTER TABLE public.user_preferences
+  DROP COLUMN IF EXISTS calorie_safety_floor_value,
+  ADD CONSTRAINT user_preferences_calorie_safety_floor_mode_check
+    CHECK (calorie_safety_floor_mode IN ('standard', 'clinical_minimum'));
+
+COMMENT ON COLUMN public.user_preferences.calorie_safety_floor_mode IS
+  'Adaptive calorie target clamping: standard = max(RMR, clinical minimum); clinical_minimum = clinical minimum only.';

--- a/SparkyFitnessServer/models/preferenceRepository.ts
+++ b/SparkyFitnessServer/models/preferenceRepository.ts
@@ -46,7 +46,6 @@ async function updateUserPreferences(userId: any, preferenceData: any) {
         measurement_decimal_places = COALESCE($40, measurement_decimal_places),
         added_sugar_algorithm = COALESCE($43, added_sugar_algorithm),
         calorie_safety_floor_mode = COALESCE($45, calorie_safety_floor_mode),
-        calorie_safety_floor_value = COALESCE($46, calorie_safety_floor_value),
         updated_at = now()
       WHERE user_id = $28
       RETURNING *`,
@@ -96,7 +95,6 @@ async function updateUserPreferences(userId: any, preferenceData: any) {
         preferenceData.added_sugar_algorithm,
         preferenceData.time_format,
         preferenceData.calorie_safety_floor_mode,
-        preferenceData.calorie_safety_floor_value,
       ]
     );
     return result.rows[0];
@@ -184,7 +182,6 @@ async function upsertUserPreferences(preferenceData: any) {
        active_vision_ai_service_id,
        added_sugar_algorithm,
        calorie_safety_floor_mode,
-       calorie_safety_floor_value,
        created_at, updated_at
      ) VALUES (
        $1, COALESCE($2, 'yyyy-MM-dd'), COALESCE($44, 'HH:mm'), COALESCE($3, 'lbs'), COALESCE($4, 'in'), COALESCE($5, 'km'),
@@ -211,7 +208,6 @@ async function upsertUserPreferences(preferenceData: any) {
        $41,
        COALESCE($43, 'WHO_IDEAL'),
        COALESCE($45, 'standard'),
-       COALESCE($46, 1200),
        now(), now()
      )
      ON CONFLICT (user_id) DO UPDATE SET
@@ -255,7 +251,6 @@ async function upsertUserPreferences(preferenceData: any) {
        measurement_decimal_places = COALESCE(EXCLUDED.measurement_decimal_places, user_preferences.measurement_decimal_places),
        added_sugar_algorithm = COALESCE(EXCLUDED.added_sugar_algorithm, user_preferences.added_sugar_algorithm),
        calorie_safety_floor_mode = COALESCE($45, user_preferences.calorie_safety_floor_mode),
-       calorie_safety_floor_value = COALESCE($46, user_preferences.calorie_safety_floor_value),
        time_format = COALESCE($44, user_preferences.time_format),
        updated_at = now()
      RETURNING *`,
@@ -305,7 +300,6 @@ async function upsertUserPreferences(preferenceData: any) {
         preferenceData.added_sugar_algorithm,
         preferenceData.time_format,
         preferenceData.calorie_safety_floor_mode,
-        preferenceData.calorie_safety_floor_value,
       ]
     );
     return result.rows[0];

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -16,8 +16,7 @@ import {
   todayInZone,
   CALORIE_CALCULATION_CONSTANTS,
   computeCalorieTarget,
-  resolveCalorieSafetyFloor,
-  DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+  DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
   ACTIVITY_MULTIPLIERS,
 } from '@workspace/shared';
 import customNutrientService from './customNutrientService.js';
@@ -277,18 +276,14 @@ async function getUserGoalsForRange(
 
       // Apply adaptive TDEE base adjustment — mirrors DashboardService
       if (adjustmentMode === 'adaptive' && adaptiveTdeeData && bmr > 0) {
-        const adaptiveGoal = Math.round(
-          adaptiveTdeeData.tdee + calorieGoalOffset
+        // Predates the safety-floor preference and is deliberately left alone: this
+        // bound belongs to the adaptive *adjustment* path, not the goal-mode clamp
+        // the preference governs. Changing it would move goals for every existing
+        // user on this adjustment mode.
+        goalCalories = Math.max(
+          1200,
+          Math.round(adaptiveTdeeData.tdee + calorieGoalOffset)
         );
-        const adaptiveGoalFloor = resolveCalorieSafetyFloor(
-          userPreferences?.calorie_safety_floor_mode,
-          userPreferences?.calorie_safety_floor_value,
-          DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR
-        );
-        goalCalories =
-          adaptiveGoalFloor === null
-            ? adaptiveGoal
-            : Math.max(adaptiveGoalFloor, adaptiveGoal);
       }
 
       // Apply goal mode deficit AND baseline replacement.
@@ -322,10 +317,8 @@ async function getUserGoalsForRange(
           currentGoalCalories: goalCalories,
           calculateBmrFn: bmrService.calculateBmr,
           calorieSafetyFloorMode:
-            userPreferences?.calorie_safety_floor_mode || 'standard',
-          calorieSafetyFloorValue:
-            userPreferences?.calorie_safety_floor_value ||
-            DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+            userPreferences?.calorie_safety_floor_mode ||
+            DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
         });
         goalCalories = targetResult.finalTarget;
       }

--- a/SparkyFitnessServer/services/preferenceService.ts
+++ b/SparkyFitnessServer/services/preferenceService.ts
@@ -5,9 +5,7 @@ import {
   SUPPORTED_TIME_FORMATS,
   MAX_GOAL_MODE_PERCENTAGE,
   CALORIE_SAFETY_FLOOR_MODES,
-  MIN_CALORIE_SAFETY_FLOOR,
-  MAX_CALORIE_SAFETY_FLOOR,
-  DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+  DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
   type UserPreferencesMutator,
 } from '@workspace/shared';
 
@@ -19,10 +17,7 @@ type GoalModePreferenceInput = Partial<
   >
 >;
 type CalorieSafetyFloorPreferenceInput = Partial<
-  Pick<
-    UserPreferencesMutator,
-    'calorie_safety_floor_mode' | 'calorie_safety_floor_value'
-  >
+  Pick<UserPreferencesMutator, 'calorie_safety_floor_mode'>
 >;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function validateTimezone(preferenceData: any) {
@@ -116,22 +111,6 @@ async function validateCalorieSafetyFloor(
       { status: 400 }
     );
   }
-  if (preferenceData.calorie_safety_floor_value !== undefined) {
-    const value = preferenceData.calorie_safety_floor_value;
-    if (
-      typeof value !== 'number' ||
-      !Number.isInteger(value) ||
-      value < MIN_CALORIE_SAFETY_FLOOR ||
-      value > MAX_CALORIE_SAFETY_FLOOR
-    ) {
-      throw Object.assign(
-        new Error(
-          `Invalid calorie_safety_floor_value: '${preferenceData.calorie_safety_floor_value}'. Must be an integer between ${MIN_CALORIE_SAFETY_FLOOR} and ${MAX_CALORIE_SAFETY_FLOOR}.`
-        ),
-        { status: 400 }
-      );
-    }
-  }
 }
 function getDefaultPreferences() {
   return {
@@ -139,8 +118,7 @@ function getDefaultPreferences() {
     show_net_carbs: false,
     timezone: null,
     time_format: 'h:mm A',
-    calorie_safety_floor_mode: 'standard',
-    calorie_safety_floor_value: DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+    calorie_safety_floor_mode: DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
   };
 }
 async function updateUserPreferences(

--- a/SparkyFitnessServer/tests/calorieSafetyFloor.test.ts
+++ b/SparkyFitnessServer/tests/calorieSafetyFloor.test.ts
@@ -62,55 +62,61 @@ describe('goalService calorie safety floor preference', () => {
     );
   });
 
-  it('allows the measured target below RMR when a lower custom floor is configured', async () => {
-    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
-      calorie_goal_adjustment_mode: 'fixed',
-      goal_mode: 'maintain',
-      goal_mode_calculation_method: 'adaptive',
-      goal_mode_custom_percentage: 0,
-      activity_level: 'not_much',
-      bmr_algorithm: 'Mifflin-St Jeor',
-      calorie_safety_floor_mode: 'custom',
-      calorie_safety_floor_value: 1200,
-      timezone: 'Europe/Berlin',
-    });
-
-    const result = await goalService.getUserGoalsForRange(
-      userId,
-      date,
-      date,
-      true
-    );
-
-    expect((result[date] as { calories: number }).calories).toBe(1606);
+  const prefs = (mode: string, adjustmentMode = 'fixed', method = 'adaptive') => ({
+    calorie_goal_adjustment_mode: adjustmentMode,
+    goal_mode: 'maintain',
+    goal_mode_calculation_method: method,
+    goal_mode_custom_percentage: 0,
+    activity_level: 'not_much',
+    bmr_algorithm: 'Mifflin-St Jeor',
+    calorie_safety_floor_mode: mode,
+    timezone: 'Europe/Berlin',
   });
 
-  it('preserves the legacy 1200 kcal floor for the standard adaptive adjustment path', async () => {
+  const caloriesFor = async (mode: string, adjustmentMode?: string, method?: string) => {
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue(
+      prefs(mode, adjustmentMode, method)
+    );
+    const result = await goalService.getUserGoalsForRange(userId, date, date, true);
+    return (result[date] as { calories: number }).calories;
+  };
+
+  // The scenario from #2124: RMR 1642, measured adaptive TDEE 1606. Under
+  // `standard` the RMR half of the floor overrides the measured target by 36 kcal
+  // and the user is pinned there permanently, because both sides scale with body
+  // size. `clinical_minimum` drops that half and lets the measurement through.
+  it('clamps the measured target up to RMR under the standard floor', async () => {
+    expect(await caloriesFor('standard')).toBe(1642);
+  });
+
+  it('allows a measured target below RMR under the clinical minimum floor', async () => {
+    expect(await caloriesFor('clinical_minimum')).toBe(1606);
+  });
+
+  it('never allows a target below the clinical minimum, whatever the mode', async () => {
+    vi.mocked(adaptiveTdeeService.calculateAdaptiveTdeeRange).mockResolvedValue({
+      [date]: {
+        tdee: 900,
+        confidence: 'HIGH',
+        isFallback: false,
+        daysOfData: 60,
+        lastCalculated: date,
+      },
+    });
+    expect(await caloriesFor('clinical_minimum')).toBe(1200);
+  });
+
+  // The `calorie_goal_adjustment_mode: 'adaptive'` path used to hardcode a flat
+  // 1200 floor, which ignored RMR and applied the female minimum to men. It now
+  // resolves the same floor as every other path.
+  it('applies the RMR floor on the adaptive adjustment path', async () => {
     vi.mocked(goalRepository.getMostRecentGoalBeforeDate).mockResolvedValue({
       calories: 1000,
       protein_percentage: null,
       carbs_percentage: null,
       fat_percentage: null,
     });
-    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
-      calorie_goal_adjustment_mode: 'adaptive',
-      goal_mode: 'maintain',
-      goal_mode_calculation_method: 'manual',
-      goal_mode_custom_percentage: 0,
-      activity_level: 'not_much',
-      bmr_algorithm: 'Mifflin-St Jeor',
-      calorie_safety_floor_mode: 'standard',
-      calorie_safety_floor_value: 1200,
-      timezone: 'Europe/Berlin',
-    });
-
-    const result = await goalService.getUserGoalsForRange(
-      userId,
-      date,
-      date,
-      true
-    );
-
-    expect((result[date] as { calories: number }).calories).toBe(1200);
+    expect(await caloriesFor('standard', 'adaptive', 'manual')).toBe(1200);
+    expect(await caloriesFor('clinical_minimum', 'adaptive', 'manual')).toBe(1200);
   });
 });

--- a/SparkyFitnessServer/tests/calorieSafetyFloor.test.ts
+++ b/SparkyFitnessServer/tests/calorieSafetyFloor.test.ts
@@ -121,10 +121,10 @@ describe('goalService calorie safety floor preference', () => {
     expect(await caloriesFor('clinical_minimum')).toBe(1200);
   });
 
-  // The `calorie_goal_adjustment_mode: 'adaptive'` path used to hardcode a flat
-  // 1200 floor, which ignored RMR and applied the female minimum to men. It now
-  // resolves the same floor as every other path.
-  it('applies the RMR floor on the adaptive adjustment path', async () => {
+  // The adaptive *adjustment* path keeps its own fixed 1200 bound, which predates
+  // the safety-floor preference and is deliberately not governed by it. Pinned in
+  // both modes so a future change there is a decision rather than an accident.
+  it('leaves the adaptive adjustment path on its own fixed 1200 bound', async () => {
     vi.mocked(goalRepository.getMostRecentGoalBeforeDate).mockResolvedValue({
       calories: 1000,
       protein_percentage: null,

--- a/SparkyFitnessServer/tests/calorieSafetyFloor.test.ts
+++ b/SparkyFitnessServer/tests/calorieSafetyFloor.test.ts
@@ -62,7 +62,11 @@ describe('goalService calorie safety floor preference', () => {
     );
   });
 
-  const prefs = (mode: string, adjustmentMode = 'fixed', method = 'adaptive') => ({
+  const prefs = (
+    mode: string,
+    adjustmentMode = 'fixed',
+    method = 'adaptive'
+  ) => ({
     calorie_goal_adjustment_mode: adjustmentMode,
     goal_mode: 'maintain',
     goal_mode_calculation_method: method,
@@ -73,11 +77,20 @@ describe('goalService calorie safety floor preference', () => {
     timezone: 'Europe/Berlin',
   });
 
-  const caloriesFor = async (mode: string, adjustmentMode?: string, method?: string) => {
+  const caloriesFor = async (
+    mode: string,
+    adjustmentMode?: string,
+    method?: string
+  ) => {
     vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue(
       prefs(mode, adjustmentMode, method)
     );
-    const result = await goalService.getUserGoalsForRange(userId, date, date, true);
+    const result = await goalService.getUserGoalsForRange(
+      userId,
+      date,
+      date,
+      true
+    );
     return (result[date] as { calories: number }).calories;
   };
 
@@ -94,15 +107,17 @@ describe('goalService calorie safety floor preference', () => {
   });
 
   it('never allows a target below the clinical minimum, whatever the mode', async () => {
-    vi.mocked(adaptiveTdeeService.calculateAdaptiveTdeeRange).mockResolvedValue({
-      [date]: {
-        tdee: 900,
-        confidence: 'HIGH',
-        isFallback: false,
-        daysOfData: 60,
-        lastCalculated: date,
-      },
-    });
+    vi.mocked(adaptiveTdeeService.calculateAdaptiveTdeeRange).mockResolvedValue(
+      {
+        [date]: {
+          tdee: 900,
+          confidence: 'HIGH',
+          isFallback: false,
+          daysOfData: 60,
+          lastCalculated: date,
+        },
+      }
+    );
     expect(await caloriesFor('clinical_minimum')).toBe(1200);
   });
 
@@ -117,6 +132,8 @@ describe('goalService calorie safety floor preference', () => {
       fat_percentage: null,
     });
     expect(await caloriesFor('standard', 'adaptive', 'manual')).toBe(1200);
-    expect(await caloriesFor('clinical_minimum', 'adaptive', 'manual')).toBe(1200);
+    expect(await caloriesFor('clinical_minimum', 'adaptive', 'manual')).toBe(
+      1200
+    );
   });
 });

--- a/SparkyFitnessServer/tests/preferenceRepository.test.ts
+++ b/SparkyFitnessServer/tests/preferenceRepository.test.ts
@@ -138,32 +138,25 @@ describe('preferenceRepository bootstrapUserTimezoneIfUnset', () => {
     expect(mockClient.query.mock.calls[0][1]).toContain(15);
   });
 
-  it('round-trips calorie safety floor preferences through save and load', async () => {
+  it('round-trips the calorie safety floor mode through save and load', async () => {
     const row = {
       user_id: 'user-1',
-      calorie_safety_floor_mode: 'custom',
-      calorie_safety_floor_value: 1200,
+      calorie_safety_floor_mode: 'clinical_minimum',
     };
     mockClient.query.mockResolvedValueOnce({ rows: [row] });
     mockClient.query.mockResolvedValueOnce({ rows: [row] });
 
     await preferenceRepository.upsertUserPreferences({
       user_id: 'user-1',
-      calorie_safety_floor_mode: 'custom',
-      calorie_safety_floor_value: 1200,
+      calorie_safety_floor_mode: 'clinical_minimum',
     });
     const result = await preferenceRepository.getUserPreferences('user-1');
 
-    expect(result.calorie_safety_floor_mode).toBe('custom');
-    expect(result.calorie_safety_floor_value).toBe(1200);
+    expect(result.calorie_safety_floor_mode).toBe('clinical_minimum');
     expect(mockClient.query.mock.calls[0][0]).toContain(
       'calorie_safety_floor_mode'
     );
-    expect(mockClient.query.mock.calls[0][0]).toContain(
-      'calorie_safety_floor_value'
-    );
-    expect(mockClient.query.mock.calls[0][1]).toContain('custom');
-    expect(mockClient.query.mock.calls[0][1]).toContain(1200);
+    expect(mockClient.query.mock.calls[0][1]).toContain('clinical_minimum');
   });
 
   it('preserves saved safety-floor preferences when a partial upsert omits them', async () => {
@@ -177,9 +170,6 @@ describe('preferenceRepository bootstrapUserTimezoneIfUnset', () => {
     const sql = mockClient.query.mock.calls[0][0] as string;
     expect(sql).toContain(
       'calorie_safety_floor_mode = COALESCE($45, user_preferences.calorie_safety_floor_mode)'
-    );
-    expect(sql).toContain(
-      'calorie_safety_floor_value = COALESCE($46, user_preferences.calorie_safety_floor_value)'
     );
   });
 });

--- a/SparkyFitnessServer/tests/preferenceSafetyFloor.test.ts
+++ b/SparkyFitnessServer/tests/preferenceSafetyFloor.test.ts
@@ -12,13 +12,12 @@ describe('calorie safety floor preference validation', () => {
     });
   });
 
-  it.each([800, 5000])(
-    'accepts inclusive custom floor boundary %s',
-    async (value) => {
+  it.each(['standard', 'clinical_minimum'])(
+    'accepts the %s mode',
+    async (mode) => {
       await expect(
         preferenceService.updateUserPreferences('user-1', 'user-1', {
-          calorie_safety_floor_mode: 'custom',
-          calorie_safety_floor_value: value,
+          calorie_safety_floor_mode: mode,
         })
       ).resolves.toEqual({ user_id: 'user-1' });
     }
@@ -32,22 +31,24 @@ describe('calorie safety floor preference validation', () => {
     ).rejects.toMatchObject({ status: 400 });
   });
 
-  it.each([799, 5001, 1200.5])(
-    'rejects invalid custom floor value %s',
-    async (value) => {
+  // The three-mode design briefly allowed turning clamping off entirely. The
+  // clinical minimum is not opt-out, so these must not be revived by accident.
+  it.each(['custom', 'disabled'])(
+    'rejects the retired %s mode',
+    async (mode) => {
       await expect(
         preferenceService.updateUserPreferences('user-1', 'user-1', {
-          calorie_safety_floor_value: value,
+          calorie_safety_floor_mode: mode,
         })
       ).rejects.toMatchObject({ status: 400 });
     }
   );
 
-  it('rejects non-number values instead of coercing them', async () => {
+  it('leaves the mode untouched when the update omits it', async () => {
     await expect(
       preferenceService.updateUserPreferences('user-1', 'user-1', {
-        calorie_safety_floor_value: true,
-      } as never)
-    ).rejects.toMatchObject({ status: 400 });
+        activity_level: 'light',
+      })
+    ).resolves.toEqual({ user_id: 'user-1' });
   });
 });

--- a/docs/content/2.features/7.settings/calculation-settings.md
+++ b/docs/content/2.features/7.settings/calculation-settings.md
@@ -110,10 +110,10 @@ SparkyFitness shows two recommended safety limits for calorie goals:
 >
 > The clinical minimum applies in both modes and cannot be switched off.
 
-Safety floors only ever apply to deficits. A surplus can never trip them.
+Under the Adaptive method the floor applies whenever the calculated target falls below it. That is almost always a deficit, but a surplus can trip it too if your whole maintenance sits below the clinical minimum.
 
 > [!TIP]
-> The Standard floor binds whenever your requested deficit exceeds $1 - 1/\text{activityMultiplier}$ — about $17\%$ at **Sedentary** ($\times 1.2$), and $0\%$ at **None** ($\times 1.0$). That is a property of your activity level, not your body size: a sedentary man and a sedentary woman hit the same ceiling. If a goal mode appears to have no effect, check your **Activity Level** first, since it sets that ceiling and is the most common thing to have understated. If your target has been agreed with a qualified clinician and still falls below your RMR, switch to **Clinical minimum only**. Very low calorie targets can carry health risks and may require medical supervision.
+> If a goal mode appears to have no effect, the floor is binding. With the fallback estimate (TDEE = RMR × activity multiplier) and RMR as the binding half, that happens once your deficit exceeds roughly $1 - 1/\text{activityMultiplier}$ — about $17\%$ at **Sedentary** ($\times 1.2$), and $0\%$ at **None** ($\times 1.0$). Once Adaptive has enough history it uses your *measured* TDEE, so the real limit is set by how far your expenditure sits above your RMR. Either way this is a property of your activity, not your body size: a sedentary man and a sedentary woman hit the same ceiling. Check your **Activity Level** first, since it is the most common thing to have understated. If your target has been agreed with a qualified clinician and still falls below your RMR, switch to **Clinical minimum only**. Very low calorie targets can carry health risks and may require medical supervision.
 
 ---
 

--- a/docs/content/2.features/7.settings/calculation-settings.md
+++ b/docs/content/2.features/7.settings/calculation-settings.md
@@ -105,14 +105,15 @@ SparkyFitness shows two recommended safety limits for calorie goals:
 > **Adaptive Safety Floor:**
 >
 > - **Standard (default):** The higher of your estimated RMR and the sex-specific clinical minimum is enforced. If an Adaptive target falls below it, SparkyFitness raises the target and explains which limit bound.
-> - **Custom minimum:** Replaces the Standard floor with a calorie value you choose. This can be below or above the recommended limits; those recommendations and health warnings remain visible.
-> - **Disabled:** Does not automatically raise Adaptive targets. The calculated target is used as-is, while recommended limits and health warnings remain visible.
+> - **Clinical minimum only:** Drops the RMR half of the floor and enforces only the clinical minimum ($1{,}200$ / $1{,}500$ kcal). Targets below your estimated RMR are allowed; the recommendation and health warnings remain visible.
 > - Under the **Manual** method, the target is **not automatically raised**, but a prominent warning banner is displayed warning you that your budget is in an unsafe range.
+>
+> The clinical minimum applies in both modes and cannot be switched off.
 
 Safety floors only ever apply to deficits. A surplus can never trip them.
 
 > [!TIP]
-> If you are small-bodied, the Standard floor can bind before you reach your chosen deficit — for example, a measured TDEE of $1{,}400$ kcal with a $15\%$ cut computes to $1{,}190$ kcal, below the $1{,}200$ floor. If that recommendation does not fit a target you have agreed with a qualified clinician, choose a **Custom minimum** or **Disabled**. First check that your **Activity Level** and profile data are accurate, because they affect the estimate. Very low calorie targets can carry health risks and may require medical supervision.
+> The Standard floor binds whenever your requested deficit exceeds $1 - 1/\text{activityMultiplier}$ — about $17\%$ at **Sedentary** ($\times 1.2$), and $0\%$ at **None** ($\times 1.0$). That is a property of your activity level, not your body size: a sedentary man and a sedentary woman hit the same ceiling. If a goal mode appears to have no effect, check your **Activity Level** first, since it sets that ceiling and is the most common thing to have understated. If your target has been agreed with a qualified clinician and still falls below your RMR, switch to **Clinical minimum only**. Very low calorie targets can carry health risks and may require medical supervision.
 
 ---
 

--- a/shared/src/constants/calorieConstants.ts
+++ b/shared/src/constants/calorieConstants.ts
@@ -42,19 +42,29 @@ export const CALORIE_CALCULATION_CONSTANTS = {
  */
 export const ENERGY_DENSITY_KCAL_PER_KG = 6000;
 
+/**
+ * How far the adaptive calorie target may be clamped upwards.
+ *
+ * `standard` keeps the historical floor: the higher of the user's own resting
+ * metabolism and the sex-specific clinical minimum. `clinical_minimum` drops the
+ * RMR half and enforces only the clinical minimum.
+ *
+ * The RMR half binds whenever the requested deficit exceeds `1 - 1/activityMultiplier`,
+ * which for a sedentary user is ~17% — so it makes deeper goal modes unreachable
+ * regardless of body size. Opting out of that half is what #2124 asked for. The
+ * clinical minimum is never opt-out: it is the bound with guideline backing, and
+ * removing it would matter most to the users least able to absorb it.
+ */
 export const CALORIE_SAFETY_FLOOR_MODES = [
   "standard",
-  "custom",
-  "disabled",
+  "clinical_minimum",
 ] as const;
 
 export type CalorieSafetyFloorMode =
   (typeof CALORIE_SAFETY_FLOOR_MODES)[number];
 
-/** Guardrails for persisted custom values; disabling remains an explicit mode. */
-export const MIN_CALORIE_SAFETY_FLOOR = 800;
-export const MAX_CALORIE_SAFETY_FLOOR = 5_000;
-export const DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR = 1200;
+export const DEFAULT_CALORIE_SAFETY_FLOOR_MODE: CalorieSafetyFloorMode =
+  "standard";
 
 export const ACTIVITY_MULTIPLIERS: Record<string, number> = {
   none: 1.0,

--- a/shared/src/schemas/database/UserPreferences.zod.ts
+++ b/shared/src/schemas/database/UserPreferences.zod.ts
@@ -2,8 +2,6 @@
 import { z } from "zod";
 import {
   CALORIE_SAFETY_FLOOR_MODES,
-  MAX_CALORIE_SAFETY_FLOOR,
-  MIN_CALORIE_SAFETY_FLOOR,
 } from "../../constants/calorieConstants.ts";
 
 export const SUPPORTED_TIME_FORMATS = ["HH:mm", "h:mm A", "h:mm a"] as const;
@@ -57,11 +55,6 @@ export const userPreferencesSchema = z.object({
   goal_mode_calculation_method: z.enum(["adaptive", "manual"]),
   goal_mode_custom_percentage: z.number().int().min(-40).max(40),
   calorie_safety_floor_mode: z.enum(CALORIE_SAFETY_FLOOR_MODES),
-  calorie_safety_floor_value: z
-    .number()
-    .int()
-    .min(MIN_CALORIE_SAFETY_FLOOR)
-    .max(MAX_CALORIE_SAFETY_FLOOR),
   measurement_decimal_places: z.number().int().min(0),
   // Manually added (file is ts-to-zod generated; precedent: MealFoods.zod.ts). Keep on regen.
   use_external_bmr: z.boolean(),
@@ -120,12 +113,6 @@ export const userPreferencesInitializerSchema = z.object({
   goal_mode_calculation_method: z.enum(["adaptive", "manual"]).optional(),
   goal_mode_custom_percentage: z.number().int().min(-40).max(40).optional(),
   calorie_safety_floor_mode: z.enum(CALORIE_SAFETY_FLOOR_MODES).optional(),
-  calorie_safety_floor_value: z
-    .number()
-    .int()
-    .min(MIN_CALORIE_SAFETY_FLOOR)
-    .max(MAX_CALORIE_SAFETY_FLOOR)
-    .optional(),
   measurement_decimal_places: z.number().int().min(0).optional(),
   use_external_bmr: z.boolean().optional(),
   active_ai_service_id: z.string().uuid().nullable().optional(),
@@ -183,12 +170,6 @@ export const userPreferencesMutatorSchema = z.object({
   goal_mode_calculation_method: z.enum(["adaptive", "manual"]).optional(),
   goal_mode_custom_percentage: z.number().int().min(-40).max(40).optional(),
   calorie_safety_floor_mode: z.enum(CALORIE_SAFETY_FLOOR_MODES).optional(),
-  calorie_safety_floor_value: z
-    .number()
-    .int()
-    .min(MIN_CALORIE_SAFETY_FLOOR)
-    .max(MAX_CALORIE_SAFETY_FLOOR)
-    .optional(),
   measurement_decimal_places: z.number().int().min(0).optional(),
   use_external_bmr: z.boolean().optional(),
   active_ai_service_id: z.string().uuid().nullable().optional(),

--- a/shared/src/utils/calorieCalculations.ts
+++ b/shared/src/utils/calorieCalculations.ts
@@ -1,10 +1,8 @@
 import {
   ACTIVITY_MULTIPLIERS,
   CALORIE_CALCULATION_CONSTANTS,
-  DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+  DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
   ENERGY_DENSITY_KCAL_PER_KG,
-  MAX_CALORIE_SAFETY_FLOOR,
-  MIN_CALORIE_SAFETY_FLOOR,
   type CalorieSafetyFloorMode,
 } from "../constants/calorieConstants.ts";
 
@@ -526,12 +524,12 @@ export interface CalorieTargetResult {
    * Only ever true for `calculationMethod === "adaptive"`.
    */
   wasClampedToFloor: boolean;
-  /** Which floor bound: RMR, the flat absolute minimum, or a user override. */
-  clampedFloorSource: "rmr" | "absolute" | "custom" | null;
-  /** Recommended default (the higher of RMR and the sex-specific absolute floor). */
+  /** Which floor bound: the user's own RMR, or the flat clinical minimum. */
+  clampedFloorSource: "rmr" | "absolute" | null;
+  /** The `standard` floor (higher of RMR and the clinical minimum), for comparison. */
   recommendedSafetyFloor: number;
-  /** Floor that is actually enforced, or null when automatic clamping is disabled. */
-  effectiveSafetyFloor: number | null;
+  /** Floor actually enforced, which depends on the user's floor mode. */
+  effectiveSafetyFloor: number;
   /**
    * Largest deficit, in percent, that still clears the safety floor.
    * Null when the goal is not a deficit or the floor never binds.
@@ -539,23 +537,25 @@ export interface CalorieTargetResult {
   maxFeasibleDeficitPercent: number | null;
 }
 
+/**
+ * The floor actually enforced for a user, given their floor mode.
+ *
+ * Takes the RMR and sex directly rather than a pre-computed "standard floor", so
+ * a caller cannot pass the wrong baseline. The clinical minimum applies in both
+ * modes, so this never returns null: there is no way to switch clamping off.
+ */
 export function resolveCalorieSafetyFloor(
   mode: CalorieSafetyFloorMode | string | null | undefined,
-  customValue: number | null | undefined,
-  standardFloor: number,
-): number | null {
-  if (mode === "disabled") return null;
-  if (
-    mode === "custom" &&
-    Number.isInteger(customValue) &&
-    Number(customValue) >= MIN_CALORIE_SAFETY_FLOOR &&
-    Number(customValue) <= MAX_CALORIE_SAFETY_FLOOR
-  ) {
-    return Number(customValue);
-  }
-  return standardFloor;
+  rmr: number,
+  gender: "male" | "female",
+): number {
+  const clinicalMinimum = getClinicalCalorieMinimum(gender);
+  return mode === "clinical_minimum"
+    ? clinicalMinimum
+    : Math.max(rmr, clinicalMinimum);
 }
 
+/** The `standard` floor, whatever mode the user is actually on. */
 export function getRecommendedCalorieSafetyFloor(
   rmr: number,
   gender: "male" | "female",
@@ -567,11 +567,18 @@ export function getClinicalCalorieMinimum(gender: "male" | "female"): number {
   return gender === "female" ? 1200 : 1500;
 }
 
-export function shouldShowCalorieSafetyWarning(
-  goalMode: string,
-  calculationMethod: string,
-): boolean {
-  return goalMode !== "maintain" && calculationMethod === "manual";
+/**
+ * Whether a low-target warning is worth showing at all.
+ *
+ * Deliberately not gated on the calculation method. The floor only ever clamps
+ * under `adaptive`, so gating on `manual` silenced the warning in exactly the
+ * configuration that can now land below RMR (adaptive + `clinical_minimum`).
+ * Callers pair this with the outcome — `finalTarget < rmr` and friends — which
+ * is self-limiting: an unrelaxed adaptive target is clamped at or above the
+ * floor, so the comparison is false and nothing renders.
+ */
+export function shouldShowCalorieSafetyWarning(goalMode: string): boolean {
+  return goalMode !== "maintain";
 }
 
 export function computeCalorieTarget({
@@ -591,8 +598,7 @@ export function computeCalorieTarget({
   bmrAlgorithm,
   currentGoalCalories,
   calculateBmrFn,
-  calorieSafetyFloorMode = "standard",
-  calorieSafetyFloorValue = DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
+  calorieSafetyFloorMode = DEFAULT_CALORIE_SAFETY_FLOOR_MODE,
 }: {
   goalMode: string;
   calculationMethod: string;
@@ -611,7 +617,6 @@ export function computeCalorieTarget({
   currentGoalCalories: number;
   calculateBmrFn?: BmrCalculatorFn;
   calorieSafetyFloorMode?: CalorieSafetyFloorMode;
-  calorieSafetyFloorValue?: number;
 }): CalorieTargetResult {
   const rmr = calculateMinimumMetabolism(
     weightKg,
@@ -650,36 +655,28 @@ export function computeCalorieTarget({
   const recommendedSafetyFloor = getRecommendedCalorieSafetyFloor(rmr, gender);
   const effectiveSafetyFloor = resolveCalorieSafetyFloor(
     calorieSafetyFloorMode,
-    calorieSafetyFloorValue,
-    recommendedSafetyFloor,
+    rmr,
+    gender,
   );
   const wasClampedToFloor =
-    calculationMethod === "adaptive" &&
-    effectiveSafetyFloor !== null &&
-    calculatedTarget < effectiveSafetyFloor;
+    calculationMethod === "adaptive" && calculatedTarget < effectiveSafetyFloor;
   const finalTarget = wasClampedToFloor
     ? Math.round(effectiveSafetyFloor)
     : Math.round(calculatedTarget);
 
   // Name which floor actually bound, so the UI can explain rather than just clamp.
-  const usesValidCustomFloor =
-    calorieSafetyFloorMode === "custom" &&
-    Number.isInteger(calorieSafetyFloorValue) &&
-    calorieSafetyFloorValue >= MIN_CALORIE_SAFETY_FLOOR &&
-    calorieSafetyFloorValue <= MAX_CALORIE_SAFETY_FLOOR;
-  const clampedFloorSource: "rmr" | "absolute" | "custom" | null =
-    wasClampedToFloor
-      ? usesValidCustomFloor
-        ? "custom"
-        : rmr >= absoluteFloorValue
-          ? "rmr"
-          : "absolute"
-      : null;
+  // On `clinical_minimum` the RMR half is not enforced, so only the flat minimum
+  // can ever be the binding constraint.
+  const clampedFloorSource: "rmr" | "absolute" | null = wasClampedToFloor
+    ? effectiveSafetyFloor > absoluteFloorValue
+      ? "rmr"
+      : "absolute"
+    : null;
 
   // The largest deficit that still clears the floor. Surfaced so a user who asked
   // for more than is feasible gets an actionable number instead of a silent override.
   const maxFeasibleDeficitPercent =
-    wasClampedToFloor && baselineTdee > 0 && effectiveSafetyFloor !== null
+    wasClampedToFloor && baselineTdee > 0
       ? Math.max(0, (1 - effectiveSafetyFloor / baselineTdee) * 100)
       : null;
 
@@ -720,8 +717,7 @@ export function computeCalorieTarget({
     wasClampedToFloor,
     clampedFloorSource,
     recommendedSafetyFloor: Math.round(recommendedSafetyFloor),
-    effectiveSafetyFloor:
-      effectiveSafetyFloor === null ? null : Math.round(effectiveSafetyFloor),
+    effectiveSafetyFloor: Math.round(effectiveSafetyFloor),
     maxFeasibleDeficitPercent,
   };
 }


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Follow-up to #2200. That PR shipped the configurable safety floor with three modes — `standard`, a stored `custom` integer (800–5000), and `disabled`. This collapses them to two: `standard` and `clinical_minimum`.

#2124 was reported as a body-size problem, but it isn't one. The floor binds whenever the requested deficit exceeds `1 - 1/activityMultiplier`:

```
activity      mult   ceiling
none         1.000     0.0%
not_much     1.200    16.7%
light        1.375    27.3%
moderate     1.550    35.5%
```

A 178cm/90kg man and a 155cm/100kg woman on Sedentary hit the identical 16.7% ceiling. The reporter's own numbers confirm it: 1606/1642 = 0.978, so TDEE ≈ 2007 and TDEE/BMR = 1.22 — a sedentary user asking for a 20% cut.

What blocked her was the **RMR half** of `max(RMR, clinicalMinimum)`. She asked for 1200, which is already our clinical minimum. Dropping only that half closes the issue for her and for every sedentary user, without a stored number.

**How did you implement the solution?**

- `standard` keeps `max(RMR, clinicalMinimum)`; `clinical_minimum` enforces only the clinical minimum. The clinical minimum is not opt-out in either mode — it is the bound with guideline backing.
- `resolveCalorieSafetyFloor(mode, rmr, gender)` now takes RMR and sex directly instead of a pre-computed floor, so a caller cannot pass the wrong baseline. It never returns null.
- Fixes `shouldShowCalorieSafetyWarning`, which gated on `calculationMethod === 'manual'` while the floor only ever clamps under `adaptive` — silencing the warning in exactly the configuration that can now land below RMR. It now takes only `goalMode`; callers already pair it with the outcome (`finalTarget < rmr`), which is self-limiting.
- Migration maps existing `custom` and `disabled` rows to `clinical_minimum` and drops `calorie_safety_floor_value`.

**Why a mode and not a number:** a stored integer does not track weight change the way the formula does — it goes stale at whatever was typed once. Measured against the reporter's own trajectory, a fully disabled floor buys 17 kcal below 60kg, which does not justify the mode.

**Deliberately not changed:** the pre-existing `Math.max(1200, …)` in the `calorie_goal_adjustment_mode: 'adaptive'` path. It predates this preference and does not belong to it; changing it would raise goals for every existing user on that adjustment mode. A test pins it so a future change there is a decision rather than an accident.

Linked Issue: Closes #2124

## How to Test

1. Server: `pnpm exec vitest run tests/calorieSafetyFloor.test.ts tests/preferenceSafetyFloor.test.ts tests/preferenceRepository.test.ts tests/adaptiveTdeeService.test.ts`
2. Frontend: `pnpm exec jest --runInBand src/tests/utils/calorieCalculations.test.ts src/tests/utils/calculateBasePlan.test.ts src/tests/components/CalorieTargetBreakdown.test.tsx`
3. Mobile: `pnpm exec jest --watchman=false --runInBand --forceExit --coverage=false __tests__/screens/CalorieSettingsScreen.test.tsx`
4. Restart the server to apply the migration, then open **Settings > Calories & BMR**. Switch the Adaptive Safety Floor between Standard and Clinical minimum only and save each.
5. With Activity level **Sedentary** and Goal Mode **High Cut**, confirm Standard clamps to RMR and Clinical minimum only lets the calculated target through.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [x] Refactor
- [ ] Documentation

## Checklist

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).
- [x] **[MANDATORY for Frontend changes] Quality**: `pnpm run validate` passes.
- [x] **[MANDATORY for Frontend changes] Translations**: Only the English (`en`) file was updated.
- [x] **[MANDATORY for Backend changes] Code Quality**: typecheck, lint, and tests pass.
- [x] **[MANDATORY for Backend changes] Database Security**: no new tables; `user_preferences` RLS is unchanged.
- [x] **[MANDATORY for Mobile changes] Tested**: mobile suite passes; screen renders the two modes.

## Notes for Reviewers

Full suites pass: server 3270, frontend 963, mobile 5361. `pnpm run validate` clean in all three packages. `db_schema_backup.sql` deliberately untouched — CI regenerates it after merge.

**Merge before the next release.** Nothing has shipped with three modes yet, so no user has persisted a `custom` or `disabled` value and the data migration stays hypothetical. If a release goes out first, real values get rewritten.

Disclosure of the deficit ceiling in the goal-mode picker is tracked separately in #2205 and is not in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified calorie safety settings to **Standard** and **Clinical minimum only**.
  * Clinical-minimum mode allows targets below estimated RMR while retaining low-target warnings.
  * Safety-floor displays now show the calculated effective calorie floor.
  * Adaptive calorie targets use a consistent 1,200-calorie minimum.
  * Added clearer guidance distinguishing RMR from clinical minimums.

* **Bug Fixes**
  * Improved safety-floor calculations and warnings for low-calorie plans.
  * Existing custom and disabled settings are migrated to clinical-minimum mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->