### PR TITLE
fix(calories): show low-target warnings when a relaxed safety floor is in use

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
@@ -1571,10 +1571,7 @@ const CalculationSettings = () => {
           )}
 
           {/* Warning callouts */}
-          {shouldShowCalorieSafetyWarning(
-            goalMode,
-            goalModeCalculationMethod
-          ) &&
+          {shouldShowCalorieSafetyWarning(goalMode) &&
             previewResult.finalTarget < previewResult.rmr &&
             previewResult.finalTarget >= previewResult.absoluteFloorValue && (
               <div className="p-4 bg-amber-50 dark:bg-amber-950/20 border border-amber-200 dark:border-amber-900/50 rounded-xl flex gap-3 text-sm text-amber-800 dark:text-amber-300">
@@ -1594,10 +1591,7 @@ const CalculationSettings = () => {
             )}
 
           {/* Absolute Floor Danger Callout */}
-          {shouldShowCalorieSafetyWarning(
-            goalMode,
-            goalModeCalculationMethod
-          ) &&
+          {shouldShowCalorieSafetyWarning(goalMode) &&
             previewResult.finalTarget < previewResult.absoluteFloorValue && (
               <div className="p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-900/50 rounded-xl flex gap-3 text-sm text-red-800 dark:text-red-300">
                 <ShieldAlert className="w-5 h-5 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />

--- a/SparkyFitnessFrontend/src/tests/utils/calorieCalculations.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/calorieCalculations.test.ts
@@ -623,16 +623,56 @@ describe('computeCalorieTarget safety floor reporting', () => {
 
 describe('shouldShowCalorieSafetyWarning', () => {
   it('does not warn while maintaining weight', () => {
-    expect(shouldShowCalorieSafetyWarning('maintain', 'manual')).toBe(false);
+    expect(shouldShowCalorieSafetyWarning('maintain')).toBe(false);
   });
 
   it.each(['recomp', 'cut', 'high_cut', 'lean_bulk', 'bulk', 'manual'])(
-    'warns for a manually configured non-maintenance %s goal',
+    'warns for a non-maintenance %s goal regardless of method',
     (goalMode) => {
-      expect(shouldShowCalorieSafetyWarning(goalMode, 'manual')).toBe(true);
-      expect(shouldShowCalorieSafetyWarning(goalMode, 'adaptive')).toBe(false);
+      expect(shouldShowCalorieSafetyWarning(goalMode)).toBe(true);
     }
   );
+});
+
+describe('safety warnings reach a relaxed adaptive floor', () => {
+  // A custom or disabled floor lets an adaptive target land below RMR. Gating the
+  // warning on the manual method used to silence it there, which is precisely
+  // where it matters: the floor never clamps under manual in the first place.
+  const base = {
+    goalMode: 'high_cut',
+    calculationMethod: 'adaptive' as const,
+    customPercentage: 0,
+    bmr: 1633,
+    activityLevelMultiplier: 1.2,
+    adaptiveTdee: 1959,
+    adaptiveTdeeFallback: false,
+    adaptiveTdeeDaysOfData: 60,
+    weightKg: 100,
+    heightCm: 155,
+    age: 35,
+    gender: 'female' as const,
+    currentGoalCalories: 1959,
+  };
+
+  it('produces a below-RMR target the warning must cover', () => {
+    const result = computeCalorieTarget({
+      ...base,
+      calorieSafetyFloorMode: 'disabled',
+    });
+
+    expect(result.finalTarget).toBeLessThan(result.rmr);
+    expect(shouldShowCalorieSafetyWarning(base.goalMode)).toBe(true);
+  });
+
+  it('stays quiet when the standard floor already clamped the target', () => {
+    const result = computeCalorieTarget({
+      ...base,
+      calorieSafetyFloorMode: 'standard',
+    });
+
+    // The helper is permissive; the outcome comparison is what silences it.
+    expect(result.finalTarget).toBeGreaterThanOrEqual(result.rmr);
+  });
 });
 
 describe('normalizeCalorieGoalAdjustmentMode', () => {

--- a/docs/content/2.features/7.settings/calculation-settings.md
+++ b/docs/content/2.features/7.settings/calculation-settings.md
@@ -109,10 +109,12 @@ SparkyFitness shows two recommended safety limits for calorie goals:
 > - **Disabled:** Does not automatically raise Adaptive targets. The calculated target is used as-is, while recommended limits and health warnings remain visible.
 > - Under the **Manual** method, the target is **not automatically raised**, but a prominent warning banner is displayed warning you that your budget is in an unsafe range.
 
-Safety floors only ever apply to deficits. A surplus can never trip them.
+Under the Adaptive method the floor applies whenever the calculated target falls below it. That is almost always a deficit, but a surplus can trip it too: if your entire maintenance sits below the clinical minimum, even a gain goal is raised to that minimum.
 
 > [!TIP]
-> If you are small-bodied, the Standard floor can bind before you reach your chosen deficit — for example, a measured TDEE of $1{,}400$ kcal with a $15\%$ cut computes to $1{,}190$ kcal, below the $1{,}200$ floor. If that recommendation does not fit a target you have agreed with a qualified clinician, choose a **Custom minimum** or **Disabled**. First check that your **Activity Level** and profile data are accurate, because they affect the estimate. Very low calorie targets can carry health risks and may require medical supervision.
+> If a goal mode appears to have no effect, the Standard floor is binding. That is usually about your **activity level**, not your body size. With the fallback estimate (TDEE = RMR × activity multiplier) and RMR as the binding half, the floor bites once your deficit exceeds roughly $1 - 1/\text{activityMultiplier}$ — about $17\%$ at **Sedentary** ($\times 1.2$), and $0\%$ at **None** ($\times 1.0$), where every deficit mode returns the same target. Once Adaptive has enough history it uses your *measured* TDEE, so the real limit is how far your expenditure sits above your RMR. A sedentary man and a sedentary woman of very different sizes hit the same ceiling.
+>
+> Check your **Activity Level** and profile data first, since they set that ceiling and are the most common things to have understated. If your target has been agreed with a qualified clinician and still falls below the Standard floor, choose a **Custom minimum** or **Disabled**. Very small adults may find the clinical minimum sits above their own maintenance, in which case those two options are the only way to set a deficit at all. Very low calorie targets can carry health risks and may require medical supervision.
 
 ---
 

--- a/shared/src/utils/calorieCalculations.ts
+++ b/shared/src/utils/calorieCalculations.ts
@@ -567,11 +567,21 @@ export function getClinicalCalorieMinimum(gender: "male" | "female"): number {
   return gender === "female" ? 1200 : 1500;
 }
 
-export function shouldShowCalorieSafetyWarning(
-  goalMode: string,
-  calculationMethod: string,
-): boolean {
-  return goalMode !== "maintain" && calculationMethod === "manual";
+/**
+ * Whether a low-target warning is worth showing at all.
+ *
+ * Deliberately not gated on the calculation method. The floor only ever clamps
+ * under `adaptive`, so gating on `manual` silenced the warning in exactly the
+ * configurations that can land below RMR: a custom floor, or a disabled one.
+ * Those are also the settings the smallest users depend on, because a clinical
+ * minimum of 1200/1500 can sit above their entire maintenance.
+ *
+ * Callers pair this with the outcome (`finalTarget < rmr` and friends), which is
+ * self-limiting: an unclamped adaptive target sits at or above its floor, so the
+ * comparison is false and nothing renders.
+ */
+export function shouldShowCalorieSafetyWarning(goalMode: string): boolean {
+  return goalMode !== "maintain";
 }
 
 export function computeCalorieTarget({


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Follow-up to #2200, covering only the defects in it. The configurable floor itself is kept exactly as merged.

`shouldShowCalorieSafetyWarning` gates on `calculationMethod === 'manual'`, but the safety floor only ever clamps under `adaptive`. The warning is therefore silent in exactly the configurations that can land below RMR — a **Custom** floor, or a **Disabled** one — while firing only where no clamp exists in the first place.

That matters most for the smallest users, because a clinical minimum of 1200/1500 can sit above their entire maintenance:

```
who                RMR  TDEE  wants(-20%)  standard  custom800  disabled
achondroplasia F   889  1067        854      1200       854      854
achondroplasia M  1199  1439       1151      1500      1151     1151
elderly small F    827   992        794      1200       800      794
```

For them, Standard clamps to a surplus and Custom or Disabled is the only way to set a deficit at all. Those were precisely the users getting no warning.

**How did you implement the solution?**

Dropped the method argument. Callers already pair the helper with the outcome (`finalTarget < rmr`, `finalTarget < absoluteFloorValue`), which is self-limiting: an unclamped adaptive target sits at or above its floor, so the comparison is false and nothing renders. No behaviour change for anyone on Standard.

Also corrects two claims in the settings documentation:

- *"A surplus can never trip them"* is false. When maintenance is below the clinical minimum, a gain goal is clamped upward too — verified at 150cm/45kg/80y: TDEE 992, lean_bulk wants 1091, clamps to 1200.
- The deficit ceiling is only exactly `1 - 1/activityMultiplier` under the fallback estimate. With a measured Adaptive TDEE the limit is the real gap between expenditure and RMR.

The tip now points at **Activity Level** as the lever. That is what actually sets the ceiling — about 17% at Sedentary, 0% at None — and it is a property of activity, not body size: a sedentary man and a sedentary woman of very different sizes hit the same ceiling.

## How to Test

1. `pnpm exec jest --runInBand src/tests/utils/calorieCalculations.test.ts` in `SparkyFitnessFrontend`.
2. Settings > Calories & BMR: set Calculation Method **Adaptive**, Goal Mode **High Cut**, Safety Floor **Disabled**, and an activity level low enough that the target lands under RMR. The amber "below minimum metabolism" callout should now appear; on `main` it does not.
3. Set Safety Floor back to **Standard** and confirm the callout disappears, since the target is clamped at or above RMR.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [x] Documentation

## Checklist

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).
- [x] **[MANDATORY for Frontend changes] Quality**: `pnpm run validate` passes.
- [x] **[MANDATORY for Frontend changes] Translations**: no translation files changed.

## Notes for Reviewers

Four files, no schema change, no new preference. Server 3502 tests and frontend 964 tests pass; `pnpm run validate` clean in both packages.

Separately tracked: #2205 covers surfacing the deficit ceiling in the goal-mode picker, so unreachable modes are visible before the clamp rather than after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Calorie safety warnings now appear for all non-maintenance goals, regardless of calculation method.
  - Improved warning behavior when adaptive safety floors are used.
  - Standard safety floors continue to keep calorie targets at or above resting metabolic rate.

- **Documentation**
  - Clarified how adaptive floors, activity level, RMR, measured TDEE, and profile data affect calorie targets.
  - Added guidance on when to use custom minimums or disable safety floors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->