### PR TITLE
fix(calories): apply the adaptive TDEE maturity test to the saved goal

### DIFF
--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -12,6 +12,7 @@ import {
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { getEnergyUnitString } from '@/utils/nutritionCalculations';
 import {
+  ADAPTIVE_TDEE_GOAL_MIN_DAYS,
   getGoalModeAdjustment,
   ENERGY_DENSITY_KCAL_PER_KG,
   type CalorieTargetResult,
@@ -263,8 +264,8 @@ Calculated: ${bfp.toFixed(1)}%`;
       return `Goal target will use fallback BMR (${fallbackVal} ${unitStr}) due to: ${adaptiveTdeeData.fallbackReason}`;
     }
 
-    if (daysOfCalorieLogs < 14) {
-      return `Goal target will use fallback BMR (${fallbackVal} ${unitStr}) until 14 days of calorie logs are reached (currently ${daysOfCalorieLogs}/14 days logged).`;
+    if (daysOfCalorieLogs < ADAPTIVE_TDEE_GOAL_MIN_DAYS) {
+      return `Goal target will use fallback BMR (${fallbackVal} ${unitStr}) until ${ADAPTIVE_TDEE_GOAL_MIN_DAYS} days of calorie logs are reached (currently ${daysOfCalorieLogs}/${ADAPTIVE_TDEE_GOAL_MIN_DAYS} days logged).`;
     }
 
     return '';
@@ -433,14 +434,14 @@ Calculated: ${bfp.toFixed(1)}%`;
                     </span>
                     <span
                       className={
-                        daysOfCalorieLogs >= 14
+                        daysOfCalorieLogs >= ADAPTIVE_TDEE_GOAL_MIN_DAYS
                           ? 'text-green-600 font-semibold'
                           : 'text-amber-600 font-semibold'
                       }
                     >
-                      {daysOfCalorieLogs >= 14
-                        ? `✓ Met (${daysOfCalorieLogs}/14 days logged)`
-                        : `⚠️ Missing (${daysOfCalorieLogs}/14 days logged)`}
+                      {daysOfCalorieLogs >= ADAPTIVE_TDEE_GOAL_MIN_DAYS
+                        ? `✓ Met (${daysOfCalorieLogs}/${ADAPTIVE_TDEE_GOAL_MIN_DAYS} days logged)`
+                        : `⚠️ Missing (${daysOfCalorieLogs}/${ADAPTIVE_TDEE_GOAL_MIN_DAYS} days logged)`}
                     </span>
                   </div>
                 </div>
@@ -562,7 +563,8 @@ Calculated: ${bfp.toFixed(1)}%`;
                     )
                   )}{' '}
                   {getEnergyUnitString(energyUnit)} (Fallback used: not enough
-                  history [&lt;14 days]; raw calculation of{' '}
+                  history [&lt;{ADAPTIVE_TDEE_GOAL_MIN_DAYS} days]; raw
+                  calculation of{' '}
                   {adaptiveTdeeData
                     ? Math.round(
                         convertEnergy(
@@ -714,14 +716,15 @@ Calculated: ${bfp.toFixed(1)}%`;
               )}
             </div>
           )}
-          {isAdaptiveMethod && daysOfCalorieLogs < 14 && (
-            <div className="flex items-start gap-1 mt-1 p-1 bg-yellow-100 dark:bg-yellow-900/30 rounded border border-yellow-200 dark:border-yellow-800 text-xs">
-              <Info className="w-3 h-3 text-yellow-600 dark:text-yellow-400 shrink-0 mt-0.5" />
-              <span className="text-yellow-700 dark:text-yellow-300">
-                {getTargetFallbackNotice()}
-              </span>
-            </div>
-          )}
+          {isAdaptiveMethod &&
+            daysOfCalorieLogs < ADAPTIVE_TDEE_GOAL_MIN_DAYS && (
+              <div className="flex items-start gap-1 mt-1 p-1 bg-yellow-100 dark:bg-yellow-900/30 rounded border border-yellow-200 dark:border-yellow-800 text-xs">
+                <Info className="w-3 h-3 text-yellow-600 dark:text-yellow-400 shrink-0 mt-0.5" />
+                <span className="text-yellow-700 dark:text-yellow-300">
+                  {getTargetFallbackNotice()}
+                </span>
+              </div>
+            )}
           <div className="pt-1 border-t border-border/60 font-bold text-foreground mt-1 flex justify-between items-center text-sm">
             <span>Final Energy Budget Target:</span>
             <span className="text-primary text-sm font-semibold">

--- a/SparkyFitnessFrontend/src/pages/Diary/DailyProgress.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/DailyProgress.tsx
@@ -44,6 +44,8 @@ import {
   ACTIVITY_MULTIPLIERS,
   calculateAge,
   computeCalorieTarget,
+  isAdaptiveTdeeMature,
+  ADAPTIVE_TDEE_GOAL_MIN_DAYS,
   calculateBmr,
   computeExerciseCredited,
   normalizeCalorieGoalAdjustmentMode,
@@ -226,7 +228,16 @@ const DailyProgress = ({ selectedDate }: { selectedDate: string }) => {
 
   let adjustedManualGoal = rawManualGoal;
   if (calorieGoalAdjustmentMode === 'adaptive' && adaptiveTdeeData && bmr > 0) {
-    const adaptiveGoal = Math.round(adaptiveTdeeData.tdee + calorieGoalOffset);
+    // Mirrors goalService: hold the estimated baseline until the measured estimate
+    // is settled, so the diary matches the goal the server actually saves.
+    const adaptiveBaseline = isAdaptiveTdeeMature(
+      adaptiveTdeeData.tdee,
+      adaptiveTdeeData.isFallback,
+      adaptiveTdeeData.daysOfData
+    )
+      ? adaptiveTdeeData.tdee
+      : Math.round(bmr * activityMultiplier);
+    const adaptiveGoal = Math.round(adaptiveBaseline + calorieGoalOffset);
     const adaptiveGoalFloor = resolveCalorieSafetyFloor(
       calorieSafetyFloorMode,
       calorieSafetyFloorValue,
@@ -290,8 +301,8 @@ const DailyProgress = ({ selectedDate }: { selectedDate: string }) => {
       return `Goal target will use fallback BMR (${fallbackVal} ${unitStr}) due to: ${adaptiveTdeeData.fallbackReason}`;
     }
 
-    if (daysOfCalorieLogs < 14) {
-      return `Goal target will use fallback BMR (${fallbackVal} ${unitStr}) until 14 days of calorie logs are reached (currently ${daysOfCalorieLogs}/14 days logged).`;
+    if (daysOfCalorieLogs < ADAPTIVE_TDEE_GOAL_MIN_DAYS) {
+      return `Goal target will use fallback BMR (${fallbackVal} ${unitStr}) until ${ADAPTIVE_TDEE_GOAL_MIN_DAYS} days of calorie logs are reached (currently ${daysOfCalorieLogs}/${ADAPTIVE_TDEE_GOAL_MIN_DAYS} days logged).`;
     }
 
     return '';
@@ -647,7 +658,8 @@ const DailyProgress = ({ selectedDate }: { selectedDate: string }) => {
               )}
 
               {!adaptiveTdeeData.isFallback &&
-                (adaptiveTdeeData.daysOfData ?? 0) < 14 && (
+                (adaptiveTdeeData.daysOfData ?? 0) <
+                  ADAPTIVE_TDEE_GOAL_MIN_DAYS && (
                   <div className="flex items-start gap-1 mt-1 p-1.5 bg-blue-100 dark:bg-blue-900/30 rounded border border-blue-200 dark:border-blue-800">
                     <Info className="w-3 h-3 text-blue-600 dark:text-blue-400 shrink-0 mt-0.5" />
                     <span className="text-[10px] text-blue-700 dark:text-blue-300">

--- a/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
@@ -58,6 +58,7 @@ import { useMostRecentMeasurement } from '@/hooks/CheckIn/useCheckIn';
 import { CalorieTargetBreakdown } from '@/components/CalorieTargetBreakdown';
 import {
   computeCalorieTarget,
+  isAdaptiveTdeeMature,
   todayInZone,
   ACTIVITY_MULTIPLIERS,
   getGoalModeAdjustment,
@@ -414,9 +415,16 @@ const CalculationSettings = () => {
       : Math.round(bmr > 0 ? bmr * activityMultiplier : 2000);
 
   if (calorieGoalAdjustmentMode === 'adaptive' && adaptiveTdeeData && bmr > 0) {
-    const adaptiveGoal = Math.round(
-      (adaptiveTdeeData.tdee ?? 0) + calorieGoalOffset
-    );
+    // Mirrors goalService: hold the estimated baseline until the measured estimate
+    // is settled, so this preview matches the goal the server actually saves.
+    const adaptiveBaseline = isAdaptiveTdeeMature(
+      adaptiveTdeeData.tdee,
+      adaptiveTdeeData.isFallback,
+      adaptiveTdeeData.daysOfData
+    )
+      ? adaptiveTdeeData.tdee
+      : Math.round(bmr * activityMultiplier);
+    const adaptiveGoal = Math.round(adaptiveBaseline + calorieGoalOffset);
     const adaptiveGoalFloor = resolveCalorieSafetyFloor(
       calorieSafetyFloorMode,
       calorieSafetyFloorValue,
@@ -470,12 +478,14 @@ const CalculationSettings = () => {
 
   // Measured adaptive TDEE, shown only when the same sufficiency test used by
   // computeCalorieTarget passes; constant across goal modes and methods.
-  const measuredAdaptiveTdee =
-    adaptiveTdeeData?.isFallback === false &&
-    adaptiveTdeeData.tdee != null &&
-    (adaptiveTdeeData.daysOfData ?? 0) >= 14
-      ? adaptiveTdeeData.tdee
-      : null;
+  const reportedAdaptiveTdee = adaptiveTdeeData?.tdee;
+  const measuredAdaptiveTdee = isAdaptiveTdeeMature(
+    reportedAdaptiveTdee,
+    adaptiveTdeeData?.isFallback,
+    adaptiveTdeeData?.daysOfData
+  )
+    ? reportedAdaptiveTdee
+    : null;
 
   let baselineLabel: string;
   if (goalModeCalculationMethod === 'adaptive') {

--- a/SparkyFitnessFrontend/src/tests/utils/calorieCalculations.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/calorieCalculations.test.ts
@@ -711,6 +711,15 @@ describe('isAdaptiveTdeeMature', () => {
     expect(isAdaptiveTdeeMature(1800, true, 365)).toBe(false);
   });
 
+  // The service always sets the flag, but the web types it optional and forwards
+  // it unmodified, so an unknown provenance must not be read as "measured".
+  it.each([null, undefined])(
+    'rejects an estimate whose fallback status is %p',
+    (isFallback) => {
+      expect(isAdaptiveTdeeMature(1800, isFallback, 365)).toBe(false);
+    }
+  );
+
   it('rejects a missing or unusable estimate', () => {
     expect(isAdaptiveTdeeMature(null, false, 30)).toBe(false);
     expect(isAdaptiveTdeeMature(undefined, false, 30)).toBe(false);

--- a/SparkyFitnessFrontend/src/tests/utils/calorieCalculations.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/calorieCalculations.test.ts
@@ -9,6 +9,8 @@ import {
   computeCalorieProgress,
   normalizeCalorieGoalAdjustmentMode,
   shouldShowCalorieSafetyWarning,
+  isAdaptiveTdeeMature,
+  ADAPTIVE_TDEE_GOAL_MIN_DAYS,
   convertEnergyValue,
 } from '@workspace/shared';
 import {
@@ -690,6 +692,66 @@ describe('deficit ceiling is available before the clamp (issue #2205)', () => {
     });
 
     expect(result.maxFeasibleDeficitPercent).toBeNull();
+  });
+});
+
+describe('isAdaptiveTdeeMature', () => {
+  // AdaptiveTdeeService releases a raw estimate at 7 days; goals wait for the
+  // stabler window. The gap between those two numbers is where the saved goal and
+  // the settings preview used to disagree.
+  it.each([0, 6, 7, 13])('rejects a measured estimate at %i days', (days) => {
+    expect(isAdaptiveTdeeMature(1800, false, days)).toBe(false);
+  });
+
+  it.each([14, 30])('accepts a measured estimate at %i days', (days) => {
+    expect(isAdaptiveTdeeMature(1800, false, days)).toBe(true);
+  });
+
+  it('rejects a fallback estimate no matter how much history backs it', () => {
+    expect(isAdaptiveTdeeMature(1800, true, 365)).toBe(false);
+  });
+
+  it('rejects a missing or unusable estimate', () => {
+    expect(isAdaptiveTdeeMature(null, false, 30)).toBe(false);
+    expect(isAdaptiveTdeeMature(undefined, false, 30)).toBe(false);
+    expect(isAdaptiveTdeeMature(0, false, 30)).toBe(false);
+    expect(isAdaptiveTdeeMature(NaN, false, 30)).toBe(false);
+  });
+
+  it('treats a missing day count as no history', () => {
+    expect(isAdaptiveTdeeMature(1800, false, null)).toBe(false);
+    expect(isAdaptiveTdeeMature(1800, false, undefined)).toBe(false);
+  });
+
+  it('is the threshold computeCalorieTarget actually applies', () => {
+    const base = {
+      goalMode: 'maintain',
+      calculationMethod: 'adaptive' as const,
+      customPercentage: 0,
+      bmr: 1600,
+      activityLevelMultiplier: 1.2,
+      adaptiveTdee: 1420,
+      adaptiveTdeeFallback: false,
+      weightKg: 80,
+      heightCm: 178,
+      age: 36,
+      gender: 'male' as const,
+      currentGoalCalories: 1900,
+    };
+
+    const immature = computeCalorieTarget({
+      ...base,
+      adaptiveTdeeDaysOfData: ADAPTIVE_TDEE_GOAL_MIN_DAYS - 1,
+    });
+    const mature = computeCalorieTarget({
+      ...base,
+      adaptiveTdeeDaysOfData: ADAPTIVE_TDEE_GOAL_MIN_DAYS,
+    });
+
+    expect(immature.insufficientHistory).toBe(true);
+    expect(immature.baselineTdee).toBe(1920);
+    expect(mature.insufficientHistory).toBe(false);
+    expect(mature.baselineTdee).toBe(1420);
   });
 });
 

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -16,6 +16,7 @@ import {
   todayInZone,
   CALORIE_CALCULATION_CONSTANTS,
   computeCalorieTarget,
+  isAdaptiveTdeeMature,
   resolveCalorieSafetyFloor,
   DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
   ACTIVITY_MULTIPLIERS,
@@ -275,11 +276,20 @@ async function getUserGoalsForRange(
         }
       }
 
-      // Apply adaptive TDEE base adjustment — mirrors DashboardService
+      // Apply adaptive TDEE base adjustment.
       if (adjustmentMode === 'adaptive' && adaptiveTdeeData && bmr > 0) {
-        const adaptiveGoal = Math.round(
-          adaptiveTdeeData.tdee + calorieGoalOffset
-        );
+        // Hold the estimated baseline until the measured estimate is settled, the
+        // same test computeCalorieTarget applies below. Without it this path
+        // budgeted against a raw 7-day estimate that the settings preview was
+        // still rejecting, so the goal and the preview disagreed.
+        const adaptiveBaseline = isAdaptiveTdeeMature(
+          adaptiveTdeeData.tdee,
+          adaptiveTdeeData.isFallback,
+          adaptiveTdeeData.daysOfData
+        )
+          ? adaptiveTdeeData.tdee
+          : Math.round(bmr * activityMultiplier);
+        const adaptiveGoal = Math.round(adaptiveBaseline + calorieGoalOffset);
         const adaptiveGoalFloor = resolveCalorieSafetyFloor(
           userPreferences?.calorie_safety_floor_mode,
           userPreferences?.calorie_safety_floor_value,

--- a/SparkyFitnessServer/tests/goalServiceAdaptiveMaturity.test.ts
+++ b/SparkyFitnessServer/tests/goalServiceAdaptiveMaturity.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import goalService from '../services/goalService.js';
+import goalRepository from '../models/goalRepository.js';
+import weeklyGoalPlanRepository from '../models/weeklyGoalPlanRepository.js';
+import preferenceRepository from '../models/preferenceRepository.js';
+import userRepository from '../models/userRepository.js';
+import measurementRepository from '../models/measurementRepository.js';
+import bmrService from '../services/bmrService.js';
+import adaptiveTdeeService from '../services/AdaptiveTdeeService.js';
+import { computeCalorieTarget } from '@workspace/shared';
+
+vi.mock('../models/goalRepository.js');
+vi.mock('../models/weeklyGoalPlanRepository.js');
+vi.mock('../models/goalPresetRepository.js');
+vi.mock('../models/userRepository.js');
+vi.mock('../models/preferenceRepository.js');
+vi.mock('../models/measurementRepository.js');
+vi.mock('../models/exerciseEntry.js');
+vi.mock('../services/bmrService.js');
+vi.mock('../services/AdaptiveTdeeService.js');
+
+const userId = 'user-1';
+const date = '2026-08-21';
+
+// BMR 1600 x 1.2 = 1920 estimated baseline. The raw measured estimate is set well
+// below that so the two baselines are impossible to confuse in an assertion.
+const BMR = 1600;
+const ESTIMATED_BASELINE = 1920;
+const RAW_MEASURED_TDEE = 1420;
+const STORED_GOAL = 1900;
+const OFFSET = STORED_GOAL - ESTIMATED_BASELINE; // -20
+
+/**
+ * `AdaptiveTdeeService` releases a raw estimate at 7 qualifying days, but a goal
+ * budget waits for the stabler window. These tests pin that the adaptive
+ * *adjustment* path applies the same maturity test the settings preview does —
+ * they had drifted apart, so the saved goal and the preview disagreed for anyone
+ * sitting between 7 and 13 days of logs.
+ */
+describe('goalService adaptive TDEE maturity', () => {
+  const mockAdaptive = (
+    tdee: number,
+    isFallback: boolean,
+    daysOfData: number
+  ) =>
+    vi
+      .mocked(adaptiveTdeeService.calculateAdaptiveTdeeRange)
+      .mockResolvedValue({
+        [date]: {
+          tdee,
+          confidence: 'HIGH',
+          isFallback,
+          daysOfData,
+          lastCalculated: date,
+        },
+      });
+
+  const caloriesForDate = async () => {
+    const result = await goalService.getUserGoalsForRange(
+      userId,
+      date,
+      date,
+      true
+    );
+    return (result[date] as { calories: number }).calories;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(
+      weeklyGoalPlanRepository.getActiveWeeklyGoalPlan
+    ).mockResolvedValue(null);
+    vi.mocked(goalRepository.getGoalsInRange).mockResolvedValue([]);
+    vi.mocked(goalRepository.getMostRecentGoalBeforeDate).mockResolvedValue({
+      calories: STORED_GOAL,
+      protein_percentage: null,
+      carbs_percentage: null,
+      fat_percentage: null,
+    });
+    vi.mocked(userRepository.getUserProfile).mockResolvedValue({
+      date_of_birth: '1990-01-01',
+      gender: 'male',
+    });
+    vi.mocked(
+      measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
+    ).mockResolvedValue({ entry_date: date, weight: 80, height: 178 });
+    vi.mocked(
+      measurementRepository.getCheckInMeasurementsByDateRange
+    ).mockResolvedValue([]);
+    vi.mocked(bmrService.calculateBmr).mockReturnValue(BMR);
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      calorie_goal_adjustment_mode: 'adaptive',
+      goal_mode: 'maintain',
+      goal_mode_calculation_method: 'manual',
+      goal_mode_custom_percentage: 0,
+      activity_level: 'not_much',
+      bmr_algorithm: 'Mifflin-St Jeor',
+      calorie_safety_floor_mode: 'standard',
+      calorie_safety_floor_value: 1200,
+      timezone: 'Europe/Berlin',
+    });
+  });
+
+  it('ignores a raw estimate that has not reached the goal threshold', async () => {
+    mockAdaptive(RAW_MEASURED_TDEE, false, 7);
+
+    // Estimated baseline + offset, not the raw 1420 that the service handed back.
+    expect(await caloriesForDate()).toBe(ESTIMATED_BASELINE + OFFSET);
+  });
+
+  it('still ignores it on the last immature day', async () => {
+    mockAdaptive(RAW_MEASURED_TDEE, false, 13);
+
+    expect(await caloriesForDate()).toBe(ESTIMATED_BASELINE + OFFSET);
+  });
+
+  it('uses the measured estimate once it is settled', async () => {
+    mockAdaptive(RAW_MEASURED_TDEE, false, 14);
+
+    expect(await caloriesForDate()).toBe(RAW_MEASURED_TDEE + OFFSET);
+  });
+
+  it('ignores a fallback estimate however far back it goes', async () => {
+    // isFallback means the value already IS bmr x multiplier, so the result is the
+    // same either way — but consuming it as though it were measured would be wrong.
+    mockAdaptive(ESTIMATED_BASELINE, true, 30);
+
+    expect(await caloriesForDate()).toBe(ESTIMATED_BASELINE + OFFSET);
+  });
+
+  it('agrees with the settings preview at 7 days, which is the bug this pins', async () => {
+    mockAdaptive(RAW_MEASURED_TDEE, false, 7);
+
+    const goal = await caloriesForDate();
+    const preview = computeCalorieTarget({
+      goalMode: 'maintain',
+      calculationMethod: 'adaptive',
+      customPercentage: 0,
+      bmr: BMR,
+      activityLevelMultiplier: 1.2,
+      adaptiveTdee: RAW_MEASURED_TDEE,
+      adaptiveTdeeFallback: false,
+      adaptiveTdeeDaysOfData: 7,
+      weightKg: 80,
+      heightCm: 178,
+      age: 36,
+      gender: 'male',
+      currentGoalCalories: STORED_GOAL,
+    });
+
+    expect(preview.baselineTdee).toBe(ESTIMATED_BASELINE);
+    expect(goal).toBe(preview.baselineTdee + OFFSET);
+  });
+});

--- a/shared/src/constants/calorieConstants.ts
+++ b/shared/src/constants/calorieConstants.ts
@@ -42,6 +42,16 @@ export const CALORIE_CALCULATION_CONSTANTS = {
  */
 export const ENERGY_DENSITY_KCAL_PER_KG = 6000;
 
+/**
+ * Qualifying calorie-log days before a measured adaptive TDEE may drive a goal.
+ *
+ * `AdaptiveTdeeService` releases a raw estimate at 7 days, which is enough to
+ * report but not enough to budget against: the estimate is still moving, and a
+ * goal that tracks it lurches. Goals therefore wait for a stabler window, which
+ * is the threshold the settings UI calls "target budget stability".
+ */
+export const ADAPTIVE_TDEE_GOAL_MIN_DAYS = 14;
+
 export const CALORIE_SAFETY_FLOOR_MODES = [
   "standard",
   "custom",

--- a/shared/src/utils/calorieCalculations.ts
+++ b/shared/src/utils/calorieCalculations.ts
@@ -553,6 +553,12 @@ export interface CalorieTargetResult {
  * re-expressed at each call site — they had already drifted apart once, with the
  * settings preview holding out for a mature estimate while the saved goal took the
  * raw one.
+ *
+ * Fails closed on an unknown fallback status. The service always populates the
+ * flag, but the web types it as optional and pass it through unmodified, so a
+ * partial or stale payload could otherwise let an estimate of unknown provenance
+ * set someone's calorie target. Requiring an explicit `false` costs nothing when
+ * the field is present and degrades to the estimated baseline when it is not.
  */
 export function isAdaptiveTdeeMature(
   tdee: number | null | undefined,
@@ -563,7 +569,7 @@ export function isAdaptiveTdeeMature(
     typeof tdee === "number" &&
     Number.isFinite(tdee) &&
     tdee > 0 &&
-    isFallback !== true &&
+    isFallback === false &&
     (daysOfData ?? 0) >= ADAPTIVE_TDEE_GOAL_MIN_DAYS
   );
 }

--- a/shared/src/utils/calorieCalculations.ts
+++ b/shared/src/utils/calorieCalculations.ts
@@ -1,5 +1,6 @@
 import {
   ACTIVITY_MULTIPLIERS,
+  ADAPTIVE_TDEE_GOAL_MIN_DAYS,
   CALORIE_CALCULATION_CONSTANTS,
   DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
   ENERGY_DENSITY_KCAL_PER_KG,
@@ -543,6 +544,30 @@ export interface CalorieTargetResult {
   maxFeasibleDeficitPercent: number | null;
 }
 
+/**
+ * Whether a measured adaptive TDEE is settled enough to drive a calorie goal.
+ *
+ * `AdaptiveTdeeService` hands back a raw estimate at 7 qualifying days, but a goal
+ * budget wants a stabler number than that. Every consumer that turns adaptive TDEE
+ * into a target must ask this same question, so it lives here rather than being
+ * re-expressed at each call site — they had already drifted apart once, with the
+ * settings preview holding out for a mature estimate while the saved goal took the
+ * raw one.
+ */
+export function isAdaptiveTdeeMature(
+  tdee: number | null | undefined,
+  isFallback: boolean | null | undefined,
+  daysOfData: number | null | undefined,
+): tdee is number {
+  return (
+    typeof tdee === "number" &&
+    Number.isFinite(tdee) &&
+    tdee > 0 &&
+    isFallback !== true &&
+    (daysOfData ?? 0) >= ADAPTIVE_TDEE_GOAL_MIN_DAYS
+  );
+}
+
 export function resolveCalorieSafetyFloor(
   mode: CalorieSafetyFloorMode | string | null | undefined,
   customValue: number | null | undefined,
@@ -643,7 +668,13 @@ export function computeCalorieTarget({
   let insufficientHistory = false;
 
   if (calculationMethod === "adaptive") {
-    if (adaptiveTdeeFallback || !adaptiveTdee || adaptiveTdeeDaysOfData < 14) {
+    if (
+      !isAdaptiveTdeeMature(
+        adaptiveTdee,
+        adaptiveTdeeFallback,
+        adaptiveTdeeDaysOfData,
+      )
+    ) {
       baselineTdee = Math.round(bmr * activityLevelMultiplier);
       insufficientHistory = true;
     } else {


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Closes #2216. Adaptive TDEE was gated by two different rules depending on which code path consumed it, so the Calculation Settings preview and the saved daily goal could be computed from different baselines.

`AdaptiveTdeeService.calculateAdaptiveTdee` releases a **raw** measured estimate once **7** days of ≥200 kcal logs exist (`AdaptiveTdeeService.ts:251`). `computeCalorieTarget` refuses to budget against one that immature and falls back to `bmr × activityMultiplier` until **14** days. The `calorie_goal_adjustment_mode === 'adaptive'` path in `goalService` applied no such test — it consumed `adaptiveTdeeData.tdee` directly.

So between day 7 and day 13, the preview and the goal disagreed. The settings UI already advertises both thresholds in its own checklist — *"Calorie Logs for TDEE calculation (7+ days)"* and *"…for target budget stability (14+ days)"* — so the 14-day rule was promised to the user and then not applied where it mattered.

The same unguarded expression had been copied into `DailyProgress.tsx` and `CalculationSettings.tsx`, so the web reproduced the server's behaviour rather than catching it.

**How did you implement the solution?**

- Raised the goal path to meet the preview, not the reverse. A goal that tracks a still-moving estimate lurches, and 14 days is the number the UI already names.
- Extracted the predicate as `isAdaptiveTdeeMature(tdee, isFallback, daysOfData)` in `@workspace/shared` and used it at all four sites. It is a type predicate (`tdee is number`) so it narrows at the call site.
- Named the threshold `ADAPTIVE_TDEE_GOAL_MIN_DAYS` instead of repeating a bare `14` in seven places — including the user-facing strings, which would otherwise have gone stale the first time anyone tuned it.

**Deliberately not changed:** the flat `Math.max(1200, …)` in the adaptive-adjustment path. It predates this preference and is not what this fixes (see the closed #2207 for why it was left alone).

## How to Test

1. `cd SparkyFitnessServer && pnpm run validate && pnpm exec vitest run tests/goalServiceAdaptiveMaturity.test.ts`
2. `cd SparkyFitnessFrontend && pnpm run validate && pnpm exec jest --runInBand src/tests/utils/calorieCalculations.test.ts`
3. To confirm the regression test is not passing vacuously, revert the guard in `goalService.ts` — 3 of the 5 new tests should fail, including `agrees with the settings preview at 7 days`.
4. In the app: Settings → Calories & BMR with adjustment mode Adaptive. The "Estimated TDEE" in the preview and the goal on the Diary must agree.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [x] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: no translation files changed.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: typecheck, lint and tests pass. New test file is TypeScript.
- [x] **[MANDATORY for Backend changes] Database Security**: no schema change, no new tables, `rls_policies.sql` untouched.

## Notes for Reviewers

Eight files, no schema change, no new preference, no new translation keys.

Server 3507 tests and frontend 979 tests pass; `pnpm run validate` clean in both packages.

**Blast radius is zero.** Read-only SQL against production: only three accounts use `calorie_goal_adjustment_mode = 'adaptive'`, and all three currently have **0** qualifying calorie-log days. Nobody is inside the 7–13 day window, so no existing goal changes on deploy.

```sql
WITH days AS (
  SELECT fe.user_id, fe.entry_date
  FROM food_entries fe JOIN food_variants fv ON fv.id = fe.variant_id
  WHERE fe.entry_date > CURRENT_DATE - 28
  GROUP BY fe.user_id, fe.entry_date
  HAVING SUM(fe.quantity * fv.calories / NULLIF(fv.serving_size,0)) >= 200
)
SELECT up.user_id, COUNT(d.entry_date) AS qualifying_days
FROM user_preferences up LEFT JOIN days d ON d.user_id = up.user_id
WHERE up.calorie_goal_adjustment_mode = 'adaptive'
GROUP BY up.user_id;
```

One stale comment corrected in passing: `goalService` claimed this block "mirrors DashboardService", but `DashboardService` has no adaptive path any more.

Two follow-ups noted in #2216 and deliberately out of scope here: the `calories >= 200` day filter is permissive enough that sparse logging can produce a raw estimate *below the user's own BMR*, and the flat 1200 bound is currently what stops such an estimate driving the goal lower still.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Adaptive calorie goals now use measured TDEE after at least 14 qualifying days of data.
  * Before reaching the threshold—or when data is invalid or fallback-based—goals use a BMR- and activity-based estimate.
  * Calorie breakdowns, daily progress, and settings previews now show consistent maturity notices and warnings.
* **Bug Fixes**
  * Resolved differences between saved calorie goals and settings previews during early adaptive-TDEE tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->