### PR TITLE
feat(docker): support Docker Compose secrets for sensitive variables

### DIFF
--- a/SparkyFitnessServer/tests/secretLoader.test.ts
+++ b/SparkyFitnessServer/tests/secretLoader.test.ts
@@ -1,0 +1,122 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadSecrets } from '../utils/secretLoader.js';
+
+describe('secretLoader', () => {
+  const originalEnv = { ...process.env };
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sparky-secrets-test-'));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...originalEnv };
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads secrets from *_FILE variables when target variable is unset', () => {
+    const secretFile = path.join(tempDir, 'db_password.txt');
+    fs.writeFileSync(secretFile, 'supersecret_password\n');
+
+    delete process.env.SPARKY_FITNESS_DB_PASSWORD;
+    process.env.SPARKY_FITNESS_DB_PASSWORD_FILE = secretFile;
+
+    loadSecrets();
+
+    expect(process.env.SPARKY_FITNESS_DB_PASSWORD).toBe('supersecret_password');
+  });
+
+  it('loads secrets when target variable is an empty string', () => {
+    const secretFile = path.join(tempDir, 'app_db_password.txt');
+    fs.writeFileSync(secretFile, 'app_password_123');
+
+    process.env.SPARKY_FITNESS_APP_DB_PASSWORD = '';
+    process.env.SPARKY_FITNESS_APP_DB_PASSWORD_FILE = secretFile;
+
+    loadSecrets();
+
+    expect(process.env.SPARKY_FITNESS_APP_DB_PASSWORD).toBe('app_password_123');
+  });
+
+  it('loads secrets when target variable contains only whitespace', () => {
+    const secretFile = path.join(tempDir, 'email_pass.txt');
+    fs.writeFileSync(secretFile, 'email_secret_pass');
+
+    process.env.SPARKY_FITNESS_EMAIL_PASS = '   ';
+    process.env.SPARKY_FITNESS_EMAIL_PASS_FILE = secretFile;
+
+    loadSecrets();
+
+    expect(process.env.SPARKY_FITNESS_EMAIL_PASS).toBe('email_secret_pass');
+  });
+
+  it('preserves existing non-empty environment variable when both VAR and VAR_FILE are set', () => {
+    const secretFile = path.join(tempDir, 'encryption_key.txt');
+    fs.writeFileSync(secretFile, 'key_from_file');
+
+    process.env.SPARKY_FITNESS_API_ENCRYPTION_KEY = 'explicit_env_key';
+    process.env.SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE = secretFile;
+
+    loadSecrets();
+
+    expect(process.env.SPARKY_FITNESS_API_ENCRYPTION_KEY).toBe(
+      'explicit_env_key'
+    );
+  });
+
+  it('handles multiple sensitive secret files simultaneously', () => {
+    const secrets: Record<string, string> = {
+      SPARKY_FITNESS_DB_PASSWORD: 'db_secret_pass',
+      SPARKY_FITNESS_APP_DB_PASSWORD: 'app_db_secret_pass',
+      SPARKY_FITNESS_EMAIL_PASS: 'smtp_secret_pass',
+      SPARKY_FITNESS_OIDC_CLIENT_ID: 'oidc_client_id_val',
+      SPARKY_FITNESS_OIDC_CLIENT_SECRET: 'oidc_client_secret_val',
+      BETTER_AUTH_SECRET: 'better_auth_secret_val',
+      SPARKY_FITNESS_API_ENCRYPTION_KEY: 'encryption_key_val',
+    };
+
+    for (const [varName, value] of Object.entries(secrets)) {
+      const filePath = path.join(tempDir, `${varName}.txt`);
+      fs.writeFileSync(filePath, `${value} \n`);
+      delete process.env[varName];
+      process.env[`${varName}_FILE`] = filePath;
+    }
+
+    loadSecrets();
+
+    for (const [varName, expectedValue] of Object.entries(secrets)) {
+      expect(process.env[varName]).toBe(expectedValue);
+    }
+  });
+
+  it('logs a warning without throwing if secret file does not exist', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.NON_EXISTENT_SECRET_FILE = path.join(
+      tempDir,
+      'does_not_exist.txt'
+    );
+    delete process.env.NON_EXISTENT_SECRET;
+
+    expect(() => loadSecrets()).not.toThrow();
+    expect(process.env.NON_EXISTENT_SECRET).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '[Secrets] WARNING: File specified in NON_EXISTENT_SECRET_FILE'
+      )
+    );
+  });
+
+  it('ignores *_FILE variables with empty file paths', () => {
+    process.env.EMPTY_PATH_VAR_FILE = '';
+    delete process.env.EMPTY_PATH_VAR;
+
+    expect(() => loadSecrets()).not.toThrow();
+    expect(process.env.EMPTY_PATH_VAR).toBeUndefined();
+  });
+});

--- a/SparkyFitnessServer/utils/secretLoader.ts
+++ b/SparkyFitnessServer/utils/secretLoader.ts
@@ -17,8 +17,8 @@ function loadSecrets() {
     if (key.endsWith('_FILE')) {
       const targetVar = key.slice(0, -5); // Remove '_FILE' suffix
       const filePath = process.env[key];
-      // If the target variable is already set, skip (allow override via explicit env var)
-      if (process.env[targetVar]) {
+      // If the target variable is already set with a non-empty value, skip (allow override via explicit env var)
+      if (process.env[targetVar] && process.env[targetVar].trim() !== '') {
         // console.debug(`[Secrets] Ignoring ${key} because ${targetVar} is already set.`);
         return;
       }
@@ -39,9 +39,9 @@ function loadSecrets() {
           );
         }
       } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : String(err);
         console.error(
-          // @ts-expect-error TS(2571): Object is of type 'unknown'.
-          `[Secrets] ERROR: Error reading file for ${key} (${filePath}): ${err.message}`
+          `[Secrets] ERROR: Error reading file for ${key} (${filePath}): ${errorMsg}`
         );
       }
     }

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -8,9 +8,14 @@ SPARKY_FITNESS_DB_NAME=sparkyfitness_db
 #SPARKY_FITNESS_DB_USER is super user for DB initialization and migrations.
 SPARKY_FITNESS_DB_USER=sparky
 SPARKY_FITNESS_DB_PASSWORD=changeme_db_password
+# For Docker Swarm/Kubernetes/Compose secrets, you can use a file-based secret instead:
+# SPARKY_FITNESS_DB_PASSWORD_FILE=/run/secrets/sparkyfitness_db_password
+
 # Application database user with limited privileges. it can be changed any time after initialization.
 SPARKY_FITNESS_APP_DB_USER=sparky_app
 SPARKY_FITNESS_APP_DB_PASSWORD=password
+# For Docker Swarm/Kubernetes/Compose secrets, you can use a file-based secret instead:
+# SPARKY_FITNESS_APP_DB_PASSWORD_FILE=/run/secrets/sparkyfitness_app_db_password
 
 # For Docker Compose deployments, SPARKY_FITNESS_DB_HOST will be the service name (e.g., 'sparkyfitness-db').
 #SPARKY_FITNESS_DB_HOST=sparkyfitness-db
@@ -135,7 +140,9 @@ SPARKY_FITNESS_DISABLE_SIGNUP=false
 
 # OIDC client credentials from your IdP.
 # SPARKY_FITNESS_OIDC_CLIENT_ID=
+# SPARKY_FITNESS_OIDC_CLIENT_ID_FILE=/run/secrets/sparkyfitness_oidc_client_id
 # SPARKY_FITNESS_OIDC_CLIENT_SECRET=
+# SPARKY_FITNESS_OIDC_CLIENT_SECRET_FILE=/run/secrets/sparkyfitness_oidc_client_secret
 
 # SPARKY_FITNESS_OIDC_SCOPE=openid email profile
 
@@ -167,6 +174,7 @@ SPARKY_FITNESS_FORCE_EMAIL_LOGIN=true
 # SPARKY_FITNESS_EMAIL_SECURE=true # Use 'true' for TLS/SSL, 'false' for plain text
 # SPARKY_FITNESS_EMAIL_USER=your_email@example.com
 # SPARKY_FITNESS_EMAIL_PASS=your_email_password
+# SPARKY_FITNESS_EMAIL_PASS_FILE=/run/secrets/sparkyfitness_email_pass
 # SPARKY_FITNESS_EMAIL_FROM=no-reply@example.com
 
 # --- Volume Paths (Optional) ---

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -8,7 +8,9 @@ services:
     environment:
       POSTGRES_DB: ${SPARKY_FITNESS_DB_NAME:?Variable is required and must be set}
       POSTGRES_USER: ${SPARKY_FITNESS_DB_USER:?Variable is required and must be set}
-      POSTGRES_PASSWORD: ${SPARKY_FITNESS_DB_PASSWORD:?Variable is required and must be set}
+      POSTGRES_PASSWORD: ${SPARKY_FITNESS_DB_PASSWORD:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # POSTGRES_PASSWORD_FILE: /run/secrets/sparkyfitness_db_password
     volumes:
       - ./docker_volume/postgresql:/var/lib/postgresql:z
     networks:
@@ -24,33 +26,49 @@ services:
     env_file:
       - ../.env
     environment:
-      SPARKY_FITNESS_LOG_LEVEL: ${SPARKY_FITNESS_LOG_LEVEL}
-      ALLOW_PRIVATE_NETWORK_CORS: ${ALLOW_PRIVATE_NETWORK_CORS:-false}
-      SPARKY_FITNESS_EXTRA_TRUSTED_ORIGINS: ${SPARKY_FITNESS_EXTRA_TRUSTED_ORIGINS:-}
-      SPARKY_FITNESS_PUBLIC_API_DOCS: ${SPARKY_FITNESS_PUBLIC_API_DOCS:-false}
-      SPARKY_FITNESS_DB_USER: ${SPARKY_FITNESS_DB_USER:-sparky}
+      # --- Database Connection ---
       SPARKY_FITNESS_DB_HOST: ${SPARKY_FITNESS_DB_HOST:-sparkyfitness-db}
-      SPARKY_FITNESS_DB_NAME: ${SPARKY_FITNESS_DB_NAME}
-      SPARKY_FITNESS_DB_PASSWORD: ${SPARKY_FITNESS_DB_PASSWORD:?Variable is required and must be set}
-      SPARKY_FITNESS_APP_DB_USER: ${SPARKY_FITNESS_APP_DB_USER:-sparkyapp}
-      SPARKY_FITNESS_APP_DB_PASSWORD: ${SPARKY_FITNESS_APP_DB_PASSWORD:?Variable is required and must be set}
       SPARKY_FITNESS_DB_PORT: ${SPARKY_FITNESS_DB_PORT:-5432}
-      SPARKY_FITNESS_API_ENCRYPTION_KEY: ${SPARKY_FITNESS_API_ENCRYPTION_KEY:?Variable is required and must be set}
+      SPARKY_FITNESS_DB_NAME: ${SPARKY_FITNESS_DB_NAME:?Variable is required and must be set}
+      SPARKY_FITNESS_DB_USER: ${SPARKY_FITNESS_DB_USER:-sparky}
+      SPARKY_FITNESS_DB_PASSWORD: ${SPARKY_FITNESS_DB_PASSWORD:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # SPARKY_FITNESS_DB_PASSWORD_FILE: /run/secrets/sparkyfitness_db_password
+      SPARKY_FITNESS_APP_DB_USER: ${SPARKY_FITNESS_APP_DB_USER:-sparkyapp}
+      SPARKY_FITNESS_APP_DB_PASSWORD: ${SPARKY_FITNESS_APP_DB_PASSWORD:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # SPARKY_FITNESS_APP_DB_PASSWORD_FILE: /run/secrets/sparkyfitness_app_db_password
+
+      # --- Essential App Security ---
+      SPARKY_FITNESS_FRONTEND_URL: ${SPARKY_FITNESS_FRONTEND_URL:-http://localhost:3004}
+      SPARKY_FITNESS_API_ENCRYPTION_KEY: ${SPARKY_FITNESS_API_ENCRYPTION_KEY:-}
       # Uncomment the line below and comment the line above to use a file-based secret
       # SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE: /run/secrets/sparkyfitness_api_key
-
-      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?Variable is required and must be set}
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-}
       # Uncomment the line below and comment the line above to use a file-based secret
       # BETTER_AUTH_SECRET_FILE: /run/secrets/sparkyfitness_better_auth_secret
-      SPARKY_FITNESS_FRONTEND_URL: ${SPARKY_FITNESS_FRONTEND_URL:-http://localhost:3004}
+
+      # --- Server Runtime & Admin ---
+      SPARKY_FITNESS_LOG_LEVEL: ${SPARKY_FITNESS_LOG_LEVEL:-ERROR}
+      SPARKY_FITNESS_PUBLIC_API_DOCS: ${SPARKY_FITNESS_PUBLIC_API_DOCS:-false}
       SPARKY_FITNESS_DISABLE_SIGNUP: ${SPARKY_FITNESS_DISABLE_SIGNUP}
-      SPARKY_FITNESS_ADMIN_EMAIL: ${SPARKY_FITNESS_ADMIN_EMAIL} #User with this email can access the admin panel
+      SPARKY_FITNESS_ADMIN_EMAIL: ${SPARKY_FITNESS_ADMIN_EMAIL} # User with this email can access the admin panel
+
+      # --- Network & CORS ---
+      ALLOW_PRIVATE_NETWORK_CORS: ${ALLOW_PRIVATE_NETWORK_CORS:-false}
+      SPARKY_FITNESS_EXTRA_TRUSTED_ORIGINS: ${SPARKY_FITNESS_EXTRA_TRUSTED_ORIGINS:-}
+
+      # --- Email Settings (optional) ---
       SPARKY_FITNESS_EMAIL_HOST: ${SPARKY_FITNESS_EMAIL_HOST}
       SPARKY_FITNESS_EMAIL_PORT: ${SPARKY_FITNESS_EMAIL_PORT}
       SPARKY_FITNESS_EMAIL_SECURE: ${SPARKY_FITNESS_EMAIL_SECURE}
       SPARKY_FITNESS_EMAIL_USER: ${SPARKY_FITNESS_EMAIL_USER}
       SPARKY_FITNESS_EMAIL_PASS: ${SPARKY_FITNESS_EMAIL_PASS}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # SPARKY_FITNESS_EMAIL_PASS_FILE: /run/secrets/sparkyfitness_email_pass
       SPARKY_FITNESS_EMAIL_FROM: ${SPARKY_FITNESS_EMAIL_FROM}
+
+      # --- Integrations ---
       GARMIN_MICROSERVICE_URL: ${GARMIN_MICROSERVICE_URL:-http://sparkyfitness-garmin:${GARMIN_SERVICE_PORT:-8000}} # Garmin microservice URL
     volumes:
       - ../SparkyFitnessServer:/app/SparkyFitnessServer:z

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -9,7 +9,9 @@ services:
     environment:
       POSTGRES_DB: ${SPARKY_FITNESS_DB_NAME:?Variable is required and must be set}
       POSTGRES_USER: ${SPARKY_FITNESS_DB_USER:?Variable is required and must be set}
-      POSTGRES_PASSWORD: ${SPARKY_FITNESS_DB_PASSWORD:?Variable is required and must be set}
+      POSTGRES_PASSWORD: ${SPARKY_FITNESS_DB_PASSWORD:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # POSTGRES_PASSWORD_FILE: /run/secrets/sparkyfitness_db_password
       PUID: 1000
       GUID: 1000
     volumes:
@@ -20,43 +22,54 @@ services:
   sparkyfitness-server:
     image: codewithcj/sparkyfitness_server:latest # Use pre-built image
     environment:
+      # --- Database Connection ---
+      SPARKY_FITNESS_DB_HOST: ${SPARKY_FITNESS_DB_HOST:-sparkyfitness-db} # Use the service name 'sparkyfitness-db' for inter-container communication
+      SPARKY_FITNESS_DB_PORT: 5432 # Uses internal container port. Do NOT change this if SPARKY_FITNESS_DB_HOST is using container name.
+      SPARKY_FITNESS_DB_NAME: ${SPARKY_FITNESS_DB_NAME:?Variable is required and must be set}
+      SPARKY_FITNESS_DB_USER: ${SPARKY_FITNESS_DB_USER:-sparky}
+      SPARKY_FITNESS_DB_PASSWORD: ${SPARKY_FITNESS_DB_PASSWORD:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # SPARKY_FITNESS_DB_PASSWORD_FILE: /run/secrets/sparkyfitness_db_password
+      SPARKY_FITNESS_APP_DB_USER: ${SPARKY_FITNESS_APP_DB_USER:-sparkyapp}
+      SPARKY_FITNESS_APP_DB_PASSWORD: ${SPARKY_FITNESS_APP_DB_PASSWORD:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # SPARKY_FITNESS_APP_DB_PASSWORD_FILE: /run/secrets/sparkyfitness_app_db_password
+
+      # --- Essential App Security ---
+      SPARKY_FITNESS_FRONTEND_URL: ${SPARKY_FITNESS_FRONTEND_URL:-http://0.0.0.0:3004}
+      SPARKY_FITNESS_API_ENCRYPTION_KEY: ${SPARKY_FITNESS_API_ENCRYPTION_KEY:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE: /run/secrets/sparkyfitness_api_key
+      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # BETTER_AUTH_SECRET_FILE: /run/secrets/sparkyfitness_better_auth_secret
+
+      # --- Server Runtime & Admin ---
+      NODE_ENV: ${NODE_ENV:-production}
+      TZ: ${TZ:-Etc/UTC}
       SPARKY_FITNESS_LOG_LEVEL: ${SPARKY_FITNESS_LOG_LEVEL:-ERROR}
+      SPARKY_FITNESS_PUBLIC_API_DOCS: ${SPARKY_FITNESS_PUBLIC_API_DOCS:-false}
+      SPARKY_FITNESS_DISABLE_SIGNUP: ${SPARKY_FITNESS_DISABLE_SIGNUP:-false}
+      SPARKY_FITNESS_ADMIN_EMAIL: ${SPARKY_FITNESS_ADMIN_EMAIL:-} # User with this email can access the admin panel
+
+      # --- Network & CORS ---
       ALLOW_PRIVATE_NETWORK_CORS: ${ALLOW_PRIVATE_NETWORK_CORS:-false}
       ALLOW_PRIVATE_NETWORK_AI: ${ALLOW_PRIVATE_NETWORK_AI:-false}
       SPARKY_FITNESS_EXTRA_TRUSTED_ORIGINS: ${SPARKY_FITNESS_EXTRA_TRUSTED_ORIGINS:-}
-      SPARKY_FITNESS_PUBLIC_API_DOCS: ${SPARKY_FITNESS_PUBLIC_API_DOCS:-false}
-      SPARKY_FITNESS_DB_USER: ${SPARKY_FITNESS_DB_USER:-sparky}
-      SPARKY_FITNESS_DB_HOST: ${SPARKY_FITNESS_DB_HOST:-sparkyfitness-db} # Use the service name 'sparkyfitness-db' for inter-container communication
-      SPARKY_FITNESS_DB_NAME: ${SPARKY_FITNESS_DB_NAME:?Variable is required and must be set}
-      SPARKY_FITNESS_DB_PASSWORD: ${SPARKY_FITNESS_DB_PASSWORD:?Variable is required and must be set}
-      SPARKY_FITNESS_APP_DB_USER: ${SPARKY_FITNESS_APP_DB_USER:-sparkyapp}
-      SPARKY_FITNESS_APP_DB_PASSWORD: ${SPARKY_FITNESS_APP_DB_PASSWORD:?Variable is required and must be set}
-      SPARKY_FITNESS_DB_PORT: 5432 # Uses internal container port. Do NOT change this if SPARKY_FITNESS_DB_HOST is using container name.
-      SPARKY_FITNESS_API_ENCRYPTION_KEY: ${SPARKY_FITNESS_API_ENCRYPTION_KEY:?Variable is required and must be set}
-      # Uncomment the line below and comment the line above to use a file-based secret
-      # SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE: /run/secrets/sparkyfitness_api_key
 
-      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?Variable is required and must be set}
-      # Uncomment the line below and comment the line above to use a file-based secret
-      # BETTER_AUTH_SECRET_FILE: /run/secrets/sparkyfitness_better_auth_secret
-      SPARKY_FITNESS_FRONTEND_URL: ${SPARKY_FITNESS_FRONTEND_URL:-http://0.0.0.0:3004}
-      SPARKY_FITNESS_DISABLE_SIGNUP: ${SPARKY_FITNESS_DISABLE_SIGNUP:-false}
-      SPARKY_FITNESS_ADMIN_EMAIL: ${SPARKY_FITNESS_ADMIN_EMAIL:-} #User with this email can access the admin panel
+      # --- Email Settings (optional) ---
       SPARKY_FITNESS_EMAIL_HOST: ${SPARKY_FITNESS_EMAIL_HOST:-}
       SPARKY_FITNESS_EMAIL_PORT: ${SPARKY_FITNESS_EMAIL_PORT:-}
       SPARKY_FITNESS_EMAIL_SECURE: ${SPARKY_FITNESS_EMAIL_SECURE:-}
       SPARKY_FITNESS_EMAIL_USER: ${SPARKY_FITNESS_EMAIL_USER:-}
       SPARKY_FITNESS_EMAIL_PASS: ${SPARKY_FITNESS_EMAIL_PASS:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # SPARKY_FITNESS_EMAIL_PASS_FILE: /run/secrets/sparkyfitness_email_pass
       SPARKY_FITNESS_EMAIL_FROM: ${SPARKY_FITNESS_EMAIL_FROM:-}
-      GARMIN_MICROSERVICE_URL: ${GARMIN_MICROSERVICE_URL:-http://sparkyfitness-garmin:${GARMIN_SERVICE_PORT:-8000}} # Garmin microservice URL
-      HTTP_PROXY: ${HTTP_PROXY:-} # Optional forward proxy for the server's outbound requests
-      HTTPS_PROXY: ${HTTPS_PROXY:-}
-      NO_PROXY: ${NO_PROXY:-}
-      NODE_ENV: ${NODE_ENV:-production}
-      TZ: ${TZ:-Etc/UTC}
+
+      # --- Login & OIDC Authentication (optional) ---
       SPARKY_FITNESS_FORCE_EMAIL_LOGIN: ${SPARKY_FITNESS_FORCE_EMAIL_LOGIN:-}
       SPARKY_FITNESS_DISABLE_EMAIL_LOGIN: ${SPARKY_FITNESS_DISABLE_EMAIL_LOGIN:-}
-      # --- OIDC Authentication (optional) ---
       SPARKY_FITNESS_OIDC_AUTH_ENABLED: ${SPARKY_FITNESS_OIDC_AUTH_ENABLED:-}
       SPARKY_FITNESS_OIDC_PROVIDER_SLUG: ${SPARKY_FITNESS_OIDC_PROVIDER_SLUG:-}
       SPARKY_FITNESS_OIDC_PROVIDER_NAME: ${SPARKY_FITNESS_OIDC_PROVIDER_NAME:-}
@@ -65,7 +78,11 @@ services:
       SPARKY_FITNESS_OIDC_ISSUER_URL: ${SPARKY_FITNESS_OIDC_ISSUER_URL:-}
       SPARKY_FITNESS_OIDC_DOMAIN: ${SPARKY_FITNESS_OIDC_DOMAIN:-}
       SPARKY_FITNESS_OIDC_CLIENT_ID: ${SPARKY_FITNESS_OIDC_CLIENT_ID:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # SPARKY_FITNESS_OIDC_CLIENT_ID_FILE: /run/secrets/sparkyfitness_oidc_client_id
       SPARKY_FITNESS_OIDC_CLIENT_SECRET: ${SPARKY_FITNESS_OIDC_CLIENT_SECRET:-}
+      # Uncomment the line below and comment the line above to use a file-based secret
+      # SPARKY_FITNESS_OIDC_CLIENT_SECRET_FILE: /run/secrets/sparkyfitness_oidc_client_secret
       SPARKY_FITNESS_OIDC_SCOPE: ${SPARKY_FITNESS_OIDC_SCOPE:-}
       SPARKY_FITNESS_OIDC_AUTO_REDIRECT: ${SPARKY_FITNESS_OIDC_AUTO_REDIRECT:-}
       SPARKY_FITNESS_OIDC_ADMIN_GROUP: ${SPARKY_FITNESS_OIDC_ADMIN_GROUP:-}
@@ -73,13 +90,24 @@ services:
       SPARKY_FITNESS_OIDC_ID_TOKEN_SIGNED_ALG: ${SPARKY_FITNESS_OIDC_ID_TOKEN_SIGNED_ALG:-}
       SPARKY_FITNESS_OIDC_USERINFO_SIGNED_ALG: ${SPARKY_FITNESS_OIDC_USERINFO_SIGNED_ALG:-}
       SPARKY_FITNESS_OIDC_TIMEOUT: ${SPARKY_FITNESS_OIDC_TIMEOUT:-}
-      # --- Custom storage paths (optional, standalone installs) ---
+
+      # --- Integrations ---
+      GARMIN_MICROSERVICE_URL: ${GARMIN_MICROSERVICE_URL:-http://sparkyfitness-garmin:${GARMIN_SERVICE_PORT:-8000}} # Garmin microservice URL
+
+      # --- Outbound Proxy Settings (optional) ---
+      HTTP_PROXY: ${HTTP_PROXY:-} # Optional forward proxy for the server's outbound requests
+      HTTPS_PROXY: ${HTTPS_PROXY:-}
+      NO_PROXY: ${NO_PROXY:-}
+
+      # --- Storage Paths (optional, standalone installs) ---
       SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY: ${SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY:-}
       SPARKY_FITNESS_CUSTOM_BACKUP_DIRECTORY: ${SPARKY_FITNESS_CUSTOM_BACKUP_DIRECTORY:-}
-      # --- API key rate limiting (optional) ---
+
+      # --- API Key Rate Limiting (optional) ---
       SPARKY_FITNESS_API_KEY_RATELIMIT_WINDOW_MS: ${SPARKY_FITNESS_API_KEY_RATELIMIT_WINDOW_MS:-}
       SPARKY_FITNESS_API_KEY_RATELIMIT_MAX_REQUESTS: ${SPARKY_FITNESS_API_KEY_RATELIMIT_MAX_REQUESTS:-}
-      # --- Dev tools (optional) ---
+
+      # --- Dev Tools (optional) ---
       DEV_TOOLS_ENABLED: ${DEV_TOOLS_ENABLED:-false}
       PUID: 1000
       GUID: 1000

--- a/docs/content/1.install/7.environment-variables.md
+++ b/docs/content/1.install/7.environment-variables.md
@@ -16,15 +16,14 @@ The following environment variables are **mandatory** and must be supplied for t
 
 - **`SPARKY_FITNESS_DB_NAME`**: Your desired PostgreSQL database name (e.g., `sparkyfitness_db`).
 - **`SPARKY_FITNESS_DB_USER`**: Your desired PostgreSQL database user (e.g., `sparky`). This user is used for DB initialization and migrations.
-- **`SPARKY_FITNESS_DB_PASSWORD`**: A strong password for your PostgreSQL database. This shouldn't be changed after initial setup. If you need to change it, you will need to update the password in the database and update this env variable.
+- **`SPARKY_FITNESS_DB_PASSWORD`**: A strong password for your PostgreSQL database. This shouldn't be changed after initial setup. If you need to change it, you will need to update the password in the database and update this env variable. (Can also be supplied via **`SPARKY_FITNESS_DB_PASSWORD_FILE`**).
 - **`SPARKY_FITNESS_APP_DB_USER`**: Application database user with limited privileges. It can be changed any time after initialization.
-- **`SPARKY_FITNESS_APP_DB_PASSWORD`**: Password for the application database user.
+- **`SPARKY_FITNESS_APP_DB_PASSWORD`**: Password for the application database user. (Can also be supplied via **`SPARKY_FITNESS_APP_DB_PASSWORD_FILE`**).
 - **`SPARKY_FITNESS_FRONTEND_URL`**: The public URL of your frontend (e.g., `http://localhost:8080` for local testing, or your domain like `https://fitness.example.com` for production). This is crucial for CORS security.
-- **`SPARKY_FITNESS_API_ENCRYPTION_KEY`**: A 64-character hex string for data encryption. You can generate one using:
+- **`SPARKY_FITNESS_API_ENCRYPTION_KEY`**: A 64-character hex string for data encryption. (Can also be supplied via **`SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE`**). You can generate one using:
   - `openssl rand -hex 32`
   - `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
-  - **`SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE`**: (Optional) Path to a file containing the encryption key. Useful for Docker Swarm/Kubernetes secrets. When this variable is set, the application will read the encryption key from the specified file path, allowing for more secure secret management in containerized environments.
-- **`BETTER_AUTH_SECRET`**: A secret key used by Better Auth to sign sessions and tokens. Make this a long, random, and secure string. You can generate one using:
+- **`BETTER_AUTH_SECRET`**: A secret key used by Better Auth to sign sessions and tokens. (Can also be supplied via **`BETTER_AUTH_SECRET_FILE`**). Make this a long, random, and secure string. You can generate one using:
   - `openssl rand -hex 32`
   - `node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"`
   - > [!CAUTION]
@@ -159,4 +158,23 @@ These variables configure code signing, bundle identifiers, and shared App Group
 * **`IOS_APP_GROUP_DEV`**: The shared App Group identifier used to pass data between the main app and the widgets during development (defaults to `group.org.SparkyApps.SparkyFitnessMobile.dev`).
 * **`IOS_APP_GROUP_PROD`**: The shared App Group identifier used to pass data between the main app and the widgets in production (defaults to `group.com.SparkyApps.SparkyFitnessMobile.shared`).
 
+## Docker Secrets & File-Based Configuration (`*_FILE`)
 
+SparkyFitness natively supports loading sensitive configuration values from files mounted by **Docker Compose secrets**, **Docker Swarm**, or **Kubernetes**.
+
+Any backend environment variable `VAR` can be supplied via a corresponding `VAR_FILE` environment variable pointing to the mounted secret file. When `VAR_FILE` is provided and `VAR` is unset, empty, or contains only whitespace, the server automatically reads and trims the secret from the specified file on startup.
+
+### Supported Secret Variables
+
+Common variables supporting `*_FILE` include:
+
+| Environment Variable | File-Based Alternative (`*_FILE`) | Description |
+| :--- | :--- | :--- |
+| `POSTGRES_PASSWORD` | `POSTGRES_PASSWORD_FILE` | PostgreSQL container superuser password |
+| `SPARKY_FITNESS_DB_PASSWORD` | `SPARKY_FITNESS_DB_PASSWORD_FILE` | Backend database superuser password |
+| `SPARKY_FITNESS_APP_DB_PASSWORD` | `SPARKY_FITNESS_APP_DB_PASSWORD_FILE` | Application database password |
+| `SPARKY_FITNESS_API_ENCRYPTION_KEY` | `SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE` | 64-character encryption key |
+| `BETTER_AUTH_SECRET` | `BETTER_AUTH_SECRET_FILE` | Better Auth signing secret |
+| `SPARKY_FITNESS_EMAIL_PASS` | `SPARKY_FITNESS_EMAIL_PASS_FILE` | SMTP password |
+| `SPARKY_FITNESS_OIDC_CLIENT_ID` | `SPARKY_FITNESS_OIDC_CLIENT_ID_FILE` | OIDC Client ID |
+| `SPARKY_FITNESS_OIDC_CLIENT_SECRET` | `SPARKY_FITNESS_OIDC_CLIENT_SECRET_FILE` | OIDC Client Secret |


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Allows all sensitive environment variables (database passwords, API encryption key, Better Auth secret, SMTP password, OIDC credentials) to be supplied via Docker Compose secrets or file-based `*_FILE` configuration. Previously, Docker Compose failed at startup when secrets were supplied via `_FILE` instead of inline environment variables.

**How did you implement the solution?**
- Updated `secretLoader` to treat empty string / whitespace environment values as unset, preventing Compose defaults from blocking file secret resolution.
- Updated `docker-compose.prod.yml` and `docker-compose.dev.yml` to pass through `*_FILE` variables and support `POSTGRES_PASSWORD_FILE`.
- Added unit tests in `SparkyFitnessServer/tests/secretLoader.test.ts`.
- Documented file-based secret configuration in `docker/.env.example` and `docs/content/1.install/7.environment-variables.md`.

Linked Issue: Closes #2193

## How to Test

1. Run `pnpm --filter sparkyfitnessserver test tests/secretLoader.test.ts` to verify secret file loading logic and fallback behavior.
2. Run `pnpm --filter sparkyfitnessserver validate` to ensure typecheck, lint, and formatting pass.

## PR Type

- [x] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [x] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

N/A

### After

N/A

</details>

## Notes for Reviewers

No database migrations or breaking changes were introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading database, authentication, encryption, email, and OIDC secrets from files.
  * Added documented `*_FILE` options for Docker, Docker Swarm, and Kubernetes deployments.
  * Added file-based secret configuration examples for development and production.
  * Direct environment values take precedence when provided.

* **Bug Fixes**
  * Empty or whitespace-only values now fall back to configured files.
  * Secret file contents are trimmed when loaded.
  * Missing secret files generate warnings without stopping startup.
  * Improved handling of file-read errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->