### PR TITLE
fix(auth): respect request protocol for active profile cookie

### DIFF
--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -244,7 +244,7 @@ app.use(async (req, res, next) => {
       console.log(
         '[AUTH HANDLER] Manual Cleanup: Clearing sparky_active_user_id on logout'
       );
-      applySignOutCookieCleanup(res);
+      applySignOutCookieCleanup(res, req.secure);
     }
     log(
       'debug',

--- a/SparkyFitnessServer/middleware/signOutCookieCleanup.ts
+++ b/SparkyFitnessServer/middleware/signOutCookieCleanup.ts
@@ -6,10 +6,13 @@ import type { ServerResponse } from 'http';
 // merged into whatever Better Auth writes. Attributes must match those used
 // when the cookie was originally set in routes/auth/userProfileRoutes.js
 // /switch-context, otherwise some browsers won't honor the delete.
-export function applySignOutCookieCleanup(res: ServerResponse): void {
+export function applySignOutCookieCleanup(
+  res: ServerResponse,
+  isSecure = false
+): void {
   const clearCookieStr =
     'sparky_active_user_id=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; HttpOnly; SameSite=Strict' +
-    (process.env.NODE_ENV === 'production' ? '; Secure' : '');
+    (isSecure ? '; Secure' : '');
 
   const originalSetHeader = res.setHeader.bind(res);
   res.setHeader = function (

--- a/SparkyFitnessServer/routes/auth/userProfileRoutes.ts
+++ b/SparkyFitnessServer/routes/auth/userProfileRoutes.ts
@@ -127,7 +127,7 @@ router.post('/switch-context', authenticate, async (req, res, next) => {
     // Set the new active user ID in the cookie
     res.cookie('sparky_active_user_id', activeUserId, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: req.secure,
       sameSite: 'strict',
       path: '/',
     });

--- a/SparkyFitnessServer/tests/signOutCookieCleanup.test.ts
+++ b/SparkyFitnessServer/tests/signOutCookieCleanup.test.ts
@@ -21,8 +21,9 @@ function fakeBetterAuthHandler(cookies: string[]) {
 
 function buildApp(handler: (req: Request, res: Response) => void) {
   const app = express();
+  app.set('trust proxy', 1);
   app.post('/api/auth/sign-out', (req, res) => {
-    applySignOutCookieCleanup(res);
+    applySignOutCookieCleanup(res, req.secure);
     handler(req, res);
   });
   return app;
@@ -116,15 +117,17 @@ describe('applySignOutCookieCleanup', () => {
     );
   });
 
-  it('includes Secure attribute in production', async () => {
-    const prev = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
-    try {
-      const app = buildApp(fakeBetterAuthHandler([]));
-      const res = await request(app).post('/api/auth/sign-out');
-      expect(res.headers['set-cookie'][0]).toContain('Secure');
-    } finally {
-      process.env.NODE_ENV = prev;
-    }
+  it('omits Secure attribute on plain HTTP requests', async () => {
+    const app = buildApp(fakeBetterAuthHandler([]));
+    const res = await request(app).post('/api/auth/sign-out');
+    expect(res.headers['set-cookie'][0]).not.toContain('Secure');
+  });
+
+  it('includes Secure attribute on HTTPS requests', async () => {
+    const app = buildApp(fakeBetterAuthHandler([]));
+    const res = await request(app)
+      .post('/api/auth/sign-out')
+      .set('X-Forwarded-Proto', 'https');
+    expect(res.headers['set-cookie'][0]).toContain('Secure');
   });
 });

--- a/SparkyFitnessServer/tests/switchContextCookie.test.ts
+++ b/SparkyFitnessServer/tests/switchContextCookie.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'
+import request from 'supertest';
+import express, {
+  type Request,
+  type Response,
+  type NextFunction,
+} from 'express';
+import authService from '../services/authService.js';
+import errorHandler from '../middleware/errorHandler.js';
+import userProfileRoutes from '../routes/auth/userProfileRoutes.js';
+
+vi.mock('../services/authService.js', () => ({
+  default: {
+    switchUserContext: vi.fn(),
+  },
+}));
+
+vi.mock('../middleware/authMiddleware.js', () => ({
+  authenticate: (req: Request, _res: Response, next: NextFunction) => {
+    (req as Request & { authenticatedUserId: string }).authenticatedUserId =
+      'auth-user-id';
+    next();
+  },
+}));
+
+vi.mock('multer', () => {
+  const multer = () => ({
+    single: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+  });
+  multer.diskStorage = () => ({});
+  return { default: multer };
+});
+
+const app = express();
+app.set('trust proxy', 1);
+app.use(express.json());
+app.use('/api/identity', userProfileRoutes);
+app.use(errorHandler);
+
+describe('POST /api/identity/switch-context cookie security', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('omits Secure flag on plain HTTP requests', async () => {
+    // @ts-expect-error TS(2339)
+    authService.switchUserContext.mockResolvedValue({
+      activeUserId: 'target-user-id',
+    });
+
+    const res = await request(app)
+      .post('/api/identity/switch-context')
+      .send({ targetUserId: 'target-user-id' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      message: 'Context switched successfully.',
+      activeUserId: 'target-user-id',
+    });
+
+    const cookies = res.headers['set-cookie'];
+    expect(cookies).toBeDefined();
+    const cookieStr = cookies[0];
+    expect(cookieStr).toContain('sparky_active_user_id=target-user-id');
+    expect(cookieStr).toContain('HttpOnly');
+    expect(cookieStr).toContain('SameSite=Strict');
+    expect(cookieStr).toContain('Path=/');
+    expect(cookieStr).not.toContain('Secure');
+  });
+
+  it('includes Secure flag on HTTPS requests', async () => {
+    // @ts-expect-error TS(2339)
+    authService.switchUserContext.mockResolvedValue({
+      activeUserId: 'target-user-id',
+    });
+
+    const res = await request(app)
+      .post('/api/identity/switch-context')
+      .set('X-Forwarded-Proto', 'https')
+      .send({ targetUserId: 'target-user-id' });
+
+    expect(res.status).toBe(200);
+    const cookies = res.headers['set-cookie'];
+    expect(cookies).toBeDefined();
+    const cookieStr = cookies[0];
+    expect(cookieStr).toContain('sparky_active_user_id=target-user-id');
+    expect(cookieStr).toContain('Secure');
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
When running SparkyFitness over plain HTTP in production (`NODE_ENV=production`), switching user context in Family Access does not persist because the `sparky_active_user_id` cookie unconditionally had the `Secure` flag set, causing browsers to reject the cookie on insecure origins.

**How did you implement the solution?**
- Updated `POST /identity/switch-context` in `SparkyFitnessServer/routes/auth/userProfileRoutes.ts` to set `secure: req.secure` instead of `process.env.NODE_ENV === 'production'`, matching Better Auth's dynamic cookie handling.
- Updated `applySignOutCookieCleanup` in `SparkyFitnessServer/middleware/signOutCookieCleanup.ts` and `SparkyFitnessServer.ts` to clear the cookie matching the request's security context (`req.secure`).
- Added unit tests in `SparkyFitnessServer/tests/switchContextCookie.test.ts` and updated `SparkyFitnessServer/tests/signOutCookieCleanup.test.ts` to verify cookie flags over both HTTP and HTTPS.

Linked Issue: Closes #2225

## How to Test

1. Run server tests: `cd SparkyFitnessServer && pnpm test`
2. Test context switching over HTTP:
   - Call `POST /identity/switch-context` with `targetUserId`.
   - Verify `Set-Cookie: sparky_active_user_id=...` does NOT contain `Secure` on plain HTTP.
3. Test context switching over HTTPS:
   - Call `POST /identity/switch-context` with `X-Forwarded-Proto: https`.
   - Verify `Set-Cookie: sparky_active_user_id=...` contains `Secure`.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

N/A

### After

N/A

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication cookie handling based on the actual connection security.
  * Sign-out and context-switch cookies now correctly include the `Secure` attribute for HTTPS connections and omit it for HTTP connections.

* **Tests**
  * Added coverage for secure and non-secure cookie behavior during sign-out and context switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->