### PR TITLE
fix: preserve Health Connect calories and calibrate step fallback

### DIFF
--- a/SparkyFitnessMobile/AGENTS.md
+++ b/SparkyFitnessMobile/AGENTS.md
@@ -121,7 +121,7 @@ npx expo prebuild --clean
 - On iOS, cumulative metrics should use HealthKit statistics queries, not raw sample summation.
 - On Android, cumulative metrics (`Steps`, `Distance`, `ActiveCaloriesBurned`, `TotalCaloriesBurned`, `FloorsClimbed`) use Health Connect `aggregateGroupByPeriod` once per range. Native source-priority dedup should match Health Connect UI; do not reintroduce JS `Math.max` or source allowlist dedup.
 - Android read helpers return `{ records, error }` via `readHealthRecordsDetailed` and `aggregateCumulativeMetricByDayDetailed`; legacy wrappers unwrap only records.
-- Android exercise sessions are enriched with `aggregateRecord` for active/total calories and distance over the session window, scoped to `dataOrigin` and filtered for plausibility.
+- Android exercise sessions are enriched with `aggregateRecord` for active/total calories and distance over the session window. Calories stay unfiltered so Health Connect applies source priority; distance is scoped to `dataOrigin`. Both are filtered for plausibility.
 - iOS HealthKit locked-device failures surface as database-inaccessible warnings. Do not treat these as successful empty reads.
 - `app.config.ts` grants `android.permission.health.READ_HEALTH_DATA_HISTORY` so Android can read data older than 30 days.
 - Health Connect permission migrations belong in `services/shared/healthPermissionMigration.ts`, not UI-only state.

--- a/SparkyFitnessMobile/AGENTS.md
+++ b/SparkyFitnessMobile/AGENTS.md
@@ -121,7 +121,7 @@ npx expo prebuild --clean
 - On iOS, cumulative metrics should use HealthKit statistics queries, not raw sample summation.
 - On Android, cumulative metrics (`Steps`, `Distance`, `ActiveCaloriesBurned`, `TotalCaloriesBurned`, `FloorsClimbed`) use Health Connect `aggregateGroupByPeriod` once per range. Native source-priority dedup should match Health Connect UI; do not reintroduce JS `Math.max` or source allowlist dedup.
 - Android read helpers return `{ records, error }` via `readHealthRecordsDetailed` and `aggregateCumulativeMetricByDayDetailed`; legacy wrappers unwrap only records.
-- Android exercise sessions are enriched with `aggregateRecord` for active/total calories and distance over the session window. Calories stay unfiltered so Health Connect applies source priority; distance is scoped to `dataOrigin`. Both are filtered for plausibility.
+- Android exercise sessions are enriched with `aggregateRecord` for active/total calories and distance over the session window. Calories start scoped to `dataOrigin`; incomplete or implausible pairs retry without the origin filter so Health Connect can apply source priority. Distance always stays origin-scoped. Both are filtered for plausibility.
 - iOS HealthKit locked-device failures surface as database-inaccessible warnings. Do not treat these as successful empty reads.
 - `app.config.ts` grants `android.permission.health.READ_HEALTH_DATA_HISTORY` so Android can read data older than 30 days.
 - Health Connect permission migrations belong in `services/shared/healthPermissionMigration.ts`, not UI-only state.

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
@@ -1056,11 +1056,21 @@ describe('getAggregatedActiveCaloriesByDate', () => {
 
   test('does not replace a reported active-calorie aggregate', async () => {
     mockAggregateGroupByPeriod.mockImplementation(
-      ({ recordType }: { recordType: string }) => recordType === 'ActiveCaloriesBurned'
-        ? Promise.resolve([
+      ({ recordType }: { recordType: string }) => {
+        if (recordType === 'ActiveCaloriesBurned') {
+          return Promise.resolve([
             periodBucket(2024, 1, 15, { ACTIVE_CALORIES_TOTAL: { inKilocalories: 525 } }),
-          ])
-        : Promise.resolve([]),
+          ]);
+        }
+        if (recordType === 'TotalCaloriesBurned') {
+          return Promise.resolve([
+            periodBucket(2024, 1, 15, { ENERGY_TOTAL: { inKilocalories: 2400 } }),
+          ]);
+        }
+        return Promise.resolve([
+          periodBucket(2024, 1, 15, { BASAL_CALORIES_TOTAL: { inKilocalories: 1750 } }),
+        ]);
+      },
     );
 
     const result = await getAggregatedActiveCaloriesByDate(
@@ -1070,18 +1080,55 @@ describe('getAggregatedActiveCaloriesByDate', () => {
 
     expect(result[0].value).toBe(525);
     expect(result).toHaveLength(1);
-    expect(mockAggregateGroupByPeriod).toHaveBeenCalledTimes(1);
   });
 
-  test('does not derive missing dates when the active aggregate has any records', async () => {
+  test('does not query basal calories when total has no dates missing from active', async () => {
     mockAggregateGroupByPeriod.mockImplementation(
-      ({ recordType }: { recordType: string }) => recordType === 'ActiveCaloriesBurned'
-        ? Promise.resolve([
+      ({ recordType }: { recordType: string }) => {
+        if (recordType === 'ActiveCaloriesBurned') {
+          return Promise.resolve([
             periodBucket(2024, 1, 15, { ACTIVE_CALORIES_TOTAL: { inKilocalories: 525 } }),
-          ])
-        : Promise.resolve([
+          ]);
+        }
+        if (recordType === 'TotalCaloriesBurned') {
+          return Promise.resolve([
+            periodBucket(2024, 1, 15, { ENERGY_TOTAL: { inKilocalories: 2400 } }),
+          ]);
+        }
+        return Promise.reject(new Error('Basal permission denied'));
+      },
+    );
+
+    const result = await getAggregatedActiveCaloriesByDateDetailed(
+      localMidnight(2024, 1, 15),
+      localEndOfDay(2024, 1, 15),
+    );
+
+    expect(result).toEqual({
+      records: [{ date: '2024-01-15', value: 525, type: 'active_calories' }],
+    });
+    expect(mockAggregateGroupByPeriod.mock.calls.map(
+      (call: unknown[]) => (call[0] as { recordType: string }).recordType,
+    )).not.toContain('BasalMetabolicRate');
+  });
+
+  test('derives only dates missing from a partial active-calorie aggregate', async () => {
+    mockAggregateGroupByPeriod.mockImplementation(
+      ({ recordType }: { recordType: string }) => {
+        if (recordType === 'ActiveCaloriesBurned') {
+          return Promise.resolve([
+            periodBucket(2024, 1, 15, { ACTIVE_CALORIES_TOTAL: { inKilocalories: 525 } }),
+          ]);
+        }
+        if (recordType === 'TotalCaloriesBurned') {
+          return Promise.resolve([
             periodBucket(2024, 1, 16, { ENERGY_TOTAL: { inKilocalories: 2400 } }),
-          ]),
+          ]);
+        }
+        return Promise.resolve([
+          periodBucket(2024, 1, 16, { BASAL_CALORIES_TOTAL: { inKilocalories: 1750 } }),
+        ]);
+      },
     );
 
     const result = await getAggregatedActiveCaloriesByDate(
@@ -1091,8 +1138,8 @@ describe('getAggregatedActiveCaloriesByDate', () => {
 
     expect(result).toEqual([
       { date: '2024-01-15', value: 525, type: 'active_calories' },
+      { date: '2024-01-16', value: 650, type: 'active_calories' },
     ]);
-    expect(mockAggregateGroupByPeriod).toHaveBeenCalledTimes(1);
   });
 
   test('propagates an active-read error even when fallback rows are derived', async () => {
@@ -1295,17 +1342,43 @@ describe('enrichExerciseSessions', () => {
     expect(mockAggregateRecord).not.toHaveBeenCalled();
   });
 
-  test('issues all three aggregates in parallel with the same dataOriginFilter', async () => {
+  test('lets Health Connect resolve calorie sources while keeping distance scoped to the session origin', async () => {
     mockAggregateRecord.mockResolvedValue({});
 
     await enrichExerciseSessions([makeSession({ metadata: { dataOrigin: 'com.ohealth' } })], createTelemetryRunContext());
 
-    const recordTypes = mockAggregateRecord.mock.calls.map((c: unknown[]) => (c[0] as { recordType: string }).recordType);
-    expect(recordTypes).toHaveLength(3);
-    expect(recordTypes).toEqual(expect.arrayContaining(['ActiveCaloriesBurned', 'TotalCaloriesBurned', 'Distance']));
-    for (const call of mockAggregateRecord.mock.calls) {
-      expect(call[0].dataOriginFilter).toEqual(['com.ohealth']);
-    }
+    const requests = mockAggregateRecord.mock.calls.map((call: unknown[]) => call[0] as {
+      recordType: string;
+      dataOriginFilter?: string[];
+    });
+    expect(requests).toHaveLength(3);
+    expect(requests.find(request => request.recordType === 'ActiveCaloriesBurned')?.dataOriginFilter).toBeUndefined();
+    expect(requests.find(request => request.recordType === 'TotalCaloriesBurned')?.dataOriginFilter).toBeUndefined();
+    expect(requests.find(request => request.recordType === 'Distance')?.dataOriginFilter).toEqual(['com.ohealth']);
+  });
+
+  test('uses a higher-priority calorie source for a Hevy exercise session', async () => {
+    mockAggregateRecord.mockImplementation((request: { recordType: string; dataOriginFilter?: string[] }) => {
+      if (request.recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 50 } });
+      }
+      if (request.recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve(request.dataOriginFilter
+          ? {}
+          : { ENERGY_TOTAL: { inKilocalories: 307 } });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await enrichExerciseSessions([
+      makeSession({
+        startTime: '2024-01-15T10:00:00Z',
+        endTime: '2024-01-15T10:40:00Z',
+        metadata: { dataOrigin: 'app.hevy' },
+      }),
+    ], createTelemetryRunContext());
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 307 });
   });
 
   test('prefers TotalCaloriesBurned when ActiveCaloriesBurned is a tiny passive fragment (issue #1296: 41-min walk)', async () => {

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
@@ -1137,6 +1137,32 @@ describe('getAggregatedActiveCaloriesByDate', () => {
     });
   });
 
+  test('surfaces a total-calorie error when native active coverage is only partial', async () => {
+    mockAggregateGroupByPeriod.mockImplementation(
+      ({ recordType }: { recordType: string }) => {
+        if (recordType === 'ActiveCaloriesBurned') {
+          return Promise.resolve([
+            periodBucket(2024, 1, 15, { ACTIVE_CALORIES_TOTAL: { inKilocalories: 525 } }),
+          ]);
+        }
+        if (recordType === 'TotalCaloriesBurned') {
+          return Promise.reject(new Error('Total read failed'));
+        }
+        return Promise.resolve([]);
+      },
+    );
+
+    const result = await getAggregatedActiveCaloriesByDateDetailed(
+      localMidnight(2024, 1, 15),
+      localEndOfDay(2024, 1, 16),
+    );
+
+    expect(result.records).toEqual([
+      { date: '2024-01-15', value: 525, type: 'active_calories' },
+    ]);
+    expect(result.error).toContain('Total read failed');
+  });
+
   test('derives only dates missing from a partial active-calorie aggregate', async () => {
     mockAggregateGroupByPeriod.mockImplementation(
       ({ recordType }: { recordType: string }) => {
@@ -1472,6 +1498,32 @@ describe('enrichExerciseSessions', () => {
     expect(calorieRequests.slice(2).every(
       request => request.dataOriginFilter == null,
     )).toBe(true);
+  });
+
+  test('rejects scoped active calories above total and retries across origins', async () => {
+    mockAggregateRecord.mockImplementation((request: { recordType: string; dataOriginFilter?: string[] }) => {
+      if (request.recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({
+          ACTIVE_CALORIES_TOTAL: { inKilocalories: request.dataOriginFilter ? 400 : 320 },
+        });
+      }
+      if (request.recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({
+          ENERGY_TOTAL: { inKilocalories: request.dataOriginFilter ? 300 : 350 },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await enrichExerciseSessions([
+      makeSession({ metadata: { dataOrigin: 'app.hevy' } }),
+    ], createTelemetryRunContext());
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 320 });
+    const calorieRequests = mockAggregateRecord.mock.calls
+      .map((call: unknown[]) => call[0] as { recordType: string; dataOriginFilter?: string[] })
+      .filter(request => request.recordType !== 'Distance');
+    expect(calorieRequests).toHaveLength(4);
   });
 
   test('prefers TotalCaloriesBurned when ActiveCaloriesBurned is a tiny passive fragment (issue #1296: 41-min walk)', async () => {

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
@@ -1112,6 +1112,31 @@ describe('getAggregatedActiveCaloriesByDate', () => {
     )).not.toContain('BasalMetabolicRate');
   });
 
+  test('does not surface an optional total-calorie error after the native active read succeeds', async () => {
+    mockAggregateGroupByPeriod.mockImplementation(
+      ({ recordType }: { recordType: string }) => {
+        if (recordType === 'ActiveCaloriesBurned') {
+          return Promise.resolve([
+            periodBucket(2024, 1, 15, { ACTIVE_CALORIES_TOTAL: { inKilocalories: 525 } }),
+          ]);
+        }
+        if (recordType === 'TotalCaloriesBurned') {
+          return Promise.reject(new Error('Total permission denied'));
+        }
+        return Promise.resolve([]);
+      },
+    );
+
+    const result = await getAggregatedActiveCaloriesByDateDetailed(
+      localMidnight(2024, 1, 15),
+      localEndOfDay(2024, 1, 15),
+    );
+
+    expect(result).toEqual({
+      records: [{ date: '2024-01-15', value: 525, type: 'active_calories' }],
+    });
+  });
+
   test('derives only dates missing from a partial active-calorie aggregate', async () => {
     mockAggregateGroupByPeriod.mockImplementation(
       ({ recordType }: { recordType: string }) => {
@@ -1342,22 +1367,37 @@ describe('enrichExerciseSessions', () => {
     expect(mockAggregateRecord).not.toHaveBeenCalled();
   });
 
-  test('lets Health Connect resolve calorie sources while keeping distance scoped to the session origin', async () => {
-    mockAggregateRecord.mockResolvedValue({});
+  test('keeps complete calorie and distance aggregates scoped to the session origin', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 300 } });
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 350 } });
+      }
+      return Promise.resolve({ DISTANCE: { inMeters: 5000 } });
+    });
 
-    await enrichExerciseSessions([makeSession({ metadata: { dataOrigin: 'com.ohealth' } })], createTelemetryRunContext());
+    const result = await enrichExerciseSessions(
+      [makeSession({ metadata: { dataOrigin: 'com.ohealth' } })],
+      createTelemetryRunContext(),
+    );
 
     const requests = mockAggregateRecord.mock.calls.map((call: unknown[]) => call[0] as {
       recordType: string;
       dataOriginFilter?: string[];
     });
     expect(requests).toHaveLength(3);
-    expect(requests.find(request => request.recordType === 'ActiveCaloriesBurned')?.dataOriginFilter).toBeUndefined();
-    expect(requests.find(request => request.recordType === 'TotalCaloriesBurned')?.dataOriginFilter).toBeUndefined();
-    expect(requests.find(request => request.recordType === 'Distance')?.dataOriginFilter).toEqual(['com.ohealth']);
+    expect(requests.every(request =>
+      request.dataOriginFilter?.[0] === 'com.ohealth',
+    )).toBe(true);
+    expect(result[0]).toMatchObject({
+      energy: { inKilocalories: 300 },
+      distance: { inMeters: 5000 },
+    });
   });
 
-  test('uses a higher-priority calorie source for a Hevy exercise session', async () => {
+  test('uses cross-origin calories when the Hevy-scoped pair is incomplete', async () => {
     mockAggregateRecord.mockImplementation((request: { recordType: string; dataOriginFilter?: string[] }) => {
       if (request.recordType === 'ActiveCaloriesBurned') {
         return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 50 } });
@@ -1379,6 +1419,59 @@ describe('enrichExerciseSessions', () => {
     ], createTelemetryRunContext());
 
     expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 307 });
+    const calorieRequests = mockAggregateRecord.mock.calls
+      .map((call: unknown[]) => call[0] as { recordType: string; dataOriginFilter?: string[] })
+      .filter(request => request.recordType !== 'Distance');
+    expect(calorieRequests).toEqual([
+      expect.objectContaining({
+        recordType: 'ActiveCaloriesBurned',
+        dataOriginFilter: ['app.hevy'],
+      }),
+      expect.objectContaining({
+        recordType: 'TotalCaloriesBurned',
+        dataOriginFilter: ['app.hevy'],
+      }),
+      expect.objectContaining({ recordType: 'ActiveCaloriesBurned' }),
+      expect.objectContaining({ recordType: 'TotalCaloriesBurned' }),
+    ]);
+    expect(calorieRequests[2]).not.toHaveProperty('dataOriginFilter');
+    expect(calorieRequests[3]).not.toHaveProperty('dataOriginFilter');
+  });
+
+  test('uses cross-origin calories when the scoped pair fails the session ratio check', async () => {
+    mockAggregateRecord.mockImplementation((request: { recordType: string; dataOriginFilter?: string[] }) => {
+      if (request.recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({
+          ACTIVE_CALORIES_TOTAL: { inKilocalories: request.dataOriginFilter ? 20 : 45 },
+        });
+      }
+      if (request.recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({
+          ENERGY_TOTAL: { inKilocalories: request.dataOriginFilter ? 150 : 307 },
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await enrichExerciseSessions([
+      makeSession({
+        startTime: '2024-01-15T10:00:00Z',
+        endTime: '2024-01-15T10:40:00Z',
+        metadata: { dataOrigin: 'app.hevy' },
+      }),
+    ], createTelemetryRunContext());
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 307 });
+    const calorieRequests = mockAggregateRecord.mock.calls
+      .map((call: unknown[]) => call[0] as { recordType: string; dataOriginFilter?: string[] })
+      .filter(request => request.recordType !== 'Distance');
+    expect(calorieRequests).toHaveLength(4);
+    expect(calorieRequests.slice(0, 2).every(
+      request => request.dataOriginFilter?.[0] === 'app.hevy',
+    )).toBe(true);
+    expect(calorieRequests.slice(2).every(
+      request => request.dataOriginFilter == null,
+    )).toBe(true);
   });
 
   test('prefers TotalCaloriesBurned when ActiveCaloriesBurned is a tiny passive fragment (issue #1296: 41-min walk)', async () => {

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/provider.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/provider.test.ts
@@ -87,8 +87,8 @@ describe('healthconnect provider', () => {
 
     test('enriches exercise sessions with native calories and distance aggregates', async () => {
       // enrichExerciseSessions aggregates ActiveCalories/TotalCalories/Distance over
-      // each session window (scoped to its dataOrigin) and attaches the selected,
-      // plausibility-checked values back onto the record.
+      // each session window and attaches the selected, plausibility-checked values
+      // back onto the record.
       const sessionStart = '2026-07-02T08:00:00.000Z';
       const sessionEnd = '2026-07-02T09:00:00.000Z'; // 1h session
       const records = [
@@ -111,9 +111,14 @@ describe('healthconnect provider', () => {
         energy: { inKilocalories: 400 },
         distance: { inMeters: 8000 },
       });
-      // Aggregates are scoped to the session window and its data origin.
+      // Health Connect resolves calorie source priority across origins. Distance
+      // remains scoped so a concurrent activity cannot donate its route length.
       expect(mockAggregateRecord).toHaveBeenCalledWith(expect.objectContaining({
         recordType: 'ActiveCaloriesBurned',
+        timeRangeFilter: { operator: 'between', startTime: sessionStart, endTime: sessionEnd },
+      }));
+      expect(mockAggregateRecord).toHaveBeenCalledWith(expect.objectContaining({
+        recordType: 'Distance',
         timeRangeFilter: { operator: 'between', startTime: sessionStart, endTime: sessionEnd },
         dataOriginFilter: ['com.example.app'],
       }));

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/provider.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/provider.test.ts
@@ -111,11 +111,12 @@ describe('healthconnect provider', () => {
         energy: { inKilocalories: 400 },
         distance: { inMeters: 8000 },
       });
-      // Health Connect resolves calorie source priority across origins. Distance
-      // remains scoped so a concurrent activity cannot donate its route length.
+      // The first pass is scoped to the session origin. Cross-origin calorie
+      // source priority is only used when that scoped pair needs a fallback.
       expect(mockAggregateRecord).toHaveBeenCalledWith(expect.objectContaining({
         recordType: 'ActiveCaloriesBurned',
         timeRangeFilter: { operator: 'between', startTime: sessionStart, endTime: sessionEnd },
+        dataOriginFilter: ['com.example.app'],
       }));
       expect(mockAggregateRecord).toHaveBeenCalledWith(expect.objectContaining({
         recordType: 'Distance',

--- a/SparkyFitnessMobile/src/services/healthconnect/index.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/index.ts
@@ -1077,7 +1077,13 @@ export const getAggregatedActiveCaloriesByDateDetailed = async (
   if (derivedRecords.length > 0) {
     addLog('[HealthConnectService] Derived missing active-calorie days from total minus basal calories', 'DEBUG');
   }
-  const fallbackDependedOnTotal = activeResult.records.length === 0 || fallbackTotals.length > 0;
+  const expectedDayCount = Math.max(
+    0,
+    dayIndexSpan(wallClockParts(startDate), endDate) + 1,
+  );
+  const activeDayCount = new Set(activeResult.records.map(record => record.date)).size;
+  const activeCoversFullRange = activeDayCount >= expectedDayCount;
+  const fallbackDependedOnTotal = !activeCoversFullRange || fallbackTotals.length > 0;
   const totalError = fallbackDependedOnTotal ? totalResult.error : undefined;
   const error = activeResult.error ?? totalError ?? basalError;
   const records = [...activeResult.records, ...derivedRecords]
@@ -1175,6 +1181,7 @@ const activeCaloriesPassSessionCheck = (
   total: number,
   durationMs: number,
 ): boolean => {
+  if (active > total) return false;
   const ratio = active / total;
   const durationMinutes = durationMs / 60_000;
   const delta = total - active;

--- a/SparkyFitnessMobile/src/services/healthconnect/index.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/index.ts
@@ -1077,7 +1077,9 @@ export const getAggregatedActiveCaloriesByDateDetailed = async (
   if (derivedRecords.length > 0) {
     addLog('[HealthConnectService] Derived missing active-calorie days from total minus basal calories', 'DEBUG');
   }
-  const error = activeResult.error ?? totalResult.error ?? basalError;
+  const fallbackDependedOnTotal = activeResult.records.length === 0 || fallbackTotals.length > 0;
+  const totalError = fallbackDependedOnTotal ? totalResult.error : undefined;
+  const error = activeResult.error ?? totalError ?? basalError;
   const records = [...activeResult.records, ...derivedRecords]
     .sort((a, b) => a.date.localeCompare(b.date));
   return { records, ...(error ? { error } : {}) };
@@ -1165,6 +1167,21 @@ const MIN_DISTANCE_FOR_LONG_SESSION_M = 100;
 const CALORIE_ACTIVE_RATIO_MIN = 0.5;
 const CALORIE_BMR_KCAL_PER_MIN_CAP = 2;
 
+const isPositiveCalories = (value: number | undefined): value is number =>
+  value != null && value > 0;
+
+const activeCaloriesPassSessionCheck = (
+  active: number,
+  total: number,
+  durationMs: number,
+): boolean => {
+  const ratio = active / total;
+  const durationMinutes = durationMs / 60_000;
+  const delta = total - active;
+  const bmrCap = durationMinutes * CALORIE_BMR_KCAL_PER_MIN_CAP;
+  return ratio >= CALORIE_ACTIVE_RATIO_MIN || delta <= bmrCap;
+};
+
 /**
  * Picks the session calorie value from the Active/Total pair.
  * Treats 0 and undefined as "missing" (Android bridge returns 0.0 for empty ranges).
@@ -1180,23 +1197,44 @@ export const selectSessionCalories = (
   total: number | undefined,
   durationMs: number,
 ): number | undefined => {
-  const activeValid = active != null && active > 0 ? active : undefined;
-  const totalValid = total != null && total > 0 ? total : undefined;
+  const activeValid = isPositiveCalories(active) ? active : undefined;
+  const totalValid = isPositiveCalories(total) ? total : undefined;
 
   if (activeValid == null && totalValid == null) return undefined;
   if (activeValid == null) return totalValid;
   if (totalValid == null) return activeValid;
 
-  const ratio = activeValid / totalValid;
-  const durationMinutes = durationMs / 60_000;
-  const delta = totalValid - activeValid;
-  const bmrCap = durationMinutes * CALORIE_BMR_KCAL_PER_MIN_CAP;
-
-  if (ratio >= CALORIE_ACTIVE_RATIO_MIN || delta <= bmrCap) {
+  if (activeCaloriesPassSessionCheck(activeValid, totalValid, durationMs)) {
     return activeValid;
   }
   return totalValid;
 };
+
+const shouldTryCrossOriginCalories = (
+  active: number | undefined,
+  total: number | undefined,
+  durationMs: number,
+): boolean => {
+  if (!isPositiveCalories(active) || !isPositiveCalories(total)) return true;
+  return !activeCaloriesPassSessionCheck(active, total, durationMs);
+};
+
+type SessionCaloriePair = {
+  active?: number;
+  total?: number;
+};
+
+const extractSessionCaloriePair = (
+  activeResult: PromiseSettledResult<unknown>,
+  totalResult: PromiseSettledResult<unknown>,
+): SessionCaloriePair => ({
+  active: activeResult.status === 'fulfilled'
+    ? (activeResult.value as { ACTIVE_CALORIES_TOTAL?: { inKilocalories?: number } }).ACTIVE_CALORIES_TOTAL?.inKilocalories
+    : undefined,
+  total: totalResult.status === 'fulfilled'
+    ? (totalResult.value as { ENERGY_TOTAL?: { inKilocalories?: number } }).ENERGY_TOTAL?.inKilocalories
+    : undefined,
+});
 
 /**
  * Distance is plausible unless the session is long enough that a real workout
@@ -1286,19 +1324,21 @@ export const enrichExerciseSessions = async (
       return record;
     }
 
-    // Leave calorie aggregates unfiltered so Health Connect can apply the user's
-    // Activity-data source priority. For example, Hevy may own the session while
-    // Samsung Health owns the more complete calorie total for the same window.
-    // Distance remains scoped to the session origin to avoid attaching another
-    // concurrent activity's route distance to this workout.
+    // Start with the session origin, matching Health Connect's associated-session
+    // guidance and preventing another concurrent activity from donating energy or
+    // distance. If that origin has an incomplete or implausible calorie pair, retry
+    // calories without an origin filter so Health Connect can apply the user's
+    // Activity source priority (for example, Hevy session + Samsung calories).
     const [activeCaloriesResult, totalCaloriesResult, distanceResult] = await Promise.allSettled([
       aggregateRecord({
         recordType: 'ActiveCaloriesBurned',
         timeRangeFilter,
+        dataOriginFilter,
       }),
       aggregateRecord({
         recordType: 'TotalCaloriesBurned',
         timeRangeFilter,
+        dataOriginFilter,
       }),
       aggregateRecord({
         recordType: 'Distance',
@@ -1312,14 +1352,37 @@ export const enrichExerciseSessions = async (
     // overwrite potentially valid data with a synthetic zero.
     const enrichedFields: Record<string, unknown> = {};
 
-    const active = activeCaloriesResult.status === 'fulfilled'
-      ? (activeCaloriesResult.value as { ACTIVE_CALORIES_TOTAL?: { inKilocalories?: number } }).ACTIVE_CALORIES_TOTAL?.inKilocalories
-      : undefined;
-    const total = totalCaloriesResult.status === 'fulfilled'
-      ? (totalCaloriesResult.value as { ENERGY_TOTAL?: { inKilocalories?: number } }).ENERGY_TOTAL?.inKilocalories
-      : undefined;
+    const scopedCalories = extractSessionCaloriePair(activeCaloriesResult, totalCaloriesResult);
+    let kcal = selectSessionCalories(scopedCalories.active, scopedCalories.total, durationMs);
+    if (dataOriginFilter && shouldTryCrossOriginCalories(
+      scopedCalories.active,
+      scopedCalories.total,
+      durationMs,
+    )) {
+      const [unfilteredActiveResult, unfilteredTotalResult] = await Promise.allSettled([
+        aggregateRecord({
+          recordType: 'ActiveCaloriesBurned',
+          timeRangeFilter,
+        }),
+        aggregateRecord({
+          recordType: 'TotalCaloriesBurned',
+          timeRangeFilter,
+        }),
+      ]);
+      const unfilteredCalories = extractSessionCaloriePair(
+        unfilteredActiveResult,
+        unfilteredTotalResult,
+      );
+      const unfilteredKcal = selectSessionCalories(
+        unfilteredCalories.active,
+        unfilteredCalories.total,
+        durationMs,
+      );
+      if (unfilteredKcal != null && (kcal == null || unfilteredKcal > kcal)) {
+        kcal = unfilteredKcal;
+      }
+    }
 
-    const kcal = selectSessionCalories(active, total, durationMs);
     if (kcal != null) {
       enrichedFields.energy = { inKilocalories: kcal };
     }

--- a/SparkyFitnessMobile/src/services/healthconnect/index.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/index.ts
@@ -1043,39 +1043,44 @@ const getAggregatedBasalCaloriesByDateDetailed = (
     endDate,
   );
 
-/** Prefer reported active energy; derive total minus basal only when absent. */
+/** Prefer reported active energy per day; derive total minus basal only for missing days. */
 export const getAggregatedActiveCaloriesByDateDetailed = async (
   startDate: Date,
   endDate: Date,
 ): Promise<HealthConnectAggregateResult> => {
-  const activeResult = await getNativeActiveCaloriesByDateDetailed(startDate, endDate);
-  if (activeResult.records.length > 0) {
-    return activeResult;
-  }
-
-  const [totalResult, basalResult] = await Promise.all([
+  const [activeResult, totalResult] = await Promise.all([
+    getNativeActiveCaloriesByDateDetailed(startDate, endDate),
     getAggregatedTotalCaloriesByDateDetailed(startDate, endDate),
-    getAggregatedBasalCaloriesByDateDetailed(startDate, endDate),
   ]);
 
-  const basalByDate = new Map(basalResult.records.map(record => [record.date, record.value]));
-  const derivedRecords = totalResult.records.flatMap(totalRecord => {
-    const basal = basalByDate.get(totalRecord.date);
-    if (basal == null) return [];
-    const derived = deriveActiveCalories(totalRecord.value, basal);
-    if (derived == null) return [];
-    return [{
-      ...totalRecord,
-      value: Math.round(derived),
-      type: 'active_calories',
-    }];
-  });
+  const activeDates = new Set(activeResult.records.map(record => record.date));
+  const fallbackTotals = totalResult.records.filter(record => !activeDates.has(record.date));
+  let derivedRecords: AggregatedHealthRecord[] = [];
+  let basalError: string | undefined;
+  if (fallbackTotals.length > 0) {
+    const basalResult = await getAggregatedBasalCaloriesByDateDetailed(startDate, endDate);
+    basalError = basalResult.error;
+    const basalByDate = new Map(basalResult.records.map(record => [record.date, record.value]));
+    derivedRecords = fallbackTotals.flatMap(totalRecord => {
+      const basal = basalByDate.get(totalRecord.date);
+      if (basal == null) return [];
+      const derived = deriveActiveCalories(totalRecord.value, basal);
+      if (derived == null) return [];
+      return [{
+        ...totalRecord,
+        value: Math.round(derived),
+        type: 'active_calories',
+      }];
+    });
+  }
 
   if (derivedRecords.length > 0) {
-    addLog('[HealthConnectService] Active calorie aggregate missing; derived fallback from total minus basal calories', 'DEBUG');
+    addLog('[HealthConnectService] Derived missing active-calorie days from total minus basal calories', 'DEBUG');
   }
-  const error = activeResult.error ?? totalResult.error ?? basalResult.error;
-  return { records: derivedRecords, ...(error ? { error } : {}) };
+  const error = activeResult.error ?? totalResult.error ?? basalError;
+  const records = [...activeResult.records, ...derivedRecords]
+    .sort((a, b) => a.date.localeCompare(b.date));
+  return { records, ...(error ? { error } : {}) };
 };
 
 export const getAggregatedActiveCaloriesByDate = (
@@ -1281,16 +1286,19 @@ export const enrichExerciseSessions = async (
       return record;
     }
 
+    // Leave calorie aggregates unfiltered so Health Connect can apply the user's
+    // Activity-data source priority. For example, Hevy may own the session while
+    // Samsung Health owns the more complete calorie total for the same window.
+    // Distance remains scoped to the session origin to avoid attaching another
+    // concurrent activity's route distance to this workout.
     const [activeCaloriesResult, totalCaloriesResult, distanceResult] = await Promise.allSettled([
       aggregateRecord({
         recordType: 'ActiveCaloriesBurned',
         timeRangeFilter,
-        dataOriginFilter,
       }),
       aggregateRecord({
         recordType: 'TotalCaloriesBurned',
         timeRangeFilter,
-        dataOriginFilter,
       }),
       aggregateRecord({
         recordType: 'Distance',

--- a/SparkyFitnessMobile/src/services/healthconnect/provider.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/provider.ts
@@ -62,7 +62,8 @@ export const readMinMaxAvgByDay = async (
 /**
  * Platform massaging of non-empty raw reads before transform. Exercise sessions
  * are enriched with active/total calories and distance via native aggregateRecord
- * over the session window, scoped to the session's data origin.
+ * over the session window. Health Connect resolves calorie source priority across
+ * origins; distance stays scoped to the session's data origin.
  */
 export const postProcessRaw = async (
   metric: Pick<HealthMetric, 'recordType'>,

--- a/SparkyFitnessMobile/src/services/healthconnect/provider.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/provider.ts
@@ -62,8 +62,9 @@ export const readMinMaxAvgByDay = async (
 /**
  * Platform massaging of non-empty raw reads before transform. Exercise sessions
  * are enriched with active/total calories and distance via native aggregateRecord
- * over the session window. Health Connect resolves calorie source priority across
- * origins; distance stays scoped to the session's data origin.
+ * over the session window. Reads start at the session's data origin; incomplete
+ * or implausible calorie pairs retry across origins so Health Connect can apply
+ * source priority. Distance always stays scoped to the session origin.
  */
 export const postProcessRaw = async (
   metric: Pick<HealthMetric, 'recordType'>,

--- a/SparkyFitnessServer/tests/calorieCalculations.test.ts
+++ b/SparkyFitnessServer/tests/calorieCalculations.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest';
+import {
+  CALORIE_CALCULATION_CONSTANTS,
+  computeStepCalories,
+} from '@workspace/shared';
+
+describe('computeStepCalories', () => {
+  test('keeps the shipped stride-multiplier property available', () => {
+    expect(CALORIE_CALCULATION_CONSTANTS.STRIDE_LENGTH_MULTIPLIER).toBe(0.414);
+  });
+
+  test('uses measured net walking cost for a 40,000-step day', () => {
+    // 40,000 steps × (175 cm × 0.414) = 28.98 km. At 70 kg and the
+    // measured mean net walking cost of 0.53 kcal/kg/km, that is 1,075 kcal.
+    expect(
+      computeStepCalories({
+        backgroundSteps: 40000,
+        weightKg: 70,
+        heightCm: 175,
+      })
+    ).toBe(1075);
+  });
+
+  test('scales net walking calories with body mass', () => {
+    const lighter = computeStepCalories({
+      backgroundSteps: 10000,
+      weightKg: 60,
+      heightCm: 175,
+    });
+    const heavier = computeStepCalories({
+      backgroundSteps: 10000,
+      weightKg: 90,
+      heightCm: 175,
+    });
+
+    expect(lighter).toBe(230);
+    expect(heavier).toBe(346);
+  });
+});

--- a/SparkyFitnessServer/tests/dailySummaryRangeService.test.ts
+++ b/SparkyFitnessServer/tests/dailySummaryRangeService.test.ts
@@ -93,7 +93,7 @@ const FIXTURE = {
     activitySteps: 0,
     steps: 0,
   },
-  // 5,786 steps at 80kg/180cm is 138 kcal, so logged + steps = 779 and just edges out
+  // 5,786 steps at 80kg/180cm is 183 kcal, so logged + steps = 824 and edges out
   // the 774 kcal device summary — exactly the reporter's Aug 11.
   '2026-08-11': {
     eaten: 2477,
@@ -252,15 +252,15 @@ describe('parity with the per-date Diary path', () => {
     }
   );
 
-  test('the Aug 11 row credits 779, not 1415', async () => {
+  test('the Aug 11 row credits 824, not 1415', async () => {
     const { days } = await runRange();
     const row = days.find((entry) => entry.date === '2026-08-11');
 
     // max(774, 641 + steps), never 641 + 774.
-    expect(row?.burned).toBe(779);
+    expect(row?.burned).toBe(824);
     expect(row?.burned).not.toBe(1415);
     // The identity the Reports chart uses to turn `remaining` back into a goal.
-    expect(row!.eaten + row!.remaining).toBe(GOAL + 779);
+    expect(row!.eaten + row!.remaining).toBe(GOAL + 824);
   });
 
   test('the steps-only day is credited rather than zeroed', async () => {

--- a/SparkyFitnessServer/tests/exerciseCalorieRangeService.test.ts
+++ b/SparkyFitnessServer/tests/exerciseCalorieRangeService.test.ts
@@ -72,9 +72,9 @@ describe('getResolvedExerciseCaloriesRange', () => {
       await getResolvedExerciseCaloriesRange(USER, '2026-08-20', '2026-08-20')
     ).get('2026-08-20');
 
-    // 5,786 background steps at 80kg/180cm is 138 kcal, so 150 + 138 beats 18.
-    expect(day?.stepCalories).toBe(138);
-    expect(day?.calories).toBe(288);
+    // 5,786 background steps at 80kg/180cm is 183 kcal, so 150 + 183 beats 18.
+    expect(day?.stepCalories).toBe(183);
+    expect(day?.calories).toBe(333);
     expect(day?.source).toBe('logged');
   });
 

--- a/shared/src/constants/calorieConstants.ts
+++ b/shared/src/constants/calorieConstants.ts
@@ -7,8 +7,12 @@ export const CALORIE_CALCULATION_CONSTANTS = {
   DEFAULT_HEIGHT_CM: 175,
 
   // Conversion constants
-  STRIDE_LENGTH_MULTIPLIER: 0.414, // Avg multiplier for height to stride length
-  NET_CALORIES_PER_KG_PER_KM: 0.4, // Net calories burned per kg per km (above BMR)
+  // Kept under its shipped name for API compatibility; the value represents
+  // average step length (one footfall), not a two-step gait cycle.
+  STRIDE_LENGTH_MULTIPLIER: 0.414,
+  // Mean net walking cost at 1.34 m/s: 2.22 J/kg/m = 0.53 kcal/kg/km.
+  // DOI: 10.14814/phy2.16023. Net cost avoids counting resting energy twice.
+  NET_CALORIES_PER_KG_PER_KM: 0.53,
 
   // Day projection constants
   MIN_DAY_FRACTION: 0.05, // 5% of the day (~72 min)

--- a/shared/src/utils/calorieCalculations.ts
+++ b/shared/src/utils/calorieCalculations.ts
@@ -91,9 +91,10 @@ export interface StepCalorieInputs {
 /**
  * Net (above-BMR) kcal from background walking, estimated from step count.
  *
- * Stride length is approximated from height, distance from stride × steps, and energy
- * from distance × body weight. The per-kg-per-km figure is deliberately conservative
- * because these are incidental steps, not a workout.
+ * Step length is approximated from height, distance from step length × steps, and energy
+ * from distance × body weight. The per-kg-per-km figure is the measured mean net cost
+ * of level walking at a normal pace. Net cost excludes resting energy because the daily
+ * calorie balance accounts for BMR separately.
  *
  * Shared because this arithmetic has to agree in four places that each used to carry
  * their own copy: the Diary's per-date step calories, the ranged Reports path, the
@@ -108,9 +109,9 @@ export function computeStepCalories({
 }: StepCalorieInputs): number {
   if (!Number.isFinite(backgroundSteps) || backgroundSteps <= 0) return 0;
 
-  const strideLengthM =
+  const stepLengthM =
     (heightCm * CALORIE_CALCULATION_CONSTANTS.STRIDE_LENGTH_MULTIPLIER) / 100;
-  const distanceKm = (backgroundSteps * strideLengthM) / 1000;
+  const distanceKm = (backgroundSteps * stepLengthM) / 1000;
 
   return Math.round(
     distanceKm *


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Health Connect calories can remain far below Samsung Health in v1.6.3: partial multi-day active-calorie reads skip fallback dates, and Hevy-owned sessions hide more complete Samsung calorie aggregates. The step-only fallback also uses an unsupported low net walking-cost coefficient.

**How did you implement the solution?**
Merge native active calories per date and derive only missing dates from total minus basal. Start session calorie aggregates at the session origin. Retry calories without an origin filter only when the scoped pair is incomplete or fails the existing plausibility selector, while distance stays origin-scoped. Calibrate the step fallback to the measured mean net walking cost of 0.53 kcal/kg/km and preserve the exported constant API.

Linked Issue: Closes #2233

## How to Test

1. In SparkyFitnessMobile, run pnpm run validate.
2. Run the eight Health Connect/sync Jest suites listed in the PR checks; all 329 tests should pass.
3. In SparkyFitnessServer, run the step-calculation, exercise-calorie range, daily-summary range, and dashboard tests; all 29 tests should pass.
4. On Android, sync a Hevy session whose Samsung Health calorie aggregate is higher and verify the Health Connect-prioritized value is imported.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (SparkyFitnessFrontend/):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run pnpm run validate and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (en) translation file.

**Backend changes (SparkyFitnessServer/):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated rls_policies.sql for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (SparkyFitnessMobile/):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

Not applicable; no UI changes.

## Notes for Reviewers

- Release note: the step-only fallback now uses 0.53 instead of 0.4 kcal/kg/km (+32.5%). Users without native active-calorie data can therefore see higher burned calories, including recalculated historic Reports rows.
- The step coefficient is a fallback only. Native Health Connect active calories remain preferred.
- 0.53 kcal/kg/km is the rounded conversion of the measured mean net cost 2.22 J/kg/m in 205 adults: https://doi.org/10.14814/phy2.16023
- The resolver still selects the larger complete source instead of adding device active calories to workout plus step calories, preventing double counting.
- Partial native Active coverage now propagates Total read failures, and scoped active values above total are retried across origins; both edge cases have regression coverage.
- Android emulator build, install, launch, and fatal-log checks pass; a Samsung Health/Hevy real-device source-priority check remains recommended.
- Integrity and license were reviewed and certified before merge handoff.
- Final CI on b62c82fd: Mobile Tests, Server Tests, GitGuardian, CodeRabbit, and the authorized PR validation all passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Health Connect calorie enrichment by preserving reported active calories and filling only missing daily values.
  * Added reliable fallback across Health Connect sources when calorie data is incomplete or inconsistent.
  * Kept exercise distance tied to the relevant session source.
  * Updated step-calorie calculations for more accurate daily totals and energy estimates.

* **Tests**
  * Expanded coverage for calorie fallbacks, source prioritization, distance filtering, body-mass scaling, and daily summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
