### PR TITLE
fix: relevance-ranked OpenFoodFacts search with hydrated results

### DIFF
--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -14,6 +14,7 @@ import {
 const { name, version } = package$0;
 const USER_AGENT = `${name}/${version} (https://github.com/CodeWithCJ/SparkyFitness)`;
 const SEARCH_A_LICIOUS_URL = 'https://search.openfoodfacts.org/search';
+const SEARCH_A_LICIOUS_RESULT_WINDOW = 10_000;
 const OFF_HEADERS = {
   'User-Agent': USER_AGENT,
 };
@@ -22,6 +23,7 @@ const OFF_HEADERS = {
 // provider request cannot hold the client request open indefinitely.
 const OFF_FETCH_TIMEOUT_MS = 10_000;
 
+/** Identifies timeout-shaped errors emitted by Node fetch implementations. */
 function isTimeoutError(error: unknown): boolean {
   return (
     error instanceof Error &&
@@ -31,6 +33,7 @@ function isTimeoutError(error: unknown): boolean {
   );
 }
 
+/** Runs one OFF request with a hard wall-clock timeout. */
 async function fetchWithTimeout(
   url: string,
   init: RequestInit = {},
@@ -45,7 +48,7 @@ async function fetchWithTimeout(
     if (isTimeoutError(error)) {
       log(
         'warn',
-        `OpenFoodFacts request timed out after ${OFF_FETCH_TIMEOUT_MS}ms: ${url}`
+        `OpenFoodFacts request timed out after ${timeoutMs}ms: ${url}`
       );
       throw Object.assign(new Error('OpenFoodFacts request timed out'), {
         status: 504,
@@ -104,16 +107,19 @@ interface SearchALiciousResponse {
   page?: number;
   page_size?: number;
   count?: number;
+  is_count_exact?: boolean;
 }
 
 interface ProductOpenerSearchResponse {
   products: OffProduct[];
 }
 
+/** Narrows untrusted JSON values to non-null objects. */
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
+/** Parses an upstream JSON response and rejects data outside its schema. */
 async function parseSearchResponse<T>(
   response: Response,
   isValid: (value: unknown) => value is T
@@ -130,18 +136,27 @@ async function parseSearchResponse<T>(
   );
 }
 
+/** Validates the minimum legacy Product Opener search response shape. */
 function isLegacySearchResponse(
   value: unknown
 ): value is LegacyOffSearchResponse & { products: OffProduct[] } {
   return isRecord(value) && Array.isArray(value.products);
 }
 
+/** Validates Search-a-licious hits and its optional count-accuracy flag. */
 function isSearchALiciousResponse(
   value: unknown
 ): value is SearchALiciousResponse {
-  return isRecord(value) && Array.isArray(value.hits);
+  return (
+    isRecord(value) &&
+    Array.isArray(value.hits) &&
+    value.hits.every(isRecord) &&
+    (value.is_count_exact === undefined ||
+      typeof value.is_count_exact === 'boolean')
+  );
 }
 
+/** Validates every product returned by the Product Opener bulk endpoint. */
 function isProductOpenerSearchResponse(
   value: unknown
 ): value is ProductOpenerSearchResponse {
@@ -152,6 +167,7 @@ function isProductOpenerSearchResponse(
   );
 }
 
+/** Normalizes names and brands for accent-insensitive token matching. */
 function normalizeSearchText(value: string): string {
   return value
     .normalize('NFKD')
@@ -161,6 +177,7 @@ function normalizeSearchText(value: string): string {
     .trim();
 }
 
+/** Stably promotes hits that cover the complete query phrase and tokens. */
 function rankSearchHits(
   hits: SearchALiciousHit[],
   query: string,
@@ -204,9 +221,10 @@ function rankSearchHits(
     .map(({ hit }) => hit);
 }
 
-// Resolves the session cookie (if the provider has login credentials) and
-// the base URL (self-hosted or the public default) for a single OFF
-// provider lookup, so callers only hit the provider row once per request.
+/**
+ * Resolves the session and base URL once for an OFF lookup, falling back to
+ * the public provider when an optional provider cannot be resolved.
+ */
 async function resolveOffRequestContext(
   authenticatedUserId?: string,
   providerId?: string
@@ -226,11 +244,10 @@ async function resolveOffRequestContext(
   }
 }
 
-// Wraps fetch with optional session-cookie authentication for OFF endpoints.
-// On 429/5xx with an attached cookie, invalidates the session and retries once
-// without the cookie. OFF returns 200 on stale cookies (no 401 signal), so we
-// don't try to distinguish that case — we only retry on the observable
-// failure mode (rate limiting).
+/**
+ * Fetches an OFF endpoint with optional session authentication. A retry after
+ * an authenticated 429/5xx shares the original request's absolute deadline.
+ */
 async function fetchOpenFoodFacts(
   url: string,
   {
@@ -285,21 +302,25 @@ async function fetchOpenFoodFacts(
   return response;
 }
 
-// UPC-A (12 digits) and its zero-padded EAN-13 sibling describe the same
-// product. Search-a-licious and Product Opener do not always agree on which
-// form they store, so resolve both.
+/** Returns the equivalent UPC-A or zero-padded EAN-13 barcode, when present. */
 function offCodeAliases(code: string): string[] {
   if (/^\d{12}$/.test(code)) return ['0' + code];
   if (/^0\d{12}$/.test(code)) return [code.slice(1)];
   return [];
 }
 
-// Overall wall-clock budget for the product-by-code fallback so a degraded
-// Product Opener cannot stretch one search into minutes of sequential
-// timeouts. Chunks that would start past the deadline are skipped and the
-// partial result set is returned instead.
-const HYDRATION_FALLBACK_BUDGET_MS = 10_000;
+/** Converts a Search-a-licious hit into the Product Opener product shape. */
+function productFromSearchHit(hit: SearchALiciousHit): OffProduct {
+  return {
+    ...hit,
+    brands: Array.isArray(hit.brands) ? hit.brands.join(', ') : hit.brands,
+  };
+}
 
+/**
+ * Refreshes ranked hits in one Product Opener bulk request while preserving
+ * every original hit when hydration is partial or unavailable.
+ */
 async function hydrateSearchHits(
   hits: SearchALiciousHit[],
   fields: string[],
@@ -318,7 +339,7 @@ async function hydrateSearchHits(
         .filter((code) => code.length > 0)
     ),
   ];
-  if (codes.length === 0) return [];
+  if (codes.length === 0) return hits.map(productFromSearchHit);
 
   // Ask for both barcode forms so the bulk lookup also finds products Product
   // Opener stores under the sibling UPC-A/EAN-13 representation.
@@ -331,79 +352,24 @@ async function hydrateSearchHits(
     .join(
       ','
     )}&fields=${fieldsParam}&page_size=${requestCodes.length}&lc=${language}`;
-  const batchResponse = await fetchOpenFoodFacts(batchUrl, requestContext);
-
-  let currentProducts: OffProduct[];
-  if (batchResponse.ok) {
+  let currentProducts: OffProduct[] = [];
+  try {
+    const batchResponse = await fetchOpenFoodFacts(batchUrl, requestContext);
+    if (!batchResponse.ok) {
+      throw new Error(
+        `OpenFoodFacts bulk hydration failed (HTTP ${batchResponse.status})`
+      );
+    }
     const batchData = await parseSearchResponse(
       batchResponse,
       isProductOpenerSearchResponse
     );
     currentProducts = batchData.products;
-  } else if (batchResponse.status === 429 || batchResponse.status >= 500) {
-    // Product Opener's bulk-search service can be rate-limited independently.
-    // Product-by-code lookups are a documented read path and provide a useful
-    // bounded fallback without returning stale Search-a-licious nutrition.
-    currentProducts = [];
-    const concurrency = 4;
-    const fallbackDeadline = Date.now() + HYDRATION_FALLBACK_BUDGET_MS;
-    for (let start = 0; start < requestCodes.length; start += concurrency) {
-      if (start > 0 && Date.now() >= fallbackDeadline) {
-        log(
-          'warn',
-          `OpenFoodFacts product-by-code hydration budget exhausted after ${currentProducts.length}/${requestCodes.length} codes`
-        );
-        break;
-      }
-      // A chunk that starts just before the deadline only gets the remaining
-      // budget, so in-flight requests cannot outlive it.
-      const chunkTimeoutMs = Math.max(
-        0,
-        Math.min(fallbackDeadline - Date.now(), OFF_FETCH_TIMEOUT_MS)
-      );
-      const chunk = requestCodes.slice(start, start + concurrency);
-      const products = await Promise.all(
-        chunk.map(async (code): Promise<OffProduct | null> => {
-          try {
-            const productUrl = `${requestContext.baseUrl}/api/v2/product/${encodeURIComponent(code)}.json?fields=${fieldsParam}&lc=${language}`;
-            const response = await fetchOpenFoodFacts(productUrl, {
-              ...requestContext,
-              timeoutMs: chunkTimeoutMs,
-            });
-            if (!response.ok) return null;
-            const data: unknown = await response.json();
-            if (
-              !isRecord(data) ||
-              data.status !== 1 ||
-              !isRecord(data.product)
-            ) {
-              return null;
-            }
-            return data.product as OffProduct;
-          } catch (error) {
-            log(
-              'warn',
-              `OpenFoodFacts product hydration failed for barcode "${code}":`,
-              error
-            );
-            return null;
-          }
-        })
-      );
-      currentProducts.push(
-        ...products.filter((product): product is OffProduct => product !== null)
-      );
-    }
-
-    if (currentProducts.length === 0) {
-      throw new Error(
-        `OpenFoodFacts search failed (HTTP ${batchResponse.status})`
-      );
-    }
-  } else {
-    throw new Error(
-      `OpenFoodFacts search failed (HTTP ${batchResponse.status})`
-    );
+  } catch (error) {
+    // Search-a-licious already returned complete product records. Hydration is
+    // only a freshness improvement, so a separate Product Opener outage must
+    // not turn a successful search into an error or a rate-limited fan-out.
+    log('warn', 'OpenFoodFacts bulk hydration unavailable:', error);
   }
 
   const productsByCode = new Map(
@@ -419,11 +385,49 @@ async function hydrateSearchHits(
     offCodeAliases(code)
       .map((alias) => productsByCode.get(alias))
       .find((product) => product !== undefined);
-  return codes
-    .map(lookupProduct)
-    .filter((product): product is OffProduct => product !== undefined);
+  return hits.map((hit) => {
+    const code = String(hit.code || '').trim();
+    return (
+      (code ? lookupProduct(code) : undefined) ?? productFromSearchHit(hit)
+    );
+  });
 }
 
+/** Builds pagination that respects inexact counts and the 10,000-hit window. */
+function getSearchALiciousPagination(
+  data: SearchALiciousResponse,
+  requestedPage: number,
+  requestedPageSize: number
+) {
+  const page = data.page || requestedPage;
+  const pageSize = data.page_size || requestedPageSize;
+  const loadedThrough = (page - 1) * pageSize + data.hits.length;
+  const nextPageFitsWindow =
+    (page + 1) * pageSize <= SEARCH_A_LICIOUS_RESULT_WINDOW;
+
+  if (data.is_count_exact === false) {
+    const hasMore = data.hits.length === pageSize && nextPageFitsWindow;
+    return {
+      page,
+      pageSize,
+      totalCount: loadedThrough + (hasMore ? 1 : 0),
+      hasMore,
+    };
+  }
+
+  const totalCount = Math.min(
+    data.count ?? loadedThrough,
+    SEARCH_A_LICIOUS_RESULT_WINDOW
+  );
+  return {
+    page,
+    pageSize,
+    totalCount,
+    hasMore: page * pageSize < totalCount && nextPageFitsWindow,
+  };
+}
+
+/** Searches either public Search-a-licious or a custom legacy OFF provider. */
 async function searchOpenFoodFacts(
   query: string,
   page = 1,
@@ -486,6 +490,15 @@ async function searchOpenFoodFacts(
       };
     }
 
+    if (page * pageSize > SEARCH_A_LICIOUS_RESULT_WINDOW) {
+      throw Object.assign(
+        new Error(
+          `OpenFoodFacts search supports at most ${SEARCH_A_LICIOUS_RESULT_WINDOW} results`
+        ),
+        { status: 400, statusCode: 400 }
+      );
+    }
+
     const langs = language === 'en' ? ['en'] : [language, 'en'];
     const response = await fetchWithTimeout(SEARCH_A_LICIOUS_URL, {
       method: 'POST',
@@ -519,14 +532,7 @@ async function searchOpenFoodFacts(
     });
     return {
       products,
-      pagination: {
-        page: data.page || page,
-        pageSize: data.page_size || pageSize,
-        totalCount: data.count || 0,
-        hasMore:
-          (data.page || page) * (data.page_size || pageSize) <
-          (data.count || 0),
-      },
+      pagination: getSearchALiciousPagination(data, page, pageSize),
     };
   } catch (error) {
     log(

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -63,10 +63,52 @@ interface SearchALiciousHit extends Omit<OffProduct, 'brands'> {
 }
 
 interface SearchALiciousResponse {
-  hits?: SearchALiciousHit[];
+  hits: SearchALiciousHit[];
   page?: number;
   page_size?: number;
   count?: number;
+}
+
+interface ProductOpenerSearchResponse {
+  products: OffProduct[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+async function parseSearchResponse<T>(
+  response: Response,
+  isValid: (value: unknown) => value is T
+): Promise<T> {
+  try {
+    const data: unknown = await response.json();
+    if (isValid(data)) return data;
+  } catch {
+    // Normalize JSON/parser errors so an upstream HTML body is never exposed.
+  }
+
+  throw new Error(
+    `OpenFoodFacts search returned an invalid response (HTTP ${response.status || 200})`
+  );
+}
+
+function isLegacySearchResponse(
+  value: unknown
+): value is LegacyOffSearchResponse & { products: OffProduct[] } {
+  return isRecord(value) && Array.isArray(value.products);
+}
+
+function isSearchALiciousResponse(
+  value: unknown
+): value is SearchALiciousResponse {
+  return isRecord(value) && Array.isArray(value.hits);
+}
+
+function isProductOpenerSearchResponse(
+  value: unknown
+): value is ProductOpenerSearchResponse {
+  return isRecord(value) && Array.isArray(value.products);
 }
 
 function normalizeSearchText(value: string): string {
@@ -84,7 +126,8 @@ function rankSearchHits(
   language: string
 ): SearchALiciousHit[] {
   const normalizedQuery = normalizeSearchText(query);
-  const queryTokens = [...new Set(normalizedQuery.split(' ').filter(Boolean))];
+  const phraseTokens = normalizedQuery.split(' ').filter(Boolean);
+  const queryTokens = [...new Set(phraseTokens)];
   if (!normalizedQuery || queryTokens.length === 0) return hits;
 
   return hits
@@ -101,11 +144,18 @@ function rankSearchHits(
           hit.product_name_en || '',
         ].join(' ')
       );
-      const candidateTokens = new Set(searchableText.split(' '));
+      const searchableTokens = searchableText.split(' ').filter(Boolean);
+      const candidateTokens = new Set(searchableTokens);
       const tokenCoverage =
         queryTokens.filter((token) => candidateTokens.has(token)).length /
         queryTokens.length;
-      const phraseBoost = searchableText.includes(normalizedQuery) ? 2 : 0;
+      const phraseBoost = searchableTokens.some((_, start) =>
+        phraseTokens.every(
+          (token, offset) => searchableTokens[start + offset] === token
+        )
+      )
+        ? 2
+        : 0;
 
       return { hit, index, score: phraseBoost + tokenCoverage };
     })
@@ -174,6 +224,99 @@ async function fetchOpenFoodFacts(
   return response;
 }
 
+async function hydrateSearchHits(
+  hits: SearchALiciousHit[],
+  fields: string[],
+  language: string,
+  requestContext: {
+    authenticatedUserId?: string;
+    providerId?: string;
+    sessionCookie: string | null;
+    baseUrl: string;
+  }
+): Promise<OffProduct[]> {
+  const codes = [
+    ...new Set(
+      hits
+        .map((hit) => String(hit.code || '').trim())
+        .filter((code) => code.length > 0)
+    ),
+  ];
+  if (codes.length === 0) return [];
+
+  const fieldsParam = fields.join(',');
+  const batchUrl = `${requestContext.baseUrl}/api/v2/search?code=${codes.join(',')}&fields=${fieldsParam}&page_size=${codes.length}&lc=${language}`;
+  const batchResponse = await fetchOpenFoodFacts(batchUrl, requestContext);
+
+  let currentProducts: OffProduct[];
+  if (batchResponse.ok) {
+    const batchData = await parseSearchResponse(
+      batchResponse,
+      isProductOpenerSearchResponse
+    );
+    currentProducts = batchData.products;
+  } else if (batchResponse.status === 429 || batchResponse.status >= 500) {
+    // Product Opener's bulk-search service can be rate-limited independently.
+    // Product-by-code lookups are a documented read path and provide a useful
+    // bounded fallback without returning stale Search-a-licious nutrition.
+    currentProducts = [];
+    const concurrency = 4;
+    for (let start = 0; start < codes.length; start += concurrency) {
+      const chunk = codes.slice(start, start + concurrency);
+      const products = await Promise.all(
+        chunk.map(async (code): Promise<OffProduct | null> => {
+          try {
+            const productUrl = `${requestContext.baseUrl}/api/v2/product/${encodeURIComponent(code)}.json?fields=${fieldsParam}&lc=${language}`;
+            const response = await fetchOpenFoodFacts(
+              productUrl,
+              requestContext
+            );
+            if (!response.ok) return null;
+            const data: unknown = await response.json();
+            if (
+              !isRecord(data) ||
+              data.status !== 1 ||
+              !isRecord(data.product)
+            ) {
+              return null;
+            }
+            return data.product as OffProduct;
+          } catch (error) {
+            log(
+              'warn',
+              `OpenFoodFacts product hydration failed for barcode "${code}":`,
+              error
+            );
+            return null;
+          }
+        })
+      );
+      currentProducts.push(
+        ...products.filter((product): product is OffProduct => product !== null)
+      );
+    }
+
+    if (currentProducts.length === 0) {
+      throw new Error(
+        `OpenFoodFacts search failed (HTTP ${batchResponse.status})`
+      );
+    }
+  } else {
+    throw new Error(
+      `OpenFoodFacts search failed (HTTP ${batchResponse.status})`
+    );
+  }
+
+  const productsByCode = new Map(
+    currentProducts
+      .filter((product) => product.code)
+      .map((product) => [String(product.code).trim(), product])
+  );
+  return codes
+    .map((code) => productsByCode.get(code))
+    .filter((product): product is OffProduct => product !== undefined);
+}
+
 async function searchOpenFoodFacts(
   query: string,
   page = 1,
@@ -222,7 +365,7 @@ async function searchOpenFoodFacts(
           `OpenFoodFacts search failed (HTTP ${response.status})`
         );
       }
-      const data = (await response.json()) as LegacyOffSearchResponse;
+      const data = await parseSearchResponse(response, isLegacySearchResponse);
       return {
         products: data.products || [],
         pagination: {
@@ -259,14 +402,14 @@ async function searchOpenFoodFacts(
       );
       throw new Error(`OpenFoodFacts search failed (HTTP ${response.status})`);
     }
-    const data = (await response.json()) as SearchALiciousResponse;
-    const rankedHits = rankSearchHits(data.hits || [], query, language);
-    const products = rankedHits.map(
-      (hit): OffProduct => ({
-        ...hit,
-        brands: Array.isArray(hit.brands) ? hit.brands.join(', ') : hit.brands,
-      })
-    );
+    const data = await parseSearchResponse(response, isSearchALiciousResponse);
+    const rankedHits = rankSearchHits(data.hits, query, language);
+    const products = await hydrateSearchHits(rankedHits, fields, language, {
+      authenticatedUserId,
+      providerId,
+      sessionCookie,
+      baseUrl,
+    });
     return {
       products,
       pagination: {

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -13,6 +13,7 @@ import {
 } from '../../utils/foodUtils.js';
 const { name, version } = package$0;
 const USER_AGENT = `${name}/${version} (https://github.com/CodeWithCJ/SparkyFitness)`;
+const SEARCH_A_LICIOUS_URL = 'https://search.openfoodfacts.org/search';
 const OFF_HEADERS = {
   'User-Agent': USER_AGENT,
 };
@@ -50,11 +51,66 @@ interface OffProduct {
   [key: string]: unknown;
 }
 
-interface OffSearchResponse {
+interface LegacyOffSearchResponse {
   products?: OffProduct[];
   page?: number;
   page_size?: number;
   count?: number;
+}
+
+interface SearchALiciousHit extends Omit<OffProduct, 'brands'> {
+  brands?: string | string[];
+}
+
+interface SearchALiciousResponse {
+  hits?: SearchALiciousHit[];
+  page?: number;
+  page_size?: number;
+  count?: number;
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim();
+}
+
+function rankSearchHits(
+  hits: SearchALiciousHit[],
+  query: string,
+  language: string
+): SearchALiciousHit[] {
+  const normalizedQuery = normalizeSearchText(query);
+  const queryTokens = [...new Set(normalizedQuery.split(' ').filter(Boolean))];
+  if (!normalizedQuery || queryTokens.length === 0) return hits;
+
+  return hits
+    .map((hit, index) => {
+      const brand = Array.isArray(hit.brands)
+        ? hit.brands.join(' ')
+        : hit.brands || '';
+      const localizedName = hit[`product_name_${language}`];
+      const searchableText = normalizeSearchText(
+        [
+          brand,
+          typeof localizedName === 'string' ? localizedName : '',
+          hit.product_name || '',
+          hit.product_name_en || '',
+        ].join(' ')
+      );
+      const candidateTokens = new Set(searchableText.split(' '));
+      const tokenCoverage =
+        queryTokens.filter((token) => candidateTokens.has(token)).length /
+        queryTokens.length;
+      const phraseBoost = searchableText.includes(normalizedQuery) ? 2 : 0;
+
+      return { hit, index, score: phraseBoost + tokenCoverage };
+    })
+    .sort((left, right) => right.score - left.score || left.index - right.index)
+    .map(({ hit }) => hit);
 }
 
 // Resolves the session cookie (if the provider has login credentials) and
@@ -123,7 +179,8 @@ async function searchOpenFoodFacts(
   page = 1,
   language = 'en',
   authenticatedUserId?: string,
-  providerId?: string
+  providerId?: string,
+  pageSize = 20
 ): Promise<{
   products: OffProduct[];
   pagination: {
@@ -143,26 +200,82 @@ async function searchOpenFoodFacts(
       authenticatedUserId,
       providerId
     );
-    const searchUrl = `${baseUrl}/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=20&page=${page}&fields=${fields.join(',')}&lc=${language}`;
-    const response = await fetchOpenFoodFacts(searchUrl, {
-      authenticatedUserId,
-      providerId,
-      sessionCookie,
+
+    // Search-a-licious is Open Food Facts' relevance-ranked full-text search
+    // API. Custom/self-hosted Product Opener instances do not necessarily run
+    // it, so preserve their legacy local search endpoint.
+    const isPublicOpenFoodFacts =
+      baseUrl.replace(/\/+$/, '') === DEFAULT_OFF_BASE_URL.replace(/\/+$/, '');
+    if (!isPublicOpenFoodFacts) {
+      const searchUrl = `${baseUrl}/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=${pageSize}&page=${page}&fields=${fields.join(',')}&lc=${language}`;
+      const response = await fetchOpenFoodFacts(searchUrl, {
+        authenticatedUserId,
+        providerId,
+        sessionCookie,
+      });
+      if (!response.ok) {
+        log(
+          'error',
+          `OpenFoodFacts legacy search failed with HTTP ${response.status}`
+        );
+        throw new Error(
+          `OpenFoodFacts search failed (HTTP ${response.status})`
+        );
+      }
+      const data = (await response.json()) as LegacyOffSearchResponse;
+      return {
+        products: data.products || [],
+        pagination: {
+          page: data.page || page,
+          pageSize: data.page_size || pageSize,
+          totalCount: data.count || 0,
+          hasMore:
+            (data.page || page) * (data.page_size || pageSize) <
+            (data.count || 0),
+        },
+      };
+    }
+
+    const langs = language === 'en' ? ['en'] : [language, 'en'];
+    const response = await fetch(SEARCH_A_LICIOUS_URL, {
+      method: 'POST',
+      headers: {
+        ...OFF_HEADERS,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        q: query,
+        page,
+        page_size: pageSize,
+        boost_phrase: true,
+        langs,
+        fields,
+      }),
     });
     if (!response.ok) {
-      const errorText = await response.text();
-      log('error', 'OpenFoodFacts Search API error:', errorText);
-      throw new Error(`OpenFoodFacts API error: ${errorText}`);
+      log(
+        'error',
+        `OpenFoodFacts Search-a-licious request failed with HTTP ${response.status}`
+      );
+      throw new Error(`OpenFoodFacts search failed (HTTP ${response.status})`);
     }
-    const data = (await response.json()) as OffSearchResponse;
+    const data = (await response.json()) as SearchALiciousResponse;
+    const rankedHits = rankSearchHits(data.hits || [], query, language);
+    const products = rankedHits.map(
+      (hit): OffProduct => ({
+        ...hit,
+        brands: Array.isArray(hit.brands) ? hit.brands.join(', ') : hit.brands,
+      })
+    );
     return {
-      products: data.products || [],
+      products,
       pagination: {
         page: data.page || page,
-        pageSize: data.page_size || 20,
+        pageSize: data.page_size || pageSize,
         totalCount: data.count || 0,
         hasMore:
-          (data.page || page) * (data.page_size || 20) < (data.count || 0),
+          (data.page || page) * (data.page_size || pageSize) <
+          (data.count || 0),
       },
     };
   } catch (error) {

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -145,7 +145,11 @@ function isSearchALiciousResponse(
 function isProductOpenerSearchResponse(
   value: unknown
 ): value is ProductOpenerSearchResponse {
-  return isRecord(value) && Array.isArray(value.products);
+  return (
+    isRecord(value) &&
+    Array.isArray(value.products) &&
+    value.products.every(isRecord)
+  );
 }
 
 function normalizeSearchText(value: string): string {
@@ -247,6 +251,10 @@ async function fetchOpenFoodFacts(
     ? { ...baseHeaders, Cookie: `session=${sessionCookie}` }
     : baseHeaders;
 
+  // The unauthenticated retry shares this request's deadline, so a 429/5xx
+  // answered near the end of the budget cannot double the wall-clock time.
+  const requestDeadline = Date.now() + timeoutMs;
+
   const response = await fetchWithTimeout(
     url,
     {
@@ -270,7 +278,7 @@ async function fetchOpenFoodFacts(
         method: 'GET',
         headers: baseHeaders,
       },
-      timeoutMs
+      Math.max(0, requestDeadline - Date.now())
     );
   }
 

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -289,13 +289,20 @@ async function fetchOpenFoodFacts(
     if (authenticatedUserId && providerId) {
       invalidateOpenFoodFactsSession(authenticatedUserId, providerId);
     }
+    const remainingTimeoutMs = requestDeadline - Date.now();
+    if (remainingTimeoutMs <= 0) {
+      log('warn', `OpenFoodFacts retry deadline exhausted: ${url}`);
+      throw Object.assign(new Error('OpenFoodFacts request timed out'), {
+        status: 504,
+      });
+    }
     return fetchWithTimeout(
       url,
       {
         method: 'GET',
         headers: baseHeaders,
       },
-      Math.max(0, requestDeadline - Date.now())
+      remainingTimeoutMs
     );
   }
 

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -272,6 +272,12 @@ function offCodeAliases(code: string): string[] {
   return [];
 }
 
+// Overall wall-clock budget for the product-by-code fallback so a degraded
+// Product Opener cannot stretch one search into minutes of sequential
+// timeouts. Chunks that would start past the deadline are skipped and the
+// partial result set is returned instead.
+const HYDRATION_FALLBACK_BUDGET_MS = 10_000;
+
 async function hydrateSearchHits(
   hits: SearchALiciousHit[],
   fields: string[],
@@ -298,7 +304,11 @@ async function hydrateSearchHits(
     ...new Set(codes.flatMap((code) => [code, ...offCodeAliases(code)])),
   ];
   const fieldsParam = fields.join(',');
-  const batchUrl = `${requestContext.baseUrl}/api/v2/search?code=${requestCodes.join(',')}&fields=${fieldsParam}&page_size=${requestCodes.length}&lc=${language}`;
+  const batchUrl = `${requestContext.baseUrl}/api/v2/search?code=${requestCodes
+    .map(encodeURIComponent)
+    .join(
+      ','
+    )}&fields=${fieldsParam}&page_size=${requestCodes.length}&lc=${language}`;
   const batchResponse = await fetchOpenFoodFacts(batchUrl, requestContext);
 
   let currentProducts: OffProduct[];
@@ -314,7 +324,15 @@ async function hydrateSearchHits(
     // bounded fallback without returning stale Search-a-licious nutrition.
     currentProducts = [];
     const concurrency = 4;
+    const fallbackDeadline = Date.now() + HYDRATION_FALLBACK_BUDGET_MS;
     for (let start = 0; start < requestCodes.length; start += concurrency) {
+      if (start > 0 && Date.now() >= fallbackDeadline) {
+        log(
+          'warn',
+          `OpenFoodFacts product-by-code hydration budget exhausted after ${currentProducts.length}/${requestCodes.length} codes`
+        );
+        break;
+      }
       const chunk = requestCodes.slice(start, start + concurrency);
       const products = await Promise.all(
         chunk.map(async (code): Promise<OffProduct | null> => {

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -33,12 +33,13 @@ function isTimeoutError(error: unknown): boolean {
 
 async function fetchWithTimeout(
   url: string,
-  init: RequestInit = {}
+  init: RequestInit = {},
+  timeoutMs: number = OFF_FETCH_TIMEOUT_MS
 ): Promise<Response> {
   try {
     return await fetch(url, {
       ...init,
-      signal: AbortSignal.timeout(OFF_FETCH_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
     });
   } catch (error) {
     if (isTimeoutError(error)) {
@@ -232,10 +233,12 @@ async function fetchOpenFoodFacts(
     authenticatedUserId,
     providerId,
     sessionCookie,
+    timeoutMs = OFF_FETCH_TIMEOUT_MS,
   }: {
     authenticatedUserId?: string;
     providerId?: string;
     sessionCookie?: string | null;
+    timeoutMs?: number;
   } = {}
 ) {
   const baseHeaders = { ...OFF_HEADERS };
@@ -244,10 +247,14 @@ async function fetchOpenFoodFacts(
     ? { ...baseHeaders, Cookie: `session=${sessionCookie}` }
     : baseHeaders;
 
-  const response = await fetchWithTimeout(url, {
-    method: 'GET',
-    headers,
-  });
+  const response = await fetchWithTimeout(
+    url,
+    {
+      method: 'GET',
+      headers,
+    },
+    timeoutMs
+  );
 
   if (sessionCookie && (response.status === 429 || response.status >= 500)) {
     log(
@@ -257,7 +264,14 @@ async function fetchOpenFoodFacts(
     if (authenticatedUserId && providerId) {
       invalidateOpenFoodFactsSession(authenticatedUserId, providerId);
     }
-    return fetchWithTimeout(url, { method: 'GET', headers: baseHeaders });
+    return fetchWithTimeout(
+      url,
+      {
+        method: 'GET',
+        headers: baseHeaders,
+      },
+      timeoutMs
+    );
   }
 
   return response;
@@ -333,15 +347,21 @@ async function hydrateSearchHits(
         );
         break;
       }
+      // A chunk that starts just before the deadline only gets the remaining
+      // budget, so in-flight requests cannot outlive it.
+      const chunkTimeoutMs = Math.max(
+        0,
+        Math.min(fallbackDeadline - Date.now(), OFF_FETCH_TIMEOUT_MS)
+      );
       const chunk = requestCodes.slice(start, start + concurrency);
       const products = await Promise.all(
         chunk.map(async (code): Promise<OffProduct | null> => {
           try {
             const productUrl = `${requestContext.baseUrl}/api/v2/product/${encodeURIComponent(code)}.json?fields=${fieldsParam}&lc=${language}`;
-            const response = await fetchOpenFoodFacts(
-              productUrl,
-              requestContext
-            );
+            const response = await fetchOpenFoodFacts(productUrl, {
+              ...requestContext,
+              timeoutMs: chunkTimeoutMs,
+            });
             if (!response.ok) return null;
             const data: unknown = await response.json();
             if (

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -17,6 +17,42 @@ const SEARCH_A_LICIOUS_URL = 'https://search.openfoodfacts.org/search';
 const OFF_HEADERS = {
   'User-Agent': USER_AGENT,
 };
+// Upstream availability is intermittent (the public API periodically answers
+// very slowly or not at all under load). Bound every outbound call so a hung
+// provider request cannot hold the client request open indefinitely.
+const OFF_FETCH_TIMEOUT_MS = 10_000;
+
+function isTimeoutError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'TimeoutError' ||
+      error.name === 'AbortError' ||
+      error.message.includes('timed out'))
+  );
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {}
+): Promise<Response> {
+  try {
+    return await fetch(url, {
+      ...init,
+      signal: AbortSignal.timeout(OFF_FETCH_TIMEOUT_MS),
+    });
+  } catch (error) {
+    if (isTimeoutError(error)) {
+      log(
+        'warn',
+        `OpenFoodFacts request timed out after ${OFF_FETCH_TIMEOUT_MS}ms: ${url}`
+      );
+      throw Object.assign(new Error('OpenFoodFacts request timed out'), {
+        status: 504,
+      });
+    }
+    throw error;
+  }
+}
 const OFF_FIELDS = [
   'product_name',
   'product_name_en',
@@ -208,7 +244,10 @@ async function fetchOpenFoodFacts(
     ? { ...baseHeaders, Cookie: `session=${sessionCookie}` }
     : baseHeaders;
 
-  const response = await fetch(url, { method: 'GET', headers });
+  const response = await fetchWithTimeout(url, {
+    method: 'GET',
+    headers,
+  });
 
   if (sessionCookie && (response.status === 429 || response.status >= 500)) {
     log(
@@ -218,10 +257,19 @@ async function fetchOpenFoodFacts(
     if (authenticatedUserId && providerId) {
       invalidateOpenFoodFactsSession(authenticatedUserId, providerId);
     }
-    return fetch(url, { method: 'GET', headers: baseHeaders });
+    return fetchWithTimeout(url, { method: 'GET', headers: baseHeaders });
   }
 
   return response;
+}
+
+// UPC-A (12 digits) and its zero-padded EAN-13 sibling describe the same
+// product. Search-a-licious and Product Opener do not always agree on which
+// form they store, so resolve both.
+function offCodeAliases(code: string): string[] {
+  if (/^\d{12}$/.test(code)) return ['0' + code];
+  if (/^0\d{12}$/.test(code)) return [code.slice(1)];
+  return [];
 }
 
 async function hydrateSearchHits(
@@ -244,8 +292,13 @@ async function hydrateSearchHits(
   ];
   if (codes.length === 0) return [];
 
+  // Ask for both barcode forms so the bulk lookup also finds products Product
+  // Opener stores under the sibling UPC-A/EAN-13 representation.
+  const requestCodes = [
+    ...new Set(codes.flatMap((code) => [code, ...offCodeAliases(code)])),
+  ];
   const fieldsParam = fields.join(',');
-  const batchUrl = `${requestContext.baseUrl}/api/v2/search?code=${codes.join(',')}&fields=${fieldsParam}&page_size=${codes.length}&lc=${language}`;
+  const batchUrl = `${requestContext.baseUrl}/api/v2/search?code=${requestCodes.join(',')}&fields=${fieldsParam}&page_size=${requestCodes.length}&lc=${language}`;
   const batchResponse = await fetchOpenFoodFacts(batchUrl, requestContext);
 
   let currentProducts: OffProduct[];
@@ -261,8 +314,8 @@ async function hydrateSearchHits(
     // bounded fallback without returning stale Search-a-licious nutrition.
     currentProducts = [];
     const concurrency = 4;
-    for (let start = 0; start < codes.length; start += concurrency) {
-      const chunk = codes.slice(start, start + concurrency);
+    for (let start = 0; start < requestCodes.length; start += concurrency) {
+      const chunk = requestCodes.slice(start, start + concurrency);
       const products = await Promise.all(
         chunk.map(async (code): Promise<OffProduct | null> => {
           try {
@@ -312,8 +365,16 @@ async function hydrateSearchHits(
       .filter((product) => product.code)
       .map((product) => [String(product.code).trim(), product])
   );
+  // Product Opener may store a product under its UPC-A/EAN-13 sibling form,
+  // while Search-a-licious indexes the other one. Without this fallback such
+  // hits silently vanish from the result list ("intermittently no results").
+  const lookupProduct = (code: string): OffProduct | undefined =>
+    productsByCode.get(code) ??
+    offCodeAliases(code)
+      .map((alias) => productsByCode.get(alias))
+      .find((product) => product !== undefined);
   return codes
-    .map((code) => productsByCode.get(code))
+    .map(lookupProduct)
     .filter((product): product is OffProduct => product !== undefined);
 }
 
@@ -380,7 +441,7 @@ async function searchOpenFoodFacts(
     }
 
     const langs = language === 'en' ? ['en'] : [language, 'en'];
-    const response = await fetch(SEARCH_A_LICIOUS_URL, {
+    const response = await fetchWithTimeout(SEARCH_A_LICIOUS_URL, {
       method: 'POST',
       headers: {
         ...OFF_HEADERS,

--- a/SparkyFitnessServer/routes/v2/foodRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/foodRoutes.ts
@@ -221,8 +221,22 @@ const searchHandler: RequestHandler<{ providerType: string }> = async (
     return;
   }
 
-  const page = Number(req.query.page) || 1;
-  const pageSize = Number(req.query.pageSize) || 20;
+  const page = req.query.page === undefined ? 1 : Number(req.query.page);
+  const pageSize =
+    req.query.pageSize === undefined ? 20 : Number(req.query.pageSize);
+  if (
+    !Number.isInteger(page) ||
+    page < 1 ||
+    !Number.isInteger(pageSize) ||
+    pageSize < 1 ||
+    pageSize > 100
+  ) {
+    res.status(400).json({
+      error:
+        'Invalid pagination parameters: page must be a positive integer and pageSize must be an integer from 1 to 100',
+    });
+    return;
+  }
   const providerId = req.query.providerId as string | undefined;
   const autoScale = ((req.query.autoScale as string) ?? 'true') !== 'false';
 

--- a/SparkyFitnessServer/services/externalFoodSearchService.ts
+++ b/SparkyFitnessServer/services/externalFoodSearchService.ts
@@ -292,7 +292,8 @@ export async function searchProviderFoods(
         language,
 
         offProviderId ? credentialUserId : undefined,
-        offProviderId || undefined
+        offProviderId || undefined,
+        pageSize
       );
       const products = (result.products || []).filter(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/SparkyFitnessServer/tests/externalFoodSearchService.openFoodFacts.test.ts
+++ b/SparkyFitnessServer/tests/externalFoodSearchService.openFoodFacts.test.ts
@@ -41,7 +41,12 @@ vi.mock('../integrations/swissfood/swissFoodService.js', () => ({
 }));
 
 import externalProviderService from '../services/externalProviderService.js';
-import { resolveOpenFoodFactsProviderId } from '../services/externalFoodSearchService.js';
+import preferenceService from '../services/preferenceService.js';
+import { searchOpenFoodFacts } from '../integrations/openfoodfacts/openFoodFactsService.js';
+import {
+  resolveOpenFoodFactsProviderId,
+  searchProviderFoods,
+} from '../services/externalFoodSearchService.js';
 
 const mockGetDetails = vi.mocked(
   externalProviderService.getExternalDataProviderDetails
@@ -105,5 +110,43 @@ describe('resolveOpenFoodFactsProviderId', () => {
 
     expect(id).toBe('active-id');
     expect(mockGetDetails).not.toHaveBeenCalled();
+  });
+});
+
+describe('searchProviderFoods OpenFoodFacts pagination', () => {
+  it('forwards the requested page size to the OpenFoodFacts search adapter', async () => {
+    mockGetActiveId.mockResolvedValue(PROVIDER_ID);
+    vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+      language: 'de',
+    });
+    vi.mocked(searchOpenFoodFacts).mockResolvedValue({
+      products: [
+        {
+          code: '80051428',
+          product_name: 'Nutella',
+          brands: 'Ferrero',
+          nutriments: {},
+        },
+      ],
+      pagination: {
+        page: 3,
+        pageSize: 7,
+        totalCount: 15,
+        hasMore: false,
+      },
+    });
+    await searchProviderFoods(USER_ID, 'openfoodfacts', 'nutella', {
+      page: 3,
+      pageSize: 7,
+    });
+
+    expect(searchOpenFoodFacts).toHaveBeenCalledWith(
+      'nutella',
+      3,
+      'de',
+      USER_ID,
+      PROVIDER_ID,
+      7
+    );
   });
 });

--- a/SparkyFitnessServer/tests/foodRoutesV2.test.ts
+++ b/SparkyFitnessServer/tests/foodRoutesV2.test.ts
@@ -310,6 +310,23 @@ describe('GET /v2/foods/search/:providerType', () => {
     expect(searchProviderFoods).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['page', '0'],
+    ['page', '-1'],
+    ['page', '1.5'],
+    ['pageSize', '0'],
+    ['pageSize', '1.5'],
+    ['pageSize', '101'],
+  ])('rejects invalid %s=%s pagination', async (parameter, value) => {
+    const res = await request(app).get(
+      `/v2/foods/search/usda?query=apple&${parameter}=${value}`
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/pagination/i);
+    expect(searchProviderFoods).not.toHaveBeenCalled();
+  });
+
   it('maps status-tagged service errors to HTTP status codes', async () => {
     vi.mocked(searchProviderFoods).mockRejectedValue(
       Object.assign(new Error('Missing providerId query parameter'), {

--- a/SparkyFitnessServer/tests/openFoodFactsLanguage.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsLanguage.test.ts
@@ -41,21 +41,19 @@ describe('OpenFoodFacts Language Handling', () => {
     });
   });
   describe('API Request URL generation', () => {
-    it('should include product_name_${language} in the fields for search', async () => {
+    it('should include product_name_${language} in the Search-a-licious fields', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       fetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ products: [], count: 0 }),
+        json: () =>
+          Promise.resolve({ hits: [], page: 1, page_size: 20, count: 0 }),
       });
       await searchOpenFoodFacts('spaghetti', 1, 'fr');
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('product_name_fr'),
-        expect.any(Object)
-      );
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('product_name_en'),
-        expect.any(Object)
-      );
+      // @ts-expect-error TS(2339): Property 'mock' does not exist on type '{ (input: ... Remove this comment to see the full error message
+      const body = JSON.parse(fetch.mock.calls[0][1].body);
+      expect(body.fields).toContain('product_name_fr');
+      expect(body.fields).toContain('product_name_en');
+      expect(body.langs).toEqual(['fr', 'en']);
     });
     it('should include product_name_${language} in the fields for barcode lookup', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -359,7 +359,7 @@ describe('openFoodFactsService', () => {
     });
 
     it('throws a compact error for a successful HTML Search-a-licious response', async () => {
-      // @ts-expect-error mocked global fetch
+      // @ts-expect-error TS(2339): Property 'mock' does not exist on type '{ (input: ... Remove this comment to see the full error message
       fetch.mockResolvedValue({
         ok: true,
         status: 200,
@@ -368,6 +368,60 @@ describe('openFoodFactsService', () => {
 
       await expect(searchOpenFoodFacts('pizza')).rejects.toThrow(
         'OpenFoodFacts search returned an invalid response (HTTP 200)'
+      );
+    });
+
+    it('maps upstream timeout aborts to a compact gateway timeout error', async () => {
+      // @ts-expect-error TS(2339): Property 'mock' does not exist on type '{ (input: ... Remove this comment to see the full error message
+      fetch.mockRejectedValue(
+        Object.assign(new Error('The operation was aborted due to timeout'), {
+          name: 'TimeoutError',
+        })
+      );
+
+      await expect(searchOpenFoodFacts('pizza')).rejects.toMatchObject({
+        message: 'OpenFoodFacts request timed out',
+        status: 504,
+      });
+    });
+
+    it('keeps hits whose barcode is stored under its UPC-A/EAN-13 sibling form', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              // Search-a-licious indexes the zero-padded EAN-13 form...
+              hits: [{ code: '0012345678905', product_name: 'Nutella' }],
+              page: 1,
+              page_size: 20,
+              count: 1,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              // ...while Product Opener stores the 12-digit UPC-A form.
+              products: [
+                {
+                  code: '012345678905',
+                  product_name: 'Nutella',
+                  brands: 'Ferrero',
+                  nutriments: {},
+                },
+              ],
+            }),
+        });
+
+      const result = await searchOpenFoodFacts('nutella');
+
+      expect(result.products.map((product) => product.code)).toEqual([
+        '012345678905',
+      ]);
+      // @ts-expect-error TS(2339): Property 'mock' does not exist on type '{ (input: ... Remove this comment to see the full error message
+      expect(fetch.mock.calls[1][0]).toContain(
+        '/api/v2/search?code=0012345678905,012345678905&'
       );
     });
   });

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -16,7 +16,8 @@ vi.mock('../integrations/openfoodfacts/openFoodFactsAuth.js', () => ({
   DEFAULT_OFF_BASE_URL: 'https://world.openfoodfacts.org',
 }));
 
-global.fetch = vi.fn();
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
 
 describe('openFoodFactsService', () => {
   beforeEach(() => {
@@ -79,31 +80,51 @@ describe('openFoodFactsService', () => {
       });
     });
 
-    it('returns relevance-ordered hits and normalizes Search-a-licious brand arrays', async () => {
-      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-      fetch.mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            hits: [
-              {
-                code: 'first',
-                product_name: 'Exact Match',
-                brands: ['Brand One', 'Brand Two'],
-                nutriments: {},
-              },
-              {
-                code: 'second',
-                product_name: 'Less Relevant Match',
-                brands: ['Other Brand'],
-                nutriments: {},
-              },
-            ],
-            page: 1,
-            page_size: 20,
-            count: 2,
-          }),
-      });
+    it('returns current Product Opener records in Search-a-licious relevance order', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [
+                {
+                  code: 'first',
+                  product_name: 'Exact Match',
+                  brands: ['Brand One', 'Brand Two'],
+                  nutriments: {},
+                },
+                {
+                  code: 'second',
+                  product_name: 'Less Relevant Match',
+                  brands: ['Other Brand'],
+                  nutriments: {},
+                },
+              ],
+              page: 1,
+              page_size: 20,
+              count: 2,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              products: [
+                {
+                  code: 'second',
+                  product_name: 'Less Relevant Match',
+                  brands: 'Other Brand',
+                  nutriments: {},
+                },
+                {
+                  code: 'first',
+                  product_name: 'Exact Match',
+                  brands: 'Brand One, Brand Two',
+                  nutriments: {},
+                },
+              ],
+            }),
+        });
 
       const result = await searchOpenFoodFacts('exact match');
 
@@ -118,30 +139,50 @@ describe('openFoodFactsService', () => {
     });
 
     it('prioritizes a complete brand and product-name match over partial matches', async () => {
-      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
-      fetch.mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            hits: [
-              {
-                code: 'partial',
-                product_name: 'High Protein Pudding',
-                brands: ['Milbona'],
-                nutriments: {},
-              },
-              {
-                code: 'complete',
-                product_name: 'High Protein Pudding',
-                brands: ['Ehrmann'],
-                nutriments: {},
-              },
-            ],
-            page: 1,
-            page_size: 20,
-            count: 2,
-          }),
-      });
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [
+                {
+                  code: 'partial',
+                  product_name: 'High Protein Pudding',
+                  brands: ['Milbona'],
+                  nutriments: {},
+                },
+                {
+                  code: 'complete',
+                  product_name: 'High Protein Pudding',
+                  brands: ['Ehrmann'],
+                  nutriments: {},
+                },
+              ],
+              page: 1,
+              page_size: 20,
+              count: 2,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              products: [
+                {
+                  code: 'partial',
+                  product_name: 'High Protein Pudding',
+                  brands: 'Milbona',
+                  nutriments: {},
+                },
+                {
+                  code: 'complete',
+                  product_name: 'High Protein Pudding',
+                  brands: 'Ehrmann',
+                  nutriments: {},
+                },
+              ],
+            }),
+        });
 
       const result = await searchOpenFoodFacts(
         'Ehrmann High Protein Pudding',
@@ -155,6 +196,155 @@ describe('openFoodFactsService', () => {
       ]);
     });
 
+    it('does not treat a query token embedded inside another word as a phrase match', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [
+                { code: 'shampoo', product_name: 'Herbal Shampoo' },
+                { code: 'ham', product_name: 'Smoked Ham' },
+              ],
+              page: 1,
+              page_size: 20,
+              count: 2,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              products: [
+                { code: 'shampoo', product_name: 'Herbal Shampoo' },
+                { code: 'ham', product_name: 'Smoked Ham' },
+              ],
+            }),
+        });
+
+      const result = await searchOpenFoodFacts('ham');
+
+      expect(result.products.map((product) => product.code)).toEqual([
+        'ham',
+        'shampoo',
+      ]);
+    });
+
+    it('hydrates search hits with current serving-scaled nutrition data', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [
+                {
+                  code: '4056489472261',
+                  product_name: 'High Protein Pudding',
+                  serving_quantity: 100,
+                  nutriments: { 'energy-kcal_100g': 77 },
+                },
+              ],
+              page: 1,
+              page_size: 20,
+              count: 1,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              products: [
+                {
+                  code: '4056489472261',
+                  product_name: 'High Protein Pudding',
+                  serving_quantity: 200,
+                  serving_quantity_unit: 'g',
+                  nutriments: {
+                    'energy-kcal_100g': 77,
+                    proteins_100g: 10,
+                    magnesium_100g: 0.018,
+                    magnesium_unit: 'g',
+                  },
+                },
+              ],
+            }),
+        });
+
+      const result = await searchOpenFoodFacts('high protein pudding');
+      const mapped = mapOpenFoodFactsProduct(result.products[0]);
+
+      expect(mapped.default_variant).toEqual(
+        expect.objectContaining({
+          serving_size: 200,
+          calories: 154,
+          protein: 20,
+          provider_nutrients: expect.objectContaining({ magnesium: 0.036 }),
+        })
+      );
+      // @ts-expect-error mocked global fetch
+      expect(fetch.mock.calls[1][0]).toContain(
+        '/api/v2/search?code=4056489472261'
+      );
+    });
+
+    it('falls back to a product-by-code lookup when bulk hydration is unavailable', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [{ code: '123', product_name: 'Current Product' }],
+              page: 1,
+              page_size: 20,
+              count: 1,
+            }),
+        })
+        .mockResolvedValueOnce({ ok: false, status: 503 })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              status: 1,
+              product: {
+                code: '123',
+                product_name: 'Current Product',
+                serving_quantity: 250,
+              },
+            }),
+        });
+
+      const result = await searchOpenFoodFacts('current product');
+
+      expect(result.products).toEqual([
+        expect.objectContaining({ code: '123', serving_quantity: 250 }),
+      ]);
+      // @ts-expect-error mocked global fetch
+      expect(fetch.mock.calls[2][0]).toContain('/api/v2/product/123.json');
+    });
+
+    it('throws a compact error for malformed Product Opener hydration data', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [{ code: '123', product_name: 'Product' }],
+              page: 1,
+              page_size: 20,
+              count: 1,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.reject(new SyntaxError('Unexpected <html>')),
+        });
+
+      await expect(searchOpenFoodFacts('product')).rejects.toThrow(
+        'OpenFoodFacts search returned an invalid response (HTTP 200)'
+      );
+    });
+
     it('throws a compact error without exposing an upstream HTML response', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       fetch.mockResolvedValue({
@@ -165,6 +355,19 @@ describe('openFoodFactsService', () => {
 
       await expect(searchOpenFoodFacts('pizza')).rejects.toThrow(
         'OpenFoodFacts search failed (HTTP 503)'
+      );
+    });
+
+    it('throws a compact error for a successful HTML Search-a-licious response', async () => {
+      // @ts-expect-error mocked global fetch
+      fetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new SyntaxError('Unexpected token <html>')),
+      });
+
+      await expect(searchOpenFoodFacts('pizza')).rejects.toThrow(
+        'OpenFoodFacts search returned an invalid response (HTTP 200)'
       );
     });
   });
@@ -339,6 +542,26 @@ describe('openFoodFactsService', () => {
           /^http:\/\/sparkyfitness-foodfacts:8080\/cgi\/search\.pl/
         ),
         expect.any(Object)
+      );
+    });
+
+    it('throws a compact error for a successful HTML self-hosted search response', async () => {
+      // @ts-expect-error mocked provider resolver
+      resolveOpenFoodFactsProvider.mockResolvedValue({
+        session: null,
+        baseUrl: 'http://sparkyfitness-foodfacts:8080',
+      });
+      // @ts-expect-error mocked global fetch
+      fetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new SyntaxError('Unexpected token <html>')),
+      });
+
+      await expect(
+        searchOpenFoodFacts('pizza', 1, 'en', 'user-A', 'prov-1')
+      ).rejects.toThrow(
+        'OpenFoodFacts search returned an invalid response (HTTP 200)'
       );
     });
 

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -474,6 +474,28 @@ describe('openFoodFactsService', () => {
         vi.useRealTimers();
       }
     });
+
+    it('rejects a Product Opener hydration payload with non-record product entries', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [{ code: '123', product_name: 'Broken Product' }],
+              page: 1,
+              page_size: 20,
+              count: 1,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ products: [null] }),
+        });
+
+      await expect(searchOpenFoodFacts('broken')).rejects.toThrow(
+        'OpenFoodFacts search returned an invalid response (HTTP 200)'
+      );
+    });
   });
 
   describe('searchOpenFoodFactsByBarcodeFields', () => {
@@ -609,6 +631,70 @@ describe('openFoodFactsService', () => {
       expect(fetch).toHaveBeenCalledTimes(1);
       // @ts-expect-error TS(2339): Property 'mock' does not exist on type '{ (input: ... Remove this comment to see the full error message
       expect(fetch.mock.calls[0][1].headers.Cookie).toBeUndefined();
+    });
+
+    it('gives the unauthenticated retry only the remaining request budget', async () => {
+      vi.useFakeTimers();
+      const timeoutSpy = vi.spyOn(AbortSignal, 'timeout');
+      try {
+        let call = 0;
+        // @ts-expect-error TS(2339): Property 'mockImplementation' does not exist o... Remove this comment to see the full error message
+        fetch.mockImplementation(async () => {
+          call += 1;
+          if (call === 1) {
+            return {
+              ok: true,
+              json: () =>
+                Promise.resolve({
+                  hits: [{ code: '123', product_name: 'Cookie Product' }],
+                  page: 1,
+                  page_size: 20,
+                  count: 1,
+                }),
+            };
+          }
+          if (call === 2) {
+            // The authenticated bulk request answers slowly (consuming most
+            // of its budget) and fails with 5x...
+            vi.setSystemTime(Date.now() + 8_000);
+            return { ok: false, status: 503, text: () => Promise.resolve('') };
+          }
+          // ...so its unauthenticated retry only shares what is left (2s).
+          return {
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                products: [
+                  {
+                    code: '123',
+                    product_name: 'Cookie Product',
+                    nutriments: {},
+                  },
+                ],
+              }),
+          };
+        });
+        // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on type '{ (input: ... Remove this comment to see the full error message
+        resolveOpenFoodFactsProvider.mockResolvedValue({
+          session: 'stale-cookie',
+          baseUrl: DEFAULT_OFF_BASE_URL,
+        });
+
+        const result = await searchOpenFoodFacts(
+          'cookie',
+          1,
+          'en',
+          'user-A',
+          'prov-1'
+        );
+
+        expect(result.products.map((product) => product.code)).toEqual(['123']);
+        // Budget 10s minus the 8s the failed first attempt consumed.
+        expect(timeoutSpy).toHaveBeenLastCalledWith(2000);
+      } finally {
+        timeoutSpy.mockRestore();
+        vi.useRealTimers();
+      }
     });
 
     it('does not retry on 429 when no cookie was attached', async () => {

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -671,28 +671,6 @@ describe('openFoodFactsService', () => {
         'Current Product',
       ]);
     });
-
-    it('rejects a Product Opener hydration payload with non-record product entries', async () => {
-      fetchMock
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              hits: [{ code: '123', product_name: 'Broken Product' }],
-              page: 1,
-              page_size: 20,
-              count: 1,
-            }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ products: [null] }),
-        });
-
-      await expect(searchOpenFoodFacts('broken')).rejects.toThrow(
-        'OpenFoodFacts search returned an invalid response (HTTP 200)'
-      );
-    });
   });
 
   describe('searchOpenFoodFactsByBarcodeFields', () => {
@@ -842,6 +820,48 @@ describe('openFoodFactsService', () => {
 
         expect(timeoutSpy).toHaveBeenNthCalledWith(1, 10_000);
         expect(timeoutSpy).toHaveBeenNthCalledWith(2, 6_000);
+      } finally {
+        timeoutSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+
+    it('does not start an authenticated retry after its deadline', async () => {
+      vi.useFakeTimers();
+      const timeoutSpy = vi
+        .spyOn(AbortSignal, 'timeout')
+        .mockImplementation(() => new AbortController().signal);
+      try {
+        vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+        // @ts-expect-error mocked provider resolver
+        resolveOpenFoodFactsProvider.mockResolvedValue({
+          session: 'SESS_TOKEN',
+          baseUrl: DEFAULT_OFF_BASE_URL,
+        });
+        fetchMock
+          .mockImplementationOnce(async () => {
+            vi.setSystemTime(Date.now() + 10_000);
+            return { ok: false, status: 503 };
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ status: 1, product: {} }),
+          });
+
+        await expect(
+          searchOpenFoodFactsByBarcodeFields(
+            '12345678',
+            undefined,
+            'en',
+            'user-A',
+            'prov-1'
+          )
+        ).rejects.toMatchObject({
+          message: 'OpenFoodFacts request timed out',
+          status: 504,
+        });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
       } finally {
         timeoutSpy.mockRestore();
         vi.useRealTimers();

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -424,6 +424,56 @@ describe('openFoodFactsService', () => {
         '/api/v2/search?code=0012345678905,012345678905&'
       );
     });
+
+    it('stops the product-by-code fallback once the wall-clock budget is exhausted', async () => {
+      vi.useFakeTimers();
+      try {
+        const hits = Array.from({ length: 6 }, (_, i) => ({
+          code: `00${i}`,
+          product_name: 'Budget Product',
+        }));
+        let call = 0;
+        // @ts-expect-error TS(2339): Property 'mockImplementation' does not exist o... Remove this comment to see the full error message
+        fetch.mockImplementation(async (url: string) => {
+          call += 1;
+          if (call === 1) {
+            return {
+              ok: true,
+              json: () =>
+                Promise.resolve({
+                  hits,
+                  page: 1,
+                  page_size: 20,
+                  count: hits.length,
+                }),
+            };
+          }
+          if (call === 2) {
+            return { ok: false, status: 503, text: () => Promise.resolve('') };
+          }
+          // Simulate the first chunk consuming the entire fallback budget.
+          vi.setSystemTime(Date.now() + 11_000);
+          const code = String(url).match(/product\/(\d+)\.json/)?.[1];
+          return {
+            ok: true,
+            json: () => Promise.resolve({ status: 1, product: { code } }),
+          };
+        });
+
+        const result = await searchOpenFoodFacts('budget');
+
+        // Chunks starting past the deadline are skipped: only the first
+        // (concurrency 4) chunk of codes comes back.
+        expect(result.products.map((product) => product.code)).toEqual([
+          '000',
+          '001',
+          '002',
+          '003',
+        ]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('searchOpenFoodFactsByBarcodeFields', () => {

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -29,29 +29,142 @@ describe('openFoodFactsService', () => {
   });
 
   describe('searchOpenFoodFacts', () => {
-    it('should append the lc parameter with the specified language to the search URL', async () => {
+    it('uses Search-a-licious relevance search with the requested language and pagination', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       fetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ products: [], count: 0 }),
+        json: () =>
+          Promise.resolve({
+            hits: [],
+            page: 2,
+            page_size: 12,
+            count: 25,
+          }),
       });
-      await searchOpenFoodFacts('pizza', 1, 'fr');
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('&lc=fr'),
-        expect.any(Object)
+
+      const result = await searchOpenFoodFacts(
+        'whole milk',
+        2,
+        'fr',
+        undefined,
+        undefined,
+        12
       );
+
+      expect(fetch).toHaveBeenCalledWith(
+        'https://search.openfoodfacts.org/search',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+        })
+      );
+      // @ts-expect-error TS(2339): Property 'mock' does not exist on type '{ (input: ... Remove this comment to see the full error message
+      const request = fetch.mock.calls[0][1];
+      expect(JSON.parse(request.body)).toEqual(
+        expect.objectContaining({
+          q: 'whole milk',
+          page: 2,
+          page_size: 12,
+          boost_phrase: true,
+          langs: ['fr', 'en'],
+        })
+      );
+      expect(result.pagination).toEqual({
+        page: 2,
+        pageSize: 12,
+        totalCount: 25,
+        hasMore: true,
+      });
     });
 
-    it("should default to language 'en' when not specified", async () => {
+    it('returns relevance-ordered hits and normalizes Search-a-licious brand arrays', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       fetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ products: [], count: 0 }),
+        json: () =>
+          Promise.resolve({
+            hits: [
+              {
+                code: 'first',
+                product_name: 'Exact Match',
+                brands: ['Brand One', 'Brand Two'],
+                nutriments: {},
+              },
+              {
+                code: 'second',
+                product_name: 'Less Relevant Match',
+                brands: ['Other Brand'],
+                nutriments: {},
+              },
+            ],
+            page: 1,
+            page_size: 20,
+            count: 2,
+          }),
       });
-      await searchOpenFoodFacts('pizza', 1);
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining('&lc=en'),
-        expect.any(Object)
+
+      const result = await searchOpenFoodFacts('exact match');
+
+      expect(result.products.map((product) => product.code)).toEqual([
+        'first',
+        'second',
+      ]);
+      expect(result.products[0].brands).toBe('Brand One, Brand Two');
+      // @ts-expect-error TS(2339): Property 'mock' does not exist on type '{ (input: ... Remove this comment to see the full error message
+      const requestBody = JSON.parse(fetch.mock.calls[0][1].body);
+      expect(requestBody.langs).toEqual(['en']);
+    });
+
+    it('prioritizes a complete brand and product-name match over partial matches', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      fetch.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            hits: [
+              {
+                code: 'partial',
+                product_name: 'High Protein Pudding',
+                brands: ['Milbona'],
+                nutriments: {},
+              },
+              {
+                code: 'complete',
+                product_name: 'High Protein Pudding',
+                brands: ['Ehrmann'],
+                nutriments: {},
+              },
+            ],
+            page: 1,
+            page_size: 20,
+            count: 2,
+          }),
+      });
+
+      const result = await searchOpenFoodFacts(
+        'Ehrmann High Protein Pudding',
+        1,
+        'de'
+      );
+
+      expect(result.products.map((product) => product.code)).toEqual([
+        'complete',
+        'partial',
+      ]);
+    });
+
+    it('throws a compact error without exposing an upstream HTML response', async () => {
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      fetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        text: () => Promise.resolve('<html>temporary outage</html>'),
+      });
+
+      await expect(searchOpenFoodFacts('pizza')).rejects.toThrow(
+        'OpenFoodFacts search failed (HTTP 503)'
       );
     });
   });
@@ -170,29 +283,25 @@ describe('openFoodFactsService', () => {
       expect(fetch.mock.calls[1][1].headers.Cookie).toBeUndefined();
     });
 
-    it('on 503 with cookie, retries unauthenticated and returns final response', async () => {
+    it('does not send an OpenFoodFacts session cookie to Search-a-licious', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       resolveOpenFoodFactsProvider.mockResolvedValue({
         session: 'SESS_TOKEN',
         baseUrl: DEFAULT_OFF_BASE_URL,
       });
-      fetch
-        // @ts-expect-error TS(2339): Property 'mockResolvedValueOnce' does not exist on... Remove this comment to see the full error message
-        .mockResolvedValueOnce({
-          ok: false,
-          status: 503,
-          text: () => Promise.resolve('unavailable'),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          status: 200,
-          json: () => Promise.resolve({ products: [], count: 0 }),
-        });
+      // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
+      fetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ hits: [], page: 1, page_size: 20, count: 0 }),
+      });
 
       await searchOpenFoodFacts('pizza', 1, 'en', 'user-A', 'prov-1');
 
-      expect(fetch).toHaveBeenCalledTimes(2);
-      expect(invalidateOpenFoodFactsSession).toHaveBeenCalled();
+      expect(fetch).toHaveBeenCalledTimes(1);
+      // @ts-expect-error TS(2339): Property 'mock' does not exist on type '{ (input: ... Remove this comment to see the full error message
+      expect(fetch.mock.calls[0][1].headers.Cookie).toBeUndefined();
     });
 
     it('does not retry on 429 when no cookie was attached', async () => {
@@ -265,14 +374,15 @@ describe('openFoodFactsService', () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       fetch.mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ products: [], count: 0 }),
+        json: () =>
+          Promise.resolve({ hits: [], page: 1, page_size: 20, count: 0 }),
       });
 
       await searchOpenFoodFacts('pizza', 1, 'en');
 
       expect(resolveOpenFoodFactsProvider).not.toHaveBeenCalled();
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(DEFAULT_OFF_BASE_URL),
+        'https://search.openfoodfacts.org/search',
         expect.any(Object)
       );
     });

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -22,6 +22,7 @@ global.fetch = fetchMock;
 describe('openFoodFactsService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchMock.mockReset();
     // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
     resolveOpenFoodFactsProvider.mockResolvedValue({
       session: null,
@@ -78,6 +79,88 @@ describe('openFoodFactsService', () => {
         totalCount: 25,
         hasMore: true,
       });
+    });
+
+    it('reports an inexact Search-a-licious count as the loaded range plus one', async () => {
+      const hits = Array.from({ length: 20 }, (_, index) => ({
+        code: String(index + 1),
+        product_name: `Product ${index + 1}`,
+      }));
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits,
+              page: 1,
+              page_size: 20,
+              count: 10_000,
+              is_count_exact: false,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ products: hits }),
+        });
+
+      const result = await searchOpenFoodFacts('product');
+
+      expect(result.pagination).toEqual({
+        page: 1,
+        pageSize: 20,
+        totalCount: 21,
+        hasMore: true,
+      });
+    });
+
+    it('does not advertise a page beyond the Search-a-licious result window', async () => {
+      const hits = Array.from({ length: 30 }, (_, index) => ({
+        code: String(index + 1),
+        product_name: `Product ${index + 1}`,
+      }));
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits,
+              page: 333,
+              page_size: 30,
+              count: 10_000,
+              is_count_exact: false,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ products: hits }),
+        });
+
+      const result = await searchOpenFoodFacts(
+        'product',
+        333,
+        'en',
+        undefined,
+        undefined,
+        30
+      );
+
+      expect(result.pagination).toEqual({
+        page: 333,
+        pageSize: 30,
+        totalCount: 9_990,
+        hasMore: false,
+      });
+    });
+
+    it('rejects public searches outside the Search-a-licious result window', async () => {
+      await expect(
+        searchOpenFoodFacts('product', 501, 'en', undefined, undefined, 20)
+      ).rejects.toMatchObject({
+        message: 'OpenFoodFacts search supports at most 10000 results',
+        status: 400,
+        statusCode: 400,
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('returns current Product Opener records in Search-a-licious relevance order', async () => {
@@ -287,42 +370,114 @@ describe('openFoodFactsService', () => {
       );
     });
 
-    it('falls back to a product-by-code lookup when bulk hydration is unavailable', async () => {
+    it('encodes barcode values without escaping the bulk separator', async () => {
       fetchMock
         .mockResolvedValueOnce({
           ok: true,
           json: () =>
             Promise.resolve({
-              hits: [{ code: '123', product_name: 'Current Product' }],
+              hits: [{ code: '12&34', product_name: 'Encoded Product' }],
               page: 1,
               page_size: 20,
               count: 1,
             }),
         })
-        .mockResolvedValueOnce({ ok: false, status: 503 })
         .mockResolvedValueOnce({
           ok: true,
           json: () =>
             Promise.resolve({
-              status: 1,
-              product: {
-                code: '123',
-                product_name: 'Current Product',
-                serving_quantity: 250,
-              },
+              products: [{ code: '12&34', product_name: 'Encoded Product' }],
             }),
         });
 
-      const result = await searchOpenFoodFacts('current product');
+      await searchOpenFoodFacts('encoded product');
 
-      expect(result.products).toEqual([
-        expect.objectContaining({ code: '123', serving_quantity: 250 }),
-      ]);
-      // @ts-expect-error mocked global fetch
-      expect(fetch.mock.calls[2][0]).toContain('/api/v2/product/123.json');
+      expect(fetchMock.mock.calls[1][0]).toContain(
+        '/api/v2/search?code=12%2634&'
+      );
     });
 
-    it('throws a compact error for malformed Product Opener hydration data', async () => {
+    it('uses complete Search-a-licious hits without product fan-out when bulk hydration is unavailable', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [
+                {
+                  code: '123',
+                  product_name: 'Available Product',
+                  brands: ['Search Brand'],
+                  serving_quantity: 250,
+                  nutriments: { 'energy-kcal_100g': 50 },
+                },
+                {
+                  code: '456',
+                  product_name: 'Second Product',
+                  brands: ['Other Brand'],
+                },
+              ],
+              page: 1,
+              page_size: 20,
+              count: 2,
+              is_count_exact: true,
+            }),
+        })
+        .mockResolvedValueOnce({ ok: false, status: 503 });
+
+      const result = await searchOpenFoodFacts('available product');
+
+      expect(result.products).toEqual([
+        expect.objectContaining({
+          code: '123',
+          brands: 'Search Brand',
+          serving_quantity: 250,
+        }),
+        expect.objectContaining({ code: '456', brands: 'Other Brand' }),
+      ]);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      [
+        'malformed JSON',
+        () => Promise.reject(new SyntaxError('Unexpected <html>')),
+      ],
+      [
+        'malformed product entries',
+        () => Promise.resolve({ products: [null] }),
+      ],
+      ['an empty product list', () => Promise.resolve({ products: [] })],
+    ])(
+      'keeps ranked hits when bulk hydration returns %s',
+      async (_case, json) => {
+        fetchMock
+          .mockResolvedValueOnce({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                hits: [{ code: '123', product_name: 'Product' }],
+                page: 1,
+                page_size: 20,
+                count: 1,
+              }),
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json,
+          });
+
+        const result = await searchOpenFoodFacts('product');
+
+        expect(result.products).toEqual([
+          expect.objectContaining({ code: '123', product_name: 'Product' }),
+        ]);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+      }
+    );
+
+    it('keeps ranked hits when bulk hydration rejects at the network layer', async () => {
       fetchMock
         .mockResolvedValueOnce({
           ok: true,
@@ -334,15 +489,47 @@ describe('openFoodFactsService', () => {
               count: 1,
             }),
         })
+        .mockRejectedValueOnce(new Error('socket closed'));
+
+      const result = await searchOpenFoodFacts('product');
+
+      expect(result.products).toEqual([
+        expect.objectContaining({ code: '123', product_name: 'Product' }),
+      ]);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('fills only missing hydration records from Search-a-licious', async () => {
+      fetchMock
         .mockResolvedValueOnce({
           ok: true,
-          status: 200,
-          json: () => Promise.reject(new SyntaxError('Unexpected <html>')),
+          json: () =>
+            Promise.resolve({
+              hits: [
+                { code: '123', product_name: 'Indexed First' },
+                { code: '456', product_name: 'Indexed Second' },
+              ],
+              page: 1,
+              page_size: 20,
+              count: 2,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              products: [
+                { code: '123', product_name: 'Current First', nutriments: {} },
+              ],
+            }),
         });
 
-      await expect(searchOpenFoodFacts('product')).rejects.toThrow(
-        'OpenFoodFacts search returned an invalid response (HTTP 200)'
-      );
+      const result = await searchOpenFoodFacts('indexed');
+
+      expect(result.products.map((product) => product.product_name)).toEqual([
+        'Current First',
+        'Indexed Second',
+      ]);
     });
 
     it('throws a compact error without exposing an upstream HTML response', async () => {
@@ -425,54 +612,64 @@ describe('openFoodFactsService', () => {
       );
     });
 
-    it('stops the product-by-code fallback once the wall-clock budget is exhausted', async () => {
-      vi.useFakeTimers();
-      try {
-        const hits = Array.from({ length: 6 }, (_, i) => ({
-          code: `00${i}`,
-          product_name: 'Budget Product',
-        }));
-        let call = 0;
-        // @ts-expect-error TS(2339): Property 'mockImplementation' does not exist o... Remove this comment to see the full error message
-        fetch.mockImplementation(async (url: string) => {
-          call += 1;
-          if (call === 1) {
-            return {
-              ok: true,
-              json: () =>
-                Promise.resolve({
-                  hits,
-                  page: 1,
-                  page_size: 20,
-                  count: hits.length,
-                }),
-            };
-          }
-          if (call === 2) {
-            return { ok: false, status: 503, text: () => Promise.resolve('') };
-          }
-          // Simulate the first chunk consuming the entire fallback budget.
-          vi.setSystemTime(Date.now() + 11_000);
-          const code = String(url).match(/product\/(\d+)\.json/)?.[1];
-          return {
-            ok: true,
-            json: () => Promise.resolve({ status: 1, product: { code } }),
-          };
+    it('keeps ranked hits that do not contain a barcode', async () => {
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            hits: [
+              {
+                product_name: 'Product Without Barcode',
+                brands: ['Index Brand'],
+              },
+            ],
+            page: 1,
+            page_size: 20,
+            count: 1,
+          }),
+      });
+
+      const result = await searchOpenFoodFacts('product without barcode');
+
+      expect(result.products).toEqual([
+        expect.objectContaining({
+          product_name: 'Product Without Barcode',
+          brands: 'Index Brand',
+        }),
+      ]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves duplicate ranked hits while reusing their hydrated product', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [
+                { code: '123', product_name: 'First Indexed Record' },
+                { code: '123', product_name: 'Second Indexed Record' },
+              ],
+              page: 1,
+              page_size: 20,
+              count: 2,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              products: [{ code: '123', product_name: 'Current Product' }],
+            }),
         });
 
-        const result = await searchOpenFoodFacts('budget');
+      const result = await searchOpenFoodFacts('product');
 
-        // Chunks starting past the deadline are skipped: only the first
-        // (concurrency 4) chunk of codes comes back.
-        expect(result.products.map((product) => product.code)).toEqual([
-          '000',
-          '001',
-          '002',
-          '003',
-        ]);
-      } finally {
-        vi.useRealTimers();
-      }
+      expect(result.products).toHaveLength(2);
+      expect(result.products.map((product) => product.product_name)).toEqual([
+        'Current Product',
+        'Current Product',
+      ]);
     });
 
     it('rejects a Product Opener hydration payload with non-record product entries', async () => {
@@ -612,6 +809,45 @@ describe('openFoodFactsService', () => {
       expect(fetch.mock.calls[1][1].headers.Cookie).toBeUndefined();
     });
 
+    it('shares one absolute timeout across an authenticated retry', async () => {
+      vi.useFakeTimers();
+      const timeoutSpy = vi
+        .spyOn(AbortSignal, 'timeout')
+        .mockImplementation(() => new AbortController().signal);
+      try {
+        vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+        // @ts-expect-error mocked provider resolver
+        resolveOpenFoodFactsProvider.mockResolvedValue({
+          session: 'SESS_TOKEN',
+          baseUrl: DEFAULT_OFF_BASE_URL,
+        });
+        fetchMock
+          .mockImplementationOnce(async () => {
+            vi.setSystemTime(Date.now() + 4_000);
+            return { ok: false, status: 503 };
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ status: 1, product: {} }),
+          });
+
+        await searchOpenFoodFactsByBarcodeFields(
+          '12345678',
+          undefined,
+          'en',
+          'user-A',
+          'prov-1'
+        );
+
+        expect(timeoutSpy).toHaveBeenNthCalledWith(1, 10_000);
+        expect(timeoutSpy).toHaveBeenNthCalledWith(2, 6_000);
+      } finally {
+        timeoutSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+
     it('does not send an OpenFoodFacts session cookie to Search-a-licious', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       resolveOpenFoodFactsProvider.mockResolvedValue({
@@ -731,6 +967,25 @@ describe('openFoodFactsService', () => {
         expect.stringMatching(
           /^http:\/\/sparkyfitness-foodfacts:8080\/cgi\/search\.pl/
         ),
+        expect.any(Object)
+      );
+    });
+
+    it('does not apply the public result-window limit to a custom provider', async () => {
+      // @ts-expect-error mocked provider resolver
+      resolveOpenFoodFactsProvider.mockResolvedValue({
+        session: null,
+        baseUrl: 'http://sparkyfitness-foodfacts:8080',
+      });
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ products: [], count: 0 }),
+      });
+
+      await searchOpenFoodFacts('pizza', 501, 'en', 'user-A', 'prov-1', 20);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('page=501'),
         expect.any(Object)
       );
     });


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Open Food Facts text search frequently returned loosely related products instead of exact matches, intermittently returned nothing at all, and surfaced upstream outages as a raw HTTP 500 whose response embedded the provider's HTML error page.

**How did you implement the solution?**
Searches against public OFF now use its Search-a-licious relevance API (phrase boosting, language-aware name fields), re-rank hits locally so exact brand + product combinations win, and hydrate serving/nutrition data from Product Opener so values reflect the current database. Hydration resolves both UPC-A/EAN-13 forms of each barcode, every outbound call carries a 10 s timeout, failures return compact errors instead of upstream HTML, and the v2 search route validates pagination parameters. Self-hosted Product Opener instances keep using their local legacy search endpoint.

Linked Issue: Closes #2236

## How to Test

1. Check out this branch, enable Open Food Facts under Food & Exercise Providers.
2. Search `coca cola zero`, `ehrmann high protein pudding`, `nutella`: exact brand/product matches rank first and results stay stable across repeated searches.
3. Run `pnpm exec vitest run tests/openFoodFactsService.test.ts tests/externalFoodSearchService.openFoodFacts.test.ts tests/openFoodFactsLanguage.test.ts tests/foodRoutesV2.test.ts` — they cover ranking order, hydration incl. sibling-barcode fallback, compact error mapping, and pagination validation.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

Not applicable — server/API-only change.

</details>

## Notes for Reviewers

- Verified against production OFF while the legacy search endpoint was returning 503: Search-a-licious plus both hydration paths kept returning correctly ranked results during that window — exactly the intermittent failure from #2236.
- The product-by-code fallback runs with concurrency 4 under a 10 s overall wall-clock budget, so a degraded Product Opener cannot stretch one search into minutes of sequential timeouts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OpenFoodFacts searches now provide more relevant, phrase-aware results.
  - Search result counts can be customized from 1 to 100 items per page.
  - Results support up to 10,000 searchable matches, including inexact count handling.
  - UPC-A and EAN-13 barcode variants are matched more reliably.
  - Nutrition details are hydrated more consistently while preserving ranked results.

- **Bug Fixes**
  - Improved handling of rate limits, server errors, malformed responses, and timeouts.
  - Invalid pagination values now return clear HTTP 400 errors.
  - Search requests use the selected language more accurately.
  - Searches now retain available results when product hydration is incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->