### PR TITLE
Fixed secret file mounting in compose files

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -9,13 +9,13 @@ SPARKY_FITNESS_DB_NAME=sparkyfitness_db
 SPARKY_FITNESS_DB_USER=sparky
 SPARKY_FITNESS_DB_PASSWORD=changeme_db_password
 # For Docker Swarm/Kubernetes/Compose secrets, you can use a file-based secret instead:
-# SPARKY_FITNESS_DB_PASSWORD_FILE=/run/secrets/sparkyfitness_db_password
+# SPARKY_FITNESS_DB_PASSWORD_FILE=./sparkyfitness_db_password.key
 
 # Application database user with limited privileges. it can be changed any time after initialization.
 SPARKY_FITNESS_APP_DB_USER=sparky_app
 SPARKY_FITNESS_APP_DB_PASSWORD=password
 # For Docker Swarm/Kubernetes/Compose secrets, you can use a file-based secret instead:
-# SPARKY_FITNESS_APP_DB_PASSWORD_FILE=/run/secrets/sparkyfitness_app_db_password
+# SPARKY_FITNESS_APP_DB_PASSWORD_FILE=./sparkyfitness_app_db_password.key
 
 # For Docker Compose deployments, SPARKY_FITNESS_DB_HOST will be the service name (e.g., 'sparkyfitness-db').
 #SPARKY_FITNESS_DB_HOST=sparkyfitness-db
@@ -97,7 +97,7 @@ TZ=Etc/UTC
 # Changing this will invalidate existing encrypted data. You will need to delete and add External Data sources again.
 SPARKY_FITNESS_API_ENCRYPTION_KEY=changeme_replace_with_a_64_character_hex_string
 # For Docker Swarm/Kubernetes secrets, you can use a file-based secret:
-# SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE=/run/secrets/sparkyfitness_api_key
+# SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE=./sparkyfitness_api_key.key
 
 # BETTER_AUTH_SECRET is used to sign sessions and encrypt 2FA/TOTP data.
 # CRITICAL: If you change this after users have enabled 2FA, they will be LOCKED OUT of their accounts.
@@ -105,7 +105,7 @@ SPARKY_FITNESS_API_ENCRYPTION_KEY=changeme_replace_with_a_64_character_hex_strin
 # If you MUST change it, all users must disable Two-Factor Authentication (TOTP) first.
 BETTER_AUTH_SECRET=changeme_replace_with_a_strong_better_auth_secret
 # For Docker Swarm/Kubernetes secrets, you can use a file-based secret:
-# BETTER_AUTH_SECRET_FILE=/run/secrets/sparkyfitness_better_auth_secret
+# BETTER_AUTH_SECRET_FILE=./sparkyfitness_better_auth_secret.key
 
 # --- Signup Settings ---
 # Set to 'true' to disable new user registrations.
@@ -140,9 +140,9 @@ SPARKY_FITNESS_DISABLE_SIGNUP=false
 
 # OIDC client credentials from your IdP.
 # SPARKY_FITNESS_OIDC_CLIENT_ID=
-# SPARKY_FITNESS_OIDC_CLIENT_ID_FILE=/run/secrets/sparkyfitness_oidc_client_id
+# SPARKY_FITNESS_OIDC_CLIENT_ID_FILE=./sparkyfitness_oidc_client_id.key
 # SPARKY_FITNESS_OIDC_CLIENT_SECRET=
-# SPARKY_FITNESS_OIDC_CLIENT_SECRET_FILE=/run/secrets/sparkyfitness_oidc_client_secret
+# SPARKY_FITNESS_OIDC_CLIENT_SECRET_FILE=./sparkyfitness_oidc_client_secret.key
 
 # SPARKY_FITNESS_OIDC_SCOPE=openid email profile
 
@@ -174,7 +174,7 @@ SPARKY_FITNESS_FORCE_EMAIL_LOGIN=true
 # SPARKY_FITNESS_EMAIL_SECURE=true # Use 'true' for TLS/SSL, 'false' for plain text
 # SPARKY_FITNESS_EMAIL_USER=your_email@example.com
 # SPARKY_FITNESS_EMAIL_PASS=your_email_password
-# SPARKY_FITNESS_EMAIL_PASS_FILE=/run/secrets/sparkyfitness_email_pass
+# SPARKY_FITNESS_EMAIL_PASS_FILE=./sparkyfitness_email_pass.key
 # SPARKY_FITNESS_EMAIL_FROM=no-reply@example.com
 
 # --- Volume Paths (Optional) ---

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -13,6 +13,9 @@ services:
       # POSTGRES_PASSWORD_FILE: /run/secrets/sparkyfitness_db_password
     volumes:
       - ./docker_volume/postgresql:/var/lib/postgresql:z
+    # Uncomment the below section to mount the file-based secrets
+    #secrets:
+    #  - sparkyfitness_db_password
     networks:
       - sparkyfitness-network
     ports:
@@ -76,6 +79,13 @@ services:
       #- ../node_modules:/app/node_modules:z # Uncomment to allow easily adjusting the node modules
       - ./docker_volume/uploads:/app/SparkyFitnessServer/uploads:z
       - ./docker_volume/backup:/app/SparkyFitnessServer/backup:z
+    # Uncomment the below section to mount the file-based secrets
+    #secrets:
+    #  - sparkyfitness_db_password
+    #  - sparkyfitness_app_db_password
+    #  - sparkyfitness_api_key
+    #  - sparkyfitness_better_auth_secret
+    #  - sparkyfitness_email_pass
     networks:
       - sparkyfitness-network
     ports:
@@ -125,3 +135,17 @@ services:
 networks:
   sparkyfitness-network:
     driver: bridge
+
+# Uncomment the below section to mount the file-based secrets
+# These are the file paths on the host and should not be the same as the paths mentioned above which are in the containers themselves
+#secrets:
+#   sparkyfitness_db_password:
+#     file: ${SPARKY_FITNESS_DB_PASSWORD_FILE:-./sparkyfitness_db_password.key}
+#   sparkyfitness_app_db_password:
+#     file: ${SPARKY_FITNESS_APP_DB_PASSWORD_FILE:-./sparkyfitness_app_db_password.key}
+#   sparkyfitness_api_key:
+#     file: ${SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE:-./sparkyfitness_api_key.key}
+#   sparkyfitness_better_auth_secret:
+#     file: ${BETTER_AUTH_SECRET_FILE:-./sparkyfitness_better_auth_secret.key}
+#   sparkyfitness_email_pass:
+#     file: ${SPARKY_FITNESS_EMAIL_PASS_FILE:-./sparkyfitness_email_pass.key}

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -16,6 +16,9 @@ services:
       GUID: 1000
     volumes:
       - ${DB_PATH:-./postgresql}:/var/lib/postgresql
+    # Uncomment the below section to mount the file-based secrets
+    #secrets:
+    #  - sparkyfitness_db_password
     networks:
       - sparkyfitness-network # Use the new named network
 
@@ -119,6 +122,15 @@ services:
     volumes:
       - ${SERVER_BACKUP_PATH:-./backup}:/app/SparkyFitnessServer/backup # Mount volume for backups
       - ${SERVER_UPLOADS_PATH:-./uploads}:/app/SparkyFitnessServer/uploads # Mount volume for Profile pictures and excercise images
+    # Uncomment the below section to mount the file-based secrets
+    #secrets:
+    #  - sparkyfitness_db_password
+    #  - sparkyfitness_app_db_password
+    #  - sparkyfitness_api_key
+    #  - sparkyfitness_better_auth_secret
+    #  - sparkyfitness_email_pass
+    #  - sparkyfitness_oidc_client_id
+    #  - sparkyfitness_oidc_client_secret
 
   sparkyfitness-frontend:
     image: codewithcj/sparkyfitness:latest # Use pre-built image
@@ -164,3 +176,21 @@ services:
 networks:
   sparkyfitness-network:
     driver: bridge
+
+# Uncomment the below section to mount the file-based secrets
+# These are the file paths on the host and should not be the same as the paths mentioned above which are in the containers themselves
+#secrets:
+#   sparkyfitness_db_password:
+#     file: ${SPARKY_FITNESS_DB_PASSWORD_FILE:-./sparkyfitness_db_password.key}
+#   sparkyfitness_app_db_password:
+#     file: ${SPARKY_FITNESS_APP_DB_PASSWORD_FILE:-./sparkyfitness_app_db_password.key}
+#   sparkyfitness_api_key:
+#     file: ${SPARKY_FITNESS_API_ENCRYPTION_KEY_FILE:-./sparkyfitness_api_key.key}
+#   sparkyfitness_better_auth_secret:
+#     file: ${BETTER_AUTH_SECRET_FILE:-./sparkyfitness_better_auth_secret.key}
+#   sparkyfitness_email_pass:
+#     file: ${SPARKY_FITNESS_EMAIL_PASS_FILE:-./sparkyfitness_email_pass.key}
+#   sparkyfitness_oidc_client_id:
+#     file: ${SPARKY_FITNESS_OIDC_CLIENT_ID_FILE:-./sparkyfitness_oidc_client_id.key}
+#   sparkyfitness_oidc_client_secret:
+#     file: ${SPARKY_FITNESS_OIDC_CLIENT_SECRET_FILE:-./sparkyfitness_oidc_client_secret.key}

--- a/docs/content/1.install/7.environment-variables.md
+++ b/docs/content/1.install/7.environment-variables.md
@@ -164,6 +164,8 @@ SparkyFitness natively supports loading sensitive configuration values from file
 
 Any backend environment variable `VAR` can be supplied via a corresponding `VAR_FILE` environment variable pointing to the mounted secret file. When `VAR_FILE` is provided and `VAR` is unset, empty, or contains only whitespace, the server automatically reads and trims the secret from the specified file on startup.
 
+Make sure to mount the secret files to the containers, otherwise the server will not have any secret file to read. This can be done by uncommenting the specific sections of the compose file that are mounting and defining the secret files (one section for each container, and one section at the end of the compose file). The file paths in the .env file are the paths on the host machine, not the containers themselves.
+
 ### Supported Secret Variables
 
 Common variables supporting `*_FILE` include:


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Compose secrets not implemented correctly

**How did you implement the solution?**
Added the right mounting syntax to the compose files and adjusted .env file to show the host file paths rather than the container file paths (which should be static).

Linked Issue: Closes #

## How to Test

1. Check out this branch and edit the .env and compose file
2. Start the containers
3. Try logging in

## PR Type

- [X] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [X] Documentation

## Checklist

**All PRs:**

- [X] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.
