### PR TITLE
fix(reports): interpolate hypnogram count in sleep "Show All" label

### DIFF
--- a/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsCharts.tsx
+++ b/SparkyFitnessFrontend/src/pages/Reports/SleepAnalyticsCharts.tsx
@@ -319,10 +319,10 @@ const SleepAnalyticsCharts = ({
                   </>
                 ) : (
                   <>
-                    {t(
-                      'sleepAnalyticsCharts.showAll',
-                      `Show All (${sortedHypnograms.length})`
-                    )}
+                    {t('sleepAnalyticsCharts.showAll', {
+                      count: sortedHypnograms.length,
+                      defaultValue: `Show All (${sortedHypnograms.length})`,
+                    })}
                     <ChevronDown className="w-4 h-4 ml-1" />
                   </>
                 )}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The Sleep report's "Nightly Details" toggle rendered the literal string `Show All ({{count}})` instead of the number of hypnograms. Reported in #2242 on German, but it affected every language.

**How did you implement the solution?**
- `SleepAnalyticsCharts.tsx` passed a plain default string as the second `t()` argument, so i18next resolved the `sleepAnalyticsCharts.showAll` key (which is `"Show All ({{count}})"` in `en/translation.json`) with no `count` value and left the placeholder in the output.
- Changed the call to pass an options object with `count`, keeping the literal as `defaultValue`.
- Locales other than `en` have no `sleepAnalyticsCharts` section, so they fell back to the English string and showed the same placeholder — this fixes them all with one call-site change. No translation files needed edits.
- Verified against the repo's own i18next version that a non-pluralized base key resolves correctly when `count` is passed (no `_one`/`_other` keys required), including on the `de → en` fallback path.

Linked Issue: Closes #2242

## How to Test

1. Check out this branch and run `pnpm dev` from `SparkyFitnessFrontend/`.
2. Log or sync at least 3 nights of sleep data so the "Show All" toggle appears (it only renders when there are more hypnograms than fit the collapsed view).
3. Navigate to **Reports → Sleep** (`/reports?tab=sleep-analytics`).
4. Verify the button under "Nightly Details" reads `Show All (4)` (with the real count) rather than `Show All ({{count}})`.
5. Switch the app language to German in Settings and repeat — it should show the same interpolated count via the English fallback.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. — N/A, bug fix

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. — no translation file changes were needed at all.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests. — N/A
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. — N/A

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. — text-only label change, see below

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. — N/A

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

### After

<img width="1525" height="743" alt="image" src="https://github.com/user-attachments/assets/80efc254-c696-4023-a835-5e93d6eadd4f" />

</details>

## Notes for Reviewers

- No layout or styling change; only the string passed to the button.
- The same defect pattern (a `t()` call whose key contains `{{…}}` but which passes a default string instead of an options object) exists in a few other places and will also render raw placeholders — `reportUtil.ts` body-measurement CSV headers and the custom-measurement export toast, `useUsers.ts` delete-success, `useMeals.ts` delete-failure, `UserManagement.tsx` reset-MFA confirm, `Exercises.tsx` delete confirm, and `MedicationReports.tsx` weight-vs-goal title. Left out of this PR to keep it scoped to #2242; happy to follow up.
- `pnpm format`, `pnpm test` (101 suites / 990 tests), and `pnpm validate` all pass in `SparkyFitnessFrontend/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Show All” label in sleep analytics by enabling accurate count-based translation and fallback text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->