### PR TITLE
fix(mobile): preserve Health Connect activity names for generic exercise types

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/healthconnect/dataTransformation.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/dataTransformation.test.ts
@@ -517,6 +517,68 @@ describe('transformHealthRecords', () => {
       expect(result[0].activityType).toBe('Exercise Session');
     });
 
+    // Health Connect has no bowling code, so bowling apps write
+    // EXERCISE_TYPE_OTHER_WORKOUT (0) and name the sport in the title.
+    test('uses the source title when the type is OTHER_WORKOUT', () => {
+      const records = [
+        { startTime: '2024-01-15T08:00:00Z', endTime: '2024-01-15T09:00:00Z', exerciseType: 0, title: 'Bowling' },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'ExerciseSession', unit: '', type: 'exercise' }) as TransformedExerciseSession[];
+
+      expect(result[0].activityType).toBe('Bowling');
+      expect(result[0].title).toBe('Bowling');
+    });
+
+    // 0 is falsy: the old truthiness check skipped EXERCISE_MAP entirely.
+    test('maps OTHER_WORKOUT to "Other Workout" when the record has no title', () => {
+      const records = [
+        { startTime: '2024-01-15T08:00:00Z', endTime: '2024-01-15T09:00:00Z', exerciseType: 0 },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'ExerciseSession', unit: '', type: 'exercise' }) as TransformedExerciseSession[];
+
+      expect(result[0].activityType).toBe('Other Workout');
+    });
+
+    test('uses the source title for codes newer than the map', () => {
+      const records = [
+        { startTime: '2024-01-15T08:00:00Z', endTime: '2024-01-15T09:00:00Z', exerciseType: 999, title: 'Padel' },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'ExerciseSession', unit: '', type: 'exercise' }) as TransformedExerciseSession[];
+
+      expect(result[0].activityType).toBe('Padel');
+    });
+
+    test('uses the source title when the record has no exerciseType at all', () => {
+      const records = [
+        { startTime: '2024-01-15T08:00:00Z', endTime: '2024-01-15T09:00:00Z', title: 'Bowling' },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'ExerciseSession', unit: '', type: 'exercise' }) as TransformedExerciseSession[];
+
+      expect(result[0].activityType).toBe('Bowling');
+    });
+
+    // The server creates one exercises row per distinct name, so a per-workout
+    // nickname must never displace a recognized code.
+    test('keeps the mapped name when a specific code carries a nickname title', () => {
+      const records = [
+        { startTime: '2024-01-15T08:00:00Z', endTime: '2024-01-15T09:00:00Z', exerciseType: 56, title: 'Morning Run' },
+        { startTime: '2024-01-15T10:00:00Z', endTime: '2024-01-15T11:00:00Z', exerciseType: 9, title: 'Hometrainer' },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'ExerciseSession', unit: '', type: 'exercise' }) as TransformedExerciseSession[];
+
+      expect(result[0].activityType).toBe('Running');
+      expect(result[1].activityType).toBe('Biking (Stationary)');
+    });
+
+    test('ignores a blank title', () => {
+      const records = [
+        { startTime: '2024-01-15T08:00:00Z', endTime: '2024-01-15T09:00:00Z', exerciseType: 0, title: '   ' },
+      ];
+      const result = transformHealthRecords(records, { recordType: 'ExerciseSession', unit: '', type: 'exercise' }) as TransformedExerciseSession[];
+
+      expect(result[0].activityType).toBe('Other Workout');
+    });
+
     test('uses activityType as title when no explicit title', () => {
       const records = [
         { startTime: '2024-01-15T08:00:00Z', endTime: '2024-01-15T09:00:00Z', exerciseType: 56 },

--- a/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/dataTransformation.ts
@@ -444,6 +444,14 @@ const EXERCISE_MAP: Record<number, string> = {
   83: 'Yoga',
 } as const;
 
+/**
+ * EXERCISE_TYPE_OTHER_WORKOUT. Health Connect has no code for every sport —
+ * bowling, padel and darts have none — so those apps write this code and put
+ * the real activity in the record's `title`. It is a number, and 0 is falsy,
+ * so it has to be compared explicitly rather than tested for truthiness.
+ */
+const EXERCISE_TYPE_OTHER_WORKOUT = 0;
+
 // Health Connect SleepStageType constants from react-native-health-connect.
 // We skip UNKNOWN values so they do not distort asleep-time totals downstream.
 const mapHealthConnectSleepStage = (stage: number): SleepStageType | null => {
@@ -650,10 +658,28 @@ const DIRECT_TRANSFORMERS: Record<string, DirectTransformer> = {
     if (durationInSeconds <= 0) return;
     const recordDate = toLocalDateString(rec.startTime as string);
     const exerciseType = rec.exerciseType as number | undefined;
-    const activityTypeName = exerciseType
-      ? (EXERCISE_MAP[exerciseType] || `Exercise Type ${exerciseType}`)
-      : 'Exercise Session';
-    const title = (rec.title as string) || activityTypeName;
+    const sourceTitle = typeof rec.title === 'string' ? rec.title.trim() : '';
+    const mappedName = exerciseType == null ? undefined : EXERCISE_MAP[exerciseType];
+
+    // A recognized, specific code is authoritative: it names the same activity
+    // every session, which keeps the server's exercise-library row stable. The
+    // title is a per-workout label ("Morning Run", "Lauf am Morgen"), and the
+    // server creates one exercise per distinct name, so letting it win over a
+    // specific code would fragment the library and split PR history.
+    const isSpecificType =
+      mappedName !== undefined && exerciseType !== EXERCISE_TYPE_OTHER_WORKOUT;
+
+    // Only when the code carries no activity — OTHER_WORKOUT, absent, or a code
+    // newer than EXERCISE_MAP — is the title the most specific thing we have,
+    // and it beats a generic fallback that would drop the activity entirely.
+    const genericName =
+      mappedName ??
+      (exerciseType == null ? 'Exercise Session' : `Exercise Type ${exerciseType}`);
+
+    const activityTypeName = isSpecificType
+      ? mappedName
+      : sourceTitle || genericName;
+    const title = sourceTitle || activityTypeName;
 
     // Extract calories burned
     let caloriesBurned = 0;


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Health Connect sessions logged as `EXERCISE_TYPE_OTHER_WORKOUT` imported as a generic "Exercise Session" instead of the activity the source app named in the session title, so a bowling workout lost its name.

**How did you implement the solution?**

- `EXERCISE_TYPE_OTHER_WORKOUT` is `0`, which is falsy, so the old truthiness check skipped `EXERCISE_MAP` entirely. It is now compared explicitly and resolves to "Other Workout".
- The record's `title` was computed and then discarded. It is now used when the exercise code carries no activity — `OTHER_WORKOUT`, absent, or a code newer than `EXERCISE_MAP`. Health Connect has no code for bowling, padel or darts, so the title is the only specific information those sessions carry.
- A recognized specific code still wins over the title. The title is a per-workout label ("Morning Run"), and the server creates one `exercises` row per distinct name, so letting it override a known code would fragment the exercise library and split PR history.
- Whitespace-only titles are ignored.

Linked Issue: Closes #2243

## How to Test

1. Check out this branch and run `cd SparkyFitnessMobile && pnpm test __tests__/services/healthconnect/dataTransformation.test.ts`.
2. On a device with Health Connect, log a workout whose sport has no Health Connect code (bowling, padel, darts) — the source app writes `EXERCISE_TYPE_OTHER_WORKOUT` with the sport in the title.
3. Sync Health Connect data in the app and open that day in the diary.
4. Verify the entry is named after the source activity ("Bowling") rather than "Exercise Session", and that its notes read `Activity Type: Bowling`.
5. Verify a normal run or ride still imports under its mapped name ("Running", "Biking (Stationary)") even when the source app set a nickname title like "Morning Run".

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. — N/A, bug fix

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes. — N/A, no frontend changes
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. — N/A, no translation changes

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests. — N/A, no backend changes
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. — N/A, no schema changes

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. — N/A, data transformation only, no UI changes

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. — not yet; see Notes for Reviewers

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

N/A — no UI changes. The reporter's screenshot in #2243 shows the "Exercise Session" entry this fixes.

### After

N/A — no UI changes.

</details>

## Notes for Reviewers

`pnpm run validate` passes and the full mobile suite is green (5883 tests). Covered by 6 new unit tests in `dataTransformation.test.ts`, but **not yet verified on a device** — the device check needs a real bowling/padel session in Health Connect, so the box above is left unchecked deliberately.

Scope note: #2243 also reports a stationary bike importing as "Biking". That half is **not** fixed here, and I could not reproduce it. `EXERCISE_MAP[9]` already maps `BIKING_STATIONARY` to "Biking (Stationary)", the server matches exercise names exactly, and the reporter's treadmill run (57) and table tennis (75) render correctly — so their record almost certainly arrived as `EXERCISE_TYPE_BIKING` (8) from the source app. Confirming that needs the raw record, which is already persisted in `exercise_entry_activity_details.detail_data` along with `metadata.dataOrigin` (the writing app's package name).

Two dead ends worth recording so they are not re-investigated:

- **Segments cannot recover it.** A `BIKING` session cannot carry a `BIKING_STATIONARY` segment: both androidx and the platform map it to `Set.of(EXERCISE_SEGMENT_TYPE_BIKING)` only.
- **Our numbering is correct.** androidx and the AOSP platform use different integers for the same activities (androidx `BIKING`=8, platform=4). `EXERCISE_MAP` uses androidx numbering, which is what `react-native-health-connect` exposes — confirmed by codes 57 and 75 decoding correctly, as the platform enum stops at 61.

`EXERCISE_MAP` also carries 22 codes that are not valid session types (`Bench Press`, `Squat`, and similar — androidx collapses those to `STRENGTH_TRAINING`/`CALISTHENICS`). They are unreachable rather than wrong, and `HEART_RATE_ONLY_TYPES` in `workoutTelemetry.ts` intentionally lists the same codes, so both are left alone here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exercise session activity naming when records use custom titles or unmapped exercise types.
  - Preserves recognized activity names while using source titles as appropriate fallbacks.
  - Correctly handles “Other Workout” sessions, including blank or missing titles.
  - Trims unnecessary whitespace from exercise session titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->