### PR TITLE
fix(mobile): show goal progress in the Android macro widget bars

### DIFF
--- a/SparkyFitnessMobile/__tests__/hooks/useWidgetSync.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useWidgetSync.test.ts
@@ -210,8 +210,42 @@ describe('useWidgetSync', () => {
       fat: 55,
       calories: 1540,
       remaining: 460,
+      // The widget's per-macro bars need each goal to show real progress; without
+      // them it can only compare macros against each other, which barely moves
+      // across the day (#2228).
+      proteinGoal: 150,
+      carbsGoal: 200,
+      fatGoal: 65,
     });
     expect(androidReloadMacro).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-pushes the macro snapshot when only a macro goal changes', async () => {
+    Object.defineProperty(Platform, 'OS', {
+      get: () => 'android',
+      configurable: true,
+    });
+
+    const { rerender } = renderHook(
+      ({ summary }) => useWidgetSync(summary),
+      { initialProps: { summary: makeSummary() } },
+    );
+    await flushWidgetPush();
+    expect(androidSetMacroSnapshot).toHaveBeenCalledTimes(1);
+
+    // Consumption is identical, so a snapshot keyed only on consumed grams
+    // would dedupe this away and leave the bars rendering against a stale goal.
+    rerender({
+      summary: makeSummary({ protein: { consumed: 92, goal: 180 } }),
+    });
+    await flushWidgetPush();
+
+    expect(androidSetMacroSnapshot).toHaveBeenCalledTimes(2);
+    const latest = JSON.parse(
+      androidSetMacroSnapshot.mock.calls[1][0] as string,
+    );
+    expect(latest).toMatchObject({ protein: 92, proteinGoal: 180 });
+    expect(androidReloadMacro).toHaveBeenCalledTimes(2);
   });
 
   it('skips Android pushes when only non-rendered summary fields change', async () => {

--- a/SparkyFitnessMobile/src/hooks/useWidgetSync.ts
+++ b/SparkyFitnessMobile/src/hooks/useWidgetSync.ts
@@ -128,6 +128,11 @@ export function useWidgetSync(summary: DailySummary | undefined): void {
         }
       }
 
+      // Goals ride along so the widget's per-macro bars can show progress
+      // toward each goal. Without them the widget can only compare a macro
+      // against the day's other macros, which barely moves as the day fills up
+      // (#2228). Not sent on iOS: that widget draws a composition ring, where
+      // the three shares summing to one is the intended reading.
       const macroSnapshot = {
         date,
         protein: summary.protein.consumed,
@@ -135,6 +140,9 @@ export function useWidgetSync(summary: DailySummary | undefined): void {
         fat: summary.fat.consumed,
         calories: summary.caloriesConsumed,
         remaining: balance?.remaining,
+        proteinGoal: summary.protein.goal,
+        carbsGoal: summary.carbs.goal,
+        fatGoal: summary.fat.goal,
       };
       const macroSnapshotKey = JSON.stringify(macroSnapshot);
       if (lastAndroidMacroSnapshotKeyRef.current === macroSnapshotKey) return;

--- a/SparkyFitnessMobile/src/hooks/useWidgetSync.ts
+++ b/SparkyFitnessMobile/src/hooks/useWidgetSync.ts
@@ -14,6 +14,41 @@ const CALORIE_SNAPSHOT_KEY = 'calorieSnapshot';
 const MACRO_WIDGET_KIND = 'macroWidget';
 const MACRO_SNAPSHOT_KEY = 'macroSnapshot';
 
+/**
+ * The Android widget snapshot contracts, mirrored by `parseSnapshot` in
+ * `CalorieWidget.kt.tmpl` and `MacroWidget.kt.tmpl`.
+ *
+ * Declared explicitly so a field cannot be renamed or dropped on this side
+ * without a type error. They cannot make the boundary type-safe on their own:
+ * `setCalorieSnapshot`/`setMacroSnapshot` take a `string`, and the Kotlin
+ * readers match these keys by name, so the two halves still have to be kept in
+ * step by hand.
+ *
+ * Optional fields are dropped by `JSON.stringify` rather than serialized as
+ * null, which is what the widgets' `optionalDouble` reads as "not supplied".
+ */
+interface AndroidCalorieSnapshot {
+  date: string;
+  remaining: number;
+  goal: number;
+  progress: number;
+}
+
+interface AndroidMacroSnapshot {
+  date: string;
+  protein: number;
+  carbs: number;
+  fat: number;
+  calories: number;
+  remaining?: number;
+  proteinGoal: number;
+  carbsGoal: number;
+  fatGoal: number;
+}
+
+/** A snapshot plus its push timestamp, which is deliberately not part of the dedupe key. */
+type AndroidWidgetPayload<T> = T & { lastUpdated: number };
+
 const iosAppGroup = (
   Constants.expoConfig?.extra as { iosAppGroup?: string } | undefined
 )?.iosAppGroup;
@@ -92,7 +127,7 @@ export function useWidgetSync(summary: DailySummary | undefined): void {
         const { goal, remaining, progress } = balance;
         const clampedProgress =
           goal > 0 ? Math.max(0, Math.min(1, progress / 100)) : 0;
-        const calorieSnapshot = {
+        const calorieSnapshot: AndroidCalorieSnapshot = {
           date,
           remaining,
           goal,
@@ -102,7 +137,7 @@ export function useWidgetSync(summary: DailySummary | undefined): void {
 
         if (lastAndroidCalorieSnapshotKeyRef.current !== calorieSnapshotKey) {
           lastAndroidCalorieSnapshotKeyRef.current = calorieSnapshotKey;
-          const caloriePayload = {
+          const caloriePayload: AndroidWidgetPayload<AndroidCalorieSnapshot> = {
             ...calorieSnapshot,
             lastUpdated,
           };
@@ -133,7 +168,7 @@ export function useWidgetSync(summary: DailySummary | undefined): void {
       // against the day's other macros, which barely moves as the day fills up
       // (#2228). Not sent on iOS: that widget draws a composition ring, where
       // the three shares summing to one is the intended reading.
-      const macroSnapshot = {
+      const macroSnapshot: AndroidMacroSnapshot = {
         date,
         protein: summary.protein.consumed,
         carbs: summary.carbs.consumed,
@@ -148,7 +183,7 @@ export function useWidgetSync(summary: DailySummary | undefined): void {
       if (lastAndroidMacroSnapshotKeyRef.current === macroSnapshotKey) return;
 
       lastAndroidMacroSnapshotKeyRef.current = macroSnapshotKey;
-      const macroPayload = {
+      const macroPayload: AndroidWidgetPayload<AndroidMacroSnapshot> = {
         ...macroSnapshot,
         lastUpdated,
       };

--- a/SparkyFitnessMobile/targets/android-widget/kotlin/com/sparkyapps/sparkyfitness/widget/MacroWidget.kt.tmpl
+++ b/SparkyFitnessMobile/targets/android-widget/kotlin/com/sparkyapps/sparkyfitness/widget/MacroWidget.kt.tmpl
@@ -267,6 +267,9 @@ class MacroWidget : GlanceAppWidget() {
         val fat: Double,
         val calories: Double,
         val remaining: Double?,
+        val proteinGoal: Double?,
+        val carbsGoal: Double?,
+        val fatGoal: Double?,
         val lastUpdated: Long,
     ) {
         val proteinKcal: Double = protein * 4.0
@@ -304,11 +307,10 @@ class MacroWidget : GlanceAppWidget() {
                 carbs = obj.safeDouble("carbs"),
                 fat = obj.safeDouble("fat"),
                 calories = obj.safeDouble("calories"),
-                remaining = if (obj.has("remaining")) {
-                    obj.safeDouble("remaining")
-                } else {
-                    null
-                },
+                remaining = obj.optionalDouble("remaining"),
+                proteinGoal = obj.optionalDouble("proteinGoal"),
+                carbsGoal = obj.optionalDouble("carbsGoal"),
+                fatGoal = obj.optionalDouble("fatGoal"),
                 lastUpdated = obj.optLong("lastUpdated", 0L),
             )
         } catch (e: Exception) {
@@ -316,8 +318,39 @@ class MacroWidget : GlanceAppWidget() {
         }
     }
 
+    /**
+     * Progress toward each macro's own goal, which is what a per-macro bar
+     * reads as.
+     *
+     * These are three independent bars, so the share-of-total this used to show
+     * was the wrong shape entirely: those three fractions always sum to one, and
+     * a day's macro ratio barely shifts as the day fills up, so the bars looked
+     * frozen while the kcal header moved (#2228). The iOS widget keeps the
+     * share-of-total maths because it draws one segmented ring, where the three
+     * shares summing to one is the intended reading.
+     */
     private fun MacroSnapshot?.progressFor(kind: MacroKind): Float {
         val snapshot = this ?: return 0f
+
+        val consumed = when (kind) {
+            MacroKind.PROTEIN -> snapshot.protein
+            MacroKind.CARBS -> snapshot.carbs
+            MacroKind.FAT -> snapshot.fat
+        }
+        val goal = when (kind) {
+            MacroKind.PROTEIN -> snapshot.proteinGoal
+            MacroKind.CARBS -> snapshot.carbsGoal
+            MacroKind.FAT -> snapshot.fatGoal
+        }
+
+        if (goal != null && goal > 0.0) {
+            return (consumed / goal).coerceIn(0.0, 1.0).toFloat()
+        }
+
+        // No goal in the snapshot: either it predates the goal fields (the app
+        // has not refreshed the widget since updating) or the user has no goal
+        // set for this macro. Fall back to the old share-of-total so the bar
+        // still carries some signal rather than collapsing to empty.
         val total = snapshot.macroKcalTotal
         if (total <= 0.0) return 0f
 
@@ -332,6 +365,13 @@ class MacroWidget : GlanceAppWidget() {
     private fun JSONObject.safeDouble(name: String): Double {
         val value = optDouble(name, 0.0)
         return if (value.isFinite()) value else 0.0
+    }
+
+    /** Absent, JSON null and non-finite all read as "not supplied". */
+    private fun JSONObject.optionalDouble(name: String): Double? {
+        if (!has(name) || isNull(name)) return null
+        val value = optDouble(name, Double.NaN)
+        return if (value.isFinite()) value else null
     }
 
     private fun isToday(date: String): Boolean {


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

The Android macro widget's protein/carbs/fat bars never showed goal progress — they showed each macro's share of total macro calories, which barely moves as the day fills up, so the bars looked stuck while the kcal header updated.

**How did you implement the solution?**

- The three bars are independent `LinearProgressIndicator`s, but `progressFor` returned `macroKcal / macroKcalTotal`. Those fractions always sum to one, so they track the day's macro *ratio*, not progress. With 87 g protein / 184 g carbs / 94 g fat the bars drew 18/38/44% where the dashboard showed 81/77/114%.
- The widget could not do better, because the snapshot only ever carried consumed grams. `useWidgetSync` now sends `proteinGoal`, `carbsGoal` and `fatGoal` in the Android macro snapshot. The push dedupe key is the stringified snapshot, so a goal-only change re-pushes rather than being skipped.
- `progressFor` now returns `consumed / goal`, falling back to the previous share-of-total when a goal is absent — snapshots written by an older build, and macros with no goal set, degrade instead of collapsing to empty.
- The three new optional doubles and the existing `remaining` parse through one `optionalDouble` helper, so absent, JSON null and non-finite all read as "not supplied".

The iOS widget is deliberately unchanged. It has the same share-of-total maths, but renders a single segmented `MacroRing`, where three shares summing to one is the intended reading of a composition chart. Only Android maps those shares onto independent progress bars.

Linked Issue: Closes #2228

## How to Test

1. Check out this branch, then `cd SparkyFitnessMobile && pnpm test __tests__/hooks/useWidgetSync.test.ts`.
2. Run `npx expo prebuild` — `MacroWidget.kt.tmpl` is a template that `withCalorieWidget.ts` copies into `android/` at prebuild, so the change does not reach the app without it.
3. Launch on an Android emulator or device and add the 2x2 macro widget to the home screen. Make sure macro goals are set, otherwise the fallback path renders the old behaviour.
4. Open the Dashboard at least once — `useWidgetSync` is mounted there — and log food against today.
5. Verify each bar matches the dashboard's per-macro percentage, and that logging something protein-heavy moves the protein bar while carbs and fat stay put. Previously all three shifted as they rebalanced against each other.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. — N/A, bug fix

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes. — N/A, no frontend changes
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. — N/A, no translation changes

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests. — N/A, no backend changes
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. — N/A, no schema changes

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. — widget rendering only; see the issue for the before state

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

The reporter's screenshots in #2228 show the stuck bars: the widget reads 87 g / 184 g / 94 g while the bars sit at their share-of-total positions rather than the dashboard's 81% / 77% / 114%.

### After

Verified on an Android emulator: each bar tracks its own goal and matches the dashboard.
<img width="1080" height="2400" alt="Screenshot_1787700534" src="https://github.com/user-attachments/assets/3c75b052-7513-4ef3-813b-2a5e015f1272" />

</details>

## Notes for Reviewers

`pnpm run validate` passes and the mobile suite is green (5884 tests). Verified on an Android emulator.

Coverage note: the behavioural change is split across two layers and only one is testable here. The snapshot payload is covered by `useWidgetSync.test.ts`, including a regression test that a goal-only change still re-pushes. The Kotlin half has no automated coverage because the repo has no Kotlin test harness, so `progressFor` was verified by inspection plus the emulator run.

`MacroWidget.kt.tmpl` is the tracked source for the widget — `withCalorieWidget.ts` strips the `.tmpl` suffix and substitutes `{{APPLICATION_ID}}` during prebuild, and the generated `android/` copy is gitignored.

Fallback behaviour worth a second opinion: when a goal is missing the bar keeps the old share-of-total rather than rendering empty. That keeps some signal for users with no goals set, at the cost of two different meanings for the same bar. Rendering empty instead would be more honest but looks broken.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Android macro widgets now display progress for protein, carbohydrates, and fat based on their configured daily goals.
  - Macro progress remains available using total consumption when a valid goal is unavailable.

- **Bug Fixes**
  - Updated macro goals now immediately refresh the widget with the latest progress and goal values.
  - Improved handling of missing or invalid macro goal values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->