### PR TITLE
fix(ai): give Ollama dispatch room for local model cold starts

### DIFF
--- a/SparkyFitnessServer/ai/providerDispatch.ts
+++ b/SparkyFitnessServer/ai/providerDispatch.ts
@@ -40,7 +40,6 @@ export interface ProviderConfig {
   api_key?: string;
   model_name?: string;
   custom_url?: string;
-  timeout?: number;
 }
 
 export interface DispatchImage {
@@ -73,7 +72,7 @@ export interface DispatchRequest {
   parseJson?: boolean;
   /** Forwarded to every provider family; omitted from the request body when unset. */
   temperature?: number;
-  /** Default 90_000; Ollama default 120_000 (or `provider.timeout`). */
+  /** Default 90_000; Ollama default 300_000. */
   timeoutMs?: number;
 }
 
@@ -100,7 +99,16 @@ export type DispatchResult =
     };
 
 const DEFAULT_TIMEOUT_MS = 90_000;
-const OLLAMA_DEFAULT_TIMEOUT_MS = 120_000;
+// Ollama is nearly always a local server, where the first request after an idle
+// period pays a cold start: loading a multi-billion-parameter model into VRAM
+// can take minutes on modest hardware, before inference begins. 120s was short
+// enough to fail that load outright. Matches CHAT_REQUEST_TIMEOUT_MS in
+// chatService.ts, so the dispatch path is no longer the stricter of the two.
+const OLLAMA_DEFAULT_TIMEOUT_MS = 5 * 60_000;
+// Ask Ollama to hold the model in memory well past its 5-minute default, so
+// only the first request in a session pays the cold start rather than every
+// request that follows a short pause.
+const OLLAMA_KEEP_ALIVE = '30m';
 // On Claude Opus 5 and Sonnet 5, omitting the `thinking` parameter runs
 // adaptive thinking by default, and max_tokens caps thinking *and* the visible
 // response together. At 2048 with a forced tool call, reasoning could consume
@@ -599,6 +607,7 @@ function buildOllamaRequest(ctx: BuildContext): BuiltRequest {
     model: ctx.model,
     messages: [message],
     stream: false,
+    keep_alive: OLLAMA_KEEP_ALIVE,
     options: {
       num_ctx: 8192, // Enforce 8k context window support
       ...(ctx.temperature !== undefined && { temperature: ctx.temperature }),
@@ -978,7 +987,7 @@ async function performOllama(
 function resolveTimeout(req: DispatchRequest, family: ProviderFamily): number {
   if (typeof req.timeoutMs === 'number') return req.timeoutMs;
   if (family === 'ollama') {
-    return req.provider.timeout ?? OLLAMA_DEFAULT_TIMEOUT_MS;
+    return OLLAMA_DEFAULT_TIMEOUT_MS;
   }
   return DEFAULT_TIMEOUT_MS;
 }

--- a/SparkyFitnessServer/services/aiUnitConversionService.ts
+++ b/SparkyFitnessServer/services/aiUnitConversionService.ts
@@ -176,7 +176,6 @@ export async function estimateUnitConversion(
     api_key: aiService.api_key ?? undefined,
     model_name: aiService.model_name ?? undefined,
     custom_url: aiService.custom_url ?? undefined,
-    timeout: aiService.timeout ?? undefined,
   };
 
   // 4. Build prompt + dispatch. The helper owns the api-key/custom-url checks,

--- a/SparkyFitnessServer/services/chatService.ts
+++ b/SparkyFitnessServer/services/chatService.ts
@@ -1763,7 +1763,6 @@ async function processFoodOptionsRequest(
     api_key: aiService.api_key ?? undefined,
     model_name: aiService.model_name ?? undefined,
     custom_url: aiService.custom_url ?? undefined,
-    timeout: aiService.timeout ?? undefined,
   };
 
   const prompt = `${FOOD_OPTIONS_PROMPT}\n\nGENERATE_FOOD_OPTIONS:${foodName} in ${unit}`;

--- a/SparkyFitnessServer/services/foodPhotoEstimationService.ts
+++ b/SparkyFitnessServer/services/foodPhotoEstimationService.ts
@@ -332,7 +332,6 @@ async function estimateFoodPhotoNutrition(
     api_key: aiService.api_key ?? undefined,
     model_name: aiService.model_name ?? undefined,
     custom_url: aiService.custom_url ?? undefined,
-    timeout: aiService.timeout ?? undefined,
   };
 
   const result = await dispatchAiRequest({

--- a/SparkyFitnessServer/services/labelScanService.ts
+++ b/SparkyFitnessServer/services/labelScanService.ts
@@ -65,7 +65,6 @@ async function extractNutritionFromLabel(
     api_key: aiService.api_key ?? undefined,
     model_name: aiService.model_name ?? undefined,
     custom_url: aiService.custom_url ?? undefined,
-    timeout: aiService.timeout ?? undefined,
   };
 
   const result = await dispatchAiRequest({

--- a/SparkyFitnessServer/tests/foodOptionsService.test.ts
+++ b/SparkyFitnessServer/tests/foodOptionsService.test.ts
@@ -247,13 +247,12 @@ describe('processFoodOptionsRequest', () => {
       expect(body.options.temperature).toBe(0.7);
     });
 
-    it('passes the configured timeout to the Ollama agent', async () => {
+    it('defaults the Ollama agent timeout to 300000ms', async () => {
       mockGetBackendSetting.mockResolvedValue(
         makeAiServiceDetail({
           service_type: 'ollama',
           api_key: null,
           custom_url: 'http://localhost:11434',
-          timeout: 5000,
         })
       );
       mockFetch(ollamaBody(sampleFoodOptions));
@@ -261,28 +260,8 @@ describe('processFoodOptionsRequest', () => {
       expect(result.success).toBe(true);
       expect(mockAgent).toHaveBeenCalledWith(
         expect.objectContaining({
-          headersTimeout: 5000,
-          bodyTimeout: 5000,
-        })
-      );
-    });
-
-    it('defaults the Ollama agent timeout to 120000ms when unset', async () => {
-      mockGetBackendSetting.mockResolvedValue(
-        makeAiServiceDetail({
-          service_type: 'ollama',
-          api_key: null,
-          custom_url: 'http://localhost:11434',
-          timeout: null,
-        })
-      );
-      mockFetch(ollamaBody(sampleFoodOptions));
-      const result = await runFoodOptions(true);
-      expect(result.success).toBe(true);
-      expect(mockAgent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          headersTimeout: 120000,
-          bodyTimeout: 120000,
+          headersTimeout: 300_000,
+          bodyTimeout: 300_000,
         })
       );
     });

--- a/SparkyFitnessServer/tests/labelScanService.test.ts
+++ b/SparkyFitnessServer/tests/labelScanService.test.ts
@@ -295,7 +295,7 @@ describe('extractNutritionFromLabel', () => {
       expect(init.body).toContain('Extract the nutrition facts');
     });
 
-    it('passes the configured timeout to the Ollama agent', async () => {
+    it('gives the Ollama agent the 5-minute cold-start timeout', async () => {
       mockGetVisionSetting.mockResolvedValue(
         makeAiSetting({ service_type: 'ollama' })
       );
@@ -304,7 +304,6 @@ describe('extractNutritionFromLabel', () => {
           service_type: 'ollama',
           api_key: null,
           custom_url: 'http://localhost:11434',
-          timeout: 5000,
         })
       );
       mockFetch(ollamaBody(sampleNutrition));
@@ -317,10 +316,32 @@ describe('extractNutritionFromLabel', () => {
       expect(result.success).toBe(true);
       expect(mockAgent).toHaveBeenCalledWith(
         expect.objectContaining({
-          headersTimeout: 5000,
-          bodyTimeout: 5000,
+          headersTimeout: 300_000,
+          bodyTimeout: 300_000,
         })
       );
+    });
+
+    it('asks Ollama to keep the model resident between requests', async () => {
+      mockGetVisionSetting.mockResolvedValue(
+        makeAiSetting({ service_type: 'ollama' })
+      );
+      mockGetBackendSetting.mockResolvedValue(
+        makeAiServiceDetail({
+          service_type: 'ollama',
+          api_key: null,
+          custom_url: 'http://localhost:11434',
+        })
+      );
+      const m = mockFetch(ollamaBody(sampleNutrition));
+      await extractNutritionFromLabel(
+        TEST_BASE64,
+        TEST_MIME,
+        TEST_USER_ID,
+        true
+      );
+      const init = m.mock.calls[0][1] as { body: string };
+      expect(JSON.parse(init.body).keep_alive).toBe('30m');
     });
   });
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Ollama requests failed when a local model was not already resident: loading it into VRAM can take longer than the 120s the dispatch path allowed, so the request timed out before inference began. This also removes a per-provider timeout override that never actually worked.

**How did you implement the solution?**
- Raised `OLLAMA_DEFAULT_TIMEOUT_MS` from 120s to 5 minutes, matching `CHAT_REQUEST_TIMEOUT_MS` in `chatService.ts` so the dispatch path is no longer the stricter of the two.
- Send `keep_alive: '30m'` on Ollama requests (Ollama's own default is 5 minutes), so only the first request in a session pays the cold start rather than every request after a pause.
- Removed `ProviderConfig.timeout` and its four call sites. `ai_service_settings` has no `timeout` column, so `aiService.timeout` was always `undefined` and the override was dead code.

Linked Issue: Refs #2252

## How to Test

1. Check out this branch and run `cd SparkyFitnessServer && pnpm test` — 3572 tests pass.
2. Configure an AI service with service type **Ollama** and a custom URL pointing at an Ollama server (e.g. `http://localhost:11434`, no `/v1` suffix on this service type).
3. Run `ollama stop <model>` so the model is unloaded, then trigger nutrition label scan or food photo analysis.
4. Verify the request completes rather than failing at ~120s while the model loads.
5. Trigger the same flow again after a few minutes idle and verify it responds immediately — `keep_alive` kept the model resident.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. (N/A — no schema changes.)

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

N/A — backend-only change.

</details>

## Notes for Reviewers

**This only covers the `ollama` service type.** `providerFamily()` maps only `'ollama'` to the Ollama family; `openai_compatible` and `custom` map to the OpenAI family and keep `DEFAULT_TIMEOUT_MS` (90s) with no `keep_alive`. The docs under "Local servers (LM Studio, Ollama, llama.cpp)" currently tell users to attach Ollama via its OpenAI-compatible endpoint (`http://localhost:11434/v1`), and those setups are unaffected by this change. Worth a follow-up to key the longer timeout off the local/self-hosted set that `requiresApiKey()` already recognises (`ollama`, `openai_compatible`, `custom`) rather than off the provider family.

`keep_alive` is deliberately only on the native Ollama body — I have not verified whether Ollama's `/v1/chat/completions` honours the parameter, so it is not sent there.

Two existing tests (`foodOptionsService.test.ts`, `labelScanService.test.ts`) asserted on the per-provider timeout by setting `timeout` on a mocked service detail. Since that column does not exist, the tests were green while the behaviour they described had never worked in production. They now assert the real default and `keep_alive`.

Also includes two previously committed Android widget changes from `dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * AI-powered food, label-scanning, and unit-conversion requests now allow up to five minutes by default, reducing failures during slower processing.
  * Ollama-powered requests can remain active for up to 30 minutes, improving continuity for longer-running tasks.

* **Bug Fixes**
  * Standardized AI request timeout behavior across supported features.
  * Explicitly configured request timeouts continue to be honored when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->