### PR TITLE
fix(ci): emit the support and upgrade preamble in generated release notes

### DIFF
--- a/.github/release-preamble.md
+++ b/.github/release-preamble.md
@@ -1,0 +1,15 @@
+### 💙 Support SparkyFitness
+If SparkyFitness has been useful to you & your family, please consider [sponsoring on GitHub](https://github.com/sponsors/CodeWithCJ) or supporting via [Ko-fi](https://ko-fi.com/sparkyapps). Your support helps cover recurring costs such as AI coding tools, development infrastructure, and Apple & Google Developer memberships to keep the project actively maintained.
+
+---
+
+> [!IMPORTANT]
+> 💾 **Upgrade Notice:** Always remember to back up your database and environment before upgrading to a new version.
+>
+> 👍 **Community Prioritization:** Want to see a specific feature or fix in the next release? Add a 👍 reaction to open [Issues](https://github.com/CodeWithCJ/SparkyFitness/issues) to help us prioritize what to build next!
+
+---
+
+## 🚀 Key Highlights
+
+<!-- Add key release highlights here -->

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,24 +1,14 @@
+# GitHub's native auto-generated release notes config.
+#
+# Only `changelog.exclude` and `changelog.categories` are part of the schema.
+# There is NO `template:` key and no $CHANGELOG / $CONTRIBUTORS variables here —
+# those belong to Release Drafter, and GitHub silently discards anything it does
+# not recognise. Do not add them back.
+#
+# The Support / Upgrade Notice / Key Highlights preamble lives in
+# .github/release-preamble.md and is stitched onto the generated notes by the
+# "Draft release" workflow (.github/workflows/draft-release.yml).
 changelog:
-  template: |
-    ### 💙 Support SparkyFitness
-    If SparkyFitness has been useful to you & your family, please consider [sponsoring on GitHub](https://github.com/sponsors/CodeWithCJ) or supporting via [Ko-fi](https://ko-fi.com/sparkyapps). Your support helps cover recurring costs such as AI coding tools, development infrastructure, and Apple & Google Developer memberships to keep the project actively maintained.
-
-    ---
-
-    > [!IMPORTANT]
-    > 💾 **Upgrade Notice:** Always remember to back up your database and environment before upgrading to a new version.
-    >
-    > 👍 **Community Prioritization:** Want to see a specific feature or fix in the next release? Add a 👍 reaction to open [Issues](https://github.com/CodeWithCJ/SparkyFitness/issues) to help us prioritize what to build next!
-
-    ---
-
-    ## 🚀 Key Highlights
-
-    <!-- Add key release highlights here -->
-
-    $CHANGELOG
-
-    $CONTRIBUTORS
   exclude:
     labels:
       - duplicate

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,86 @@
+name: Draft release
+
+# Creates a DRAFT release whose body is the preamble in
+# .github/release-preamble.md followed by GitHub's auto-generated changelog.
+#
+# Why this exists: GitHub's "Generate release notes" button only ever emits the
+# "What's Changed" block from .github/release.yml (categories + exclude). It has
+# no preamble support, and no workflow can patch a draft afterwards — GitHub does
+# not fire release events for draft releases. So the draft has to be built here.
+#
+# Drafts do not create the git tag (GitHub only creates the ref on publish), so
+# running this does not trigger the v* tag workflows. They run on publish, as before.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag for the new release (e.g. v1.6.4)"
+        required: true
+        type: string
+      previous_tag:
+        description: "Previous tag to diff against (optional; GitHub picks the last release if blank)"
+        required: false
+        type: string
+      target:
+        description: "Branch or commit the release is cut from"
+        required: false
+        default: main
+        type: string
+
+jobs:
+  draft:
+    name: Create draft release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build release body
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          PREVIOUS_TAG: ${{ inputs.previous_tag }}
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+
+          # Same generator the "Generate release notes" button uses, so the
+          # categories/exclude rules in .github/release.yml still apply.
+          args=(
+            -X POST
+            "repos/${GITHUB_REPOSITORY}/releases/generate-notes"
+            -f "tag_name=${TAG}"
+            -f "target_commitish=${TARGET}"
+          )
+          if [ -n "${PREVIOUS_TAG}" ]; then
+            args+=(-f "previous_tag_name=${PREVIOUS_TAG}")
+          fi
+
+          gh api "${args[@]}" --jq .body > generated-notes.md
+
+          cat .github/release-preamble.md > release-body.md
+          printf '\n' >> release-body.md
+          cat generated-notes.md >> release-body.md
+
+          echo "----- release body -----"
+          cat release-body.md
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          TARGET: ${{ inputs.target }}
+        run: |
+          set -euo pipefail
+          gh release create "${TAG}" \
+            --draft \
+            --title "${TAG}" \
+            --target "${TARGET}" \
+            --notes-file release-body.md
+
+          echo "Draft created. Review it at:"
+          gh release view "${TAG}" --json url --jq .url

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -38,6 +38,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Only needed to read .github/release-preamble.md. Every API call below
+          # authenticates through GH_TOKEN, so there is no reason to leave a
+          # credential behind in .git/config.
+          persist-credentials: false
 
       - name: Build release body
         env:


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The "💙 Support SparkyFitness", Upgrade Notice and Key Highlights sections never appeared when clicking **Generate release notes**, so they had to be pasted in by hand on every release.

**How did you implement the solution?**
- The `changelog.template` block in `.github/release.yml` has never had any effect. GitHub's native generator reads only `changelog.exclude` and `changelog.categories`; `template:`, `$CHANGELOG` and `$CONTRIBUTORS` are [Release Drafter](https://github.com/release-drafter/release-drafter) syntax, and GitHub discards unknown keys silently. Removed it and documented why it must not come back.
- A workflow cannot patch the draft after the fact either — GitHub does not fire release events for draft releases ("Workflows are not triggered for the `created`, `edited`, or `deleted` activity types for draft releases"). So the draft has to be built up front.
- Moved the preamble into `.github/release-preamble.md` so it is editable on its own.
- Added `.github/workflows/draft-release.yml`, a manually dispatched workflow that calls the same `releases/generate-notes` API the button uses (so `categories`/`exclude` still apply), prepends the preamble, and opens the draft.

New flow: **Actions → Draft release → enter tag → Run**, then fill in Key Highlights and publish.

Linked Issue: N/A — no tracking issue; the broken `template:` key was found while investigating release notes.

## How to Test

1. Merge to `main` (a `workflow_dispatch` workflow only appears in the Actions UI once it is on the default branch).
2. **Actions → Draft release → Run workflow**, tag `v0.0.0-test`, target `main`, previous tag optional.
3. Open the resulting draft and verify the body reads: Support blurb → Upgrade Notice callout → 🚀 Key Highlights → `## What's Changed` with the Features/Fixes/etc. categories → New Contributors → Full Changelog.
4. Confirm no tag was created while it is still a draft: `git ls-remote --tags origin | grep v0.0.0-test` returns nothing.
5. Delete the test draft.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

N/A — CI/release configuration only, no application code touched.

## Notes for Reviewers

Verified end to end against this repo before opening:

- The `releases/generate-notes` API call returns the correctly categorised changelog and a New Contributors section, which is why `$CONTRIBUTORS` was dropped rather than replaced.
- Created a real throwaway draft release from the assembled body. GitHub returned an `untagged-…` URL and `git ls-remote --tags origin` showed **no** tag ref, confirming drafts do not push a `v*` tag and so do not trigger `android.yml` early. The draft was deleted afterwards.
- `release-assets.yml` (`release: published`) and `android.yml` (`push: tags v*`) are both unaffected; they still run on publish.

Follow-up worth a separate look: `android.yml` runs `softprops/action-gh-release` with `generate_release_notes: true` and no `body` on every `v*` tag push. If a release already exists for that tag, that step updates it — worth confirming it is not overwriting a hand-edited release body on publish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for creating draft releases from selected tags, previous tags, and branches or commits.
  * Draft releases now combine automatically generated release notes with a consistent preamble.
  * Added release messaging covering sponsorship, upgrade preparation, community feedback, and key highlights.

* **Improvements**
  * Updated release note generation to use GitHub’s native format while preserving existing categorization and exclusions.
  * Improved release creation security by preventing credentials from persisting in repository configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
