### PR TITLE
fix(mobile): keep chat scroll position while reading history

### DIFF
--- a/SparkyFitnessMobile/__tests__/screens/ChatScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ChatScreen.test.tsx
@@ -367,6 +367,124 @@ describe('ChatScreen thread', () => {
   });
 });
 
+describe('ChatScreen auto-scroll pinning', () => {
+  const scrollEvent = (offsetY: number, contentHeight: number, viewportHeight = 600) => ({
+    nativeEvent: {
+      contentOffset: { x: 0, y: offsetY },
+      contentSize: { width: 390, height: contentHeight },
+      layoutMeasurement: { width: 390, height: viewportHeight },
+    },
+  });
+
+  let scrollToEnd: jest.Mock;
+  let animationFrames: FrameRequestCallback[];
+  let requestAnimationFrameSpy: jest.SpyInstance;
+  let cancelAnimationFrameSpy: jest.SpyInstance;
+
+  const flushAnimationFrames = async () => {
+    await act(async () => {
+      while (animationFrames.length > 0) {
+        const callbacks = animationFrames.splice(0);
+        callbacks.forEach((callback) => callback(0));
+      }
+    });
+  };
+
+  beforeEach(() => {
+    scrollToEnd = jest.fn();
+    animationFrames = [];
+    (global as any).__mockChatIsEmpty = false;
+    (global as any).__mockMessagesScrollToEnd = scrollToEnd;
+    requestAnimationFrameSpy = jest
+      .spyOn(global, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        animationFrames.push(callback);
+        return animationFrames.length;
+      });
+    cancelAnimationFrameSpy = jest
+      .spyOn(global, 'cancelAnimationFrame')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+  });
+
+  const tree = (queryClient: QueryClient) => (
+    <QueryClientProvider client={queryClient}>
+      <SafeAreaProvider initialMetrics={initialMetrics}>
+        <ChatScreen navigation={navigation} route={route} />
+      </SafeAreaProvider>
+    </QueryClientProvider>
+  );
+
+  async function renderThread() {
+    const queryClient = new QueryClient();
+    const screen = render(tree(queryClient));
+    const messages = await screen.findByTestId('thread-messages');
+    await flushAnimationFrames();
+    scrollToEnd.mockClear();
+    return { ...screen, messages, queryClient };
+  }
+
+  it('follows content growth while the user is at the bottom (streaming)', async () => {
+    const { messages } = await renderThread();
+
+    fireEvent(messages, 'scroll', scrollEvent(1400, 2000));
+    fireEvent(messages, 'contentSizeChange', 390, 2100);
+    await flushAnimationFrames();
+
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false });
+  });
+
+  it('does not snap back to the bottom when content resizes while the user is scrolled up (#2276)', async () => {
+    const { messages } = await renderThread();
+
+    // Scroll well away from the bottom, then let the list re-measure — as it
+    // does while old messages mount during a scroll-back through history.
+    fireEvent(messages, 'scroll', scrollEvent(100, 2000));
+    fireEvent(messages, 'contentSizeChange', 390, 2100);
+    fireEvent(messages, 'layout', {
+      nativeEvent: { layout: { x: 0, y: 0, width: 390, height: 600 } },
+    });
+    await flushAnimationFrames();
+
+    expect(scrollToEnd).not.toHaveBeenCalled();
+  });
+
+  it('resumes following once the user scrolls back to the bottom', async () => {
+    const { messages } = await renderThread();
+
+    fireEvent(messages, 'scroll', scrollEvent(100, 2000));
+    fireEvent(messages, 'scroll', scrollEvent(1400, 2000));
+    fireEvent(messages, 'contentSizeChange', 390, 2100);
+    await flushAnimationFrames();
+
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false });
+  });
+
+  it('re-pins to the bottom when a new run starts, even if the user scrolled up', async () => {
+    const { messages, queryClient, rerender } = await renderThread();
+
+    fireEvent(messages, 'scroll', scrollEvent(100, 2000));
+
+    // Send and retry both append at the bottom, and both flip the thread to
+    // running — that is the signal the user wants to see the new reply.
+    (global as any).__mockChatIsRunning = true;
+    rerender(tree(queryClient));
+    await flushAnimationFrames();
+
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false });
+
+    // And the pin is restored: subsequent content growth keeps following.
+    scrollToEnd.mockClear();
+    fireEvent(messages, 'contentSizeChange', 390, 2100);
+    await flushAnimationFrames();
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false });
+  });
+});
+
 describe('ChatScreen history seeding', () => {
   it('seeds the runtime with the loaded history messages', async () => {
     const seed = [

--- a/SparkyFitnessMobile/src/screens/ChatScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ChatScreen.tsx
@@ -9,6 +9,8 @@ import {
   KeyboardAvoidingView as RNKeyboardAvoidingView,
   Platform,
   TextInput,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
   type TextInputProps,
 } from 'react-native';
 import { fetch as expoFetch } from 'expo/fetch';
@@ -61,6 +63,8 @@ const ThreadMessages = ThreadPrimitive.Messages as React.ComponentType<
 
 const IOS_SMALL_NATIVE_HEADER_HEIGHT = 44;
 const CHAT_KEYBOARD_EXTRA_SPACING = 12;
+// How close (px) to the bottom still counts as "at the bottom" for auto-scroll.
+const SCROLL_PIN_THRESHOLD = 40;
 
 function ChatKeyboardAvoidingView(props: React.ComponentProps<typeof RNKeyboardAvoidingView>) {
   if (Platform.OS === 'ios') {
@@ -409,9 +413,16 @@ function ChatThread({
   const { t } = useTranslation();
   const runtime = useSparkyChatRuntime({ baseUrl, serviceConfigId, initialMessages });
 
-  // Keep the message list pinned to the bottom as content grows: lands on the
-  // latest message on mount (seeded history) and follows the stream.
+  // Keep the message list pinned to the bottom as content grows — but only
+  // while the user is at the bottom: lands on the latest message on mount
+  // (seeded history) and follows the stream. While the user scrolls back
+  // through history, the FlatList keeps re-measuring rows (variable-height
+  // markdown), firing onContentSizeChange; scrolling unconditionally on it
+  // snapped the list back to the newest message and made history unreadable
+  // (#2276). Starting a new run re-pins, since send and retry both append at
+  // the bottom and the user is asking to see that reply.
   const messagesRef = useRef<FlatList>(null);
+  const pinnedToBottomRef = useRef(true);
   const scrollFrameRef = useRef<number | null>(null);
   const scrollSettledFrameRef = useRef<number | null>(null);
 
@@ -440,6 +451,27 @@ function ChatThread({
     });
   }, [cancelScheduledScroll]);
 
+  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
+    pinnedToBottomRef.current =
+      contentOffset.y + layoutMeasurement.height >= contentSize.height - SCROLL_PIN_THRESHOLD;
+  }, []);
+
+  const scrollToBottomIfPinned = useCallback(() => {
+    if (pinnedToBottomRef.current) scrollToBottom();
+  }, [scrollToBottom]);
+
+  const handleRunningChange = useCallback(
+    (running: boolean) => {
+      if (running) {
+        pinnedToBottomRef.current = true;
+        scrollToBottom();
+      }
+      onRunningChange(running);
+    },
+    [onRunningChange, scrollToBottom]
+  );
+
   useEffect(() => {
     scrollToBottom();
     return cancelScheduledScroll;
@@ -447,7 +479,7 @@ function ChatThread({
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      <RunningReporter onRunningChange={onRunningChange} />
+      <RunningReporter onRunningChange={handleRunningChange} />
       <ThreadPrimitive.Root style={{ flex: 1 }}>
         <View style={{ flex: 1 }}>
           <ThreadPrimitive.Empty>
@@ -473,8 +505,10 @@ function ChatThread({
             ref={messagesRef}
             style={{ flex: 1 }}
             contentContainerStyle={{ padding: 16 }}
-            onContentSizeChange={scrollToBottom}
-            onLayout={scrollToBottom}
+            onScroll={handleScroll}
+            scrollEventThrottle={16}
+            onContentSizeChange={scrollToBottomIfPinned}
+            onLayout={scrollToBottomIfPinned}
           >
             {({ message }) => <MessageBubble role={message.role} />}
           </ThreadMessages>


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**

Scrolling back through Sparky chat history on Android is close to impossible: the list pulls itself back to the newest message. Reported in #2276.

**How did you implement the solution?**

`ChatThread` wired `scrollToBottom` straight to the message list's `onContentSizeChange` and `onLayout`, so any re-measure scrolled to the end regardless of where the user was. The bubbles have variable height and no `getItemLayout`, so FlatList re-measures rows as they come into view, and every row that settles while you scroll back fires the handler and pulls the list down again. `onLayout` does the same on a keyboard show/hide.

The list now tracks whether the user is at the bottom (`onScroll`, 40px threshold) and only auto-scrolls when they are, so mount-time seeding and stream-following are unchanged. Starting a run re-pins to the bottom, which covers send and retry alike: the reply lands at the end and that is what the user just asked to see.

Linked Issue: Closes #2276

## How to Test

1. Check out this branch, run `pnpm install`, then `pnpm run android` in `SparkyFitnessMobile/`.
2. Open Ask Sparky on a thread with enough history to scroll (roughly 20 exchanges).
3. Scroll back toward the older messages and stop. The list stays where you left it.
4. Scroll back to the bottom and send a message: the thread still follows the streaming reply.
5. Scroll up again, then send: the list returns to the bottom so the new reply is visible.

Automated: `pnpm exec jest --watchman=false --runInBand __tests__/screens/ChatScreen.test.tsx`

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

Not attached. See the note below on what I could and could not verify.

</details>

## Notes for Reviewers

Two checkboxes are deliberately left unticked rather than ticked on trust, so please read this before running CI.

I did not get the change onto a running screen. The debug APK builds and installs on an Android 36 emulator here, but the emulator runs on a software GPU and I could not drive it as far as the chat screen, so I have no before/after recording and cannot claim device verification. A scroll bug also needs a recording rather than a still image to show anything useful. If you would rather have that evidence before reviewing, say so and I will get a physical device on it.

What is verified, all on this machine: `pnpm run typecheck` and `pnpm run lint` are clean, and the `ChatScreen` suite is 16/16. The two new pinning tests fail against the current `main` behaviour and pass with this change, so the regression they describe is real and covered. The full mobile suite is 5986 passing; the 18 failures are the same ones present on an untouched checkout of `main` (`workoutSession`, `medicationFormat`, `i18nAudit`, `widgetResourceContract`, `healthDataDisplay`) and are unrelated to this change.

Two smaller decisions worth flagging. The threshold is 40px rather than exact equality because `contentOffset` lands fractionally short of `contentSize - layoutMeasurement` on Android and momentum scrolling stops a few pixels early. Re-pinning is driven by the thread's running state instead of the `composer.send` event because assistant-ui marks that event deprecated in favour of state observation, and the running state covers retry as well as send.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved chat auto-scrolling to keep the latest messages visible while streaming.
  - Preserves the user’s scroll position when they browse older messages.
  - Automatically resumes following new messages when the user returns to the bottom.
  - New messages and retries re-pin the chat to the latest content.

- **Tests**
  - Added coverage for pinned scrolling, manual scrolling, content resizing, and new message runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->