### PR TITLE
fix(mobile): refresh Android widgets in background

### DIFF
--- a/SparkyFitnessMobile/__tests__/services/backgroundSyncService.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/backgroundSyncService.test.ts
@@ -8,6 +8,7 @@ import { TimeoutError } from '../../src/utils/concurrency';
 import { AppState, Platform } from 'react-native';
 import * as telemetryBudget from '../../src/services/shared/telemetryBudget';
 import { fetchDailySummary } from '../../src/services/api/dailySummaryApi';
+import { ensureTimezoneBootstrapped } from '../../src/services/api/preferencesApi';
 import { CalorieWidgetBridge } from '../../src/services/CalorieWidgetBridge';
 
 jest.mock('../../src/services/LogService', () => ({
@@ -20,6 +21,10 @@ jest.mock('../../src/services/api/healthDataApi', () => ({
 
 jest.mock('../../src/services/api/dailySummaryApi', () => ({
   fetchDailySummary: jest.fn(),
+}));
+
+jest.mock('../../src/services/api/preferencesApi', () => ({
+  ensureTimezoneBootstrapped: jest.fn(),
 }));
 
 jest.mock('../../src/services/CalorieWidgetBridge', () => ({
@@ -172,6 +177,9 @@ const mockRefreshHealthSyncCache = refreshHealthSyncCache as jest.MockedFunction
 const mockFetchDailySummary = fetchDailySummary as jest.MockedFunction<
   typeof fetchDailySummary
 >;
+const mockEnsureTimezoneBootstrapped = ensureTimezoneBootstrapped as jest.MockedFunction<
+  typeof ensureTimezoneBootstrapped
+>;
 const mockSetCalorieSnapshot =
   CalorieWidgetBridge.setCalorieSnapshot as jest.MockedFunction<
     typeof CalorieWidgetBridge.setCalorieSnapshot
@@ -248,6 +256,7 @@ describe('performBackgroundSync (via triggerManualSync)', () => {
     storage.savePendingHealthSyncCacheRefresh.mockResolvedValue(undefined);
     storage.consumePendingHealthSyncCacheRefresh.mockResolvedValue(false);
     mockFetchDailySummary.mockReset();
+    mockEnsureTimezoneBootstrapped.mockReset().mockResolvedValue('UTC');
     mockSetCalorieSnapshot.mockReset().mockResolvedValue(undefined);
     mockReloadCalorieWidget.mockReset().mockResolvedValue(undefined);
     mockSetMacroSnapshot.mockReset().mockResolvedValue(undefined);
@@ -264,6 +273,29 @@ describe('performBackgroundSync (via triggerManualSync)', () => {
   });
 
   describe('Android widget refresh (#2291)', () => {
+    test('uses the account timezone to select the current server day', async () => {
+      Object.defineProperty(Platform, 'OS', {
+        configurable: true,
+        value: 'android',
+      });
+      healthService.loadHealthPreference.mockResolvedValue(false);
+      mockEnsureTimezoneBootstrapped.mockResolvedValue('Pacific/Kiritimati');
+      mockFetchDailySummary.mockResolvedValue(widgetSummaryResponse);
+
+      await triggerManualSync();
+
+      expect(mockEnsureTimezoneBootstrapped).toHaveBeenCalledWith({
+        throwOnFailure: true,
+      });
+      expect(mockFetchDailySummary).toHaveBeenCalledWith('2024-01-16');
+      expect(JSON.parse(mockSetCalorieSnapshot.mock.calls[0][0])).toMatchObject({
+        date: '2024-01-16',
+      });
+      expect(JSON.parse(mockSetMacroSnapshot.mock.calls[0][0])).toMatchObject({
+        date: '2024-01-16',
+      });
+    });
+
     test('pulls the current server summary after a no-data background run without opening the app', async () => {
       Object.defineProperty(Platform, 'OS', {
         configurable: true,

--- a/SparkyFitnessMobile/__tests__/services/backgroundSyncService.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/backgroundSyncService.test.ts
@@ -5,8 +5,10 @@ import {
 import { setBackfillRunning, tryClaimAutoSync, isSyncInFlight } from '../../src/services/autoSyncCoordinator';
 import { refreshHealthSyncCache } from '../../src/hooks/refreshHealthSyncCache';
 import { TimeoutError } from '../../src/utils/concurrency';
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import * as telemetryBudget from '../../src/services/shared/telemetryBudget';
+import { fetchDailySummary } from '../../src/services/api/dailySummaryApi';
+import { CalorieWidgetBridge } from '../../src/services/CalorieWidgetBridge';
 
 jest.mock('../../src/services/LogService', () => ({
   addLog: jest.fn(),
@@ -14,6 +16,20 @@ jest.mock('../../src/services/LogService', () => ({
 
 jest.mock('../../src/services/api/healthDataApi', () => ({
   syncHealthData: jest.fn(),
+}));
+
+jest.mock('../../src/services/api/dailySummaryApi', () => ({
+  fetchDailySummary: jest.fn(),
+}));
+
+jest.mock('../../src/services/CalorieWidgetBridge', () => ({
+  CalorieWidgetBridge: {
+    setCalorieSnapshot: jest.fn(() => Promise.resolve()),
+    reloadWidget: jest.fn(() => Promise.resolve()),
+    setMacroSnapshot: jest.fn(() => Promise.resolve()),
+    reloadMacroWidget: jest.fn(() => Promise.resolve()),
+    isAvailable: true,
+  },
 }));
 
 jest.mock('../../src/services/storage', () => ({
@@ -153,6 +169,63 @@ const healthService = {
 const mockRefreshHealthSyncCache = refreshHealthSyncCache as jest.MockedFunction<
   typeof refreshHealthSyncCache
 >;
+const mockFetchDailySummary = fetchDailySummary as jest.MockedFunction<
+  typeof fetchDailySummary
+>;
+const mockSetCalorieSnapshot =
+  CalorieWidgetBridge.setCalorieSnapshot as jest.MockedFunction<
+    typeof CalorieWidgetBridge.setCalorieSnapshot
+  >;
+const mockReloadCalorieWidget =
+  CalorieWidgetBridge.reloadWidget as jest.MockedFunction<
+    typeof CalorieWidgetBridge.reloadWidget
+  >;
+const mockSetMacroSnapshot =
+  CalorieWidgetBridge.setMacroSnapshot as jest.MockedFunction<
+    typeof CalorieWidgetBridge.setMacroSnapshot
+  >;
+const mockReloadMacroWidget =
+  CalorieWidgetBridge.reloadMacroWidget as jest.MockedFunction<
+    typeof CalorieWidgetBridge.reloadMacroWidget
+  >;
+const widgetSummaryResponse: Awaited<ReturnType<typeof fetchDailySummary>> = {
+  goals: {
+    calories: 2100,
+    protein: 160,
+    carbs: 220,
+    fat: 70,
+    dietary_fiber: 30,
+  },
+  foodEntries: [
+    {
+      id: 'remote-entry',
+      meal_type: 'snacks',
+      quantity: 1,
+      unit: 'serving',
+      entry_date: '2024-01-15',
+      serving_size: 1,
+      calories: 350,
+      protein: 20,
+      carbs: 40,
+      fat: 12,
+    },
+  ],
+  exerciseSessions: [],
+  waterIntake: 0,
+  stepCalories: 0,
+  calorieBalance: {
+    eaten: 350,
+    burned: 100,
+    remaining: 1850,
+    goal: 2100,
+    net: 250,
+    progress: 17,
+    bmr: 1700,
+    exerciseSource: 'steps',
+    tdeeProjection: null,
+  },
+  adjustedGoals: null,
+};
 
 describe('performBackgroundSync (via triggerManualSync)', () => {
   const setAppState = (state: string) => {
@@ -174,11 +247,98 @@ describe('performBackgroundSync (via triggerManualSync)', () => {
     api.syncHealthData.mockResolvedValue(undefined);
     storage.savePendingHealthSyncCacheRefresh.mockResolvedValue(undefined);
     storage.consumePendingHealthSyncCacheRefresh.mockResolvedValue(false);
+    mockFetchDailySummary.mockReset();
+    mockSetCalorieSnapshot.mockReset().mockResolvedValue(undefined);
+    mockReloadCalorieWidget.mockReset().mockResolvedValue(undefined);
+    mockSetMacroSnapshot.mockReset().mockResolvedValue(undefined);
+    mockReloadMacroWidget.mockReset().mockResolvedValue(undefined);
+    Object.defineProperty(Platform, 'OS', {
+      configurable: true,
+      value: 'ios',
+    });
     setAppState('active');
   });
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  describe('Android widget refresh (#2291)', () => {
+    test('pulls the current server summary after a no-data background run without opening the app', async () => {
+      Object.defineProperty(Platform, 'OS', {
+        configurable: true,
+        value: 'android',
+      });
+      healthService.loadHealthPreference.mockResolvedValue(false);
+      mockFetchDailySummary.mockResolvedValue(widgetSummaryResponse);
+
+      await triggerManualSync();
+
+      expect(mockFetchDailySummary).toHaveBeenCalledWith('2024-01-15');
+      const caloriePayload = JSON.parse(
+        mockSetCalorieSnapshot.mock.calls[0][0],
+      ) as Record<string, number | string>;
+      expect(caloriePayload).toMatchObject({
+        date: '2024-01-15',
+        remaining: 1850,
+        goal: 2100,
+        progress: 0.17,
+      });
+      expect(mockReloadCalorieWidget).toHaveBeenCalledTimes(1);
+
+      const macroPayload = JSON.parse(
+        mockSetMacroSnapshot.mock.calls[0][0],
+      ) as Record<string, number | string>;
+      expect(macroPayload).toMatchObject({
+        date: '2024-01-15',
+        protein: 20,
+        carbs: 40,
+        fat: 12,
+        calories: 350,
+        remaining: 1850,
+        proteinGoal: 160,
+        carbsGoal: 220,
+        fatGoal: 70,
+      });
+      expect(mockReloadMacroWidget).toHaveBeenCalledTimes(1);
+    });
+
+    test('keeps a successful background sync successful when the widget refresh fails', async () => {
+      Object.defineProperty(Platform, 'OS', {
+        configurable: true,
+        value: 'android',
+      });
+      healthService.loadHealthPreference.mockResolvedValue(false);
+      mockFetchDailySummary.mockRejectedValue(
+        new Error('daily summary unavailable'),
+      );
+      const addLog = require('../../src/services/LogService')
+        .addLog as jest.Mock;
+
+      await expect(triggerManualSync()).resolves.toBeUndefined();
+
+      expect(addLog).toHaveBeenCalledWith(
+        '[Background Sync] Android widget refresh failed: daily summary unavailable',
+        'ERROR',
+      );
+    });
+
+    test('still refreshes the macro widget when the calorie widget write fails', async () => {
+      Object.defineProperty(Platform, 'OS', {
+        configurable: true,
+        value: 'android',
+      });
+      healthService.loadHealthPreference.mockResolvedValue(false);
+      mockFetchDailySummary.mockResolvedValue(widgetSummaryResponse);
+      mockSetCalorieSnapshot.mockRejectedValue(
+        new Error('calorie widget unavailable'),
+      );
+
+      await expect(triggerManualSync()).resolves.toBeUndefined();
+
+      expect(mockSetMacroSnapshot).toHaveBeenCalledTimes(1);
+      expect(mockReloadMacroWidget).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('stale-cursor clamp and dead-client reporting (#2191)', () => {

--- a/SparkyFitnessMobile/src/hooks/useDailySummary.ts
+++ b/SparkyFitnessMobile/src/hooks/useDailySummary.ts
@@ -1,147 +1,27 @@
 import { useQuery } from '@tanstack/react-query';
 import {
-  calculateCaloriesConsumed,
-  calculateProtein,
-  calculateCarbs,
-  calculateFat,
-  calculateFiber,
-  calculateCustomNutrientTotals,
-} from '../services/api/foodEntriesApi';
-import { calculateExerciseStats } from '../utils/workoutSession';
-import { fetchDailySummary } from '../services/api/dailySummaryApi';
-import { resolveCollapsedFoodEntries } from '../utils/loggedMealCollapse';
-import type { DailySummary } from '../types/dailySummary';
-import type { DailyGoals } from '../types/goals';
-import type { FoodEntry } from '../types/foodEntries';
-import type { ExerciseSessionResponse, CalorieBalance, SupplementTotals } from '@workspace/shared';
-import { resolveSupplementTotals, addSupplementCustomNutrients } from '@workspace/shared';
-import type { WaterIntake } from '../types/measurements';
+  buildDailySummary,
+  loadDailySummaryRawData,
+} from '../services/dailySummaryService';
 
 import { useRefetchOnFocus } from './useRefetchOnFocus';
 import { dailySummaryQueryKey } from './queryKeys';
 
-export interface DailySummaryRawData {
-  goals: DailyGoals;
-  foodEntries: FoodEntry[];
-  exerciseEntries: ExerciseSessionResponse[];
-  waterIntake: WaterIntake;
-  stepCalories: number;
-  calorieBalance?: CalorieBalance;
-  supplementTotals?: SupplementTotals;
-}
+export type { DailySummaryRawData } from '../services/dailySummaryService';
 
 interface UseDailySummaryOptions {
   date: string;
   enabled?: boolean;
 }
 
-export function useDailySummary({ date, enabled = true }: UseDailySummaryOptions) {
+export function useDailySummary({
+  date,
+  enabled = true,
+}: UseDailySummaryOptions) {
   const query = useQuery({
     queryKey: dailySummaryQueryKey(date),
-    queryFn: async () => {
-      const data = await fetchDailySummary(date);
-      const foodEntries = await resolveCollapsedFoodEntries(date, data.foodEntries);
-
-      return {
-        goals: data.goals,
-        foodEntries,
-        exerciseEntries: data.exerciseSessions,
-        waterIntake: { water_ml: data.waterIntake },
-        stepCalories: data.stepCalories ?? 0,
-        calorieBalance: data.calorieBalance,
-        supplementTotals: data.supplementTotals,
-        adjustedGoals: data.adjustedGoals ?? null,
-      };
-    },
-    select: (raw): DailySummary => {
-      const { goals, foodEntries, exerciseEntries, waterIntake, stepCalories, calorieBalance, supplementTotals, adjustedGoals } = raw;
-
-      const calorieGoal = adjustedGoals?.calories ?? goals.calories ?? 0;
-      // Logged supplement doses are intake, and the server already counts them in
-      // calorieBalance.eaten, which the dashboard ring renders. Deriving everything else from
-      // food entries alone left the ring disagreeing with the macro pills beneath it, and
-      // with the nutrition details screen, which reads caloriesConsumed.
-      const supplements = resolveSupplementTotals(supplementTotals);
-      const caloriesConsumed = calculateCaloriesConsumed(foodEntries) + supplements.calories;
-      const exerciseStats = calculateExerciseStats(exerciseEntries);
-      const { caloriesBurned, activeCalories, otherExerciseCalories } = exerciseStats;
-      const exerciseMinutes = exerciseStats.durationMinutes;
-      const netCalories = caloriesConsumed - caloriesBurned;
-      const remainingCalories = calorieGoal - netCalories;
-
-      // If calorieBalance is not provided by the API (old server version), we calculate it here to
-      // ensure the UI has consistent data to work with. Uses fixed-mode logic (goal - eaten) to
-      // match the server default, with rounding and clamping to match computeCalorieBalance output.
-      const fallbackRemaining = calorieGoal - caloriesConsumed;
-      const resolvedCalorieBalance: CalorieBalance = calorieBalance ?? {
-        eaten: Math.round(caloriesConsumed),
-        burned: Math.round(caloriesBurned),
-        remaining: Math.round(fallbackRemaining),
-        goal: Math.round(calorieGoal),
-        net: Math.round(netCalories),
-        progress: calorieGoal > 0 ? Math.max(0, Math.round((caloriesConsumed / calorieGoal) * 100)) : 0,
-        bmr: 0,
-        bmrSource: 'formula' as const,
-        exerciseSource: 'none',
-        tdeeProjection: null,
-      };
-
-      return {
-        date,
-        calorieGoal,
-        caloriesConsumed,
-        caloriesBurned,
-        activeCalories,
-        otherExerciseCalories,
-        stepCalories,
-        exerciseMinutes,
-        exerciseMinutesGoal: goals.target_exercise_duration_minutes || 0,
-        exerciseCaloriesGoal: goals.target_exercise_calories_burned || 0,
-        netCalories,
-        remainingCalories,
-        protein: {
-          consumed: calculateProtein(foodEntries) + supplements.protein,
-          goal: adjustedGoals?.protein ?? goals.protein ?? 0,
-        },
-        carbs: {
-          consumed: calculateCarbs(foodEntries) + supplements.carbs,
-          goal: adjustedGoals?.carbs ?? goals.carbs ?? 0,
-        },
-        fat: {
-          consumed: calculateFat(foodEntries) + supplements.fat,
-          goal: adjustedGoals?.fat ?? goals.fat ?? 0,
-        },
-        fiber: {
-          consumed: calculateFiber(foodEntries) + supplements.dietary_fiber,
-          goal: goals.dietary_fiber || 0,
-        },
-        waterConsumed: waterIntake.water_ml || 0,
-        waterGoal: goals.water_goal_ml ?? 2500,
-        foodEntries,
-        supplementTotals: supplements,
-        exerciseEntries,
-        calorieBalance: resolvedCalorieBalance,
-        goals,
-        // Food entries plus the day's doses. Most micronutrients are custom nutrients
-        // rather than fixed columns, so for a magnesium or vitamin D supplement this is
-        // the only place its contribution can land; the fixed-field arm above cannot
-        // carry it (#2145). Every screen reading customNutrientTotals gets it from here.
-        customNutrientTotals: addSupplementCustomNutrients(
-          calculateCustomNutrientTotals(foodEntries),
-          supplements,
-        ),
-        // Per-custom-nutrient goals (keyed by name, matching customNutrientTotals).
-        // Normalized to numbers; absent/zero goals are simply not tracked.
-        customNutrientGoals: goals.custom_nutrients
-          ? Object.fromEntries(
-              Object.entries(goals.custom_nutrients).map(([name, v]) => [
-                name,
-                typeof v === 'number' ? v : parseFloat(String(v)) || 0,
-              ]),
-            )
-          : ({} as Record<string, number>),
-      };
-    },
+    queryFn: () => loadDailySummaryRawData(date),
+    select: raw => buildDailySummary(date, raw),
     enabled,
   });
 

--- a/SparkyFitnessMobile/src/hooks/useWidgetSync.ts
+++ b/SparkyFitnessMobile/src/hooks/useWidgetSync.ts
@@ -4,7 +4,11 @@ import { ExtensionStorage } from '@bacons/apple-targets';
 import Constants from 'expo-constants';
 import { Platform } from 'react-native';
 
-import { CalorieWidgetBridge } from '../services/CalorieWidgetBridge';
+import {
+  buildAndroidWidgetSnapshots,
+  pushAndroidCalorieSnapshot,
+  pushAndroidMacroSnapshot,
+} from '../services/androidWidgetSyncService';
 import { addLog } from '../services/LogService';
 import type { DailySummary } from '../types/dailySummary';
 import { getTodayDate } from '../utils/dateUtils';
@@ -13,41 +17,6 @@ const WIDGET_KIND = 'widget';
 const CALORIE_SNAPSHOT_KEY = 'calorieSnapshot';
 const MACRO_WIDGET_KIND = 'macroWidget';
 const MACRO_SNAPSHOT_KEY = 'macroSnapshot';
-
-/**
- * The Android widget snapshot contracts, mirrored by `parseSnapshot` in
- * `CalorieWidget.kt.tmpl` and `MacroWidget.kt.tmpl`.
- *
- * Declared explicitly so a field cannot be renamed or dropped on this side
- * without a type error. They cannot make the boundary type-safe on their own:
- * `setCalorieSnapshot`/`setMacroSnapshot` take a `string`, and the Kotlin
- * readers match these keys by name, so the two halves still have to be kept in
- * step by hand.
- *
- * Optional fields are dropped by `JSON.stringify` rather than serialized as
- * null, which is what the widgets' `optionalDouble` reads as "not supplied".
- */
-interface AndroidCalorieSnapshot {
-  date: string;
-  remaining: number;
-  goal: number;
-  progress: number;
-}
-
-interface AndroidMacroSnapshot {
-  date: string;
-  protein: number;
-  carbs: number;
-  fat: number;
-  calories: number;
-  remaining?: number;
-  proteinGoal: number;
-  carbsGoal: number;
-  fatGoal: number;
-}
-
-/** A snapshot plus its push timestamp, which is deliberately not part of the dedupe key. */
-type AndroidWidgetPayload<T> = T & { lastUpdated: number };
 
 const iosAppGroup = (
   Constants.expoConfig?.extra as { iosAppGroup?: string } | undefined
@@ -123,31 +92,16 @@ export function useWidgetSync(summary: DailySummary | undefined): void {
     }
 
     if (Platform.OS === 'android') {
-      if (balance) {
-        const { goal, remaining, progress } = balance;
-        const clampedProgress =
-          goal > 0 ? Math.max(0, Math.min(1, progress / 100)) : 0;
-        const calorieSnapshot: AndroidCalorieSnapshot = {
-          date,
-          remaining,
-          goal,
-          progress: clampedProgress,
-        };
+      const snapshots = buildAndroidWidgetSnapshots(summary);
+      if (snapshots.calorie) {
+        const calorieSnapshot = snapshots.calorie;
         const calorieSnapshotKey = JSON.stringify(calorieSnapshot);
 
         if (lastAndroidCalorieSnapshotKeyRef.current !== calorieSnapshotKey) {
           lastAndroidCalorieSnapshotKeyRef.current = calorieSnapshotKey;
-          const caloriePayload: AndroidWidgetPayload<AndroidCalorieSnapshot> = {
-            ...calorieSnapshot,
-            lastUpdated,
-          };
-
           void (async () => {
             try {
-              await CalorieWidgetBridge.setCalorieSnapshot(
-                JSON.stringify(caloriePayload),
-              );
-              await CalorieWidgetBridge.reloadWidget();
+              await pushAndroidCalorieSnapshot(calorieSnapshot, lastUpdated);
             } catch (error) {
               if (
                 lastAndroidCalorieSnapshotKeyRef.current === calorieSnapshotKey
@@ -168,32 +122,14 @@ export function useWidgetSync(summary: DailySummary | undefined): void {
       // against the day's other macros, which barely moves as the day fills up
       // (#2228). Not sent on iOS: that widget draws a composition ring, where
       // the three shares summing to one is the intended reading.
-      const macroSnapshot: AndroidMacroSnapshot = {
-        date,
-        protein: summary.protein.consumed,
-        carbs: summary.carbs.consumed,
-        fat: summary.fat.consumed,
-        calories: summary.caloriesConsumed,
-        remaining: balance?.remaining,
-        proteinGoal: summary.protein.goal,
-        carbsGoal: summary.carbs.goal,
-        fatGoal: summary.fat.goal,
-      };
+      const macroSnapshot = snapshots.macro;
       const macroSnapshotKey = JSON.stringify(macroSnapshot);
       if (lastAndroidMacroSnapshotKeyRef.current === macroSnapshotKey) return;
 
       lastAndroidMacroSnapshotKeyRef.current = macroSnapshotKey;
-      const macroPayload: AndroidWidgetPayload<AndroidMacroSnapshot> = {
-        ...macroSnapshot,
-        lastUpdated,
-      };
-
       void (async () => {
         try {
-          await CalorieWidgetBridge.setMacroSnapshot(
-            JSON.stringify(macroPayload),
-          );
-          await CalorieWidgetBridge.reloadMacroWidget();
+          await pushAndroidMacroSnapshot(macroSnapshot, lastUpdated);
         } catch (error) {
           if (lastAndroidMacroSnapshotKeyRef.current === macroSnapshotKey) {
             lastAndroidMacroSnapshotKeyRef.current = null;

--- a/SparkyFitnessMobile/src/services/androidWidgetSyncService.ts
+++ b/SparkyFitnessMobile/src/services/androidWidgetSyncService.ts
@@ -1,0 +1,113 @@
+import { CalorieWidgetBridge } from './CalorieWidgetBridge';
+import {
+  buildDailySummary,
+  loadDailySummaryRawData,
+} from './dailySummaryService';
+import type { DailySummary } from '../types/dailySummary';
+import { getTodayDate } from '../utils/dateUtils';
+
+/**
+ * Android widget snapshot contracts mirrored by `parseSnapshot` in the
+ * calorie and macro widget Kotlin templates. Optional fields are omitted by
+ * JSON serialization, which the native readers interpret as not supplied.
+ */
+export interface AndroidCalorieSnapshot {
+  date: string;
+  remaining: number;
+  goal: number;
+  progress: number;
+}
+
+export interface AndroidMacroSnapshot {
+  date: string;
+  protein: number;
+  carbs: number;
+  fat: number;
+  calories: number;
+  remaining?: number;
+  proteinGoal: number;
+  carbsGoal: number;
+  fatGoal: number;
+}
+
+export function buildAndroidWidgetSnapshots(summary: DailySummary): {
+  calorie?: AndroidCalorieSnapshot;
+  macro: AndroidMacroSnapshot;
+} {
+  const balance = summary.calorieBalance;
+  const calorie = balance
+    ? {
+        date: summary.date,
+        remaining: balance.remaining,
+        goal: balance.goal,
+        progress:
+          balance.goal > 0
+            ? Math.max(0, Math.min(1, balance.progress / 100))
+            : 0,
+      }
+    : undefined;
+
+  return {
+    calorie,
+    macro: {
+      date: summary.date,
+      protein: summary.protein.consumed,
+      carbs: summary.carbs.consumed,
+      fat: summary.fat.consumed,
+      calories: summary.caloriesConsumed,
+      remaining: balance?.remaining,
+      proteinGoal: summary.protein.goal,
+      carbsGoal: summary.carbs.goal,
+      fatGoal: summary.fat.goal,
+    },
+  };
+}
+
+function serializeWidgetPayload<T extends object>(
+  snapshot: T,
+  lastUpdated: number,
+): string {
+  return JSON.stringify({ ...snapshot, lastUpdated });
+}
+
+export async function pushAndroidCalorieSnapshot(
+  snapshot: AndroidCalorieSnapshot,
+  lastUpdated = Math.floor(Date.now() / 1000),
+): Promise<void> {
+  await CalorieWidgetBridge.setCalorieSnapshot(
+    serializeWidgetPayload(snapshot, lastUpdated),
+  );
+  await CalorieWidgetBridge.reloadWidget();
+}
+
+export async function pushAndroidMacroSnapshot(
+  snapshot: AndroidMacroSnapshot,
+  lastUpdated = Math.floor(Date.now() / 1000),
+): Promise<void> {
+  await CalorieWidgetBridge.setMacroSnapshot(
+    serializeWidgetPayload(snapshot, lastUpdated),
+  );
+  await CalorieWidgetBridge.reloadMacroWidget();
+}
+
+export async function refreshAndroidWidgetsFromServer(): Promise<void> {
+  const date = getTodayDate();
+  const raw = await loadDailySummaryRawData(date);
+  const summary = buildDailySummary(date, raw);
+  const snapshots = buildAndroidWidgetSnapshots(summary);
+  const lastUpdated = Math.floor(Date.now() / 1000);
+  const updates: Promise<void>[] = [];
+
+  if (snapshots.calorie) {
+    updates.push(pushAndroidCalorieSnapshot(snapshots.calorie, lastUpdated));
+  }
+  updates.push(pushAndroidMacroSnapshot(snapshots.macro, lastUpdated));
+
+  const results = await Promise.allSettled(updates);
+  const firstFailure = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+  if (firstFailure) {
+    throw firstFailure.reason;
+  }
+}

--- a/SparkyFitnessMobile/src/services/androidWidgetSyncService.ts
+++ b/SparkyFitnessMobile/src/services/androidWidgetSyncService.ts
@@ -1,10 +1,11 @@
+import { todayInZone } from '@workspace/shared';
 import { CalorieWidgetBridge } from './CalorieWidgetBridge';
+import { ensureTimezoneBootstrapped } from './api/preferencesApi';
 import {
   buildDailySummary,
   loadDailySummaryRawData,
 } from './dailySummaryService';
 import type { DailySummary } from '../types/dailySummary';
-import { getTodayDate } from '../utils/dateUtils';
 
 /**
  * Android widget snapshot contracts mirrored by `parseSnapshot` in the
@@ -91,7 +92,11 @@ export async function pushAndroidMacroSnapshot(
 }
 
 export async function refreshAndroidWidgetsFromServer(): Promise<void> {
-  const date = getTodayDate();
+  const timezone = await ensureTimezoneBootstrapped({ throwOnFailure: true });
+  if (!timezone) {
+    throw new Error('Account timezone is unavailable for widget refresh');
+  }
+  const date = todayInZone(timezone);
   const raw = await loadDailySummaryRawData(date);
   const summary = buildDailySummary(date, raw);
   const snapshots = buildAndroidWidgetSnapshots(summary);

--- a/SparkyFitnessMobile/src/services/backgroundSyncService.ts
+++ b/SparkyFitnessMobile/src/services/backgroundSyncService.ts
@@ -1,6 +1,6 @@
 import * as TaskManager from 'expo-task-manager';
 import * as BackgroundTask from 'expo-background-task';
-import { AppState } from 'react-native';
+import { AppState, Platform } from 'react-native';
 import { syncHealthData, HealthDataPayload } from './api/healthDataApi';
 import { runWriteback } from './writeback';
 import { addLog, _flushBuffer } from './LogService';
@@ -34,6 +34,7 @@ import {
   createTelemetryRunContext,
   type TelemetryRunContext,
 } from './shared/telemetryBudget';
+import { refreshAndroidWidgetsFromServer } from './androidWidgetSyncService';
 
 const isAppActive = (): boolean => AppState.currentState === 'active';
 
@@ -115,6 +116,17 @@ const performBackgroundSyncInternal = async (taskId: string): Promise<void> => {
         interactive: false,
       });
   await runBackgroundSync(taskId, telemetry);
+  if (Platform.OS === 'android') {
+    try {
+      await refreshAndroidWidgetsFromServer();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      addLog(
+        `[Background Sync] Android widget refresh failed: ${message}`,
+        'ERROR',
+      );
+    }
+  }
 };
 
 const runBackgroundSync = async (taskId: string, telemetry: TelemetryRunContext): Promise<void> => {

--- a/SparkyFitnessMobile/src/services/dailySummaryService.ts
+++ b/SparkyFitnessMobile/src/services/dailySummaryService.ts
@@ -1,0 +1,152 @@
+import {
+  calculateCaloriesConsumed,
+  calculateProtein,
+  calculateCarbs,
+  calculateFat,
+  calculateFiber,
+  calculateCustomNutrientTotals,
+} from './api/foodEntriesApi';
+import { fetchDailySummary } from './api/dailySummaryApi';
+import { resolveCollapsedFoodEntries } from '../utils/loggedMealCollapse';
+import { calculateExerciseStats } from '../utils/workoutSession';
+import type { DailySummary } from '../types/dailySummary';
+import type { DailyGoals } from '../types/goals';
+import type { FoodEntry } from '../types/foodEntries';
+import type {
+  ExerciseSessionResponse,
+  CalorieBalance,
+  SupplementTotals,
+} from '@workspace/shared';
+import {
+  resolveSupplementTotals,
+  addSupplementCustomNutrients,
+} from '@workspace/shared';
+import type { WaterIntake } from '../types/measurements';
+
+export interface DailySummaryRawData {
+  goals: DailyGoals;
+  foodEntries: FoodEntry[];
+  exerciseEntries: ExerciseSessionResponse[];
+  waterIntake: WaterIntake;
+  stepCalories: number;
+  calorieBalance?: CalorieBalance;
+  supplementTotals?: SupplementTotals;
+  adjustedGoals?: {
+    calories: number;
+    protein: number;
+    carbs: number;
+    fat: number;
+  } | null;
+}
+
+export async function loadDailySummaryRawData(
+  date: string,
+): Promise<DailySummaryRawData> {
+  const data = await fetchDailySummary(date);
+  const foodEntries = await resolveCollapsedFoodEntries(date, data.foodEntries);
+
+  return {
+    goals: data.goals,
+    foodEntries,
+    exerciseEntries: data.exerciseSessions,
+    waterIntake: { water_ml: data.waterIntake },
+    stepCalories: data.stepCalories ?? 0,
+    calorieBalance: data.calorieBalance,
+    supplementTotals: data.supplementTotals,
+    adjustedGoals: data.adjustedGoals ?? null,
+  };
+}
+
+export function buildDailySummary(
+  date: string,
+  raw: DailySummaryRawData,
+): DailySummary {
+  const {
+    goals,
+    foodEntries,
+    exerciseEntries,
+    waterIntake,
+    stepCalories,
+    calorieBalance,
+    supplementTotals,
+    adjustedGoals,
+  } = raw;
+
+  const calorieGoal = adjustedGoals?.calories ?? goals.calories ?? 0;
+  const supplements = resolveSupplementTotals(supplementTotals);
+  const caloriesConsumed =
+    calculateCaloriesConsumed(foodEntries) + supplements.calories;
+  const exerciseStats = calculateExerciseStats(exerciseEntries);
+  const { caloriesBurned, activeCalories, otherExerciseCalories } =
+    exerciseStats;
+  const exerciseMinutes = exerciseStats.durationMinutes;
+  const netCalories = caloriesConsumed - caloriesBurned;
+  const remainingCalories = calorieGoal - netCalories;
+
+  const fallbackRemaining = calorieGoal - caloriesConsumed;
+  const resolvedCalorieBalance: CalorieBalance = calorieBalance ?? {
+    eaten: Math.round(caloriesConsumed),
+    burned: Math.round(caloriesBurned),
+    remaining: Math.round(fallbackRemaining),
+    goal: Math.round(calorieGoal),
+    net: Math.round(netCalories),
+    progress:
+      calorieGoal > 0
+        ? Math.max(0, Math.round((caloriesConsumed / calorieGoal) * 100))
+        : 0,
+    bmr: 0,
+    bmrSource: 'formula' as const,
+    exerciseSource: 'none',
+    tdeeProjection: null,
+  };
+
+  return {
+    date,
+    calorieGoal,
+    caloriesConsumed,
+    caloriesBurned,
+    activeCalories,
+    otherExerciseCalories,
+    stepCalories,
+    exerciseMinutes,
+    exerciseMinutesGoal: goals.target_exercise_duration_minutes || 0,
+    exerciseCaloriesGoal: goals.target_exercise_calories_burned || 0,
+    netCalories,
+    remainingCalories,
+    protein: {
+      consumed: calculateProtein(foodEntries) + supplements.protein,
+      goal: adjustedGoals?.protein ?? goals.protein ?? 0,
+    },
+    carbs: {
+      consumed: calculateCarbs(foodEntries) + supplements.carbs,
+      goal: adjustedGoals?.carbs ?? goals.carbs ?? 0,
+    },
+    fat: {
+      consumed: calculateFat(foodEntries) + supplements.fat,
+      goal: adjustedGoals?.fat ?? goals.fat ?? 0,
+    },
+    fiber: {
+      consumed: calculateFiber(foodEntries) + supplements.dietary_fiber,
+      goal: goals.dietary_fiber || 0,
+    },
+    waterConsumed: waterIntake.water_ml || 0,
+    waterGoal: goals.water_goal_ml ?? 2500,
+    foodEntries,
+    supplementTotals: supplements,
+    exerciseEntries,
+    calorieBalance: resolvedCalorieBalance,
+    goals,
+    customNutrientTotals: addSupplementCustomNutrients(
+      calculateCustomNutrientTotals(foodEntries),
+      supplements,
+    ),
+    customNutrientGoals: goals.custom_nutrients
+      ? Object.fromEntries(
+          Object.entries(goals.custom_nutrients).map(([name, value]) => [
+            name,
+            typeof value === 'number' ? value : parseFloat(String(value)) || 0,
+          ]),
+        )
+      : {},
+  };
+}


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Android home-screen widgets are currently refreshed only while the Dashboard is mounted. As a result, Health Connect syncs and changes made on another device leave the widget stale until the app is opened.

**How did you implement the solution?**
The daily-summary pipeline is now reusable outside React hooks. After the existing Android background sync finishes, it resolves today's calendar day in the account timezone, fetches that server summary, and independently updates both widget snapshots while isolating widget failures from the health-sync worker. Regression tests cover timezone boundaries, successful refreshes, summary failures, and partial widget failures.

Linked Issue: Closes #2291
## How to Test

1. In `SparkyFitnessMobile`, run `pnpm run validate`.
2. Run `pnpm exec jest __tests__/services/backgroundSyncService.test.ts __tests__/hooks/useDailySummary.test.ts __tests__/hooks/useWidgetSync.test.ts --runInBand --watchman=false --coverage=false`.
3. On Android, enable Background Sync, add a SparkyFitness widget, and send the app to the background.
4. Add or change today's nutrition data in the web app, then wait for or manually trigger the existing Expo background worker.
5. Verify that the widget reflects the server-side change without opening the Android app.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](https://raw.githubusercontent.com/Bl4nk24/SparkyFitness/pr-assets-2291/.github/pr-assets/2291/widget-before.png)

With the app in the background, a web entry changed the expected remaining calories from 1,550 to 1,500, but the widget remained at 1,550.

### After

![after](https://raw.githubusercontent.com/Bl4nk24/SparkyFitness/pr-assets-2291/.github/pr-assets/2291/widget-after.png)

The same widget updated to 1,500 after the existing Android background worker ran, while the launcher remained in the foreground.

</details>

## Notes for Reviewers

- This deliberately reuses the existing Expo background-task cadence instead of adding another polling worker. Android decides the exact execution time, so the refresh is best-effort rather than real-time.
- Near-real-time updates for changes from another device would require a push-triggered design such as FCM and are outside this issue's scope.
- Emulator verification covered both the calorie and macro widget snapshots; the final native values matched the web and in-app dashboard totals.
- Review feedback is incorporated: account-timezone date selection is covered by a calendar-boundary regression test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Android widgets now refresh automatically after background synchronization.
  - Widget data uses the account’s timezone and the correct server date.
  - Calorie and macronutrient widgets update independently, so one failed update does not block the other.
  - Daily summaries now consistently include calories, macros, fiber, water, exercise, supplements, and custom nutrient totals.

- **Bug Fixes**
  - Improved widget refresh reliability and failure handling during background sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->