### PR TITLE
fix(withings): correct OAuth token request encoding and error handling

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1473,6 +1473,14 @@
         "clientSecretPlaceholder": "Enter YAZIO Client Secret",
         "allFieldsRequired": "All fields (Email/Username, Password, Client ID, and Client Secret) are required.",
         "languageSupportHelp": "YAZIO food searches automatically adjust to your active language preference in SparkyFitness (supporting English, German, French, Russian, Spanish, Italian, Dutch, Polish, Portuguese, Danish, Finnish, Swedish, Czech, Hungarian, Greek, Norwegian, Turkish, Chinese, Japanese, and Korean). Other languages default to standard international database parameters."
+      },
+      "oauthDashboards": {
+        "fallback": "provider's developer dashboard",
+        "withings": "Withings Developer Dashboard",
+        "fitbit": "Fitbit Developer Dashboard",
+        "oura": "Oura Developer Portal",
+        "googlehealth": "Google Cloud Console",
+        "polar": "Polar AccessLink Admin"
       }
     },
     "aiService": {

--- a/SparkyFitnessFrontend/src/pages/Settings/ProviderSpecificFields.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ProviderSpecificFields.tsx
@@ -8,28 +8,31 @@ import type { ExternalDataProvider } from './ExternalProviderSettings';
 
 // Developer dashboards where each OAuth provider's Client ID/Secret and callback
 // URL are configured. Kept in sync with the per-provider text in EditProviderForm.
+const OAUTH_DASHBOARD_LABELS =
+  'settings.foodExerciseDataProviders.oauthDashboards';
+
 const OAUTH_PROVIDER_DASHBOARDS: Record<
   string,
-  { label: string; url: string }
+  { labelKey: string; url: string }
 > = {
   withings: {
-    label: 'Withings Developer Dashboard',
+    labelKey: `${OAUTH_DASHBOARD_LABELS}.withings`,
     url: 'https://developer.withings.com/dashboard/',
   },
   fitbit: {
-    label: 'Fitbit Developer Dashboard',
+    labelKey: `${OAUTH_DASHBOARD_LABELS}.fitbit`,
     url: 'https://dev.fitbit.com/apps',
   },
   oura: {
-    label: 'Oura Developer Portal',
+    labelKey: `${OAUTH_DASHBOARD_LABELS}.oura`,
     url: 'https://developer.ouraring.com/applications',
   },
   googlehealth: {
-    label: 'Google Cloud Console',
+    labelKey: `${OAUTH_DASHBOARD_LABELS}.googlehealth`,
     url: 'https://console.cloud.google.com/apis/credentials',
   },
   polar: {
-    label: 'Polar AccessLink Admin',
+    labelKey: `${OAUTH_DASHBOARD_LABELS}.polar`,
     url: 'https://admin.polaraccesslink.com',
   },
 };
@@ -444,10 +447,10 @@ export const ProviderSpecificFields = ({
               rel="noopener noreferrer"
               className="text-blue-500 underline"
             >
-              {providerDashboard.label}
+              {t(providerDashboard.labelKey)}
             </a>
           ) : (
-            "provider's developer dashboard"
+            t(`${OAUTH_DASHBOARD_LABELS}.fallback`)
           )}
           , you must set your callback URL to:
           <strong className="flex items-center mt-1">

--- a/SparkyFitnessFrontend/src/pages/Settings/ProviderSpecificFields.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/ProviderSpecificFields.tsx
@@ -6,6 +6,34 @@ import { Clipboard } from 'lucide-react';
 import { useTranslation, Trans } from 'react-i18next';
 import type { ExternalDataProvider } from './ExternalProviderSettings';
 
+// Developer dashboards where each OAuth provider's Client ID/Secret and callback
+// URL are configured. Kept in sync with the per-provider text in EditProviderForm.
+const OAUTH_PROVIDER_DASHBOARDS: Record<
+  string,
+  { label: string; url: string }
+> = {
+  withings: {
+    label: 'Withings Developer Dashboard',
+    url: 'https://developer.withings.com/dashboard/',
+  },
+  fitbit: {
+    label: 'Fitbit Developer Dashboard',
+    url: 'https://dev.fitbit.com/apps',
+  },
+  oura: {
+    label: 'Oura Developer Portal',
+    url: 'https://developer.ouraring.com/applications',
+  },
+  googlehealth: {
+    label: 'Google Cloud Console',
+    url: 'https://console.cloud.google.com/apis/credentials',
+  },
+  polar: {
+    label: 'Polar AccessLink Admin',
+    url: 'https://admin.polaraccesslink.com',
+  },
+};
+
 interface ProviderSpecificFieldsProps {
   provider: Partial<ExternalDataProvider>;
   setProvider: React.Dispatch<
@@ -52,6 +80,9 @@ export const ProviderSpecificFields = ({
     'polar',
     'hevy',
   ].includes(provider.provider_type || '');
+
+  const providerDashboard =
+    OAUTH_PROVIDER_DASHBOARDS[provider.provider_type || ''];
 
   const getCallbackUrl = () => {
     if (provider.provider_type === 'strava') {
@@ -405,8 +436,20 @@ export const ProviderSpecificFields = ({
           This integration uses OAuth2. You will be redirected to the provider
           to authorize access after adding or updating the provider.
           <br />
-          In your provider's developer dashboard, you must set your callback URL
-          to:
+          In your{' '}
+          {providerDashboard ? (
+            <a
+              href={providerDashboard.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-500 underline"
+            >
+              {providerDashboard.label}
+            </a>
+          ) : (
+            "provider's developer dashboard"
+          )}
+          , you must set your callback URL to:
           <strong className="flex items-center mt-1">
             {getCallbackUrl()}
             <Button

--- a/SparkyFitnessServer/integrations/withings/withingsService.ts
+++ b/SparkyFitnessServer/integrations/withings/withingsService.ts
@@ -39,6 +39,16 @@ interface WithingsTokenEnvelope {
   body?: Partial<WithingsTokenBody>;
 }
 
+// A rejected response can still carry a live access_token (for example when only
+// the refresh_token is missing), so failures are described by status and error
+// alone. The raw payload must never reach the logs.
+function describeWithingsFailure(
+  data: WithingsTokenEnvelope | undefined
+): string {
+  const status = data?.status === undefined ? 'absent' : String(data.status);
+  return `status ${status}${data?.error ? `: ${data.error}` : ''}`;
+}
+
 // Withings wraps every response as { status, body } and only status 0 is success.
 // Their docs do not specify whether an error response omits `body` or sends an
 // empty one, so a truthy-body check alone is not a safe guard: check the status
@@ -49,25 +59,15 @@ function parseWithingsTokenResponse(
   data: WithingsTokenEnvelope | undefined,
   context: string
 ): WithingsTokenBody {
+  const failure = describeWithingsFailure(data);
   if (data?.status !== undefined && Number(data.status) !== 0) {
-    log(
-      'error',
-      `Withings ${context} error: status ${data.status}${
-        data.error ? ` (${data.error})` : ''
-      }.`,
-      JSON.stringify(data)
-    );
-    throw new Error(
-      `Withings ${context} failed with status ${data.status}${
-        data.error ? `: ${data.error}` : ''
-      }.`
-    );
+    log('error', `Withings ${context} error: ${failure}.`);
+    throw new Error(`Withings ${context} failed with ${failure}.`);
   }
   if (!data || !data.body) {
     log(
       'error',
-      `Withings ${context} error: Invalid response structure.`,
-      JSON.stringify(data)
+      `Withings ${context} error: invalid response structure (${failure}).`
     );
     throw new Error(`Invalid Withings API response structure (${context}).`);
   }
@@ -75,8 +75,7 @@ function parseWithingsTokenResponse(
   if (!access_token || !refresh_token) {
     log(
       'error',
-      `Withings ${context} error: response contained no tokens.`,
-      JSON.stringify(data)
+      `Withings ${context} error: response contained no usable tokens (${failure}).`
     );
     throw new Error(
       `Missing access_token or refresh_token in Withings ${context} response.`

--- a/SparkyFitnessServer/integrations/withings/withingsService.ts
+++ b/SparkyFitnessServer/integrations/withings/withingsService.ts
@@ -25,6 +25,18 @@ function interpolateQuery(sql: any, params: any) {
 }
 const WITHINGS_API_BASE_URL = 'https://wbsapi.withings.net';
 const WITHINGS_ACCOUNT_BASE_URL = 'https://account.withings.com';
+// Withings expects token requests as form-encoded POST bodies on the v2/oauth2 endpoint.
+async function requestWithingsToken(params: Record<string, string>) {
+  return axios.post(
+    `${WITHINGS_API_BASE_URL}/v2/oauth2`,
+    new URLSearchParams({ action: 'requesttoken', ...params }),
+    {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+    }
+  );
+}
 // Function to construct the Withings authorization URL
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getAuthorizationUrl(userId: any) {
@@ -94,22 +106,13 @@ async function exchangeCodeForTokens(userId: any, code: any, redirectUri: any) {
       throw new Error('Withings client ID or client secret is missing.');
     }
 
-    const response = await axios.post(
-      `${WITHINGS_API_BASE_URL}/v2/oauth2`,
-      new URLSearchParams({
-        action: 'requesttoken',
-        grant_type: 'authorization_code',
-        client_id: clientId,
-        client_secret: clientSecret,
-        code: code,
-        redirect_uri: redirectUri,
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-      }
-    );
+    const response = await requestWithingsToken({
+      grant_type: 'authorization_code',
+      client_id: clientId,
+      client_secret: clientSecret,
+      code: code,
+      redirect_uri: redirectUri,
+    });
     if (!response.data || !response.data.body) {
       log(
         'error',
@@ -250,21 +253,12 @@ async function refreshAccessToken(userId: any) {
         'Withings client ID, client secret, or refresh token is missing.'
       );
     }
-    const response = await axios.post(
-      `${WITHINGS_API_BASE_URL}/v2/oauth2`,
-      new URLSearchParams({
-        action: 'requesttoken',
-        grant_type: 'refresh_token',
-        client_id: clientId,
-        client_secret: clientSecret,
-        refresh_token: refreshToken,
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-        },
-      }
-    );
+    const response = await requestWithingsToken({
+      grant_type: 'refresh_token',
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+    });
     if (!response.data || !response.data.body) {
       log(
         'error',

--- a/SparkyFitnessServer/integrations/withings/withingsService.ts
+++ b/SparkyFitnessServer/integrations/withings/withingsService.ts
@@ -90,17 +90,23 @@ async function exchangeCodeForTokens(userId: any, code: any, redirectUri: any) {
       app_key_tag,
       ENCRYPTION_KEY
     );
+    if (!clientId || !clientSecret) {
+      throw new Error('Withings client ID or client secret is missing.');
+    }
+
     const response = await axios.post(
       `${WITHINGS_API_BASE_URL}/v2/oauth2`,
-      null,
+      new URLSearchParams({
+        action: 'requesttoken',
+        grant_type: 'authorization_code',
+        client_id: clientId,
+        client_secret: clientSecret,
+        code: code,
+        redirect_uri: redirectUri,
+      }),
       {
-        params: {
-          action: 'requesttoken',
-          grant_type: 'authorization_code',
-          client_id: clientId,
-          client_secret: clientSecret,
-          code: code,
-          redirect_uri: redirectUri,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
       }
     );
@@ -239,16 +245,23 @@ async function refreshAccessToken(userId: any) {
       refresh_token_tag,
       ENCRYPTION_KEY
     );
+    if (!clientId || !clientSecret || !refreshToken) {
+      throw new Error(
+        'Withings client ID, client secret, or refresh token is missing.'
+      );
+    }
     const response = await axios.post(
       `${WITHINGS_API_BASE_URL}/v2/oauth2`,
-      null,
+      new URLSearchParams({
+        action: 'requesttoken',
+        grant_type: 'refresh_token',
+        client_id: clientId,
+        client_secret: clientSecret,
+        refresh_token: refreshToken,
+      }),
       {
-        params: {
-          action: 'requesttoken',
-          grant_type: 'refresh_token',
-          client_id: clientId,
-          client_secret: clientSecret,
-          refresh_token: refreshToken,
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
         },
       }
     );

--- a/SparkyFitnessServer/integrations/withings/withingsService.ts
+++ b/SparkyFitnessServer/integrations/withings/withingsService.ts
@@ -25,6 +25,66 @@ function interpolateQuery(sql: any, params: any) {
 }
 const WITHINGS_API_BASE_URL = 'https://wbsapi.withings.net';
 const WITHINGS_ACCOUNT_BASE_URL = 'https://account.withings.com';
+interface WithingsTokenBody {
+  access_token: string;
+  refresh_token: string;
+  expires_in?: string | number;
+  scope?: string;
+  userid?: string | number;
+}
+
+interface WithingsTokenEnvelope {
+  status?: number | string;
+  error?: string;
+  body?: Partial<WithingsTokenBody>;
+}
+
+// Withings wraps every response as { status, body } and only status 0 is success.
+// Their docs do not specify whether an error response omits `body` or sends an
+// empty one, so a truthy-body check alone is not a safe guard: check the status
+// and the token fields before anything is encrypted or persisted. encrypt()
+// returns nulls rather than throwing on a missing token, so an unguarded refresh
+// would overwrite the stored refresh token with NULL and disconnect the user.
+function parseWithingsTokenResponse(
+  data: WithingsTokenEnvelope | undefined,
+  context: string
+): WithingsTokenBody {
+  if (data?.status !== undefined && Number(data.status) !== 0) {
+    log(
+      'error',
+      `Withings ${context} error: status ${data.status}${
+        data.error ? ` (${data.error})` : ''
+      }.`,
+      JSON.stringify(data)
+    );
+    throw new Error(
+      `Withings ${context} failed with status ${data.status}${
+        data.error ? `: ${data.error}` : ''
+      }.`
+    );
+  }
+  if (!data || !data.body) {
+    log(
+      'error',
+      `Withings ${context} error: Invalid response structure.`,
+      JSON.stringify(data)
+    );
+    throw new Error(`Invalid Withings API response structure (${context}).`);
+  }
+  const { access_token, refresh_token } = data.body;
+  if (!access_token || !refresh_token) {
+    log(
+      'error',
+      `Withings ${context} error: response contained no tokens.`,
+      JSON.stringify(data)
+    );
+    throw new Error(
+      `Missing access_token or refresh_token in Withings ${context} response.`
+    );
+  }
+  return { ...data.body, access_token, refresh_token };
+}
+
 // Withings expects token requests as form-encoded POST bodies on the v2/oauth2 endpoint.
 async function requestWithingsToken(params: Record<string, string>) {
   return axios.post(
@@ -113,26 +173,13 @@ async function exchangeCodeForTokens(userId: any, code: any, redirectUri: any) {
       code: code,
       redirect_uri: redirectUri,
     });
-    if (!response.data || !response.data.body) {
-      log(
-        'error',
-        'Withings requesttoken error: Invalid response structure.',
-        JSON.stringify(response.data)
-      );
-      throw new Error('Invalid Withings API response structure.');
-    }
     const { access_token, refresh_token, expires_in, scope, userid } =
-      response.data.body;
-    if (!access_token || !refresh_token) {
-      throw new Error(
-        'Missing access_token or refresh_token in Withings API response.'
-      );
-    }
+      parseWithingsTokenResponse(response.data, 'requesttoken');
     // Encrypt tokens
     const encryptedAccessToken = await encrypt(access_token, ENCRYPTION_KEY);
     const encryptedRefreshToken = await encrypt(refresh_token, ENCRYPTION_KEY);
     // Validate expires_in
-    let validExpiresIn = parseInt(expires_in, 10);
+    let validExpiresIn = parseInt(String(expires_in), 10);
     if (isNaN(validExpiresIn) || validExpiresIn <= 0) {
       log(
         'warn',
@@ -259,24 +306,14 @@ async function refreshAccessToken(userId: any) {
       client_secret: clientSecret,
       refresh_token: refreshToken,
     });
-    if (!response.data || !response.data.body) {
-      log(
-        'error',
-        'Withings refresh access token error: Invalid response structure.',
-        JSON.stringify(response.data)
-      );
-      throw new Error(
-        'Invalid Withings API response structure during token refresh.'
-      );
-    }
     const {
       access_token,
       refresh_token: newRefreshToken,
       expires_in,
       scope,
-    } = response.data.body;
+    } = parseWithingsTokenResponse(response.data, 'token refresh');
     // Validate expires_in
-    let validExpiresIn = parseInt(expires_in, 10);
+    let validExpiresIn = parseInt(String(expires_in), 10);
     if (isNaN(validExpiresIn) || validExpiresIn <= 0) {
       log(
         'warn',

--- a/SparkyFitnessServer/tests/withingsTokenResponse.test.ts
+++ b/SparkyFitnessServer/tests/withingsTokenResponse.test.ts
@@ -1,0 +1,194 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import axios from 'axios';
+import { getClient, getSystemClient } from '../db/poolManager.js';
+import { encrypt } from '../security/encryption.js';
+import {
+  exchangeCodeForTokens,
+  refreshAccessToken,
+} from '../integrations/withings/withingsService.js';
+
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+vi.mock('../utils/diagnosticLogger.js', () => ({ logRawResponse: vi.fn() }));
+vi.mock('../integrations/withings/withingsDataProcessor.js', () => ({
+  default: {},
+}));
+vi.mock('axios', () => ({ default: { post: vi.fn() } }));
+vi.mock('../db/poolManager.js', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+vi.mock('../security/encryption.js', () => ({
+  ENCRYPTION_KEY: 'test-key',
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+}));
+
+const USER_ID = 'user-1';
+
+// The provider row both flows read before talking to Withings. Values are
+// irrelevant because decrypt is stubbed; only the row's presence matters.
+const PROVIDER_ROW = {
+  encrypted_app_id: 'a',
+  app_id_iv: 'b',
+  app_id_tag: 'c',
+  encrypted_app_key: 'd',
+  app_key_iv: 'e',
+  app_key_tag: 'f',
+  encrypted_refresh_token: 'g',
+  refresh_token_iv: 'h',
+  refresh_token_tag: 'i',
+};
+
+function mockClient() {
+  const client = {
+    query: vi.fn().mockResolvedValue({ rows: [PROVIDER_ROW], rowCount: 1 }),
+    release: vi.fn(),
+  };
+  vi.mocked(getClient).mockResolvedValue(
+    client as unknown as Awaited<ReturnType<typeof getClient>>
+  );
+  vi.mocked(getSystemClient).mockResolvedValue(
+    client as unknown as Awaited<ReturnType<typeof getSystemClient>>
+  );
+  return client;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  const { decrypt } = await import('../security/encryption.js');
+  vi.mocked(decrypt).mockResolvedValue('decrypted-value');
+  vi.mocked(encrypt).mockResolvedValue({
+    encryptedText: 'enc',
+    iv: 'iv',
+    tag: 'tag',
+  });
+});
+
+describe('Withings token response validation', () => {
+  it('rejects a non-zero status even when a body is present', async () => {
+    const client = mockClient();
+    vi.mocked(axios.post).mockResolvedValue({
+      data: { status: 342, error: 'Invalid params', body: {} },
+    });
+
+    await expect(refreshAccessToken(USER_ID)).rejects.toThrow(/342/);
+
+    expect(encrypt).not.toHaveBeenCalled();
+    // Only the initial SELECT ran; no UPDATE was issued.
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(client.release).toHaveBeenCalled();
+  });
+
+  it('surfaces the Withings error text instead of a generic message', async () => {
+    mockClient();
+    vi.mocked(axios.post).mockResolvedValue({
+      data: { status: 503, error: 'Invalid Params', body: {} },
+    });
+
+    await expect(refreshAccessToken(USER_ID)).rejects.toThrow(/Invalid Params/);
+  });
+
+  it('does not persist null tokens when the refresh body omits them', async () => {
+    const client = mockClient();
+    vi.mocked(axios.post).mockResolvedValue({
+      data: { status: 0, body: { expires_in: 10800 } },
+    });
+
+    await expect(refreshAccessToken(USER_ID)).rejects.toThrow(
+      /Missing access_token or refresh_token/
+    );
+
+    expect(encrypt).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not persist null tokens when the refresh body has only an access token', async () => {
+    const client = mockClient();
+    vi.mocked(axios.post).mockResolvedValue({
+      data: { status: 0, body: { access_token: 'at', expires_in: 10800 } },
+    });
+
+    await expect(refreshAccessToken(USER_ID)).rejects.toThrow(
+      /Missing access_token or refresh_token/
+    );
+
+    expect(encrypt).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists refreshed tokens on a successful response', async () => {
+    const client = mockClient();
+    vi.mocked(axios.post).mockResolvedValue({
+      data: {
+        status: 0,
+        body: {
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          expires_in: 10800,
+          scope: 'user.metrics',
+        },
+      },
+    });
+
+    await expect(refreshAccessToken(USER_ID)).resolves.toBe('new-access');
+
+    expect(encrypt).toHaveBeenCalledTimes(2);
+    // SELECT plus the UPDATE.
+    expect(client.query).toHaveBeenCalledTimes(2);
+    expect(client.query.mock.calls[1][0]).toMatch(/UPDATE/);
+  });
+
+  it('rejects a non-zero status during the authorization-code exchange', async () => {
+    const client = mockClient();
+    vi.mocked(axios.post).mockResolvedValue({
+      data: { status: 304, error: 'Invalid code', body: {} },
+    });
+
+    await expect(
+      exchangeCodeForTokens(
+        USER_ID,
+        'code',
+        'https://app.test/withings/callback'
+      )
+    ).rejects.toThrow(/304/);
+
+    expect(encrypt).not.toHaveBeenCalled();
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends the token request as a form-encoded body', async () => {
+    mockClient();
+    vi.mocked(axios.post).mockResolvedValue({
+      data: {
+        status: 0,
+        body: {
+          access_token: 'at',
+          refresh_token: 'rt',
+          expires_in: 10800,
+          userid: 42,
+        },
+      },
+    });
+
+    await exchangeCodeForTokens(
+      USER_ID,
+      'auth-code',
+      'https://app.test/withings/callback'
+    );
+
+    const [url, body, config] = vi.mocked(axios.post).mock.calls[0];
+    expect(url).toBe('https://wbsapi.withings.net/v2/oauth2');
+    expect(body).toBeInstanceOf(URLSearchParams);
+    expect((body as URLSearchParams).get('action')).toBe('requesttoken');
+    expect((body as URLSearchParams).get('grant_type')).toBe(
+      'authorization_code'
+    );
+    expect((body as URLSearchParams).get('code')).toBe('auth-code');
+    expect((body as URLSearchParams).get('redirect_uri')).toBe(
+      'https://app.test/withings/callback'
+    );
+    expect(config?.headers?.['Content-Type']).toBe(
+      'application/x-www-form-urlencoded'
+    );
+  });
+});

--- a/SparkyFitnessServer/tests/withingsTokenResponse.test.ts
+++ b/SparkyFitnessServer/tests/withingsTokenResponse.test.ts
@@ -1,6 +1,7 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
 import axios from 'axios';
 import { getClient, getSystemClient } from '../db/poolManager.js';
+import { log } from '../config/logging.js';
 import { encrypt } from '../security/encryption.js';
 import {
   exchangeCodeForTokens,
@@ -154,6 +155,28 @@ describe('Withings token response validation', () => {
 
     expect(encrypt).not.toHaveBeenCalled();
     expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('never writes token values to the log when rejecting a response', async () => {
+    mockClient();
+    // A refresh that returns an access_token but no refresh_token: the rejection
+    // path must not echo the live token into the logging sink (CWE-532).
+    vi.mocked(axios.post).mockResolvedValue({
+      data: {
+        status: 0,
+        body: { access_token: 'super-secret-access-token', expires_in: 10800 },
+      },
+    });
+
+    await expect(refreshAccessToken(USER_ID)).rejects.toThrow(
+      /Missing access_token or refresh_token/
+    );
+
+    const logged = vi
+      .mocked(log)
+      .mock.calls.map((call) => JSON.stringify(call))
+      .join(' ');
+    expect(logged).not.toContain('super-secret-access-token');
   });
 
   it('sends the token request as a form-encoded body', async () => {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
The Withings OAuth token exchange sends request parameters in the query string with an empty POST body, causing token exchange failures with the current Withings API. It also hides useful Withings API errors behind a generic missing-token message.

**How did you implement the solution?**
Changed authorization-code and refresh-token exchanges to send `application/x-www-form-urlencoded` POST bodies using `URLSearchParams`, and improved error handling to log the actual Withings API status/error.

Linked Issue: N/A

## How to Test

1. Configure a Withings external provider with a valid Client ID, Client Secret, and callback URL.
2. Navigate to **Settings → Developer Integrations → Withings** and click **Connect**.
3. Authorize the Withings account and verify SparkyFitness successfully links the provider.
4. Verify an invalid Client ID/Secret reports the actual Withings API error instead of only `Missing access_token or refresh_token`.

## PR Type

* [x] Issue (bug fix)
* [ ] New Feature
* [ ] Refactor
* [ ] Documentation

## Checklist

**All PRs:**

* [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [[License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE)](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

* [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

* [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
* [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

* [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
* [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. *(N/A — this change adds no tables or database schema changes.)*

**UI changes (components, screens, pages):**

* [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

* [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

Not applicable — no UI changes.

## Notes for Reviewers

Tested successfully against a real Withings account after the change.

The backend test suite reported 3575 passing tests, 221 skipped, and one failure in:

`tests/outboundProxy.test.ts > configureOutboundProxy > routes native fetch requests through the proxy`

The failure is `getaddrinfo ENOTFOUND proxied.test`. I reran that test with this PR's changes stashed and it fails identically, confirming it is unrelated to the Withings change.

<!-- restored-checklist -->
---
## ✅ Required Checklist (restored automatically)

> The mandatory checklist from our PR template is missing from this description, so it
> has been added back below. **Please tick each box and do not delete this section** —
> these checked boxes are how we record your agreement. Edit the description in place;
> no new commit is needed.

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).
- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct links to developer dashboards for Withings, Fitbit, Oura, Google Health, and Polar when configuring OAuth connections.
  * OAuth setup instructions now adapt to the selected provider with localized dashboard labels and a fallback description.

* **Bug Fixes**
  * Improved Withings authentication and token refresh validation.
  * Invalid responses, unsupported data, or missing tokens are rejected before credentials are saved, with clearer error reporting and safer logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- restored-checklist -->
---
## ✅ Required Checklist (restored automatically)

> The mandatory checklist from our PR template is missing from this description, so it
> has been added back below. **Please tick each box and do not delete this section** —
> these checked boxes are how we record your agreement. Edit the description in place;
> no new commit is needed.

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.
