### PR TITLE
fix(mobile): normalize workout active calories

### DIFF
--- a/SparkyFitnessMobile/AGENTS.md
+++ b/SparkyFitnessMobile/AGENTS.md
@@ -129,7 +129,7 @@ npx expo prebuild --clean
 - On iOS, cumulative metrics should use HealthKit statistics queries, not raw sample summation.
 - On Android, cumulative metrics (`Steps`, `Distance`, `ActiveCaloriesBurned`, `TotalCaloriesBurned`, `FloorsClimbed`) use Health Connect `aggregateGroupByPeriod` once per range. Native source-priority dedup should match Health Connect UI; do not reintroduce JS `Math.max` or source allowlist dedup.
 - Android read helpers return `{ records, error }` via `readHealthRecordsDetailed` and `aggregateCumulativeMetricByDayDetailed`; legacy wrappers unwrap only records.
-- Android exercise sessions are enriched with `aggregateRecord` for active/total calories and distance over the session window. Calories start scoped to `dataOrigin`; incomplete or implausible pairs retry without the origin filter so Health Connect can apply source priority. Distance always stays origin-scoped. Both are filtered for plausibility.
+- Android exercise sessions are enriched with `aggregateRecord` for active, total, and basal calories plus distance over the session window. Active/total calories start scoped to `dataOrigin`, while basal energy remains unfiltered; `total - basal` is compared as an active-energy candidate. Incomplete or implausible active/total pairs retry without the origin filter so Health Connect can apply source priority. Distance always stays origin-scoped.
 - iOS HealthKit locked-device failures surface as database-inaccessible warnings. Do not treat these as successful empty reads.
 - `app.config.ts` grants `android.permission.health.READ_HEALTH_DATA_HISTORY` so Android can read data older than 30 days.
 - Health Connect permission migrations belong in `services/shared/healthPermissionMigration.ts`, not UI-only state.

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
@@ -1460,6 +1460,31 @@ describe('enrichExerciseSessions', () => {
       .toEqual({ inKilocalories: 120 });
   });
 
+  test('uses total calories as active energy when the basal aggregate is zero', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 100 } });
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 180 } });
+      }
+      if (recordType === 'BasalMetabolicRate') {
+        return Promise.resolve({ BASAL_CALORIES_TOTAL: { inKilocalories: 0 } });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await enrichExerciseSessions([
+      makeSession({
+        startTime: '2024-01-15T10:00:00Z',
+        endTime: '2024-01-15T10:57:00Z',
+      }),
+    ], createTelemetryRunContext());
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy)
+      .toEqual({ inKilocalories: 180 });
+  });
+
   test('keeps the legacy active selection when the optional basal read fails', async () => {
     mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
       if (recordType === 'ActiveCaloriesBurned') {

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
@@ -1413,14 +1413,76 @@ describe('enrichExerciseSessions', () => {
       recordType: string;
       dataOriginFilter?: string[];
     });
-    expect(requests).toHaveLength(3);
-    expect(requests.every(request =>
-      request.dataOriginFilter?.[0] === 'com.ohealth',
+    expect(requests).toHaveLength(4);
+    expect(requests.find(request => request.recordType === 'BasalMetabolicRate'))
+      .not.toHaveProperty('dataOriginFilter');
+    expect(requests.filter(request => request.recordType !== 'BasalMetabolicRate').every(
+      request => request.dataOriginFilter?.[0] === 'com.ohealth',
     )).toBe(true);
     expect(result[0]).toMatchObject({
       energy: { inKilocalories: 300 },
       distance: { inMeters: 5000 },
     });
+  });
+
+  test('uses total minus basal calories when it exceeds a low Hevy active value', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({
+          ACTIVE_CALORIES_TOTAL: { inKilocalories: 71 },
+          dataOrigins: ['com.hevy'],
+        });
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({
+          ENERGY_TOTAL: { inKilocalories: 180 },
+          dataOrigins: ['com.hevy'],
+        });
+      }
+      if (recordType === 'BasalMetabolicRate') {
+        return Promise.resolve({
+          BASAL_CALORIES_TOTAL: { inKilocalories: 60 },
+          dataOrigins: ['com.samsung.android.app.health'],
+        });
+      }
+      return Promise.resolve({ dataOrigins: [] });
+    });
+
+    const result = await enrichExerciseSessions([
+      makeSession({
+        startTime: '2024-01-15T10:00:00Z',
+        endTime: '2024-01-15T10:57:00Z',
+        metadata: { dataOrigin: 'com.hevy' },
+      }),
+    ], createTelemetryRunContext());
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy)
+      .toEqual({ inKilocalories: 120 });
+  });
+
+  test('keeps the legacy active selection when the optional basal read fails', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 71 } });
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 180 } });
+      }
+      if (recordType === 'BasalMetabolicRate') {
+        return Promise.reject(new Error('Basal permission denied'));
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await enrichExerciseSessions([
+      makeSession({
+        startTime: '2024-01-15T10:00:00Z',
+        endTime: '2024-01-15T10:57:00Z',
+      }),
+    ], createTelemetryRunContext());
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy)
+      .toEqual({ inKilocalories: 71 });
   });
 
   test('uses cross-origin calories when the Hevy-scoped pair is incomplete', async () => {
@@ -1447,7 +1509,10 @@ describe('enrichExerciseSessions', () => {
     expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 307 });
     const calorieRequests = mockAggregateRecord.mock.calls
       .map((call: unknown[]) => call[0] as { recordType: string; dataOriginFilter?: string[] })
-      .filter(request => request.recordType !== 'Distance');
+      .filter(request =>
+        request.recordType === 'ActiveCaloriesBurned' ||
+        request.recordType === 'TotalCaloriesBurned',
+      );
     expect(calorieRequests).toEqual([
       expect.objectContaining({
         recordType: 'ActiveCaloriesBurned',
@@ -1490,7 +1555,10 @@ describe('enrichExerciseSessions', () => {
     expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 307 });
     const calorieRequests = mockAggregateRecord.mock.calls
       .map((call: unknown[]) => call[0] as { recordType: string; dataOriginFilter?: string[] })
-      .filter(request => request.recordType !== 'Distance');
+      .filter(request =>
+        request.recordType === 'ActiveCaloriesBurned' ||
+        request.recordType === 'TotalCaloriesBurned',
+      );
     expect(calorieRequests).toHaveLength(4);
     expect(calorieRequests.slice(0, 2).every(
       request => request.dataOriginFilter?.[0] === 'app.hevy',
@@ -1522,17 +1590,23 @@ describe('enrichExerciseSessions', () => {
     expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 320 });
     const calorieRequests = mockAggregateRecord.mock.calls
       .map((call: unknown[]) => call[0] as { recordType: string; dataOriginFilter?: string[] })
-      .filter(request => request.recordType !== 'Distance');
+      .filter(request =>
+        request.recordType === 'ActiveCaloriesBurned' ||
+        request.recordType === 'TotalCaloriesBurned',
+      );
     expect(calorieRequests).toHaveLength(4);
   });
 
-  test('prefers TotalCaloriesBurned when ActiveCaloriesBurned is a tiny passive fragment (issue #1296: 41-min walk)', async () => {
+  test('subtracts basal energy when ActiveCaloriesBurned is a tiny passive fragment (issue #1296: 41-min walk)', async () => {
     mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
       if (recordType === 'ActiveCaloriesBurned') {
         return Promise.resolve({ ACTIVE_CALORIES_TOTAL: { inKilocalories: 43.5 } });
       }
       if (recordType === 'TotalCaloriesBurned') {
         return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 265 } });
+      }
+      if (recordType === 'BasalMetabolicRate') {
+        return Promise.resolve({ BASAL_CALORIES_TOTAL: { inKilocalories: 45 } });
       }
       return Promise.resolve({});
     });
@@ -1542,7 +1616,7 @@ describe('enrichExerciseSessions', () => {
       makeSession({ startTime: '2024-01-15T10:00:00Z', endTime: '2024-01-15T10:41:00Z' }),
     ], createTelemetryRunContext());
 
-    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 265 });
+    expect((result[0] as { energy: { inKilocalories: number } }).energy).toEqual({ inKilocalories: 220 });
   });
 
   test('prefers TotalCaloriesBurned when ActiveCaloriesBurned is near-zero passive noise (issue #1296: indoor bike)', async () => {
@@ -1571,6 +1645,9 @@ describe('enrichExerciseSessions', () => {
       }
       if (recordType === 'TotalCaloriesBurned') {
         return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 385 } });
+      }
+      if (recordType === 'BasalMetabolicRate') {
+        return Promise.resolve({ BASAL_CALORIES_TOTAL: { inKilocalories: 48 } });
       }
       return Promise.resolve({});
     });
@@ -2060,9 +2137,9 @@ describe('enrichExerciseSessions bounded fan-out and reuse (#2191)', () => {
 
     await enrichExerciseSessions(tenSessions(), createTelemetryRunContext());
 
-    // AGGREGATE_CONCURRENCY (6) sessions × 3 scalar aggregates each. The point
-    // is that ten sessions do not become thirty concurrent calls.
-    expect(aggregates.peak).toBeLessThanOrEqual(18);
+    // AGGREGATE_CONCURRENCY (4) sessions × 4 scalar aggregates each. The point
+    // is that ten sessions do not become forty concurrent calls.
+    expect(aggregates.peak).toBeLessThanOrEqual(16);
   });
 
   test('telemetry stays capped at two sessions however wide the outer batch runs', async () => {
@@ -2073,7 +2150,7 @@ describe('enrichExerciseSessions bounded fan-out and reuse (#2191)', () => {
 
     // Only readRecords carries telemetry (route plus up to five sample series).
     // TELEMETRY_CONCURRENCY (2) sessions × 6 parallel reads = 12. Without the
-    // limiter the outer batch of 6 would put ~36 in flight — and the original
+    // limiter the outer batch of 4 would put ~24 in flight — and the original
     // unbounded version put all ten sessions' worth in flight at once, which is
     // what froze the UI in #2191.
     expect(telemetryReads.peak).toBeLessThanOrEqual(12);

--- a/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/healthconnect/index.test.ts
@@ -1483,6 +1483,39 @@ describe('enrichExerciseSessions', () => {
 
     expect((result[0] as { energy: { inKilocalories: number } }).energy)
       .toEqual({ inKilocalories: 180 });
+    expect(mockAggregateRecord).toHaveBeenCalledWith(expect.objectContaining({
+      recordType: 'BasalMetabolicRate',
+      timeRangeFilter: {
+        operator: 'between',
+        startTime: '2024-01-15T10:00:00Z',
+        endTime: '2024-01-15T10:57:00Z',
+      },
+    }));
+  });
+
+  test('keeps the legacy total fallback when basal consumes the total', async () => {
+    mockAggregateRecord.mockImplementation(({ recordType }: { recordType: string }) => {
+      if (recordType === 'ActiveCaloriesBurned') {
+        return Promise.resolve({});
+      }
+      if (recordType === 'TotalCaloriesBurned') {
+        return Promise.resolve({ ENERGY_TOTAL: { inKilocalories: 180 } });
+      }
+      if (recordType === 'BasalMetabolicRate') {
+        return Promise.resolve({ BASAL_CALORIES_TOTAL: { inKilocalories: 180 } });
+      }
+      return Promise.resolve({});
+    });
+
+    const result = await enrichExerciseSessions([
+      makeSession({
+        startTime: '2024-01-15T10:00:00Z',
+        endTime: '2024-01-15T10:57:00Z',
+      }),
+    ], createTelemetryRunContext());
+
+    expect((result[0] as { energy: { inKilocalories: number } }).energy)
+      .toEqual({ inKilocalories: 180 });
   });
 
   test('keeps the legacy active selection when the optional basal read fails', async () => {

--- a/SparkyFitnessMobile/src/services/healthconnect/index.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/index.ts
@@ -1253,8 +1253,10 @@ const selectBasalNormalizedSessionCalories = (
     ? derivedActive
     : undefined;
 
+  if (derivedPositive == null) {
+    return selectSessionCalories(active, total, durationMs);
+  }
   if (reportedActive == null) return derivedPositive;
-  if (derivedPositive == null) return reportedActive;
   return Math.max(reportedActive, derivedPositive);
 };
 

--- a/SparkyFitnessMobile/src/services/healthconnect/index.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/index.ts
@@ -34,7 +34,7 @@ export { sessionCacheKey };
 /**
  * Enrichment runs two very different costs per session, so they get two limits.
  *
- * The three calories/distance aggregates return a single scalar each — cheap to
+ * The four calorie/basal/distance aggregates return a single scalar each — cheap to
  * carry over the bridge. Throttling those as hard as telemetry is what would
  * push a large workout library toward the 60s per-metric timeout, so they run
  * at the wider limit.
@@ -47,7 +47,7 @@ export { sessionCacheKey };
  * Both are far below the unbounded fan-out that caused the bug, and well inside
  * the Health Connect API call quota (see shared/quotaError.ts).
  */
-const AGGREGATE_CONCURRENCY = 6;
+const AGGREGATE_CONCURRENCY = 4;
 const TELEMETRY_CONCURRENCY = 2;
 
 /**
@@ -1231,6 +1231,31 @@ type SessionCaloriePair = {
   total?: number;
 };
 
+const selectBasalNormalizedSessionCalories = (
+  active: number | undefined,
+  total: number | undefined,
+  basal: number | undefined,
+  durationMs: number,
+): number | undefined => {
+  const totalValid = isPositiveCalories(total) ? total : undefined;
+  const basalValid = isPositiveCalories(basal) ? basal : undefined;
+  if (totalValid == null || basalValid == null) {
+    return selectSessionCalories(active, total, durationMs);
+  }
+
+  const reportedActive = isPositiveCalories(active) && active <= totalValid
+    ? active
+    : undefined;
+  const derivedActive = deriveActiveCalories(totalValid, basalValid);
+  const derivedPositive = derivedActive != null && derivedActive > 0
+    ? derivedActive
+    : undefined;
+
+  if (reportedActive == null) return derivedPositive;
+  if (derivedPositive == null) return reportedActive;
+  return Math.max(reportedActive, derivedPositive);
+};
+
 const extractSessionCaloriePair = (
   activeResult: PromiseSettledResult<unknown>,
   totalResult: PromiseSettledResult<unknown>,
@@ -1255,8 +1280,10 @@ export const isPlausibleSessionDistance = (meters: number, durationMs: number): 
 /**
  * Enriches raw exercise session records with calories and distance data.
  * Health Connect stores these as separate record types, so we query
- * ActiveCaloriesBurned, TotalCaloriesBurned, and Distance aggregated over
- * each session's time range and apply plausibility checks (see #593, #1296).
+ * ActiveCaloriesBurned, TotalCaloriesBurned, BasalMetabolicRate, and Distance
+ * over each session's time range. Total minus basal is compared as an active-
+ * energy candidate before applying legacy plausibility fallbacks (see #593,
+ * #1296, #2295).
  */
 export const enrichExerciseSessions = async (
   records: unknown[],
@@ -1331,12 +1358,15 @@ export const enrichExerciseSessions = async (
       return record;
     }
 
-    // Start with the session origin, matching Health Connect's associated-session
-    // guidance and preventing another concurrent activity from donating energy or
-    // distance. If that origin has an incomplete or implausible calorie pair, retry
-    // calories without an origin filter so Health Connect can apply the user's
-    // Activity source priority (for example, Hevy session + Samsung calories).
-    const [activeCaloriesResult, totalCaloriesResult, distanceResult] = await Promise.allSettled([
+    // Start activity and total energy at the session origin, matching Health
+    // Connect's associated-session guidance and preventing another concurrent
+    // activity from donating energy or distance. Basal energy is intentionally
+    // unfiltered because it comes from the user's metabolism source, not the
+    // workout writer. If the origin has an incomplete or implausible calorie pair,
+    // retry activity and total energy without an origin filter so Health Connect
+    // can apply the user's Activity source priority (for example, Hevy session +
+    // Samsung calories).
+    const [activeCaloriesResult, totalCaloriesResult, basalCaloriesResult, distanceResult] = await Promise.allSettled([
       aggregateRecord({
         recordType: 'ActiveCaloriesBurned',
         timeRangeFilter,
@@ -1346,6 +1376,10 @@ export const enrichExerciseSessions = async (
         recordType: 'TotalCaloriesBurned',
         timeRangeFilter,
         dataOriginFilter,
+      }),
+      aggregateRecord({
+        recordType: 'BasalMetabolicRate',
+        timeRangeFilter,
       }),
       aggregateRecord({
         recordType: 'Distance',
@@ -1360,7 +1394,16 @@ export const enrichExerciseSessions = async (
     const enrichedFields: Record<string, unknown> = {};
 
     const scopedCalories = extractSessionCaloriePair(activeCaloriesResult, totalCaloriesResult);
-    let kcal = selectSessionCalories(scopedCalories.active, scopedCalories.total, durationMs);
+    const basalCalories = basalCaloriesResult.status === 'fulfilled'
+      ? (basalCaloriesResult.value as { BASAL_CALORIES_TOTAL?: { inKilocalories?: number } })
+        .BASAL_CALORIES_TOTAL?.inKilocalories
+      : undefined;
+    let kcal = selectBasalNormalizedSessionCalories(
+      scopedCalories.active,
+      scopedCalories.total,
+      basalCalories,
+      durationMs,
+    );
     if (dataOriginFilter && shouldTryCrossOriginCalories(
       scopedCalories.active,
       scopedCalories.total,
@@ -1380,9 +1423,10 @@ export const enrichExerciseSessions = async (
         unfilteredActiveResult,
         unfilteredTotalResult,
       );
-      const unfilteredKcal = selectSessionCalories(
+      const unfilteredKcal = selectBasalNormalizedSessionCalories(
         unfilteredCalories.active,
         unfilteredCalories.total,
+        basalCalories,
         durationMs,
       );
       if (unfilteredKcal != null && (kcal == null || unfilteredKcal > kcal)) {

--- a/SparkyFitnessMobile/src/services/healthconnect/index.ts
+++ b/SparkyFitnessMobile/src/services/healthconnect/index.ts
@@ -1238,7 +1238,9 @@ const selectBasalNormalizedSessionCalories = (
   durationMs: number,
 ): number | undefined => {
   const totalValid = isPositiveCalories(total) ? total : undefined;
-  const basalValid = isPositiveCalories(basal) ? basal : undefined;
+  const basalValid = basal != null && Number.isFinite(basal) && basal >= 0
+    ? basal
+    : undefined;
   if (totalValid == null || basalValid == null) {
     return selectSessionCalories(active, total, durationMs);
   }


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Health Connect exercise sessions can retain an implausibly low reported active-calorie value even when total and basal energy provide a better active-energy value.

**How did you implement the solution?**
Exercise enrichment now reads session-window basal energy, derives `TotalCaloriesBurned - BasalCalories`, and selects the larger valid active-energy candidate without adding or estimating calories. Existing origin scoping, cross-origin fallback, non-fatal fallback behavior, and bounded fan-out remain intact.

Linked Issue: Closes #2295

## How to Test

1. Check out this branch and run `cd SparkyFitnessMobile`.
2. Run `pnpm run validate`.
3. Run `pnpm exec jest --watchman=false --runInBand --coverage=false __tests__/services/healthconnect __tests__/services/healthConnectService.test.ts __tests__/services/healthConnectService.ios.test.ts __tests__/services/healthconnectWorkoutTelemetry.test.ts`.
4. Verify the Hevy regression fixture selects 120 active kcal from 180 total kcal minus 60 basal kcal instead of the reported 71 active kcal.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

N/A — no UI changes.

### After

N/A — no UI changes.

</details>

## Notes for Reviewers

- `pnpm run validate` passes.
- The Health Connect-focused matrix passes: 10 suites and 387 tests.
- Android 14 emulator verification passed: the existing Health Connect-capable dev client loaded this branch from Metro, resumed `MainActivity`, and rendered onboarding without a fatal or bundle error.
- The complete local `pnpm test` run passed 362 of 368 suites. Six unrelated existing/environment-sensitive suites failed due Windows locale formatting, symlink permissions, a widget source contract, and one UI timeout; none overlap the changed files or Health Connect paths.
- Session aggregate concurrency was reduced from six to four because enrichment now performs four scalar aggregates per session, keeping peak native scalar calls bounded at 16.
- Regression coverage includes zero basal energy and non-positive derived active-energy fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exercise calorie reporting by separating basal energy from active calories.
  * Active calories now use the more accurate value between reported active energy and total calories minus basal energy.
  * Added reliable fallback behavior when basal-energy data is unavailable, zero, or total calories are provided without active calories.
  * Improved consistency when processing exercise data from different Health Connect sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


