### PR TITLE
fix(openfoodfacts): exclude incomplete nutrition results

### DIFF
--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -98,6 +98,7 @@ const OFF_CORE_NUTRIENT_SERVING_SEARCH_CLAUSE = `(${OFF_CORE_NUTRIENT_SERVING_KE
 ).join(' OR ')})`;
 const OFF_CORE_NUTRITION_SEARCH_CLAUSE = `(${OFF_CORE_NUTRIENT_100G_SEARCH_CLAUSE} OR (serving_quantity:[0.000001 TO *] AND ${OFF_CORE_NUTRIENT_SERVING_SEARCH_CLAUSE}))`;
 const LEGACY_SEARCH_BATCH_SIZE = 100;
+const LEGACY_SEARCH_MAX_BATCHES = 10;
 
 interface OffProduct {
   product_name?: string;
@@ -507,15 +508,27 @@ async function searchOpenFoodFacts(
       const requestedStart = (page - 1) * pageSize;
       const requestedEnd = page * pageSize;
       const usableProducts: OffProduct[] = [];
+      const scanDeadline = Date.now() + OFF_FETCH_TIMEOUT_MS;
       let providerPage = 1;
       let hasMoreCandidates = true;
 
       while (hasMoreCandidates && usableProducts.length <= requestedEnd) {
+        const remainingTimeoutMs = scanDeadline - Date.now();
+        if (
+          providerPage > LEGACY_SEARCH_MAX_BATCHES ||
+          remainingTimeoutMs <= 0
+        ) {
+          throw Object.assign(
+            new Error('OpenFoodFacts legacy search scan limit reached'),
+            { status: 504, statusCode: 504 }
+          );
+        }
         const searchUrl = `${baseUrl}/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=${LEGACY_SEARCH_BATCH_SIZE}&page=${providerPage}&fields=${fields.join(',')}&lc=${language}`;
         const response = await fetchOpenFoodFacts(searchUrl, {
           authenticatedUserId,
           providerId,
           sessionCookie,
+          timeoutMs: remainingTimeoutMs,
         });
         if (!response.ok) {
           log(

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -97,6 +97,8 @@ const OFF_CORE_NUTRIENT_SERVING_SEARCH_CLAUSE = `(${OFF_CORE_NUTRIENT_SERVING_KE
   (key) => `nutriments.${key}:*`
 ).join(' OR ')})`;
 const OFF_CORE_NUTRITION_SEARCH_CLAUSE = `(${OFF_CORE_NUTRIENT_100G_SEARCH_CLAUSE} OR (serving_quantity:[0.000001 TO *] AND ${OFF_CORE_NUTRIENT_SERVING_SEARCH_CLAUSE}))`;
+const LEGACY_CORE_NUTRITION_QUERY =
+  'nutriment_0=energy&nutriment_compare_0=gte&nutriment_value_0=0';
 
 interface OffProduct {
   product_name?: string;
@@ -418,9 +420,15 @@ async function hydrateSearchHits(
       .find((product) => product !== undefined);
   return hits.map((hit) => {
     const code = String(hit.code || '').trim();
-    return (
-      (code ? lookupProduct(code) : undefined) ?? productFromSearchHit(hit)
-    );
+    const indexedProduct = productFromSearchHit(hit);
+    const currentProduct = code ? lookupProduct(code) : undefined;
+
+    // The full-text index can still hold nutrition while Product Opener is
+    // temporarily stale or incomplete. Keep the qualified ranked hit in that
+    // case so hydration cannot underfill an otherwise valid search page.
+    return currentProduct && hasUsableOffCoreNutrition(currentProduct)
+      ? currentProduct
+      : indexedProduct;
   });
 }
 
@@ -492,7 +500,9 @@ async function searchOpenFoodFacts(
     const isPublicOpenFoodFacts =
       baseUrl.replace(/\/+$/, '') === DEFAULT_OFF_BASE_URL.replace(/\/+$/, '');
     if (!isPublicOpenFoodFacts) {
-      const searchUrl = `${baseUrl}/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=${pageSize}&page=${page}&fields=${fields.join(',')}&lc=${language}`;
+      // Product Opener applies nutriment filters before its page boundary, so
+      // its count and has-more metadata describe products we can actually map.
+      const searchUrl = `${baseUrl}/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=${pageSize}&page=${page}&fields=${fields.join(',')}&lc=${language}&${LEGACY_CORE_NUTRITION_QUERY}`;
       const response = await fetchOpenFoodFacts(searchUrl, {
         authenticatedUserId,
         providerId,

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -97,8 +97,7 @@ const OFF_CORE_NUTRIENT_SERVING_SEARCH_CLAUSE = `(${OFF_CORE_NUTRIENT_SERVING_KE
   (key) => `nutriments.${key}:*`
 ).join(' OR ')})`;
 const OFF_CORE_NUTRITION_SEARCH_CLAUSE = `(${OFF_CORE_NUTRIENT_100G_SEARCH_CLAUSE} OR (serving_quantity:[0.000001 TO *] AND ${OFF_CORE_NUTRIENT_SERVING_SEARCH_CLAUSE}))`;
-const LEGACY_CORE_NUTRITION_QUERY =
-  'nutriment_0=energy&nutriment_compare_0=gte&nutriment_value_0=0';
+const LEGACY_SEARCH_BATCH_SIZE = 100;
 
 interface OffProduct {
   product_name?: string;
@@ -500,33 +499,61 @@ async function searchOpenFoodFacts(
     const isPublicOpenFoodFacts =
       baseUrl.replace(/\/+$/, '') === DEFAULT_OFF_BASE_URL.replace(/\/+$/, '');
     if (!isPublicOpenFoodFacts) {
-      // Product Opener applies nutriment filters before its page boundary, so
-      // its count and has-more metadata describe products we can actually map.
-      const searchUrl = `${baseUrl}/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=${pageSize}&page=${page}&fields=${fields.join(',')}&lc=${language}&${LEGACY_CORE_NUTRITION_QUERY}`;
-      const response = await fetchOpenFoodFacts(searchUrl, {
-        authenticatedUserId,
-        providerId,
-        sessionCookie,
-      });
-      if (!response.ok) {
-        log(
-          'error',
-          `OpenFoodFacts legacy search failed with HTTP ${response.status}`
+      // Legacy Product Opener combines multiple nutriment filters with AND, so
+      // it cannot express the same energy-or-macro rule as
+      // hasUsableOffCoreNutrition. Scan provider pages in larger batches and
+      // apply the rule before slicing the requested page. The one-item
+      // lookahead keeps hasMore truthful without scanning an entire catalogue.
+      const requestedStart = (page - 1) * pageSize;
+      const requestedEnd = page * pageSize;
+      const usableProducts: OffProduct[] = [];
+      let providerPage = 1;
+      let hasMoreCandidates = true;
+
+      while (hasMoreCandidates && usableProducts.length <= requestedEnd) {
+        const searchUrl = `${baseUrl}/cgi/search.pl?search_terms=${encodeURIComponent(query)}&search_simple=1&action=process&json=1&page_size=${LEGACY_SEARCH_BATCH_SIZE}&page=${providerPage}&fields=${fields.join(',')}&lc=${language}`;
+        const response = await fetchOpenFoodFacts(searchUrl, {
+          authenticatedUserId,
+          providerId,
+          sessionCookie,
+        });
+        if (!response.ok) {
+          log(
+            'error',
+            `OpenFoodFacts legacy search failed with HTTP ${response.status}`
+          );
+          throw new Error(
+            `OpenFoodFacts search failed (HTTP ${response.status})`
+          );
+        }
+        const data = await parseSearchResponse(
+          response,
+          isLegacySearchResponse
         );
-        throw new Error(
-          `OpenFoodFacts search failed (HTTP ${response.status})`
-        );
+        usableProducts.push(...data.products.filter(hasUsableOffCoreNutrition));
+
+        const providerPageSize =
+          typeof data.page_size === 'number' && data.page_size > 0
+            ? data.page_size
+            : LEGACY_SEARCH_BATCH_SIZE;
+        const providerCount =
+          typeof data.count === 'number' && data.count >= 0 ? data.count : null;
+        hasMoreCandidates =
+          data.products.length > 0 &&
+          (providerCount !== null
+            ? providerPage * providerPageSize < providerCount
+            : data.products.length === providerPageSize);
+        providerPage += 1;
       }
-      const data = await parseSearchResponse(response, isLegacySearchResponse);
+
+      const hasMore = usableProducts.length > requestedEnd;
       return {
-        products: data.products.filter(hasUsableOffCoreNutrition),
+        products: usableProducts.slice(requestedStart, requestedEnd),
         pagination: {
-          page: data.page || page,
-          pageSize: data.page_size || pageSize,
-          totalCount: data.count || 0,
-          hasMore:
-            (data.page || page) * (data.page_size || pageSize) <
-            (data.count || 0),
+          page,
+          pageSize,
+          totalCount: usableProducts.length,
+          hasMore,
         },
       };
     }

--- a/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
+++ b/SparkyFitnessServer/integrations/openfoodfacts/openFoodFactsService.ts
@@ -74,6 +74,30 @@ const OFF_FIELDS = [
   'image_url',
 ];
 
+const OFF_CORE_NUTRIENT_100G_KEYS = [
+  'energy-kcal_100g',
+  'energy-kj_100g',
+  'energy_100g',
+  'proteins_100g',
+  'carbohydrates_100g',
+  'fat_100g',
+] as const;
+const OFF_CORE_NUTRIENT_SERVING_KEYS = [
+  'energy-kcal_serving',
+  'energy-kj_serving',
+  'energy_serving',
+  'proteins_serving',
+  'carbohydrates_serving',
+  'fat_serving',
+] as const;
+const OFF_CORE_NUTRIENT_100G_SEARCH_CLAUSE = `(${OFF_CORE_NUTRIENT_100G_KEYS.map(
+  (key) => `nutriments.${key}:*`
+).join(' OR ')})`;
+const OFF_CORE_NUTRIENT_SERVING_SEARCH_CLAUSE = `(${OFF_CORE_NUTRIENT_SERVING_KEYS.map(
+  (key) => `nutriments.${key}:*`
+).join(' OR ')})`;
+const OFF_CORE_NUTRITION_SEARCH_CLAUSE = `(${OFF_CORE_NUTRIENT_100G_SEARCH_CLAUSE} OR (serving_quantity:[0.000001 TO *] AND ${OFF_CORE_NUTRIENT_SERVING_SEARCH_CLAUSE}))`;
+
 interface OffProduct {
   product_name?: string;
   product_name_en?: string;
@@ -485,7 +509,7 @@ async function searchOpenFoodFacts(
       }
       const data = await parseSearchResponse(response, isLegacySearchResponse);
       return {
-        products: data.products || [],
+        products: data.products.filter(hasUsableOffCoreNutrition),
         pagination: {
           page: data.page || page,
           pageSize: data.page_size || pageSize,
@@ -514,7 +538,10 @@ async function searchOpenFoodFacts(
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        q: query,
+        // Search-a-licious treats adjacent free-text and field clauses as
+        // required terms. Grouping the free text itself (or inserting AND
+        // after a multi-word phrase) currently yields an empty result set.
+        q: `${query} ${OFF_CORE_NUTRITION_SEARCH_CLAUSE}`,
         page,
         page_size: pageSize,
         boost_phrase: true,
@@ -531,12 +558,14 @@ async function searchOpenFoodFacts(
     }
     const data = await parseSearchResponse(response, isSearchALiciousResponse);
     const rankedHits = rankSearchHits(data.hits, query, language);
-    const products = await hydrateSearchHits(rankedHits, fields, language, {
-      authenticatedUserId,
-      providerId,
-      sessionCookie,
-      baseUrl,
-    });
+    const products = (
+      await hydrateSearchHits(rankedHits, fields, language, {
+        authenticatedUserId,
+        providerId,
+        sessionCookie,
+        baseUrl,
+      })
+    ).filter(hasUsableOffCoreNutrition);
     return {
       products,
       pagination: getSearchALiciousPagination(data, page, pageSize),
@@ -728,6 +757,28 @@ function parseOffNumber(val: unknown): number | null {
     if (Number.isFinite(parsed)) return parsed;
   }
   return null;
+}
+
+/** Returns true when OFF declares nutrition that the core mapper can use. */
+function hasUsableOffCoreNutrition(product: OffProduct): boolean {
+  if (!isRecord(product.nutriments)) return false;
+
+  if (
+    OFF_CORE_NUTRIENT_100G_KEYS.some(
+      (key) => parseOffNumber(product.nutriments?.[key]) !== null
+    )
+  ) {
+    return true;
+  }
+
+  const servingQuantity = parseOffNumber(product.serving_quantity);
+  return (
+    servingQuantity !== null &&
+    servingQuantity > 0 &&
+    OFF_CORE_NUTRIENT_SERVING_KEYS.some(
+      (key) => parseOffNumber(product.nutriments?.[key]) !== null
+    )
+  );
 }
 
 function getOffNutrient100g(

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -1328,6 +1328,36 @@ describe('openFoodFactsService', () => {
       }
     });
 
+    it('bounds self-hosted candidate scans that cannot fill the requested page', async () => {
+      // @ts-expect-error mocked provider resolver
+      resolveOpenFoodFactsProvider.mockResolvedValue({
+        session: null,
+        baseUrl: 'http://sparkyfitness-foodfacts:8080',
+      });
+      const unusableProducts = Array.from({ length: 100 }, (_, index) => ({
+        code: `missing-${index}`,
+        product_name: 'Missing Nutrition',
+        nutriments: { fiber_100g: 3 },
+      }));
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            products: unusableProducts,
+            page_size: 100,
+            count: 2000,
+          }),
+      });
+
+      await expect(
+        searchOpenFoodFacts('banana', 1, 'en', 'user-A', 'prov-1', 20)
+      ).rejects.toMatchObject({
+        message: 'OpenFoodFacts legacy search scan limit reached',
+        status: 504,
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(10);
+    });
+
     it('builds the search URL from a resolved custom base_url', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       resolveOpenFoodFactsProvider.mockResolvedValue({

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -131,6 +131,55 @@ describe('openFoodFactsService', () => {
       ]);
     });
 
+    it('retains qualified index nutrition when the hydrated product loses it', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [
+                {
+                  code: 'stale-hydration',
+                  product_name: 'Indexed Banana',
+                  nutriments: { 'energy-kcal_100g': 89 },
+                },
+              ],
+              page: 1,
+              page_size: 20,
+              count: 1,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              products: [
+                {
+                  code: 'stale-hydration',
+                  product_name: 'Current Banana',
+                  nutriments: { 'added-sugars_100g': 0 },
+                },
+              ],
+            }),
+        });
+
+      const result = await searchOpenFoodFacts('banana');
+
+      expect(result.products).toEqual([
+        expect.objectContaining({
+          code: 'stale-hydration',
+          product_name: 'Indexed Banana',
+          nutriments: { 'energy-kcal_100g': 89 },
+        }),
+      ]);
+      expect(result.pagination).toEqual({
+        page: 1,
+        pageSize: 20,
+        totalCount: 1,
+        hasMore: false,
+      });
+    });
+
     it('keeps products that explicitly declare zero core nutrition values', async () => {
       const zeroNutritionProduct = {
         code: 'zero',
@@ -1201,6 +1250,31 @@ describe('openFoodFactsService', () => {
         'explicit-zero',
         'usable-serving',
       ]);
+    });
+
+    it('requests self-hosted energy data before provider pagination', async () => {
+      // @ts-expect-error mocked provider resolver
+      resolveOpenFoodFactsProvider.mockResolvedValue({
+        session: null,
+        baseUrl: 'http://sparkyfitness-foodfacts:8080',
+      });
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            products: [],
+            page: 2,
+            page_size: 20,
+            count: 0,
+          }),
+      });
+
+      await searchOpenFoodFacts('banana', 2, 'en', 'user-A', 'prov-1');
+
+      const requestUrl = new URL(String(fetchMock.mock.calls[0][0]));
+      expect(requestUrl.searchParams.get('nutriment_0')).toBe('energy');
+      expect(requestUrl.searchParams.get('nutriment_compare_0')).toBe('gte');
+      expect(requestUrl.searchParams.get('nutriment_value_0')).toBe('0');
     });
 
     it('builds the search URL from a resolved custom base_url', async () => {

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -1252,29 +1252,80 @@ describe('openFoodFactsService', () => {
       ]);
     });
 
-    it('requests self-hosted energy data before provider pagination', async () => {
+    it('fills self-hosted pages without excluding protein-only nutrition', async () => {
       // @ts-expect-error mocked provider resolver
       resolveOpenFoodFactsProvider.mockResolvedValue({
         session: null,
         baseUrl: 'http://sparkyfitness-foodfacts:8080',
       });
-      fetchMock.mockResolvedValue({
-        ok: true,
-        json: () =>
-          Promise.resolve({
-            products: [],
-            page: 2,
-            page_size: 20,
-            count: 0,
-          }),
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              products: [
+                {
+                  code: 'missing-first',
+                  product_name: 'Missing Nutrition',
+                  nutriments: { 'added-sugars_100g': 0 },
+                },
+                {
+                  code: 'protein-only',
+                  product_name: 'Protein Only',
+                  nutriments: { proteins_100g: 12 },
+                },
+              ],
+              page: 1,
+              page_size: 2,
+              count: 4,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              products: [
+                {
+                  code: 'missing-second',
+                  product_name: 'Still Missing Nutrition',
+                  nutriments: { fiber_100g: 3 },
+                },
+                {
+                  code: 'energy',
+                  product_name: 'Energy Product',
+                  nutriments: { 'energy-kcal_100g': 42 },
+                },
+              ],
+              page: 2,
+              page_size: 2,
+              count: 4,
+            }),
+        });
+
+      const result = await searchOpenFoodFacts(
+        'banana',
+        1,
+        'en',
+        'user-A',
+        'prov-1',
+        2
+      );
+
+      expect(result.products.map((product) => product.code)).toEqual([
+        'protein-only',
+        'energy',
+      ]);
+      expect(result.pagination).toEqual({
+        page: 1,
+        pageSize: 2,
+        totalCount: 2,
+        hasMore: false,
       });
-
-      await searchOpenFoodFacts('banana', 2, 'en', 'user-A', 'prov-1');
-
-      const requestUrl = new URL(String(fetchMock.mock.calls[0][0]));
-      expect(requestUrl.searchParams.get('nutriment_0')).toBe('energy');
-      expect(requestUrl.searchParams.get('nutriment_compare_0')).toBe('gte');
-      expect(requestUrl.searchParams.get('nutriment_value_0')).toBe('0');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      for (const [request] of fetchMock.mock.calls) {
+        const requestUrl = new URL(String(request));
+        expect(requestUrl.searchParams.has('nutriment_0')).toBe(false);
+      }
     });
 
     it('builds the search URL from a resolved custom base_url', async () => {
@@ -1299,7 +1350,7 @@ describe('openFoodFactsService', () => {
       );
     });
 
-    it('does not apply the public result-window limit to a custom provider', async () => {
+    it('does not apply the public result-window limit while scanning a custom provider', async () => {
       // @ts-expect-error mocked provider resolver
       resolveOpenFoodFactsProvider.mockResolvedValue({
         session: null,
@@ -1310,10 +1361,15 @@ describe('openFoodFactsService', () => {
         json: () => Promise.resolve({ products: [], count: 0 }),
       });
 
-      await searchOpenFoodFacts('pizza', 501, 'en', 'user-A', 'prov-1', 20);
+      await expect(
+        searchOpenFoodFacts('pizza', 501, 'en', 'user-A', 'prov-1', 20)
+      ).resolves.toMatchObject({
+        products: [],
+        pagination: { page: 501, pageSize: 20, hasMore: false },
+      });
 
       expect(fetchMock).toHaveBeenCalledWith(
-        expect.stringContaining('page=501'),
+        expect.stringContaining('page=1'),
         expect.any(Object)
       );
     });

--- a/SparkyFitnessServer/tests/openFoodFactsService.test.ts
+++ b/SparkyFitnessServer/tests/openFoodFactsService.test.ts
@@ -18,6 +18,7 @@ vi.mock('../integrations/openfoodfacts/openFoodFactsAuth.js', () => ({
 
 const fetchMock = vi.fn();
 global.fetch = fetchMock;
+const EXPLICIT_ZERO_CORE_NUTRITION = { 'energy-kcal_100g': 0 };
 
 describe('openFoodFactsService', () => {
   beforeEach(() => {
@@ -66,7 +67,7 @@ describe('openFoodFactsService', () => {
       const request = fetch.mock.calls[0][1];
       expect(JSON.parse(request.body)).toEqual(
         expect.objectContaining({
-          q: 'whole milk',
+          q: 'whole milk ((nutriments.energy-kcal_100g:* OR nutriments.energy-kj_100g:* OR nutriments.energy_100g:* OR nutriments.proteins_100g:* OR nutriments.carbohydrates_100g:* OR nutriments.fat_100g:*) OR (serving_quantity:[0.000001 TO *] AND (nutriments.energy-kcal_serving:* OR nutriments.energy-kj_serving:* OR nutriments.energy_serving:* OR nutriments.proteins_serving:* OR nutriments.carbohydrates_serving:* OR nutriments.fat_serving:*)))',
           page: 2,
           page_size: 12,
           boost_phrase: true,
@@ -79,6 +80,124 @@ describe('openFoodFactsService', () => {
         totalCount: 25,
         hasMore: true,
       });
+    });
+
+    it('excludes products without mapped calories or core macros after hydration', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [
+                {
+                  code: 'incomplete',
+                  product_name: 'Incomplete Banana',
+                  nutriments: { 'added-sugars_100g': 0 },
+                },
+                {
+                  code: 'complete',
+                  product_name: 'Complete Banana',
+                  nutriments: { 'energy-kcal_100g': 89 },
+                },
+              ],
+              page: 1,
+              page_size: 20,
+              count: 2,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              products: [
+                {
+                  code: 'incomplete',
+                  product_name: 'Incomplete Banana',
+                  nutriments: { 'added-sugars_100g': 0 },
+                },
+                {
+                  code: 'complete',
+                  product_name: 'Complete Banana',
+                  nutriments: { 'energy-kcal_100g': 89 },
+                },
+              ],
+            }),
+        });
+
+      const result = await searchOpenFoodFacts('banana');
+
+      expect(result.products.map((product) => product.code)).toEqual([
+        'complete',
+      ]);
+    });
+
+    it('keeps products that explicitly declare zero core nutrition values', async () => {
+      const zeroNutritionProduct = {
+        code: 'zero',
+        product_name: 'Mineral Water',
+        nutriments: {
+          'energy-kcal_100g': 0,
+          proteins_100g: 0,
+          carbohydrates_100g: 0,
+          fat_100g: 0,
+        },
+      };
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits: [zeroNutritionProduct],
+              page: 1,
+              page_size: 20,
+              count: 1,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ products: [zeroNutritionProduct] }),
+        });
+
+      const result = await searchOpenFoodFacts('mineral water');
+
+      expect(result.products.map((product) => product.code)).toEqual(['zero']);
+    });
+
+    it('keeps serving-only nutrition only when a serving quantity is declared', async () => {
+      const hits = [
+        {
+          code: 'missing-serving-size',
+          product_name: 'Unknown Portion',
+          nutriments: { proteins_serving: 5 },
+        },
+        {
+          code: 'usable-serving',
+          product_name: 'Known Portion',
+          serving_quantity: 50,
+          nutriments: { proteins_serving: 5 },
+        },
+      ];
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              hits,
+              page: 1,
+              page_size: 20,
+              count: 2,
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ products: hits }),
+        });
+
+      const result = await searchOpenFoodFacts('portion');
+
+      expect(result.products.map((product) => product.code)).toEqual([
+        'usable-serving',
+      ]);
     });
 
     it('reports an inexact Search-a-licious count as the loaded range plus one', async () => {
@@ -174,13 +293,13 @@ describe('openFoodFactsService', () => {
                   code: 'first',
                   product_name: 'Exact Match',
                   brands: ['Brand One', 'Brand Two'],
-                  nutriments: {},
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                 },
                 {
                   code: 'second',
                   product_name: 'Less Relevant Match',
                   brands: ['Other Brand'],
-                  nutriments: {},
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                 },
               ],
               page: 1,
@@ -197,13 +316,13 @@ describe('openFoodFactsService', () => {
                   code: 'second',
                   product_name: 'Less Relevant Match',
                   brands: 'Other Brand',
-                  nutriments: {},
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                 },
                 {
                   code: 'first',
                   product_name: 'Exact Match',
                   brands: 'Brand One, Brand Two',
-                  nutriments: {},
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                 },
               ],
             }),
@@ -232,13 +351,13 @@ describe('openFoodFactsService', () => {
                   code: 'partial',
                   product_name: 'High Protein Pudding',
                   brands: ['Milbona'],
-                  nutriments: {},
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                 },
                 {
                   code: 'complete',
                   product_name: 'High Protein Pudding',
                   brands: ['Ehrmann'],
-                  nutriments: {},
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                 },
               ],
               page: 1,
@@ -255,13 +374,13 @@ describe('openFoodFactsService', () => {
                   code: 'partial',
                   product_name: 'High Protein Pudding',
                   brands: 'Milbona',
-                  nutriments: {},
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                 },
                 {
                   code: 'complete',
                   product_name: 'High Protein Pudding',
                   brands: 'Ehrmann',
-                  nutriments: {},
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                 },
               ],
             }),
@@ -286,8 +405,16 @@ describe('openFoodFactsService', () => {
           json: () =>
             Promise.resolve({
               hits: [
-                { code: 'shampoo', product_name: 'Herbal Shampoo' },
-                { code: 'ham', product_name: 'Smoked Ham' },
+                {
+                  code: 'shampoo',
+                  product_name: 'Herbal Shampoo',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
+                {
+                  code: 'ham',
+                  product_name: 'Smoked Ham',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
               ],
               page: 1,
               page_size: 20,
@@ -299,8 +426,16 @@ describe('openFoodFactsService', () => {
           json: () =>
             Promise.resolve({
               products: [
-                { code: 'shampoo', product_name: 'Herbal Shampoo' },
-                { code: 'ham', product_name: 'Smoked Ham' },
+                {
+                  code: 'shampoo',
+                  product_name: 'Herbal Shampoo',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
+                {
+                  code: 'ham',
+                  product_name: 'Smoked Ham',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
               ],
             }),
         });
@@ -415,6 +550,7 @@ describe('openFoodFactsService', () => {
                   code: '456',
                   product_name: 'Second Product',
                   brands: ['Other Brand'],
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                 },
               ],
               page: 1,
@@ -456,7 +592,13 @@ describe('openFoodFactsService', () => {
             ok: true,
             json: () =>
               Promise.resolve({
-                hits: [{ code: '123', product_name: 'Product' }],
+                hits: [
+                  {
+                    code: '123',
+                    product_name: 'Product',
+                    nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                  },
+                ],
                 page: 1,
                 page_size: 20,
                 count: 1,
@@ -483,7 +625,13 @@ describe('openFoodFactsService', () => {
           ok: true,
           json: () =>
             Promise.resolve({
-              hits: [{ code: '123', product_name: 'Product' }],
+              hits: [
+                {
+                  code: '123',
+                  product_name: 'Product',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
+              ],
               page: 1,
               page_size: 20,
               count: 1,
@@ -506,8 +654,16 @@ describe('openFoodFactsService', () => {
           json: () =>
             Promise.resolve({
               hits: [
-                { code: '123', product_name: 'Indexed First' },
-                { code: '456', product_name: 'Indexed Second' },
+                {
+                  code: '123',
+                  product_name: 'Indexed First',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
+                {
+                  code: '456',
+                  product_name: 'Indexed Second',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
               ],
               page: 1,
               page_size: 20,
@@ -519,7 +675,11 @@ describe('openFoodFactsService', () => {
           json: () =>
             Promise.resolve({
               products: [
-                { code: '123', product_name: 'Current First', nutriments: {} },
+                {
+                  code: '123',
+                  product_name: 'Current First',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
               ],
             }),
         });
@@ -595,7 +755,7 @@ describe('openFoodFactsService', () => {
                   code: '012345678905',
                   product_name: 'Nutella',
                   brands: 'Ferrero',
-                  nutriments: {},
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                 },
               ],
             }),
@@ -621,6 +781,7 @@ describe('openFoodFactsService', () => {
               {
                 product_name: 'Product Without Barcode',
                 brands: ['Index Brand'],
+                nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
               },
             ],
             page: 1,
@@ -647,8 +808,16 @@ describe('openFoodFactsService', () => {
           json: () =>
             Promise.resolve({
               hits: [
-                { code: '123', product_name: 'First Indexed Record' },
-                { code: '123', product_name: 'Second Indexed Record' },
+                {
+                  code: '123',
+                  product_name: 'First Indexed Record',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
+                {
+                  code: '123',
+                  product_name: 'Second Indexed Record',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
               ],
               page: 1,
               page_size: 20,
@@ -659,7 +828,13 @@ describe('openFoodFactsService', () => {
           ok: true,
           json: () =>
             Promise.resolve({
-              products: [{ code: '123', product_name: 'Current Product' }],
+              products: [
+                {
+                  code: '123',
+                  product_name: 'Current Product',
+                  nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                },
+              ],
             }),
         });
 
@@ -902,7 +1077,13 @@ describe('openFoodFactsService', () => {
               ok: true,
               json: () =>
                 Promise.resolve({
-                  hits: [{ code: '123', product_name: 'Cookie Product' }],
+                  hits: [
+                    {
+                      code: '123',
+                      product_name: 'Cookie Product',
+                      nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+                    },
+                  ],
                   page: 1,
                   page_size: 20,
                   count: 1,
@@ -924,7 +1105,7 @@ describe('openFoodFactsService', () => {
                   {
                     code: '123',
                     product_name: 'Cookie Product',
-                    nutriments: {},
+                    nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
                   },
                 ],
               }),
@@ -969,6 +1150,59 @@ describe('openFoodFactsService', () => {
   });
 
   describe('self-hosted base_url resolution', () => {
+    it('filters self-hosted results without usable core nutrition', async () => {
+      // @ts-expect-error mocked provider resolver
+      resolveOpenFoodFactsProvider.mockResolvedValue({
+        session: null,
+        baseUrl: 'http://sparkyfitness-foodfacts:8080',
+      });
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            products: [
+              {
+                code: 'missing',
+                product_name: 'Missing Nutrition',
+                nutriments: { 'added-sugars_100g': 0 },
+              },
+              {
+                code: 'explicit-zero',
+                product_name: 'Explicit Zero',
+                nutriments: EXPLICIT_ZERO_CORE_NUTRITION,
+              },
+              {
+                code: 'serving-without-size',
+                product_name: 'Unknown Serving',
+                nutriments: { proteins_serving: 5 },
+              },
+              {
+                code: 'usable-serving',
+                product_name: 'Known Serving',
+                serving_quantity: 50,
+                nutriments: { proteins_serving: 5 },
+              },
+            ],
+            page: 1,
+            page_size: 20,
+            count: 4,
+          }),
+      });
+
+      const result = await searchOpenFoodFacts(
+        'product',
+        1,
+        'en',
+        'user-A',
+        'prov-1'
+      );
+
+      expect(result.products.map((product) => product.code)).toEqual([
+        'explicit-zero',
+        'usable-serving',
+      ]);
+    });
+
     it('builds the search URL from a resolved custom base_url', async () => {
       // @ts-expect-error TS(2339): Property 'mockResolvedValue' does not exist on typ... Remove this comment to see the full error message
       resolveOpenFoodFactsProvider.mockResolvedValue({


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Open Food Facts search results with no usable calorie or macro data were presented as products with zero calories and zero macros.

**How did you implement the solution?**
Require indexed 100 g nutrition, or serving nutrition with a positive serving quantity, before Search-a-licious pagination. Preserve qualified index data when hydration is stale. For self-hosted Product Opener searches, scan candidate batches and apply the same predicate before slicing the requested page so macro-only and serving-only records remain eligible while pages stay full. Legacy candidate scans are capped at ten batches and share a ten-second timeout budget.

Linked Issue: Closes #2310

## How to Test

1. From `SparkyFitnessServer/`, run `pnpm exec vitest run tests/openFoodFactsService.test.ts tests/openFoodFactsLanguage.test.ts tests/externalFoodSearchService.openFoodFacts.test.ts`.
2. Run `pnpm exec vitest run --testTimeout=60000 --hookTimeout=120000`.
3. Run `pnpm run validate` and verify all checks pass.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

N/A - server-side search behavior; no UI change.

### After

N/A - server-side search behavior; no UI change.

</details>

## Notes for Reviewers

Live checks against the public API returned only usable core nutrition for the first page of both `Banane` and `Zwiebel`. The post-hydration filter also protects against incomplete Product Opener responses and bulk-hydration fallback data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenFoodFacts search results by excluding products without usable core nutrition details, including calories, protein, carbohydrates, or fat.
  * Added support for nutrition information provided per serving when a serving quantity is available.
  * Preserved products with explicitly reported zero nutrition values.
  * Applied consistent nutrition filtering across paginated and hydrated results.
  * Improved result paging so qualified products can fill the requested page.
  * Added safeguards to stop searches that cannot find enough qualifying results within a reasonable limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->