### PR TITLE
fix(docs): render calculation settings formulas without LaTeX

### DIFF
--- a/docs/content/2.features/7.settings/calculation-settings.md
+++ b/docs/content/2.features/7.settings/calculation-settings.md
@@ -8,15 +8,15 @@ This page explains how BMR formulas, body fat algorithms, daily energy adjustmen
 
 Your Basal Metabolic Rate (BMR) represents the energy your body requires to perform basic life-sustaining functions at rest. SparkyFitness supports multiple clinical formulas to estimate BMR:
 
-| Algorithm                       | Required Inputs             | Best For                          | Formula                                                                                                   |
-| :------------------------------ | :-------------------------- | :-------------------------------- | :-------------------------------------------------------------------------------------------------------- |
-| **Mifflin-St Jeor** _(Default)_ | Age, Gender, Height, Weight | General population                | $\text{Male: } 10W + 6.25H - 5A + 5$<br>$\text{Female: } 10W + 6.25H - 5A - 161$                          |
-| **Revised Harris-Benedict**     | Age, Gender, Height, Weight | Historical comparison             | $\text{Male: } 13.397W + 4.799H - 5.677A + 88.362$<br>$\text{Female: } 9.247W + 3.098H - 4.33A + 447.593$ |
-| **Katch-McArdle**               | Weight, Body Fat %          | Individuals with tracked body fat | $370 + 21.6 \times \text{LBM}$<br>_(LBM = Lean Body Mass)_                                                |
-| **Cunningham**                  | Weight, Body Fat %          | Highly athletic/muscular builds   | $500 + 22 \times \text{LBM}$                                                                              |
-| **Oxford**                      | Weight, Gender              | Varied age groups & demographics  | $\text{Male: } 14.2W + 593$<br>$\text{Female: } 10.9W + 677$                                              |
+| Algorithm                       | Required Inputs             | Best For                          | Formula                                                                                          |
+| :------------------------------ | :-------------------------- | :-------------------------------- | :--------------------------------------------------------------------------------------------- |
+| **Mifflin-St Jeor** _(Default)_ | Age, Gender, Height, Weight | General population                | Male: `10W + 6.25H - 5A + 5`<br>Female: `10W + 6.25H - 5A - 161`                               |
+| **Revised Harris-Benedict**     | Age, Gender, Height, Weight | Historical comparison             | Male: `13.397W + 4.799H - 5.677A + 88.362`<br>Female: `9.247W + 3.098H - 4.33A + 447.593`      |
+| **Katch-McArdle**               | Weight, Body Fat %          | Individuals with tracked body fat | `370 + 21.6 × LBM`<br>_(LBM = Lean Body Mass)_                                                 |
+| **Cunningham**                  | Weight, Body Fat %          | Highly athletic/muscular builds   | `500 + 22 × LBM`                                                                               |
+| **Oxford**                      | Weight, Gender              | Varied age groups & demographics  | Male: `14.2W + 593`<br>Female: `10.9W + 677`                                                   |
 
-_Note: Weight ($W$) is in kg, Height ($H$) is in cm, and Age ($A$) is in years._
+_Note: Weight (`W`) is in kg, Height (`H`) is in cm, and Age (`A`) is in years._
 
 ---
 
@@ -28,16 +28,16 @@ Body Fat Percentage is used directly in lean-mass BMR formulas (Katch-McArdle/Cu
 
 Uses circumferences to estimate body fat. Measurements are converted to inches for the standard formula:
 
-- **Males:** $86.01 \times \log_{10}(\text{waist} - \text{neck}) - 70.041 \times \log_{10}(\text{height}) + 36.76$
-- **Females:** $163.205 \times \log_{10}(\text{waist} + \text{hips} - \text{neck}) - 97.684 \times \log_{10}(\text{height}) - 78.387$
+- **Males:** `86.01 × log10(waist - neck) - 70.041 × log10(height) + 36.76`
+- **Females:** `163.205 × log10(waist + hips - neck) - 97.684 × log10(height) - 78.387`
 
 ### BMI Method
 
 Uses height, weight, and age to estimate body fat:
 
-- **Males:** $1.2 \times \text{BMI} + 0.23 \times \text{Age} - 16.2$
-- **Females:** $1.2 \times \text{BMI} + 0.23 \times \text{Age} - 5.4$
-- _(where $\text{BMI} = \text{Weight (kg)} / \text{Height (m)}^2$)_
+- **Males:** `1.2 × BMI + 0.23 × Age - 16.2`
+- **Females:** `1.2 × BMI + 0.23 × Age - 5.4`
+- _(where `BMI = Weight (kg) / Height (m)²`)_
 
 ---
 
@@ -47,17 +47,17 @@ This setting determines **how physical activity changes your calorie budget** th
 
 - **Adaptive TDEE:** Dynamically computes your metabolic expenditure by correlating your actual weight changes with your historical calorie intake over the last 28 days. _(Best for high-precision tracking)._
   - **Expenditure (Adaptive TDEE):** On the Diary page, "Expenditure" represents your calculated Total Daily Energy Expenditure (TDEE). This is the baseline number from which your deficit/surplus is subtracted.
-  - **Fallback Behavior:** If you have insufficient history (less than 14 days of weight and calorie data, or fewer than 7 days of calorie entries $\ge 200\text{ kcal}$), the system will use a fallback estimate based on the standard `BMR × Activity Multiplier` formula until enough data is collected.
-  - **The formula:** $\text{TDEE} = \text{Average Daily Calories} - (\text{Daily Weight Change in kg} \times 6{,}000\text{ kcal/kg})$.
+  - **Fallback Behavior:** If you have insufficient history (less than 14 days of weight and calorie data, or fewer than 7 days of calorie entries ≥ 200 kcal), the system will use a fallback estimate based on the standard `BMR × Activity Multiplier` formula until enough data is collected.
+  - **The formula:** `TDEE = Average Daily Calories - (Daily Weight Change in kg × 6,000 kcal/kg)`.
 
-    The $6{,}000\text{ kcal/kg}$ term is an energy density — how many calories a kilogram of body weight represents — which is what lets a weight trend be converted into calories. If you ate $2{,}000$ kcal/day and lost $0.5$ kg over 14 days, that lost weight represents about $3{,}000$ kcal your body burned beyond what you ate, or $\sim214$ kcal/day, so your true expenditure was $\sim2{,}214$ kcal/day.
+    The `6,000 kcal/kg` term is an energy density — how many calories a kilogram of body weight represents — which is what lets a weight trend be converted into calories. If you ate 2,000 kcal/day and lost 0.5 kg over 14 days, that lost weight represents about 3,000 kcal your body burned beyond what you ate, or ~214 kcal/day, so your true expenditure was ~2,214 kcal/day.
 
-    Weight lost or gained is never pure fat. Fat carries $\sim9{,}441\text{ kcal/kg}$ and lean tissue and water only $\sim1{,}816\text{ kcal/kg}$; $6{,}000$ reflects a typical blend of roughly $55\%$ fat to $45\%$ lean and water. This is a modelling constant and is not user-configurable — it is not something you can observe about yourself without a body composition scan, and a wrong value would skew every calorie target with no visible symptom.
+    Weight lost or gained is never pure fat. Fat carries ~9,441 kcal/kg and lean tissue and water only ~1,816 kcal/kg; 6,000 reflects a typical blend of roughly 55% fat to 45% lean and water. This is a modelling constant and is not user-configurable — it is not something you can observe about yourself without a body composition scan, and a wrong value would skew every calorie target with no visible symptom.
 
 - **Dynamic Goal:** Increases your budget as you burn active calories or take steps (adds exercise directly back to your budget).
 - **Fixed Goal:** Your calorie target remains completely static, ignoring daily exercise.
-- **Percentage Earn-Back:** Adds back a custom percentage (e.g., $50\%$) of active calories burned to create a buffer against device calorie over-estimations.
-- **Device Projection:** Uses the cumulative **Total Calories** value synced from Health Connect (resting plus active energy). For the current day, it projects that value from its dedicated source capture time to midnight and treats the result as your live TDEE; completed days use the recorded total without extrapolation. Goal Mode is then applied directly: for example, a projected TDEE of $2{,}400$ kcal becomes $2{,}400$ kcal at Maintain, $2{,}160$ kcal at Body Recomposition ($-10\%$), or $2{,}640$ kcal at Lean Bulk ($+10\%$). Enable **Total Calories** in the Android Health Connect sync settings. When that value is unavailable, too early, or implausible for a complete daily total, SparkyFitness falls back to BMR plus projected active calories.
+- **Percentage Earn-Back:** Adds back a custom percentage (e.g., 50%) of active calories burned to create a buffer against device calorie over-estimations.
+- **Device Projection:** Uses the cumulative **Total Calories** value synced from Health Connect (resting plus active energy). For the current day, it projects that value from its dedicated source capture time to midnight and treats the result as your live TDEE; completed days use the recorded total without extrapolation. Goal Mode is then applied directly: for example, a projected TDEE of 2,400 kcal becomes 2,400 kcal at Maintain, 2,160 kcal at Body Recomposition (-10%), or 2,640 kcal at Lean Bulk (+10%). Enable **Total Calories** in the Android Health Connect sync settings. When that value is unavailable, too early, or implausible for a complete daily total, SparkyFitness falls back to BMR plus projected active calories.
 
 > [!NOTE]
 > If you use [Nutrient Goal Direction](/features/goals)'s **Target range** for calories, note that Adaptive, Dynamic, Percentage Earn-Back, and Device Projection all recalculate your calorie goal value regularly — a manually entered target band won't move with it. Target range for calories works best paired with **Fixed Goal**.
@@ -68,22 +68,22 @@ This setting determines **how physical activity changes your calorie budget** th
 
 **Goal Mode** applies a body composition percentage-based adjustment to your baseline maintenance. The sign works the way you would expect: **positive adds calories, negative cuts them.**
 
-| Goal Mode              | Adjustment              | Target Purpose                                       |
-| :--------------------- | :---------------------- | :--------------------------------------------------- |
-| **Maintain**           | $0\%$                   | Weight maintenance                                   |
-| **Body Recomposition** | $-10\%$                 | Gain muscle while losing fat simultaneously          |
-| **Cut**                | $-15\%$                 | Steady fat loss                                      |
-| **High Cut**           | $-20\%$                 | Aggressive fat loss                                  |
-| **Lean Bulk**          | $+10\%$                 | Muscle gain with minimal fat gain                    |
-| **Bulk**               | $+20\%$                 | Faster weight gain                                   |
-| **Manual**             | Custom ($-40\% - 40\%$) | Personalized rate; enter $-15$ to cut, $+15$ to gain |
+| Goal Mode              | Adjustment            | Target Purpose                                     |
+| :--------------------- | :-------------------- | :------------------------------------------------ |
+| **Maintain**           | 0%                    | Weight maintenance                                 |
+| **Body Recomposition** | -10%                  | Gain muscle while losing fat simultaneously        |
+| **Cut**                | -15%                  | Steady fat loss                                    |
+| **High Cut**           | -20%                  | Aggressive fat loss                               |
+| **Lean Bulk**          | +10%                  | Muscle gain with minimal fat gain                  |
+| **Bulk**               | +20%                  | Faster weight gain                                 |
+| **Manual**             | Custom (-40% – 40%)   | Personalized rate; enter -15 to cut, +15 to gain   |
 
 ### Rate of Change Guidance
 
 The app rates your projected rate of change, and the safe range is not symmetric:
 
-- **Weight loss:** up to $\sim1.0\%$ of body weight per week is comfortable; above $1.5\%$ is flagged as excessive.
-- **Weight gain:** up to $\sim0.25\%$ per week is comfortable; above $0.5\%$ is flagged, because past that point the extra weight is predominantly fat rather than muscle.
+- **Weight loss:** up to ~1.0% of body weight per week is comfortable; above 1.5% is flagged as excessive.
+- **Weight gain:** up to ~0.25% per week is comfortable; above 0.5% is flagged, because past that point the extra weight is predominantly fat rather than muscle.
 
 Gain is deliberately much slower than loss. Muscle growth is limited by training and recovery, not by how large the surplus is.
 
@@ -101,7 +101,7 @@ Device Projection always uses the projected device TDEE as the live baseline for
 SparkyFitness shows two recommended safety limits for calorie goals:
 
 1.  **Resting Metabolism (RMR) Floor:** Your target should not fall below your resting metabolic rate.
-2.  **Absolute Clinical Floor:** $1,200$ kcal for biological females; $1,500$ kcal for biological males.
+2.  **Absolute Clinical Floor:** 1,200 kcal for biological females; 1,500 kcal for biological males.
 
 > [!IMPORTANT]
 > **Adaptive Safety Floor:**
@@ -114,7 +114,7 @@ SparkyFitness shows two recommended safety limits for calorie goals:
 Under the Adaptive method the floor applies whenever the calculated target falls below it. That is almost always a deficit, but a surplus can trip it too: if your entire maintenance sits below the clinical minimum, even a gain goal is raised to that minimum.
 
 > [!TIP]
-> If a goal mode appears to have no effect, the Standard floor is binding. That is usually about your **activity level**, not your body size. With the fallback estimate (TDEE = RMR × activity multiplier) and RMR as the binding half, the floor bites once your deficit exceeds roughly $1 - 1/\text{activityMultiplier}$ — about $17\%$ at **Sedentary** ($\times 1.2$), and $0\%$ at **None** ($\times 1.0$), where every deficit mode returns the same target. Once Adaptive has enough history it uses your _measured_ TDEE, so the real limit is how far your expenditure sits above your RMR. A sedentary man and a sedentary woman of very different sizes hit the same ceiling.
+> If a goal mode appears to have no effect, the Standard floor is binding. That is usually about your **activity level**, not your body size. With the fallback estimate (TDEE = RMR × activity multiplier) and RMR as the binding half, the floor bites once your deficit exceeds roughly `1 - 1/activityMultiplier` — about 17% at **Sedentary** (×1.2), and 0% at **None** (×1.0), where every deficit mode returns the same target. Once Adaptive has enough history it uses your _measured_ TDEE, so the real limit is how far your expenditure sits above your RMR. A sedentary man and a sedentary woman of very different sizes hit the same ceiling.
 >
 > If you are still on the fallback estimate, check your **Activity Level** and profile data first, since they set the ceiling there and are the most common things to have understated. Once Adaptive is using measured TDEE the setting no longer feeds the calculation, and the ceiling reflects your real expenditure instead. If your target has been agreed with a qualified clinician and still falls below the Standard floor, choose a **Custom minimum** or **Disabled**. Very small adults may find the clinical minimum sits above their own maintenance, in which case those two options are the only way to set a deficit at all. Very low calorie targets can carry health risks and may require medical supervision.
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The Calculation Settings docs page was written with LaTeX math syntax, but the Docus (Nuxt Content) site has no math plugin enabled, so formulas rendered as raw text (`$0%$`, `$-10%$`, `sim214`, `\times`, `\text{}`).

**How did you implement the solution?**
- Replaced every `$...$` math span with plain Markdown code spans.
- Used Unicode operators (`×`, `≥`, `~`, `²`) in place of `\times`, `\ge`, `\sim`, and `^2`.
- Left all formulas, table contents, and prose otherwise unchanged. This was the only docs page using LaTeX, so no site-wide math tooling is needed.

Linked Issue: Closes #2290

## How to Test

1. Check out this branch and run `cd docs && pnpm dev`.
2. Navigate to **Features → Settings → Calculation Settings**.
3. Verify sections 1, 2, 3, 4 and 5 render formulas as readable text/code (e.g. the Goal Mode table shows `-10%`, not `$-10%$`; the Adaptive TDEE formula reads `TDEE = Average Daily Calories - (Daily Weight Change in kg × 6,000 kcal/kg)`).

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [x] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

Reported in #2290 — the Goal Mode table and BMR formulas render literal `$...$` LaTeX delimiters.

### After

N/A (docs text only; run `cd docs && pnpm dev` to view the corrected page).

</details>

## Notes for Reviewers

The alternative fix is to add `remark-math` + `rehype-katex` (plus KaTeX CSS) to `docs/nuxt.config.ts`. I went with the plain-Markdown rewrite instead because this is the only page in `docs/content/` that used LaTeX, and it avoids adding build dependencies and a webfont for one page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of mathematical expressions in the calculation settings documentation.
  * Preserved all formulas, values, and explanatory content unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->