### PR TITLE
fix: allow clearing food quantity input

### DIFF
--- a/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { NumericInput } from '@/components/NumericInput';
 import { Label } from '@/components/ui/label';
 import {
   Select,
@@ -131,8 +132,7 @@ const FoodUnitSelector = ({
   const [selectedVariant, setSelectedVariant] = useState<FoodVariant | null>(
     null
   );
-  const [quantityInput, setQuantityInput] = useState('1');
-  const quantity = quantityInput === '' ? 0 : Number(quantityInput);
+  const [quantity, setQuantity] = useState<number | undefined>(1);
   const [entryTime, setEntryTime] = useState('');
   const [mealType, setMealType] = useState('');
   const [loading, setLoading] = useState(false);
@@ -218,7 +218,7 @@ const FoodUnitSelector = ({
     selectedVariant,
     onVariantSelect: (_variantId, variant) => {
       setSelectedVariant(variant);
-      setQuantityInput(String(variant.serving_size));
+      setQuantity(variant.serving_size);
     },
   });
 
@@ -393,12 +393,10 @@ const FoodUnitSelector = ({
           null;
         setSelectedVariant(selected);
       }
-      setQuantityInput(
-        String(
-          initialQuantity !== undefined
-            ? initialQuantity
-            : food.default_variant?.serving_size || 1
-        )
+      setQuantity(
+        initialQuantity !== undefined
+          ? initialQuantity
+          : food.default_variant?.serving_size || 1
       );
       resetConversionState();
     }
@@ -417,6 +415,8 @@ const FoodUnitSelector = ({
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     debug(loggingLevel, 'Handling submit.');
+
+    if (quantity === undefined) return;
 
     if (isConverting) {
       const convertedVariant = buildConvertedVariant();
@@ -446,7 +446,7 @@ const FoodUnitSelector = ({
           showMealTypeSelect ? mealType : null
         );
         onOpenChange(false);
-        setQuantityInput('1');
+        setQuantity(1);
       } catch (err) {
         error(loggingLevel, 'Error creating converted variant:', err);
         setConversionError('Failed to save the new unit. Please try again.');
@@ -470,7 +470,7 @@ const FoodUnitSelector = ({
         showMealTypeSelect ? mealType : null
       );
       onOpenChange(false);
-      setQuantityInput('1');
+      setQuantity(1);
     } else {
       warn(loggingLevel, 'Submit called with no selected variant.');
     }
@@ -482,7 +482,7 @@ const FoodUnitSelector = ({
     : selectedVariant;
 
   const nutrition = (() => {
-    if (!activeVariant) return null;
+    if (!activeVariant || quantity === undefined) return null;
     const ratio = quantity / (activeVariant.serving_size || 1);
     return {
       calories: (activeVariant.calories || 0) * ratio,
@@ -507,11 +507,14 @@ const FoodUnitSelector = ({
   const displayUnit = isConverting
     ? pendingUnit.trim() || '?'
     : selectedVariant?.serving_unit || '';
-  const displayServing = isConverting
-    ? `${quantity} ${displayUnit}`.trim()
-    : selectedVariant
-      ? formatQuantityServingLabel(quantity, selectedVariant)
-      : `${quantity} ${displayUnit}`.trim();
+  const displayServing =
+    quantity === undefined
+      ? ''
+      : isConverting
+        ? `${quantity} ${displayUnit}`.trim()
+        : selectedVariant
+          ? formatQuantityServingLabel(quantity, selectedVariant)
+          : `${quantity} ${displayUnit}`.trim();
 
   return (
     <Dialog
@@ -548,18 +551,17 @@ const FoodUnitSelector = ({
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <Label htmlFor="quantity">Quantity</Label>
-                  <Input
+                  <NumericInput
                     ref={quantityInputRef}
                     id="quantity"
-                    type="number"
                     step="any"
                     min="0.01"
+                    decimals={3}
                     required
-                    value={quantityInput}
-                    onChange={(e) => {
-                      const newQuantity = e.target.value;
+                    value={quantity}
+                    onValueChange={(newQuantity) => {
                       debug(loggingLevel, 'Quantity changed:', newQuantity);
-                      setQuantityInput(newQuantity);
+                      setQuantity(newQuantity);
                     }}
                   />
                 </div>

--- a/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodUnitSelector.tsx
@@ -131,7 +131,8 @@ const FoodUnitSelector = ({
   const [selectedVariant, setSelectedVariant] = useState<FoodVariant | null>(
     null
   );
-  const [quantity, setQuantity] = useState(1);
+  const [quantityInput, setQuantityInput] = useState('1');
+  const quantity = quantityInput === '' ? 0 : Number(quantityInput);
   const [entryTime, setEntryTime] = useState('');
   const [mealType, setMealType] = useState('');
   const [loading, setLoading] = useState(false);
@@ -217,7 +218,7 @@ const FoodUnitSelector = ({
     selectedVariant,
     onVariantSelect: (_variantId, variant) => {
       setSelectedVariant(variant);
-      setQuantity(variant.serving_size);
+      setQuantityInput(String(variant.serving_size));
     },
   });
 
@@ -392,10 +393,12 @@ const FoodUnitSelector = ({
           null;
         setSelectedVariant(selected);
       }
-      setQuantity(
-        initialQuantity !== undefined
-          ? initialQuantity
-          : food.default_variant?.serving_size || 1
+      setQuantityInput(
+        String(
+          initialQuantity !== undefined
+            ? initialQuantity
+            : food.default_variant?.serving_size || 1
+        )
       );
       resetConversionState();
     }
@@ -443,7 +446,7 @@ const FoodUnitSelector = ({
           showMealTypeSelect ? mealType : null
         );
         onOpenChange(false);
-        setQuantity(1);
+        setQuantityInput('1');
       } catch (err) {
         error(loggingLevel, 'Error creating converted variant:', err);
         setConversionError('Failed to save the new unit. Please try again.');
@@ -467,7 +470,7 @@ const FoodUnitSelector = ({
         showMealTypeSelect ? mealType : null
       );
       onOpenChange(false);
-      setQuantity(1);
+      setQuantityInput('1');
     } else {
       warn(loggingLevel, 'Submit called with no selected variant.');
     }
@@ -551,11 +554,12 @@ const FoodUnitSelector = ({
                     type="number"
                     step="any"
                     min="0.01"
-                    value={quantity}
+                    required
+                    value={quantityInput}
                     onChange={(e) => {
-                      const newQuantity = Number(e.target.value);
+                      const newQuantity = e.target.value;
                       debug(loggingLevel, 'Quantity changed:', newQuantity);
-                      setQuantity(newQuantity);
+                      setQuantityInput(newQuantity);
                     }}
                   />
                 </div>

--- a/SparkyFitnessFrontend/src/tests/components/FoodUnitSelector.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/FoodUnitSelector.test.tsx
@@ -308,23 +308,27 @@ describe('FoodUnitSelector', () => {
     expect(quantityInput).toHaveValue(1);
   });
 
-  it('keeps fractional quantities editable', async () => {
+  it('keeps autofocus and selection when using NumericInput', async () => {
     const food = createFood(
       createVariant({
         id: 'default-variant',
-        serving_size: 1,
+        serving_size: 3,
         serving_unit: 'g',
       })
     );
+    const selectSpy = jest.spyOn(HTMLInputElement.prototype, 'select');
 
     mockFetchQuery.mockResolvedValue([]);
 
     await renderSelector(food);
 
     const quantityInput = screen.getByLabelText(/^Quantity$/i);
-    fireEvent.change(quantityInput, { target: { value: '0.25' } });
+    await waitFor(() => {
+      expect(quantityInput).toHaveFocus();
+      expect(selectSpy).toHaveBeenCalled();
+    });
 
-    expect(quantityInput).toHaveValue(0.25);
+    selectSpy.mockRestore();
   });
 
   it('does not show compatible-unit checks when the selected saved variant is AI-estimated', async () => {

--- a/SparkyFitnessFrontend/src/tests/components/FoodUnitSelector.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/FoodUnitSelector.test.tsx
@@ -285,6 +285,48 @@ describe('FoodUnitSelector', () => {
     ).toBeInTheDocument();
   });
 
+  it('allows clearing and replacing the quantity without forcing zero', async () => {
+    const food = createFood(
+      createVariant({
+        id: 'default-variant',
+        serving_size: 3,
+        serving_unit: 'g',
+      })
+    );
+
+    mockFetchQuery.mockResolvedValue([]);
+
+    await renderSelector(food);
+
+    const quantityInput = screen.getByLabelText(/^Quantity$/i);
+    expect(quantityInput).toHaveValue(3);
+
+    fireEvent.change(quantityInput, { target: { value: '' } });
+    expect(quantityInput).toHaveValue(null);
+
+    fireEvent.change(quantityInput, { target: { value: '1' } });
+    expect(quantityInput).toHaveValue(1);
+  });
+
+  it('keeps fractional quantities editable', async () => {
+    const food = createFood(
+      createVariant({
+        id: 'default-variant',
+        serving_size: 1,
+        serving_unit: 'g',
+      })
+    );
+
+    mockFetchQuery.mockResolvedValue([]);
+
+    await renderSelector(food);
+
+    const quantityInput = screen.getByLabelText(/^Quantity$/i);
+    fireEvent.change(quantityInput, { target: { value: '0.25' } });
+
+    expect(quantityInput).toHaveValue(0.25);
+  });
+
   it('does not show compatible-unit checks when the selected saved variant is AI-estimated', async () => {
     const food = createFood(
       createVariant({

--- a/SparkyFitnessFrontend/src/tests/components/FoodUnitSelector.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/FoodUnitSelector.test.tsx
@@ -308,6 +308,32 @@ describe('FoodUnitSelector', () => {
     expect(quantityInput).toHaveValue(1);
   });
 
+  it('submits fractional quantities through the selector', async () => {
+    const food = createFood(
+      createVariant({
+        id: 'default-variant',
+        serving_size: 1,
+        serving_unit: 'g',
+      })
+    );
+    const onSelect = jest.fn();
+
+    mockFetchQuery.mockResolvedValue([]);
+
+    await renderSelector(food, { onSelect });
+
+    const quantityInput = screen.getByLabelText(/^Quantity$/i);
+    fireEvent.change(quantityInput, { target: { value: '0.25' } });
+    expect(quantityInput).toHaveValue(0.25);
+
+    fireEvent.click(screen.getByRole('button', { name: /Add to Meal/i }));
+
+    await waitFor(() => {
+      expect(onSelect).toHaveBeenCalledTimes(1);
+    });
+    expect(onSelect.mock.calls[0]?.[1]).toBe(0.25);
+  });
+
   it('keeps autofocus and selection when using NumericInput', async () => {
     const food = createFood(
       createVariant({


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

The food quantity field changes to `0` when cleared, so typing a replacement value can leave a leading zero such as `01`.

**How did you implement the solution?**

The quantity field now uses the existing `NumericInput` component, which allows the field to be temporarily empty while editing. The quantity is required, supports up to three decimal places, and submission is skipped while no quantity is entered.

Regression tests cover clearing and replacing the value, submitting a fractional quantity, and preserving autofocus/selection behavior.

Linked Issue: Closes #2325

## How to Test

1. From `SparkyFitnessFrontend`, run `pnpm test FoodUnitSelector.test.tsx --runInBand`.
2. Open the diary, add a food, and enter a quantity such as `3`.
3. Clear the quantity field with Backspace and verify it stays empty.
4. Enter `1` and verify the field shows `1`, not `01`.
5. Enter `0.25`, add the food, and verify the diary entry uses `0.25`.
6. Enter `0.001`, move focus away from the field, and verify it clamps to the minimum value of `0.01`.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="2563" height="600" alt="Quantity field bug" src="https://github.com/user-attachments/assets/6e344b77-729f-40ab-a92a-70bb8f159d77" />

### After

<img width="2508" height="572" alt="Quantity field fixed" src="https://github.com/user-attachments/assets/dea86267-f449-4620-b3a6-e6b7dae4e2ba" />

### Manual tests

<img width="2008" height="1031" alt="Fractional and minimum quantity tests" src="https://github.com/user-attachments/assets/133e1939-78ca-45ee-98d3-7db30e6fe065" />

</details>

## Notes for Reviewers

`FoodUnitSelector.test.tsx` passes all 8 tests. The regression coverage verifies:

- clearing and replacing the quantity without forcing `0`
- submitting a fractional quantity of `0.25`
- preserving autofocus and selection when using `NumericInput`

`pnpm run validate` passes, including typecheck, ESLint, Prettier, and Knip. The production build also passes.

Manual browser testing was performed against the existing backend. I verified:

- `3` → clear → empty → `1`
- `0.25` submits and is stored as `0.25`
- `0.001` clamps to the minimum `0.01` on blur

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved food quantity entry when clearing and replacing values.
  * Preserved fractional quantities, including values with up to three decimal places, while editing.
  * Quantity entry is now required, preventing submission when no quantity is provided.
  * Nutrition details and calculated values remain hidden until a valid quantity is entered.

* **Tests**
  * Added coverage for replacing cleared quantities, decimal values, and retaining input focus with text selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->