### PR TITLE
fix(mobile): derive widget string keys and read %% as a literal

### DIFF
--- a/SparkyFitnessMobile/AGENTS.md
+++ b/SparkyFitnessMobile/AGENTS.md
@@ -31,7 +31,7 @@ English (`en`) is the canonical source locale and the deterministic fallback. Fe
 
 Feature developers do not need to know or translate Polish or any future language, and do not need to wait for Weblate. Translators/Weblate own Polish and future translations and linguistic QA. Missing translation content is non-blocking and falls back to English; existing translated content remains structurally validated.
 
-The shipped locale registry is `src/localization/localeRegistry.ts`. Adding a catalog to Weblate does not ship it. Shipping requires explicit registry enablement plus native/platform support verification. RN catalogs and native resources are separate surfaces (Expo metadata, Android widget resources, and iOS widget/Live Activity `.lproj` resources).
+The shipped locale registry is `src/localization/localeRegistry.json`, read through the typed accessors in `src/localization/localeRegistry.ts`. Adding a catalog to Weblate does not ship it. Shipping requires explicit registry enablement plus native/platform support verification. RN catalogs and native resources are separate surfaces (Expo metadata, Android widget resources, and iOS widget/Live Activity `.lproj` resources).
 
 ## Commands
 
@@ -243,6 +243,7 @@ npx expo prebuild --clean
 
 - iOS widgets live under `targets/widget/`, share data through the app group from `app.identifiers.js`, and reload through `ExtensionStorage` in `useWidgetSync`.
 - Current iOS widgets are calorie and macro widgets. When changing display, update Swift views, shared helpers, TS snapshot shape, and reload kind handling together.
+- Widget string keys are derived from the Swift sources, not tracked by hand: `__tests__/config/helpers/widgetSwiftKeys.ts` discovers every `.swift` file under `targets/widget/` (recursively) and extracts the literal keys passed to `localizedWidgetString`, `configurationDisplayName` and `.description`. A new key must therefore be added to `targets/widget/en.lproj/Localizable.strings`, and — for `localizedWidgetString` keys — to the `fallbackWidgetString` map, or the contract tests fail. Target-language files stay optional and fall back to EN.
 - Android widgets live under `targets/android-widget/`. `plugins/withCalorieWidget.ts` copies Kotlin/templates/resources, registers receivers, wires the native module package, and documents the pattern for adding another widget.
 - `src/services/CalorieWidgetBridge.ts` is the JS bridge for Android widget snapshot writes and Glance reloads.
 - The scheduled "Rest complete" alert fires exactly only with the `SCHEDULE_EXACT_ALARM` special access ("Alarms & reminders", user-granted, denied by default on Android 13+) — without it expo-notifications falls back to inexact alarms the OS batches ~15s late. The `targets/android-exact-alarm/` Kotlin module (registered by `plugins/withExactAlarmModule.ts`) exposes `canScheduleExactAlarms`/`openExactAlarmSettings` through `src/services/ExactAlarmBridge.ts`; `maybePromptForExactAlarmPermission` in `notifications.ts` owns the one-time grant prompt at workout start.

--- a/SparkyFitnessMobile/AGENTS.md
+++ b/SparkyFitnessMobile/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-_Last updated: 2026-08-29_
+_Last updated: 2026-08-31_
 
 SparkyFitness Mobile is a React Native 0.85 + Expo SDK 56 app for syncing Apple Health / Health Connect data with the SparkyFitness backend, tracking nutrition, hydration, fasting, measurements, exercise, saved foods, meal templates, custom exercises, workout presets, iOS / Android widgets, the active workout HUD, and the Sparky AI chat.
 
@@ -321,6 +321,7 @@ const androidService = require('../../src/services/healthConnectService.ts');
 - Measurements/hydration bug: inspect dashboard/diary/measurements screens, summaries/gauges, measurement/water/check-in hooks, API, date helpers, widget sync, writeback, and unit conversions.
 - Scan/photo bug: inspect food scan/search, `FoodPhotoFlow`, photo screens, AI setting hook/API, estimate hook/API, intro persistence, haptics, icon usage, and route params.
 - Widget/deep-link bug: inspect `useWidgetSync`, `CalorieWidgetBridge`, widget targets, widget plugins, `app.config.ts`, `app.identifiers.js`, `App.tsx`, and dashboard.
+- Widget string shows as a raw key: inspect `targets/widget/en.lproj/Localizable.strings`, the `fallbackWidgetString` map in `SharedHelpers.swift`, and the derived-key contract in `__tests__/config/helpers/widgetSwiftKeys.ts`.
 - Settings/diagnostics bug: inspect settings screens, `SettingsRow`, haptics/theme/sounds/notification services, diagnostics services, `DevTools`, and screen error boundaries.
 
 ## Priority Rule

--- a/SparkyFitnessMobile/__tests__/config/helpers/widgetSwiftKeys.ts
+++ b/SparkyFitnessMobile/__tests__/config/helpers/widgetSwiftKeys.ts
@@ -1,0 +1,61 @@
+import fs from 'fs';
+import path from 'path';
+
+const WIDGET_ROOT = path.join(__dirname, '../../../targets/widget');
+
+export type WidgetKeyUsage = { file: string; key: string };
+
+export function widgetSwiftFiles(): string[] {
+  const walk = (dir: string): string[] =>
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return walk(full);
+      return entry.name.endsWith('.swift')
+        ? [path.relative(WIDGET_ROOT, full)]
+        : [];
+    });
+  return walk(WIDGET_ROOT).sort();
+}
+
+export function readWidgetSwift(relativePath: string): string {
+  return fs.readFileSync(path.join(WIDGET_ROOT, relativePath), 'utf8');
+}
+
+function usages(pattern: RegExp): WidgetKeyUsage[] {
+  return widgetSwiftFiles().flatMap((file) => {
+    const source = readWidgetSwift(file);
+    return [...source.matchAll(new RegExp(pattern.source, 'g'))].map(
+      (match) => ({
+        file,
+        key: match[1],
+      })
+    );
+  });
+}
+
+/** Keys resolved at runtime through the helper, so they reach fallbackWidgetString. */
+export function helperKeyUsages(): WidgetKeyUsage[] {
+  return usages(/localizedWidgetString\(\s*"([^"]+)"\s*\)/);
+}
+
+/** Gallery metadata keys, resolved by SwiftUI's LocalizedStringKey rather than the helper. */
+export function galleryKeyUsages(): WidgetKeyUsage[] {
+  return usages(
+    /(?:configurationDisplayName|\.description)\(\s*"([^"]+)"\s*\)/
+  );
+}
+
+/** Null when the stable fallback map no longer exists. */
+export function fallbackMapKeys(): Set<string> | null {
+  for (const file of widgetSwiftFiles()) {
+    const body = /func fallbackWidgetString[\s\S]*?\n\}/.exec(
+      readWidgetSwift(file)
+    );
+    if (body) {
+      return new Set(
+        [...body[0].matchAll(/case\s+"([^"]+)"\s*:/g)].map((match) => match[1])
+      );
+    }
+  }
+  return null;
+}

--- a/SparkyFitnessMobile/__tests__/config/iosWidgetResources.test.ts
+++ b/SparkyFitnessMobile/__tests__/config/iosWidgetResources.test.ts
@@ -1,150 +1,104 @@
 import fs from 'fs';
 import path from 'path';
+import {
+  SHIPPED_LOCALES,
+  SOURCE_LOCALE,
+} from '../../src/localization/localeRegistry';
+import { parseIosStrings } from '../../scripts/validate-native-widget-locales.mjs';
+import { galleryKeyUsages, helperKeyUsages } from './helpers/widgetSwiftKeys';
 
 const WIDGET_ROOT = path.join(__dirname, '../../targets/widget');
+const SHIPPED = Object.keys(SHIPPED_LOCALES);
 
-function readStringsFile(relativePath: string): Map<string, string> {
-  const content = fs.readFileSync(path.join(WIDGET_ROOT, relativePath), 'utf8');
-  const map = new Map<string, string>();
-  const regex = /"([^"]+)"\s*=\s*"([^"]*)";/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(content)) !== null) {
-    map.set(match[1], match[2]);
-  }
-  return map;
+/** The validator's reader understands escaped quotes; a naive regex silently drops them. */
+function readStringsFile(locale: string): Map<string, string> {
+  return parseIosStrings(
+    fs.readFileSync(
+      path.join(WIDGET_ROOT, `${locale}.lproj/Localizable.strings`),
+      'utf8'
+    )
+  );
 }
 
 const REQUIRED_KEYS = [
-  'widget.calorie.name',
-  'widget.calorie.description',
-  'widget.macro.name',
-  'widget.macro.description',
-  'widget.kcal_left',
-  'widget.kcal',
-  'widget.food',
-  'widget.burned',
-  'widget.goal',
-  'widget.protein',
-  'widget.carbs',
-  'widget.fat',
-  'widget.grams',
-  'widget.a11y.kcal_left',
-  'widget.a11y.kcal',
-  'widget.search_food',
-  'widget.scan_barcode',
-];
+  ...new Set(
+    [...helperKeyUsages(), ...galleryKeyUsages()].map((usage) => usage.key)
+  ),
+].sort();
 
 describe('iOS WidgetKit localization resources', () => {
   describe('Localizable.strings contract', () => {
-    it('defines every required key in the English catalog', () => {
-      const en = readStringsFile('en.lproj/Localizable.strings');
-      for (const key of REQUIRED_KEYS) {
-        expect(en.has(key)).toBe(true);
+    it('defines every key the Swift sources reference in the English catalog', () => {
+      const en = readStringsFile(SOURCE_LOCALE);
+      expect(REQUIRED_KEYS.length).toBeGreaterThan(0);
+      const missing = [...helperKeyUsages(), ...galleryKeyUsages()]
+        .filter((usage) => !en.has(usage.key))
+        .map((usage) => `${usage.file}: ${usage.key}`);
+      expect(missing).toEqual([]);
+    });
+
+    it('ships a Localizable.strings for every registered locale', () => {
+      for (const locale of SHIPPED) {
+        expect(
+          fs.existsSync(
+            path.join(WIDGET_ROOT, `${locale}.lproj/Localizable.strings`)
+          )
+        ).toBe(true);
       }
     });
 
-    it('defines the same key set in English, Polish and Spanish', () => {
-      const en = [
-        ...readStringsFile('en.lproj/Localizable.strings').keys(),
-      ].sort();
-      const pl = [
-        ...readStringsFile('pl.lproj/Localizable.strings').keys(),
-      ].sort();
-      const es = [
-        ...readStringsFile('es.lproj/Localizable.strings').keys(),
-      ].sort();
-
-      expect(pl).toEqual(en);
-      expect(es).toEqual(en);
-    });
-
-    it('has non-empty values in all shipped locales', () => {
-      for (const locale of ['en.lproj', 'pl.lproj', 'es.lproj']) {
-        const strings = readStringsFile(`${locale}/Localizable.strings`);
-        for (const [key, value] of strings) {
-          expect(`${locale}:${key}`).not.toBe('');
-          expect(value).not.toBe('');
+    it('never emits a key the source does not define', () => {
+      // Missing keys are allowed: localizedWidgetString falls back to en.lproj.
+      // Extra keys would be dead weight and stay blocking.
+      const en = new Set(readStringsFile(SOURCE_LOCALE).keys());
+      for (const locale of SHIPPED) {
+        for (const key of readStringsFile(locale).keys()) {
+          expect(en.has(key)).toBe(true);
         }
       }
     });
 
-    it('uses approved Polish translations for key labels', () => {
-      const pl = readStringsFile('pl.lproj/Localizable.strings');
-
-      expect(pl.get('widget.calorie.name')).toBe('Kalorie');
-      expect(pl.get('widget.macro.name')).toBe('Makroskładniki');
-      expect(pl.get('widget.protein')).toBe('Białko');
-      expect(pl.get('widget.carbs')).toBe('Węglowodany');
-      expect(pl.get('widget.fat')).toBe('Tłuszcz');
-      expect(pl.get('widget.food')).toBe('Spożycie');
-      expect(pl.get('widget.burned')).toBe('Spalone');
-      expect(pl.get('widget.goal')).toBe('Cel');
-      // Word order under the ring number: "1515 / kcal pozostało" reads as
-      // "1515 kcal pozostało". The a11y string stays "Pozostało %@ kcal".
-      expect(pl.get('widget.kcal_left')).toBe('kcal pozostało');
-      expect(pl.get('widget.search_food')).toBe('Wyszukaj produkt');
-      expect(pl.get('widget.scan_barcode')).toBe('Skanuj kod kreskowy');
+    it('has non-empty values in every shipped locale', () => {
+      for (const locale of SHIPPED) {
+        for (const [key, value] of readStringsFile(locale)) {
+          expect(`${locale}:${key}:${value}`).not.toBe(`${locale}:${key}:`);
+        }
+      }
     });
 
-    it('uses approved Spanish translations for key labels', () => {
-      const es = readStringsFile('es.lproj/Localizable.strings');
-
-      expect(es.get('widget.calorie.name')).toBe('Calorías');
-      expect(es.get('widget.macro.name')).toBe('Macros');
-      expect(es.get('widget.protein')).toBe('Proteínas');
-      expect(es.get('widget.carbs')).toBe('Carbohidratos');
-      expect(es.get('widget.fat')).toBe('Grasas');
-      expect(es.get('widget.food')).toBe('Comida');
-      expect(es.get('widget.burned')).toBe('Quemadas');
-      expect(es.get('widget.goal')).toBe('Objetivo');
-      expect(es.get('widget.kcal_left')).toBe('kcal restantes');
-      expect(es.get('widget.search_food')).toBe('Buscar comida');
-      expect(es.get('widget.scan_barcode')).toBe('Escanear código');
-    });
-
-    it('keeps the two widget names distinct', () => {
-      const en = readStringsFile('en.lproj/Localizable.strings');
-      const pl = readStringsFile('pl.lproj/Localizable.strings');
-      const es = readStringsFile('es.lproj/Localizable.strings');
-
-      expect(en.get('widget.calorie.name')).not.toBe(
-        en.get('widget.macro.name')
-      );
-      expect(pl.get('widget.calorie.name')).not.toBe(
-        pl.get('widget.macro.name')
-      );
-      expect(es.get('widget.calorie.name')).not.toBe(
-        es.get('widget.macro.name')
-      );
+    it('keeps the two widget names distinct in every shipped locale', () => {
+      for (const locale of SHIPPED) {
+        const strings = readStringsFile(locale);
+        expect(strings.get('widget.calorie.name')).not.toBe(
+          strings.get('widget.macro.name')
+        );
+      }
     });
 
     it('does not use i18next placeholder syntax', () => {
-      for (const locale of ['en.lproj', 'pl.lproj', 'es.lproj']) {
-        const strings = readStringsFile(`${locale}/Localizable.strings`);
-        for (const value of strings.values()) {
+      for (const locale of SHIPPED) {
+        for (const value of readStringsFile(locale).values()) {
           expect(value).not.toMatch(/\{\{/);
           expect(value).not.toMatch(/\}\}/);
         }
       }
     });
 
-    it('keeps format placeholder compatibility between EN, PL and ES', () => {
-      const en = readStringsFile('en.lproj/Localizable.strings');
-      const pl = readStringsFile('pl.lproj/Localizable.strings');
-      const es = readStringsFile('es.lproj/Localizable.strings');
-
-      for (const key of [
+    it('keeps format placeholder compatibility across every shipped locale', () => {
+      const en = readStringsFile(SOURCE_LOCALE);
+      const placeholderKeys = [
         'widget.grams',
         'widget.a11y.kcal_left',
         'widget.a11y.kcal',
-      ]) {
-        const enCount = (en.get(key)?.match(/%\@/g) ?? []).length;
-        const plCount = (pl.get(key)?.match(/%\@/g) ?? []).length;
-        const esCount = (es.get(key)?.match(/%\@/g) ?? []).length;
-        expect(plCount).toBe(enCount);
-        expect(esCount).toBe(enCount);
-        expect(plCount).toBeGreaterThan(0);
-        expect(esCount).toBeGreaterThan(0);
+      ];
+      for (const locale of SHIPPED) {
+        const target = readStringsFile(locale);
+        for (const key of placeholderKeys) {
+          const enCount = (en.get(key)?.match(/%@/g) ?? []).length;
+          expect(enCount).toBeGreaterThan(0);
+          if (!target.has(key)) continue;
+          expect((target.get(key)?.match(/%@/g) ?? []).length).toBe(enCount);
+        }
       }
     });
   });

--- a/SparkyFitnessMobile/__tests__/config/iosWidgetSwiftContract.test.ts
+++ b/SparkyFitnessMobile/__tests__/config/iosWidgetSwiftContract.test.ts
@@ -1,14 +1,14 @@
 import fs from 'fs';
 import path from 'path';
+import {
+  fallbackMapKeys,
+  helperKeyUsages,
+  widgetSwiftFiles,
+} from './helpers/widgetSwiftKeys';
 
 const WIDGET_ROOT = path.join(__dirname, '../../targets/widget');
 
-const SWIFT_FILES = [
-  'index.swift',
-  'widgets.swift',
-  'macroWidget.swift',
-  'SharedHelpers.swift',
-];
+const SWIFT_FILES = widgetSwiftFiles();
 
 function readSwift(relativePath: string): string {
   return fs.readFileSync(path.join(WIDGET_ROOT, relativePath), 'utf8');
@@ -213,6 +213,26 @@ describe('iOS WidgetKit Swift contract', () => {
       expect(shared).toContain(
         'case "widget.scan_barcode": return "Scan barcode"'
       );
+    });
+  });
+
+  describe('source-derived key coverage', () => {
+    it('discovers the Swift sources instead of tracking a fixed list', () => {
+      expect(SWIFT_FILES).toContain('SharedHelpers.swift');
+      expect(SWIFT_FILES).toContain('widgets.swift');
+      expect(SWIFT_FILES).toContain('macroWidget.swift');
+    });
+
+    it('covers every helper-consumed key in the stable fallback map', () => {
+      const fallback = fallbackMapKeys();
+      // Null once fallbackWidgetString is gone, which retires this guard with it.
+      const missing =
+        fallback === null
+          ? []
+          : helperKeyUsages()
+              .filter((usage) => !fallback.has(usage.key))
+              .map((usage) => `${usage.file}: ${usage.key}`);
+      expect(missing).toEqual([]);
     });
   });
 

--- a/SparkyFitnessMobile/__tests__/config/nativeLocales.test.ts
+++ b/SparkyFitnessMobile/__tests__/config/nativeLocales.test.ts
@@ -1,6 +1,12 @@
-import en from '../../locales/en.json';
-import pl from '../../locales/pl.json';
-import es from '../../locales/es.json';
+import fs from 'fs';
+import path from 'path';
+import {
+  SHIPPED_LOCALES,
+  SOURCE_LOCALE,
+} from '../../src/localization/localeRegistry';
+
+const MOBILE_ROOT = path.join(__dirname, '../..');
+const SHIPPED = Object.keys(SHIPPED_LOCALES);
 
 const REQUIRED_IOS_KEYS = [
   'NSCameraUsageDescription',
@@ -9,43 +15,47 @@ const REQUIRED_IOS_KEYS = [
   'NSLocalNetworkUsageDescription',
 ] as const;
 
+function readMetadata(locale: string): { ios?: Record<string, string> } {
+  return JSON.parse(
+    fs.readFileSync(path.join(MOBILE_ROOT, `locales/${locale}.json`), 'utf8')
+  );
+}
+
 describe('native app locale resources', () => {
-  it('contains the same non-empty iOS permission keys in English, Polish and Spanish', () => {
-    for (const key of REQUIRED_IOS_KEYS) {
-      expect(en.ios[key]).toEqual(expect.any(String));
-      expect(pl.ios[key]).toEqual(expect.any(String));
-      expect(es.ios[key]).toEqual(expect.any(String));
-      expect(en.ios[key]).not.toBe('');
-      expect(pl.ios[key]).not.toBe('');
-      expect(es.ios[key]).not.toBe('');
+  it('ships an Expo metadata catalog for every registered locale', () => {
+    for (const locale of SHIPPED) {
+      expect(
+        fs.existsSync(path.join(MOBILE_ROOT, `locales/${locale}.json`))
+      ).toBe(true);
     }
-    expect(Object.keys(en.ios).sort()).toEqual(Object.keys(pl.ios).sort());
-    expect(Object.keys(en.ios).sort()).toEqual(Object.keys(es.ios).sort());
   });
 
-  it('uses the approved Polish permission copy', () => {
-    expect(pl.ios).toEqual({
-      NSCameraUsageDescription:
-        'SparkyFitness potrzebuje dostępu do aparatu, aby skanować kody kreskowe i etykiety produktów.',
-      NSHealthShareUsageDescription:
-        'SparkyFitness odczytuje dane zdrowotne, takie jak aktywność, treningi i pomiary ciała, aby wyświetlać je w aplikacji i synchronizować z Twoim samodzielnie hostowanym serwerem SparkyFitness.',
-      NSHealthUpdateUsageDescription:
-        'SparkyFitness zapisuje rejestrowane w aplikacji wartości odżywcze i nawodnienie w Apple Health, aby zachować synchronizację.',
-      NSLocalNetworkUsageDescription:
-        'SparkyFitness łączy się z samodzielnie hostowanymi serwerami w Twojej sieci lokalnej.',
-    });
+  it('defines every required iOS permission key in the source locale', () => {
+    const ios = readMetadata(SOURCE_LOCALE).ios ?? {};
+    for (const key of REQUIRED_IOS_KEYS) {
+      expect(ios[key]).toEqual(expect.any(String));
+      expect(ios[key]).not.toBe('');
+    }
   });
 
-  it('uses the approved Spanish permission copy', () => {
-    expect(es.ios).toEqual({
-      NSCameraUsageDescription:
-        'SparkyFitness necesita acceder a tu cámara para escanear códigos de barras y etiquetas de alimentos.',
-      NSHealthShareUsageDescription:
-        'SparkyFitness lee datos de Salud (como actividad, entrenamientos y medidas corporales) para mostrarlos en la app y sincronizarlos con tu servidor SparkyFitness autoalojado.',
-      NSHealthUpdateUsageDescription:
-        'SparkyFitness escribe en Apple Salud la nutrición y la hidratación que registras en la app, manteniendo ambas sincronizadas.',
-      NSLocalNetworkUsageDescription:
-        'SparkyFitness se conecta a servidores autoalojados en tu red local.',
-    });
+  it('never emits a permission key the source does not define', () => {
+    // A missing key falls back to the base Info.plist copy; an unknown one is
+    // dead weight and stays blocking.
+    const source = new Set(Object.keys(readMetadata(SOURCE_LOCALE).ios ?? {}));
+    for (const locale of SHIPPED) {
+      for (const key of Object.keys(readMetadata(locale).ios ?? {})) {
+        expect(source.has(key)).toBe(true);
+      }
+    }
+  });
+
+  it('has non-empty permission copy in every shipped locale', () => {
+    for (const locale of SHIPPED) {
+      for (const [key, value] of Object.entries(
+        readMetadata(locale).ios ?? {}
+      )) {
+        expect(`${locale}:${key}:${value}`).not.toBe(`${locale}:${key}:`);
+      }
+    }
   });
 });

--- a/SparkyFitnessMobile/__tests__/config/nativeLocales.test.ts
+++ b/SparkyFitnessMobile/__tests__/config/nativeLocales.test.ts
@@ -51,10 +51,9 @@ describe('native app locale resources', () => {
 
   it('has non-empty permission copy in every shipped locale', () => {
     for (const locale of SHIPPED) {
-      for (const [key, value] of Object.entries(
-        readMetadata(locale).ios ?? {}
-      )) {
-        expect(`${locale}:${key}:${value}`).not.toBe(`${locale}:${key}:`);
+      for (const value of Object.values(readMetadata(locale).ios ?? {})) {
+        expect(value).toEqual(expect.any(String));
+        expect(value).not.toBe('');
       }
     }
   });

--- a/SparkyFitnessMobile/__tests__/config/widgetResourceContract.test.ts
+++ b/SparkyFitnessMobile/__tests__/config/widgetResourceContract.test.ts
@@ -189,37 +189,15 @@ describe('Android widget localization contract', () => {
       // the native widget validator and the placeholder tests below.
     });
 
-    it('uses approved Polish translations with diacritics where natural', () => {
-      // PL-specific regression guard: these translations were reviewed and
-      // approved. This test is intentionally PL-specific (not registry-driven)
-      // because it verifies known-good linguistic content, not architecture.
-      const pl = new Map(
-        readWidgetStringResources('pl').map((r) => [r.name, r.value])
-      );
-
-      expect(pl.get('sparky_calorie_widget_name')).toBe('Kalorie');
-      expect(pl.get('sparky_macro_widget_name')).toBe('Makroskładniki');
-      expect(pl.get('widget_protein')).toBe('Białko');
-      expect(pl.get('widget_carbs')).toBe('Węglowodany');
-      expect(pl.get('widget_fat')).toBe('Tłuszcz');
-      expect(pl.get('widget_search_food')).toBe('Wyszukaj produkt');
-      expect(pl.get('widget_scan_barcode')).toBe('Skanuj kod kreskowy');
-      expect(pl.get('widget_kcal_left')).toBe('Pozostało %1$s kcal');
-    });
-
-    it('uses approved Spanish translations with diacritics where natural', () => {
-      const es = new Map(
-        readWidgetStringResources('es').map((r) => [r.name, r.value])
-      );
-
-      expect(es.get('sparky_calorie_widget_name')).toBe('Calorías');
-      expect(es.get('sparky_macro_widget_name')).toBe('Macros');
-      expect(es.get('widget_protein')).toBe('Proteínas');
-      expect(es.get('widget_carbs')).toBe('Carbohidratos');
-      expect(es.get('widget_fat')).toBe('Grasas');
-      expect(es.get('widget_search_food')).toBe('Buscar comida');
-      expect(es.get('widget_scan_barcode')).toBe('Escanear código');
-      expect(es.get('widget_kcal_left')).toBe('%1$s kcal restantes');
+    it('keeps the two widget names distinct in every shipped locale', () => {
+      for (const locale of SHIPPED_WIDGET_LOCALES) {
+        const strings = new Map(
+          readWidgetStringResources(locale).map((r) => [r.name, r.value])
+        );
+        expect(strings.get('sparky_calorie_widget_name')).not.toBe(
+          strings.get('sparky_macro_widget_name')
+        );
+      }
     });
 
     it('keeps placeholder positions compatible across all shipped widget locales', () => {

--- a/SparkyFitnessMobile/__tests__/scripts/localeResourcePipeline.test.ts
+++ b/SparkyFitnessMobile/__tests__/scripts/localeResourcePipeline.test.ts
@@ -165,9 +165,24 @@ describe('registry-driven locale resource pipeline', () => {
     // Unless `%%` is consumed first, the second `%` starts a match that takes the
     // following space as a flag and the next letter as the conversion, inventing an
     // argument that differs per language ("% o" here, "% d" in the translations).
-    writeNative(root, 'en', '<resources><string name="goal">50%% of goal</string></resources>', '"goal" = "50%% of goal";');
-    writeNative(root, 'pl', '<resources><string name="goal">50%% do celu</string></resources>', '"goal" = "50%% do celu";');
-    writeNative(root, 'de', '<resources><string name="goal">50%% des Ziels</string></resources>', '"goal" = "50%% des Ziels";');
+    writeNative(
+      root,
+      'en',
+      '<resources><string name="goal">50%% of goal</string></resources>',
+      '"goal" = "50%% of goal";'
+    );
+    writeNative(
+      root,
+      'pl',
+      '<resources><string name="goal">50%% do celu</string></resources>',
+      '"goal" = "50%% do celu";'
+    );
+    writeNative(
+      root,
+      'de',
+      '<resources><string name="goal">50%% des Ziels</string></resources>',
+      '"goal" = "50%% des Ziels";'
+    );
     const output = run(nativeValidator, ['--root', root]);
     expect(output).toContain('pl: 1/1 (0 missing)');
     expect(output).toContain('de: 1/1 (0 missing)');

--- a/SparkyFitnessMobile/__tests__/scripts/localeResourcePipeline.test.ts
+++ b/SparkyFitnessMobile/__tests__/scripts/localeResourcePipeline.test.ts
@@ -159,4 +159,18 @@ describe('registry-driven locale resource pipeline', () => {
     );
     fs.rmSync(root, { recursive: true, force: true });
   });
+
+  it('reads a doubled percent as a literal rather than a format argument', () => {
+    const root = fixtureRoot();
+    // Unless `%%` is consumed first, the second `%` starts a match that takes the
+    // following space as a flag and the next letter as the conversion, inventing an
+    // argument that differs per language ("% o" here, "% d" in the translations).
+    writeNative(root, 'en', '<resources><string name="goal">50%% of goal</string></resources>', '"goal" = "50%% of goal";');
+    writeNative(root, 'pl', '<resources><string name="goal">50%% do celu</string></resources>', '"goal" = "50%% do celu";');
+    writeNative(root, 'de', '<resources><string name="goal">50%% des Ziels</string></resources>', '"goal" = "50%% des Ziels";');
+    const output = run(nativeValidator, ['--root', root]);
+    expect(output).toContain('pl: 1/1 (0 missing)');
+    expect(output).toContain('de: 1/1 (0 missing)');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
 });

--- a/SparkyFitnessMobile/package.json
+++ b/SparkyFitnessMobile/package.json
@@ -141,7 +141,8 @@
     ],
     "testPathIgnorePatterns": [
       "__tests__/hooks/queryTestUtils\\.ts$",
-      "__tests__/screens/helpers/"
+      "__tests__/screens/helpers/",
+      "__tests__/config/helpers/"
     ],
     "moduleNameMapper": {
       "^@workspace/shared$": "<rootDir>/../shared/src/index.ts",

--- a/SparkyFitnessMobile/scripts/validate-native-widget-locales.mjs
+++ b/SparkyFitnessMobile/scripts/validate-native-widget-locales.mjs
@@ -3,12 +3,18 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-const ANDROID_FORMAT = /%(?:\d+\$)?(?:[-#+ 0,(<]*\d*(?:\.\d+)?)?[a-zA-Z]/g;
+// `%%` must be consumed first: otherwise in "50%% goal" the second `%` starts a
+// match, takes the space as a flag and `g` as the conversion, inventing a "% g"
+// argument that differs per language.
+const ANDROID_FORMAT = /%%|%(?:\d+\$)?(?:[-#+ 0,(<]*\d*(?:\.\d+)?)?[a-zA-Z]/g;
 const IOS_FORMAT =
-  /%(?:\d+\$)?(?:[-+ #0]*\d*(?:\.\d+)?)?(?:lld|llu|ld|lu|@|d|D|i|u|U|o|x|X|f|F|e|E|g|G|c|C|s|S|p)/g;
+  /%%|%(?:\d+\$)?(?:[-+ #0]*\d*(?:\.\d+)?)?(?:lld|llu|ld|lu|@|d|D|i|u|U|o|x|X|f|F|e|E|g|G|c|C|s|S|p)/g;
 const isBlank = (value) => value.trim() === '';
 const formats = (value, regex) =>
-  [...value.matchAll(regex)].map((match) => match[0]).sort();
+  [...value.matchAll(regex)]
+    .map((match) => match[0])
+    .filter((match) => match !== '%%')
+    .sort();
 const equal = (left, right) =>
   left.length === right.length &&
   left.every((value, index) => value === right[index]);
@@ -177,6 +183,6 @@ function main() {
 }
 if (
   process.argv[1] &&
-  import.meta.url === new URL(`file://${process.argv[1]}`).href
+  import.meta?.url === new URL(`file://${process.argv[1]}`).href
 )
   main();

--- a/docs/content/8.developer/9.translations.md
+++ b/docs/content/8.developer/9.translations.md
@@ -1,6 +1,10 @@
 # Internationalization (i18n) Setup in SparkyFitnessFrontend
 
-This document outlines the setup for internationalization (i18n) in the SparkyFitnessFrontend application using `i18next` and `react-i18next`.
+This document outlines the technical setup for internationalization (i18n) in the SparkyFitnessFrontend application using `i18next` and `react-i18next`.
+
+::alert{type="info"}
+**Only the English (`en`) files may be edited by hand.** Every other language is translated on [Weblate](https://hosted.weblate.org/engage/sparkyfitness) and synced from [SparkyFitnessTranslations](https://github.com/CodeWithCJ/SparkyFitnessTranslations).
+::
 
 ## 1. Core Libraries
 
@@ -17,8 +21,8 @@ These dependencies are installed in the `SparkyFitnessFrontend` directory.
 
 Translation files are stored in the `public/locales` directory, following the format `public/locales/{{languageCode}}/translation.json`.
 
--   `public/locales/en/translation.json`: Contains English translations.
--   `public/locales/ta/translation.json`: Contains Tamil translations.
+-   `public/locales/en/translation.json`: the English source, and the only file a code contributor edits.
+-   `public/locales/{{languageCode}}/translation.json`: every other language, owned by translators and synced from [SparkyFitnessTranslations](https://github.com/CodeWithCJ/SparkyFitnessTranslations) via Weblate.
 
 Each `translation.json` file is a simple JSON object where keys represent translation identifiers and values are the translated strings. Nested objects can be used to organize translations (e.g., `"nav.diary"`).
 
@@ -47,13 +51,14 @@ import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import HttpApi from 'i18next-http-backend';
+import { getSupportedLanguages } from './utils/languageUtils';
 
 i18n
   .use(HttpApi)
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    supportedLngs: ['en', 'ta'], // List of supported languages
+    supportedLngs: getSupportedLanguages(), // from src/utils/languageUtils.ts
     fallbackLng: 'en', // Fallback language if a translation is missing
     detection: {
       order: ['localStorage', 'querystring', 'cookie', 'sessionStorage', 'navigator', 'htmlTag'],
@@ -72,7 +77,7 @@ export default i18n;
 
 **Key Configuration Details:**
 
--   `supportedLngs`: An array of language codes that your application supports.
+-   `supportedLngs`: the languages the app offers, from `getSupportedLanguages()` in [`SparkyFitnessFrontend/src/utils/languageUtils.ts`](https://github.com/CodeWithCJ/SparkyFitness/blob/main/SparkyFitnessFrontend/src/utils/languageUtils.ts). A locale directory that is not listed there cannot be selected.
 -   `fallbackLng`: The language to use if a translation for the current language is missing.
 -   `detection.order`: Specifies the order in which `i18next` tries to detect the user's language. `localStorage` is prioritized to use the user's saved preference.
 -   `backend.loadPath`: The URL pattern to fetch translation files. `{{lng}}` is replaced by the current language code, and `{{ns}}` by the namespace (defaulting to `translation`).
@@ -82,23 +87,20 @@ export default i18n;
 
 The `i18next` instance is initialized and provided to the React application in [`SparkyFitnessFrontend/src/main.tsx`](SparkyFitnessFrontend/src/main.tsx).
 
-```typescript
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
-import { BrowserRouter } from 'react-router-dom';
-import { AuthProvider } from './hooks/useAuth.tsx';
-import './i18n'; // Import the i18n configuration
+```tsx
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import './i18n'; // side-effect import: configures the shared i18next instance
 import { Suspense } from 'react';
+// ...
 
-createRoot(document.getElementById("root")!).render(
+createRoot(document.getElementById('root')!).render(
   <Suspense fallback="loading">
-    <BrowserRouter>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
-    </BrowserRouter>
-  </Suspense>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </Suspense>,
 );
 ```
 
@@ -152,49 +154,30 @@ const MyComponent = () => {
 
 The `t` function takes a translation key (e.g., `"nav.diary"`) and returns the corresponding translated string for the currently active language.
 
-## 7. Language Switcher in Settings (`src/components/Settings.tsx`)
+## 7. Language Switcher in Settings (`src/pages/Settings/PreferenceSettings.tsx`)
 
-The language switcher is integrated into the `Preferences` section of the `Settings` component. It uses the `language` state and `setLanguage` function from `PreferencesContext` to update the user's preferred language.
+The language switcher lives in the Preferences section of the settings page. It renders one entry per supported language, so adding a language to `languageUtils.ts` is enough to make it appear — the list is never hardcoded here.
 
-```typescript
-// Inside Settings.tsx
-import { useTranslation } from "react-i18next";
-import { usePreferences } from "@/contexts/PreferencesContext";
-// ... other imports
+```tsx
+import { getLanguageDisplayName, getSupportedLanguages } from "@/utils/languageUtils";
+// ...
 
-const Settings: React.FC<SettingsProps> = ({ onShowAboutDialog }) => {
-  const { t } = useTranslation();
-  const { language, setLanguage } = usePreferences();
-  // ... other state and functions
-
-  // Inside the Preferences AccordionContent
-  <div>
-    <Label htmlFor="language">{t('settings.preferences.language')}</Label>
-    <Select
-      value={language}
-      onValueChange={setLanguage}
-    >
-      <SelectTrigger>
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value="en">English</SelectItem>
-        <SelectItem value="ta">தமிழ்</SelectItem>
-      </SelectContent>
-    </Select>
-  </div>
-  // ...
-};
+<Select value={language} onValueChange={setLanguage}>
+  <SelectTrigger>
+    <SelectValue />
+  </SelectTrigger>
+  <SelectContent>
+    {getSupportedLanguages().map((langCode) => (
+      <SelectItem key={langCode} value={langCode}>
+        {getLanguageDisplayName(langCode)}
+      </SelectItem>
+    ))}
+  </SelectContent>
+</Select>
 ```
+
+`getLanguageDisplayName` returns each language's endonym — `Deutsch`, `Español`, `日本語` — so the list reads the same whatever the interface language is.
 
 ## 8. Adding New Languages
 
-To add a new language (e.g., Spanish - `es`):
-
-1.  **Create Translation File:** Create a new JSON file: `public/locales/es/translation.json`.
-2.  **Add Translations:** Populate `translation.json` with Spanish translations for all keys used in the application.
-3.  **Update `i18n.ts`:** Add `'es'` to the `supportedLngs` array in [`SparkyFitnessFrontend/src/i18n.ts`](SparkyFitnessFrontend/src/i18n.ts).
-4.  **Update Language Switcher:** Add a new `SelectItem` for Spanish in the language switcher within [`SparkyFitnessFrontend/src/components/Settings.tsx`](SparkyFitnessFrontend/src/components/Settings.tsx).
-5.  **Backend Update (if applicable):** If you want to store the language preference in the backend, ensure the `user_preferences` table and associated API endpoints can handle the new language code.
-
-By following these steps, you can easily extend the application to support additional languages.
+Translation files are not created by hand. A language is requested on [Weblate](https://hosted.weblate.org/engage/sparkyfitness), translated there, and synced into `public/locales/` automatically; a maintainer then enables it by adding the code to `getSupportedLanguages()` and `getLanguageDisplayName()` in `src/utils/languageUtils.ts`.

--- a/docs/content/8.developer/9.translations.md
+++ b/docs/content/8.developer/9.translations.md
@@ -104,7 +104,7 @@ createRoot(document.getElementById('root')!).render(
 );
 ```
 
-The `Suspense` component is used to display a fallback (e.g., "loading") while translations are being loaded.
+`react.useSuspense` is `false`, so `i18next` does not suspend while a catalog loads — it renders the fallback language until the translation arrives. The `Suspense` boundary above is therefore not what handles translation loading; set `useSuspense` to `true` if you want it to.
 
 ## 5. Language Handling Component (`src/components/LanguageHandler.tsx`)
 
@@ -180,4 +180,4 @@ import { getLanguageDisplayName, getSupportedLanguages } from "@/utils/languageU
 
 ## 8. Adding New Languages
 
-Translation files are not created by hand. A language is requested on [Weblate](https://hosted.weblate.org/engage/sparkyfitness), translated there, and synced into `public/locales/` automatically; a maintainer then enables it by adding the code to `getSupportedLanguages()` and `getLanguageDisplayName()` in `src/utils/languageUtils.ts`.
+Translation files are not created by hand. A language is requested on [Weblate](https://hosted.weblate.org/engage/sparkyfitness) and translated there. A maintainer then runs the **Sync Translations** workflow (`workflow_dispatch`), which copies the non-English files into `public/locales/` and opens a pull request. Enabling the language is a separate edit: add the code to `getSupportedLanguages()` and `getLanguageDisplayName()` in `src/utils/languageUtils.ts`.


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Two gaps in the mobile widget localization contract, both of which let a defect reach users with the suite green.

The contract tests tracked two lists by hand — the required key set and the Swift file list — and `fallbackWidgetString` ends in `default: return key`. So a new `localizedWidgetString("widget.new_label")` call, or any key in a Swift file nobody remembered to add to the list, could ship with no `en.lproj` entry and no fallback, and render as a raw key to users.

Separately, the widget resource validator compared format specifiers without consuming `%%` first. In `"50%% of goal"` the second `%` started a match, took the following space as a flag and the next letter as the conversion, inventing an argument whose position differs per language. Correct resources were reported as placeholder mismatches.

**How did you implement the solution?**

- **Keys are derived from the Swift sources.** `__tests__/config/helpers/widgetSwiftKeys.ts` discovers every `.swift` file under `targets/widget/` recursively and extracts the literal keys passed to `localizedWidgetString`, `configurationDisplayName` and `.description`. The tests assert each exists in `en.lproj/Localizable.strings` and that every helper-consumed key is in the fallback map. Gallery metadata keys are kept separate on purpose: SwiftUI resolves those through `LocalizedStringKey`, so they never reach `fallbackWidgetString` and requiring them there would be wrong. While that function exists the map check runs; the helper returns null if it is ever removed, retiring the guard with it.
- **`%%` is consumed first** and dropped before comparing, in both the Android and the Apple format expressions.
- **Widget assertions are structural.** They pinned the exact Spanish and Polish text of each string; those files belong to translators, so any wording improvement failed the suite and a new language needed a hand-written block before it could ship. They are now driven from `localeRegistry.json`: every shipped locale must parse, cover the source keys, keep placeholders aligned and keep the two widget names distinct — which holds for a language nobody has written yet.
- **`9.translations.md` corrections.** Its "Adding New Languages" section told contributors to create locale JSON by hand, which contradicts `CONTRIBUTING.md` and produces a pull request CI rejects. Alongside it the locale list claimed only English and Tamil exist (there are 27), `supportedLngs` was shown as an inline array rather than coming from `languageUtils.ts`, the switcher was documented in a component that no longer holds it, the `main.tsx` sample predated the current providers, and the i18next example called `getSupportedLanguages()` without importing it.

No translation file is modified. The 10 changed files are two scripts, six test files, the package guide and one docs page.

Linked Issue: #2301 (related — the Weblate sync work that closes it lands separately)

## How to Test

1. Check out this branch, run `pnpm install` from the repo root, then `cd SparkyFitnessMobile`.
2. Run the gate: `pnpm run validate` and `pnpm test`.
3. Confirm the `%%` regression test actually catches the bug. Temporarily drop the `%%|` alternative from `ANDROID_FORMAT` and `IOS_FORMAT` in `scripts/validate-native-widget-locales.mjs` and re-run:
   ```bash
   pnpm exec jest --watchman=false --runInBand __tests__/scripts/localeResourcePipeline.test.ts
   ```
   The new case fails with four spurious mismatches — Android `de` and `pl`, iOS `de` and `pl`. Restore the file and it passes.
4. Confirm the widget key guard catches both regressions it exists for:
   ```bash
   # (a) rename any localizedWidgetString key in targets/widget/widgets.swift
   #     to one that does not exist, e.g. widget.kcal_left -> widget.new_label
   # (b) a new key in a Swift file no fixed list would have covered
   mkdir -p targets/widget/LiveActivity
   echo 'Text(localizedWidgetString("widget.brand_new_key"))' > targets/widget/LiveActivity/NewActivity.swift

   pnpm exec jest --watchman=false --runInBand __tests__/config/iosWidgetResources.test.ts \
     __tests__/config/iosWidgetSwiftContract.test.ts
   # both fail, each naming the offending "<file>: <key>"; then restore
   git checkout targets/widget/widgets.swift && rm -rf targets/widget/LiveActivity
   ```
5. Docs: `cd docs && pnpm install && NUXT_APP_BASE_URL=/SparkyFitness/ pnpm exec nuxt build --preset github_pages`, then check `/developer/translations`.

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [x] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

> Checklist notes: no `SparkyFitnessFrontend/`, `SparkyFitnessServer/` or UI source files are touched, so those blocks are N/A and left unchecked. Mobile validation was run — `pnpm run validate` exit 0 and the suite at 368 files / 5991 tests — but the device/emulator box stays unchecked because the app has not been run on hardware.

## Screenshots

<details>
<summary>Click to expand</summary>

N/A — no UI change and no user-visible string change. This PR touches two scripts, six test files, the package guide and one docs page.

</details>

## Notes for Reviewers

**This is the widget half of the split.** `sync-translations.yml` and everything that describes or depends on that pipeline — the guard in `pr-validation.yml`, the workflow README section, the `CONTRIBUTING.md` bullet, `4.translations.md`, the audit scoping in `i18n-audit/core.cjs` and the Weblate clause in the package guide — are held on `feat/translations-weblate-sync` and will come as their own PR once the translations repo has a `mobile/` tree and the Weblate components exist. Nothing here depends on any of it: `validate` passes without the audit scoping, since only registered locales exist today.

**Correction on the `%%` fix: it had no regression test, and now it does.** I previously described it as covered — it was, by a test that was deleted along with the generator, and I did not notice. `%%` appeared in exactly one file in the whole package: the validator itself. The new case lives in `localeResourcePipeline.test.ts`, reusing the fixture helpers already there rather than duplicating them, and it was verified in both directions — against the previous expressions the same fixture reports four spurious mismatches across both native surfaces.

**What gives confidence the key extraction is right**, rather than merely green: the derived set reproduces exactly the seventeen keys the manual list held. Both regressions were reproduced before and after — a new `localizedWidgetString` call in an existing file, and a new key in a Swift file under a subdirectory that no fixed list would have covered (`targets/widget/LiveActivity/`, which is the shape future Live Activity work will take).

**Adding a widget string now has a contract**, documented in the package guide: the key must go into `en.lproj/Localizable.strings`, and — for `localizedWidgetString` keys — into the `fallbackWidgetString` map, or the tests fail. Target-language files stay optional and fall back to English.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed localization validation so literal percent signs are handled correctly across Android and iOS widget resources.
  - Improved consistency of translated widget names, descriptions, and permission messages across supported languages.
  - Prevented missing, unexpected, or empty translation entries from going unnoticed.

- **Documentation**
  - Clarified translation workflows, supported-language handling, language switching, and Weblate synchronization.
  - Updated localization guidance and examples to reflect the current application setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->