### PR TITLE
fix(food-search): paginate local food search so later matches stay reachable

### DIFF
--- a/SparkyFitnessFrontend/src/api/Foods/foodService.ts
+++ b/SparkyFitnessFrontend/src/api/Foods/foodService.ts
@@ -141,17 +141,17 @@ export const getRecentAndTopFoods = async (
   return apiCall(`/foods?${params.toString()}`);
 };
 
-export const searchDatabaseFoods = async (
-  term: string,
-  limit: number,
-  mealType?: string
-) => {
+/**
+ * Name lookup used to match an incoming meal food against an existing food
+ * before creating a duplicate. Not the dialog's user-facing search: that one
+ * paginates through `loadFoods`.
+ */
+export const lookupFoodsByName = async (term: string, limit: number) => {
   const params = new URLSearchParams({
     name: term,
     broadMatch: 'true',
     limit: limit.toString(),
   });
-  if (mealType) params.append('mealType', mealType);
 
   return apiCall(`/foods?${params.toString()}`);
 };

--- a/SparkyFitnessFrontend/src/api/keys/meals.ts
+++ b/SparkyFitnessFrontend/src/api/keys/meals.ts
@@ -24,8 +24,12 @@ export const foodKeys = {
     [...foodKeys.lists(), { searchTerm, filter, page, limit, sort }] as const,
   recentTop: (limit: number, mealType?: string) =>
     [...foodKeys.all, 'recentTop', limit, mealType] as const,
-  databaseSearch: (term: string, limit: number, mealType?: string) =>
-    [...foodKeys.all, 'search', term, limit, mealType] as const,
+  databaseSearch: (term: string, pageSize: number, filter: MealFilter) =>
+    [...foodKeys.all, 'search', term, pageSize, filter] as const,
+  // Separate namespace from `databaseSearch`: that one is an infinite query
+  // whose cached shape is {pages}, this one resolves to a single response.
+  nameLookup: (term: string, limit: number) =>
+    [...foodKeys.all, 'nameLookup', term, limit] as const,
   favorites: () => [...foodKeys.all, 'favorites'] as const,
 };
 

--- a/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
+++ b/SparkyFitnessFrontend/src/components/FoodSearch/FoodSearch.tsx
@@ -172,7 +172,6 @@ const EnhancedFoodSearch = ({
     foodSearchAllProvidersDefault,
     defaultBarcodeProviderId,
     itemDisplayLimit,
-    foodDisplayLimit,
     nutrientDisplayPreferences,
     energyUnit,
     convertEnergy,
@@ -260,13 +259,22 @@ const EnhancedFoodSearch = ({
     topMeals,
     isLoading: isLoadingRecentMeals,
   } = useRecentAndTopMealsQuery(itemDisplayLimit, showMeals && isSearchEmpty);
-  const { data: searchData, isFetching: isFetchingSearch } =
-    useDatabaseFoodSearchQuery(
-      debouncedSearchTerm,
-      foodDisplayLimit,
-      mealType,
-      showLocalFoods && !!debouncedSearchTerm.trim()
-    );
+  // Local food search is paginated on the server, page size item_display_limit.
+  // The ownership filter goes with the request so it narrows the match set
+  // before the page boundary; filtering the page in the browser would hide
+  // matches that simply sat on a later page.
+  const {
+    data: searchData,
+    isFetching: isFetchingSearch,
+    hasNextPage: hasMoreLocalFoods,
+    fetchNextPage: fetchMoreLocalFoods,
+    isFetchingNextPage: isLoadingMoreLocalFoods,
+  } = useDatabaseFoodSearchQuery(
+    debouncedSearchTerm,
+    itemDisplayLimit,
+    ownershipFilter,
+    showLocalFoods && !!debouncedSearchTerm.trim()
+  );
 
   // Starred foods and meals. Shared cache with the row star in FoodResultCard,
   // so this is one fetch, not two.
@@ -400,7 +408,8 @@ const EnhancedFoodSearch = ({
   // and filter preserves it, so favorites stay relevance-ordered among
   // themselves too.
   const searchFoodsFavFirst = useMemo(() => {
-    const results: Food[] = searchData?.searchResults || [];
+    const results: Food[] =
+      searchData?.pages.flatMap((page) => page.foods) || [];
     const isFavorite = (food: Food) =>
       favoriteKeys.has(landingKey('food', food.id));
     return [
@@ -417,10 +426,8 @@ const EnhancedFoodSearch = ({
     ];
   }, [meals, favoriteKeys]);
 
-  const filteredSearchFoodsFavFirst = useMemo(
-    () => filterItems(searchFoodsFavFirst, ownershipFilter, user?.id),
-    [searchFoodsFavFirst, ownershipFilter, user?.id]
-  );
+  // No client-side ownership filter here: the search request already carries
+  // it. Meals below still need one, since the meal search has no such param.
   const filteredSearchMealsFavFirst = useMemo(
     () => filterItems(searchMealsFavFirst, ownershipFilter, user?.id),
     [searchMealsFavFirst, ownershipFilter, user?.id]
@@ -516,7 +523,7 @@ const EnhancedFoodSearch = ({
       isAllProviders &&
       (ownershipFilter === 'all' || ownershipFilter === 'public'),
     autoScale: autoScaleOpenFoodFactsImports,
-    foodDisplayLimit,
+    itemDisplayLimit,
   });
 
   // Collapse expanded By Source sections when the aggregated query changes.
@@ -651,7 +658,7 @@ const EnhancedFoodSearch = ({
             'usda',
             term,
             id,
-            foodDisplayLimit,
+            itemDisplayLimit,
             undefined,
             page
           )
@@ -694,7 +701,7 @@ const EnhancedFoodSearch = ({
             'yazio',
             term,
             id,
-            foodDisplayLimit,
+            itemDisplayLimit,
             undefined,
             page
           )
@@ -739,7 +746,7 @@ const EnhancedFoodSearch = ({
         };
       },
     }),
-    [queryClient, autoScaleOpenFoodFactsImports, foodDisplayLimit]
+    [queryClient, autoScaleOpenFoodFactsImports, itemDisplayLimit]
   );
 
   // Online results stream in alongside local results, using the default
@@ -1127,7 +1134,7 @@ const EnhancedFoodSearch = ({
     !isSearchEmpty && debouncedSearchTerm !== searchTerm;
   const localPending = isFetchingSearch || isMealLoading || isDebouncePending;
   const noLocalResults =
-    filteredSearchFoodsFavFirst.length === 0 &&
+    searchFoodsFavFirst.length === 0 &&
     filteredSearchMealsFavFirst.length === 0;
   const showLocalEmpty =
     showLocalFoods && !isSearchEmpty && !localPending && noLocalResults;
@@ -1379,12 +1386,12 @@ const EnhancedFoodSearch = ({
         {!isSearchEmpty && (
           <>
             {/* Local foods */}
-            {showLocalFoods && filteredSearchFoodsFavFirst.length > 0 && (
+            {showLocalFoods && searchFoodsFavFirst.length > 0 && (
               <>
                 <SectionHeader>
                   {t('enhancedFoodSearch.yourFoods', 'Your Foods')}
                 </SectionHeader>
-                {filteredSearchFoodsFavFirst.map((food: Food) => (
+                {searchFoodsFavFirst.map((food: Food) => (
                   <FoodResultCard
                     key={food.id}
                     item={food}
@@ -1393,6 +1400,22 @@ const EnhancedFoodSearch = ({
                     onCardClick={() => onFoodSelect(food, 'food')}
                   />
                 ))}
+                {hasMoreLocalFoods && (
+                  <div className="flex justify-center py-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={isLoadingMoreLocalFoods}
+                      onClick={() => fetchMoreLocalFoods()}
+                    >
+                      {isLoadingMoreLocalFoods ? (
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                      ) : (
+                        t('enhancedFoodSearch.loadMore', 'Load more')
+                      )}
+                    </Button>
+                  </div>
+                )}
               </>
             )}
 

--- a/SparkyFitnessFrontend/src/components/MealBuilder.tsx
+++ b/SparkyFitnessFrontend/src/components/MealBuilder.tsx
@@ -38,7 +38,7 @@ import {
   useUpdateMealMutation,
 } from '@/hooks/Foods/useMeals';
 import {
-  databaseFoodSearchOptions,
+  foodNameLookupOptions,
   useCreateFoodDatabaseItemMutation,
 } from '@/hooks/Foods/useFoods';
 import {
@@ -733,7 +733,7 @@ const MealBuilder: React.FC<MealBuilderProps> = ({
         if (cleanName) {
           try {
             const searchResults = (await queryClient.fetchQuery(
-              databaseFoodSearchOptions(mf.food_name || '', 5)
+              foodNameLookupOptions(mf.food_name || '', 5)
             )) as Food[];
             const found = (
               Array.isArray(searchResults) ? searchResults : []

--- a/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
@@ -96,7 +96,6 @@ interface PreferencesContextType {
   // turning this off.
   foodSearchAllProvidersDefault: boolean;
   timezone: string;
-  foodDisplayLimit: number;
   itemDisplayLimit: number;
   calorieGoalAdjustmentMode: CalorieGoalAdjustmentMode;
   energyUnit: EnergyUnit;
@@ -210,7 +209,6 @@ export interface DefaultPreferences {
   logging_level: LoggingLevel;
   timezone: string;
   item_display_limit: number;
-  food_display_limit: number;
   water_display_unit: WaterDisplayUnit;
   add_exercise_water_to_goal: boolean;
   language: string;
@@ -293,7 +291,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
     Intl.DateTimeFormat().resolvedOptions().timeZone
   );
   const [itemDisplayLimit, setItemDisplayLimitState] = useState<number>(10);
-  const [foodDisplayLimit, setFoodDisplayLimitState] = useState<number>(10);
   const [calorieGoalAdjustmentMode, setCalorieGoalAdjustmentModeState] =
     useState<CalorieGoalAdjustmentMode>('dynamic');
   const [exerciseCaloriePercentage, setExerciseCaloriePercentageState] =
@@ -615,7 +612,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         logging_level: 'ERROR' as const,
         timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         item_display_limit: 10,
-        food_display_limit: 10,
         water_display_unit: waterDisplayUnit,
         language: 'en',
         calorie_goal_adjustment_mode: 'dynamic' as const,
@@ -692,7 +688,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
           data.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
         );
         setItemDisplayLimitState(data.item_display_limit || 10);
-        setFoodDisplayLimitState(data.food_display_limit || 10);
         setWaterDisplayUnitState(data.water_display_unit || 'ml');
         setLanguageState(data.language || 'en');
         setCalorieGoalAdjustmentModeState(
@@ -888,7 +883,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
           foodSearchAllProvidersDefault,
         timezone: newPrefs?.timezone ?? timezone,
         item_display_limit: newPrefs?.itemDisplayLimit ?? itemDisplayLimit,
-        food_display_limit: foodDisplayLimit,
         water_display_unit: newPrefs?.water_display_unit ?? waterDisplayUnit,
         language: newPrefs?.language ?? language,
         calorie_goal_adjustment_mode:
@@ -968,7 +962,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       foodSearchAllProvidersDefault,
       timezone,
       itemDisplayLimit,
-      foodDisplayLimit,
       waterDisplayUnit,
       addExerciseWaterToGoal,
       language,
@@ -1222,7 +1215,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       foodSearchAllProvidersDefault,
       timezone,
       itemDisplayLimit,
-      foodDisplayLimit,
       calorieGoalAdjustmentMode,
       exerciseCaloriePercentage,
       activityLevel,
@@ -1319,7 +1311,6 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       foodSearchAllProvidersDefault,
       timezone,
       itemDisplayLimit,
-      foodDisplayLimit,
       calorieGoalAdjustmentMode,
       exerciseCaloriePercentage,
       activityLevel,

--- a/SparkyFitnessFrontend/src/hooks/Foods/useAllProvidersFoodSearch.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useAllProvidersFoodSearch.ts
@@ -103,7 +103,7 @@ const PAGE_SIZE_PROVIDERS = ['usda', 'yazio'];
 async function fetchProviderResults(
   provider: DataProvider,
   query: string,
-  options: { autoScale?: boolean; foodDisplayLimit?: number }
+  options: { autoScale?: boolean; itemDisplayLimit?: number }
 ): Promise<NormalisedProviderResult> {
   if (provider.provider_type === 'nutritionix') {
     const data: NutritionixItem[] = await searchNutritionixFoods(
@@ -123,7 +123,7 @@ async function fetchProviderResults(
   }
 
   const pageSize = PAGE_SIZE_PROVIDERS.includes(provider.provider_type)
-    ? options.foodDisplayLimit
+    ? options.itemDisplayLimit
     : undefined;
   const data = await searchFoodsV2(
     provider.provider_type,
@@ -159,7 +159,7 @@ export function useAllProvidersFoodSearch(
   options?: {
     enabled?: boolean;
     autoScale?: boolean;
-    foodDisplayLimit?: number;
+    itemDisplayLimit?: number;
   }
 ): {
   providerResults: ProviderFoodSearchResult[];
@@ -170,7 +170,7 @@ export function useAllProvidersFoodSearch(
   // step with the aggregated results rather than a faster local debounce.
   debouncedSearch: string;
 } {
-  const { enabled = true, autoScale, foodDisplayLimit } = options ?? {};
+  const { enabled = true, autoScale, itemDisplayLimit } = options ?? {};
   const debouncedSearch = useDebounce(searchTerm.trim(), DEBOUNCE_MS);
   // Require both the live and the debounced term to clear the threshold. The
   // debounced check gates the queries; the live check makes backspacing below
@@ -221,7 +221,7 @@ export function useAllProvidersFoodSearch(
       queryFn: () =>
         fetchProviderResults(provider, debouncedSearch, {
           autoScale,
-          foodDisplayLimit,
+          itemDisplayLimit,
         }),
       enabled: isSearchActive && enabled,
       staleTime: STALE_TIME,

--- a/SparkyFitnessFrontend/src/hooks/Foods/useAllProvidersFoodSearch.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useAllProvidersFoodSearch.ts
@@ -80,11 +80,16 @@ const noop = () => {};
 // Kept distinct from v2FoodKeys.search / nutritionixKeys.search because those
 // cache the providers' raw response shapes; reusing them here with a different
 // (normalised) shape would corrupt the shared cache.
+// itemDisplayLimit belongs in the key because it is the pageSize for the
+// providers in PAGE_SIZE_PROVIDERS. Omitting it serves results fetched under
+// the previous limit once the preference changes. That was harmless while the
+// limit was a dead constant; it is a live preference now.
 const allProvidersFoodSearchKey = (
   providerType: string,
   query: string,
   providerId?: string,
-  autoScale?: boolean
+  autoScale?: boolean,
+  itemDisplayLimit?: number
 ) =>
   [
     'v2',
@@ -94,6 +99,7 @@ const allProvidersFoodSearchKey = (
     query,
     providerId,
     autoScale,
+    itemDisplayLimit,
   ] as const;
 
 // Providers whose single-provider search caps results at the food display
@@ -216,7 +222,8 @@ export function useAllProvidersFoodSearch(
         provider.provider_type,
         debouncedSearch,
         provider.id,
-        autoScale
+        autoScale,
+        itemDisplayLimit
       ),
       queryFn: () =>
         fetchProviderResults(provider, debouncedSearch, {

--- a/SparkyFitnessFrontend/src/hooks/Foods/useFoods.ts
+++ b/SparkyFitnessFrontend/src/hooks/Foods/useFoods.ts
@@ -12,12 +12,13 @@ import {
   getRecentAndTopFoods,
   importFoodsFromCsv,
   loadFoods,
-  searchDatabaseFoods,
+  lookupFoodsByName,
   togglePublicSharing,
   updateFoodEntriesSnapshot,
 } from '@/api/Foods/foodService';
 import {
   keepPreviousData,
+  useInfiniteQuery,
   useMutation,
   useQuery,
   useQueryClient,
@@ -259,25 +260,36 @@ export const useRecentAndTopFoodsQuery = (
   });
 };
 
-export const databaseFoodSearchOptions = (
-  term: string,
-  limit: number,
-  mealType?: string
-) => ({
-  queryKey: foodKeys.databaseSearch(term, limit, mealType),
-  queryFn: () => searchDatabaseFoods(term, limit, mealType),
+export const foodNameLookupOptions = (term: string, limit: number) => ({
+  queryKey: foodKeys.nameLookup(term, limit),
+  queryFn: () => lookupFoodsByName(term, limit),
 });
 
+/**
+ * Paginated local-food search for the food search dialog.
+ *
+ * Uses the same endpoint the Food library and the mobile app already use, so a
+ * match that sorts past the first page stays reachable through "Load more"
+ * instead of being silently dropped by a fixed LIMIT. `filter` is sent to the
+ * server so ownership narrows the result set before the page is cut, not after.
+ */
 export const useDatabaseFoodSearchQuery = (
   term: string,
-  limit: number,
-  mealType?: string,
+  pageSize: number,
+  filter: MealFilter = 'all',
   enabled: boolean = true
 ) => {
   const { t } = useTranslation();
 
-  return useQuery({
-    ...databaseFoodSearchOptions(term, limit, mealType),
+  return useInfiniteQuery({
+    queryKey: foodKeys.databaseSearch(term, pageSize, filter),
+    queryFn: ({ pageParam = 1 }) =>
+      loadFoods(term, filter, pageParam, pageSize, 'name:asc'),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, allPages) =>
+      allPages.length * pageSize < lastPage.totalCount
+        ? allPages.length + 1
+        : undefined,
     enabled,
     meta: {
       errorMessage: t(

--- a/SparkyFitnessFrontend/src/tests/components/MealBuilder.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/MealBuilder.test.tsx
@@ -31,7 +31,7 @@ jest.mock('@/contexts/ActiveUserContext', () => ({
 jest.mock('@/contexts/PreferencesContext', () => ({
   usePreferences: () => ({
     loggingLevel: 'debug',
-    foodDisplayLimit: 100,
+    itemDisplayLimit: 100,
     nutrientDisplayPreferences: [
       {
         view_group: 'quick_info',

--- a/SparkyFitnessFrontend/src/tests/components/MealManagement.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/MealManagement.test.tsx
@@ -37,7 +37,7 @@ jest.mock('@/contexts/ActiveUserContext', () => ({
 jest.mock('@/contexts/PreferencesContext', () => ({
   usePreferences: () => ({
     loggingLevel: 'debug',
-    foodDisplayLimit: 100,
+    itemDisplayLimit: 100,
     nutrientDisplayPreferences: [
       {
         view_group: 'quick_info',

--- a/SparkyFitnessFrontend/src/tests/components/MealPlanCalendar.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/MealPlanCalendar.test.tsx
@@ -25,7 +25,7 @@ jest.mock('@/contexts/ActiveUserContext', () => ({
   useActiveUser: () => ({ activeUserId: 'test-user-id' }),
 }));
 jest.mock('@/contexts/PreferencesContext', () => ({
-  usePreferences: () => ({ loggingLevel: 'debug', foodDisplayLimit: 100 }),
+  usePreferences: () => ({ loggingLevel: 'debug', itemDisplayLimit: 100 }),
 }));
 
 // Mock toast

--- a/SparkyFitnessFrontend/src/tests/hooks/useAllProvidersFoodSearch.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useAllProvidersFoodSearch.test.tsx
@@ -1,0 +1,84 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useAllProvidersFoodSearch } from '@/hooks/Foods/useAllProvidersFoodSearch';
+import { searchFoodsV2 } from '@/api/Foods/foodService';
+import type { DataProvider } from '@/types/settings';
+
+jest.mock('@/api/Foods/foodService', () => ({
+  searchFoodsV2: jest.fn(),
+}));
+jest.mock('@/api/Foods/nutrionix', () => ({
+  searchNutritionixFoods: jest.fn(),
+}));
+// The hook debounces before it queries; collapse that to a pass-through so the
+// test asserts caching, not timer behaviour.
+jest.mock('@/hooks/useDebounce', () => ({
+  useDebounce: (value: string) => value,
+}));
+
+const mockSearch = searchFoodsV2 as jest.MockedFunction<typeof searchFoodsV2>;
+
+const usda = {
+  id: 'provider-usda',
+  provider_type: 'usda',
+  is_active: true,
+} as unknown as DataProvider;
+
+describe('useAllProvidersFoodSearch cache key', () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    mockSearch.mockResolvedValue({
+      foods: [],
+      pagination: { page: 1, pageSize: 10, totalCount: 0, hasMore: false },
+    });
+  });
+
+  // Regression: `itemDisplayLimit` is the pageSize for the PAGE_SIZE_PROVIDERS,
+  // so a key that omits it serves results fetched under the old limit after the
+  // preference changes. Harmless while the limit was a dead constant, real once
+  // it became a live preference.
+  it('refetches with the new page size when the display limit changes', async () => {
+    const { rerender } = renderHook(
+      ({ limit }: { limit: number }) =>
+        useAllProvidersFoodSearch('bread', [usda], {
+          enabled: true,
+          itemDisplayLimit: limit,
+        }),
+      { wrapper, initialProps: { limit: 10 } }
+    );
+
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    expect(mockSearch.mock.calls[0]).toEqual(expect.arrayContaining([10]));
+
+    rerender({ limit: 25 });
+
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
+    expect(mockSearch.mock.calls[1]).toEqual(expect.arrayContaining([25]));
+  });
+
+  it('serves the cache when the display limit is unchanged', async () => {
+    const { rerender } = renderHook(
+      ({ limit }: { limit: number }) =>
+        useAllProvidersFoodSearch('bread', [usda], {
+          enabled: true,
+          itemDisplayLimit: limit,
+        }),
+      { wrapper, initialProps: { limit: 10 } }
+    );
+
+    await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
+    rerender({ limit: 10 });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/hooks/useAllProvidersFoodSearch.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useAllProvidersFoodSearch.test.tsx
@@ -57,13 +57,32 @@ describe('useAllProvidersFoodSearch cache key', () => {
       { wrapper, initialProps: { limit: 10 } }
     );
 
+    // Assert the exact call, not that the number appears somewhere in it:
+    // pageSize is the 5th argument of searchFoodsV2, and `page` sits next to it,
+    // so a containment check would pass on a limit that landed in the wrong slot.
     await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(1));
-    expect(mockSearch.mock.calls[0]).toEqual(expect.arrayContaining([10]));
+    expect(mockSearch).toHaveBeenNthCalledWith(
+      1,
+      'usda',
+      'bread',
+      'provider-usda',
+      undefined,
+      10,
+      undefined
+    );
 
     rerender({ limit: 25 });
 
     await waitFor(() => expect(mockSearch).toHaveBeenCalledTimes(2));
-    expect(mockSearch.mock.calls[1]).toEqual(expect.arrayContaining([25]));
+    expect(mockSearch).toHaveBeenNthCalledWith(
+      2,
+      'usda',
+      'bread',
+      'provider-usda',
+      undefined,
+      25,
+      undefined
+    );
   });
 
   it('serves the cache when the display limit is unchanged', async () => {

--- a/SparkyFitnessFrontend/src/tests/hooks/useDatabaseFoodSearchQuery.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useDatabaseFoodSearchQuery.test.tsx
@@ -1,0 +1,127 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useDatabaseFoodSearchQuery } from '@/hooks/Foods/useFoods';
+import { loadFoods } from '@/api/Foods/foodService';
+import type { Food } from '@/types/food';
+
+jest.mock('@/api/Foods/foodService', () => ({
+  loadFoods: jest.fn(),
+}));
+jest.mock('@/i18n', () => ({
+  __esModule: true,
+  default: {
+    t: (key: string, fallback?: string) => fallback || key,
+    use: jest.fn().mockReturnThis(),
+    init: jest.fn(),
+  },
+}));
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
+}));
+
+const mockLoadFoods = loadFoods as jest.MockedFunction<typeof loadFoods>;
+
+const food = (id: string, name: string) => ({ id, name }) as Food;
+
+// Regression: the dialog's local search used to hit a fixed `LIMIT 10` endpoint
+// with no pagination, so a match sorting 11th or later was unreachable even
+// though the Food library (same WHERE, same ORDER BY, paginated) listed it.
+// It also filtered by ownership in the browser, after the server had truncated.
+describe('useDatabaseFoodSearchQuery', () => {
+  let queryClient: QueryClient;
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+  });
+
+  it('reaches a match that sorts past the first page', async () => {
+    mockLoadFoods
+      .mockResolvedValueOnce({
+        foods: Array.from({ length: 10 }, (_, i) =>
+          food(`p1-${i}`, `Bread ${i}`)
+        ),
+        totalCount: 13,
+      })
+      .mockResolvedValueOnce({
+        foods: [food('late', 'Zzz White Bread')],
+        totalCount: 13,
+      });
+
+    const { result } = renderHook(
+      () => useDatabaseFoodSearchQuery('bread', 10, 'all', true),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    // 13 matches, 10 shown: the remaining 3 must be reachable, not dropped.
+    expect(result.current.hasNextPage).toBe(true);
+    expect(result.current.data?.pages.flatMap((p) => p.foods)).toHaveLength(10);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.pages.flatMap((p) => p.foods)).toHaveLength(
+        11
+      )
+    );
+    expect(
+      result.current.data?.pages
+        .flatMap((p) => p.foods)
+        .some((f) => f.name === 'Zzz White Bread')
+    ).toBe(true);
+    expect(mockLoadFoods).toHaveBeenNthCalledWith(
+      2,
+      'bread',
+      'all',
+      2,
+      10,
+      'name:asc'
+    );
+  });
+
+  it('stops paging once the loaded count reaches totalCount', async () => {
+    mockLoadFoods.mockResolvedValueOnce({
+      foods: [food('only', 'Rye Bread')],
+      totalCount: 1,
+    });
+
+    const { result } = renderHook(
+      () => useDatabaseFoodSearchQuery('rye', 10, 'all', true),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.hasNextPage).toBe(false);
+  });
+
+  // The ownership filter has to reach the server. Applied in the browser it
+  // narrows only the rows that survived the page cut, so "Mine" could show a
+  // couple of foods while dozens of matches sat on later pages.
+  it('sends the ownership filter to the server', async () => {
+    mockLoadFoods.mockResolvedValue({ foods: [], totalCount: 0 });
+
+    const { result } = renderHook(
+      () => useDatabaseFoodSearchQuery('bread', 10, 'mine', true),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockLoadFoods).toHaveBeenCalledWith(
+      'bread',
+      'mine',
+      1,
+      10,
+      'name:asc'
+    );
+  });
+});

--- a/SparkyFitnessServer/services/foodCoreService.ts
+++ b/SparkyFitnessServer/services/foodCoreService.ts
@@ -86,7 +86,10 @@ async function searchFoods(
         authenticatedUserId,
         authenticatedUserId
       );
-      const limit = userPreferences?.food_display_limit || limitFromRequest; // Use food_display_limit for search results
+      // item_display_limit, not food_display_limit: the column was renamed by
+      // migration 20250720201800 and this read was never updated, so it
+      // resolved to undefined and the preference silently did nothing.
+      const limit = userPreferences?.item_display_limit || limitFromRequest;
       const foods = await foodRepository.searchFoods(
         name,
         targetUserId || authenticatedUserId,

--- a/SparkyFitnessServer/tests/foodCoreService.test.ts
+++ b/SparkyFitnessServer/tests/foodCoreService.test.ts
@@ -239,7 +239,6 @@ describe('foodCoreService.searchFoods provider metadata', () => {
     // @ts-expect-error mocked in test
     preferenceService.getUserPreferences.mockResolvedValue({
       item_display_limit: 10,
-      food_display_limit: 10,
     });
   });
 
@@ -298,6 +297,65 @@ describe('foodCoreService.searchFoods provider metadata', () => {
 
     expect(foodRepository.updateFood).not.toHaveBeenCalled();
     expect(result.searchResults[0]).toBe(localFood);
+  });
+
+  // Regression: the search limit used to read `food_display_limit`, a column
+  // renamed to `item_display_limit` by migration 20250720201800. That read was
+  // always undefined, so the preference was ignored and the request's own
+  // number won every time. The two must not be equal here, or the assertion
+  // can't tell the preference from the fallback.
+  it('honours the item_display_limit preference over the request limit', async () => {
+    // @ts-expect-error mocked in test
+    preferenceService.getUserPreferences.mockResolvedValue({
+      item_display_limit: 25,
+    });
+    // @ts-expect-error mocked in test
+    foodRepository.searchFoods.mockResolvedValue([]);
+
+    await foodCoreService.searchFoods(
+      TEST_USER_ID,
+      'local',
+      TEST_USER_ID,
+      false,
+      true,
+      false,
+      10
+    );
+
+    expect(foodRepository.searchFoods).toHaveBeenCalledWith(
+      'local',
+      TEST_USER_ID,
+      false,
+      true,
+      false,
+      25
+    );
+  });
+
+  it('falls back to the request limit when no preference is set', async () => {
+    // @ts-expect-error mocked in test
+    preferenceService.getUserPreferences.mockResolvedValue(null);
+    // @ts-expect-error mocked in test
+    foodRepository.searchFoods.mockResolvedValue([]);
+
+    await foodCoreService.searchFoods(
+      TEST_USER_ID,
+      'local',
+      TEST_USER_ID,
+      false,
+      true,
+      false,
+      10
+    );
+
+    expect(foodRepository.searchFoods).toHaveBeenCalledWith(
+      'local',
+      TEST_USER_ID,
+      false,
+      true,
+      false,
+      10
+    );
   });
 });
 

--- a/docs/content/8.developer/7.testing.md
+++ b/docs/content/8.developer/7.testing.md
@@ -83,7 +83,7 @@ jest.mock('@/contexts/ActiveUserContext', () => ({
   useActiveUser: () => ({ activeUserId: 'test-user-id' }),
 }));
 jest.mock('@/contexts/PreferencesContext', () => ({
-  usePreferences: () => ({ loggingLevel: 'debug', foodDisplayLimit: 100 }),
+  usePreferences: () => ({ loggingLevel: 'debug', itemDisplayLimit: 100 }),
 }));
 
 // 3. Mock toast


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

The local food search in the add-food dialog was capped at a fixed number of rows with no pagination, so a match sorting past that cap couldn't be reached at all, even though the Food library listed it and the mobile app found it. The ownership filter made it worse by filtering in the browser, after the server had already truncated.

**How did you implement the solution?**

The dialog's local search now uses `/foods/foods-paginated`, the endpoint the Food library and the mobile app already use, with `item_display_limit` as the page size and a "Load more" that mirrors the existing online-provider results. The ownership filter goes with the request, so it narrows the match set before the page boundary instead of after it.

Separately, the search limit on `GET /foods` and `/foods/search` read `userPreferences.food_display_limit`. Migration `20250720201800_rename_food_display_limit_to_item_display_limit.sql` renamed that column, so the read resolved to `undefined` and the preference never applied to anything. It now reads `item_display_limit`. The frontend mirror of the same dead preference is removed, and the online-provider page size reads the surviving preference instead.

Linked Issue: Closes #2333

## How to Test

1. Check out this branch, then run `pnpm install` and start the stack.
2. Create enough foods that a common search word matches more than `item_display_limit` of them (default 10), and make sure one of them sorts alphabetically last, for example brand "Test Bakery", name "Zzz White Keto Bread".
3. Open the diary, pick a meal, and click the add-food button. Search for the common word.
4. The local "Your Foods" list now ends with a "Load more" button. Click it and confirm the last-sorting food appears.
5. Set the ownership dropdown to "My Foods" and repeat. The count should reflect every food you own that matches, not just the ones that survived the first page.

Automated coverage:

- `SparkyFitnessFrontend/src/tests/hooks/useDatabaseFoodSearchQuery.test.tsx` covers reaching a match past the first page, stopping at `totalCount`, and sending the ownership filter to the server.
- `SparkyFitnessServer/tests/foodCoreService.test.ts` covers the preference being honoured and the fallback when none is set.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

<img width="1043" height="550" alt="2026-08-31 16_33_24-Greenshot" src="https://github.com/user-attachments/assets/8ac9432f-50ed-4a27-959f-297fb45116db" />

</details>

## Notes for Reviewers

No new endpoints or tables, so the Zod and RLS items don't apply. No translation keys were added: the button reuses the existing `enhancedFoodSearch.loadMore`.

Two things:

Removing the dead `food_display_limit` preference leaves `item_display_limit` governing both the landing sections and the search page size. Defaults are unchanged at 10, so this is not a behaviour change out of the box, but it does mean the existing Settings control now affects search results as well. Happy to split that into its own change if we'd rather keep the preferences separate.

`MealBuilder` used the old capped search helper for a different job: matching an incoming meal food against an existing food by name before creating a duplicate. That call is preserved as `foodNameLookupOptions` with its own cache key rather than folded into the paginated search. Note that this lookup reads the response as an array while the endpoint returns `{ searchResults: [...] }`, so the match never succeeds. That predates this PR and isn't changed here, but it looks like a real bug worth its own issue.

The search ordering is still exact-substring-first then name, with no recency or relevance weighting. That's unchanged here, and it's the reason a newly added food can land on a later page in the first place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added paginated food search with server-side ownership filtering.
  * Added a “Load more” option for the “Your Foods” section.
  * Improved name matching when adding imported or unsaved meal ingredients.

* **Bug Fixes**
  * Food searches now honor the configured item display limit.
  * Search results refresh correctly when the display limit changes.

* **Improvements**
  * Renamed the food display limit preference to the broader item display limit.
  * Improved consistency across provider searches and cached results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->