### PR TITLE
fix(mobile): stop the food-search provider overriding the barcode provider

### DIFF
--- a/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/FoodSearchScreen.test.tsx
@@ -861,6 +861,36 @@ describe('FoodSearchScreen', () => {
     );
   });
 
+  it('does not forward the food-search provider to the barcode scanner', () => {
+    // A provider is actively selected in food search (no saved default, so the
+    // screen falls back to providers[0] — the "First Available" case). The
+    // barcode scanner must not inherit it: the server has to be left free to
+    // resolve default_barcode_provider_id, or an explicit Barcode Scanning
+    // preference gets silently overridden by Default Food Source.
+    mockUseExternalProviders.mockReturnValue(fatSecretProvider);
+    const screen = render(
+      <SafeAreaProvider initialMetrics={{ insets, frame }}>
+        <FoodSearchScreen navigation={navigation} route={route} />
+      </SafeAreaProvider>
+    );
+    fireEvent.press(screen.getByLabelText('Scan Food'));
+
+    // Positive control: the screen really has settled on FatSecret for online
+    // search. Without this the absence check below could pass simply because no
+    // provider was selected yet.
+    expect(mockUseExternalFoodSearch).toHaveBeenLastCalledWith(
+      expect.anything(),
+      'fatsecret',
+      expect.objectContaining({ providerId: 'p1' })
+    );
+
+    const scanCall = navigation.navigate.mock.calls.find(
+      ([screenName]: [string]) => screenName === 'FoodScan'
+    );
+    expect(scanCall).toBeDefined();
+    expect(scanCall[1]).not.toHaveProperty('providerId');
+  });
+
   describe('persisted "All Providers" default', () => {
     const twoProviders = {
       providers: [

--- a/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FoodSearchScreen.tsx
@@ -385,21 +385,13 @@ const FoodSearchScreen: React.FC<FoodSearchScreenProps> = ({
       // Preserve the originating meal type (MealTypeDetail → FoodSearch → scan).
       mealTypeId: mealTypeId ?? undefined,
       mealPlanTarget,
-      // Never forward the All Providers sentinel as a real provider; the scanner
-      // should fall back to its default provider in that mode.
-      providerId:
-        selectedProvider === ALL_PROVIDERS_VALUE
-          ? undefined
-          : (selectedProvider ?? undefined),
+      // Deliberately no providerId. The food-search provider is not the barcode
+      // provider, and the server treats an explicit providerId as winning over
+      // default_barcode_provider_id, so forwarding it here silently overrode the
+      // user's Barcode Scanning setting. Let the server resolve the preference,
+      // matching the "+" → Scan Food entry point.
     });
-  }, [
-    navigation,
-    date,
-    mealPlanTarget,
-    mealTypeId,
-    selectedProvider,
-    selectionPickerMode,
-  ]);
+  }, [navigation, date, mealPlanTarget, mealTypeId, selectionPickerMode]);
 
   // Only the custom-header path opens the JS menu; on the native path the
   // system presents a UIMenu from the header item directly.


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

On the mobile app, a barcode scan started from the food search screen ignores the Barcode Scanning provider setting, so the same barcode can resolve through a different provider than the one the user picked.

**How did you implement the solution?**

`FoodSearchScreen` forwarded the currently selected food-search provider as `providerId` when navigating to `FoodScan`. The server resolves the barcode provider as `providerId || default_barcode_provider_id`, so an explicit param always wins and the Barcode Scanning preference never applies on that path. The "+" -> Scan Food entry point sends no `providerId` and already behaves correctly, so the same barcode resolved differently depending on which entry point was used. With Default Food Source set to "First Available" the screen falls back to `providers[0]`, which pins barcode lookups to whichever provider happens to sort first.

This drops the param so both entry points let the server resolve the preference, matching the web client, which prefers `defaultBarcodeProviderId`.

Linked Issue: Closes #2339

## How to Test

1. In app Settings, set Default Food Source to a provider that isn't your barcode provider (or to "First Available"), and set Barcode Scanning to a different provider, for example USDA.
2. Open a meal, tap "+" -> Scan Food, and scan a barcode. Note which provider the result comes from. This path was already correct.
3. Go back, open Food Search, and tap the scan icon in the search bar. Scan the same barcode.
4. Before this change, step 3 used the food-search provider and could fail or return a different item than step 2. After it, both paths use the Barcode Scanning provider and return the same result.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

No visual change. The fix only affects which provider the scanner asks, so there's nothing to show side by side.

## Notes for Reviewers

The removed branch also handled the All Providers sentinel, which is why the old code read as deliberate. That guard is no longer needed: with no `providerId` at all, the sentinel can never reach the scanner, and the server's own default resolution takes over.

Test coverage: `__tests__/screens/FoodSearchScreen.test.tsx` gets a case asserting the navigate payload has no `providerId`. It carries a positive control that the screen really has settled on a food-search provider first, so the assertion can't pass just because nothing was selected yet.

**A follow-up worth deciding separately, not in this PR.** After this change nothing in the app sets the `providerId` route param on `FoodScan`, but `types/navigation.ts` still declares it and `FoodScanScreen` still reads it, so it's now a consumer with no producer. `EditBarcodeScreen` already calls `lookupBarcodeV2(barcode)` with no provider, so the one-arg form is the norm in mobile and this screen was the odd one out.

I've left the param in place deliberately, to keep this a tight bugfix and because the web `BarcodeScannerDialog` has a per-scan provider dropdown that mobile doesn't yet, so the slot has a plausible future consumer if mobile ever reaches parity. The argument the other way is that an unset `providerId` slot on a barcode screen is what invited this bug: someone saw an empty parameter and wired the nearest plausible value into it, and leaving it keeps that available to the next person. Stripping it would spread the diff into `FoodScanScreen` and the navigation types, which turns a bugfix into a fix plus refactor.

Happy to strip it in a follow-up if we'd prefer the preference to be the single source of truth for provider selection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Barcode scanning now uses the server-configured provider instead of inheriting the provider selected for food search.
  - Scanning works consistently when a specific provider or “All Providers” is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->