### PR TITLE
fix(mobile): show a point marker on charts with a single data point

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/WeightLineChart.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/WeightLineChart.test.tsx
@@ -9,8 +9,8 @@ import type { WeightDataPoint } from '../../src/hooks/useMeasurementsRange';
 // `LineSeriesMark` itself is deliberately left real, so these cases assert what the user
 // actually sees rather than only the prop wiring.
 jest.mock('victory-native', () => {
-  const ReactModule = require('react');
-  const { View } = require('react-native');
+  const ReactModule: typeof import('react') = require('react');
+  const { View }: typeof import('react-native') = require('react-native');
   return {
     CartesianChart: ({
       children,

--- a/SparkyFitnessMobile/__tests__/components/WeightLineChart.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/WeightLineChart.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import WeightLineChart from '../../src/components/WeightLineChart';
+import type { WeightDataPoint } from '../../src/hooks/useMeasurementsRange';
+
+// The global `victory-native` mock in jest.setup.js drops `CartesianChart`'s children and
+// exports neither `Line` nor `Scatter`, so no mark would ever render. Stub the chart to
+// invoke its render-prop with plotted points, and each mark as an identifiable View.
+// `LineSeriesMark` itself is deliberately left real, so these cases assert what the user
+// actually sees rather than only the prop wiring.
+jest.mock('victory-native', () => {
+  const ReactModule = require('react');
+  const { View } = require('react-native');
+  return {
+    CartesianChart: ({
+      children,
+      data,
+    }: {
+      children: (arg: unknown) => React.ReactNode;
+      data: { day: string; weight: number }[];
+    }) => {
+      // Stable identity across renders: `ChartLayoutReporter` reports the render arg through
+      // an effect keyed on it, so fresh objects each render would spin the chart's layout state.
+      const renderArg = ReactModule.useMemo(
+        () => ({
+          points: {
+            weight: data.map((datum, index) => ({
+              x: index * 10,
+              xValue: datum.day,
+              y: 100 - index,
+              yValue: datum.weight,
+            })),
+          },
+          chartBounds: { left: 0, right: 100, top: 0, bottom: 100 },
+        }),
+        [data]
+      );
+
+      return ReactModule.createElement(
+        View,
+        { testID: 'cartesian-chart' },
+        children(renderArg)
+      );
+    },
+    Line: (props: Record<string, unknown>) =>
+      ReactModule.createElement(View, { testID: 'line-mark', ...props }),
+    Scatter: (props: Record<string, unknown>) =>
+      ReactModule.createElement(View, { testID: 'scatter-mark', ...props }),
+  };
+});
+
+const weightSeries = (count: number): WeightDataPoint[] =>
+  Array.from({ length: count }, (_, index) => ({
+    day: `2026-06-0${index + 1}`,
+    weight: 80 + index,
+  }));
+
+const renderChart = (data: WeightDataPoint[]) =>
+  render(
+    <WeightLineChart
+      data={data}
+      isLoading={false}
+      isError={false}
+      range="7d"
+      unit="kg"
+    />
+  );
+
+describe('WeightLineChart', () => {
+  it('draws a point mark when the window holds a single weigh-in', () => {
+    renderChart(weightSeries(1));
+
+    expect(screen.getByTestId('scatter-mark')).toBeTruthy();
+    expect(screen.queryByTestId('line-mark')).toBeNull();
+  });
+
+  it('draws a line when the window holds several weigh-ins', () => {
+    renderChart(weightSeries(3));
+
+    expect(screen.getByTestId('line-mark')).toBeTruthy();
+    expect(screen.queryByTestId('scatter-mark')).toBeNull();
+  });
+
+  it("keeps the weight line's stroke, curve, and animation settings", () => {
+    renderChart(weightSeries(3));
+
+    const line = screen.getByTestId('line-mark');
+    expect(line.props.strokeWidth).toBe(2);
+    expect(line.props.curveType).toBe('cardinal');
+    expect(line.props.connectMissingData).toBe(true);
+    expect(line.props.animate).toEqual({ type: 'timing', duration: 300 });
+    // The global `uniwind` mock resolves every CSS variable to this value.
+    expect(line.props.color).toBe('#888888');
+  });
+
+  it('renders nothing when there is no weight data and the query is idle', () => {
+    expect(renderChart([]).toJSON()).toBeNull();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/components/charts/LineSeriesMark.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/charts/LineSeriesMark.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import type { PointsArray } from 'victory-native';
+import LineSeriesMark from '../../../src/components/charts/LineSeriesMark';
+
+// The global `victory-native` mock in jest.setup.js exports neither `Line` nor `Scatter`,
+// so both would be `undefined` here. Stub each as an identifiable View carrying its props
+// so the forwarded values can be read back off the rendered element.
+jest.mock('victory-native', () => {
+  const ReactModule = require('react');
+  const { View } = require('react-native');
+  return {
+    Line: (props: Record<string, unknown>) =>
+      ReactModule.createElement(View, { testID: 'line-mark', ...props }),
+    Scatter: (props: Record<string, unknown>) =>
+      ReactModule.createElement(View, { testID: 'scatter-mark', ...props }),
+  };
+});
+
+const makePoints = (count: number): PointsArray =>
+  Array.from({ length: count }, (_, index) => ({
+    x: index * 10,
+    xValue: `2026-06-0${index + 1}`,
+    y: 100 - index,
+    yValue: 80 + index,
+  }));
+
+const ANIMATE = { type: 'timing', duration: 300 } as const;
+
+describe('LineSeriesMark', () => {
+  it('renders a Scatter instead of a Line for a one-point series', () => {
+    render(<LineSeriesMark points={makePoints(1)} color="#ABCDEF" />);
+
+    expect(screen.getByTestId('scatter-mark')).toBeTruthy();
+    expect(screen.queryByTestId('line-mark')).toBeNull();
+  });
+
+  it("gives the single-point Scatter a circle shape, a 5px radius, and the caller's color", () => {
+    render(<LineSeriesMark points={makePoints(1)} color="#ABCDEF" />);
+
+    const scatter = screen.getByTestId('scatter-mark');
+    expect(scatter.props.shape).toBe('circle');
+    expect(scatter.props.radius).toBe(5);
+    expect(scatter.props.color).toBe('#ABCDEF');
+  });
+
+  it("forwards the caller's animate config to the Scatter", () => {
+    render(
+      <LineSeriesMark
+        points={makePoints(1)}
+        color="#ABCDEF"
+        animate={ANIMATE}
+      />
+    );
+
+    expect(screen.getByTestId('scatter-mark').props.animate).toEqual(ANIMATE);
+  });
+
+  it('renders a Scatter without throwing for an empty series', () => {
+    render(<LineSeriesMark points={makePoints(0)} color="#ABCDEF" />);
+
+    expect(screen.getByTestId('scatter-mark').props.points).toHaveLength(0);
+  });
+
+  it('renders a Line once the series has two points', () => {
+    render(<LineSeriesMark points={makePoints(2)} color="#ABCDEF" />);
+
+    expect(screen.getByTestId('line-mark')).toBeTruthy();
+    expect(screen.queryByTestId('scatter-mark')).toBeNull();
+  });
+
+  it('forwards every line prop verbatim for a multi-point series', () => {
+    render(
+      <LineSeriesMark
+        points={makePoints(3)}
+        color="#ABCDEF"
+        strokeWidth={2}
+        curveType="cardinal"
+        connectMissingData
+        animate={ANIMATE}
+      />
+    );
+
+    const line = screen.getByTestId('line-mark');
+    expect(line.props.color).toBe('#ABCDEF');
+    expect(line.props.strokeWidth).toBe(2);
+    expect(line.props.curveType).toBe('cardinal');
+    expect(line.props.connectMissingData).toBe(true);
+    expect(line.props.animate).toEqual(ANIMATE);
+  });
+});

--- a/SparkyFitnessMobile/__tests__/components/charts/LineSeriesMark.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/charts/LineSeriesMark.test.tsx
@@ -7,8 +7,8 @@ import LineSeriesMark from '../../../src/components/charts/LineSeriesMark';
 // so both would be `undefined` here. Stub each as an identifiable View carrying its props
 // so the forwarded values can be read back off the rendered element.
 jest.mock('victory-native', () => {
-  const ReactModule = require('react');
-  const { View } = require('react-native');
+  const ReactModule: typeof import('react') = require('react');
+  const { View }: typeof import('react-native') = require('react-native');
   return {
     Line: (props: Record<string, unknown>) =>
       ReactModule.createElement(View, { testID: 'line-mark', ...props }),

--- a/SparkyFitnessMobile/__tests__/components/wellness/BBTLineChart.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/wellness/BBTLineChart.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import BBTLineChart from '../../../src/components/wellness/BBTLineChart';
+
+// Same reason as `WeightLineChart.test.tsx`: the global `victory-native` mock renders no
+// chart children and exports no marks. Note the y-key here is `yValue`, not `weight`.
+jest.mock('victory-native', () => {
+  const ReactModule = require('react');
+  const { View } = require('react-native');
+  return {
+    CartesianChart: ({
+      children,
+      data,
+    }: {
+      children: (arg: unknown) => React.ReactNode;
+      data: { xValue: string; yValue: number }[];
+    }) => {
+      // The render arg has to keep a stable identity across renders. `ChartLayoutReporter`
+      // reports it through an effect keyed on it, and `BBTLineChart` feeds that straight
+      // into state — fresh objects here would loop until the heap gives out.
+      const renderArg = ReactModule.useMemo(
+        () => ({
+          points: {
+            yValue: data.map((datum, index) => ({
+              x: index * 10,
+              xValue: datum.xValue,
+              y: 100 - index,
+              yValue: datum.yValue,
+            })),
+          },
+          chartBounds: { left: 0, right: 100, top: 0, bottom: 100 },
+        }),
+        [data]
+      );
+
+      return ReactModule.createElement(
+        View,
+        { testID: 'cartesian-chart' },
+        children(renderArg)
+      );
+    },
+    Line: (props: Record<string, unknown>) =>
+      ReactModule.createElement(View, { testID: 'line-mark', ...props }),
+    Scatter: (props: Record<string, unknown>) =>
+      ReactModule.createElement(View, { testID: 'scatter-mark', ...props }),
+  };
+});
+
+const bbtSeries = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    date: `2026-06-0${index + 1}`,
+    bbt: 36.4 + index * 0.1,
+  }));
+
+const renderChart = (data: ReturnType<typeof bbtSeries>) =>
+  render(<BBTLineChart data={data} isLoading={false} />);
+
+describe('BBTLineChart', () => {
+  it('draws a point mark for a single temperature reading', () => {
+    renderChart(bbtSeries(1));
+
+    expect(screen.getByTestId('scatter-mark')).toBeTruthy();
+    expect(screen.queryByTestId('line-mark')).toBeNull();
+  });
+
+  it('draws a line for several temperature readings', () => {
+    renderChart(bbtSeries(3));
+
+    expect(screen.getByTestId('line-mark')).toBeTruthy();
+    expect(screen.queryByTestId('scatter-mark')).toBeNull();
+  });
+
+  it("does not pick up the weight chart's curve or animation options", () => {
+    renderChart(bbtSeries(3));
+
+    const line = screen.getByTestId('line-mark');
+    expect(line.props.strokeWidth).toBe(2);
+    expect(line.props.curveType).toBeUndefined();
+    expect(line.props.connectMissingData).toBeUndefined();
+    expect(line.props.animate).toBeUndefined();
+  });
+
+  it('keeps the empty state when there are no readings', () => {
+    renderChart([]);
+
+    expect(
+      screen.getByText('Log daily temperature logs to view your BBT chart.')
+    ).toBeTruthy();
+    expect(screen.queryByTestId('line-mark')).toBeNull();
+    expect(screen.queryByTestId('scatter-mark')).toBeNull();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/components/wellness/BBTLineChart.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/wellness/BBTLineChart.test.tsx
@@ -5,8 +5,8 @@ import BBTLineChart from '../../../src/components/wellness/BBTLineChart';
 // Same reason as `WeightLineChart.test.tsx`: the global `victory-native` mock renders no
 // chart children and exports no marks. Note the y-key here is `yValue`, not `weight`.
 jest.mock('victory-native', () => {
-  const ReactModule = require('react');
-  const { View } = require('react-native');
+  const ReactModule: typeof import('react') = require('react');
+  const { View }: typeof import('react-native') = require('react-native');
   return {
     CartesianChart: ({
       children,

--- a/SparkyFitnessMobile/src/components/WeightLineChart.tsx
+++ b/SparkyFitnessMobile/src/components/WeightLineChart.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View, Text } from 'react-native';
-import { CartesianChart, Line } from 'victory-native';
+import { CartesianChart } from 'victory-native';
 import { useCSSVariable } from 'uniwind';
 import { formatLocalizedNumber } from '../localization/i18n';
 import {
@@ -11,6 +11,7 @@ import {
   formatXLabel30d90d,
   formatTooltipDate,
 } from './charts/chartFormatting';
+import LineSeriesMark from './charts/LineSeriesMark';
 import type { WeightDataPoint } from '../hooks/useMeasurementsRange';
 import type { HealthTrendDateRange } from '../types/healthTrends';
 import ChartTouchOverlay, {
@@ -188,7 +189,7 @@ const WeightLineChart: React.FC<WeightLineChartProps> = ({
                   points={points.weight}
                   onChange={handleTouchLayoutChange}
                 />
-                <Line
+                <LineSeriesMark
                   points={points.weight}
                   color={accentColor}
                   strokeWidth={2}

--- a/SparkyFitnessMobile/src/components/charts/LineSeriesMark.tsx
+++ b/SparkyFitnessMobile/src/components/charts/LineSeriesMark.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Line, Scatter } from 'victory-native';
+
+/**
+ * A one-point series has no line to stroke — `d3-shape` emits a bare `moveTo` for it and
+ * Skia draws nothing — so the lone reading is rendered as a dot instead. Sized to read as
+ * a deliberate marker rather than a stray pixel at the trend charts' plot height.
+ */
+const SINGLE_POINT_RADIUS = 5;
+
+type LineSeriesMarkProps = React.ComponentProps<typeof Line>;
+
+/**
+ * Drop-in replacement for victory-native's `<Line>` that stays visible below two points.
+ * Takes the same props, so a caller's curve, animation, and stroke options carry over
+ * untouched on the multi-point path.
+ */
+const LineSeriesMark: React.FC<LineSeriesMarkProps> = ({
+  points,
+  ...lineProps
+}) => {
+  if (points.length < 2) {
+    return (
+      <Scatter
+        points={points}
+        color={lineProps.color}
+        radius={SINGLE_POINT_RADIUS}
+        shape="circle"
+        animate={lineProps.animate}
+      />
+    );
+  }
+
+  return <Line points={points} {...lineProps} />;
+};
+
+export default LineSeriesMark;

--- a/SparkyFitnessMobile/src/components/wellness/BBTLineChart.tsx
+++ b/SparkyFitnessMobile/src/components/wellness/BBTLineChart.tsx
@@ -1,9 +1,10 @@
 import React, { useMemo, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { View, Text } from 'react-native';
-import { CartesianChart, Line } from 'victory-native';
+import { CartesianChart } from 'victory-native';
 import { useCSSVariable } from 'uniwind';
 import { makeChartFont, formatTooltipDate } from '../charts/chartFormatting';
+import LineSeriesMark from '../charts/LineSeriesMark';
 import { formatLocalizedNumber, getAppLocale } from '../../localization';
 import ChartTouchOverlay, {
   ChartLayoutReporter,
@@ -153,7 +154,7 @@ const BBTLineChart: React.FC<BBTLineChartProps> = ({ data, isLoading }) => {
         >
           {({ points, chartBounds }) => (
             <>
-              <Line
+              <LineSeriesMark
                 points={points.yValue}
                 color={accentColor || '#3B82F6'}
                 strokeWidth={2}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

When a Health Trends window contains exactly one weight measurement, the chart draws its card, axes and tick labels but nothing in the plot area, so the measurement is invisible. The Cycle Hub BBT chart has the same defect.

**How did you implement the solution?**

- A line has no geometry for a one-point series — `d3-shape`'s `line()` emits a bare `moveTo` with no segment after it, so Skia strokes an empty path. The data and the scales were already correct: `transformInputData` widens both degenerate domains, and `buildChartTouchZones` already gives a lone point the full chart width, which is why long-pressing the blank plot area surfaced the right tooltip.
- Added `src/components/charts/LineSeriesMark.tsx`, a drop-in replacement for victory-native's `<Line>` that renders a `<Scatter>` circle when the series holds fewer than two points and delegates to `<Line>` otherwise. It takes `<Line>`'s exact prop surface, so each caller's curve, stroke and animation options carry over untouched on the multi-point path.
- Swapped `<Line>` for it in `WeightLineChart` (Health Trends) and `wellness/BBTLineChart` (Cycle Hub). Extracting rather than duplicating follows the repo's rule-of-two guidance, since this is the second occurrence of the same defect.
- No dots are added on top of the line at any range size — the marker appears only when a line cannot be drawn.

Linked Issue: Closes #2343

## How to Test

1. Check out this branch and run `cd SparkyFitnessMobile && pnpm exec jest --watchman=false --runInBand __tests__/components/charts/LineSeriesMark.test.tsx __tests__/components/WeightLineChart.test.tsx __tests__/components/wellness/BBTLineChart.test.tsx`
2. On device or emulator, record a weight measurement for exactly one day inside the last 7 days.
3. Go to Dashboard → scroll to **Health Trends** → swipe to the **Weight** page with the **7d** range selected.
4. Verify a dot is drawn at that measurement.
5. Record a second weigh-in in the same window (or switch to **30d** / **90d** with several weigh-ins) and verify the chart returns to the usual line, unchanged.
6. For the BBT chart: Cycle Hub → Insights with a single logged temperature shows a dot; several readings show the line.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

<img width="250" alt="Weight chart with a single measurement renders an empty plot area" src="https://github.com/user-attachments/assets/7d872e94-6fe2-4982-b724-823bfecebd10" />

### After

<img width="250" alt="Screenshot_1788316257" src="https://github.com/user-attachments/assets/5b9abede-7926-4b40-899e-1b3c9fe0a2ea" />

</details>

## Notes for Reviewers

- **BBT chart is included deliberately.** #2343 only reports the weight chart, but `wellness/BBTLineChart` had the identical `<Line>`-only structure and the identical blind spot. It matters more there: BBT logging starts from zero readings, so a user's first logged temperature is exactly the one-point case. Happy to split it out if you'd rather keep the PR to the reported symptom.
- **`points.length < 2`, not `=== 1`** — the predicate states the real condition (a line needs two endpoints). Both callers already short-circuit the empty case before rendering, so the branch is only reached with exactly one point in practice.
- **`SINGLE_POINT_RADIUS` is module-private** rather than exported, so Knip doesn't flag it as an unused export during `pnpm run validate`.
- **The check counts raw points, not points with a numeric `yValue`.** A two-point series with one `null` y would still stroke nothing. No caller produces one today (`weightData` only holds real weigh-ins; `bbtSeries` types `bbt` as non-nullable), so this is a bounded assumption rather than a live bug — worth revisiting if a sparse series is ever passed.
- **Test-harness note for anyone extending these suites:** the global `victory-native` mock in `jest.setup.js` exports no `Line`/`Scatter` and its `CartesianChart` drops `children`, so each new suite supplies a local mock. That local `CartesianChart` stub must *memoize* the object it hands to the render-prop — `ChartLayoutReporter` reports it through an effect keyed on it and `BBTLineChart` feeds that straight into state, so a fresh object per render loops until the Node heap is exhausted. Real victory-native memoizes `points`, so this is a harness constraint only.
- **Verification:** `pnpm run validate` and the full mobile suite (394 suites / 6314 tests) pass; the single-point case was confirmed on an Android emulator. The multi-point path is covered by the new tests rather than re-checked by hand on device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weight and basal body temperature charts so a single reading is displayed as a visible data point instead of appearing blank.
  * Preserved line chart styling, animation, and display behavior when multiple readings are available.
  * Improved empty-state handling so charts with no readings continue to show the appropriate empty state.

* **Tests**
  * Added coverage for single-reading, multiple-reading, styling, animation, and empty-state chart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->