### PR TITLE
feat(mobile): show ask-user options as quick replies

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/chat/AskUserToolCard.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/chat/AskUserToolCard.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react-native';
+import AskUserToolCard from '../../../src/components/chat/AskUserToolCard';
+
+const mockAppend = jest.fn();
+let mockIsLast = true;
+let mockIsRunning = false;
+
+jest.mock('@assistant-ui/react-native', () => ({
+  useAui: () => ({
+    thread: () => ({ append: mockAppend }),
+  }),
+  useAuiState: (
+    selector: (state: {
+      message: { isLast: boolean };
+      thread: { isRunning: boolean };
+    }) => unknown
+  ) =>
+    selector({
+      message: { isLast: mockIsLast },
+      thread: { isRunning: mockIsRunning },
+    }),
+}));
+
+const askPart = {
+  type: 'tool-call' as const,
+  toolCallId: 'ask-1',
+  toolName: 'sparky_ask_user',
+  args: {
+    mode: 'choose' as const,
+    question: 'Which serving?',
+    options: ['Small', 'Medium', 'Large'],
+  },
+  argsText:
+    '{"mode":"choose","question":"Which serving?","options":["Small","Medium","Large"]}',
+  result: 'Presented 3 options to the user.',
+};
+
+describe('AskUserToolCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsLast = true;
+    mockIsRunning = false;
+  });
+
+  it('renders the question and every quick-reply option', () => {
+    const { getByText } = render(<AskUserToolCard part={askPart} />);
+
+    expect(getByText('Which serving?')).toBeTruthy();
+    expect(getByText('Small')).toBeTruthy();
+    expect(getByText('Medium')).toBeTruthy();
+    expect(getByText('Large')).toBeTruthy();
+  });
+
+  it('sends a selected option as an ordinary user message', () => {
+    const { getByText } = render(<AskUserToolCard part={askPart} />);
+
+    fireEvent.press(getByText('Medium'));
+
+    expect(mockAppend).toHaveBeenCalledWith({
+      role: 'user',
+      content: [{ type: 'text', text: 'Medium' }],
+    });
+  });
+
+  it('prevents duplicate sends from repeated taps', () => {
+    const { getByText } = render(<AskUserToolCard part={askPart} />);
+
+    fireEvent.press(getByText('Large'));
+    fireEvent.press(getByText('Large'));
+
+    expect(mockAppend).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables stale options from older messages', () => {
+    mockIsLast = false;
+    const { getByText } = render(<AskUserToolCard part={askPart} />);
+
+    fireEvent.press(getByText('Small'));
+
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('disables options while the thread is running', () => {
+    mockIsRunning = true;
+    const { getByText } = render(<AskUserToolCard part={askPart} />);
+
+    fireEvent.press(getByText('Small'));
+
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it('waits for the streamed question before rendering options', () => {
+    const { queryByText } = render(
+      <AskUserToolCard
+        part={{
+          ...askPart,
+          args: { mode: 'choose', options: askPart.args.options },
+        }}
+      />
+    );
+
+    expect(queryByText('Small')).toBeNull();
+    expect(queryByText('Medium')).toBeNull();
+    expect(queryByText('Large')).toBeNull();
+  });
+
+  it('waits for at least two streamed options before rendering', () => {
+    const { queryByText } = render(
+      <AskUserToolCard
+        part={{
+          ...askPart,
+          args: { ...askPart.args, options: ['Small'] },
+        }}
+      />
+    );
+
+    expect(queryByText('Which serving?')).toBeNull();
+    expect(queryByText('Small')).toBeNull();
+  });
+});

--- a/SparkyFitnessMobile/src/components/chat/AskUserToolCard.tsx
+++ b/SparkyFitnessMobile/src/components/chat/AskUserToolCard.tsx
@@ -1,0 +1,64 @@
+import { useRef } from 'react';
+import { Pressable, Text, View } from 'react-native';
+import {
+  useAui,
+  useAuiState,
+  type ToolCallMessagePart,
+} from '@assistant-ui/react-native';
+import { MIN_ASK_USER_OPTIONS, type AskUserInput } from '@workspace/shared';
+
+export default function AskUserToolCard({
+  part,
+}: {
+  part: ToolCallMessagePart;
+}) {
+  const aui = useAui();
+  const isLast = useAuiState((state) => state.message.isLast);
+  const isRunning = useAuiState((state) => state.thread.isRunning);
+  const sentRef = useRef(false);
+  const args = part.args as Partial<AskUserInput>;
+  const options = Array.isArray(args.options)
+    ? args.options.filter(
+        (option): option is string => typeof option === 'string'
+      )
+    : [];
+  const question =
+    typeof args.question === 'string' ? args.question.trim() : '';
+
+  if (!question || options.length < MIN_ASK_USER_OPTIONS) return null;
+
+  const disabled = !isLast || isRunning;
+  const send = (option: string) => {
+    if (!isLast || isRunning || sentRef.current) return;
+    sentRef.current = true;
+    aui.thread().append({
+      role: 'user',
+      content: [{ type: 'text', text: option }],
+    });
+  };
+
+  return (
+    <View className="my-2 gap-2">
+      <Text className="text-text-secondary text-sm">{question}</Text>
+      <View className="flex-row flex-wrap gap-2">
+        {options.map((option) => (
+          <Pressable
+            key={option}
+            accessibilityRole="button"
+            accessibilityLabel={option}
+            accessibilityState={{ disabled }}
+            disabled={disabled}
+            onPress={() => send(option)}
+            className={`rounded-full border border-border-subtle bg-background px-3 py-2 ${
+              disabled ? 'opacity-50' : 'active:bg-surface'
+            }`}
+          >
+            <Text className="text-text-primary text-sm font-medium">
+              {option}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}

--- a/SparkyFitnessMobile/src/screens/ChatScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ChatScreen.tsx
@@ -42,7 +42,9 @@ import {
   useChatRuntime,
   AssistantChatTransport,
 } from '@assistant-ui/react-ai-sdk';
+import { ASK_USER_TOOL_NAME } from '@workspace/shared';
 import Icon from '../components/Icon';
+import AskUserToolCard from '../components/chat/AskUserToolCard';
 import ToolCallCard from '../components/chat/ToolCallCard';
 import TypingIndicator from '../components/chat/TypingIndicator';
 import MarkdownMessage from '../components/chat/MarkdownMessage';
@@ -218,7 +220,13 @@ function MessageBubble({ role }: { role: MessageRole }) {
                 <MarkdownMessage text={part.text} streaming={isStreaming} />
               )
             }
-            renderToolCall={({ part }) => <ToolCallCard part={part} />}
+            renderToolCall={({ part }) =>
+              part.toolName === ASK_USER_TOOL_NAME ? (
+                <AskUserToolCard part={part} />
+              ) : (
+                <ToolCallCard part={part} />
+              )
+            }
           />
         )}
       </View>


### PR DESCRIPTION
## Description

Mobile showed `sparky_ask_user` as a generic tool card, so the question options could not be selected. This adds a dedicated mobile card with tappable quick replies.

Tapping an option sends it as a normal user message. Options are disabled while the thread is running and after the conversation moves on.

Linked Issue: Closes #2149

## How to Test

1. Configure a chat provider and open Ask Sparky in the mobile app.
2. Send an ambiguous request that asks for clarification, such as `Add five pancakes`.
3. Verify that the question and options appear as buttons.
4. Tap an option and verify that it is sent as a user message.
5. Verify that options on older messages cannot be selected again.

Checks run:

- `pnpm exec jest --watchman=false --runInBand` — 392 suites, 6307 tests passed
- `pnpm run validate`
- Verified on a physical Android device

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

### Before

The generic tool card only showed the tool result text, so there was no way to select an option. See the reproduction details in #2149.

### After

![Ask-user options in the mobile chat](https://github.com/user-attachments/assets/894e1d5a-572b-4ac8-9013-2bedba73ceea)

## Notes for Reviewers

The component uses shared React Native primitives and follows the existing web behavior. The implementation was verified on Android; the issue reporter also offered to test it on iOS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick-reply cards to chat when the assistant asks a question.
  * Users can select an available response to send it directly as a message.
  * Quick replies remain unavailable for outdated messages or while a response is processing.
* **Bug Fixes**
  * Prevented duplicate submissions from repeated taps.
  * Cards remain hidden until a valid question and sufficient response options are available.
* **Tests**
  * Added coverage for rendering, selection, disabled states, streaming readiness, and duplicate-submission prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->