### PR TITLE
fix(exercise): data sync orphaned child writes

### DIFF
--- a/SparkyFitnessServer/models/activityDetailsRepository.ts
+++ b/SparkyFitnessServer/models/activityDetailsRepository.ts
@@ -1,5 +1,6 @@
 import { getClient } from '../db/poolManager.js';
 import { log } from '../config/logging.js';
+import type { PoolClient } from 'pg';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function _createActivityDetailWithClient(client: any, detail: any) {
   const {
@@ -297,24 +298,27 @@ async function deleteActivityDetail(userId: any, id: any) {
   }
 }
 async function _deleteActivityDetailsByEntryIdAndProviderWithClient(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  client: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  entryId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  providerName: any
+  client: PoolClient,
+  userId: string,
+  entryId: string,
+  providerName: string,
+  detailType?: string
 ) {
   const query = `
         DELETE FROM exercise_entry_activity_details
         WHERE (exercise_entry_id = $1 OR exercise_preset_entry_id = $1)
           AND provider_name = $2
+          AND ($4::text IS NULL OR detail_type = $4)
           AND (exercise_entry_id IN (SELECT id FROM exercise_entries WHERE user_id = $3)
                OR exercise_preset_entry_id IN (SELECT id FROM exercise_preset_entries WHERE user_id = $3));
     `;
   try {
-    const result = await client.query(query, [entryId, providerName, userId]);
+    const result = await client.query(query, [
+      entryId,
+      providerName,
+      userId,
+      detailType ?? null,
+    ]);
     log(
       'debug',
       `Successfully deleted ${result.rowCount} activity details for entry ID ${entryId} and provider ${providerName}.`

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -605,6 +605,12 @@ async function _updateExerciseEntryWithClient(
   }
   return _getExerciseEntryByIdWithClient(client, id);
 }
+// _updateExerciseEntryWithClient hands back the whole entry row, but the create
+// path below only needs the identity of the row it touched: the full entry is
+// re-read through _getExerciseEntryByIdWithClient before being returned.
+interface MatchedExerciseEntry {
+  id: string;
+}
 async function _createExerciseEntryWithClient(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   client: any,
@@ -631,39 +637,45 @@ async function _createExerciseEntryWithClient(
       'Fitbit',
       'Strava',
     ].includes(entrySource);
-    let existingEntryResult;
-    // 1. Attempt precise sync deduplication via source_id if available
-    if (syncDuplicateCheck) {
-      existingEntryResult = await client.query(
-        'SELECT id FROM exercise_entries WHERE user_id = $1 AND source = $2 AND source_id = $3',
-        [userId, entrySource, entryData.source_id]
-      );
-    }
-    // 2. If no source_id match and NOT a sync source, fall back to "Manual" deduplication (name/date).
-    // Skip this fallback when source_id was provided: a source_id miss means it's a genuinely new
-    // activity (different activityId), so we must INSERT rather than match on exercise_id + date.
-    if (
-      !existingEntryResult?.rows?.length &&
-      !exercisePresetEntryId &&
-      !skipManualDuplicateCheck &&
-      !syncDuplicateCheck &&
-      !options.skipDuplicateCheck
-    ) {
-      if (entryData.workout_plan_assignment_id) {
-        // If it's linked to a workout plan assignment, it's unique by that assignment ID and date.
+    // Both deduplication lookups live behind one function so that the update
+    // path can re-run exactly the lookup that produced its match. Returns the
+    // id of the matched entry, or null when this is a genuinely new one.
+    const findExistingEntryId = async (): Promise<string | null> => {
+      let existingEntryResult;
+      // 1. Attempt precise sync deduplication via source_id if available
+      if (syncDuplicateCheck) {
         existingEntryResult = await client.query(
-          'SELECT id FROM exercise_entries WHERE user_id = $1 AND workout_plan_assignment_id = $2 AND entry_date = $3',
-          [userId, entryData.workout_plan_assignment_id, entryData.entry_date]
-        );
-      } else {
-        // For manual entries (no assignment), keep traditional uniqueness check by exercise_id and date.
-        // We explicitly ensure workout_plan_assignment_id is NULL to avoid matching template-generated entries.
-        existingEntryResult = await client.query(
-          'SELECT id FROM exercise_entries WHERE user_id = $1 AND exercise_id = $2 AND entry_date = $3 AND source = $4 AND exercise_preset_entry_id IS NULL AND workout_plan_assignment_id IS NULL',
-          [userId, entryData.exercise_id, entryData.entry_date, entrySource]
+          'SELECT id FROM exercise_entries WHERE user_id = $1 AND source = $2 AND source_id = $3',
+          [userId, entrySource, entryData.source_id]
         );
       }
-    }
+      // 2. If no source_id match and NOT a sync source, fall back to "Manual" deduplication (name/date).
+      // Skip this fallback when source_id was provided: a source_id miss means it's a genuinely new
+      // activity (different activityId), so we must INSERT rather than match on exercise_id + date.
+      if (
+        !existingEntryResult?.rows?.length &&
+        !exercisePresetEntryId &&
+        !skipManualDuplicateCheck &&
+        !syncDuplicateCheck &&
+        !options.skipDuplicateCheck
+      ) {
+        if (entryData.workout_plan_assignment_id) {
+          // If it's linked to a workout plan assignment, it's unique by that assignment ID and date.
+          existingEntryResult = await client.query(
+            'SELECT id FROM exercise_entries WHERE user_id = $1 AND workout_plan_assignment_id = $2 AND entry_date = $3',
+            [userId, entryData.workout_plan_assignment_id, entryData.entry_date]
+          );
+        } else {
+          // For manual entries (no assignment), keep traditional uniqueness check by exercise_id and date.
+          // We explicitly ensure workout_plan_assignment_id is NULL to avoid matching template-generated entries.
+          existingEntryResult = await client.query(
+            'SELECT id FROM exercise_entries WHERE user_id = $1 AND exercise_id = $2 AND entry_date = $3 AND source = $4 AND exercise_preset_entry_id IS NULL AND workout_plan_assignment_id IS NULL',
+            [userId, entryData.exercise_id, entryData.entry_date, entrySource]
+          );
+        }
+      }
+      return existingEntryResult?.rows?.[0]?.id ?? null;
+    };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let newEntryId: any;
     let operation: 'created' | 'updated';
@@ -672,10 +684,9 @@ async function _createExerciseEntryWithClient(
     // overlapping sync of the same source is enough. For delete-then-insert
     // ingest a vanished parent means "insert", not "fail", so fall through to
     // the create path below rather than writing children against a dead id.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let updatedEntry: any = null;
-    if (existingEntryResult && existingEntryResult.rows.length > 0) {
-      const existingEntryId = existingEntryResult.rows[0].id;
+    let updatedEntry: MatchedExerciseEntry | null = null;
+    const existingEntryId = await findExistingEntryId();
+    if (existingEntryId) {
       log(
         'info',
         `Existing exercise entry found for user ${userId}, exercise ${entryData.exercise_id}, date ${entryData.entry_date}, source ${entrySource}. Updating entry ${existingEntryId}.`
@@ -690,10 +701,33 @@ async function _createExerciseEntryWithClient(
         { returnNullIfMissing: true }
       );
       if (!updatedEntry) {
+        // The writer that deleted the row is a delete-then-insert sync, so it
+        // may already have committed its own replacement for the same natural
+        // key. exercise_entries has no unique constraint to catch a duplicate,
+        // so inserting blindly here would store the workout twice. Re-run the
+        // same lookup and update that row instead. Once only: a sync that keeps
+        // racing falls through to the insert rather than spinning, which leaves
+        // a much smaller window than the one this closes.
+        const replacementEntryId = await findExistingEntryId();
         log(
           'warn',
-          `Exercise entry ${existingEntryId} was deleted by a concurrent writer before it could be updated (user ${userId}, source ${entrySource}, date ${entryData.entry_date}). Inserting a replacement.`
+          `Exercise entry ${existingEntryId} was deleted by a concurrent writer before it could be updated (user ${userId}, source ${entrySource}, date ${entryData.entry_date}). ${
+            replacementEntryId
+              ? `Updating the replacement entry ${replacementEntryId} that writer left behind.`
+              : 'Inserting a replacement.'
+          }`
         );
+        if (replacementEntryId) {
+          updatedEntry = await _updateExerciseEntryWithClient(
+            client,
+            replacementEntryId,
+            userId,
+            entryData,
+            createdByUserId,
+            entrySource,
+            { returnNullIfMissing: true }
+          );
+        }
       }
     }
     if (updatedEntry) {

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -354,8 +354,7 @@ async function _updateExerciseEntryWithClient(
   updateData: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   updatedByUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  entrySource: any,
+  entrySource: string | undefined,
   // A caller that can recover from a vanished row (the sync path, which just
   // inserts a replacement) passes returnNullIfMissing and gets null instead of
   // an exception. Callers acting on a user-chosen entry leave it unset, because
@@ -611,6 +610,20 @@ async function _updateExerciseEntryWithClient(
 interface MatchedExerciseEntry {
   id: string;
 }
+
+/**
+ * Serializes destructive range deletes and deduplicating writes for one
+ * user's provider source until the surrounding transaction ends.
+ */
+async function acquireExerciseEntrySyncLockWithClient(
+  client: PoolClient,
+  userId: string,
+  entrySource: string
+): Promise<void> {
+  const key = `exercise-entry-sync:${userId}:${entrySource}`;
+  await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [key]);
+}
+
 async function _createExerciseEntryWithClient(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   client: any,
@@ -631,6 +644,9 @@ async function _createExerciseEntryWithClient(
     // Callers that must always insert (e.g. the chatbot, where logging the
     // same exercise twice in a day means two workouts) pass skipDuplicateCheck.
     const syncDuplicateCheck = entryData.source_id ? true : false;
+    if (syncDuplicateCheck) {
+      await acquireExerciseEntrySyncLockWithClient(client, userId, entrySource);
+    }
     const skipManualDuplicateCheck = [
       'HealthKit',
       'Health Connect',
@@ -676,8 +692,7 @@ async function _createExerciseEntryWithClient(
       }
       return existingEntryResult?.rows?.[0]?.id ?? null;
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let newEntryId: any;
+    let newEntryId: string;
     let operation: 'created' | 'updated';
     // The matched row can be gone by the time we update it. A provider sync
     // range-deletes by source and day span before re-inserting, so an
@@ -1584,6 +1599,7 @@ async function deleteExerciseEntriesByEntrySourceAndDateWithClient(
   entrySource: string,
   excludedExerciseName?: string
 ) {
+  await acquireExerciseEntrySyncLockWithClient(client, userId, entrySource);
   // Get IDs of exercise entries to be deleted
   const entryIdsResult = await client.query(
     `SELECT id FROM exercise_entries

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -886,7 +886,7 @@ async function createExerciseEntry(
   const client = await getClient(userId);
   try {
     await client.query('BEGIN');
-    const { entry } = await _createExerciseEntryWithClient(
+    const { entry, operation } = await _createExerciseEntryWithClient(
       client,
       userId,
       entryData,
@@ -896,6 +896,15 @@ async function createExerciseEntry(
       options
     );
     if (options.activityDetail) {
+      if (operation === 'updated') {
+        await activityDetailsRepository._deleteActivityDetailsByEntryIdAndProviderWithClient(
+          client,
+          userId,
+          entry.id,
+          options.activityDetail.provider_name,
+          options.activityDetail.detail_type
+        );
+      }
       await activityDetailsRepository._createActivityDetailWithClient(client, {
         ...options.activityDetail,
         exercise_entry_id: entry.id,

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -355,7 +355,12 @@ async function _updateExerciseEntryWithClient(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   updatedByUserId: any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  entrySource: any
+  entrySource: any,
+  // A caller that can recover from a vanished row (the sync path, which just
+  // inserts a replacement) passes returnNullIfMissing and gets null instead of
+  // an exception. Callers acting on a user-chosen entry leave it unset, because
+  // for them a missing row really is an error.
+  options: { returnNullIfMissing?: boolean } = {}
 ) {
   // Fetch existing entry to get current snapshot values if not provided in updateData
   const existingEntryResult = await client.query(
@@ -363,6 +368,9 @@ async function _updateExerciseEntryWithClient(
     [id, userId]
   );
   if (existingEntryResult.rows.length === 0) {
+    if (options.returnNullIfMissing) {
+      return null;
+    }
     throw new Error('Exercise entry not found for update.');
   }
   const currentEntry = existingEntryResult.rows[0];
@@ -481,7 +489,7 @@ async function _updateExerciseEntryWithClient(
   const telemetrySetClause = EXERCISE_ENTRY_TELEMETRY_COLUMNS.map(
     (column, index) => `${column} = $${32 + index}`
   ).join(',\n      ');
-  await client.query(
+  const updateResult = await client.query(
     `UPDATE exercise_entries SET
       exercise_id = $1,
       duration_minutes = $2,
@@ -551,6 +559,20 @@ async function _updateExerciseEntryWithClient(
       ...telemetryParams,
     ]
   );
+  // The row can be deleted by a competing writer between the existence check
+  // above and this UPDATE: a successful UPDATE would hold a row lock until
+  // commit, so the only interleaving that reaches here with no row is one where
+  // the delete committed first. Left unchecked the UPDATE affects zero rows
+  // without erroring, and the child writes below then run against an id that no
+  // longer exists. Because the sets and activity-detail RLS policies resolve
+  // their parent through an EXISTS subquery, that surfaces as a row-level
+  // security violation rather than the foreign-key error it really is.
+  if (updateResult.rowCount === 0) {
+    if (options.returnNullIfMissing) {
+      return null;
+    }
+    throw new Error('Exercise entry not found for update.');
+  }
   // Handle sets update
   if (updateData.sets !== undefined) {
     // Only modify sets if they are explicitly provided
@@ -645,21 +667,36 @@ async function _createExerciseEntryWithClient(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let newEntryId: any;
     let operation: 'created' | 'updated';
+    // The matched row can be gone by the time we update it. A provider sync
+    // range-deletes by source and day span before re-inserting, so an
+    // overlapping sync of the same source is enough. For delete-then-insert
+    // ingest a vanished parent means "insert", not "fail", so fall through to
+    // the create path below rather than writing children against a dead id.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let updatedEntry: any = null;
     if (existingEntryResult && existingEntryResult.rows.length > 0) {
-      // Entry exists, update it
       const existingEntryId = existingEntryResult.rows[0].id;
       log(
         'info',
         `Existing exercise entry found for user ${userId}, exercise ${entryData.exercise_id}, date ${entryData.entry_date}, source ${entrySource}. Updating entry ${existingEntryId}.`
       );
-      const updatedEntry = await _updateExerciseEntryWithClient(
+      updatedEntry = await _updateExerciseEntryWithClient(
         client,
         existingEntryId,
         userId,
         entryData,
         createdByUserId,
-        entrySource
+        entrySource,
+        { returnNullIfMissing: true }
       );
+      if (!updatedEntry) {
+        log(
+          'warn',
+          `Exercise entry ${existingEntryId} was deleted by a concurrent writer before it could be updated (user ${userId}, source ${entrySource}, date ${entryData.entry_date}). Inserting a replacement.`
+        );
+      }
+    }
+    if (updatedEntry) {
       newEntryId = updatedEntry.id;
       operation = 'updated';
     } else {

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -840,6 +840,20 @@ async function _createExerciseEntryWithClient(
     throw error;
   }
 }
+// The raw provider dump that belongs with the entry being written. A caller
+// that has one passes it here instead of storing it afterwards, so the pair is
+// written in a single transaction: exercise_entry_activity_details resolves its
+// parent through an EXISTS subquery in its RLS policy, so an insert against a
+// parent that is committed but has since been deleted fails as a row-level
+// security violation and the detail is silently lost.
+interface ExerciseEntryActivityDetail {
+  provider_name: string;
+  detail_type: string;
+  // Either the object itself or its JSON text; the repository normalises both.
+  detail_data: unknown;
+  created_by_user_id: string;
+  updated_by_user_id: string;
+}
 async function createExerciseEntry(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   userId: any,
@@ -849,7 +863,10 @@ async function createExerciseEntry(
   createdByUserId: any,
   entrySource = 'Manual',
   exercisePresetEntryId: string | null = null,
-  options: { skipDuplicateCheck?: boolean } = {}
+  options: {
+    skipDuplicateCheck?: boolean;
+    activityDetail?: ExerciseEntryActivityDetail | null;
+  } = {}
 ) {
   const client = await getClient(userId);
   try {
@@ -863,6 +880,12 @@ async function createExerciseEntry(
       exercisePresetEntryId,
       options
     );
+    if (options.activityDetail) {
+      await activityDetailsRepository._createActivityDetailWithClient(client, {
+        ...options.activityDetail,
+        exercise_entry_id: entry.id,
+      });
+    }
     await client.query('COMMIT');
     return entry;
   } catch (error) {

--- a/SparkyFitnessServer/services/healthDataHandlers.ts
+++ b/SparkyFitnessServer/services/healthDataHandlers.ts
@@ -4,7 +4,6 @@ import exerciseDb from '../models/exercise.js';
 import exerciseEntryDb, {
   EXERCISE_ENTRY_TELEMETRY_COLUMNS,
 } from '../models/exerciseEntry.js';
-import activityDetailsRepository from '../models/activityDetailsRepository.js';
 import foodRepository from '../models/foodRepository.js';
 import moodRepository from '../models/moodRepository.js';
 import waterContainerRepository from '../models/waterContainerRepository.js';
@@ -1610,7 +1609,24 @@ const workoutHandler: HealthTypeHandler = {
           ...telemetry,
         },
         ctx.actingUserId,
-        source
+        source,
+        null,
+        // Stored inside the entry's own transaction rather than afterwards: a
+        // second sync of the same source range-deletes and re-inserts these
+        // rows, so a detail written against an already committed parent can hit
+        // a parent that is gone, which its RLS policy reports as a row-level
+        // security violation and the workout loses its raw data.
+        raw_data
+          ? {
+              activityDetail: {
+                provider_name: source,
+                detail_type: `${type}_raw_data`,
+                detail_data: JSON.stringify(raw_data),
+                created_by_user_id: ctx.actingUserId,
+                updated_by_user_id: ctx.actingUserId,
+              },
+            }
+          : {}
       );
       if (gpsPoints.length > 0 || hrSamples.length > 0 || entry.laps) {
         try {
@@ -1635,16 +1651,6 @@ const workoutHandler: HealthTypeHandler = {
             `[processHealthData] Saved workout ${exerciseEntry.id} but failed to persist its telemetry: ${message}`
           );
         }
-      }
-      if (raw_data) {
-        await activityDetailsRepository.createActivityDetail(ctx.userId, {
-          exercise_entry_id: exerciseEntry.id,
-          provider_name: source,
-          detail_type: `${type}_raw_data`,
-          detail_data: JSON.stringify(raw_data),
-          created_by_user_id: ctx.actingUserId,
-          updated_by_user_id: ctx.actingUserId,
-        });
       }
       return { status: 'success', data: exerciseEntry };
     } catch (workoutError) {

--- a/SparkyFitnessServer/tests/exerciseEntry.activityDetail.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntry.activityDetail.test.ts
@@ -153,4 +153,75 @@ describe('createExerciseEntry with a provider activity detail', () => {
       indexOfStatement(/INSERT INTO exercise_entry_activity_details/i)
     ).toBe(-1);
   });
+
+  it('replaces the matching detail when the same source record is synced twice', async () => {
+    let parentExists = false;
+    let detailRows = 0;
+    mockClient.query.mockImplementation((sql: string) => {
+      if (/^\s*(BEGIN|COMMIT|ROLLBACK)/i.test(sql)) return { rows: [] };
+      if (/pg_advisory_xact_lock/i.test(sql)) return { rows: [] };
+      if (/DELETE FROM exercise_entry_activity_details/i.test(sql)) {
+        detailRows = 0;
+        return { rows: [], rowCount: 1 };
+      }
+      if (/SELECT id FROM exercise_entries/i.test(sql)) {
+        return {
+          rows: parentExists ? [{ id: ENTRY_ID }] : [],
+          rowCount: parentExists ? 1 : 0,
+        };
+      }
+      if (/SELECT \* FROM exercise_entries/i.test(sql)) {
+        return {
+          rows: [{ id: ENTRY_ID, user_id: 'user-1', ...entryData }],
+          rowCount: 1,
+        };
+      }
+      if (/UPDATE exercise_entries/i.test(sql)) {
+        return { rows: [{ id: ENTRY_ID }], rowCount: 1 };
+      }
+      if (/FROM exercises WHERE id/i.test(sql)) {
+        return { rows: [{ name: 'Calisthenics', modality: 'strength' }] };
+      }
+      if (/INSERT INTO exercise_entries/i.test(sql)) {
+        parentExists = true;
+        return { rows: [{ id: ENTRY_ID }], rowCount: 1 };
+      }
+      if (/INSERT INTO exercise_entry_activity_details/i.test(sql)) {
+        detailRows += 1;
+        return { rows: [{ id: `detail-${detailRows}` }], rowCount: 1 };
+      }
+      return { rows: [{ id: ENTRY_ID, ...entryData }], rowCount: 1 };
+    });
+
+    await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect',
+      null,
+      { activityDetail }
+    );
+    await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect',
+      null,
+      { activityDetail }
+    );
+
+    expect(detailRows).toBe(1);
+    const deleteCalls = mockClient.query.mock.calls.filter(
+      (call) =>
+        typeof call[0] === 'string' &&
+        /DELETE FROM exercise_entry_activity_details/i.test(call[0])
+    );
+    expect(deleteCalls).toHaveLength(1);
+    expect(deleteCalls[0][1]).toEqual([
+      ENTRY_ID,
+      'Health Connect',
+      'user-1',
+      'ExerciseSession_raw_data',
+    ]);
+  });
 });

--- a/SparkyFitnessServer/tests/exerciseEntry.activityDetail.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntry.activityDetail.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import exerciseEntryDb from '../models/exerciseEntry.js';
+import * as poolManager from '../db/poolManager.js';
+
+vi.mock('../db/poolManager.js', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+// A provider's raw dump used to be stored after the exercise entry had already
+// committed, on a connection of its own. That leaves a window in which another
+// sync of the same source deletes the parent it is about to reference, and
+// because the exercise_entry_activity_details RLS policy resolves the parent
+// through an EXISTS subquery, the insert fails as a row-level security
+// violation rather than a foreign-key error. The workout survives, its raw data
+// does not, and the failure reads like a permissions misconfiguration.
+describe('createExerciseEntry with a provider activity detail', () => {
+  const ENTRY_ID = 'entry-created-by-this-request';
+
+  const entryData = {
+    exercise_id: 'ex-1',
+    entry_date: '2026-08-30',
+    duration_minutes: 45,
+    calories_burned: 400,
+    source_id: 'hc-activity-9',
+  };
+
+  const activityDetail = {
+    provider_name: 'Health Connect',
+    detail_type: 'ExerciseSession_raw_data',
+    detail_data: JSON.stringify({ activityId: 'hc-activity-9' }),
+    created_by_user_id: 'user-1',
+    updated_by_user_id: 'user-1',
+  };
+
+  const mockClient = { query: vi.fn(), release: vi.fn() };
+
+  const arrange = (opts: { detailInsertFails?: boolean } = {}) => {
+    mockClient.query.mockImplementation((sql: string) => {
+      if (/^\s*(BEGIN|COMMIT|ROLLBACK)/i.test(sql)) return { rows: [] };
+      // No match on the dedup lookup: this is a brand new entry.
+      if (/SELECT id FROM exercise_entries/i.test(sql)) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (/FROM exercises WHERE id/i.test(sql)) {
+        return { rows: [{ name: 'Calisthenics', modality: 'strength' }] };
+      }
+      if (/INSERT INTO exercise_entries/i.test(sql)) {
+        return { rows: [{ id: ENTRY_ID }], rowCount: 1 };
+      }
+      if (/INSERT INTO exercise_entry_activity_details/i.test(sql)) {
+        if (opts.detailInsertFails) {
+          throw new Error('new row violates row-level security policy');
+        }
+        return { rows: [{ id: 'detail-1' }], rowCount: 1 };
+      }
+      return { rows: [{ id: ENTRY_ID, ...entryData }], rowCount: 1 };
+    });
+  };
+
+  const statements = () =>
+    mockClient.query.mock.calls.map((c: unknown[]) => String(c[0]));
+
+  const indexOfStatement = (pattern: RegExp) =>
+    statements().findIndex((sql) => pattern.test(sql));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (poolManager.getClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockClient
+    );
+  });
+
+  it('writes the detail on the entry transaction, before it commits', async () => {
+    arrange();
+
+    await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect',
+      null,
+      { activityDetail }
+    );
+
+    // One connection means one transaction: a second getClient would put the
+    // detail back on its own connection, which is the defect being fixed.
+    expect(poolManager.getClient).toHaveBeenCalledTimes(1);
+    const detailAt = indexOfStatement(
+      /INSERT INTO exercise_entry_activity_details/i
+    );
+    expect(detailAt).toBeGreaterThan(indexOfStatement(/^\s*BEGIN/i));
+    expect(detailAt).toBeLessThan(indexOfStatement(/^\s*COMMIT/i));
+  });
+
+  it('carries the entry id and the caller detail into the insert', async () => {
+    arrange();
+
+    await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect',
+      null,
+      { activityDetail }
+    );
+
+    const call = mockClient.query.mock.calls.find(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' &&
+        /INSERT INTO exercise_entry_activity_details/i.test(c[0])
+    );
+    const values = call?.[1] as unknown[];
+    expect(values[0]).toBe(ENTRY_ID);
+    expect(values[2]).toBe('Health Connect');
+    expect(values[3]).toBe('ExerciseSession_raw_data');
+    expect(values[4]).toEqual({ activityId: 'hc-activity-9' });
+  });
+
+  // Atomicity in the other direction. A half-written pair is what made the
+  // reported failure so hard to see, so a detail that cannot be stored must
+  // take the entry down with it rather than leave the workout without it.
+  it('rolls the entry back when the detail cannot be written', async () => {
+    arrange({ detailInsertFails: true });
+
+    await expect(
+      exerciseEntryDb.createExerciseEntry(
+        'user-1',
+        entryData,
+        'user-1',
+        'Health Connect',
+        null,
+        { activityDetail }
+      )
+    ).rejects.toThrow(/row-level security policy/);
+
+    expect(statements().some((sql) => /^\s*ROLLBACK/i.test(sql))).toBe(true);
+    expect(statements().some((sql) => /^\s*COMMIT/i.test(sql))).toBe(false);
+  });
+
+  it('writes no detail when the caller has none', async () => {
+    arrange();
+
+    await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect'
+    );
+
+    expect(
+      indexOfStatement(/INSERT INTO exercise_entry_activity_details/i)
+    ).toBe(-1);
+  });
+});

--- a/SparkyFitnessServer/tests/exerciseEntry.vanishedParent.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntry.vanishedParent.test.ts
@@ -77,6 +77,11 @@ describe('createExerciseEntry when the matched parent is deleted mid-request', (
     });
   };
 
+  const queriesMatching = (pattern: RegExp) =>
+    mockClient.query.mock.calls.filter(
+      (c: unknown[]) => typeof c[0] === 'string' && pattern.test(c[0] as string)
+    );
+
   const setsInsertParents = () =>
     mockClient.query.mock.calls
       .filter(
@@ -111,6 +116,67 @@ describe('createExerciseEntry when the matched parent is deleted mid-request', (
     expect(insertedEntry, 'expected a replacement parent to be inserted').toBe(
       true
     );
+    // The recovery re-checks for a replacement row once before inserting. It
+    // must not keep retrying against a writer that deletes on every pass.
+    expect(
+      queriesMatching(/UPDATE exercise_entries/i).length
+    ).toBeLessThanOrEqual(2);
+  });
+
+  // The competing writer is a delete-then-insert sync, so by the time our stale
+  // UPDATE reports zero rows it may already have committed its own row for the
+  // same natural key. exercise_entries has no unique constraint on
+  // (user_id, source, source_id), so inserting blindly would store the workout
+  // twice with nothing to catch it.
+  it('updates the replacement row instead of storing the workout twice', async () => {
+    const REPLACEMENT_ID = 'entry-reinserted-by-the-concurrent-sync';
+    let dedupLookups = 0;
+    mockClient.query.mockImplementation((sql: string, params?: unknown[]) => {
+      if (/^\s*(BEGIN|COMMIT|ROLLBACK)/i.test(sql)) return { rows: [] };
+      if (/SELECT id FROM exercise_entries/i.test(sql)) {
+        dedupLookups += 1;
+        // The competitor's delete and re-insert both commit between our first
+        // lookup and the re-check, which is one pass of its normal sync.
+        return dedupLookups === 1
+          ? { rows: [{ id: STALE_ID }], rowCount: 1 }
+          : { rows: [{ id: REPLACEMENT_ID }], rowCount: 1 };
+      }
+      if (/SELECT \* FROM exercise_entries/i.test(sql)) {
+        return { rows: [existingEntry], rowCount: 1 };
+      }
+      if (/UPDATE exercise_entries/i.test(sql)) {
+        // Only the stale row is gone; the replacement updates normally.
+        return params?.includes(STALE_ID)
+          ? { rows: [], rowCount: 0 }
+          : { rows: [{ id: REPLACEMENT_ID }], rowCount: 1 };
+      }
+      if (/INSERT INTO exercise_entries/i.test(sql)) {
+        return { rows: [{ id: FRESH_ID }], rowCount: 1 };
+      }
+      return { rows: [{ id: REPLACEMENT_ID, ...entryData }], rowCount: 1 };
+    });
+
+    const entry = await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect'
+    );
+
+    expect(entry.id).toBe(REPLACEMENT_ID);
+    expect(
+      queriesMatching(/INSERT INTO exercise_entries/i).length,
+      'the replacement row already exists, so a second parent must not be inserted'
+    ).toBe(0);
+    expect(dedupLookups).toBe(2);
+    for (const sql of setsInsertParents()) {
+      expect(sql).not.toContain(STALE_ID);
+      expect(sql).toContain(REPLACEMENT_ID);
+    }
+    // The sets of the row we are about to rewrite, never those of the dead id.
+    for (const call of queriesMatching(/DELETE FROM exercise_entry_sets/i)) {
+      expect(call[1]).not.toContain(STALE_ID);
+    }
   });
 
   // The regression itself. Sets written against the deleted id are what tripped

--- a/SparkyFitnessServer/tests/exerciseEntry.vanishedParent.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntry.vanishedParent.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import exerciseEntryDb from '../models/exerciseEntry.js';
+import * as poolManager from '../db/poolManager.js';
+
+vi.mock('../db/poolManager.js', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+// A provider sync range-deletes a source's entries for the batch's day span and
+// then re-inserts them. Two overlapping syncs of the same source therefore race:
+// one can delete a parent exercise_entries row that the other has already
+// matched and is about to update.
+//
+// The dangerous part is that the parent UPDATE does not error when its row is
+// gone, it just affects zero rows. Execution used to carry on and write sets
+// against an id that no longer existed. Because the exercise_entry_sets RLS
+// policy resolves its parent through an EXISTS subquery, and WITH CHECK is
+// evaluated before the foreign key's AFTER ROW trigger, the failure surfaced as
+// "new row violates row-level security policy" rather than as a foreign-key
+// violation, which reads like a permissions misconfiguration.
+describe('createExerciseEntry when the matched parent is deleted mid-request', () => {
+  const STALE_ID = 'entry-deleted-by-a-concurrent-sync';
+  const FRESH_ID = 'entry-inserted-as-a-replacement';
+
+  const existingEntry = {
+    id: STALE_ID,
+    user_id: 'user-1',
+    exercise_id: 'ex-1',
+    entry_date: '2026-08-30',
+    duration_minutes: 45,
+    calories_burned: 400,
+    source: 'Health Connect',
+    source_id: 'hc-activity-9',
+  };
+
+  const entryData = {
+    exercise_id: 'ex-1',
+    entry_date: '2026-08-30',
+    duration_minutes: 45,
+    calories_burned: 400,
+    source_id: 'hc-activity-9',
+    sets: [{ set_number: 1, reps: 10, weight: 20 }],
+  };
+
+  const mockClient = { query: vi.fn(), release: vi.fn() };
+
+  // Wires the mock so the row exists for every read but the UPDATE reports zero
+  // affected rows, which is exactly what a delete committing first looks like.
+  const arrange = (opts: { updateAffectsRows: number }) => {
+    mockClient.query.mockImplementation((sql: string) => {
+      if (/^\s*(BEGIN|COMMIT|ROLLBACK)/i.test(sql)) return { rows: [] };
+      // Dedup lookup by (user_id, source, source_id): the row is still visible.
+      if (/SELECT id FROM exercise_entries/i.test(sql)) {
+        return { rows: [{ id: STALE_ID }], rowCount: 1 };
+      }
+      if (/SELECT \* FROM exercise_entries/i.test(sql)) {
+        return { rows: [existingEntry], rowCount: 1 };
+      }
+      if (/UPDATE exercise_entries/i.test(sql)) {
+        return opts.updateAffectsRows === 0
+          ? { rows: [], rowCount: 0 }
+          : { rows: [{ id: STALE_ID }], rowCount: 1 };
+      }
+      if (/FROM exercises WHERE id/i.test(sql)) {
+        return { rows: [{ name: 'Calisthenics', modality: 'strength' }] };
+      }
+      if (/INSERT INTO exercise_entries/i.test(sql)) {
+        return { rows: [{ id: FRESH_ID }], rowCount: 1 };
+      }
+      if (/INSERT INTO exercise_entry_sets/i.test(sql)) {
+        return { rows: [], rowCount: 1 };
+      }
+      // Final read-back of the entry.
+      return { rows: [{ id: FRESH_ID, ...entryData }], rowCount: 1 };
+    });
+  };
+
+  const setsInsertParents = () =>
+    mockClient.query.mock.calls
+      .filter(
+        (c: unknown[]) =>
+          typeof c[0] === 'string' &&
+          /INSERT INTO exercise_entry_sets/i.test(c[0])
+      )
+      .map((c: unknown[]) => c[0] as string);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (poolManager.getClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockClient
+    );
+  });
+
+  it('inserts a replacement instead of failing when the parent is gone', async () => {
+    arrange({ updateAffectsRows: 0 });
+
+    const entry = await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect'
+    );
+
+    expect(entry.id).toBe(FRESH_ID);
+    const insertedEntry = mockClient.query.mock.calls.some(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' && /INSERT INTO exercise_entries/i.test(c[0])
+    );
+    expect(insertedEntry, 'expected a replacement parent to be inserted').toBe(
+      true
+    );
+  });
+
+  // The regression itself. Sets written against the deleted id are what tripped
+  // the RLS policy in production, so assert on the id embedded in the statement
+  // rather than merely on the call succeeding.
+  it('never writes sets against the deleted parent id', async () => {
+    arrange({ updateAffectsRows: 0 });
+
+    await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect'
+    );
+
+    const statements = setsInsertParents();
+    expect(statements.length).toBeGreaterThan(0);
+    for (const sql of statements) {
+      expect(sql).not.toContain(STALE_ID);
+      expect(sql).toContain(FRESH_ID);
+    }
+  });
+
+  // The delete can also land before the update helper's own existence read,
+  // which used to throw 'Exercise entry not found for update.' and lose the
+  // workout with an error instead of storing it. Same recovery, earlier point.
+  it('inserts a replacement when the parent is gone before the existence read', async () => {
+    mockClient.query.mockImplementation((sql: string) => {
+      if (/^\s*(BEGIN|COMMIT|ROLLBACK)/i.test(sql)) return { rows: [] };
+      if (/SELECT id FROM exercise_entries/i.test(sql)) {
+        return { rows: [{ id: STALE_ID }], rowCount: 1 };
+      }
+      // The row is already gone by the time the update helper reads it.
+      if (/SELECT \* FROM exercise_entries/i.test(sql)) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (/FROM exercises WHERE id/i.test(sql)) {
+        return { rows: [{ name: 'Calisthenics', modality: 'strength' }] };
+      }
+      if (/INSERT INTO exercise_entries/i.test(sql)) {
+        return { rows: [{ id: FRESH_ID }], rowCount: 1 };
+      }
+      return { rows: [{ id: FRESH_ID, ...entryData }], rowCount: 1 };
+    });
+
+    const entry = await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect'
+    );
+
+    expect(entry.id).toBe(FRESH_ID);
+    for (const sql of setsInsertParents()) {
+      expect(sql).not.toContain(STALE_ID);
+    }
+  });
+
+  it('still takes the update path when the parent is present', async () => {
+    arrange({ updateAffectsRows: 1 });
+
+    await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect'
+    );
+
+    const insertedEntry = mockClient.query.mock.calls.some(
+      (c: unknown[]) =>
+        typeof c[0] === 'string' && /INSERT INTO exercise_entries/i.test(c[0])
+    );
+    expect(insertedEntry, 'a live parent must not be duplicated').toBe(false);
+  });
+});
+
+// The recovery above is opt-in. A user editing one of their own diary entries
+// must still get a real error when it is gone, not a silent no-op.
+describe('updateExerciseEntry on a row that no longer exists', () => {
+  const mockClient = { query: vi.fn(), release: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (poolManager.getClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockClient
+    );
+  });
+
+  it('throws when the UPDATE affects zero rows', async () => {
+    mockClient.query.mockImplementation((sql: string) => {
+      if (/^\s*(BEGIN|COMMIT|ROLLBACK)/i.test(sql)) return { rows: [] };
+      if (/SELECT \* FROM exercise_entries/i.test(sql)) {
+        return {
+          rows: [{ id: 'entry-1', user_id: 'user-1', exercise_id: 'ex-1' }],
+          rowCount: 1,
+        };
+      }
+      if (/UPDATE exercise_entries/i.test(sql)) {
+        return { rows: [], rowCount: 0 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    await expect(
+      exerciseEntryDb.updateExerciseEntry('entry-1', 'user-1', 'user-1', {
+        duration_minutes: 30,
+      })
+    ).rejects.toThrow('Exercise entry not found for update.');
+  });
+});

--- a/SparkyFitnessServer/tests/exerciseEntry.vanishedParent.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntry.vanishedParent.test.ts
@@ -123,6 +123,32 @@ describe('createExerciseEntry when the matched parent is deleted mid-request', (
     ).toBeLessThanOrEqual(2);
   });
 
+  it('locks the provider source before the deduplication lookup', async () => {
+    arrange({ updateAffectsRows: 1 });
+
+    await exerciseEntryDb.createExerciseEntry(
+      'user-1',
+      entryData,
+      'user-1',
+      'Health Connect'
+    );
+
+    const statements = mockClient.query.mock.calls.map((call) =>
+      String(call[0])
+    );
+    const lockIndex = statements.findIndex((sql) =>
+      /pg_advisory_xact_lock/i.test(sql)
+    );
+    const lookupIndex = statements.findIndex((sql) =>
+      /SELECT id FROM exercise_entries/i.test(sql)
+    );
+    expect(lockIndex).toBeGreaterThan(statements.indexOf('BEGIN'));
+    expect(lockIndex).toBeLessThan(lookupIndex);
+    expect(mockClient.query.mock.calls[lockIndex][1]).toEqual([
+      'exercise-entry-sync:user-1:Health Connect',
+    ]);
+  });
+
   // The competing writer is a delete-then-insert sync, so by the time our stale
   // UPDATE reports zero rows it may already have committed its own row for the
   // same natural key. exercise_entries has no unique constraint on

--- a/SparkyFitnessServer/tests/exerciseEntryGarminCleanup.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntryGarminCleanup.test.ts
@@ -36,7 +36,14 @@ describe('Garmin exercise cleanup', () => {
       'Active Calories'
     );
 
-    const [selectSql, params] = mockClient.query.mock.calls[1];
+    const lockCall = mockClient.query.mock.calls.find(([sql]) =>
+      String(sql).includes('pg_advisory_xact_lock')
+    );
+    expect(lockCall?.[1]).toEqual(['exercise-entry-sync:user-1:garmin']);
+
+    const [selectSql, params] = mockClient.query.mock.calls.find(([sql]) =>
+      String(sql).includes('SELECT id FROM exercise_entries')
+    )!;
     expect(selectSql).toContain('NOT EXISTS');
     expect(selectSql).toContain('exercises');
     expect(params).toEqual([

--- a/SparkyFitnessServer/tests/measurementService.healthDataContract.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.healthDataContract.test.ts
@@ -151,7 +151,11 @@ describe('processHealthData per-record error contract', () => {
         ],
       }),
       actingUserId,
-      'HealthKit'
+      'HealthKit',
+      null,
+      // No raw provider dump on this payload, so no activity detail rides
+      // along in the entry's transaction.
+      {}
     );
   });
 
@@ -192,7 +196,11 @@ describe('processHealthData per-record error contract', () => {
         sets: [{ set_number: 1, set_type: 'Working Set', duration: 300 }],
       }),
       actingUserId,
-      'HealthKit'
+      'HealthKit',
+      null,
+      // No raw provider dump on this payload, so no activity detail rides
+      // along in the entry's transaction.
+      {}
     );
   });
 
@@ -229,7 +237,11 @@ describe('processHealthData per-record error contract', () => {
         sets: [{ set_number: 1, set_type: 'Working Set', duration: 300 }],
       }),
       actingUserId,
-      'HealthKit'
+      'HealthKit',
+      null,
+      // No raw provider dump on this payload, so no activity detail rides
+      // along in the entry's transaction.
+      {}
     );
   });
 

--- a/SparkyFitnessServer/tests/workoutHandlerTelemetry.test.ts
+++ b/SparkyFitnessServer/tests/workoutHandlerTelemetry.test.ts
@@ -41,6 +41,9 @@ const { HEALTH_TYPE_HANDLERS } =
   await import('../services/healthDataHandlers.js');
 const exerciseDb = (await import('../models/exercise.js')).default;
 const exerciseEntryDb = (await import('../models/exerciseEntry.js')).default;
+const activityDetailsRepository = (
+  await import('../models/activityDetailsRepository.js')
+).default;
 const telemetryRepo = await import('../models/workoutTelemetryRepository.js');
 const { upsertSamplesByDay } =
   await import('../services/healthMetricSampleWriter.js');
@@ -93,6 +96,41 @@ beforeEach(() => {
   (exerciseDb.createExercise as Mock).mockResolvedValue({ id: 'exercise-1' });
   (exerciseEntryDb.createExerciseEntry as Mock).mockResolvedValue({
     id: ENTRY_ID,
+  });
+});
+
+// The raw provider dump used to be stored after the entry had committed, on a
+// connection of its own. That is how the reported sync lost it: a second sync of
+// the same source deletes the parent between the two writes, and the detail's
+// RLS policy resolves that parent through an EXISTS subquery, so the insert
+// fails as a row-level security violation instead of a foreign-key error.
+describe('workoutHandler — raw provider data', () => {
+  it('hands the raw dump to the entry write instead of a second connection', async () => {
+    await workoutHandler.handle(
+      baseEntry({ raw_data: { activityId: 'hk-workout-1' } }),
+      makeCtx()
+    );
+
+    const options = (exerciseEntryDb.createExerciseEntry as Mock).mock
+      .calls[0][5];
+    expect(options.activityDetail).toEqual({
+      provider_name: 'HealthKit',
+      detail_type: 'ExerciseSession_raw_data',
+      detail_data: JSON.stringify({ activityId: 'hk-workout-1' }),
+      created_by_user_id: 'user-1',
+      updated_by_user_id: 'user-1',
+    });
+    expect(
+      activityDetailsRepository.createActivityDetail
+    ).not.toHaveBeenCalled();
+  });
+
+  it('sends no activity detail when the provider sent no raw data', async () => {
+    await workoutHandler.handle(baseEntry(), makeCtx());
+
+    const options = (exerciseEntryDb.createExerciseEntry as Mock).mock
+      .calls[0][5];
+    expect(options?.activityDetail).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Health Connect workout sync can lose a workout's sets and its raw provider data while reporting success. Both child writes fail with a row level security error because the parent `exercise_entries` row was deleted by a concurrent sync of the same source, and neither the parent `UPDATE` result nor the separate activity detail write was guarded against that.

**How did you implement the solution?**

Two changes, both in the sync write path.

1. The parent `UPDATE` result is now checked. A zero row update used to pass silently and the child inserts then ran against an id that no longer existed. On the sync path a vanished parent means "insert", since delete-then-insert ingest is idempotent, so it re-runs its own deduplication lookup once and updates the replacement row if the competing writer already committed one, and inserts only when the key is genuinely free. Callers acting on a user chosen entry still get a real error.
2. The raw activity detail is written on the entry's own connection inside the same transaction, through the existing `_createActivityDetailWithClient`, instead of afterwards on a connection of its own. The parent is then present and locked when the child insert runs.

The reason this surfaced as a permissions error rather than a foreign key violation is that both child tables resolve their parent through an `EXISTS` subquery in their RLS policy, and `WITH CHECK` is evaluated before the foreign key's `AFTER ROW` trigger.

Linked Issue: Closes #2351

## How to Test

1. Check out this branch, then `cd SparkyFitnessServer && pnpm install`.
2. Run `pnpm run typecheck && pnpm run lint && pnpm run format:check`.
3. Run `pnpm run test:ci`. The new coverage is in `tests/exerciseEntry.vanishedParent.test.ts` and `tests/exerciseEntry.activityDetail.test.ts`, plus two cases added to `tests/workoutHandlerTelemetry.test.ts`.
4. For the behaviour itself: sync a Health Connect workout batch that carries sets and raw activity data, then confirm the rows land in `exercise_entry_sets` and `exercise_entry_activity_details` and that no `42501` appears in the Postgres log.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

No UI changes, so there is nothing to show.

## Notes for Reviewers

There are no new tables and no new endpoints, so the Zod and `rls_policies.sql` items above are satisfied by there being nothing to add. No migrations either.

A known limit, and the part I would most like a second opinion on: the re-check narrows the duplicate window but it cannot close it: if our lookup lands after the competing sync's delete commits and before its re-insert commits, we insert and it inserts, and there is no unique constraint on `(user_id, source, source_id)` to reject either row. Closing it properly needs either that unique key plus an upsert, which wants a dedupe migration first because existing installs may already hold duplicates from this bug, or a lock held across the whole delete-then-insert group rather than inside a single entry write. Both felt like a call @CodeWithCJ should make rather than something to slip into a bug fix. The trade as it stands is that the old code failed loudly and lost the workout, and this keeps the workout at the cost of a possible duplicate that clears on the next sync of that day.

Two smaller things left alone deliberately. The pre-cleanup still commits in its own transaction before per record validation, so a failure part way through a batch leaves the range delete committed. And the other provider integrations (Oura, Hevy, Strava, Google Health, Fitbit, Polar, Withings) still store their raw dumps on a separate connection after the entry write, so they carry the same latent race. Garmin and the FIT importer already write in transaction. Adopting the new option is about one line each if you want that in a follow up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workout synchronization when entries are deleted and recreated concurrently, preventing updates to stale records.
  - Prevented duplicate workouts during overlapping synchronization operations.
  - Preserved the original activity source when updating exercise entries.
  - Saved provider activity details atomically with the associated workout, rolling back both if saving fails.
  - Replaced outdated activity details when updated workout data is synchronized.
  - Improved handling of missing entries during synchronization to maintain consistent workout data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->