### PR TITLE
fix(exercise): cache the free-exercise-db dataset

### DIFF
--- a/SparkyFitnessServer/integrations/freeexercisedb/FreeExerciseDBService.ts
+++ b/SparkyFitnessServer/integrations/freeexercisedb/FreeExerciseDBService.ts
@@ -27,7 +27,7 @@ interface DatasetHolder {
 }
 
 function isExerciseDataset(value: unknown): value is FreeExercise[] {
-  if (!Array.isArray(value)) return false;
+  if (!Array.isArray(value) || value.length === 0) return false;
   return value.every(
     (exercise: unknown) =>
       typeof exercise === 'object' &&
@@ -94,10 +94,6 @@ class FreeExerciseDBService {
       now - lastDatasetFetchFailureAt < STALE_RETRY_INTERVAL_MS
     ) {
       if (dataset) {
-        log(
-          'warn',
-          `[FreeExerciseDBService] Serving stale exercise dataset after a refresh failure; age: ${now - dataset.fetchedAt}ms`
-        );
         return dataset.data;
       }
       log(
@@ -132,13 +128,11 @@ class FreeExerciseDBService {
           }
           if (dataset) {
             const age = Date.now() - dataset.fetchedAt;
-            if (age >= DATASET_TTL_MS) {
-              log(
-                'warn',
-                `[FreeExerciseDBService] Serving stale exercise dataset after a refresh failure; age: ${age}ms`,
-                error instanceof Error ? error.message : error
-              );
-            }
+            log(
+              'warn',
+              `[FreeExerciseDBService] Serving stale exercise dataset after a refresh failure; age: ${age}ms`,
+              error instanceof Error ? error.message : error
+            );
             return dataset.data;
           }
           throw error;

--- a/SparkyFitnessServer/integrations/freeexercisedb/FreeExerciseDBService.ts
+++ b/SparkyFitnessServer/integrations/freeexercisedb/FreeExerciseDBService.ts
@@ -8,6 +8,41 @@ const GITHUB_RAW_BASE_URL =
 const EXERCISES_PATH = 'exercises'; // No leading slash for API
 // Initialize cache for GitHub API responses (e.g., 1 hour TTL)
 const githubCache = new NodeCache({ stdTTL: 3600 });
+const DATASET_TTL_MS = 60 * 60 * 1000;
+// Bound a stalled shared download so it cannot block every exercise search indefinitely.
+const DATASET_REQUEST_TIMEOUT_MS = 15 * 1000;
+// Avoid hammering GitHub and making every search wait during an upstream outage.
+const STALE_RETRY_INTERVAL_MS = 5 * 60 * 1000;
+
+interface FreeExercise {
+  name: string;
+  equipment?: string;
+  primaryMuscles?: string[];
+  secondaryMuscles?: string[];
+}
+
+interface DatasetHolder {
+  data: FreeExercise[];
+  fetchedAt: number;
+}
+
+function isExerciseDataset(value: unknown): value is FreeExercise[] {
+  if (!Array.isArray(value)) return false;
+  if (value.length === 0) return true;
+
+  const firstExercise: unknown = value[0];
+  return (
+    typeof firstExercise === 'object' &&
+    firstExercise !== null &&
+    'name' in firstExercise &&
+    typeof firstExercise.name === 'string'
+  );
+}
+
+let dataset: DatasetHolder | null = null;
+let exercisesDatasetPromise: Promise<FreeExercise[]> | null = null;
+let lastDatasetFetchFailureAt: number | null = null;
+
 class FreeExerciseDBService {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   exerciseList: any;
@@ -51,6 +86,74 @@ class FreeExerciseDBService {
       return null;
     }
   }
+  async getAllExercises(): Promise<FreeExercise[]> {
+    const now = Date.now();
+    if (dataset && now - dataset.fetchedAt < DATASET_TTL_MS) {
+      return dataset.data;
+    }
+    if (
+      lastDatasetFetchFailureAt !== null &&
+      now - lastDatasetFetchFailureAt < STALE_RETRY_INTERVAL_MS
+    ) {
+      if (dataset) {
+        log(
+          'warn',
+          `[FreeExerciseDBService] Serving stale exercise dataset after a refresh failure; age: ${now - dataset.fetchedAt}ms`
+        );
+        return dataset.data;
+      }
+      log(
+        'warn',
+        '[FreeExerciseDBService] Skipping exercise dataset fetch during retry interval after a cold-start failure'
+      );
+      throw new Error('Exercise dataset fetch retry interval is active');
+    }
+    if (!exercisesDatasetPromise) {
+      const exercisesJsonUrl = `${GITHUB_RAW_BASE_URL}/dist/exercises.json`;
+      const currentPromise = axios
+        .get<unknown>(exercisesJsonUrl, {
+          timeout: DATASET_REQUEST_TIMEOUT_MS,
+        })
+        .then((response) => {
+          if (!isExerciseDataset(response.data)) {
+            log(
+              'warn',
+              '[FreeExerciseDBService] Rejected invalid exercise dataset response'
+            );
+            throw new Error('Invalid exercise dataset response');
+          }
+          if (exercisesDatasetPromise === currentPromise) {
+            dataset = { data: response.data, fetchedAt: Date.now() };
+            lastDatasetFetchFailureAt = null;
+          }
+          return response.data;
+        })
+        .catch((error: unknown) => {
+          if (exercisesDatasetPromise === currentPromise) {
+            lastDatasetFetchFailureAt = Date.now();
+          }
+          if (dataset) {
+            const age = Date.now() - dataset.fetchedAt;
+            if (age >= DATASET_TTL_MS) {
+              log(
+                'warn',
+                `[FreeExerciseDBService] Serving stale exercise dataset after a refresh failure; age: ${age}ms`,
+                error instanceof Error ? error.message : error
+              );
+            }
+            return dataset.data;
+          }
+          throw error;
+        })
+        .finally(() => {
+          if (exercisesDatasetPromise === currentPromise) {
+            exercisesDatasetPromise = null;
+          }
+        });
+      exercisesDatasetPromise = currentPromise;
+    }
+    return exercisesDatasetPromise;
+  }
   async searchExercises(
     query: string | null | undefined,
     equipmentFilter: string[] = [],
@@ -58,43 +161,26 @@ class FreeExerciseDBService {
     limit = 50,
     offset = 0
   ) {
-    const cacheKey = `search_exercises_${query}_${equipmentFilter.join(',')}_${muscleGroupFilter.join(',')}_${limit}_${offset}`;
-    const cachedResults = githubCache.get(cacheKey);
-    if (cachedResults) {
-      console.log(
-        `[FreeExerciseDBService] Cache hit for search query: ${query}, equipment: ${equipmentFilter}, muscles: ${muscleGroupFilter}, limit: ${limit}, offset: ${offset}`
-      );
-      return cachedResults;
-    }
     try {
-      const exercisesJsonUrl =
-        'https://api.github.com/repos/yuhonas/free-exercise-db/contents/dist/exercises.json';
-      console.log(
-        `[FreeExerciseDBService] Fetching exercises from: ${exercisesJsonUrl}`
-      );
-      const response = await axios.get(exercisesJsonUrl, {
-        headers: { Accept: 'application/vnd.github.raw+json' },
-      });
-      const allExercises = response.data;
+      const allExercises = await this.getAllExercises();
 
       // 1. Filter by equipment and muscle group first
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const preFiltered = allExercises.filter((exercise: any) => {
+      const preFiltered = allExercises.filter((exercise) => {
         const matchesEquipment =
           equipmentFilter.length === 0 ||
           (exercise.equipment &&
             equipmentFilter.some((filter) =>
-              exercise.equipment.includes(filter)
+              exercise.equipment?.includes(filter)
             ));
         const matchesMuscleGroup =
           muscleGroupFilter.length === 0 ||
           (exercise.primaryMuscles &&
             muscleGroupFilter.some((filter) =>
-              exercise.primaryMuscles.includes(filter)
+              exercise.primaryMuscles?.includes(filter)
             )) ||
           (exercise.secondaryMuscles &&
             muscleGroupFilter.some((filter) =>
-              exercise.secondaryMuscles.includes(filter)
+              exercise.secondaryMuscles?.includes(filter)
             ));
         return matchesEquipment && matchesMuscleGroup;
       });
@@ -102,7 +188,7 @@ class FreeExerciseDBService {
       // 2. Filter and sort by search query using the shared utility
       const filteredExercises = filterAndSortByTerms(
         preFiltered,
-        (ex: any) => ex.name,
+        (exercise) => exercise.name,
         query || ''
       );
 
@@ -111,14 +197,12 @@ class FreeExerciseDBService {
         offset,
         offset + limit
       );
-      const result = { exercises: paginatedExercises, totalCount };
-      githubCache.set(cacheKey, result);
-      return result;
+      return { exercises: paginatedExercises, totalCount };
     } catch (error) {
-      console.error(
+      log(
+        'error',
         `[FreeExerciseDBService] Error searching exercises for query "${query}" with limit ${limit}:`,
-        // @ts-expect-error TS(2571): Object is of type 'unknown'.
-        error.message
+        error instanceof Error ? error.message : error
       );
       return { exercises: [], totalCount: 0 };
     }
@@ -136,5 +220,13 @@ class FreeExerciseDBService {
     return imageUrl;
   }
 }
+
+export function resetFreeExerciseDBCache() {
+  githubCache.flushAll();
+  dataset = null;
+  exercisesDatasetPromise = null;
+  lastDatasetFetchFailureAt = null;
+}
+
 const freeExerciseDBService = new FreeExerciseDBService();
 export default freeExerciseDBService;

--- a/SparkyFitnessServer/integrations/freeexercisedb/FreeExerciseDBService.ts
+++ b/SparkyFitnessServer/integrations/freeexercisedb/FreeExerciseDBService.ts
@@ -28,14 +28,12 @@ interface DatasetHolder {
 
 function isExerciseDataset(value: unknown): value is FreeExercise[] {
   if (!Array.isArray(value)) return false;
-  if (value.length === 0) return true;
-
-  const firstExercise: unknown = value[0];
-  return (
-    typeof firstExercise === 'object' &&
-    firstExercise !== null &&
-    'name' in firstExercise &&
-    typeof firstExercise.name === 'string'
+  return value.every(
+    (exercise: unknown) =>
+      typeof exercise === 'object' &&
+      exercise !== null &&
+      'name' in exercise &&
+      typeof exercise.name === 'string'
   );
 }
 

--- a/SparkyFitnessServer/tests/freeExerciseDBSearch.test.ts
+++ b/SparkyFitnessServer/tests/freeExerciseDBSearch.test.ts
@@ -3,8 +3,10 @@ import axios from 'axios';
 import freeExerciseDBService, {
   resetFreeExerciseDBCache,
 } from '../integrations/freeexercisedb/FreeExerciseDBService.js';
+import { log } from '../config/logging.js';
 
 vi.mock('axios');
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
 
 describe('FreeExerciseDBService search', () => {
   beforeEach(() => {
@@ -184,6 +186,27 @@ describe('FreeExerciseDBService search', () => {
     expect(axios.get).toHaveBeenCalledTimes(2);
   });
 
+  it('rejects an empty dataset and retries after the interval', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    vi.mocked(axios.get).mockResolvedValueOnce({ data: [] });
+
+    const firstResult = await freeExerciseDBService.searchExercises('lunge');
+    vi.advanceTimersByTime(300_001);
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Dumbbell Curl' }],
+    });
+
+    const retryResult = await freeExerciseDBService.searchExercises('curl');
+
+    expect(firstResult).toEqual({ exercises: [], totalCount: 0 });
+    expect(retryResult).toEqual({
+      exercises: [{ name: 'Dumbbell Curl' }],
+      totalCount: 1,
+    });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
   it('accepts searchable dataset entries with optional fields omitted', async () => {
     vi.mocked(axios.get).mockResolvedValue({
       data: [{ name: 'Lunge' }, { name: 'Dumbbell Curl' }],
@@ -289,6 +312,9 @@ describe('FreeExerciseDBService search', () => {
       totalCount: 1,
     });
     expect(axios.get).toHaveBeenCalledTimes(2);
+    expect(
+      vi.mocked(log).mock.calls.filter(([level]) => level === 'warn')
+    ).toHaveLength(1);
   });
 
   it('serves stale data after a timeout without retrying inside the interval', async () => {

--- a/SparkyFitnessServer/tests/freeExerciseDBSearch.test.ts
+++ b/SparkyFitnessServer/tests/freeExerciseDBSearch.test.ts
@@ -161,6 +161,43 @@ describe('FreeExerciseDBService search', () => {
     expect(axios.get).toHaveBeenCalledTimes(2);
   });
 
+  it('rejects a mixed-validity dataset and retries after the interval', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: [{ name: 'Lunge' }, {}],
+    });
+
+    const firstResult = await freeExerciseDBService.searchExercises('lunge');
+    vi.advanceTimersByTime(300_001);
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Dumbbell Curl' }],
+    });
+
+    const retryResult = await freeExerciseDBService.searchExercises('curl');
+
+    expect(firstResult).toEqual({ exercises: [], totalCount: 0 });
+    expect(retryResult).toEqual({
+      exercises: [{ name: 'Dumbbell Curl' }],
+      totalCount: 1,
+    });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('accepts searchable dataset entries with optional fields omitted', async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Lunge' }, { name: 'Dumbbell Curl' }],
+    });
+
+    const result = await freeExerciseDBService.searchExercises('lunge');
+
+    expect(result).toEqual({
+      exercises: [{ name: 'Lunge' }],
+      totalCount: 1,
+    });
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
   it('retries a failed cold-start download after the retry interval', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));

--- a/SparkyFitnessServer/tests/freeExerciseDBSearch.test.ts
+++ b/SparkyFitnessServer/tests/freeExerciseDBSearch.test.ts
@@ -1,12 +1,16 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
 import axios from 'axios';
-import freeExerciseDBService from '../integrations/freeexercisedb/FreeExerciseDBService.js';
+import freeExerciseDBService, {
+  resetFreeExerciseDBCache,
+} from '../integrations/freeexercisedb/FreeExerciseDBService.js';
 
 vi.mock('axios');
 
 describe('FreeExerciseDBService search', () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
+    resetFreeExerciseDBCache();
   });
 
   it('matches split-term queries and prioritizes exact match sequence sorting', async () => {
@@ -17,7 +21,7 @@ describe('FreeExerciseDBService search', () => {
       { name: 'Barbell Walking Lunge' },
     ];
 
-    vi.mocked(axios.get).mockResolvedValueOnce({ data: mockExercises });
+    vi.mocked(axios.get).mockResolvedValue({ data: mockExercises });
 
     // Search for "lunge barbe" which should split to "lunge" and "barbe" and match case insensitively.
     // Since "Barbe" matches "Barbell", we expect matches.
@@ -32,6 +36,7 @@ describe('FreeExerciseDBService search', () => {
       'Barbell Walking Lunge',
       'Lunge (Barbell)',
     ]);
+    expect(axios.get).toHaveBeenCalledTimes(1);
   });
 
   it('prioritizes exact matches', async () => {
@@ -41,7 +46,7 @@ describe('FreeExerciseDBService search', () => {
       { name: 'Barbell Walking Lunge' },
     ];
 
-    vi.mocked(axios.get).mockResolvedValueOnce({ data: mockExercises });
+    vi.mocked(axios.get).mockResolvedValue({ data: mockExercises });
 
     // Search for "barbell lunge"
     // "Barbell Lunge" contains the exact sequence "barbell lunge", so it should rank first.
@@ -54,5 +59,235 @@ describe('FreeExerciseDBService search', () => {
       'Barbell Walking Lunge', // Priority 1 (alphabetical)
       'Lunge (Barbell)', // Priority 1 (alphabetical)
     ]);
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('downloads the dataset once for different sequential queries', async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Barbell Lunge' }, { name: 'Dumbbell Curl' }],
+    });
+
+    await freeExerciseDBService.searchExercises('lunge');
+    const curlResult = await freeExerciseDBService.searchExercises('curl');
+
+    expect(curlResult).toEqual({
+      exercises: [{ name: 'Dumbbell Curl' }],
+      totalCount: 1,
+    });
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('downloads the dataset from the raw GitHub host', async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: [] });
+
+    await freeExerciseDBService.searchExercises('lunge');
+
+    const requestedUrl = vi.mocked(axios.get).mock.calls[0]?.[0];
+    expect(requestedUrl).toBe(
+      'https://raw.githubusercontent.com/yuhonas/free-exercise-db/main/dist/exercises.json'
+    );
+    expect(requestedUrl).not.toContain('api.github.com');
+  });
+
+  it('configures a timeout for the dataset request', async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: [] });
+
+    await freeExerciseDBService.searchExercises('lunge');
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/yuhonas/free-exercise-db/main/dist/exercises.json',
+      { timeout: 15_000 }
+    );
+  });
+
+  it('shares one cold-cache download across concurrent searches', async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [
+        { name: 'Barbell Lunge' },
+        { name: 'Dumbbell Curl' },
+        { name: 'Cable Row' },
+      ],
+    });
+
+    const results = await Promise.all([
+      freeExerciseDBService.searchExercises('lunge'),
+      freeExerciseDBService.searchExercises('curl'),
+      freeExerciseDBService.searchExercises('row'),
+      freeExerciseDBService.searchExercises('barbell'),
+    ]);
+
+    expect(results).toEqual([
+      { exercises: [{ name: 'Barbell Lunge' }], totalCount: 1 },
+      { exercises: [{ name: 'Dumbbell Curl' }], totalCount: 1 },
+      { exercises: [{ name: 'Cable Row' }], totalCount: 1 },
+      { exercises: [{ name: 'Barbell Lunge' }], totalCount: 1 },
+    ]);
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a failed cold-start download during the retry interval', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    vi.mocked(axios.get).mockRejectedValue(new Error('network error'));
+
+    const firstResult = await freeExerciseDBService.searchExercises('lunge');
+    const retryResult = await freeExerciseDBService.searchExercises('curl');
+
+    expect(firstResult).toEqual({ exercises: [], totalCount: 0 });
+    expect(retryResult).toEqual({ exercises: [], totalCount: 0 });
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries after rejecting an invalid cold-start dataset response', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    vi.mocked(axios.get).mockResolvedValueOnce({
+      data: '<html>Proxy interstitial</html>',
+    });
+
+    const firstResult = await freeExerciseDBService.searchExercises('lunge');
+    vi.advanceTimersByTime(300_001);
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Dumbbell Curl' }],
+    });
+
+    const retryResult = await freeExerciseDBService.searchExercises('curl');
+
+    expect(firstResult).toEqual({ exercises: [], totalCount: 0 });
+    expect(retryResult).toEqual({
+      exercises: [{ name: 'Dumbbell Curl' }],
+      totalCount: 1,
+    });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries a failed cold-start download after the retry interval', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    vi.mocked(axios.get).mockRejectedValueOnce(new Error('network error'));
+
+    await freeExerciseDBService.searchExercises('lunge');
+    vi.advanceTimersByTime(300_001);
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Dumbbell Curl' }],
+    });
+
+    const retryResult = await freeExerciseDBService.searchExercises('curl');
+
+    expect(retryResult).toEqual({
+      exercises: [{ name: 'Dumbbell Curl' }],
+      totalCount: 1,
+    });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves the last good dataset when a refetch fails', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Barbell Lunge' }],
+    });
+    await freeExerciseDBService.searchExercises('lunge');
+    vi.advanceTimersByTime(3_600_001);
+    vi.mocked(axios.get).mockRejectedValue(new Error('network error'));
+
+    const result = await freeExerciseDBService.searchExercises('barbell');
+
+    expect(result).toEqual({
+      exercises: [{ name: 'Barbell Lunge' }],
+      totalCount: 1,
+    });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Dumbbell Curl' }],
+    });
+    vi.advanceTimersByTime(300_001);
+
+    const refreshedResult = await freeExerciseDBService.searchExercises('curl');
+
+    expect(refreshedResult).toEqual({
+      exercises: [{ name: 'Dumbbell Curl' }],
+      totalCount: 1,
+    });
+    expect(axios.get).toHaveBeenCalledTimes(3);
+  });
+
+  it('serves the last good dataset when a refresh response is invalid', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Barbell Lunge' }],
+    });
+    await freeExerciseDBService.searchExercises('lunge');
+    vi.advanceTimersByTime(3_600_001);
+    vi.mocked(axios.get).mockResolvedValue({
+      data: { message: 'Rate limit exceeded' },
+    });
+
+    const result = await freeExerciseDBService.searchExercises('barbell');
+
+    expect(result).toEqual({
+      exercises: [{ name: 'Barbell Lunge' }],
+      totalCount: 1,
+    });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves stale data without refetching during the retry interval', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Barbell Lunge' }],
+    });
+    await freeExerciseDBService.searchExercises('lunge');
+    vi.advanceTimersByTime(3_600_001);
+    vi.mocked(axios.get).mockRejectedValue(new Error('network error'));
+
+    await freeExerciseDBService.searchExercises('barbell');
+    const retryResult = await freeExerciseDBService.searchExercises('lunge');
+
+    expect(retryResult).toEqual({
+      exercises: [{ name: 'Barbell Lunge' }],
+      totalCount: 1,
+    });
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves stale data after a timeout without retrying inside the interval', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Barbell Lunge' }],
+    });
+    await freeExerciseDBService.searchExercises('lunge');
+    vi.advanceTimersByTime(3_600_001);
+    vi.mocked(axios.get).mockRejectedValue(
+      Object.assign(new Error('timeout of 15000ms exceeded'), {
+        code: 'ECONNABORTED',
+      })
+    );
+
+    const staleResult = await freeExerciseDBService.searchExercises('barbell');
+    const retryResult = await freeExerciseDBService.searchExercises('lunge');
+
+    expect(staleResult).toEqual({
+      exercises: [{ name: 'Barbell Lunge' }],
+      totalCount: 1,
+    });
+    expect(retryResult).toEqual(staleResult);
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the same dataset array reference for consecutive reads', async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [{ name: 'Barbell Lunge' }],
+    });
+
+    const first = await freeExerciseDBService.getAllExercises();
+    const second = await freeExerciseDBService.getAllExercises();
+
+    expect(second).toBe(first);
+    expect(axios.get).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The free-exercise-db integration re-downloads the entire `exercises.json` on every distinct search term, because the cache key includes the query, the filters, the limit and the offset. It also fetches through the GitHub REST API, which is the unauthenticated 60 requests per hour bucket, counted per IP and so shared by everyone on an instance. free-exercise-db is seeded as a default provider for every user, so this is on the common path.

**How did you implement the solution?**
The parsed dataset is now held once in a module-level record with its fetch timestamp and filtered in memory, fetched from `raw.githubusercontent.com` using the `GITHUB_RAW_BASE_URL` constant that was already in the file. It's deliberately kept out of the shared `NodeCache`, whose `useClones` default would otherwise deep-clone the whole dataset on every read. A single-flight promise means a burst of cold searches after a restart triggers one download rather than one per search.

The refresh path is bounded and defensive: the request carries an explicit timeout so a stalled connection can't leave every search waiting on one shared promise, the response is validated as an exercise array before it's cached so a proxy interstitial or error page can't poison the cache for the full TTL, and a failed refresh serves the last good dataset with a warning that includes its age. A five minute retry interval then applies whether or not a cached dataset exists, so a cold-start outage fails fast instead of firing a fresh request per search.

`searchExercises()` keeps its signature, so no caller changes.

Linked Issue: Closes #2367

## How to Test

1. Check out this branch and run `pnpm test` in `SparkyFitnessServer`.
2. The tests in `tests/freeExerciseDBSearch.test.ts` assert the new behaviour directly: two different queries result in exactly one `axios.get`, concurrent cold searches share one download, the request goes to the raw host, a timeout is configured, an invalid payload is rejected rather than cached, and a failed refresh serves the previous dataset and then backs off for the retry interval.
3. For a manual check, search the Online tab with free-exercise-db selected, then search again with a different term, and confirm only the first search hits the network.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

Not applicable

## Notes for Reviewers

There were no tests asserting how often the network gets hit, which is why the per-query key went unnoticed for so long, so the new tests cover that specifically. The file goes from 2 tests to 14.

The dataset is held outside `NodeCache` on purpose. `node-cache` defaults `useClones` to true, so keeping a multi-megabyte dataset in it would deep-clone the whole thing on every read, which measured at roughly 6ms per search locally. The `getExerciseById` cache entry is unchanged and still uses `NodeCache`.

Stale data is served with a warning rather than silently, so an instance whose upstream is permanently failing shows up in the logs instead of quietly serving very old exercises.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Exercise searches now reuse a cached dataset, reducing repeated downloads and improving response times.
  - Concurrent searches share a single data request instead of triggering duplicate downloads.

- **Reliability**
  - Added request timeouts and automatic retry handling for unavailable or invalid exercise data.
  - Previously retrieved data remains available during temporary refresh failures.

- **Data Quality**
  - Exercise datasets are fully validated before use, preventing malformed or inconsistent entries from appearing in search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->