### PR TITLE
feat(i18n): sync the four mobile translation surfaces with Weblate

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -159,7 +159,7 @@ Five Weblate components. The mobile app has four because its surfaces use differ
 
 A mobile surface missing from the translations repo is skipped with a notice, so the workflow is safe to run before all the components exist; the push side seeds each English source on the first run. `pr-validation.yml` rejects a human PR that edits any non-`en` translation file.
 
-Only locales listed in `SparkyFitnessMobile/src/localization/localeRegistry.json` are shipped on mobile. Others sync in as translation candidates, are reported by the i18n audit as non-blocking diagnostics, and are never bundled.
+Only locales listed in `SparkyFitnessMobile/src/localization/localeRegistry.json` are shipped on mobile. Others sync in as translation candidates, are reported by the i18n audit as non-blocking diagnostics, and are never bundled. The widget resources are the exception to "sync in": Android compiles every `values-*` directory and the iOS widget target ships every `.lproj` folder, so those two surfaces are pulled for registered locales only and a candidate's widget arrives on the sync after it is registered.
 
 **Triggers**: Manual workflow dispatch only. Requires the `TRANSLATIONS_PAT` secret.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -143,6 +143,28 @@ hasUIChanges = .tsx/.jsx/.css files in components/screens/pages/
 
 ---
 
+#### `sync-translations.yml`
+
+**Purpose**: Bidirectional sync with [SparkyFitnessTranslations](https://github.com/CodeWithCJ/SparkyFitnessTranslations), the repository Weblate is connected to. Pushes the English sources out and pulls every other language back, opening one PR on each side (`i18n/update-english-locales` there, `i18n/sync-weblate-translations` here).
+
+Five Weblate components. The mobile app has four because its surfaces use different formats and placeholder rules (`{{value}}`, `%1$s`, `%@`), so Weblate translates each native file directly and no format conversion sits in between:
+
+| Component | In the translations repo | In this repo |
+| --- | --- | --- |
+| Web | `locales/` | `SparkyFitnessFrontend/public/locales/` |
+| Mobile runtime | `mobile/src/localization/locales/` | `SparkyFitnessMobile/src/localization/locales/` |
+| Mobile Expo metadata | `mobile/locales/` | `SparkyFitnessMobile/locales/` |
+| Mobile Android widgets | `mobile/targets/android-widget/res/` | `SparkyFitnessMobile/targets/android-widget/res/` |
+| Mobile iOS widgets | `mobile/targets/widget/` | `SparkyFitnessMobile/targets/widget/` |
+
+A mobile surface missing from the translations repo is skipped with a notice, so the workflow is safe to run before all the components exist; the push side seeds each English source on the first run. `pr-validation.yml` rejects a human PR that edits any non-`en` translation file.
+
+Only locales listed in `SparkyFitnessMobile/src/localization/localeRegistry.json` are shipped on mobile. Others sync in as translation candidates, are reported by the i18n audit as non-blocking diagnostics, and are never bundled.
+
+**Triggers**: Manual workflow dispatch only. Requires the `TRANSLATIONS_PAT` secret.
+
+---
+
 #### `auto-merge-bot-prs.yml`
 
 **Purpose**: Automatically and safely merges clean automated PRs for Translations (`i18n/*`) and Nix hashes (`nix/*`) once all CI checks pass. If there are any merge conflicts, the PR is held untouched for manual review.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -72,12 +72,23 @@ jobs:
             const hasBackendChanges  = changedFiles.some(f => f.startsWith('SparkyFitnessServer/'));
             const hasMobileChanges   = changedFiles.some(f => f.startsWith('SparkyFitnessMobile/'));
 
+            // Every non-English translation file is owned by Weblate and arrives
+            // through the sync workflow.
             const localesRoot = 'SparkyFitnessFrontend/public/locales/';
+            const mobileLocalesRoot = 'SparkyFitnessMobile/src/localization/locales/';
+            const mobileNativeSurfaces = [
+              /^SparkyFitnessMobile\/locales\/(?!en\.json$)[^/]+\.json$/,
+              /^SparkyFitnessMobile\/targets\/android-widget\/res\/values-[^/]+\/widget_strings\.xml$/,
+              /^SparkyFitnessMobile\/targets\/widget\/(?!en\.lproj\/)[^/]+\.lproj\/Localizable\.strings$/,
+            ];
             const nonEnLocaleFiles = changedFiles.filter(f =>
-              f.startsWith(localesRoot) && !f.startsWith(`${localesRoot}en/`)
+              (f.startsWith(localesRoot) && !f.startsWith(`${localesRoot}en/`)) ||
+              (f.startsWith(mobileLocalesRoot) && !f.startsWith(`${mobileLocalesRoot}en/`)) ||
+              mobileNativeSurfaces.some(re => re.test(f))
             );
             const hasEnTranslationChange = changedFiles.some(f =>
-              f === `${localesRoot}en/translation.json`
+              f === `${localesRoot}en/translation.json` ||
+              f === `${mobileLocalesRoot}en/translation.json`
             );
             const hasSQLChanges = changedFiles.some(f => f.includes('rls_policies.sql'));
 
@@ -215,7 +226,8 @@ jobs:
             }
             if (nonEnLocaleFiles.length > 0) {
               errors.push(
-                `**[MANDATORY]** Only the \`en\` translation file may be modified. ` +
+                `**[MANDATORY]** Only the \`en\` translation files may be modified. ` +
+                `Every other language is owned by Weblate and arrives through the sync workflow. ` +
                 `Remove changes to: ${nonEnLocaleFiles.map(f => '`' + f + '`').join(', ')}.`
               );
             }

--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -58,9 +58,32 @@ jobs:
           MOBILE=main-repo/SparkyFitnessMobile
           MIRROR=translation-repo/mobile
 
+          # The runtime catalog and the Expo metadata are gated at build time, so an
+          # unregistered one costs nothing sitting in the repo. The widget resources
+          # are not: withCalorieWidget copies the whole res/ tree and the iOS widget
+          # target is a synchronized folder, so anything that lands there is compiled
+          # into the app. Pull only the registered locales for those two surfaces.
+          shipped=$(node -e '
+            const path = require("path");
+            const root = process.argv[1];
+            const registry = require(path.join(root, "src/localization/localeRegistry.json"));
+            const { androidDirForLocale } = require(
+              path.join(root, "scripts/androidLocaleQualifiers.cjs")
+            );
+            const locales = Object.keys(registry.locales);
+            console.log(
+              locales.map((l) => androidDirForLocale(l, registry.sourceLocale)).join(" ")
+            );
+            console.log(locales.map((l) => l + ".lproj").join(" "));
+          ' "$PWD/$MOBILE")
+          SHIPPED_ANDROID=$(echo "$shipped" | sed -n 1p)
+          SHIPPED_LPROJ=$(echo "$shipped" | sed -n 2p)
+          echo "Registered Android widget resources: $SHIPPED_ANDROID"
+          echo "Registered iOS widget resources: $SHIPPED_LPROJ"
+
           echo "=== Copying non-English mobile translations from translation repo to main repo ==="
           sync_dirs() {
-            src="$1"; dest="$2"; source_unit="$3"; pattern="${4:-*}"
+            src="$1"; dest="$2"; source_unit="$3"; pattern="${4:-*}"; allow="${5:-}"
             if [ ! -d "$src" ]; then
               echo "  $src not in the translations repo yet; skipping."
               return
@@ -71,6 +94,12 @@ jobs:
               [ -d "$dir" ] || continue
               unit=$(basename "$dir")
               [ "$unit" = "$source_unit" ] && continue
+              if [ -n "$allow" ]; then
+                case " $allow " in
+                  *" $unit "*) ;;
+                  *) echo "  skipping $unit: not in localeRegistry.json"; continue ;;
+                esac
+              fi
               echo "  $dest/$unit"
               rm -rf "${dest:?}/$unit"
               cp -r "$dir" "$dest/"
@@ -78,8 +107,8 @@ jobs:
           }
 
           sync_dirs "$MIRROR/src/localization/locales" "$MOBILE/src/localization/locales" en
-          sync_dirs "$MIRROR/targets/android-widget/res" "$MOBILE/targets/android-widget/res" values 'values-*'
-          sync_dirs "$MIRROR/targets/widget" "$MOBILE/targets/widget" en.lproj '*.lproj'
+          sync_dirs "$MIRROR/targets/android-widget/res" "$MOBILE/targets/android-widget/res" values 'values-*' "$SHIPPED_ANDROID"
+          sync_dirs "$MIRROR/targets/widget" "$MOBILE/targets/widget" en.lproj '*.lproj' "$SHIPPED_LPROJ"
 
           if [ -d "$MIRROR/locales" ]; then
             for file in "$MIRROR"/locales/*.json; do
@@ -171,7 +200,7 @@ jobs:
 
             It copies all non-English translation files from the [SparkyFitnessTranslations](https://github.com/CodeWithCJ/SparkyFitnessTranslations) repository (connected to Weblate) to the main repository, across the web catalog and the four mobile surfaces (runtime catalog, Expo metadata, Android widget resources and iOS widget resources).
 
-            Only locales listed in `SparkyFitnessMobile/src/localization/localeRegistry.json` are shipped on mobile; the others sync in as translation candidates and are not bundled.
+            Only locales listed in `SparkyFitnessMobile/src/localization/localeRegistry.json` are shipped on mobile; the others sync in as translation candidates and are not bundled. The widget resources are pulled for registered locales only, because Android and iOS compile whatever resource directories they find, so a candidate's widget arrives on the sync after it is registered.
           labels: |
             i18n
             translations

--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -53,14 +53,69 @@ jobs:
             exit 1
           fi
 
+          # Four surfaces with different formats and placeholder rules, so each is
+          # its own Weblate component rather than one shared with the others.
+          MOBILE=main-repo/SparkyFitnessMobile
+          MIRROR=translation-repo/mobile
+
+          echo "=== Copying non-English mobile translations from translation repo to main repo ==="
+          sync_dirs() {
+            src="$1"; dest="$2"; source_unit="$3"; pattern="${4:-*}"
+            if [ ! -d "$src" ]; then
+              echo "  $src not in the translations repo yet; skipping."
+              return
+            fi
+            # $pattern is deliberately unquoted so the shell expands it. res/ also
+            # holds drawable/, layout/ and xml/, which are not translation units.
+            for dir in "$src"/$pattern; do
+              [ -d "$dir" ] || continue
+              unit=$(basename "$dir")
+              [ "$unit" = "$source_unit" ] && continue
+              echo "  $dest/$unit"
+              rm -rf "${dest:?}/$unit"
+              cp -r "$dir" "$dest/"
+            done
+          }
+
+          sync_dirs "$MIRROR/src/localization/locales" "$MOBILE/src/localization/locales" en
+          sync_dirs "$MIRROR/targets/android-widget/res" "$MOBILE/targets/android-widget/res" values 'values-*'
+          sync_dirs "$MIRROR/targets/widget" "$MOBILE/targets/widget" en.lproj '*.lproj'
+
+          if [ -d "$MIRROR/locales" ]; then
+            for file in "$MIRROR"/locales/*.json; do
+              [ -f "$file" ] || continue
+              [ "$(basename "$file")" = "en.json" ] && continue
+              echo "  $MOBILE/locales/$(basename "$file")"
+              cp "$file" "$MOBILE/locales/"
+            done
+          else
+            echo "  $MIRROR/locales not in the translations repo yet; skipping."
+          fi
+
+          echo "=== Copying English mobile sources from main repo to translation repo ==="
+          # Unconditional: this seeds the four components on the first run.
+          mkdir -p "$MIRROR/src/localization/locales" "$MIRROR/locales" \
+                   "$MIRROR/targets/android-widget/res" "$MIRROR/targets/widget"
+          rm -rf "$MIRROR/src/localization/locales/en" "$MIRROR/targets/android-widget/res/values" \
+                 "$MIRROR/targets/widget/en.lproj"
+          cp -r "$MOBILE/src/localization/locales/en" "$MIRROR/src/localization/locales/"
+          cp -r "$MOBILE/targets/android-widget/res/values" "$MIRROR/targets/android-widget/res/"
+          cp -r "$MOBILE/targets/widget/en.lproj" "$MIRROR/targets/widget/"
+          cp "$MOBILE/locales/en.json" "$MIRROR/locales/"
+          echo "Copied English mobile sources successfully."
+
       # 3.5 Format the updated localization files with Prettier
       - name: Format localization files with Prettier
         run: |
           echo "=== Formatting synced files to match codebase styling ==="
           npx prettier --write "main-repo/SparkyFitnessFrontend/public/locales/**/*.json"
+          npx prettier --write "main-repo/SparkyFitnessMobile/src/localization/locales/**/*.json"
+          npx prettier --write "main-repo/SparkyFitnessMobile/locales/*.json"
           # Only format the English locale here; the other languages are owned by
           # Weblate and reformatting them would drag them into the English-only PR.
           npx prettier --write "translation-repo/locales/en/**/*.json"
+          npx prettier --write "translation-repo/mobile/src/localization/locales/en/**/*.json"
+          npx prettier --write "translation-repo/mobile/locales/en.json"
 
       # 4. Create a Pull Request in the translation repository for English locales
       - name: Create Pull Request in SparkyFitnessTranslations
@@ -70,6 +125,10 @@ jobs:
           path: translation-repo
           add-paths: |
             locales/en
+            mobile/src/localization/locales/en
+            mobile/locales/en.json
+            mobile/targets/android-widget/res/values
+            mobile/targets/widget/en.lproj
           commit-message: "chore(i18n): update English locales from main repo"
           branch: i18n/update-english-locales
           delete-branch: true
@@ -77,7 +136,15 @@ jobs:
           body: |
             This pull request was automatically created by the **Sync Translations** workflow.
 
-            It updates the English translation files (`locales/en`) with the latest keys from the main repository.
+            It updates the English source files with the latest keys from the main repository, one per Weblate component:
+
+            | Component | Path |
+            | --- | --- |
+            | Web | `locales/en` |
+            | Mobile runtime | `mobile/src/localization/locales/en` |
+            | Mobile Expo metadata | `mobile/locales/en.json` |
+            | Mobile Android widgets | `mobile/targets/android-widget/res/values` |
+            | Mobile iOS widgets | `mobile/targets/widget/en.lproj` |
 
       # 5. Create a Pull Request in the main repository for other language files
       - name: Create Pull Request in SparkyFitness
@@ -88,6 +155,13 @@ jobs:
           add-paths: |
             SparkyFitnessFrontend/public/locales
             :!SparkyFitnessFrontend/public/locales/en
+            SparkyFitnessMobile/src/localization/locales
+            :!SparkyFitnessMobile/src/localization/locales/en
+            SparkyFitnessMobile/locales
+            :!SparkyFitnessMobile/locales/en.json
+            SparkyFitnessMobile/targets/android-widget/res/values-*/widget_strings.xml
+            SparkyFitnessMobile/targets/widget/*.lproj/Localizable.strings
+            :!SparkyFitnessMobile/targets/widget/en.lproj
           commit-message: "chore(i18n): sync non-English translations from Weblate"
           branch: i18n/sync-weblate-translations
           delete-branch: true
@@ -95,7 +169,9 @@ jobs:
           body: |
             This pull request was automatically created by the **Sync Translations** workflow.
 
-            It copies all non-English translation files from the [SparkyFitnessTranslations](https://github.com/CodeWithCJ/SparkyFitnessTranslations) repository (connected to Weblate) to the main repository.
+            It copies all non-English translation files from the [SparkyFitnessTranslations](https://github.com/CodeWithCJ/SparkyFitnessTranslations) repository (connected to Weblate) to the main repository, across the web catalog and the four mobile surfaces (runtime catalog, Expo metadata, Android widget resources and iOS widget resources).
+
+            Only locales listed in `SparkyFitnessMobile/src/localization/localeRegistry.json` are shipped on mobile; the others sync in as translation candidates and are not bundled.
           labels: |
             i18n
             translations

--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -63,23 +63,57 @@ jobs:
           # are not: withCalorieWidget copies the whole res/ tree and the iOS widget
           # target is a synchronized folder, so anything that lands there is compiled
           # into the app. Pull only the registered locales for those two surfaces.
-          shipped=$(node -e '
+          registry=$(node -e '
+            const fs = require("fs");
             const path = require("path");
             const root = process.argv[1];
-            const registry = require(path.join(root, "src/localization/localeRegistry.json"));
-            const { androidDirForLocale } = require(
+            const manifest = require(path.join(root, "src/localization/localeRegistry.json"));
+            const { androidDirForLocale, localeFromAndroidDir } = require(
               path.join(root, "scripts/androidLocaleQualifiers.cjs")
             );
-            const locales = Object.keys(registry.locales);
+            const source = manifest.sourceLocale;
+            const locales = Object.keys(manifest.locales);
+            const android = locales.map((l) => androidDirForLocale(l, source));
+            const lproj = locales.map((l) => l + ".lproj");
+            // Dropping a locale from the registry has to unship its widget too, so
+            // list what is already here and no longer registered. localeFromAndroidDir
+            // returns null for values-night and the other non-locale qualifiers, which
+            // keeps them out of the removal list.
+            const stale = (dir, isUnit, keep) =>
+              fs
+                .readdirSync(path.join(root, dir))
+                .filter((name) => isUnit(name) && !keep.includes(name));
+            console.log(android.join(" "));
+            console.log(lproj.join(" "));
             console.log(
-              locales.map((l) => androidDirForLocale(l, registry.sourceLocale)).join(" ")
+              stale(
+                "targets/android-widget/res",
+                (name) => localeFromAndroidDir(name, source) !== null,
+                android
+              ).join(" ")
             );
-            console.log(locales.map((l) => l + ".lproj").join(" "));
+            console.log(
+              stale(
+                "targets/widget",
+                (name) => name.endsWith(".lproj"),
+                lproj
+              ).join(" ")
+            );
           ' "$PWD/$MOBILE")
-          SHIPPED_ANDROID=$(echo "$shipped" | sed -n 1p)
-          SHIPPED_LPROJ=$(echo "$shipped" | sed -n 2p)
+          SHIPPED_ANDROID=$(echo "$registry" | sed -n 1p)
+          SHIPPED_LPROJ=$(echo "$registry" | sed -n 2p)
           echo "Registered Android widget resources: $SHIPPED_ANDROID"
           echo "Registered iOS widget resources: $SHIPPED_LPROJ"
+
+          prune_unregistered() {
+            dest="$1"
+            for unit in $2; do
+              echo "  removing $dest/$unit: no longer in localeRegistry.json"
+              rm -rf "${dest:?}/$unit"
+            done
+          }
+          prune_unregistered "$MOBILE/targets/android-widget/res" "$(echo "$registry" | sed -n 3p)"
+          prune_unregistered "$MOBILE/targets/widget" "$(echo "$registry" | sed -n 4p)"
 
           echo "=== Copying non-English mobile translations from translation repo to main repo ==="
           sync_dirs() {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,7 @@ Every PR must include:
   - **Zod Validation**: New endpoints must include Zod schemas for request/response validation
   - **Endpoint Tests**: New endpoints must include automated tests
 - **Translations**: If applicable, only update the English (`en`) translation file. Translations should have hardcoded fall back directly in the code Non-English translation files are maintained in a separate repository linked with Webplate. https://github.com/CodeWithCJ/SparkyFitnessTranslations
+  - This covers the mobile app too, which has four translated surfaces: the runtime catalog, the Expo permission metadata, and the Android and iOS widget resources. Each is a separate Weblate component; edit only its `en` source.
 - **Architecture**: Follow the existing project standards
 - **Database Security**: Any new user-specific tables must be added to Row Level Security (RLS) in `SparkyFitnessServer/db/rls_policies.sql`.
 - **Code Integrity**: You certify that your contribution contains no malicious code (phishing, malware, etc.)

--- a/SparkyFitnessMobile/AGENTS.md
+++ b/SparkyFitnessMobile/AGENTS.md
@@ -31,7 +31,7 @@ English (`en`) is the canonical source locale and the deterministic fallback. Fe
 
 Feature developers do not need to know or translate Polish or any future language, and do not need to wait for Weblate. Translators/Weblate own Polish and future translations and linguistic QA. Missing translation content is non-blocking and falls back to English; existing translated content remains structurally validated.
 
-The shipped locale registry is `src/localization/localeRegistry.json`, read through the typed accessors in `src/localization/localeRegistry.ts`. Adding a catalog to Weblate does not ship it. Shipping requires explicit registry enablement plus native/platform support verification. RN catalogs and native resources are separate surfaces (Expo metadata, Android widget resources, and iOS widget/Live Activity `.lproj` resources).
+The shipped locale registry is `src/localization/localeRegistry.json`, read through the typed accessors in `src/localization/localeRegistry.ts`. Adding a catalog to Weblate does not ship it. Shipping requires explicit registry enablement plus native/platform support verification. RN catalogs and native resources are separate surfaces (Expo metadata, Android widget resources, and iOS widget/Live Activity `.lproj` resources), each its own Weblate component and each synced by `.github/workflows/sync-translations.yml`. Only the `en` side of any surface is edited by hand; the i18n audit blocks on registered locales and reports unregistered ones without failing.
 
 ## Commands
 

--- a/SparkyFitnessMobile/AGENTS.md
+++ b/SparkyFitnessMobile/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-_Last updated: 2026-09-02_
+_Last updated: 2026-09-04_
 
 SparkyFitness Mobile is a React Native 0.85 + Expo SDK 56 app for syncing Apple Health / Health Connect data with the SparkyFitness backend, tracking nutrition, hydration, fasting, measurements, exercise, saved foods, meal templates, custom exercises, workout presets, iOS / Android widgets, the active workout HUD, and the Sparky AI chat.
 
@@ -31,7 +31,7 @@ English (`en`) is the canonical source locale and the deterministic fallback. Fe
 
 Feature developers do not need to know or translate Polish or any future language, and do not need to wait for Weblate. Translators/Weblate own Polish and future translations and linguistic QA. Missing translation content is non-blocking and falls back to English; existing translated content remains structurally validated.
 
-The shipped locale registry is `src/localization/localeRegistry.json`, read through the typed accessors in `src/localization/localeRegistry.ts`. Adding a catalog to Weblate does not ship it. Shipping requires explicit registry enablement plus native/platform support verification. RN catalogs and native resources are separate surfaces (Expo metadata, Android widget resources, and iOS widget/Live Activity `.lproj` resources), each its own Weblate component and each synced by `.github/workflows/sync-translations.yml`. Only the `en` side of any surface is edited by hand; the i18n audit blocks on registered locales and reports unregistered ones without failing.
+The shipped locale registry is `src/localization/localeRegistry.json`, read through the typed accessors in `src/localization/localeRegistry.ts`. Adding a catalog to Weblate does not ship it. Shipping requires explicit registry enablement plus native/platform support verification. RN catalogs and native resources are separate surfaces (Expo metadata, Android widget resources, and iOS widget/Live Activity `.lproj` resources), each its own Weblate component and each synced by `.github/workflows/sync-translations.yml`. Only the `en` side of any surface is edited by hand; the i18n audit blocks on registered locales and reports unregistered ones without failing. The workflow pulls the widget resources for registered locales only, because Android and iOS compile whatever resource directories are present and there is no build-time registry check for them.
 
 ## Commands
 

--- a/SparkyFitnessMobile/__tests__/config/widgetResourceContract.test.ts
+++ b/SparkyFitnessMobile/__tests__/config/widgetResourceContract.test.ts
@@ -1,9 +1,17 @@
 import fs from 'fs';
 import path from 'path';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
 import {
   SHIPPED_LOCALES,
   SOURCE_LOCALE,
 } from '../../src/localization/localeRegistry';
+
+const require = createRequire(pathToFileURL(__filename));
+const { localeFromAndroidDir } =
+  require('../../scripts/androidLocaleQualifiers.cjs') as {
+    localeFromAndroidDir: (name: string, source: string) => string | null;
+  };
 
 const TARGETS_ROOT = path.join(__dirname, '../../targets/android-widget');
 
@@ -19,22 +27,14 @@ const RES_ROOT = path.join(TARGETS_ROOT, 'res');
 
 /**
  * Discover every Android widget resource directory below `res/`, mapping
- * locale tags the same way the native validator does (`values` → source,
- * `values-de` → `de`, `values-b+de+DE` → `de-DE`).
+ * locale tags with the same helper the native validator uses.
  */
 function discoverWidgetLocaleDirs(): Map<string, string> {
   const result = new Map<string, string>();
   for (const entry of fs.readdirSync(RES_ROOT, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
-    if (entry.name === 'values') {
-      result.set(SOURCE_LOCALE, entry.name);
-    } else if (entry.name.startsWith('values-')) {
-      const qualifier = entry.name.slice('values-'.length);
-      const locale = qualifier.startsWith('b+')
-        ? qualifier.slice(2).replaceAll('+', '-')
-        : qualifier;
-      result.set(locale, entry.name);
-    }
+    const locale = localeFromAndroidDir(entry.name, SOURCE_LOCALE);
+    if (locale) result.set(locale, entry.name);
   }
   return result;
 }
@@ -169,7 +169,7 @@ describe('Android widget localization contract', () => {
     });
 
     it('does not keep resource keys that lost their consumer after the resize removal', () => {
-      for (const locale of WIDGET_LOCALE_DIRS.keys()) {
+      for (const locale of SHIPPED_WIDGET_LOCALES) {
         const resources = new Set(
           readWidgetStringResources(locale).map((r) => r.name)
         );
@@ -222,8 +222,11 @@ describe('Android widget localization contract', () => {
       }
     });
 
-    it('does not use i18next placeholder syntax in any Android widget XML', () => {
-      for (const locale of WIDGET_LOCALE_DIRS.keys()) {
+    // Weblate writes a directory long before anyone ships it, so these assertions
+    // cover the source and the registered locales; the rest are candidates and are
+    // reported by the native validator instead.
+    it('does not use i18next placeholder syntax in any shipped Android widget XML', () => {
+      for (const locale of SHIPPED_WIDGET_LOCALES) {
         for (const resource of readWidgetStringResources(locale)) {
           expect(resource.value).not.toMatch(/\{\{/);
           expect(resource.value).not.toMatch(/\}\}/);

--- a/SparkyFitnessMobile/__tests__/scripts/i18nAudit.test.ts
+++ b/SparkyFitnessMobile/__tests__/scripts/i18nAudit.test.ts
@@ -1895,4 +1895,32 @@ describe('unregistered locale catalogs', () => {
       'invalid-locale-tag'
     );
   });
+
+  it('does not abort the audit when an unregistered catalog is not valid JSON', () => {
+    const tmpDir = createFixtureStructure({ en: SOURCE, pl: SOURCE, de: '{' });
+    unregister(tmpDir, 'de');
+
+    const { report, hasErrors } = auditRun(tmpDir);
+
+    expect(hasErrors).toBe(false);
+    expect(report.localeStructuralErrors).toHaveLength(0);
+    const finding = report.unregisteredLocaleFindings.find(
+      (e) => e.rule === 'malformed-json'
+    );
+    expect(finding?.locale).toBe('de');
+    // The audit ran to completion instead of returning at the parse failure.
+    expect(Object.keys(report.translationCoverage)).toContain('pl');
+  });
+
+  it('still blocks when a registered catalog is not valid JSON', () => {
+    const tmpDir = createFixtureStructure({ en: SOURCE, pl: SOURCE, de: '{' });
+
+    const { report, hasErrors } = auditRun(tmpDir);
+
+    expect(hasErrors).toBe(true);
+    expect(report.localeStructuralErrors.map((e) => e.rule)).toContain(
+      'malformed-json'
+    );
+    expect(report.unregisteredLocaleFindings).toHaveLength(0);
+  });
 });

--- a/SparkyFitnessMobile/__tests__/scripts/i18nAudit.test.ts
+++ b/SparkyFitnessMobile/__tests__/scripts/i18nAudit.test.ts
@@ -59,6 +59,7 @@ interface AuditReport {
   dynamicI18nFindings: AuditError[];
   hardcodedUiFindings: AuditFinding[];
   unsafeNumberFormatFindings: AuditFinding[];
+  unregisteredLocaleFindings: AuditError[];
   summary: Record<string, number>;
   translationCoverage: Record<string, LocaleCoverage>;
 }
@@ -1820,5 +1821,78 @@ describe('Multilingual source-first regressions', () => {
       enLocalePath: path.join(tmpDir, 'nonexistent', 'en', 'translation.json'),
     });
     expect(result.hasErrors).toBe(true);
+  });
+});
+
+describe('unregistered locale catalogs', () => {
+  const BROKEN = JSON.stringify({ greeting: 'Hola {{wrong}}' });
+  const SOURCE = JSON.stringify({ greeting: 'Hello {{name}}' });
+
+  interface FixtureRegistry {
+    locales: Record<string, unknown>;
+  }
+
+  /** Leaves the locale directory on disk, only the registry entry goes. */
+  function unregister(tmpDir: string, locale: string): void {
+    const registryPath = path.join(
+      tmpDir,
+      'src/localization/localeRegistry.json'
+    );
+    const registry = JSON.parse(
+      fs.readFileSync(registryPath, 'utf8')
+    ) as unknown as FixtureRegistry;
+    delete registry.locales[locale];
+    fs.writeFileSync(registryPath, JSON.stringify(registry, null, 2));
+  }
+
+  it('does not block on a placeholder mismatch in a catalog that is not registered', () => {
+    const tmpDir = createFixtureStructure({ en: SOURCE, pl: BROKEN });
+    unregister(tmpDir, 'pl');
+
+    const { report, hasErrors } = auditRun(tmpDir);
+
+    expect(hasErrors).toBe(false);
+    expect(report.placeholderErrors).toHaveLength(0);
+    const finding = report.unregisteredLocaleFindings.find(
+      (e) => e.rule === 'placeholder-mismatch'
+    );
+    expect(finding?.locale).toBe('pl');
+    expect(report.summary.unregisteredLocaleFindings).toBe(
+      report.unregisteredLocaleFindings.length
+    );
+  });
+
+  it('still blocks on the same defect once the locale is registered', () => {
+    const tmpDir = createFixtureStructure({ en: SOURCE, pl: BROKEN });
+
+    const { report, hasErrors } = auditRun(tmpDir);
+
+    expect(hasErrors).toBe(true);
+    expect(report.placeholderErrors.map((e) => e.locale)).toContain('pl');
+    expect(report.unregisteredLocaleFindings).toHaveLength(0);
+  });
+
+  it('reports coverage for an unregistered catalog rather than ignoring it', () => {
+    const tmpDir = createFixtureStructure({ en: SOURCE, pl: BROKEN });
+    unregister(tmpDir, 'pl');
+
+    const { report } = auditRun(tmpDir);
+
+    expect(Object.keys(report.translationCoverage)).toContain('pl');
+  });
+
+  it('does not block on an unregistered directory whose name is not a valid locale tag', () => {
+    const tmpDir = createFixtureStructure({ en: SOURCE, pl: SOURCE });
+    const strayDir = path.join(tmpDir, 'src/localization/locales/not a locale');
+    fs.mkdirSync(strayDir, { recursive: true });
+    fs.writeFileSync(path.join(strayDir, 'translation.json'), SOURCE);
+
+    const { report, hasErrors } = auditRun(tmpDir);
+
+    expect(hasErrors).toBe(false);
+    expect(report.localeStructuralErrors).toHaveLength(0);
+    expect(report.unregisteredLocaleFindings.map((e) => e.rule)).toContain(
+      'invalid-locale-tag'
+    );
   });
 });

--- a/SparkyFitnessMobile/__tests__/scripts/localeResourcePipeline.test.ts
+++ b/SparkyFitnessMobile/__tests__/scripts/localeResourcePipeline.test.ts
@@ -188,4 +188,84 @@ describe('registry-driven locale resource pipeline', () => {
     expect(output).toContain('de: 1/1 (0 missing)');
     fs.rmSync(root, { recursive: true, force: true });
   });
+
+  it('resolves the Android resource qualifiers Weblate writes for a shipped regional or aliased locale', () => {
+    const root = fixtureRoot();
+    const registryPath = path.join(
+      root,
+      'src/localization/localeRegistry.json'
+    );
+    const registry = JSON.parse(fs.readFileSync(registryPath, 'utf8'));
+    for (const [locale, intlLocale] of [
+      ['pt-BR', 'pt-BR'],
+      ['id', 'id-ID'],
+    ]) {
+      registry.locales[locale] = {
+        languageCode: locale,
+        intlLocale,
+        displayNameKey: `settings.language.${locale}`,
+        defaultDisplayName: locale,
+      };
+      fs.mkdirSync(path.join(root, 'src/localization/locales', locale), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(root, 'src/localization/locales', locale, 'translation.json'),
+        '{}'
+      );
+      fs.writeFileSync(path.join(root, 'locales', `${locale}.json`), '{}');
+    }
+    fs.writeFileSync(registryPath, JSON.stringify(registry));
+    writeNative(
+      root,
+      'en',
+      '<resources><string name="title">Hello</string></resources>',
+      '"title" = "Hello";'
+    );
+    for (const locale of ['pl', 'de']) {
+      writeNative(
+        root,
+        locale,
+        '<resources><string name="title">Hello</string></resources>',
+        '"title" = "Hello";'
+      );
+    }
+    // Android's own qualifiers, which is what the Weblate component emits:
+    // a region is -rXX and Indonesian keeps its legacy `in` code.
+    for (const [dir, lproj] of [
+      ['values-pt-rBR', 'pt-BR'],
+      ['values-in', 'id'],
+    ]) {
+      fs.mkdirSync(path.join(root, 'targets/android-widget/res', dir), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(
+          root,
+          'targets/android-widget/res',
+          dir,
+          'widget_strings.xml'
+        ),
+        '<resources><string name="title">Olá</string></resources>'
+      );
+      fs.mkdirSync(path.join(root, 'targets/widget', `${lproj}.lproj`), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(
+          root,
+          'targets/widget',
+          `${lproj}.lproj`,
+          'Localizable.strings'
+        ),
+        '"title" = "Olá";'
+      );
+    }
+
+    const output = run(nativeValidator, ['--root', root]);
+
+    expect(output).toContain('pt-BR: 1/1 (0 missing)');
+    expect(output).toContain('id: 1/1 (0 missing)');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
 });

--- a/SparkyFitnessMobile/__tests__/scripts/multilingualFoundation.test.ts
+++ b/SparkyFitnessMobile/__tests__/scripts/multilingualFoundation.test.ts
@@ -12,6 +12,15 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const require = createRequire(pathToFileURL(__filename));
+const androidQualifiers =
+  require('../../scripts/androidLocaleQualifiers.cjs') as {
+    localeFromAndroidDir: (name: string, source: string) => string | null;
+    androidDirForLocale: (locale: string, source: string) => string;
+  };
 
 const MOBILE_ROOT = path.resolve(__dirname, '../..');
 const generator = path.join(
@@ -874,13 +883,21 @@ describe('Android widget values-de can be added without Kotlin edits', () => {
     expect(pluginSource).not.toMatch(/values-en/);
   });
 
-  it('Android BCP-47 mapping: language-only uses values-<locale>, regional uses b+', () => {
-    // Verify the native validator's androidDirForLocale logic.
-    const validatorSource = fs.readFileSync(
-      path.join(MOBILE_ROOT, 'scripts/validate-native-widget-locales.mjs'),
-      'utf8'
-    );
-    expect(validatorSource).toContain('values-${locale}');
-    expect(validatorSource).toContain('values-b+');
+  it('Android qualifier mapping: language-only is values-<locale>, a region is -rXX and a script is b+', () => {
+    const { localeFromAndroidDir, androidDirForLocale } = androidQualifiers;
+
+    expect(androidDirForLocale('en', 'en')).toBe('values');
+    expect(androidDirForLocale('de', 'en')).toBe('values-de');
+    expect(androidDirForLocale('pt-BR', 'en')).toBe('values-pt-rBR');
+    expect(androidDirForLocale('yue-Hant', 'en')).toBe('values-b+yue+Hant');
+    // Android keeps legacy codes for a few languages, and Weblate writes them.
+    expect(androidDirForLocale('id', 'en')).toBe('values-in');
+    expect(androidDirForLocale('zh-Hans', 'en')).toBe('values-zh-rCN');
+
+    expect(localeFromAndroidDir('values', 'en')).toBe('en');
+    expect(localeFromAndroidDir('values-pt-rBR', 'en')).toBe('pt-BR');
+    expect(localeFromAndroidDir('values-b+yue+Hant', 'en')).toBe('yue-Hant');
+    expect(localeFromAndroidDir('values-in', 'en')).toBe('id');
+    expect(localeFromAndroidDir('drawable', 'en')).toBeNull();
   });
 });

--- a/SparkyFitnessMobile/__tests__/scripts/multilingualFoundation.test.ts
+++ b/SparkyFitnessMobile/__tests__/scripts/multilingualFoundation.test.ts
@@ -900,4 +900,18 @@ describe('Android widget values-de can be added without Kotlin edits', () => {
     expect(localeFromAndroidDir('values-in', 'en')).toBe('id');
     expect(localeFromAndroidDir('drawable', 'en')).toBeNull();
   });
+
+  it('does not read a non-locale Android qualifier as a locale', () => {
+    // `values-` is shared with every other qualifier, so a widget_strings.xml under
+    // values-night would otherwise be validated as a locale called "night".
+    for (const dir of [
+      'values-night',
+      'values-v31',
+      'values-sw600dp',
+      'values-land',
+      'values-xlarge',
+    ]) {
+      expect(androidQualifiers.localeFromAndroidDir(dir, 'en')).toBeNull();
+    }
+  });
 });

--- a/SparkyFitnessMobile/docs/multilingual-i18n-foundation.md
+++ b/SparkyFitnessMobile/docs/multilingual-i18n-foundation.md
@@ -54,6 +54,13 @@ is not bundled, and the i18n audit reports its defects as non-blocking
 `unregisteredLocaleFindings` so an unshipped language cannot redden CI.
 Registered locales stay fully blocking.
 
+The runtime catalog and the metadata are gated at build time, so a candidate is
+free to sit in the repo. The widget resources have no such gate — Android
+compiles every `values-*` directory and the iOS widget target ships every
+`.lproj` folder — so the sync workflow pulls those two surfaces for registered
+locales only, and a candidate's widget arrives on the sync after it is
+registered.
+
 `pnpm run i18n:generate` deterministically emits
 `src/localization/generatedLocaleResources.ts` with Metro-safe static imports
 for every shipped runtime catalog. `pnpm run i18n:generate:check` is included in

--- a/SparkyFitnessMobile/docs/multilingual-i18n-foundation.md
+++ b/SparkyFitnessMobile/docs/multilingual-i18n-foundation.md
@@ -30,9 +30,10 @@ widget locale bridge.
 2. **Expo/native metadata** — source `locales/en.json`; mask `locales/*.json`.
 3. **Android widgets** — source
    `targets/android-widget/res/values/widget_strings.xml`; targets
-   `targets/android-widget/res/values-*/widget_strings.xml`. Language-only tags
-   use `values-de`; BCP-47 tags with region/script use Android's
-   `values-b+de+DE` form.
+   `targets/android-widget/res/values-*/widget_strings.xml`. Directory names are
+   Android qualifiers, not BCP-47 tags: `values-de` for a language, `values-pt-rBR`
+   for a region, `values-b+yue+Hant` for a script, and a few legacy aliases such as
+   `values-in` for `id`. `scripts/androidLocaleQualifiers.cjs` maps both ways.
 4. **iOS widgets / Live Activities** — source
    `targets/widget/en.lproj/Localizable.strings`; mask
    `targets/widget/*.lproj/Localizable.strings`.
@@ -43,11 +44,17 @@ source of each is pushed to `mobile/…` in
 [SparkyFitnessTranslations](https://github.com/CodeWithCJ/SparkyFitnessTranslations),
 and every other language is pulled back. Translators edit the real native files,
 so no format conversion sits between Weblate and the app. EN is the canonical
-source and fallback. Only EN requires complete, non-empty source coverage. Target missing
-or empty values are coverage diagnostics and fall back to EN/default native
-resources; malformed JSON/XML/strings, incompatible type/array shape,
+source and fallback. Only EN requires complete, non-empty source coverage. A key a
+target does not define is a coverage diagnostic and resolves to EN or the default
+native resource; malformed JSON/XML/strings, incompatible type/array shape,
 placeholder mismatch, plural collision, and invalid CLDR plural category remain
 blocking.
+
+An _empty_ value is not the same as a missing one on the native surfaces. Android
+returns the empty string for `<string name="x"></string>` in `values-de/` rather
+than falling back to `values/`, so an empty entry would render a blank widget
+label. Weblate omits untranslated units instead of writing them empty, which is
+why the widget resources fall back key by key in practice.
 
 A catalog that arrives without a registry entry is a translation candidate: it
 is not bundled, and the i18n audit reports its defects as non-blocking

--- a/SparkyFitnessMobile/docs/multilingual-i18n-foundation.md
+++ b/SparkyFitnessMobile/docs/multilingual-i18n-foundation.md
@@ -37,12 +37,22 @@ widget locale bridge.
    `targets/widget/en.lproj/Localizable.strings`; mask
    `targets/widget/*.lproj/Localizable.strings`.
 
-These may be separate Weblate components. EN is the canonical source and
-fallback. Only EN requires complete, non-empty source coverage. Target missing
+These are four separate Weblate components, synced both ways by
+`.github/workflows/sync-translations.yml` alongside the web catalog: the English
+source of each is pushed to `mobile/…` in
+[SparkyFitnessTranslations](https://github.com/CodeWithCJ/SparkyFitnessTranslations),
+and every other language is pulled back. Translators edit the real native files,
+so no format conversion sits between Weblate and the app. EN is the canonical
+source and fallback. Only EN requires complete, non-empty source coverage. Target missing
 or empty values are coverage diagnostics and fall back to EN/default native
 resources; malformed JSON/XML/strings, incompatible type/array shape,
 placeholder mismatch, plural collision, and invalid CLDR plural category remain
 blocking.
+
+A catalog that arrives without a registry entry is a translation candidate: it
+is not bundled, and the i18n audit reports its defects as non-blocking
+`unregisteredLocaleFindings` so an unshipped language cannot redden CI.
+Registered locales stay fully blocking.
 
 `pnpm run i18n:generate` deterministically emits
 `src/localization/generatedLocaleResources.ts` with Metro-safe static imports
@@ -55,7 +65,8 @@ native resource resolution falls back to default/source resources.
 ### Adding `de`
 
 1. Let Weblate create/sync runtime, metadata, Android-widget and iOS-widget
-   translations. They can be incomplete throughout translation work.
+   translations; the sync workflow brings them into the repo. They can be
+   incomplete throughout translation work.
 2. When ready to ship, add `de` metadata to `localeRegistry.json`, provide its
    runtime and metadata files plus (possibly partial) native widget files, and
    run `pnpm run i18n:generate`.

--- a/SparkyFitnessMobile/scripts/androidLocaleQualifiers.cjs
+++ b/SparkyFitnessMobile/scripts/androidLocaleQualifiers.cjs
@@ -11,14 +11,22 @@ const TAG_TO_ANDROID = Object.fromEntries(
   Object.entries(ANDROID_TO_TAG).map(([qualifier, tag]) => [tag, qualifier])
 );
 const REGION_TAG = /^[A-Za-z]{2,3}-(?:[A-Za-z]{2}|\d{3})$/;
+// `values-` is shared with every other Android qualifier, so a locale has to be
+// recognized rather than assumed: values-night, values-v31 and values-sw600dp
+// are not translation units.
+const ANDROID_LANGUAGE = /^[a-z]{2,3}$/;
+const ANDROID_LANGUAGE_REGION = /^[a-z]{2,3}-r(?:[A-Z]{2}|\d{3})$/;
 
 function localeFromAndroidDir(name, source) {
   if (name === 'values') return source;
   if (!name.startsWith('values-')) return null;
   const qualifier = name.slice('values-'.length);
-  const tag = qualifier.startsWith('b+')
-    ? qualifier.slice(2).replaceAll('+', '-')
-    : qualifier.replace(/-r(?=(?:[A-Za-z]{2}|\d{3})$)/, '-');
+  let tag;
+  if (qualifier.startsWith('b+')) tag = qualifier.slice(2).replaceAll('+', '-');
+  else if (ANDROID_LANGUAGE.test(qualifier)) tag = qualifier;
+  else if (ANDROID_LANGUAGE_REGION.test(qualifier))
+    tag = qualifier.replace('-r', '-');
+  else return null;
   return ANDROID_TO_TAG[tag] ?? tag;
 }
 

--- a/SparkyFitnessMobile/scripts/androidLocaleQualifiers.cjs
+++ b/SparkyFitnessMobile/scripts/androidLocaleQualifiers.cjs
@@ -1,0 +1,34 @@
+// Android resource qualifiers are not BCP-47 tags: a region is written `-rXX`, a
+// script needs the `b+` form, and a few languages keep a legacy code. Weblate emits
+// these (values-pt-rBR, values-zh-rCN, values-in), so the registry tag and the
+// directory name have to be translated in both directions.
+const ANDROID_TO_TAG = {
+  in: 'id',
+  'zh-CN': 'zh-Hans',
+  'zh-TW': 'zh-Hant',
+};
+const TAG_TO_ANDROID = Object.fromEntries(
+  Object.entries(ANDROID_TO_TAG).map(([qualifier, tag]) => [tag, qualifier])
+);
+const REGION_TAG = /^[A-Za-z]{2,3}-(?:[A-Za-z]{2}|\d{3})$/;
+
+function localeFromAndroidDir(name, source) {
+  if (name === 'values') return source;
+  if (!name.startsWith('values-')) return null;
+  const qualifier = name.slice('values-'.length);
+  const tag = qualifier.startsWith('b+')
+    ? qualifier.slice(2).replaceAll('+', '-')
+    : qualifier.replace(/-r(?=(?:[A-Za-z]{2}|\d{3})$)/, '-');
+  return ANDROID_TO_TAG[tag] ?? tag;
+}
+
+function androidDirForLocale(locale, source) {
+  if (locale === source) return 'values';
+  const qualifier = TAG_TO_ANDROID[locale] ?? locale;
+  if (!qualifier.includes('-')) return `values-${qualifier}`;
+  return REGION_TAG.test(qualifier)
+    ? `values-${qualifier.replace('-', '-r')}`
+    : `values-b+${qualifier.replaceAll('-', '+')}`;
+}
+
+module.exports = { localeFromAndroidDir, androidDirForLocale };

--- a/SparkyFitnessMobile/scripts/audit-mobile-i18n.mjs
+++ b/SparkyFitnessMobile/scripts/audit-mobile-i18n.mjs
@@ -65,6 +65,15 @@ function printHumanReport() {
     }
   }
 
+  if ((report.unregisteredLocaleFindings ?? []).length > 0) {
+    console.log('\nUnregistered locale findings (non-blocking, not shipped):');
+    for (const e of report.unregisteredLocaleFindings) {
+      console.log(
+        `  - ${e.locale} ${e.rule}${e.key ? ` ${e.key}` : ''}: ${e.message ?? ''}`
+      );
+    }
+  }
+
   console.log('\n=== Summary ===');
   console.log(`source locale: ${summary.sourceLocale ?? 'en'}`);
   console.log(`fallback locale: ${summary.fallbackLocale ?? 'en'}`);

--- a/SparkyFitnessMobile/scripts/i18n-audit/core.cjs
+++ b/SparkyFitnessMobile/scripts/i18n-audit/core.cjs
@@ -96,9 +96,14 @@ function runAudit(options = {}) {
     dynamicI18nFindings: [],
     unsafeNumberFormatFindings: [],
     manualPluralizationFindings: [],
+    // Weblate creates a catalog long before anyone ships it, so defects in an
+    // unregistered one are reported but never block. Registered locales do.
+    unregisteredLocaleFindings: [],
     translationCoverage: {},
     summary: {},
   };
+
+  const isShipped = (locale) => Object.hasOwn(manifest.locales ?? {}, locale);
 
   const sourceLocaleDir = path.dirname(enLocalePath);
   const localeRoot = path.dirname(sourceLocaleDir);
@@ -122,11 +127,15 @@ function runAudit(options = {}) {
           );
           return true;
         } catch {
-          report.localeStructuralErrors.push({
+          const finding = {
             rule: 'invalid-locale-tag',
             locale: entry.locale,
             message: `Invalid locale tag "${entry.intlLocale}" discovered in locale root; skipping`,
-          });
+          };
+          (isShipped(entry.locale)
+            ? report.localeStructuralErrors
+            : report.unregisteredLocaleFindings
+          ).push(finding);
           return false;
         }
       });
@@ -152,7 +161,14 @@ function runAudit(options = {}) {
   report.translationCoverage = localeResult.coverage || {};
 
   for (const error of localeResult.errors) {
-    if (error.rule === 'missing-plural-form') {
+    // Errors without a locale belong to the source catalog.
+    if (
+      error.locale !== undefined &&
+      error.locale !== SOURCE_LOCALE &&
+      !isShipped(error.locale)
+    ) {
+      report.unregisteredLocaleFindings.push(error);
+    } else if (error.rule === 'missing-plural-form') {
       report.pluralErrors.push(error);
     } else if (error.rule === 'placeholder-mismatch') {
       report.placeholderErrors.push(error);
@@ -317,6 +333,8 @@ function buildSummary(report) {
     dynamicI18nFindings: report.dynamicI18nFindings.length,
     unsafeNumberFormatFindings: report.unsafeNumberFormatFindings.length,
     manualPluralizationFindings: report.manualPluralizationFindings.length,
+    unregisteredLocaleFindings: (report.unregisteredLocaleFindings ?? [])
+      .length,
     sourceScanErrors: report.localeStructuralErrors.filter(
       (e) => e.rule === SOURCE_SCAN_ERROR_RULE
     ).length,

--- a/SparkyFitnessMobile/scripts/validate-native-widget-locales.mjs
+++ b/SparkyFitnessMobile/scripts/validate-native-widget-locales.mjs
@@ -2,6 +2,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+// A static import, not createRequire: the widget tests import this module through
+// Jest's CommonJS transform, where `import.meta` is undefined.
+import {
+  localeFromAndroidDir,
+  androidDirForLocale,
+} from './androidLocaleQualifiers.cjs';
 
 // `%%` must be consumed first: otherwise in "50%% goal" the second `%` starts a
 // match, takes the space as a flag and `g` as the conversion, inventing a "% g"
@@ -43,21 +49,6 @@ export function parseIosStrings(content) {
   if (content.trim() && values.size === 0)
     throw new Error('iOS Localizable.strings has no parseable declarations');
   return values;
-}
-function localeFromAndroidDir(name, source) {
-  if (name === 'values') return source;
-  if (!name.startsWith('values-')) return null;
-  const qualifier = name.slice('values-'.length);
-  return qualifier.startsWith('b+')
-    ? qualifier.slice(2).replaceAll('+', '-')
-    : qualifier;
-}
-function androidDirForLocale(locale, source) {
-  if (locale === source) return 'values';
-  // Android BCP-47 resource syntax: language-only is values-de; regional/script tags use b+.
-  return locale.includes('-')
-    ? `values-b+${locale.replaceAll('-', '+')}`
-    : `values-${locale}`;
 }
 function sourceMap(maps, source, surface) {
   const result = maps.get(source);

--- a/SparkyFitnessMobile/scripts/validate-native-widget-locales.mjs
+++ b/SparkyFitnessMobile/scripts/validate-native-widget-locales.mjs
@@ -65,8 +65,9 @@ function sourceMap(maps, source, surface) {
     throw new Error(`${surface} has no source resource catalog for ${source}`);
   return result;
 }
-function validateSurface({ maps, source, surface, formatRegex }) {
+function validateSurface({ maps, source, surface, formatRegex, isShipped }) {
   const errors = [];
+  const findings = [];
   const coverage = {};
   const base = sourceMap(maps, source, surface);
   for (const [key, value] of base) {
@@ -78,23 +79,26 @@ function validateSurface({ maps, source, surface, formatRegex }) {
       );
   }
   for (const [locale, target] of maps) {
+    // Weblate writes a directory long before anyone ships it, so only a
+    // registered locale's defects can block; the rest are reported.
+    const sink = locale === source || isShipped(locale) ? errors : findings;
     let translated = 0;
     for (const [key, value] of target) {
       if (!base.has(key)) {
-        errors.push(`${surface} ${locale}:${key} does not exist in source`);
+        sink.push(`${surface} ${locale}:${key} does not exist in source`);
         continue;
       }
       if (isBlank(value)) {
         continue;
       }
       if (/\{\{.*?\}\}/.test(value))
-        errors.push(
+        sink.push(
           `${surface} ${locale}:${key} uses i18next placeholder syntax`
         );
       if (
         !equal(formats(base.get(key), formatRegex), formats(value, formatRegex))
       )
-        errors.push(`${surface} ${locale}:${key} placeholder mismatch`);
+        sink.push(`${surface} ${locale}:${key} placeholder mismatch`);
       translated += 1;
     }
     coverage[locale] = {
@@ -105,41 +109,67 @@ function validateSurface({ maps, source, surface, formatRegex }) {
         base.size === 0 ? 100 : Math.round((translated / base.size) * 100),
     };
   }
-  return { errors, coverage };
+  return { errors, findings, coverage };
 }
 export function validateNativeWidgetLocales({ root, registry }) {
   const source = registry.sourceLocale;
   const shipped = new Set(Object.keys(registry.locales));
   const androidRoot = path.join(root, 'targets/android-widget/res');
   const iosRoot = path.join(root, 'targets/widget');
+  const isShipped = (locale) => shipped.has(locale);
+  const parseFindings = [];
+  // An unparseable catalog throws; for a locale nobody ships that must not abort the run.
+  const readSurface = (locale, file, parse, surface) => {
+    try {
+      return parse(fs.readFileSync(file, 'utf8'));
+    } catch (error) {
+      if (isShipped(locale)) throw error;
+      parseFindings.push(`${surface} ${locale}: ${error.message}`);
+      return null;
+    }
+  };
   const android = new Map();
   for (const entry of fs.readdirSync(androidRoot, { withFileTypes: true })) {
     const locale = localeFromAndroidDir(entry.name, source);
     const file = path.join(androidRoot, entry.name, 'widget_strings.xml');
-    if (locale && fs.existsSync(file))
-      android.set(locale, parseAndroidStrings(fs.readFileSync(file, 'utf8')));
+    if (!locale || !fs.existsSync(file)) continue;
+    const parsed = readSurface(
+      locale,
+      file,
+      parseAndroidStrings,
+      'Android widget'
+    );
+    if (parsed) android.set(locale, parsed);
   }
   const ios = new Map();
   for (const entry of fs.readdirSync(iosRoot, { withFileTypes: true })) {
     if (!entry.isDirectory() || !entry.name.endsWith('.lproj')) continue;
     const locale = entry.name.slice(0, -'.lproj'.length);
     const file = path.join(iosRoot, entry.name, 'Localizable.strings');
-    if (fs.existsSync(file))
-      ios.set(locale, parseIosStrings(fs.readFileSync(file, 'utf8')));
+    if (!fs.existsSync(file)) continue;
+    const parsed = readSurface(locale, file, parseIosStrings, 'iOS widget');
+    if (parsed) ios.set(locale, parsed);
   }
   const androidResult = validateSurface({
     maps: android,
     source,
     surface: 'Android widget',
     formatRegex: ANDROID_FORMAT,
+    isShipped,
   });
   const iosResult = validateSurface({
     maps: ios,
     source,
     surface: 'iOS widget',
     formatRegex: IOS_FORMAT,
+    isShipped,
   });
   const errors = [...androidResult.errors, ...iosResult.errors];
+  const unregisteredFindings = [
+    ...parseFindings,
+    ...androidResult.findings,
+    ...iosResult.findings,
+  ];
   for (const locale of shipped) {
     if (!android.has(locale))
       errors.push(
@@ -152,6 +182,7 @@ export function validateNativeWidgetLocales({ root, registry }) {
   }
   return {
     errors,
+    unregisteredFindings,
     androidCoverage: androidResult.coverage,
     iosCoverage: iosResult.coverage,
     androidDirForLocale,
@@ -179,6 +210,11 @@ function main() {
     console.log(
       `  ${locale}: ${coverage.translated}/${coverage.total} (${coverage.missing} missing)`
     );
+  if (result.unregisteredFindings.length) {
+    console.log('Unregistered locale findings (non-blocking, not shipped):');
+    for (const finding of result.unregisteredFindings)
+      console.log(`  ${finding}`);
+  }
   if (result.errors.length) throw new Error(result.errors.join('\n'));
 }
 if (

--- a/docs/content/8.developer/8.advanced/4.translations.md
+++ b/docs/content/8.developer/8.advanced/4.translations.md
@@ -47,12 +47,15 @@ you edit an en/ source
 You do not create translation files by hand.
 
 1. Ask on [Weblate](https://weblate.sparkyfitness.com/engage/sparkyfitness/) for the language to be added. Translation can start immediately and stay incomplete for as long as it needs — missing strings fall back to English, and a partially translated widget falls back to the English resource.
-2. The sync workflow brings the files into this repository. At this point the language is a *translation candidate*: present in the repo, not yet shipped.
+2. The sync workflow brings the catalogs into this repository. At this point the language is a *translation candidate*: present in the repo, not yet shipped.
 3. A maintainer enables it when it is complete enough:
    - **Web** — add the code to `getSupportedLanguages()` and `getLanguageDisplayName()` in `SparkyFitnessFrontend/src/utils/languageUtils.ts`.
    - **Mobile** — add an entry to `SparkyFitnessMobile/src/localization/localeRegistry.json`, then run `pnpm run i18n:generate`.
+4. The next sync brings that language's widget resources in as well.
 
-Only step 3 makes a language visible to users. Until then it costs nothing: an unregistered mobile catalog is never bundled into the app, and defects in it are reported as diagnostics rather than failing CI for everyone.
+Only step 3 makes a language visible to users, and until then it costs nothing: an unregistered mobile catalog is never bundled into the app, and defects in it are reported as diagnostics rather than failing CI for everyone.
+
+The widget resources arrive a step later than the catalogs, and that is deliberate. Android compiles every `values-*` directory it finds and the iOS widget target ships every `.lproj` folder in it, so a widget resource is live as soon as it lands — there is no registry check at build time to hold it back. Pulling those two surfaces only for registered locales keeps `localeRegistry.json` the single answer to "which languages does this app ship", and avoids a device showing a translated widget above an English app.
 
 ## Checking your work
 

--- a/docs/content/8.developer/8.advanced/4.translations.md
+++ b/docs/content/8.developer/8.advanced/4.translations.md
@@ -1,3 +1,67 @@
 # Translations
 
-This section will provide details on translations within SparkyFitness. This feature is planned for future development.
+SparkyFitness is translated through [Weblate](https://weblate.sparkyfitness.com/engage/sparkyfitness/). Contributors who write code touch only the English files; every other language is owned by translators and reaches the apps automatically.
+
+## The one rule for contributors
+
+**Only edit the English (`en`) files.** A pull request that changes any other language is rejected by CI.
+
+Always pair a key with an English fallback in the code itself, so a missing translation degrades to readable English rather than a raw key:
+
+```tsx
+t('nav.diary', { defaultValue: 'Diary' })
+```
+
+## Five Weblate components
+
+The web app has one translated file per language. The mobile app has four, because its surfaces use different formats and placeholder syntax and cannot share a component — Weblate translates each real file directly.
+
+| Component | English source | Format |
+| --- | --- | --- |
+| Web | `SparkyFitnessFrontend/public/locales/en/translation.json` | i18next JSON, `{{value}}` |
+| Mobile runtime | `SparkyFitnessMobile/src/localization/locales/en/translation.json` | i18next JSON, `{{value}}` |
+| Mobile permissions | `SparkyFitnessMobile/locales/en.json` | Expo metadata JSON |
+| Android widget | `SparkyFitnessMobile/targets/android-widget/res/values/widget_strings.xml` | Android resources, `%1$s` |
+| iOS widget | `SparkyFitnessMobile/targets/widget/en.lproj/Localizable.strings` | Apple Strings, `%@` |
+
+The widgets need real Android and iOS resource files rather than the JSON catalog: they render outside the app process, so the widget itself, its name and description in the widget gallery, and its appearance before the first data sync cannot depend on the app's runtime translations.
+
+## How a translation travels
+
+```text
+you edit an en/ source
+        │
+        ▼
+ sync-translations.yml ──push──►  SparkyFitnessTranslations  ──►  Weblate
+                                        (translators)
+        ◄──────────────────pull──────────────────┘
+        │
+        ▼
+ PR "chore(i18n): sync translations from Weblate"  ──►  merged  ──►  shipped
+```
+
+[`SparkyFitnessTranslations`](https://github.com/CodeWithCJ/SparkyFitnessTranslations) is the repository Weblate is connected to. The workflow runs on demand and opens one pull request on each side. Translators never open a pull request here, and you never open one there.
+
+## Adding a language
+
+You do not create translation files by hand.
+
+1. Ask on [Weblate](https://weblate.sparkyfitness.com/engage/sparkyfitness/) for the language to be added. Translation can start immediately and stay incomplete for as long as it needs — missing strings fall back to English, and a partially translated widget falls back to the English resource.
+2. The sync workflow brings the files into this repository. At this point the language is a *translation candidate*: present in the repo, not yet shipped.
+3. A maintainer enables it when it is complete enough:
+   - **Web** — add the code to `getSupportedLanguages()` and `getLanguageDisplayName()` in `SparkyFitnessFrontend/src/utils/languageUtils.ts`.
+   - **Mobile** — add an entry to `SparkyFitnessMobile/src/localization/localeRegistry.json`, then run `pnpm run i18n:generate`.
+
+Only step 3 makes a language visible to users. Until then it costs nothing: an unregistered mobile catalog is never bundled into the app, and defects in it are reported as diagnostics rather than failing CI for everyone.
+
+## Checking your work
+
+```bash
+# Web
+cd SparkyFitnessFrontend && pnpm run validate
+
+# Mobile — includes the i18n audit and the native widget resource validator
+cd SparkyFitnessMobile && pnpm run validate
+```
+
+The mobile audit is strict about the English source: every key used with `t()` must exist, plural families must be complete, and placeholders must line up. It is deliberately lenient about translations, which are allowed to be missing or incomplete.

--- a/docs/content/8.developer/9.translations.md
+++ b/docs/content/8.developer/9.translations.md
@@ -3,7 +3,7 @@
 This document outlines the technical setup for internationalization (i18n) in the SparkyFitnessFrontend application using `i18next` and `react-i18next`.
 
 ::alert{type="info"}
-**Only the English (`en`) files may be edited by hand.** Every other language is translated on [Weblate](https://hosted.weblate.org/engage/sparkyfitness) and synced from [SparkyFitnessTranslations](https://github.com/CodeWithCJ/SparkyFitnessTranslations).
+**Only the English (`en`) files may be edited by hand.** Every other language is translated on [Weblate](https://weblate.sparkyfitness.com/engage/sparkyfitness) and synced from [SparkyFitnessTranslations](https://github.com/CodeWithCJ/SparkyFitnessTranslations).
 ::
 
 ## 1. Core Libraries
@@ -180,4 +180,4 @@ import { getLanguageDisplayName, getSupportedLanguages } from "@/utils/languageU
 
 ## 8. Adding New Languages
 
-Translation files are not created by hand. A language is requested on [Weblate](https://hosted.weblate.org/engage/sparkyfitness) and translated there. A maintainer then runs the **Sync Translations** workflow (`workflow_dispatch`), which copies the non-English files into `public/locales/` and opens a pull request. Enabling the language is a separate edit: add the code to `getSupportedLanguages()` and `getLanguageDisplayName()` in `src/utils/languageUtils.ts`.
+Translation files are not created by hand. A language is requested on [Weblate](https://weblate.sparkyfitness.com/engage/sparkyfitness) and translated there. A maintainer then runs the **Sync Translations** workflow (`workflow_dispatch`), which copies the non-English files into `public/locales/` and opens a pull request. Enabling the language is a separate edit: add the code to `getSupportedLanguages()` and `getLanguageDisplayName()` in `src/utils/languageUtils.ts`.


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

The mobile app has four translated surfaces and none of them were connected to Weblate, so every language had to be hand-carried into the repo — which is what made adding Spanish in CodeWithCJ/SparkyFitness#2268 a per-language file drop. This wires all four into the existing sync workflow so a translation reaches the app without anyone editing a file by hand, which is the outcome CodeWithCJ/SparkyFitness#2301 asks for.

**How did you implement the solution?**

Each surface is its own Weblate component, because they cannot share one — they have different formats and placeholder rules:

| Component | English source | Format |
| --- | --- | --- |
| Mobile runtime | `SparkyFitnessMobile/src/localization/locales/en/translation.json` | i18next JSON, `{{value}}` |
| Mobile Expo metadata | `SparkyFitnessMobile/locales/en.json` | Expo metadata JSON |
| Android widgets | `SparkyFitnessMobile/targets/android-widget/res/values/widget_strings.xml` | Android resources, `%1$s` |
| iOS widgets | `SparkyFitnessMobile/targets/widget/en.lproj/Localizable.strings` | Apple Strings, `%@` |

Weblate translates each real file directly, so no format conversion sits between a translator and the app. The widgets keep genuine Android and iOS resources: they render outside the app process, so the widget, its name and description in the gallery, and its appearance before the first data sync cannot depend on the app's runtime translations. An incomplete target file falls back natively — Android to `values/`, iOS to the development region — so a language can ship partially translated.

The four mirror the mobile package under `mobile/` in the translations repo. On the way in, a surface that does not exist there yet is skipped with a notice; on the way out the English source of each is pushed unconditionally.

`localeRegistry.json` decides which of them ship, and it has to do that at two different moments. The runtime catalog and the Expo metadata are gated at build time — `generatedLocaleResources.ts` imports only registered locales, `expo-localization` takes `supportedLocales` from `nativeLanguageTags()` — so an unregistered one costs nothing sitting in the repo. The widget resources have no such gate: `withCalorieWidget` copies the whole `res/` tree into the Android project, and the iOS widget target is a `PBXFileSystemSynchronizedRootGroup`, so a `values-ru/` or `ru.lproj/` is compiled into the app the moment it lands. Those two surfaces are therefore pulled for registered locales only, mapping each registered tag through the Android qualifier helper below. A candidate language still syncs its catalogs, is still audited for coverage, and is still one registry entry away from shipping — its widget arrives on the next sync.

Five smaller changes fall out of that:

- **`pr-validation.yml`** — the "only `en` may be edited" guard covered the web catalog only. It now covers all four mobile surfaces, since every non-English file among them is Weblate-owned. Automation PRs are already exempt, so the sync PR is unaffected.
- **`scripts/i18n-audit/core.cjs`** — the audit discovers locales by directory and blocks on any defect, but only registry entries are ever bundled. Now that Weblate writes straight into the repo, a defect in a language nobody ships would redden CI for the sync PR and every mobile PR after it. Defects in an unregistered locale are reported without blocking; registered locales are unchanged.
- **`scripts/validate-native-widget-locales.mjs`** — the same scoping for the widget resources, plus a `try` around each read so an unparseable catalog in an unshipped locale is reported instead of aborting the run.
- **`scripts/androidLocaleQualifiers.cjs`** (new) — Android resource qualifiers are not BCP-47 tags, and the Weblate component writes Android's own form: `values-pt-rBR`, `values-zh-rCN`, `values-in`. The validator assumed every non-plain tag used the `b+` syntax, so registering a regional or aliased locale would have made it demand a directory Weblate never creates. Both directions now go through one helper, shared with the widget contract test, which had its own copy of the mapping.
- **Widget contract test** — two assertions walked every `values-*` directory on disk. A translator's typo in a language nobody ships would have failed the mobile suite; they now cover the source and the registered locales, which is the same line the audit and the native validator draw.

`localeRegistry.json` is untouched and remains the shipping contract, mirroring `getSupportedLanguages()` on web: a synced language is a translation candidate until a maintainer registers it.

Documentation: `/developer/advanced/translations` was a three-line placeholder and now carries the whole workflow; `sync-translations.yml` had no entry in the workflow README; `CONTRIBUTING.md` and the mobile package guide say the English-only rule covers mobile too. The two Weblate links left on `/developer/translations` move to the self-hosted instance, matching the README.

**No translation file is modified by this PR.** The 16 changed files are three workflow files, four scripts, four test files and five documentation files.

Linked Issue: Closes #2301

## How to Test

1. Check out this branch, run `pnpm install` from the repo root, then `cd SparkyFitnessMobile`.
2. Run the gate: `pnpm run validate` and `pnpm test`.
3. Confirm the audit scoping does what it claims — an unregistered locale cannot break the build, a registered one still can:
   ```bash
   cp -r src/localization/locales/es src/localization/locales/de
   # break a placeholder in de/translation.json, e.g. {{count}} -> {{cont}}
   pnpm run i18n:audit        # "Unregistered locale findings", exit 0
   rm -rf src/localization/locales/de
   # now break the same placeholder in es/, a registered locale
   pnpm run i18n:audit        # "Placeholder errors", exit 1
   ```
4. Confirm an incomplete native file is non-blocking, so a partially translated widget can ship:
   ```bash
   # delete any one string entry from targets/android-widget/res/values-es/widget_strings.xml
   pnpm run native-locales:check   # es: 16/17 (1 missing), exit 0
   ```
5. Confirm the registry decides which widget resources the sync pulls:
   ```bash
   node -e '
   const path = require("path");
   const root = path.resolve("."); // run from SparkyFitnessMobile/
   const registry = require(path.join(root, "src/localization/localeRegistry.json"));
   const { androidDirForLocale } = require(path.join(root, "scripts/androidLocaleQualifiers.cjs"));
   const locales = Object.keys(registry.locales);
   console.log(locales.map((l) => androidDirForLocale(l, registry.sourceLocale)).join(" "));
   console.log(locales.map((l) => l + ".lproj").join(" "));'
   # values values-pl values-es
   # en.lproj pl.lproj es.lproj
   ```
   Those two lines are the allowlist the sync step builds; every other `values-*` and `*.lproj` in the translations repo is skipped with a notice.
6. Confirm the Android qualifier mapping round-trips through every form the Weblate component emits:
   ```bash
   node -e '
   const q = require("./scripts/androidLocaleQualifiers.cjs");
   for (const d of ["values","values-de","values-in","values-nb-rNO","values-pt-rBR","values-zh-rCN","values-b+yue+Hant","drawable"]) {
     const tag = q.localeFromAndroidDir(d, "en");
     console.log(d, "->", tag, "->", tag && q.androidDirForLocale(tag, "en"));
   }'
   ```
7. Check the guard patterns against the paths that must and must not match:
   ```bash
   node -e '
   const re = [
     /^SparkyFitnessMobile\/locales\/(?!en\.json$)[^/]+\.json$/,
     /^SparkyFitnessMobile\/targets\/android-widget\/res\/values-[^/]+\/widget_strings\.xml$/,
     /^SparkyFitnessMobile\/targets\/widget\/(?!en\.lproj\/)[^/]+\.lproj\/Localizable\.strings$/,
   ];
   for (const f of process.argv.slice(1)) console.log(re.some(r => r.test(f)), f);
   ' SparkyFitnessMobile/locales/es.json \
     SparkyFitnessMobile/locales/en.json \
     SparkyFitnessMobile/targets/android-widget/res/values-es/widget_strings.xml \
     SparkyFitnessMobile/targets/android-widget/res/values/widget_strings.xml \
     SparkyFitnessMobile/targets/widget/es.lproj/Localizable.strings \
     SparkyFitnessMobile/targets/widget/en.lproj/Localizable.strings
   ```
8. Docs: `cd docs && pnpm install && NUXT_APP_BASE_URL=/SparkyFitness/ pnpm exec nuxt build --preset github_pages`, then check `/developer/advanced/translations`.

## PR Type

- [ ] Issue (bug fix)
- [ ] New Feature
- [x] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

> Checklist notes: no `SparkyFitnessFrontend/`, `SparkyFitnessServer/` or UI files are touched, so those blocks are N/A and left unchecked. Mobile validation was run — `pnpm run validate` exit 0 and the full Jest suite green — but the device/emulator box stays unchecked because the app has not been run on hardware.

## Screenshots

<details>
<summary>Click to expand</summary>

N/A — no UI change and no user-visible string change. This PR touches workflows, scripts, tests and documentation only.

</details>

## Notes for Reviewers

**Design — this takes a different route from the one CodeWithCJ/SparkyFitness#2301 sketches, deliberately.** That issue proposes making the i18next catalog authoritative and generating the Android XML, iOS `.strings` and Expo metadata from it. I built that first, then moved away from it on review: the native files stay real Android and iOS resources and Weblate translates them directly, as four independent components. It costs ~9 strings duplicated between the Android and iOS widget files, and it buys resources that behave the way the platforms expect and a pipeline with no conversion layer to get wrong — no placeholder reordering, no per-format escaping, nothing to keep in sync. The issue's goal is unchanged and met: adding a language touches no XML or `.strings` by hand.

**The four components are already live** at `weblate.sparkyfitness.com`, and `CodeWithCJ/SparkyFitnessTranslations` already carries the `mobile/` tree on `main`. Nothing here needs a manual step first, and the scoping in this PR is no longer precautionary — the files it protects against are sitting in the translations repo today.

### What the first sync actually brings

I ran this branch's pull step against the real translations repo, twice: once without the registry filter to see the whole picture, and once with it.

Unfiltered it is **128 new files** across 32 candidate languages on the four surfaces. **Filtered it is 64** — the 32 runtime catalogs and the 32 metadata files — with `res/` and `targets/widget/` byte-identical to what is in the repo now. `drawable/`, `layout/` and `xml/` are untouched either way, which is what the `values-*` pattern is for. In both cases 2 files are modified: the shipped `es` and `pl` runtime catalogs.

Most of what arrives is placeholders; Weblate omits untranslated units, so a 0% language is `{}`. What actually carries content today:

| | runtime | metadata | Android widget | iOS widget |
| --- | :---: | :---: | :---: | :---: |
| ru | 3779/3779 | 4/4 | 17/17 | 17/17 |
| nl | 102 | 4/4 | — | 17/17 |
| pt-BR | 117 | 4/4 | 17/17 | 17/17 |
| nb-NO | — | — | 17/17 | — |
| zh-Hans | — | — | 17/17 | — |
| fr | — | — | 5/17 | — |

The four right-hand columns are what the registry filter holds back. Without it the first sync would have shipped widgets in five languages the app itself does not ship — including a French one at 5/17, English for the rest of the strings — while the app stayed English for those users.

Russian is complete on all four surfaces and is the obvious first candidate for the registry, once the plural issue below is fixed; registering it is a `localeRegistry.json` entry plus `pnpm run i18n:generate`, and the following sync brings its widgets in.

The two modified files: `es` gains 236 keys and loses 3 (recent repo keys Weblate has not seen yet, which the push side sends over); `pl` loses 87 keys, which is the next point.

### One blocker, and it is on the Weblate side

With those files in place, `pnpm run validate` passes cleanly — 0 structural, placeholder and plural errors, coverage reported for all 34 languages, native validator green. **The test suite does not**: 3 suites, 5 assertions fail, all the same cause.

```
formatLocalizedUnitQuantity(1.5, 'cup')   expected "1,5 szklanki"  got "1,5 cups"
i18n.t('importHistory.…', {count: 1.2})   expected "z 1,2 dni"     got "of 1,2 days"
```

Weblate's plural definition for Polish has three forms (`one/few/many`); i18next v4 follows CLDR and needs a fourth (`other`) for fractional counts. The sync therefore drops `_other` from 87 Polish keys, and decimal quantities fall back to English. `__tests__/localization/i18n.test.ts` already had a case named *"resolves the Polish other category for decimal day counts"*, so the repo catches it — the sync PR would sit red rather than auto-merge, and no bad Polish would ship. But the pipeline is blocked until the Polish (and Russian, which has the same three-form definition) plural is switched to the CLDR four-form variant in Weblate. Nothing in this PR can fix that, and I would rather flag it than land a workflow whose first run is guaranteed red.

### Verification

The workflow is `workflow_dispatch` and needs `secrets.TRANSLATIONS_PAT`, so it cannot run from a PR. Instead: both workflows parse as YAML, with the inline script parsing as JS the way `github-script` wraps it; the sync step's shell was extracted and run under `bash -e` against the real translations repository, which is where the file counts above come from, and it skipped 32 candidate directories on each widget surface while leaving `drawable/`, `layout/` and `xml/` alone; the guard patterns were checked against 15 real paths including the ones that must not match; and the Android qualifier mapping round-trips through every directory the component emits. Both new regression tests were confirmed to fail against the previous code before the fix. The guard itself only takes effect once merged, since `pull_request_target` evaluates the workflow from the base branch — it cannot judge the PR that introduces it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added bidirectional translation synchronization for web and mobile apps, including runtime text, permissions metadata, and Android/iOS widgets.
  - Added support for regional, script-based, and legacy locale formats.
  - Unregistered language translations can now be reviewed as non-blocking candidates and are excluded from shipped mobile builds.
  - Improved localization validation and coverage reporting for supported locales.

- **Documentation**
  - Added guidance for translation workflows, mobile translation surfaces, adding languages, and validation.
  - Updated translation platform links and contributor guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->