### PR TITLE
fix(mobile) : clear cached data when the app switches account

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/ReauthModal.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/ReauthModal.test.tsx
@@ -4,6 +4,7 @@ import ReauthModal from '../../src/components/ReauthModal';
 import {
   fetchAuthSettings,
   loginWithOidc,
+  notifyIdentityChanged,
   type AuthSettings,
 } from '../../src/services/api/authService';
 import {
@@ -26,6 +27,7 @@ jest.mock('../../src/services/api/authService', () => ({
   fetchAuthSettings: jest.fn(),
   loginWithOidc: jest.fn(),
   loginWithPasskey: jest.fn(),
+  notifyIdentityChanged: jest.fn(),
 }));
 
 jest.mock('../../src/services/storage', () => ({
@@ -58,6 +60,9 @@ const mockGetAllServerConfigs = getAllServerConfigs as jest.MockedFunction<
 >;
 const mockSaveServerConfig = saveServerConfig as jest.MockedFunction<
   typeof saveServerConfig
+>;
+const mockNotifyIdentityChanged = notifyIdentityChanged as jest.MockedFunction<
+  typeof notifyIdentityChanged
 >;
 
 const sessionConfig: ServerConfig = {
@@ -177,6 +182,9 @@ describe('ReauthModal', () => {
     expect(mockSaveServerConfig).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'config-1', sessionToken: 'fresh-token' })
     );
+    // The new session may belong to a different account on the same server,
+    // and the configuration id gives nothing away, so the caches go either way.
+    expect(mockNotifyIdentityChanged).toHaveBeenCalledTimes(1);
     expect(onLoginSuccess).toHaveBeenCalled();
   });
 

--- a/SparkyFitnessMobile/__tests__/components/ServerConfigModal.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/ServerConfigModal.test.tsx
@@ -11,6 +11,7 @@ import {
   verifyEmailOtp,
   fetchAuthSettings,
   type AuthSettings,
+  notifyIdentityChanged,
 } from '../../src/services/api/authService';
 import { saveServerConfig } from '../../src/services/storage';
 
@@ -28,6 +29,7 @@ jest.mock('../../src/services/api/authService', () => ({
   fetchAuthSettings: jest.fn(),
   loginWithOidc: jest.fn(),
   loginWithPasskey: jest.fn(),
+  notifyIdentityChanged: jest.fn(),
 }));
 
 jest.mock('../../src/services/storage', () => ({
@@ -64,6 +66,9 @@ const mockVerifyEmailOtp = verifyEmailOtp as jest.MockedFunction<
 >;
 const mockFetchAuthSettings = fetchAuthSettings as jest.MockedFunction<
   typeof fetchAuthSettings
+>;
+const mockNotifyIdentityChanged = notifyIdentityChanged as jest.MockedFunction<
+  typeof notifyIdentityChanged
 >;
 const mockSaveServerConfig = saveServerConfig as jest.MockedFunction<
   typeof saveServerConfig
@@ -339,6 +344,35 @@ describe('ServerConfigModal', () => {
         })
       );
       expect(onSuccess).toHaveBeenCalled();
+    });
+
+    // saveServerConfig ends in setActiveServerConfig, so a sign-in here always
+    // leaves the app reading a different account than the one it had cached.
+    it('announces the identity change so the caches are dropped', async () => {
+      mockLogin.mockResolvedValue({
+        type: 'success',
+        sessionToken: 'new-session-token',
+        user: { email: 'someone-else@example.com' },
+      });
+
+      const result = renderModal({ onSuccess: jest.fn() });
+      await waitForForm(result);
+      await enterUrl(result);
+
+      fireEvent.changeText(
+        result.getByPlaceholderText(EMAIL_PLACEHOLDER),
+        'someone-else@example.com'
+      );
+      fireEvent.changeText(
+        result.getByPlaceholderText('Password'),
+        'password123'
+      );
+
+      await act(async () => {
+        pressConnectButton(result);
+      });
+
+      expect(mockNotifyIdentityChanged).toHaveBeenCalledTimes(1);
     });
 
     it('strips trailing slash from server URL', async () => {

--- a/SparkyFitnessMobile/__tests__/hooks/useAuth.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useAuth.test.ts
@@ -8,6 +8,7 @@ import {
   suppressSessionExpired,
 } from '../../src/services/api/authService';
 import { clearServerConfigCache } from '../../src/services/storage';
+import { addLog } from '../../src/services/LogService';
 import type { ServerConfig } from '../../src/services/storage';
 import { createTestQueryClient, createQueryWrapper } from './queryTestUtils';
 import type { QueryClient } from './queryTestUtils';
@@ -30,6 +31,10 @@ jest.mock('expo-image', () => ({
   },
 }));
 
+jest.mock('../../src/services/LogService', () => ({
+  addLog: jest.fn(),
+}));
+
 const mockSetOnSessionExpired = setOnSessionExpired as jest.MockedFunction<
   typeof setOnSessionExpired
 >;
@@ -46,6 +51,7 @@ const mockSuppressSessionExpired =
 const mockClearMemoryCache = Image.clearMemoryCache as jest.MockedFunction<
   typeof Image.clearMemoryCache
 >;
+const mockAddLog = addLog as jest.MockedFunction<typeof addLog>;
 const mockClearDiskCache = Image.clearDiskCache as jest.MockedFunction<
   typeof Image.clearDiskCache
 >;
@@ -120,23 +126,36 @@ describe('useAuth', () => {
       identityChangedCb();
     });
 
-    // expo-image keys on the URI, which carries no account, so a query-cache
-    // clear on its own still leaves the previous account's photos on screen.
+    // Dropping the queries leaves the bytes themselves in expo-image's caches,
+    // so a departed account's progress photos would stay on the device.
     expect(mockClearMemoryCache).toHaveBeenCalledTimes(1);
     expect(mockClearDiskCache).toHaveBeenCalledTimes(1);
   });
 
-  test('a rejected image cache clear does not escape the callback', async () => {
+  test('a rejected image cache clear is reported, not swallowed', async () => {
     mockClearMemoryCache.mockRejectedValueOnce(new Error('no activity'));
     mockClearDiskCache.mockRejectedValueOnce(new Error('no activity'));
 
     renderUseAuth();
     await act(async () => {});
+    mockAddLog.mockClear();
 
     const identityChangedCb = mockSetOnIdentityChanged.mock.calls[0][0];
     await act(async () => {
+      // The sign-in that triggered this must not fail because a cache sweep did.
       expect(() => identityChangedCb()).not.toThrow();
     });
+
+    // A failure leaves the previous account's images on disk, so it has to be
+    // visible in the logs rather than disappearing into an empty catch.
+    expect(mockAddLog).toHaveBeenCalledWith(
+      expect.stringContaining('image memory cache'),
+      'WARNING'
+    );
+    expect(mockAddLog).toHaveBeenCalledWith(
+      expect.stringContaining('image disk cache'),
+      'WARNING'
+    );
   });
 
   test('session expired callback shows reauth modal with config ID', async () => {

--- a/SparkyFitnessMobile/__tests__/hooks/useAuth.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useAuth.test.ts
@@ -3,14 +3,18 @@ import { useAuth } from '../../src/hooks/useAuth';
 import {
   setOnSessionExpired,
   setOnNoConfigs,
+  setOnIdentityChanged,
   suppressSessionExpired,
 } from '../../src/services/api/authService';
 import { clearServerConfigCache } from '../../src/services/storage';
 import type { ServerConfig } from '../../src/services/storage';
+import { createTestQueryClient, createQueryWrapper } from './queryTestUtils';
+import type { QueryClient } from './queryTestUtils';
 
 jest.mock('../../src/services/api/authService', () => ({
   setOnSessionExpired: jest.fn(),
   setOnNoConfigs: jest.fn(),
+  setOnIdentityChanged: jest.fn(),
   suppressSessionExpired: jest.fn(),
 }));
 
@@ -24,18 +28,29 @@ const mockSetOnSessionExpired = setOnSessionExpired as jest.MockedFunction<
 const mockSetOnNoConfigs = setOnNoConfigs as jest.MockedFunction<
   typeof setOnNoConfigs
 >;
+const mockSetOnIdentityChanged = setOnIdentityChanged as jest.MockedFunction<
+  typeof setOnIdentityChanged
+>;
 const mockClearServerConfigCache =
   clearServerConfigCache as jest.MockedFunction<typeof clearServerConfigCache>;
 const mockSuppressSessionExpired =
   suppressSessionExpired as jest.MockedFunction<typeof suppressSessionExpired>;
 
 describe('useAuth', () => {
+  let queryClient: QueryClient;
+
+  // The hook reads the query client to drop caches on an identity change, so
+  // every render needs a provider around it.
+  const renderUseAuth = () =>
+    renderHook(() => useAuth(), { wrapper: createQueryWrapper(queryClient) });
+
   beforeEach(() => {
     jest.clearAllMocks();
+    queryClient = createTestQueryClient();
   });
 
   test('does not auto-show any modal on mount', async () => {
-    const { result } = renderHook(() => useAuth());
+    const { result } = renderUseAuth();
 
     await act(async () => {});
 
@@ -45,7 +60,7 @@ describe('useAuth', () => {
   });
 
   test('registers callbacks on mount', async () => {
-    renderHook(() => useAuth());
+    renderUseAuth();
 
     await act(async () => {});
 
@@ -53,10 +68,34 @@ describe('useAuth', () => {
     expect(mockSetOnSessionExpired).toHaveBeenCalledWith(expect.any(Function));
     expect(mockSetOnNoConfigs).toHaveBeenCalledTimes(1);
     expect(mockSetOnNoConfigs).toHaveBeenCalledWith(expect.any(Function));
+    expect(mockSetOnIdentityChanged).toHaveBeenCalledTimes(1);
+    expect(mockSetOnIdentityChanged).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  test('identity changed callback drops every cached query', async () => {
+    renderUseAuth();
+    await act(async () => {});
+
+    queryClient.setQueryData(['dailySummary', '2026-01-01'], {
+      calories: 1800,
+    });
+    queryClient.setQueryData(['measurements', '2026-01-01'], { weight: 70 });
+
+    const identityChangedCb = mockSetOnIdentityChanged.mock.calls[0][0];
+    act(() => {
+      identityChangedCb();
+    });
+
+    expect(
+      queryClient.getQueryData(['dailySummary', '2026-01-01'])
+    ).toBeUndefined();
+    expect(
+      queryClient.getQueryData(['measurements', '2026-01-01'])
+    ).toBeUndefined();
   });
 
   test('session expired callback shows reauth modal with config ID', async () => {
-    const { result } = renderHook(() => useAuth());
+    const { result } = renderUseAuth();
     await act(async () => {});
 
     const sessionExpiredCb = mockSetOnSessionExpired.mock.calls[0][0];
@@ -71,7 +110,7 @@ describe('useAuth', () => {
   });
 
   test('session expired clears config cache on first trigger', async () => {
-    const { result } = renderHook(() => useAuth());
+    const { result } = renderUseAuth();
     await act(async () => {});
 
     expect(result.current.showReauthModal).toBe(false);
@@ -86,7 +125,7 @@ describe('useAuth', () => {
   });
 
   test('no-configs callback shows setup modal', async () => {
-    const { result } = renderHook(() => useAuth());
+    const { result } = renderUseAuth();
     await act(async () => {});
     expect(result.current.showSetupModal).toBe(false);
 
@@ -100,7 +139,7 @@ describe('useAuth', () => {
   });
 
   test('dismissModal resets state', async () => {
-    const { result } = renderHook(() => useAuth());
+    const { result } = renderUseAuth();
     await act(async () => {});
 
     const sessionExpiredCb = mockSetOnSessionExpired.mock.calls[0][0];
@@ -121,7 +160,7 @@ describe('useAuth', () => {
   });
 
   test('handleLoginSuccess resets state', async () => {
-    const { result } = renderHook(() => useAuth());
+    const { result } = renderUseAuth();
     await act(async () => {});
 
     const sessionExpiredCb = mockSetOnSessionExpired.mock.calls[0][0];
@@ -150,7 +189,7 @@ describe('useAuth', () => {
     };
 
     test('handleSwitchToApiKey hides reauth modal and exposes config', async () => {
-      const { result } = renderHook(() => useAuth());
+      const { result } = renderUseAuth();
       await act(async () => {});
 
       // Trigger session expired first
@@ -172,7 +211,7 @@ describe('useAuth', () => {
     });
 
     test('handleSwitchToApiKey keeps suppression active', async () => {
-      const { result } = renderHook(() => useAuth());
+      const { result } = renderUseAuth();
       await act(async () => {});
 
       const sessionExpiredCb = mockSetOnSessionExpired.mock.calls[0][0];
@@ -190,7 +229,7 @@ describe('useAuth', () => {
     });
 
     test('handleSwitchToApiKeyDone clears state and unsuppresses', async () => {
-      const { result } = renderHook(() => useAuth());
+      const { result } = renderUseAuth();
       await act(async () => {});
 
       const sessionExpiredCb = mockSetOnSessionExpired.mock.calls[0][0];
@@ -213,7 +252,7 @@ describe('useAuth', () => {
     });
 
     test('session expired callback clears switchToApiKeyConfig', async () => {
-      const { result } = renderHook(() => useAuth());
+      const { result } = renderUseAuth();
       await act(async () => {});
 
       act(() => {
@@ -232,7 +271,7 @@ describe('useAuth', () => {
     });
 
     test('no-configs callback clears switchToApiKeyConfig', async () => {
-      const { result } = renderHook(() => useAuth());
+      const { result } = renderUseAuth();
       await act(async () => {});
 
       act(() => {

--- a/SparkyFitnessMobile/__tests__/hooks/useAuth.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useAuth.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-native';
+import { Image } from 'expo-image';
 import { useAuth } from '../../src/hooks/useAuth';
 import {
   setOnSessionExpired,
@@ -22,6 +23,13 @@ jest.mock('../../src/services/storage', () => ({
   clearServerConfigCache: jest.fn(),
 }));
 
+jest.mock('expo-image', () => ({
+  Image: {
+    clearMemoryCache: jest.fn().mockResolvedValue(true),
+    clearDiskCache: jest.fn().mockResolvedValue(true),
+  },
+}));
+
 const mockSetOnSessionExpired = setOnSessionExpired as jest.MockedFunction<
   typeof setOnSessionExpired
 >;
@@ -35,6 +43,12 @@ const mockClearServerConfigCache =
   clearServerConfigCache as jest.MockedFunction<typeof clearServerConfigCache>;
 const mockSuppressSessionExpired =
   suppressSessionExpired as jest.MockedFunction<typeof suppressSessionExpired>;
+const mockClearMemoryCache = Image.clearMemoryCache as jest.MockedFunction<
+  typeof Image.clearMemoryCache
+>;
+const mockClearDiskCache = Image.clearDiskCache as jest.MockedFunction<
+  typeof Image.clearDiskCache
+>;
 
 describe('useAuth', () => {
   let queryClient: QueryClient;
@@ -92,6 +106,37 @@ describe('useAuth', () => {
     expect(
       queryClient.getQueryData(['measurements', '2026-01-01'])
     ).toBeUndefined();
+  });
+
+  test('identity changed callback drops the image caches', async () => {
+    renderUseAuth();
+    await act(async () => {});
+
+    expect(mockClearMemoryCache).not.toHaveBeenCalled();
+    expect(mockClearDiskCache).not.toHaveBeenCalled();
+
+    const identityChangedCb = mockSetOnIdentityChanged.mock.calls[0][0];
+    await act(async () => {
+      identityChangedCb();
+    });
+
+    // expo-image keys on the URI, which carries no account, so a query-cache
+    // clear on its own still leaves the previous account's photos on screen.
+    expect(mockClearMemoryCache).toHaveBeenCalledTimes(1);
+    expect(mockClearDiskCache).toHaveBeenCalledTimes(1);
+  });
+
+  test('a rejected image cache clear does not escape the callback', async () => {
+    mockClearMemoryCache.mockRejectedValueOnce(new Error('no activity'));
+    mockClearDiskCache.mockRejectedValueOnce(new Error('no activity'));
+
+    renderUseAuth();
+    await act(async () => {});
+
+    const identityChangedCb = mockSetOnIdentityChanged.mock.calls[0][0];
+    await act(async () => {
+      expect(() => identityChangedCb()).not.toThrow();
+    });
   });
 
   test('session expired callback shows reauth modal with config ID', async () => {

--- a/SparkyFitnessMobile/__tests__/hooks/useAuth.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useAuth.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react-native';
 import { Image } from 'expo-image';
 import { useAuth } from '../../src/hooks/useAuth';
 import {
+  clearAuthCookies,
   setOnSessionExpired,
   setOnNoConfigs,
   setOnIdentityChanged,
@@ -14,6 +15,7 @@ import { createTestQueryClient, createQueryWrapper } from './queryTestUtils';
 import type { QueryClient } from './queryTestUtils';
 
 jest.mock('../../src/services/api/authService', () => ({
+  clearAuthCookies: jest.fn().mockResolvedValue(undefined),
   setOnSessionExpired: jest.fn(),
   setOnNoConfigs: jest.fn(),
   setOnIdentityChanged: jest.fn(),
@@ -54,6 +56,9 @@ const mockClearMemoryCache = Image.clearMemoryCache as jest.MockedFunction<
 const mockAddLog = addLog as jest.MockedFunction<typeof addLog>;
 const mockClearDiskCache = Image.clearDiskCache as jest.MockedFunction<
   typeof Image.clearDiskCache
+>;
+const mockClearAuthCookies = clearAuthCookies as jest.MockedFunction<
+  typeof clearAuthCookies
 >;
 
 describe('useAuth', () => {
@@ -130,6 +135,53 @@ describe('useAuth', () => {
     // so a departed account's progress photos would stay on the device.
     expect(mockClearMemoryCache).toHaveBeenCalledTimes(1);
     expect(mockClearDiskCache).toHaveBeenCalledTimes(1);
+  });
+
+  test('identity changed callback drops the cookie jar', async () => {
+    renderUseAuth();
+    await act(async () => {});
+
+    expect(mockClearAuthCookies).not.toHaveBeenCalled();
+
+    const identityChangedCb = mockSetOnIdentityChanged.mock.calls[0][0];
+    await act(async () => {
+      await identityChangedCb();
+    });
+
+    // The native cookie jar is keyed by host, so two accounts on one server
+    // share it. Left in place, the server resolves the previous account's
+    // session cookie ahead of the Bearer token and answers as that account.
+    expect(mockClearAuthCookies).toHaveBeenCalledTimes(1);
+  });
+
+  test('identity change does not settle until the cookies are gone', async () => {
+    let releaseCookieClear: () => void = () => {};
+    mockClearAuthCookies.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releaseCookieClear = resolve;
+      })
+    );
+
+    renderUseAuth();
+    await act(async () => {});
+
+    const identityChangedCb = mockSetOnIdentityChanged.mock.calls[0][0];
+    let settled = false;
+    const pending = Promise.resolve(identityChangedCb()).then(() => {
+      settled = true;
+    });
+
+    // Callers await this before refetching. Resolving early would let the next
+    // request overtake the sweep and go out carrying the old session cookie,
+    // which is the whole failure this guards against.
+    await act(async () => {});
+    expect(settled).toBe(false);
+
+    releaseCookieClear();
+    await act(async () => {
+      await pending;
+    });
+    expect(settled).toBe(true);
   });
 
   test('a rejected image cache clear is reported, not swallowed', async () => {

--- a/SparkyFitnessMobile/__tests__/hooks/useAuth.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useAuth.test.ts
@@ -15,7 +15,7 @@ import { createTestQueryClient, createQueryWrapper } from './queryTestUtils';
 import type { QueryClient } from './queryTestUtils';
 
 jest.mock('../../src/services/api/authService', () => ({
-  clearAuthCookies: jest.fn().mockResolvedValue(undefined),
+  clearAuthCookies: jest.fn().mockResolvedValue(true),
   setOnSessionExpired: jest.fn(),
   setOnNoConfigs: jest.fn(),
   setOnIdentityChanged: jest.fn(),
@@ -182,6 +182,43 @@ describe('useAuth', () => {
       await pending;
     });
     expect(settled).toBe(true);
+  });
+
+  test('a cookie jar that could not be cleared is reported', async () => {
+    // The native sweep can fail without throwing: no Networking module, or a
+    // missing WebView provider leaving the callback uncalled. Passing that over
+    // would leave the previous account's session cookie on the wire silently.
+    mockClearAuthCookies.mockResolvedValueOnce(false);
+
+    renderUseAuth();
+    await act(async () => {});
+    mockAddLog.mockClear();
+
+    const identityChangedCb = mockSetOnIdentityChanged.mock.calls[0][0];
+    await act(async () => {
+      await identityChangedCb();
+    });
+
+    expect(mockAddLog).toHaveBeenCalledWith(
+      expect.stringContaining('cookie jar was not cleared'),
+      'ERROR'
+    );
+  });
+
+  test('a cleared cookie jar reports nothing', async () => {
+    renderUseAuth();
+    await act(async () => {});
+    mockAddLog.mockClear();
+
+    const identityChangedCb = mockSetOnIdentityChanged.mock.calls[0][0];
+    await act(async () => {
+      await identityChangedCb();
+    });
+
+    expect(mockAddLog).not.toHaveBeenCalledWith(
+      expect.stringContaining('cookie jar'),
+      'ERROR'
+    );
   });
 
   test('a rejected image cache clear is reported, not swallowed', async () => {

--- a/SparkyFitnessMobile/__tests__/screens/ServerSettingsScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/ServerSettingsScreen.test.tsx
@@ -11,7 +11,10 @@ import {
   setActiveServerConfig,
   type ServerConfig,
 } from '../../src/services/storage';
-import { notifyNoConfigs } from '../../src/services/api/authService';
+import {
+  notifyIdentityChanged,
+  notifyNoConfigs,
+} from '../../src/services/api/authService';
 import { useServerConfigs, useServerConnection } from '../../src/hooks';
 
 const mockGoBack = jest.fn();
@@ -39,6 +42,7 @@ jest.mock('../../src/services/storage', () => ({
 }));
 
 jest.mock('../../src/services/api/authService', () => ({
+  notifyIdentityChanged: jest.fn(),
   notifyNoConfigs: jest.fn(),
 }));
 
@@ -94,6 +98,9 @@ const mockDeleteServerConfig = deleteServerConfig as jest.MockedFunction<
 >;
 const mockNotifyNoConfigs = notifyNoConfigs as jest.MockedFunction<
   typeof notifyNoConfigs
+>;
+const mockNotifyIdentityChanged = notifyIdentityChanged as jest.MockedFunction<
+  typeof notifyIdentityChanged
 >;
 
 const insets = { top: 0, bottom: 0, left: 0, right: 0 };
@@ -157,6 +164,69 @@ describe('ServerSettingsScreen', () => {
       expect(mockDeleteServerConfig).toHaveBeenCalledWith('a');
       expect(mockSetActiveServerConfig).toHaveBeenCalledWith('b');
       expect(mockNotifyNoConfigs).not.toHaveBeenCalled();
+      // The app is now on another account, so the caches have to go.
+      expect(mockNotifyIdentityChanged).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test('does not announce an identity change when deleting a non-active server', async () => {
+    const active = buildConfig('a', 'https://a.example.com');
+    const other = buildConfig('b', 'https://b.example.com');
+
+    mockUseServerConfigs.mockReturnValue({
+      allConfigs: [active, other],
+      activeConfig: active,
+      refetch: jest.fn(),
+      isLoading: false,
+    });
+
+    mockGetAllServerConfigs.mockResolvedValue([active]);
+
+    const { getByLabelText } = renderScreen();
+
+    fireEvent.press(getByLabelText('Options for https://b.example.com'));
+
+    const alertButtons = (Alert.alert as jest.Mock).mock.calls[0][2];
+    const deleteButton = alertButtons.find((b: any) => b.text === 'Delete');
+
+    await act(async () => {
+      await deleteButton.onPress();
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteServerConfig).toHaveBeenCalledWith('b');
+    });
+    expect(mockSetActiveServerConfig).not.toHaveBeenCalled();
+    expect(mockNotifyIdentityChanged).not.toHaveBeenCalled();
+  });
+
+  test('announces an identity change when activating a different server', async () => {
+    const active = buildConfig('a', 'https://a.example.com');
+    const other = buildConfig('b', 'https://b.example.com');
+
+    mockUseServerConfigs.mockReturnValue({
+      allConfigs: [active, other],
+      activeConfig: active,
+      refetch: jest.fn(),
+      isLoading: false,
+    });
+
+    const { getByLabelText } = renderScreen();
+
+    fireEvent.press(getByLabelText('Options for https://b.example.com'));
+
+    const alertButtons = (Alert.alert as jest.Mock).mock.calls[0][2];
+    const setActiveButton = alertButtons.find(
+      (b: any) => b.text === 'Set Active'
+    );
+
+    await act(async () => {
+      await setActiveButton.onPress();
+    });
+
+    await waitFor(() => {
+      expect(mockSetActiveServerConfig).toHaveBeenCalledWith('b');
+      expect(mockNotifyIdentityChanged).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -185,6 +255,8 @@ describe('ServerSettingsScreen', () => {
     await waitFor(() => {
       expect(mockDeleteServerConfig).toHaveBeenCalledWith('only');
       expect(mockSetActiveServerConfig).not.toHaveBeenCalled();
+      // Nothing is left to read the caches, but the next server added would.
+      expect(mockNotifyIdentityChanged).toHaveBeenCalledTimes(1);
     });
 
     // The "Success" alert should have buttons; press OK to fire notifyNoConfigs

--- a/SparkyFitnessMobile/__tests__/services/authService.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/authService.test.ts
@@ -10,7 +10,6 @@ import {
   verifyTotp,
   sendEmailOtp,
   verifyEmailOtp,
-  clearAuthCookies,
   _requestPasskeyRegistrationTicket,
   addPasskey,
   _clearTrustedOriginCache,
@@ -649,8 +648,60 @@ describe('authService', () => {
   // --- clearAuthCookies ---
 
   describe('clearAuthCookies', () => {
-    test('resolves when NativeModules.Networking is undefined', async () => {
-      await expect(clearAuthCookies()).resolves.toBeUndefined();
+    // `networkingModule` is read once at import, so each case installs its own
+    // fake and loads the service fresh against it.
+    // isolateModules rather than resetModules: the latter empties the registry
+    // the rest of this file is still holding references into, which breaks the
+    // mocks of tests that run afterwards.
+    const loadWithNetworking = (
+      networking: unknown
+    ): (() => Promise<boolean>) => {
+      let clear!: () => Promise<boolean>;
+      jest.isolateModules(() => {
+        const rn = require('react-native');
+        rn.NativeModules.Networking = networking;
+        clear = require('../../src/services/api/authService').clearAuthCookies;
+      });
+      return clear;
+    };
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test('reports failure when NativeModules.Networking is missing', async () => {
+      await expect(loadWithNetworking(undefined)()).resolves.toBe(false);
+    });
+
+    test('treats an already-empty jar as cleared', async () => {
+      // Android's callback reports whether anything was *removed*, so an empty
+      // jar answers false. Being called at all is the success signal; reading
+      // that boolean as failure would cry wolf on every clean switch.
+      const clear = loadWithNetworking({
+        clearCookies: (cb: (result: boolean) => void) => cb(false),
+      });
+      await expect(clear()).resolves.toBe(true);
+    });
+
+    test('reports failure when the native call throws', async () => {
+      const clear = loadWithNetworking({
+        clearCookies: () => {
+          throw new Error('no cookie manager');
+        },
+      });
+      await expect(clear()).resolves.toBe(false);
+    });
+
+    test('gives up instead of hanging when the callback never fires', async () => {
+      // ForwardingCookieHandler is `cookieManager?.removeAllCookies`, and
+      // cookieManager is null when the WebView provider is missing: the call
+      // does nothing and never calls back. Without a deadline this would stall
+      // the identity change awaiting it forever.
+      jest.useFakeTimers();
+      const clear = loadWithNetworking({ clearCookies: () => {} });
+      const pending = clear();
+      jest.advanceTimersByTime(3_000);
+      await expect(pending).resolves.toBe(false);
     });
   });
 

--- a/SparkyFitnessMobile/__tests__/services/authService.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/authService.test.ts
@@ -4,6 +4,8 @@ import {
   notifySessionExpired,
   setOnNoConfigs,
   notifyNoConfigs,
+  setOnIdentityChanged,
+  notifyIdentityChanged,
   login,
   LoginError,
   fetchMfaFactors,
@@ -16,6 +18,7 @@ import {
   _setTrustedOriginCache,
 } from '../../src/services/api/authService';
 import { ServerConfig } from '../../src/services/storage';
+import * as LogService from '../../src/services/LogService';
 import { TimeoutError } from '../../src/utils/concurrency';
 import * as WebBrowser from 'expo-web-browser';
 
@@ -46,6 +49,7 @@ describe('authService', () => {
     // Clear stale callbacks between tests
     setOnSessionExpired(() => {});
     setOnNoConfigs(() => {});
+    setOnIdentityChanged(() => {});
   });
 
   afterEach(() => {
@@ -126,6 +130,41 @@ describe('authService', () => {
     test('no-op when no callback registered', () => {
       setOnNoConfigs(undefined as any);
       expect(() => notifyNoConfigs()).not.toThrow();
+    });
+  });
+
+  describe('setOnIdentityChanged / notifyIdentityChanged', () => {
+    test('registered callback is awaited', async () => {
+      const order: string[] = [];
+      setOnIdentityChanged(async () => {
+        await Promise.resolve();
+        order.push('handler');
+      });
+
+      await notifyIdentityChanged();
+      order.push('caller');
+
+      // Callers refetch straight after this resolves, so a handler that has
+      // not finished clearing the cookie jar would let the next request out
+      // carrying the previous account's session.
+      expect(order).toEqual(['handler', 'caller']);
+    });
+
+    test('an unregistered handler is reported, not passed over', async () => {
+      const addLogSpy = jest
+        .spyOn(LogService, 'addLog')
+        .mockResolvedValue(undefined);
+      setOnIdentityChanged(undefined as any);
+
+      await expect(notifyIdentityChanged()).resolves.toBeUndefined();
+
+      // The screens that change identity no longer clear anything themselves,
+      // so with nothing registered the previous account's caches survive the
+      // switch and nothing else would say so.
+      expect(addLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('no handler registered'),
+        'ERROR'
+      );
     });
   });
 

--- a/SparkyFitnessMobile/src/components/ReauthModal.tsx
+++ b/SparkyFitnessMobile/src/components/ReauthModal.tsx
@@ -30,6 +30,7 @@ import {
   fetchAuthSettings,
   loginWithOidc,
   loginWithPasskey,
+  notifyIdentityChanged,
   type MfaFactors,
   type AuthSettings,
   type OidcProvider,
@@ -175,6 +176,13 @@ const ReauthModal: React.FC<ReauthModalProps> = ({
       sessionToken,
       proxyHeaders: config.proxyHeaders,
     });
+    // The configuration keeps its id, but nothing here says the credentials
+    // just entered belong to the account that owned the expired session: the
+    // same server can be signed into as anyone. There is no stored email to
+    // compare against, so announce the change unconditionally — signing back
+    // into the same account costs a refetch, the other case would otherwise
+    // show one person's diary to another.
+    notifyIdentityChanged();
   };
 
   // --- Sign In ---

--- a/SparkyFitnessMobile/src/components/ReauthModal.tsx
+++ b/SparkyFitnessMobile/src/components/ReauthModal.tsx
@@ -182,7 +182,7 @@ const ReauthModal: React.FC<ReauthModalProps> = ({
     // compare against, so announce the change unconditionally — signing back
     // into the same account costs a refetch, the other case would otherwise
     // show one person's diary to another.
-    notifyIdentityChanged();
+    await notifyIdentityChanged();
   };
 
   // --- Sign In ---

--- a/SparkyFitnessMobile/src/components/ServerConfigModal.tsx
+++ b/SparkyFitnessMobile/src/components/ServerConfigModal.tsx
@@ -40,6 +40,7 @@ import {
   fetchAuthSettings,
   loginWithOidc,
   loginWithPasskey,
+  notifyIdentityChanged,
   type MfaFactors,
   type AuthSettings,
   type OidcProvider,
@@ -282,6 +283,11 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
       proxyHeaders: cleanedHeaders(),
       ...overrides,
     });
+    // saveServerConfig ends in setActiveServerConfig, so whatever was just
+    // saved is now the account the app reads. Signing in here can be a
+    // different person on the same server, and adding a server is a different
+    // one outright, so the caches from before cannot be carried over.
+    notifyIdentityChanged();
   };
 
   // --- Sign In flow ---
@@ -748,6 +754,10 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
         ...authFields,
         proxyHeaders: cleanedHeaders(),
       });
+      // Same reason as saveConfig above: this re-activates the configuration,
+      // and the edit may have repointed it at another server or swapped a
+      // session for an API key belonging to someone else.
+      notifyIdentityChanged();
       addLog('Server configuration updated.', 'INFO');
       onSuccess();
     } catch (err) {

--- a/SparkyFitnessMobile/src/components/ServerConfigModal.tsx
+++ b/SparkyFitnessMobile/src/components/ServerConfigModal.tsx
@@ -287,7 +287,7 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
     // saved is now the account the app reads. Signing in here can be a
     // different person on the same server, and adding a server is a different
     // one outright, so the caches from before cannot be carried over.
-    notifyIdentityChanged();
+    await notifyIdentityChanged();
   };
 
   // --- Sign In flow ---
@@ -757,7 +757,7 @@ const ServerConfigModal: React.FC<ServerConfigModalProps> = ({
       // Same reason as saveConfig above: this re-activates the configuration,
       // and the edit may have repointed it at another server or swapped a
       // session for an API key belonging to someone else.
-      notifyIdentityChanged();
+      await notifyIdentityChanged();
       addLog('Server configuration updated.', 'INFO');
       onSuccess();
     } catch (err) {

--- a/SparkyFitnessMobile/src/hooks/useAuth.ts
+++ b/SparkyFitnessMobile/src/hooks/useAuth.ts
@@ -9,6 +9,7 @@ import {
 } from '../services/api/authService';
 import { clearServerConfigCache } from '../services/storage';
 import type { ServerConfig } from '../services/storage';
+import { addLog } from '../services/LogService';
 
 export type AuthModalReason = 'session_expired' | 'no_configs' | null;
 
@@ -39,14 +40,21 @@ export function useAuth() {
     // reads it until each query happens to refetch.
     setOnIdentityChanged(() => {
       queryClient.clear();
-      // expo-image keys on the URI alone, so it ignores the Authorization
-      // header that made the request account-specific. Check-in photos and
-      // exercise images are served from per-server paths that two accounts can
-      // both produce, which is enough for the previous account's picture to be
-      // painted for the new one. Fire and forget: nothing waits on the result,
-      // and a rejection here must not take down the sign-in that caused it.
-      void Image.clearMemoryCache().catch(() => {});
-      void Image.clearDiskCache().catch(() => {});
+      // The image caches go too, but for data at rest rather than for what the
+      // next account can see: every server-backed image URI carries a uuid --
+      // `check-in-photos/file/{uuid}` and `/uploads/{domain}/{id}/{uuid}-name`
+      // -- so the new account cannot request a path that resolves to the
+      // previous one's bytes. What it can do is leave a departed account's
+      // progress photos sitting in the app's disk cache indefinitely, which is
+      // why this is deliberately not awaited: nothing on screen depends on it,
+      // and blocking a sign-in on a disk sweep would buy nothing. A failure is
+      // logged rather than swallowed, since it leaves those files behind.
+      void Image.clearMemoryCache().catch((err: unknown) => {
+        addLog(`Failed to clear the image memory cache: ${err}`, 'WARNING');
+      });
+      void Image.clearDiskCache().catch((err: unknown) => {
+        addLog(`Failed to clear the image disk cache: ${err}`, 'WARNING');
+      });
     });
   }, [queryClient]);
 

--- a/SparkyFitnessMobile/src/hooks/useAuth.ts
+++ b/SparkyFitnessMobile/src/hooks/useAuth.ts
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   setOnSessionExpired,
   setOnNoConfigs,
+  setOnIdentityChanged,
   suppressSessionExpired,
 } from '../services/api/authService';
 import { clearServerConfigCache } from '../services/storage';
@@ -10,6 +12,7 @@ import type { ServerConfig } from '../services/storage';
 export type AuthModalReason = 'session_expired' | 'no_configs' | null;
 
 export function useAuth() {
+  const queryClient = useQueryClient();
   const [authModalReason, setAuthModalReason] = useState<AuthModalReason>(null);
   const [expiredConfigId, setExpiredConfigId] = useState<string | null>(null);
   const [switchToApiKeyConfig, setSwitchToApiKeyConfig] =
@@ -31,7 +34,12 @@ export function useAuth() {
       setSwitchToApiKeyConfig(null);
       setAuthModalReason('no_configs');
     });
-  }, []);
+    // Everything cached under the previous account has to go, or the new one
+    // reads it until each query happens to refetch.
+    setOnIdentityChanged(() => {
+      queryClient.clear();
+    });
+  }, [queryClient]);
 
   const dismissModal = useCallback(() => {
     setAuthModalReason(null);

--- a/SparkyFitnessMobile/src/hooks/useAuth.ts
+++ b/SparkyFitnessMobile/src/hooks/useAuth.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { Image } from 'expo-image';
 import {
   setOnSessionExpired,
   setOnNoConfigs,
@@ -38,6 +39,14 @@ export function useAuth() {
     // reads it until each query happens to refetch.
     setOnIdentityChanged(() => {
       queryClient.clear();
+      // expo-image keys on the URI alone, so it ignores the Authorization
+      // header that made the request account-specific. Check-in photos and
+      // exercise images are served from per-server paths that two accounts can
+      // both produce, which is enough for the previous account's picture to be
+      // painted for the new one. Fire and forget: nothing waits on the result,
+      // and a rejection here must not take down the sign-in that caused it.
+      void Image.clearMemoryCache().catch(() => {});
+      void Image.clearDiskCache().catch(() => {});
     });
   }, [queryClient]);
 

--- a/SparkyFitnessMobile/src/hooks/useAuth.ts
+++ b/SparkyFitnessMobile/src/hooks/useAuth.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Image } from 'expo-image';
 import {
+  clearAuthCookies,
   setOnSessionExpired,
   setOnNoConfigs,
   setOnIdentityChanged,
@@ -38,8 +39,18 @@ export function useAuth() {
     });
     // Everything cached under the previous account has to go, or the new one
     // reads it until each query happens to refetch.
-    setOnIdentityChanged(() => {
+    setOnIdentityChanged(async () => {
       queryClient.clear();
+      // The cookie jar is the third thing carrying identity, and the only one
+      // that survives dropping every cache: it belongs to the native HTTP
+      // client and is keyed by host, not by configured server, so two accounts
+      // on one server share it. The sign-in paths already clear it for exactly
+      // this reason; the identity changes that skip sign-in (switching the
+      // active server, deleting it) reach here instead. Left in place, the
+      // server resolves the stale cookie ahead of the Bearer token this app
+      // sends and answers as the account we just left. Awaited, unlike the
+      // image sweep below, because the next request must not overtake it.
+      await clearAuthCookies();
       // The image caches go too, but for data at rest rather than for what the
       // next account can see: every server-backed image URI carries a uuid --
       // `check-in-photos/file/{uuid}` and `/uploads/{domain}/{id}/{uuid}-name`

--- a/SparkyFitnessMobile/src/hooks/useAuth.ts
+++ b/SparkyFitnessMobile/src/hooks/useAuth.ts
@@ -50,7 +50,15 @@ export function useAuth() {
       // server resolves the stale cookie ahead of the Bearer token this app
       // sends and answers as the account we just left. Awaited, unlike the
       // image sweep below, because the next request must not overtake it.
-      await clearAuthCookies();
+      // A failure is reported rather than passed over: it leaves a session
+      // cookie that a server which prefers it over the Bearer token would
+      // answer from, so the reader needs to know the sweep did not happen.
+      if (!(await clearAuthCookies())) {
+        addLog(
+          'Identity changed but the cookie jar was not cleared; requests may still carry the previous session.',
+          'ERROR'
+        );
+      }
       // The image caches go too, but for data at rest rather than for what the
       // next account can see: every server-backed image URI carries a uuid --
       // `check-in-photos/file/{uuid}` and `/uploads/{domain}/{id}/{uuid}-name`

--- a/SparkyFitnessMobile/src/screens/ServerSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ServerSettingsScreen.tsx
@@ -29,7 +29,10 @@ import {
   type ServerConfig,
 } from '../services/storage';
 import { addLog } from '../services/LogService';
-import { notifyNoConfigs } from '../services/api/authService';
+import {
+  notifyIdentityChanged,
+  notifyNoConfigs,
+} from '../services/api/authService';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 import { useScreenHeader } from '../hooks/useScreenHeader';
 import { useServerConfigs, useServerConnection } from '../hooks';
@@ -95,7 +98,7 @@ const ServerSettingsScreen: React.FC<ServerSettingsScreenProps> = ({
     }
     try {
       await setActiveServerConfig(configId);
-      queryClient.clear();
+      notifyIdentityChanged();
       await refetchServerConfigs();
       refetchConnection();
       Toast.show({

--- a/SparkyFitnessMobile/src/screens/ServerSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ServerSettingsScreen.tsx
@@ -134,6 +134,13 @@ const ServerSettingsScreen: React.FC<ServerSettingsScreenProps> = ({
       if (wasActive && remaining.length > 0) {
         await setActiveServerConfig(remaining[0].id);
       }
+      // Deleting the active configuration moves the app to another account
+      // just as the Set Active button does, so it has to drop the caches for
+      // the same reason. With no configuration left there is nothing to read
+      // the stale data, but it would still be there for the next one added.
+      if (wasActive) {
+        notifyIdentityChanged();
+      }
       await invalidateServerConfigs();
       refetchConnection();
       addLog('Server configuration deleted.', 'INFO');

--- a/SparkyFitnessMobile/src/screens/ServerSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/ServerSettingsScreen.tsx
@@ -98,7 +98,7 @@ const ServerSettingsScreen: React.FC<ServerSettingsScreenProps> = ({
     }
     try {
       await setActiveServerConfig(configId);
-      notifyIdentityChanged();
+      await notifyIdentityChanged();
       await refetchServerConfigs();
       refetchConnection();
       Toast.show({
@@ -139,7 +139,7 @@ const ServerSettingsScreen: React.FC<ServerSettingsScreenProps> = ({
       // the same reason. With no configuration left there is nothing to read
       // the stale data, but it would still be there for the next one added.
       if (wasActive) {
-        notifyIdentityChanged();
+        await notifyIdentityChanged();
       }
       await invalidateServerConfigs();
       refetchConnection();

--- a/SparkyFitnessMobile/src/services/api/authService.ts
+++ b/SparkyFitnessMobile/src/services/api/authService.ts
@@ -78,6 +78,26 @@ export const notifyNoConfigs = (): void => {
   onNoConfigsCallback?.();
 };
 
+let onIdentityChangedCallback: (() => void) | null = null;
+
+export const setOnIdentityChanged = (cb: () => void): void => {
+  onIdentityChangedCallback = cb;
+};
+
+/**
+ * The account whose data the app is showing is no longer the one it was:
+ * a different active server, a session replaced through the reauth modal, or
+ * the active configuration deleted.
+ *
+ * Callers only announce it. Deciding what to drop belongs to whoever holds the
+ * caches, which is why this mirrors the two callbacks above rather than reaching
+ * for the query client from a screen: a new path that changes identity then has
+ * one call to make instead of a list of caches to remember.
+ */
+export const notifyIdentityChanged = (): void => {
+  onIdentityChangedCallback?.();
+};
+
 let pendingProxyHeaders: Record<string, string> = {};
 export const setPendingProxyHeaders = (
   headers: Record<string, string>

--- a/SparkyFitnessMobile/src/services/api/authService.ts
+++ b/SparkyFitnessMobile/src/services/api/authService.ts
@@ -78,9 +78,9 @@ export const notifyNoConfigs = (): void => {
   onNoConfigsCallback?.();
 };
 
-let onIdentityChangedCallback: (() => void) | null = null;
+let onIdentityChangedCallback: (() => void | Promise<void>) | null = null;
 
-export const setOnIdentityChanged = (cb: () => void): void => {
+export const setOnIdentityChanged = (cb: () => void | Promise<void>): void => {
   onIdentityChangedCallback = cb;
 };
 
@@ -93,9 +93,14 @@ export const setOnIdentityChanged = (cb: () => void): void => {
  * caches, which is why this mirrors the two callbacks above rather than reaching
  * for the query client from a screen: a new path that changes identity then has
  * one call to make instead of a list of caches to remember.
+ *
+ * Await it before issuing another request. Part of what the handler drops is
+ * the cookie jar, and a request that goes out first still carries the previous
+ * account's session cookie -- which the server prefers over the Bearer token
+ * this app sends, so the reply would describe the account we just left.
  */
-export const notifyIdentityChanged = (): void => {
-  onIdentityChangedCallback?.();
+export const notifyIdentityChanged = async (): Promise<void> => {
+  await onIdentityChangedCallback?.();
 };
 
 let pendingProxyHeaders: Record<string, string> = {};

--- a/SparkyFitnessMobile/src/services/api/authService.ts
+++ b/SparkyFitnessMobile/src/services/api/authService.ts
@@ -101,7 +101,18 @@ export const setOnIdentityChanged = (cb: () => void | Promise<void>): void => {
  * this app sends, so the reply would describe the account we just left.
  */
 export const notifyIdentityChanged = async (): Promise<void> => {
-  await onIdentityChangedCallback?.();
+  if (!onIdentityChangedCallback) {
+    // The screens that change identity no longer drop anything themselves, so
+    // an unregistered handler means the previous account's caches survive the
+    // switch in silence. Nothing here can recover them -- the caches belong to
+    // the tree that failed to register -- but it must not pass unnoticed.
+    addLog(
+      "[AuthService] Identity changed with no handler registered; the previous account's caches were left in place.",
+      'ERROR'
+    );
+    return;
+  }
+  await onIdentityChangedCallback();
 };
 
 let pendingProxyHeaders: Record<string, string> = {};

--- a/SparkyFitnessMobile/src/services/api/authService.ts
+++ b/SparkyFitnessMobile/src/services/api/authService.ts
@@ -13,6 +13,7 @@ import {
   CONNECTION_CHECK_TIMEOUT_MS,
   DEFAULT_API_TIMEOUT_MS,
   fetchWithTimeout,
+  withTimeout,
 } from '../../utils/concurrency';
 
 // Re-exported so existing `import { LoginError } from '.../authService'` call
@@ -267,21 +268,53 @@ const parseAuthErrorText = (errorText: string): string => {
   return errorText.trim();
 };
 
-export const clearAuthCookies = async (): Promise<void> => {
-  await new Promise<void>((resolve) => {
+/**
+ * How long to wait for the native cookie jar to answer. Android's
+ * `ForwardingCookieHandler.clearCookies` is `cookieManager?.removeAllCookies`,
+ * and `cookieManager` is null whenever the WebView provider is missing -- a
+ * case React Native handles by returning null rather than throwing. The call
+ * then does nothing *and never invokes the callback*, so without a deadline the
+ * promise, and the identity change awaiting it, would hang forever.
+ */
+const COOKIE_CLEAR_TIMEOUT_MS = 3_000;
+
+/**
+ * Empties the native HTTP cookie jar.
+ *
+ * Returns whether the jar can be considered cleared. False means a session
+ * cookie may still be on the wire, which matters because a server that
+ * resolves it ahead of our Bearer token would answer as the previous account,
+ * so failures are logged as errors rather than passed over.
+ */
+export const clearAuthCookies = async (): Promise<boolean> => {
+  if (!networkingModule) {
+    addLog(
+      '[AuthService] No Networking module: auth cookies were left in place.',
+      'ERROR'
+    );
+    return false;
+  }
+
+  const cleared = new Promise<boolean>((resolve, reject) => {
     try {
-      networkingModule?.clearCookies(() => resolve());
-      if (!networkingModule) {
-        resolve();
-      }
+      // The callback's boolean reports whether anything was *removed*, not
+      // whether the sweep worked: Android answers false for an already-empty
+      // jar. Being called at all is the success signal.
+      networkingModule.clearCookies(() => resolve(true));
     } catch (error) {
-      addLog(
-        `[AuthService] Failed to clear auth cookies: ${getErrorMessage(error)}`,
-        'WARNING'
-      );
-      resolve();
+      reject(error);
     }
   });
+
+  try {
+    return await withTimeout(cleared, COOKIE_CLEAR_TIMEOUT_MS, 'Cookie clear');
+  } catch (error) {
+    addLog(
+      `[AuthService] Failed to clear auth cookies: ${getErrorMessage(error)}`,
+      'ERROR'
+    );
+    return false;
+  }
 };
 
 /**

--- a/SparkyFitnessServer/tests/bearerAuthBridge.test.ts
+++ b/SparkyFitnessServer/tests/bearerAuthBridge.test.ts
@@ -1,0 +1,137 @@
+import { vi, describe, expect, it } from 'vitest';
+
+vi.mock('../auth.js', () => ({
+  auth: {
+    api: { getSession: vi.fn() },
+    options: {
+      advanced: { cookiePrefix: 'sparky', useSecureCookies: false },
+      secret: 'test-secret',
+    },
+  },
+}));
+
+vi.mock('../config/logging.js', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('better-call', () => ({
+  serializeSignedCookie: vi
+    .fn()
+    .mockImplementation(
+      async (name: string, value: string) =>
+        `${name}=${value}.signature; Path=/; HttpOnly`
+    ),
+}));
+
+import { bridgeBearerAuthHeader } from '../utils/bearerAuthBridge.js';
+
+const COOKIE_NAME = 'sparky.session_token';
+// Session tokens are the branch that becomes a cookie: under 64 chars, or
+// containing a dot, so they are not mistaken for an API key.
+const SESSION_A = 'session-token-account-a.abc';
+const SESSION_B = 'session-token-account-b.xyz';
+
+function makeReq(headers: Record<string, string | string[] | undefined>): {
+  headers: Record<string, string | string[] | undefined>;
+} {
+  return { headers };
+}
+
+/** The cookie names present, in order, as a parser would encounter them. */
+function cookieNames(header: string): string[] {
+  return header.split(';').map((part) => part.trim().split('=')[0]);
+}
+
+function cookieValue(header: string, name: string): string | undefined {
+  for (const part of header.split(';')) {
+    const trimmed = part.trim();
+    const eq = trimmed.indexOf('=');
+    if (eq > 0 && trimmed.slice(0, eq) === name) return trimmed.slice(eq + 1);
+  }
+  return undefined;
+}
+
+describe('bridgeBearerAuthHeader', () => {
+  it('injects the session cookie when the client sent none', async () => {
+    const req = makeReq({ authorization: `Bearer ${SESSION_A}` });
+
+    await bridgeBearerAuthHeader(req);
+
+    expect(cookieValue(req.headers.cookie as string, COOKIE_NAME)).toBe(
+      `${SESSION_A}.signature`
+    );
+    expect(req.headers.authorization).toBeUndefined();
+  });
+
+  it('replaces a session cookie belonging to another account', async () => {
+    // Two accounts on one host share a cookie jar, so the client can send a
+    // session cookie for B while asking, via Bearer, to be A.
+    const req = makeReq({
+      authorization: `Bearer ${SESSION_A}`,
+      cookie: `${COOKIE_NAME}=${SESSION_B}.signature`,
+    });
+
+    await bridgeBearerAuthHeader(req);
+
+    const header = req.headers.cookie as string;
+    // Cookie parsing is first-wins, so a surviving duplicate would shadow ours
+    // however it is ordered: the stale name must be gone, not merely later.
+    expect(cookieNames(header).filter((n) => n === COOKIE_NAME)).toHaveLength(
+      1
+    );
+    expect(cookieValue(header, COOKIE_NAME)).toBe(`${SESSION_A}.signature`);
+    expect(header).not.toContain(SESSION_B);
+  });
+
+  it('keeps unrelated cookies', async () => {
+    const req = makeReq({
+      authorization: `Bearer ${SESSION_A}`,
+      cookie: `theme=dark; ${COOKIE_NAME}=${SESSION_B}.signature; locale=es`,
+    });
+
+    await bridgeBearerAuthHeader(req);
+
+    const header = req.headers.cookie as string;
+    expect(cookieValue(header, 'theme')).toBe('dark');
+    expect(cookieValue(header, 'locale')).toBe('es');
+    expect(cookieValue(header, COOKIE_NAME)).toBe(`${SESSION_A}.signature`);
+  });
+
+  it('leaves a valueless cookie part intact', async () => {
+    // `slice(0, indexOf('='))` on a part with no `=` would mangle the name it
+    // compares, so such a part is matched whole instead.
+    const req = makeReq({
+      authorization: `Bearer ${SESSION_A}`,
+      cookie: `flag; ${COOKIE_NAME}=${SESSION_B}.signature`,
+    });
+
+    await bridgeBearerAuthHeader(req);
+
+    const header = req.headers.cookie as string;
+    expect(header).toContain('flag');
+    expect(header).not.toContain(SESSION_B);
+  });
+
+  it('maps an API key to x-api-key without touching cookies', async () => {
+    const apiKey = 'k'.repeat(64);
+    const req = makeReq({
+      authorization: `Bearer ${apiKey}`,
+      cookie: `${COOKIE_NAME}=${SESSION_B}.signature`,
+    });
+
+    const result = await bridgeBearerAuthHeader(req);
+
+    expect(result.apiKeyToken).toBe(apiKey);
+    expect(req.headers['x-api-key']).toBe(apiKey);
+    expect(req.headers.cookie).toBe(`${COOKIE_NAME}=${SESSION_B}.signature`);
+  });
+
+  it('does nothing without a Bearer header', async () => {
+    const req = makeReq({ cookie: `${COOKIE_NAME}=${SESSION_B}.signature` });
+
+    const result = await bridgeBearerAuthHeader(req);
+
+    expect(result.apiKeyToken).toBeNull();
+    expect(req.headers.cookie).toBe(`${COOKIE_NAME}=${SESSION_B}.signature`);
+  });
+});

--- a/SparkyFitnessServer/utils/bearerAuthBridge.ts
+++ b/SparkyFitnessServer/utils/bearerAuthBridge.ts
@@ -68,10 +68,31 @@ export async function bridgeBearerAuthHeader(
   );
   const cookieHeader = signed.split(';')[0];
   const existingCookie = req.headers.cookie;
-  req.headers.cookie =
+  // Drop any session cookie the client already sent before appending ours.
+  // Cookie parsing is first-wins (better-call's parseCookies skips a repeated
+  // name), so appending to a stale `session_token` would leave the Bearer
+  // token silently ignored and authenticate the request as whoever the cookie
+  // belongs to. That happens whenever one client holds sessions for two
+  // accounts on the same host -- the mobile app's cookie jar is per host, not
+  // per configured server -- so an explicit Authorization header has to win.
+  // Other cookies are preserved untouched.
+  const cookieNameOf = (part: string): string => {
+    const eq = part.indexOf('=');
+    // A valueless part is not a `name=value` pair; keep it as-is rather than
+    // letting a negative index mangle the name we compare against.
+    return eq === -1 ? part : part.slice(0, eq).trim();
+  };
+  const preservedCookies =
     typeof existingCookie === 'string' && existingCookie
-      ? `${existingCookie}; ${cookieHeader}`
-      : cookieHeader;
+      ? existingCookie
+          .split(';')
+          .map((part) => part.trim())
+          .filter((part) => part !== '' && cookieNameOf(part) !== cookieName)
+          .join('; ')
+      : '';
+  req.headers.cookie = preservedCookies
+    ? `${preservedCookies}; ${cookieHeader}`
+    : cookieHeader;
   delete req.headers.authorization;
   log(
     'debug',


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Switching the mobile app to another account leaves the previous account's data on screen — one person's weight and progress photos shown to another.

**How did you implement the solution?**
Three things carry identity: the React Query cache, the image caches and the HTTP cookie jar. `authService` gains a `setOnIdentityChanged` / `notifyIdentityChanged` pair alongside the existing `onSessionExpired` and `onNoConfigs`; `useAuth` subscribes and drops all three. The screens that change identity just announce it — activating a different configuration, deleting the active one, and saving a session in `ReauthModal` or `ServerConfigModal`.

The cookie jar needed a server-side fix too. It is keyed by host, not by configured server, so two accounts on one server share it, and `bridgeBearerAuthHeader` appended its Bearer-derived cookie to whatever the client sent. Cookie parsing is first-wins, so the stale cookie won and the `Authorization` header was ignored without a trace. It now replaces a session cookie of the same name and preserves the rest.

Linked Issue: Closes #2375

## How to Test

1. Check out this branch, then `cd SparkyFitnessMobile && pnpm start`.
2. Add **two server configurations pointing at the same server**, signed into different accounts with visibly different data (weight, a logged meal, progress photos). Same server matters: with two different servers the cookie jars never collide and the bug does not reproduce.
3. Open the Diary and let it load, including the progress photos so they land in the image cache.
4. Settings → Server → `Set Active` on the other configuration. The Diary shows that account's weight, meal and photos.
5. Delete the active configuration. The app falls through to the remaining one and shows its data.
6. Trigger the reauth modal (Settings → Dev Tools → Auth → Show ReauthModal), sign in as the other account, and confirm the diary and photos belong to it.
7. Delete a *non*-active configuration and confirm the diary does **not** refetch — only the active configuration triggers a clear.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [x] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

No visual change to capture: the same screens render, the change is which account's data they show.

## Notes for Reviewers

**No database work.** No new tables and no SQL, so `rls_policies.sql` is untouched and that box stays unchecked.

**Validation.** `pnpm run validate` passes in both `SparkyFitnessServer/` and `SparkyFitnessMobile/`. The suites pass too (3855 and 6430); a handful of unrelated tests hit the default 5s timeout on a loaded dev machine and pass when run on their own — worth knowing if CI flakes on them.

**The server fix stands on its own.** Any client holding a session cookie for another account on the same host authenticated as the wrong account, regardless of platform. It ships here because it is what made the mobile symptom survive the cache clear, but it is reviewable separately if you'd rather split it.

**`notifyIdentityChanged` is awaited.** Clearing the jar is async and the callers refetch immediately afterwards; unawaited, that request overtakes the sweep and goes out with the old cookie. The image cache sweep stays unawaited — nothing on screen depends on it.

**The reauth clear is unconditional, deliberately.** A configuration keeps its id across a re-login and nothing stored says which account the new session belongs to, so signing back into the same account costs one refetch. Happy to make it conditional if you'd rather store the account identity on the configuration.

**Clearing the whole `expo-image` disk cache is blunt.** It also drops food and exercise images that are not account-specific. `expo-image` gives no way to evict by URI prefix; the alternative is a per-account `cacheKey` on every `Image` in the app, which is a much wider change.

**Six commits, reviewable in order:** the first introduces the mechanism and migrates the existing call site with no behaviour change, the rest are the fixes. Squash if you prefer.

**Cookie-clear failures are reported, not blocking.** The native sweep can fail without throwing — no Networking module, or a null `cookieManager` when the WebView provider is missing, which leaves the callback uninvoked. That last case would stall an awaited identity change forever, so the call now races a 3s deadline and a failure is logged as an error. It does not abort the switch: the server-side fix already makes the Bearer token authoritative, and aborting would leave the user unable to change accounts while barely blocking anything, since the caches are cleared before this point and the next focus refetches anyway. Happy to make it hard-fail if you'd rather.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved data refresh when switching, deleting, or reauthenticating an active server.
* Cleared cached app data, images, and authentication cookies when the signed-in identity changes.
* Improved error reporting when authentication-cookie or cache cleanup fails.
* Prevented cache-cleanup errors from disrupting authentication and server-management flows.
* Ensured Bearer-token requests replace stale session cookies, preventing requests from using the wrong account.
* Preserved unrelated cookies and correctly handled API-key authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->