### PR TITLE
feat(mobile): add a Hydration graph to Health Trends

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/HealthTrendsPager.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/HealthTrendsPager.test.tsx
@@ -340,6 +340,59 @@ describe('HealthTrendsPager', () => {
     expect(chartOrder()).toEqual(['steps-chart']);
   });
 
+  // `useHydrationRange` zero-fills every day in the window, so hydration's `data` is
+  // never empty and a `data.length` check would show the page to someone who has never
+  // logged water — the same trap sleep's padded series already sidesteps.
+  test('hides hydration when every day in the window is a zero fill', () => {
+    renderPager({
+      hydration: {
+        data: [
+          { day: '2026-06-01', milliliters: 0 },
+          { day: '2026-06-02', milliliters: 0 },
+          { day: '2026-06-03', milliliters: 0 },
+        ],
+        isLoading: false,
+        isError: false,
+      },
+      visibleTrends: ['steps', 'hydration'],
+    });
+
+    expect(chartOrder()).toEqual(['steps-chart']);
+  });
+
+  test('shows hydration when a single day in the window has water logged', () => {
+    renderPager({
+      hydration: {
+        data: [
+          { day: '2026-06-01', milliliters: 0 },
+          { day: '2026-06-02', milliliters: 250 },
+          { day: '2026-06-03', milliliters: 0 },
+        ],
+        isLoading: false,
+        isError: false,
+      },
+      visibleTrends: ['steps', 'hydration'],
+    });
+
+    expect(chartOrder()).toEqual(['steps-chart', 'hydration-chart']);
+  });
+
+  test('still falls back to hydration when its window is all zero fills', () => {
+    renderPager({
+      steps: emptySeries(),
+      weight: emptySeries(),
+      sleep: sleepTrend(),
+      hydration: {
+        data: [{ day: '2026-06-03', milliliters: 0 }],
+        isLoading: false,
+        isError: false,
+      },
+      visibleTrends: ['hydration', 'steps'],
+    });
+
+    expect(chartOrder()).toEqual(['hydration-chart']);
+  });
+
   // The charts are mocked here, so this only asserts which page the fallback picks. That
   // the page is not blank is each chart's own responsibility, covered by its empty-state
   // test — see `WeightLineChart.test.tsx`, which is where the fallback used to render

--- a/SparkyFitnessMobile/__tests__/components/HealthTrendsPager.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/HealthTrendsPager.test.tsx
@@ -35,6 +35,16 @@ jest.mock('../../src/components/SleepTimelineChart', () => {
   };
 });
 
+jest.mock('../../src/components/HydrationBarChart', () => {
+  const ReactModule = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: () =>
+      ReactModule.createElement(View, { testID: 'hydration-chart' }),
+  };
+});
+
 type PagerProps = React.ComponentProps<typeof HealthTrendsPager>;
 
 const emptySeries = <TPoint,>(): HealthTrendSeries<TPoint> => ({
@@ -92,13 +102,17 @@ const sleepSeries = sleepTrend({
   nightsWithData: 1,
 });
 
+const hydrationSeries = populated({ day: '2026-06-03', milliliters: 1500 });
+
 const baseProps = (): PagerProps => ({
   steps: stepsSeries,
   weight: emptySeries(),
   sleep: sleepTrend(),
+  hydration: emptySeries(),
   range: '7d',
   weightUnit: 'kg',
-  visibleTrends: ['steps', 'weight', 'sleep'],
+  waterUnit: 'ml',
+  visibleTrends: ['steps', 'weight', 'sleep', 'hydration'],
   activePage: 0,
   onPageSelected: jest.fn(),
 });
@@ -301,17 +315,17 @@ describe('HealthTrendsPager', () => {
 
   test('renders pages in the order the user chose', () => {
     renderPager({
-      weight: weightSeries,
-      visibleTrends: ['weight', 'steps'],
+      hydration: hydrationSeries,
+      visibleTrends: ['hydration', 'steps'],
     });
 
-    expect(chartOrder()).toEqual(['weight-chart', 'steps-chart']);
+    expect(chartOrder()).toEqual(['hydration-chart', 'steps-chart']);
   });
 
   test('omits a trend the user hid, even with data for it', () => {
     renderPager({
       weight: weightSeries,
-      visibleTrends: ['steps', 'sleep'],
+      visibleTrends: ['steps', 'sleep', 'hydration'],
     });
 
     expect(screen.queryByTestId('weight-chart')).toBeNull();
@@ -319,8 +333,8 @@ describe('HealthTrendsPager', () => {
 
   test('still hides a shown trend that has no data in this window', () => {
     renderPager({
-      weight: emptySeries(),
-      visibleTrends: ['steps', 'weight'],
+      hydration: emptySeries(),
+      visibleTrends: ['steps', 'hydration'],
     });
 
     expect(chartOrder()).toEqual(['steps-chart']);
@@ -334,11 +348,12 @@ describe('HealthTrendsPager', () => {
     renderPager({
       steps: emptySeries(),
       weight: emptySeries(),
-      sleep: sleepTrend({ nightsWithData: 0 }),
-      visibleTrends: ['weight', 'steps'],
+      sleep: sleepTrend(),
+      hydration: emptySeries(),
+      visibleTrends: ['hydration', 'steps'],
     });
 
-    expect(chartOrder()).toEqual(['weight-chart']);
+    expect(chartOrder()).toEqual(['hydration-chart']);
   });
 
   test('renders the all-hidden card when nothing is visible', () => {

--- a/SparkyFitnessMobile/__tests__/components/HydrationBarChart.test.ts
+++ b/SparkyFitnessMobile/__tests__/components/HydrationBarChart.test.ts
@@ -1,0 +1,70 @@
+import i18n, { initializeI18n } from '../../src/localization/i18n';
+import { buildHydrationTooltipText } from '../../src/components/HydrationBarChart';
+import { volumeFromMl } from '../../src/utils/unitConversions';
+
+// `buildHydrationTooltipText` takes an ALREADY-converted point — the component owns the
+// millilitres boundary — so each case converts with the same helper the component uses.
+const pointFor = (milliliters: number, unit: string) => ({
+  day: '2026-06-03',
+  volume: volumeFromMl(milliliters, unit),
+});
+
+describe('HydrationBarChart buildHydrationTooltipText', () => {
+  beforeAll(async () => {
+    await initializeI18n('en');
+  });
+
+  beforeEach(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  afterAll(async () => {
+    await i18n.changeLanguage('en');
+  });
+
+  test('states the volume, the unit label and the date', () => {
+    const text = buildHydrationTooltipText(pointFor(500, 'ml'), 'ml', i18n.t);
+
+    expect(text).toContain('500');
+    expect(text).toContain('ml');
+    expect(text).toContain('Jun');
+  });
+
+  test('reads a 500 ml point in the display unit, not in millilitres', () => {
+    const text = buildHydrationTooltipText(pointFor(500, 'oz'), 'oz', i18n.t);
+
+    expect(text).toContain('16.9');
+    expect(text).toContain('oz');
+    expect(text).not.toContain('500');
+  });
+
+  test('uses the WATER_UNIT_LABELS label rather than the raw key', () => {
+    const text = buildHydrationTooltipText(
+      pointFor(1500, 'liter'),
+      'liter',
+      i18n.t
+    );
+
+    expect(text).toContain('L');
+    expect(text).not.toContain('liter');
+  });
+
+  test('follows the active locale', async () => {
+    const englishText = buildHydrationTooltipText(
+      pointFor(500, 'oz'),
+      'oz',
+      i18n.t
+    );
+
+    await i18n.changeLanguage('pl');
+    const polishText = buildHydrationTooltipText(
+      pointFor(500, 'oz'),
+      'oz',
+      i18n.t
+    );
+
+    // PL groups decimals with a comma, so the same point cannot read as it did in EN.
+    expect(polishText).toContain('16,9');
+    expect(polishText).not.toBe(englishText);
+  });
+});

--- a/SparkyFitnessMobile/__tests__/components/HydrationGauge.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/HydrationGauge.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import HydrationGauge from '../../src/components/HydrationGauge';
+import { initializeI18n } from '../../src/localization/i18n';
+
+// The global Skia mock's PathBuilder has no `cubicTo`, which the bottle outline needs.
+// The drawing is irrelevant here — only the headline totals are under test.
+jest.mock('@shopify/react-native-skia', () => {
+  const ReactModule = require('react');
+  const { View } = require('react-native');
+  const pathBuilder = {
+    moveTo: jest.fn().mockReturnThis(),
+    lineTo: jest.fn().mockReturnThis(),
+    cubicTo: jest.fn().mockReturnThis(),
+    close: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue(null),
+  };
+  return {
+    Canvas: ({ children, style }: { children?: unknown; style?: unknown }) =>
+      ReactModule.createElement(
+        View,
+        { style, testID: 'skia-canvas' },
+        children
+      ),
+    Group: ({ children }: { children?: unknown }) => children,
+    Path: () => null,
+    Rect: () => null,
+    Skia: {
+      PathBuilder: { Make: () => pathBuilder },
+      Path: { Rect: jest.fn(() => null) },
+      XYWHRect: jest.fn(() => ({})),
+    },
+    matchFont: jest.fn(() => null),
+  };
+});
+
+// Guards the volume-helper extraction: the gauge now formats through `volumeFromMl` /
+// `formatVolumeForUnit`, so its headline totals must read exactly as they did before.
+describe('HydrationGauge', () => {
+  beforeAll(async () => {
+    await initializeI18n('en');
+  });
+
+  test('renders consumed and goal in millilitres with no decimals', () => {
+    render(<HydrationGauge consumed={1500} goal={2000} unit="ml" />);
+
+    expect(screen.getByText('1,500 ml')).toBeTruthy();
+    expect(screen.getByText('of 2,000 ml')).toBeTruthy();
+  });
+
+  test('renders the converted value and label in fluid ounces', () => {
+    render(<HydrationGauge consumed={1500} goal={2000} unit="oz" />);
+
+    expect(screen.getByText('50.7 oz')).toBeTruthy();
+    expect(screen.getByText('of 67.6 oz')).toBeTruthy();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/components/TrendBarChart.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/TrendBarChart.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import TrendBarChart from '../../src/components/TrendBarChart';
+import { CHART_TOUCH_LONG_PRESS_DELAY_MS } from '../../src/components/ChartTouchOverlay';
+
+/**
+ * The Skia plot is replaced by a stub that still hands `CartesianChart`'s render prop a
+ * real layout, so `ChartLayoutReporter` reports it and `ChartTouchOverlay` can resolve a
+ * touch to a bar index — selection is what these cases are actually about.
+ */
+jest.mock('victory-native', () => {
+  const ReactModule = require('react');
+  const { View } = require('react-native');
+  return {
+    CartesianChart: ({
+      children,
+      data,
+    }: {
+      children: (arg: {
+        points: { value: unknown[] };
+        chartBounds: {
+          left: number;
+          right: number;
+          top: number;
+          bottom: number;
+        };
+      }) => React.ReactNode;
+      data: { day: string; value: number }[];
+    }) => {
+      const points = data.map((point, index) => ({
+        x: 10 + index * 20,
+        y: 0,
+        xValue: point.day,
+        yValue: point.value,
+      }));
+      const chartBounds = {
+        left: 0,
+        right: 20 * data.length,
+        top: 0,
+        bottom: 100,
+      };
+      return ReactModule.createElement(
+        View,
+        { testID: 'cartesian-chart' },
+        children({ points: { value: points }, chartBounds })
+      );
+    },
+    Bar: () => null,
+  };
+});
+
+type Point = { day: string; steps: number };
+
+const data: Point[] = [
+  { day: '2026-06-01', steps: 1000 },
+  { day: '2026-06-02', steps: 2000 },
+  { day: '2026-06-03', steps: 3000 },
+];
+
+const getValue = (point: Point): number => point.steps;
+
+const defaultProps = {
+  data,
+  isLoading: false,
+  isError: false,
+  range: '7d' as const,
+  title: 'Steps',
+  getValue,
+  formatTooltip: (point: Point) => `${point.steps} steps`,
+  errorText: 'Failed to load step data',
+  emptyText: 'No step data for this period',
+  testIDPrefix: 'trend-touch-overlay',
+};
+
+const renderChart = (overrides: Partial<typeof defaultProps> = {}) => {
+  const view = render(<TrendBarChart {...defaultProps} {...overrides} />);
+  return {
+    ...view,
+    rerenderChart: (next: Partial<typeof defaultProps> = {}) =>
+      view.rerender(<TrendBarChart {...defaultProps} {...next} />),
+  };
+};
+
+const touchEventAt = (x: number) => ({
+  nativeEvent: {
+    changedTouches: [{ locationX: x, locationY: 50 }],
+    touches: [{ locationX: x, locationY: 50 }],
+    locationX: x,
+    locationY: 50,
+  },
+});
+
+/** Holds a bar long enough for the overlay to treat the touch as a selection. */
+const selectBar = (index: number) => {
+  fireEvent(
+    screen.getByTestId('trend-touch-overlay'),
+    'touchStart',
+    touchEventAt(10 + index * 20)
+  );
+  act(() => {
+    jest.advanceTimersByTime(CHART_TOUCH_LONG_PRESS_DELAY_MS);
+  });
+};
+
+describe('TrendBarChart', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test('renders the title and the plot for a populated series', () => {
+    renderChart();
+
+    expect(screen.getByText('Steps')).toBeTruthy();
+    expect(screen.getByTestId('cartesian-chart')).toBeTruthy();
+  });
+
+  test('shows the loading copy while loading', () => {
+    renderChart({ isLoading: true });
+
+    expect(screen.getByText('Loading...')).toBeTruthy();
+    expect(screen.queryByTestId('cartesian-chart')).toBeNull();
+  });
+
+  test('shows the supplied errorText while errored', () => {
+    renderChart({ isError: true });
+
+    expect(screen.getByText('Failed to load step data')).toBeTruthy();
+    expect(screen.queryByTestId('cartesian-chart')).toBeNull();
+  });
+
+  test('shows the supplied emptyText when every value is zero', () => {
+    renderChart({
+      data: data.map((point) => ({ ...point, steps: 0 })),
+    });
+
+    expect(screen.getByText('No step data for this period')).toBeTruthy();
+    expect(screen.queryByTestId('cartesian-chart')).toBeNull();
+  });
+
+  test('clears a visible tooltip on the first render after data changes identity', () => {
+    const { rerenderChart } = renderChart();
+    selectBar(1);
+    expect(screen.getByText('2000 steps')).toBeTruthy();
+
+    // A new array with the same contents is still a new dataset to the chart.
+    rerenderChart({ data: [...data] });
+
+    expect(screen.queryByText('2000 steps')).toBeNull();
+  });
+
+  test('re-derives the visible tooltip from the current formatTooltip', () => {
+    const { rerenderChart } = renderChart();
+    selectBar(1);
+    expect(screen.getByText('2000 steps')).toBeTruthy();
+
+    // Same data, new copy — a language switch must not leave stale text on screen.
+    rerenderChart({ formatTooltip: (point: Point) => `${point.steps} kroków` });
+
+    expect(screen.getByText('2000 kroków')).toBeTruthy();
+    expect(screen.queryByText('2000 steps')).toBeNull();
+  });
+});

--- a/SparkyFitnessMobile/__tests__/constants/healthTrends.test.ts
+++ b/SparkyFitnessMobile/__tests__/constants/healthTrends.test.ts
@@ -18,6 +18,7 @@ describe('healthTrends registry', () => {
       steps: 'Steps',
       weight: 'Weight',
       sleep: 'Sleep',
+      hydration: 'Hydration',
     };
 
     for (const key of HEALTH_TREND_KEYS) {
@@ -26,8 +27,8 @@ describe('healthTrends registry', () => {
   });
 
   test('the default order leads with the trends the pager shipped with', () => {
-    // A user who never opens the settings screen must see exactly the pager they had
-    // before it became configurable, so these keys stay frozen in this order.
+    // A user who never opens the settings screen must see exactly what they saw before
+    // hydration was registered, so the first three keys are frozen in place.
     expect(HEALTH_TREND_KEYS.slice(0, 3)).toEqual(['steps', 'weight', 'sleep']);
   });
 });

--- a/SparkyFitnessMobile/__tests__/hooks/useHealthTrends.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useHealthTrends.test.ts
@@ -4,7 +4,10 @@ import {
   HEALTH_TREND_KEYS,
   type HealthTrendKey,
 } from '../../src/constants/healthTrends';
-import { fetchMeasurementsRange } from '../../src/services/api/measurementsApi';
+import {
+  fetchMeasurementsRange,
+  fetchWaterIntakeRange,
+} from '../../src/services/api/measurementsApi';
 import { fetchSleepEntries } from '../../src/services/api/sleepApi';
 import { ApiError } from '../../src/services/api/errors';
 import { getTodayDate } from '../../src/utils/dateUtils';
@@ -17,6 +20,7 @@ import {
 
 jest.mock('../../src/services/api/measurementsApi', () => ({
   fetchMeasurementsRange: jest.fn(),
+  fetchWaterIntakeRange: jest.fn(),
 }));
 
 jest.mock('../../src/services/api/sleepApi', () => ({
@@ -38,6 +42,9 @@ const mockFetchMeasurementsRange =
   fetchMeasurementsRange as jest.MockedFunction<typeof fetchMeasurementsRange>;
 const mockFetchSleepEntries = fetchSleepEntries as jest.MockedFunction<
   typeof fetchSleepEntries
+>;
+const mockFetchWaterIntakeRange = fetchWaterIntakeRange as jest.MockedFunction<
+  typeof fetchWaterIntakeRange
 >;
 
 const today = getTodayDate();
@@ -78,6 +85,7 @@ beforeEach(() => {
   queryClient = createTestQueryClient();
   mockFetchMeasurementsRange.mockResolvedValue([]);
   mockFetchSleepEntries.mockResolvedValue([]);
+  mockFetchWaterIntakeRange.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -236,19 +244,49 @@ describe('useHealthTrends', () => {
 
     expect(mockFetchMeasurementsRange).not.toHaveBeenCalled();
     expect(mockFetchSleepEntries).not.toHaveBeenCalled();
+    expect(mockFetchWaterIntakeRange).not.toHaveBeenCalled();
+  });
+
+  test('returns a hydration series for the window', async () => {
+    mockFetchWaterIntakeRange.mockResolvedValue([
+      { entry_date: today, water_ml: 1500 },
+    ]);
+
+    const { result } = renderTrends();
+
+    await waitFor(() => {
+      expect(result.current.hydration.isLoading).toBe(false);
+    });
+
+    expect(result.current.hydration.data).toHaveLength(7);
+    expect(result.current.hydration.data.at(-1)).toEqual({
+      day: today,
+      milliliters: 1500,
+    });
+  });
+
+  test('issues no hydration request when hydration is not active', async () => {
+    renderTrends('7d', true, ['steps', 'weight', 'sleep']);
+
+    await waitFor(() => {
+      expect(mockFetchMeasurementsRange).toHaveBeenCalled();
+    });
+
+    expect(mockFetchWaterIntakeRange).not.toHaveBeenCalled();
   });
 
   test('issues no measurements request when neither steps nor weight is active', async () => {
-    const { result } = renderTrends('7d', true, ['sleep']);
+    const { result } = renderTrends('7d', true, ['hydration']);
 
     await waitFor(() => {
-      expect(mockFetchSleepEntries).toHaveBeenCalled();
+      expect(mockFetchWaterIntakeRange).toHaveBeenCalled();
     });
     await waitFor(() => {
-      expect(result.current.sleep.isLoading).toBe(false);
+      expect(result.current.hydration.isLoading).toBe(false);
     });
 
     expect(mockFetchMeasurementsRange).not.toHaveBeenCalled();
+    expect(result.current.hydration.data).toHaveLength(7);
   });
 
   test('still issues one measurements request when only weight is active', async () => {
@@ -261,11 +299,11 @@ describe('useHealthTrends', () => {
   });
 
   test('refetch refreshes every active source', async () => {
-    const { result } = renderTrends('7d', true, ['steps', 'sleep']);
+    const { result } = renderTrends('7d', true, ['steps', 'hydration']);
 
     await waitFor(() => {
       expect(mockFetchMeasurementsRange).toHaveBeenCalledTimes(1);
-      expect(mockFetchSleepEntries).toHaveBeenCalledTimes(1);
+      expect(mockFetchWaterIntakeRange).toHaveBeenCalledTimes(1);
     });
 
     await act(async () => {
@@ -273,11 +311,11 @@ describe('useHealthTrends', () => {
     });
 
     expect(mockFetchMeasurementsRange).toHaveBeenCalledTimes(2);
-    expect(mockFetchSleepEntries).toHaveBeenCalledTimes(2);
+    expect(mockFetchWaterIntakeRange).toHaveBeenCalledTimes(2);
   });
 
   test('refetch leaves a hidden trend alone', async () => {
-    const { result } = renderTrends('7d', true, ['steps']);
+    const { result } = renderTrends('7d', true, ['steps', 'hydration']);
 
     await waitFor(() => {
       expect(mockFetchMeasurementsRange).toHaveBeenCalledTimes(1);

--- a/SparkyFitnessMobile/__tests__/hooks/useHydrationRange.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/useHydrationRange.test.ts
@@ -1,0 +1,138 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useHydrationRange } from '../../src/hooks/useHydrationRange';
+import { waterIntakeRangeQueryKey } from '../../src/hooks/queryKeys';
+import { fetchWaterIntakeRange } from '../../src/services/api/measurementsApi';
+import { addDays, getTodayDate } from '../../src/utils/dateUtils';
+import {
+  createTestQueryClient,
+  createQueryWrapper,
+  type QueryClient,
+} from './queryTestUtils';
+
+jest.mock('../../src/services/api/measurementsApi', () => ({
+  fetchWaterIntakeRange: jest.fn(),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: jest.fn((callback) => {
+    callback();
+  }),
+}));
+
+const mockFetchWaterIntakeRange = fetchWaterIntakeRange as jest.MockedFunction<
+  typeof fetchWaterIntakeRange
+>;
+
+const today = getTodayDate();
+
+describe('useHydrationRange', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetchWaterIntakeRange.mockResolvedValue([]);
+    queryClient = createTestQueryClient();
+  });
+
+  afterEach(() => {
+    queryClient.clear();
+  });
+
+  test('emits one point per day for a 7d window', async () => {
+    const { result } = renderHook(() => useHydrationRange({ range: '7d' }), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.hydrationData).toHaveLength(7);
+  });
+
+  test('zero-fills days the server did not return', async () => {
+    // A day with no logged water genuinely means zero drunk, so it gets a bar rather
+    // than being omitted the way a missing weigh-in is.
+    mockFetchWaterIntakeRange.mockResolvedValue([
+      { entry_date: today, water_ml: 1500 },
+    ]);
+
+    const { result } = renderHook(() => useHydrationRange({ range: '7d' }), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const zeroDays = result.current.hydrationData.filter(
+      (point) => point.milliliters === 0
+    );
+    expect(zeroDays).toHaveLength(6);
+    expect(
+      result.current.hydrationData.find((point) => point.day === today)
+        ?.milliliters
+    ).toBe(1500);
+  });
+
+  test('orders points chronologically ascending, ending today', async () => {
+    const { result } = renderHook(() => useHydrationRange({ range: '7d' }), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const data = result.current.hydrationData;
+    expect(data[0].day).toBe(addDays(today, -6));
+    expect(data[6].day).toBe(today);
+    for (let index = 1; index < data.length; index++) {
+      expect(data[index].day > data[index - 1].day).toBe(true);
+    }
+  });
+
+  test('requests the window matching the selected range', async () => {
+    renderHook(() => useHydrationRange({ range: '30d' }), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(mockFetchWaterIntakeRange).toHaveBeenCalledWith(
+        addDays(today, -29),
+        today
+      );
+    });
+  });
+
+  test('caches the response under waterIntakeRangeQueryKey', async () => {
+    const response = [{ entry_date: today, water_ml: 750 }];
+    mockFetchWaterIntakeRange.mockResolvedValue(response);
+
+    const { result } = renderHook(() => useHydrationRange({ range: '7d' }), {
+      wrapper: createQueryWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(
+      queryClient.getQueryData(
+        waterIntakeRangeQueryKey(addDays(today, -6), today)
+      )
+    ).toEqual(response);
+  });
+
+  test('issues no request when disabled', async () => {
+    const { result } = renderHook(
+      () => useHydrationRange({ range: '7d', enabled: false }),
+      { wrapper: createQueryWrapper(queryClient) }
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(mockFetchWaterIntakeRange).not.toHaveBeenCalled();
+    expect(result.current.hydrationData).toEqual([]);
+  });
+});

--- a/SparkyFitnessMobile/__tests__/screens/HealthTrendsSettingsScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/HealthTrendsSettingsScreen.test.tsx
@@ -66,12 +66,12 @@ describe('HealthTrendsSettingsScreen', () => {
 
   test('lists every registered trend in the saved order', () => {
     useAppPreferencesStore.setState({
-      healthTrendOrder: ['sleep', 'steps', 'weight'],
+      healthTrendOrder: ['sleep', 'steps', 'weight', 'hydration'],
     });
 
     renderScreen();
 
-    expect(orderedRowKeys()).toEqual(['sleep', 'steps', 'weight']);
+    expect(orderedRowKeys()).toEqual(['sleep', 'steps', 'weight', 'hydration']);
     expect(orderedRowKeys()).toHaveLength(HEALTH_TREND_KEYS.length);
   });
 
@@ -80,14 +80,14 @@ describe('HealthTrendsSettingsScreen', () => {
 
     renderScreen();
 
-    expect(orderedRowKeys()).toEqual(['steps', 'sleep', 'weight']);
+    expect(orderedRowKeys()).toEqual(['steps', 'sleep', 'hydration', 'weight']);
     expect(screen.getByTestId('health-trend-divider')).toBeTruthy();
   });
 
   test('dragging the last shown trend past the divider hides it', () => {
     useAppPreferencesStore.setState({
-      healthTrendOrder: ['steps', 'weight', 'sleep'],
-      hiddenHealthTrends: ['weight', 'sleep'],
+      healthTrendOrder: ['steps', 'weight', 'sleep', 'hydration'],
+      hiddenHealthTrends: ['weight', 'sleep', 'hydration'],
     });
 
     renderScreen();
@@ -101,7 +101,7 @@ describe('HealthTrendsSettingsScreen', () => {
 
   test('dragging a hidden trend above the divider shows it again', () => {
     useAppPreferencesStore.setState({
-      healthTrendOrder: ['steps', 'weight', 'sleep'],
+      healthTrendOrder: ['steps', 'weight', 'sleep', 'hydration'],
       hiddenHealthTrends: ['steps'],
     });
 
@@ -120,7 +120,12 @@ describe('HealthTrendsSettingsScreen', () => {
     moveRow('steps', 'increment');
 
     const state = useAppPreferencesStore.getState();
-    expect(state.healthTrendOrder).toEqual(['weight', 'steps', 'sleep']);
+    expect(state.healthTrendOrder).toEqual([
+      'weight',
+      'steps',
+      'sleep',
+      'hydration',
+    ]);
     expect(state.hiddenHealthTrends).toEqual([]);
   });
 

--- a/SparkyFitnessMobile/__tests__/services/api/measurementsApi.test.ts
+++ b/SparkyFitnessMobile/__tests__/services/api/measurementsApi.test.ts
@@ -1,6 +1,7 @@
 import {
   upsertCheckIn,
   fetchMeasurements,
+  fetchWaterIntakeRange,
   serverSupportsPerRecordWater,
 } from '../../../src/services/api/measurementsApi';
 import { apiFetch } from '../../../src/services/api/apiClient';
@@ -131,5 +132,34 @@ describe('serverSupportsPerRecordWater', () => {
     mockApiFetch.mockResolvedValue({ water_ml: 1500, manual_ml: 500 });
 
     await expect(serverSupportsPerRecordWater()).resolves.toBe(true);
+  });
+});
+
+describe('fetchWaterIntakeRange', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockApiFetch.mockResolvedValue([]);
+  });
+
+  test('requests the range endpoint with both dates in the path', async () => {
+    await fetchWaterIntakeRange('2026-08-01', '2026-08-30');
+
+    expect(mockApiFetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: '/api/measurements/water-intake-range/2026-08-01/2026-08-30',
+      })
+    );
+  });
+
+  test('returns the response unchanged', async () => {
+    const response = [
+      { entry_date: '2026-08-01', water_ml: 1500 },
+      { entry_date: '2026-08-03', water_ml: 750 },
+    ];
+    mockApiFetch.mockResolvedValue(response);
+
+    await expect(
+      fetchWaterIntakeRange('2026-08-01', '2026-08-30')
+    ).resolves.toEqual(response);
   });
 });

--- a/SparkyFitnessMobile/__tests__/utils/healthTrendPreferences.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/healthTrendPreferences.test.ts
@@ -9,17 +9,18 @@ import {
 
 describe('resolveHealthTrendOrder', () => {
   test('returns a saved order verbatim when it covers every registered key', () => {
-    const savedOrder = ['sleep', 'steps', 'weight'];
+    const savedOrder = ['sleep', 'steps', 'hydration', 'weight'];
 
     expect(resolveHealthTrendOrder(savedOrder)).toEqual(savedOrder);
   });
 
   test('appends registry keys the saved order never knew about', () => {
-    // An order written before a graph was registered must still reach it, at the end.
-    expect(resolveHealthTrendOrder(['steps', 'weight'])).toEqual([
+    // An order written before hydration was registered must still reach it, at the end.
+    expect(resolveHealthTrendOrder(['steps', 'weight', 'sleep'])).toEqual([
       'steps',
       'weight',
       'sleep',
+      'hydration',
     ]);
   });
 
@@ -31,6 +32,7 @@ describe('resolveHealthTrendOrder', () => {
       'steps',
       'weight',
       'sleep',
+      'hydration',
     ]);
   });
 
@@ -38,7 +40,7 @@ describe('resolveHealthTrendOrder', () => {
     const resolvedOrder = resolveHealthTrendOrder(['steps', 'steps', 'weight']);
 
     expect(resolvedOrder.filter((key) => key === 'steps')).toHaveLength(1);
-    expect(resolvedOrder).toEqual(['steps', 'weight', 'sleep']);
+    expect(resolvedOrder).toEqual(['steps', 'weight', 'sleep', 'hydration']);
   });
 
   test('returns the full default order for an empty saved order', () => {

--- a/SparkyFitnessMobile/__tests__/utils/unitConversions.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/unitConversions.test.ts
@@ -16,7 +16,13 @@ import {
   kgToStonesLbs,
   stonesLbsToKg,
   formatWeightDisplay,
+  volumeFromMl,
+  formatVolumeForUnit,
 } from '../../src/utils/unitConversions';
+import i18n, {
+  getAppLocale,
+  initializeI18n,
+} from '../../src/localization/i18n';
 
 describe('unitConversions', () => {
   describe('lbsToKg', () => {
@@ -328,6 +334,52 @@ describe('unitConversions', () => {
       const kg = stonesLbsToKg(stones, lbs);
       const split = kgToStonesLbs(kg);
       expect(stonesLbsToKg(split.stones, split.lbs)).toBeCloseTo(kg, 4);
+    });
+  });
+
+  describe('volume helpers', () => {
+    // formatVolumeForUnit formats through formatLocalizedNumber, so the expected text
+    // is whatever the app's `en` locale produces rather than a hardcoded separator.
+    beforeAll(async () => {
+      await initializeI18n('en');
+    });
+
+    beforeEach(async () => {
+      await i18n.changeLanguage('en');
+    });
+
+    describe('volumeFromMl', () => {
+      it('returns millilitres unchanged', () => {
+        expect(volumeFromMl(500, 'ml')).toBe(500);
+      });
+
+      it('converts to fluid ounces', () => {
+        expect(volumeFromMl(1000, 'oz')).toBeCloseTo(33.814, 3);
+      });
+
+      it('converts to litres', () => {
+        expect(volumeFromMl(1500, 'liter')).toBe(1.5);
+      });
+
+      it('falls back to millilitres for an unknown unit', () => {
+        expect(volumeFromMl(500, 'gallons')).toBe(500);
+      });
+    });
+
+    describe('formatVolumeForUnit', () => {
+      it('applies the per-unit decimal rule', () => {
+        const locale = getAppLocale();
+
+        expect(formatVolumeForUnit(1234.567, 'ml')).toBe(
+          (1235).toLocaleString(locale)
+        );
+        expect(formatVolumeForUnit(33.8140227, 'oz')).toBe(
+          (33.8).toLocaleString(locale, { maximumFractionDigits: 1 })
+        );
+        expect(formatVolumeForUnit(1.2345, 'liter')).toBe(
+          (1.23).toLocaleString(locale, { maximumFractionDigits: 2 })
+        );
+      });
     });
   });
 });

--- a/SparkyFitnessMobile/docs/measurements_api.md
+++ b/SparkyFitnessMobile/docs/measurements_api.md
@@ -59,6 +59,30 @@ Returns all fields. Takes a date range and returns way too much. Exercise, sleep
 ]
 ```
 
+### `GET /api/measurements/water-intake-range/{startDate}/{endDate}`
+
+One total per day that has logged water in the range, backing the Health Trends
+hydration graph. Without it a 90-day window needed 90 calls to the per-day
+`/water-intake/{date}` route, and the alternative — `/api/reports` — returns
+whole food, exercise and medication payloads a chart has no use for.
+
+Days with no logged water are simply absent from the response; the mobile hook
+(`useHydrationRange`) zero-fills them, because an unlogged day genuinely means
+no water was drunk — unlike a weigh-in, where a missing day is unknown.
+
+`water_ml` is a number: the underlying `SUM` comes back from pg as a string and
+the service normalizes it once rather than leaving every caller to parse.
+
+```json
+[
+  { "entry_date": "2025-12-01", "water_ml": 1920 },
+  ...
+]
+```
+
+Both params are validated as real `YYYY-MM-DD` calendar days, so a malformed or
+impossible date is a 400 rather than a Postgres failure surfacing as a 500.
+
 ### `GET /api/measurements/check-in-photos`
 
 Every progress photo the caller can see, newest day first, each with the weight

--- a/SparkyFitnessMobile/src/components/HealthTrendsPager.tsx
+++ b/SparkyFitnessMobile/src/components/HealthTrendsPager.tsx
@@ -77,7 +77,13 @@ const HealthTrendsPager: React.FC<HealthTrendsPagerProps> = ({
     // Sleep cannot use `shouldShowTrend`: its `data` is padded to one entry per day in the
     // window, so it is never empty and the page would show for users with no sleep at all.
     sleep: () => sleep.isLoading || sleep.isError || sleep.nightsWithData > 0,
-    hydration: () => shouldShowTrend(hydration),
+    // Hydration cannot use `shouldShowTrend` either: `useHydrationRange` zero-fills every
+    // day in the window, so `data` is never empty and the page would show for users who
+    // have never logged water. A day of zero is real data; a window of them is not.
+    hydration: () =>
+      hydration.isLoading ||
+      hydration.isError ||
+      hydration.data.some((point) => point.milliliters > 0),
   };
 
   // A trend the user configured to show but that has no data for in this window still hides itself

--- a/SparkyFitnessMobile/src/components/HealthTrendsPager.tsx
+++ b/SparkyFitnessMobile/src/components/HealthTrendsPager.tsx
@@ -11,7 +11,9 @@ import type {
 import type {
   HealthTrendDateRange,
   HealthTrendSeries,
+  HydrationDataPoint,
 } from '../types/healthTrends';
+import HydrationBarChart from './HydrationBarChart';
 import SleepTimelineChart from './SleepTimelineChart';
 import StepsBarChart from './StepsBarChart';
 import WeightLineChart from './WeightLineChart';
@@ -20,8 +22,10 @@ type HealthTrendsPagerProps = {
   steps: HealthTrendSeries<StepsDataPoint>;
   weight: HealthTrendSeries<WeightDataPoint>;
   sleep: SleepTrendSeries;
+  hydration: HealthTrendSeries<HydrationDataPoint>;
   range: HealthTrendDateRange;
   weightUnit: string;
+  waterUnit: string;
   visibleTrends: readonly HealthTrendKey[];
   activePage: number;
   onPageSelected: (page: number) => void;
@@ -46,8 +50,10 @@ const HealthTrendsPager: React.FC<HealthTrendsPagerProps> = ({
   steps,
   weight,
   sleep,
+  hydration,
   range,
   weightUnit,
+  waterUnit,
   visibleTrends,
   activePage,
   onPageSelected,
@@ -60,6 +66,9 @@ const HealthTrendsPager: React.FC<HealthTrendsPagerProps> = ({
       <WeightLineChart {...weight} range={range} unit={weightUnit} />
     ),
     sleep: () => <SleepTimelineChart {...sleep} range={range} />,
+    hydration: () => (
+      <HydrationBarChart {...hydration} range={range} unit={waterUnit} />
+    ),
   };
 
   const hasTrendData: Record<HealthTrendKey, () => boolean> = {
@@ -68,6 +77,7 @@ const HealthTrendsPager: React.FC<HealthTrendsPagerProps> = ({
     // Sleep cannot use `shouldShowTrend`: its `data` is padded to one entry per day in the
     // window, so it is never empty and the page would show for users with no sleep at all.
     sleep: () => sleep.isLoading || sleep.isError || sleep.nightsWithData > 0,
+    hydration: () => shouldShowTrend(hydration),
   };
 
   // A trend the user configured to show but that has no data for in this window still hides itself

--- a/SparkyFitnessMobile/src/components/HydrationBarChart.tsx
+++ b/SparkyFitnessMobile/src/components/HydrationBarChart.tsx
@@ -1,0 +1,105 @@
+import React, { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { formatTooltipDate } from './charts/chartFormatting';
+import type {
+  HealthTrendDateRange,
+  HydrationDataPoint,
+} from '../types/healthTrends';
+import {
+  WATER_UNIT_LABELS,
+  formatVolumeForUnit,
+  volumeFromMl,
+} from '../utils/unitConversions';
+import TrendBarChart from './TrendBarChart';
+
+type HydrationBarChartProps = {
+  data: HydrationDataPoint[];
+  isLoading: boolean;
+  isError: boolean;
+  range: HealthTrendDateRange;
+  /** The user's `water_display_unit`. Points arrive from the server in millilitres. */
+  unit: string;
+};
+
+/** A point already converted out of millilitres, so the plot and its labels agree. */
+type ConvertedHydrationPoint = {
+  day: string;
+  volume: number;
+};
+
+const getVolume = (point: ConvertedHydrationPoint): number => point.volume;
+
+const DEFAULT_TOOLTIP = '';
+
+/**
+ * Builds the tooltip copy from the selected point. The volume is already in the display
+ * unit; the number is formatted against the current application locale on every render,
+ * so an already-visible tooltip cannot retain stale copy after a language switch.
+ */
+export const buildHydrationTooltipText = (
+  point: ConvertedHydrationPoint | undefined,
+  unit: string,
+  t: ReturnType<typeof useTranslation>['t']
+): string => {
+  if (!point) return DEFAULT_TOOLTIP;
+
+  return t('charts.hydration.tooltip', {
+    defaultValue: '{{formattedVolume}} {{unit}} · {{date}}',
+    formattedVolume: formatVolumeForUnit(point.volume, unit),
+    unit: WATER_UNIT_LABELS[unit] ?? unit,
+    date: formatTooltipDate(point.day),
+  });
+};
+
+/**
+ * Daily water intake.
+ *
+ * This is the millilitres-to-display-unit boundary for the trend: converting once here
+ * keeps the bars, the y-axis labels and the tooltip in the same unit, the same way
+ * `DashboardScreen` owns the kg-to-display-unit boundary for the weight series.
+ */
+const HydrationBarChart: React.FC<HydrationBarChartProps> = ({
+  data,
+  isLoading,
+  isError,
+  range,
+  unit,
+}) => {
+  const { t } = useTranslation();
+
+  const convertedData = useMemo<ConvertedHydrationPoint[]>(
+    () =>
+      data.map((point) => ({
+        day: point.day,
+        volume: volumeFromMl(point.milliliters, unit),
+      })),
+    [data, unit]
+  );
+
+  const formatTooltip = useCallback(
+    (point: ConvertedHydrationPoint) =>
+      buildHydrationTooltipText(point, unit, t),
+    [unit, t]
+  );
+
+  return (
+    <TrendBarChart
+      data={convertedData}
+      isLoading={isLoading}
+      isError={isError}
+      range={range}
+      title={t('charts.hydration.title', { defaultValue: 'Hydration' })}
+      getValue={getVolume}
+      formatTooltip={formatTooltip}
+      errorText={t('charts.hydration.loadFailed', {
+        defaultValue: 'Failed to load hydration data',
+      })}
+      emptyText={t('charts.hydration.empty', {
+        defaultValue: 'No hydration data for this period',
+      })}
+      testIDPrefix="hydration-touch-overlay"
+    />
+  );
+};
+
+export default HydrationBarChart;

--- a/SparkyFitnessMobile/src/components/HydrationGauge.tsx
+++ b/SparkyFitnessMobile/src/components/HydrationGauge.tsx
@@ -1,18 +1,22 @@
-import React, { useMemo, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-import { View, Text, Pressable } from 'react-native';
 import { Canvas, Group, Path, Rect, Skia } from '@shopify/react-native-skia';
-import Button from './ui/Button';
+import React, { useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Pressable, Text, View } from 'react-native';
 import {
-  useSharedValue,
-  useDerivedValue,
-  withTiming,
   Easing,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
 } from 'react-native-reanimated';
 import { useCSSVariable } from 'uniwind';
-import Icon from './Icon';
-import { WATER_UNIT_LABELS } from '../utils/unitConversions';
 import { formatLocalizedNumber } from '../localization';
+import {
+  WATER_UNIT_LABELS,
+  formatVolumeForUnit,
+  volumeFromMl,
+} from '../utils/unitConversions';
+import Icon from './Icon';
+import Button from './ui/Button';
 
 interface ContainerOption {
   id: number;
@@ -30,17 +34,6 @@ interface HydrationGaugeProps {
   containers?: ContainerOption[];
   activeContainerId?: number;
   onSelectContainer?: (id: number) => void;
-}
-
-function convertFromMl(ml: number, unit: string): number {
-  switch (unit) {
-    case 'oz':
-      return ml / 29.5735;
-    case 'liter':
-      return ml / 1000;
-    default:
-      return ml;
-  }
 }
 
 const CANVAS_WIDTH = 70;
@@ -122,16 +115,11 @@ const HydrationGauge: React.FC<HydrationGaugeProps> = ({
     return Skia.Path.Rect(Skia.XYWHRect(0, y, CANVAS_WIDTH, CANVAS_HEIGHT - y));
   });
 
-  const convertedConsumed = convertFromMl(consumed, unit);
-  const convertedGoal = convertFromMl(goal, unit);
-  const formatUnitVolume = (val: number, u: string): string => {
-    const decimals = u === 'oz' ? 1 : u === 'liter' ? 2 : 0;
-    // formatLocalizedNumber keeps thousands grouping and the app locale's
-    // decimal separator; maximumFractionDigits alone strips trailing zeros.
-    return formatLocalizedNumber(val, { maximumFractionDigits: decimals });
-  };
-  const displayConsumed = formatUnitVolume(convertedConsumed, unit);
-  const displayGoal = formatUnitVolume(convertedGoal, unit);
+  const displayConsumed = formatVolumeForUnit(
+    volumeFromMl(consumed, unit),
+    unit
+  );
+  const displayGoal = formatVolumeForUnit(volumeFromMl(goal, unit), unit);
   const unitLabel = WATER_UNIT_LABELS[unit] ?? unit;
 
   const showButtons = !!onIncrement || !!onDecrement;
@@ -241,7 +229,7 @@ const HydrationGauge: React.FC<HydrationGaugeProps> = ({
         <Text className="text-xs text-text-muted text-center mt-2">
           {t('dashboard.perContainer', {
             defaultValue: '{{value}} {{unit}} per container',
-            value: formatLocalizedNumber(convertFromMl(containerVolume, unit), {
+            value: formatLocalizedNumber(volumeFromMl(containerVolume, unit), {
               maximumFractionDigits: 1,
             }),
             unit: unitLabel,

--- a/SparkyFitnessMobile/src/components/StepsBarChart.tsx
+++ b/SparkyFitnessMobile/src/components/StepsBarChart.tsx
@@ -1,25 +1,10 @@
-import React, { useMemo, useState, useCallback } from 'react';
-import { View, Text } from 'react-native';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { formatLocalizedNumber } from '../localization/i18n';
-import { CartesianChart, Bar } from 'victory-native';
-import { useCSSVariable } from 'uniwind';
-import {
-  makeChartFont,
-  CHART_LABEL_FONT_SIZE,
-  formatXLabel7d,
-  formatXLabel30d90d,
-  formatTooltipDate,
-  formatChartYLabel,
-} from './charts/chartFormatting';
+import { formatTooltipDate } from './charts/chartFormatting';
 import type { StepsDataPoint } from '../hooks/useMeasurementsRange';
 import type { HealthTrendDateRange } from '../types/healthTrends';
-import ChartTouchOverlay, {
-  ChartLayoutReporter,
-  EMPTY_CHART_TOUCH_LAYOUT,
-  createChartTouchLayoutSignature,
-  type ChartTouchLayout,
-} from './ChartTouchOverlay';
+import TrendBarChart from './TrendBarChart';
 
 type StepsBarChartProps = {
   data: StepsDataPoint[];
@@ -28,29 +13,9 @@ type StepsBarChartProps = {
   range: HealthTrendDateRange;
 };
 
-const INNER_PADDING: Record<HealthTrendDateRange, number> = {
-  '7d': 0.3,
-  '30d': 0.2,
-  '90d': 0.1,
-};
-
-const X_TICK_COUNT: Record<HealthTrendDateRange, number> = {
-  '7d': 7,
-  '30d': 6,
-  '90d': 5,
-};
-
-const font = makeChartFont(CHART_LABEL_FONT_SIZE);
-
-const formatYLabel = (value: number) => formatChartYLabel(value);
+const getSteps = (point: StepsDataPoint): number => point.steps;
 
 const DEFAULT_TOOLTIP = '';
-
-const StepsTooltip: React.FC<{ text: string }> = ({ text }) => (
-  <View className="h-6 justify-center mt-3 mb-1">
-    <Text className="text-text-secondary text-sm text-center">{text}</Text>
-  </View>
-);
 
 /**
  * Builds the tooltip copy from the semantically selected data point. The text
@@ -80,146 +45,29 @@ const StepsBarChart: React.FC<StepsBarChartProps> = ({
   range,
 }) => {
   const { t } = useTranslation();
-  const [accentColor, textMuted] = useCSSVariable([
-    '--color-accent-primary',
-    '--color-text-muted',
-  ]) as [string, string];
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-  const [touchLayout, setTouchLayout] = useState<ChartTouchLayout>(
-    EMPTY_CHART_TOUCH_LAYOUT
+
+  const formatTooltip = React.useCallback(
+    (point: StepsDataPoint) => buildTooltipText(point, t),
+    [t]
   );
-
-  const hasData = useMemo(() => data.some((d) => d.steps > 0), [data]);
-
-  const formatXLabel = range === '7d' ? formatXLabel7d : formatXLabel30d90d;
-
-  // Reset a lingering selection when the dataset or range changes. Done during
-  // render (instead of in an effect) so the tooltip is already cleared on the
-  // first render after the data changes.
-  const [tooltipResetKey, setTooltipResetKey] = useState({ data, range });
-  if (tooltipResetKey.data !== data || tooltipResetKey.range !== range) {
-    setTooltipResetKey({ data, range });
-    setSelectedIndex(null);
-  }
-
-  // Derive the presentation text from the selected point on every render, so
-  // an already-visible tooltip reflects the current app language immediately.
-  const selectedPoint = selectedIndex != null ? data[selectedIndex] : undefined;
-  const tooltipText = buildTooltipText(selectedPoint, t);
-
-  const handleTouchLayoutChange = useCallback(
-    (nextLayout: ChartTouchLayout) => {
-      setTouchLayout((currentLayout) => {
-        const currentSignature = createChartTouchLayoutSignature(currentLayout);
-        const nextSignature = createChartTouchLayoutSignature(nextLayout);
-
-        if (currentSignature === nextSignature) {
-          return currentLayout;
-        }
-
-        return nextLayout;
-      });
-    },
-    []
-  );
-
-  const handleSelectBar = useCallback(
-    (index: number) => {
-      const point = data[index];
-
-      if (!point) {
-        return;
-      }
-
-      setSelectedIndex(index);
-    },
-    [data]
-  );
-
-  const handleClearSelection = useCallback(() => {
-    setSelectedIndex(null);
-  }, []);
 
   return (
-    <View className="bg-surface rounded-xl p-4 my-2 shadow-sm">
-      <Text className="text-text-primary text-lg font-semibold mb-2">
-        {t('charts.steps.title', { defaultValue: 'Steps' })}
-      </Text>
-
-      <StepsTooltip text={tooltipText} />
-
-      {isLoading ? (
-        <View className="h-50 justify-center items-center">
-          <Text className="text-text-muted text-sm">
-            {t('common.loading', { defaultValue: 'Loading...' })}
-          </Text>
-        </View>
-      ) : isError ? (
-        <View className="h-50 justify-center items-center">
-          <Text className="text-text-muted text-sm">
-            {t('charts.steps.loadFailed', {
-              defaultValue: 'Failed to load step data',
-            })}
-          </Text>
-        </View>
-      ) : !hasData ? (
-        <View className="h-50 justify-center items-center">
-          <Text className="text-text-muted text-sm">
-            {t('charts.steps.empty', {
-              defaultValue: 'No step data for this period',
-            })}
-          </Text>
-        </View>
-      ) : (
-        <View style={{ height: 175 }}>
-          <CartesianChart
-            data={data}
-            xKey="day"
-            yKeys={['steps']}
-            domain={{ y: [0] }}
-            domainPadding={{ left: 25, right: 25 }}
-            xAxis={{
-              font,
-              tickCount: X_TICK_COUNT[range],
-              labelColor: textMuted,
-              formatXLabel,
-            }}
-            yAxis={[
-              {
-                font,
-                tickCount: 5,
-                labelColor: textMuted,
-                formatYLabel,
-              },
-            ]}
-          >
-            {({ points, chartBounds }) => (
-              <>
-                <ChartLayoutReporter
-                  chartBounds={chartBounds}
-                  points={points.steps}
-                  onChange={handleTouchLayoutChange}
-                />
-                <Bar
-                  points={points.steps}
-                  chartBounds={chartBounds}
-                  color={accentColor}
-                  innerPadding={INNER_PADDING[range]}
-                  animate={{ type: 'timing', duration: 300 }}
-                  roundedCorners={{ topLeft: 6, topRight: 6 }}
-                />
-              </>
-            )}
-          </CartesianChart>
-          <ChartTouchOverlay
-            layout={touchLayout}
-            onSelect={handleSelectBar}
-            onClear={handleClearSelection}
-            testIDPrefix="steps-touch-overlay"
-          />
-        </View>
-      )}
-    </View>
+    <TrendBarChart
+      data={data}
+      isLoading={isLoading}
+      isError={isError}
+      range={range}
+      title={t('charts.steps.title', { defaultValue: 'Steps' })}
+      getValue={getSteps}
+      formatTooltip={formatTooltip}
+      errorText={t('charts.steps.loadFailed', {
+        defaultValue: 'Failed to load step data',
+      })}
+      emptyText={t('charts.steps.empty', {
+        defaultValue: 'No step data for this period',
+      })}
+      testIDPrefix="steps-touch-overlay"
+    />
   );
 };
 

--- a/SparkyFitnessMobile/src/components/TrendBarChart.tsx
+++ b/SparkyFitnessMobile/src/components/TrendBarChart.tsx
@@ -1,0 +1,233 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { View, Text } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { CartesianChart, Bar } from 'victory-native';
+import { useCSSVariable } from 'uniwind';
+import {
+  makeChartFont,
+  CHART_LABEL_FONT_SIZE,
+  formatXLabel7d,
+  formatXLabel30d90d,
+  formatChartYLabel,
+} from './charts/chartFormatting';
+import type { HealthTrendDateRange } from '../types/healthTrends';
+import ChartTouchOverlay, {
+  ChartLayoutReporter,
+  EMPTY_CHART_TOUCH_LAYOUT,
+  createChartTouchLayoutSignature,
+  type ChartTouchLayout,
+} from './ChartTouchOverlay';
+
+/** Every point a bar trend plots, once its own shape has been projected onto a value. */
+type TrendBarPoint = {
+  day: string;
+  value: number;
+};
+
+type TrendBarChartProps<TPoint extends { day: string }> = {
+  data: TPoint[];
+  isLoading: boolean;
+  isError: boolean;
+  range: HealthTrendDateRange;
+  title: string;
+  /**
+   * The point's y-value. Every bar trend plots one number per day. Pass a stable
+   * reference (a module-level function or a memoized closure) — the plotted series is
+   * rebuilt whenever this changes.
+   */
+  getValue: (point: TPoint) => number;
+  /**
+   * Tooltip copy for the selected point. Called on every render so an already-visible
+   * tooltip re-derives its copy immediately after a language switch.
+   */
+  formatTooltip: (point: TPoint) => string;
+  formatYLabel?: (value: number) => string;
+  errorText: string;
+  emptyText: string;
+  testIDPrefix: string;
+};
+
+const INNER_PADDING: Record<HealthTrendDateRange, number> = {
+  '7d': 0.3,
+  '30d': 0.2,
+  '90d': 0.1,
+};
+
+const X_TICK_COUNT: Record<HealthTrendDateRange, number> = {
+  '7d': 7,
+  '30d': 6,
+  '90d': 5,
+};
+
+const font = makeChartFont(CHART_LABEL_FONT_SIZE);
+
+const TrendTooltip: React.FC<{ text: string }> = ({ text }) => (
+  <View className="h-6 justify-center mt-3 mb-1">
+    <Text className="text-text-secondary text-sm text-center">{text}</Text>
+  </View>
+);
+
+/**
+ * The shared daily bar-trend card: title, tooltip line, state branches and plot.
+ *
+ * Each trend wraps this with its own copy and a `getValue` projection rather than
+ * repeating the chart wiring — the concrete charts differ only in words and units.
+ */
+function TrendBarChart<TPoint extends { day: string }>({
+  data,
+  isLoading,
+  isError,
+  range,
+  title,
+  getValue,
+  formatTooltip,
+  formatYLabel = formatChartYLabel,
+  errorText,
+  emptyText,
+  testIDPrefix,
+}: TrendBarChartProps<TPoint>) {
+  const { t } = useTranslation();
+  const [accentColor, textMuted] = useCSSVariable([
+    '--color-accent-primary',
+    '--color-text-muted',
+  ]) as [string, string];
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [touchLayout, setTouchLayout] = useState<ChartTouchLayout>(
+    EMPTY_CHART_TOUCH_LAYOUT
+  );
+
+  const chartData = useMemo<TrendBarPoint[]>(
+    () => data.map((point) => ({ day: point.day, value: getValue(point) })),
+    [data, getValue]
+  );
+
+  const hasData = useMemo(
+    () => chartData.some((point) => point.value > 0),
+    [chartData]
+  );
+
+  const formatXLabel = range === '7d' ? formatXLabel7d : formatXLabel30d90d;
+
+  // Reset a lingering selection when the dataset or range changes. Done during
+  // render (instead of in an effect) so the tooltip is already cleared on the
+  // first render after the data changes.
+  const [tooltipResetKey, setTooltipResetKey] = useState({ data, range });
+  if (tooltipResetKey.data !== data || tooltipResetKey.range !== range) {
+    setTooltipResetKey({ data, range });
+    setSelectedIndex(null);
+  }
+
+  // Derive the presentation text from the selected point on every render, so
+  // an already-visible tooltip reflects the current app language immediately.
+  const selectedPoint = selectedIndex != null ? data[selectedIndex] : undefined;
+  const tooltipText = selectedPoint ? formatTooltip(selectedPoint) : '';
+
+  const handleTouchLayoutChange = useCallback(
+    (nextLayout: ChartTouchLayout) => {
+      setTouchLayout((currentLayout) => {
+        const currentSignature = createChartTouchLayoutSignature(currentLayout);
+        const nextSignature = createChartTouchLayoutSignature(nextLayout);
+
+        if (currentSignature === nextSignature) {
+          return currentLayout;
+        }
+
+        return nextLayout;
+      });
+    },
+    []
+  );
+
+  const handleSelectBar = useCallback(
+    (index: number) => {
+      const point = data[index];
+
+      if (!point) {
+        return;
+      }
+
+      setSelectedIndex(index);
+    },
+    [data]
+  );
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedIndex(null);
+  }, []);
+
+  return (
+    <View className="bg-surface rounded-xl p-4 my-2 shadow-sm">
+      <Text className="text-text-primary text-lg font-semibold mb-2">
+        {title}
+      </Text>
+
+      <TrendTooltip text={tooltipText} />
+
+      {isLoading ? (
+        <View className="h-50 justify-center items-center">
+          <Text className="text-text-muted text-sm">
+            {t('common.loading', { defaultValue: 'Loading...' })}
+          </Text>
+        </View>
+      ) : isError ? (
+        <View className="h-50 justify-center items-center">
+          <Text className="text-text-muted text-sm">{errorText}</Text>
+        </View>
+      ) : !hasData ? (
+        <View className="h-50 justify-center items-center">
+          <Text className="text-text-muted text-sm">{emptyText}</Text>
+        </View>
+      ) : (
+        <View style={{ height: 175 }}>
+          <CartesianChart
+            data={chartData}
+            xKey="day"
+            yKeys={['value']}
+            domain={{ y: [0] }}
+            domainPadding={{ left: 25, right: 25 }}
+            xAxis={{
+              font,
+              tickCount: X_TICK_COUNT[range],
+              labelColor: textMuted,
+              formatXLabel,
+            }}
+            yAxis={[
+              {
+                font,
+                tickCount: 5,
+                labelColor: textMuted,
+                formatYLabel,
+              },
+            ]}
+          >
+            {({ points, chartBounds }) => (
+              <>
+                <ChartLayoutReporter
+                  chartBounds={chartBounds}
+                  points={points.value}
+                  onChange={handleTouchLayoutChange}
+                />
+                <Bar
+                  points={points.value}
+                  chartBounds={chartBounds}
+                  color={accentColor}
+                  innerPadding={INNER_PADDING[range]}
+                  animate={{ type: 'timing', duration: 300 }}
+                  roundedCorners={{ topLeft: 6, topRight: 6 }}
+                />
+              </>
+            )}
+          </CartesianChart>
+          <ChartTouchOverlay
+            layout={touchLayout}
+            onSelect={handleSelectBar}
+            onClear={handleClearSelection}
+            testIDPrefix={testIDPrefix}
+          />
+        </View>
+      )}
+    </View>
+  );
+}
+
+export default TrendBarChart;

--- a/SparkyFitnessMobile/src/constants/healthTrends.ts
+++ b/SparkyFitnessMobile/src/constants/healthTrends.ts
@@ -5,10 +5,15 @@
  * — at the end of the list — for existing users too, because a saved order is reconciled
  * against this array rather than replacing it (see `resolveHealthTrendOrder`).
  *
- * The order deliberately matches the order the pager shipped with, so a user who never
- * opens the settings screen sees exactly what they saw before.
+ * The first three keys deliberately match the order the pager shipped with, so a user who
+ * never opens the settings screen sees exactly what they saw before.
  */
-export const HEALTH_TREND_KEYS = ['steps', 'weight', 'sleep'] as const;
+export const HEALTH_TREND_KEYS = [
+  'steps',
+  'weight',
+  'sleep',
+  'hydration',
+] as const;
 
 export type HealthTrendKey = (typeof HEALTH_TREND_KEYS)[number];
 
@@ -28,4 +33,5 @@ export const HEALTH_TREND_LABELS: Record<
   steps: (t) => t('charts.steps.title', { defaultValue: 'Steps' }),
   weight: (t) => t('charts.weight.title', { defaultValue: 'Weight' }),
   sleep: (t) => t('charts.sleep.title', { defaultValue: 'Sleep' }),
+  hydration: (t) => t('charts.hydration.title', { defaultValue: 'Hydration' }),
 };

--- a/SparkyFitnessMobile/src/hooks/queryKeys.ts
+++ b/SparkyFitnessMobile/src/hooks/queryKeys.ts
@@ -99,6 +99,9 @@ export const foodVariantsQueryKey = (foodId: string) =>
 export const measurementsRangeQueryKey = (startDate: string, endDate: string) =>
   ['measurementsRange', startDate, endDate] as const;
 
+export const waterIntakeRangeQueryKey = (startDate: string, endDate: string) =>
+  ['waterIntakeRange', startDate, endDate] as const;
+
 export const sleepRangeQueryKey = (startDate: string, endDate: string) =>
   ['sleepRange', startDate, endDate] as const;
 

--- a/SparkyFitnessMobile/src/hooks/useHealthTrends.ts
+++ b/SparkyFitnessMobile/src/hooks/useHealthTrends.ts
@@ -3,6 +3,7 @@ import type { HealthTrendKey } from '../constants/healthTrends';
 import type {
   HealthTrendDateRange,
   HealthTrendSeries,
+  HydrationDataPoint,
 } from '../types/healthTrends';
 import type { SleepTimelineDay, SleepTimelineSummary } from '../types/sleep';
 import {
@@ -10,6 +11,7 @@ import {
   type StepsDataPoint,
   type WeightDataPoint,
 } from './useMeasurementsRange';
+import { useHydrationRange } from './useHydrationRange';
 import { useSleepRange } from './useSleepRange';
 
 interface UseHealthTrendsOptions {
@@ -30,6 +32,7 @@ interface HealthTrends {
   steps: HealthTrendSeries<StepsDataPoint>;
   weight: HealthTrendSeries<WeightDataPoint>;
   sleep: SleepTrendSeries;
+  hydration: HealthTrendSeries<HydrationDataPoint>;
   refetch: () => Promise<void>;
 }
 
@@ -45,6 +48,7 @@ export function useHealthTrends({
     enabled &&
     (activeTrends.includes('steps') || activeTrends.includes('weight'));
   const isSleepEnabled = enabled && activeTrends.includes('sleep');
+  const isHydrationEnabled = enabled && activeTrends.includes('hydration');
 
   const {
     stepsData,
@@ -61,16 +65,26 @@ export function useHealthTrends({
     refetch: refetchSleep,
   } = useSleepRange({ range, enabled: isSleepEnabled });
 
+  const {
+    hydrationData,
+    isLoading: isHydrationLoading,
+    isError: isHydrationError,
+    refetch: refetchHydration,
+  } = useHydrationRange({ range, enabled: isHydrationEnabled });
+
   const refetch = useCallback(async () => {
     await Promise.all([
       isMeasurementsEnabled ? refetchMeasurements() : Promise.resolve(),
       isSleepEnabled ? refetchSleep() : Promise.resolve(),
+      isHydrationEnabled ? refetchHydration() : Promise.resolve(),
     ]);
   }, [
     isMeasurementsEnabled,
     isSleepEnabled,
+    isHydrationEnabled,
     refetchMeasurements,
     refetchSleep,
+    refetchHydration,
   ]);
 
   return {
@@ -92,6 +106,11 @@ export function useHealthTrends({
       nightsWithData: sleep.nightsWithData,
       isLoading: isSleepLoading,
       isError: isSleepError,
+    },
+    hydration: {
+      data: hydrationData,
+      isLoading: isHydrationLoading,
+      isError: isHydrationError,
     },
     refetch,
   };

--- a/SparkyFitnessMobile/src/hooks/useHydrationRange.ts
+++ b/SparkyFitnessMobile/src/hooks/useHydrationRange.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchWaterIntakeRange } from '../services/api/measurementsApi';
+import { useRefetchOnFocus } from './useRefetchOnFocus';
+import { waterIntakeRangeQueryKey } from './queryKeys';
+import { getTodayDate, addDays } from '../utils/dateUtils';
+import {
+  RANGE_DAYS,
+  type HealthTrendDateRange,
+  type HydrationDataPoint,
+} from '../types/healthTrends';
+
+interface UseHydrationRangeOptions {
+  range: HealthTrendDateRange;
+  enabled?: boolean;
+}
+
+export function useHydrationRange({
+  range,
+  enabled = true,
+}: UseHydrationRangeOptions) {
+  const today = getTodayDate();
+  const days = RANGE_DAYS[range];
+  const startDate = addDays(today, -(days - 1));
+
+  const query = useQuery({
+    queryKey: waterIntakeRangeQueryKey(startDate, today),
+    queryFn: () => fetchWaterIntakeRange(startDate, today),
+    enabled,
+    select: (entries) => {
+      const millilitersByDay = new Map<string, number>();
+      for (const entry of entries) {
+        millilitersByDay.set(entry.entry_date, entry.water_ml);
+      }
+
+      // A day with no logged water genuinely means zero drunk, so every day in the
+      // window gets a bar rather than being omitted the way a missing weigh-in is.
+      const hydrationData: HydrationDataPoint[] = [];
+      for (let dayOffset = 0; dayOffset < days; dayOffset++) {
+        const day = addDays(today, -(days - 1 - dayOffset));
+        hydrationData.push({
+          day,
+          milliliters: millilitersByDay.get(day) ?? 0,
+        });
+      }
+
+      return hydrationData;
+    },
+  });
+
+  useRefetchOnFocus(query.refetch, enabled);
+
+  return {
+    hydrationData: query.data ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError,
+    refetch: query.refetch,
+  };
+}

--- a/SparkyFitnessMobile/src/localization/locales/en/translation.json
+++ b/SparkyFitnessMobile/src/localization/locales/en/translation.json
@@ -4101,6 +4101,12 @@
       "avgTimeAsleep": "Avg time asleep",
       "rangeLabel": "{{startDate}} – {{endDate}}"
     },
+    "hydration": {
+      "title": "Hydration",
+      "loadFailed": "Failed to load hydration data",
+      "empty": "No hydration data for this period",
+      "tooltip": "{{formattedVolume}} {{unit}} · {{date}}"
+    },
     "loading": "Loading chart...",
     "weightLoadFailed": "Failed to load weight data",
     "stepsLoadFailed": "Failed to load step data",

--- a/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/DashboardScreen.tsx
@@ -230,6 +230,10 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
 
   useWidgetSync(summary);
 
+  // The hydration card and the hydration trend must agree on the unit, so both read it
+  // from here rather than each resolving the fallback chain themselves.
+  const waterDisplayUnit = waterUnit || preferences?.water_display_unit || 'ml';
+
   // The chart is a single-axis line graph; if the user picked stones+lbs, plot lbs.
   const weightUnit: 'kg' | 'lbs' =
     (preferences?.default_weight_unit ?? 'kg') === 'kg' ? 'kg' : 'lbs';
@@ -616,7 +620,7 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
           <HydrationGauge
             consumed={summary.waterConsumed}
             goal={summary.waterGoal}
-            unit={waterUnit || preferences?.water_display_unit || 'ml'}
+            unit={waterDisplayUnit}
             containerVolume={servingVolume}
             onIncrement={isContainersLoaded ? incrementWater : undefined}
             onDecrement={isContainersLoaded ? decrementWater : undefined}
@@ -660,8 +664,10 @@ const DashboardScreen: React.FC<DashboardScreenProps> = ({ navigation }) => {
           steps={trends.steps}
           weight={weightSeries}
           sleep={trends.sleep}
+          hydration={trends.hydration}
           range={trendsRange}
           weightUnit={weightUnit}
+          waterUnit={waterDisplayUnit}
           visibleTrends={visibleTrends}
           activePage={chartPage}
           onPageSelected={setChartPage}

--- a/SparkyFitnessMobile/src/services/api/measurementsApi.ts
+++ b/SparkyFitnessMobile/src/services/api/measurementsApi.ts
@@ -90,6 +90,26 @@ export const fetchMeasurementsRange = async (
   });
 };
 
+export type WaterIntakeRangeEntry = {
+  entry_date: string;
+  water_ml: number;
+};
+
+/**
+ * Fetches one water total per day that has logged water in the range. Days with no
+ * intake are absent from the response, not returned as zero.
+ */
+export const fetchWaterIntakeRange = async (
+  startDate: string,
+  endDate: string
+): Promise<WaterIntakeRangeEntry[]> => {
+  return apiFetch<WaterIntakeRangeEntry[]>({
+    endpoint: `/api/measurements/water-intake-range/${startDate}/${endDate}`,
+    serviceName: 'Measurements API',
+    operation: 'fetch water intake range',
+  });
+};
+
 /**
  * Upserts a check-in measurement record for a given date.
  *

--- a/SparkyFitnessMobile/src/types/healthTrends.ts
+++ b/SparkyFitnessMobile/src/types/healthTrends.ts
@@ -16,3 +16,9 @@ export type HealthTrendSeries<TPoint> = {
   isLoading: boolean;
   isError: boolean;
 };
+
+/** A day's total water intake, in millilitres as the server stores it. */
+export type HydrationDataPoint = {
+  day: string;
+  milliliters: number;
+};

--- a/SparkyFitnessMobile/src/utils/unitConversions.ts
+++ b/SparkyFitnessMobile/src/utils/unitConversions.ts
@@ -2,6 +2,7 @@
  * Unit conversion utilities.
  * All server-side storage is in metric (kg, cm).
  */
+import { formatLocalizedNumber } from '../localization';
 
 const LBS_TO_KG = 0.45359237;
 const KG_TO_LBS = 1 / LBS_TO_KG;
@@ -143,6 +144,42 @@ export const WATER_UNIT_LABELS: Record<string, string> = {
   oz: 'oz',
   liter: 'L',
 };
+
+const ML_PER_FLUID_OUNCE = 29.5735;
+const ML_PER_LITER = 1000;
+
+/**
+ * Water is stored in millilitres server-side; every surface that shows it converts to the
+ * user's `water_display_unit` at its own edge. An unrecognised unit falls back to ml so a
+ * new server-side unit renders a plausible number instead of nothing.
+ */
+export function volumeFromMl(milliliters: number, unit: string): number {
+  switch (unit) {
+    case 'oz':
+      return milliliters / ML_PER_FLUID_OUNCE;
+    case 'liter':
+      return milliliters / ML_PER_LITER;
+    default:
+      return milliliters;
+  }
+}
+
+/** Decimal places a volume is shown to, per unit — ml is whole, oz one place, litres two. */
+function volumeDecimalsForUnit(unit: string): number {
+  if (unit === 'oz') return 1;
+  if (unit === 'liter') return 2;
+
+  return 0;
+}
+
+/** A converted volume as display text in the app locale. */
+export function formatVolumeForUnit(value: number, unit: string): string {
+  // formatLocalizedNumber keeps thousands grouping and the app locale's
+  // decimal separator; maximumFractionDigits alone strips trailing zeros.
+  return formatLocalizedNumber(value, {
+    maximumFractionDigits: volumeDecimalsForUnit(unit),
+  });
+}
 
 /** Volume per serving, accounting for servings_per_container. */
 export function getServingVolume(container: {

--- a/SparkyFitnessServer/routes/measurementRoutes.ts
+++ b/SparkyFitnessServer/routes/measurementRoutes.ts
@@ -14,6 +14,7 @@ import {
   DateParamSchema,
   UuidParamSchema,
   DateRangeParamSchema,
+  StrictDateRangeParamSchema,
   CustomMeasurementsRangeParamSchema,
   ImportHealthDataBodySchema,
 } from '../schemas/measurementSchemas.js';
@@ -1502,6 +1503,81 @@ router.get(
           endDate
         );
       res.status(200).json(measurements);
+    } catch (error) {
+      // @ts-expect-error TS(2571): Object is of type 'unknown'.
+      if (error.message.startsWith('Forbidden')) {
+        // @ts-expect-error TS(2571): Object is of type 'unknown'.
+        return res.status(403).json({ error: error.message });
+      }
+      next(error);
+    }
+  }
+);
+/**
+ * @swagger
+ * /measurements/water-intake-range/{startDate}/{endDate}:
+ *   get:
+ *     summary: Get water intake totals within a date range
+ *     tags: [Wellness & Metrics]
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: startDate
+ *         required: true
+ *         description: Calendar day, YYYY-MM-DD.
+ *         schema:
+ *           type: string
+ *           format: date
+ *       - in: path
+ *         name: endDate
+ *         required: true
+ *         description: Calendar day, YYYY-MM-DD.
+ *         schema:
+ *           type: string
+ *           format: date
+ *     responses:
+ *       200:
+ *         description: One total per day that has logged water in the range.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   entry_date:
+ *                     type: string
+ *                     format: date
+ *                   water_ml:
+ *                     type: number
+ *                     description: Total water consumed that day, in milliliters.
+ *       400:
+ *         description: startDate or endDate is not a YYYY-MM-DD calendar date.
+ *       403:
+ *         description: Forbidden.
+ */
+router.get(
+  '/water-intake-range/:startDate/:endDate',
+  authenticate,
+  checkPermissionMiddleware('checkin'),
+  async (req, res, next) => {
+    const paramResult = StrictDateRangeParamSchema.safeParse(req.params);
+    if (!paramResult.success) {
+      return res.status(400).json({
+        error: paramResult.error.issues.map((i) => i.message).join(', '),
+      });
+    }
+    const { startDate, endDate } = paramResult.data;
+    try {
+      const waterTotals = await measurementService.getWaterIntakeByDateRange(
+        req.userId,
+
+        req.userId,
+        startDate,
+        endDate
+      );
+      res.status(200).json(waterTotals);
     } catch (error) {
       // @ts-expect-error TS(2571): Object is of type 'unknown'.
       if (error.message.startsWith('Forbidden')) {

--- a/SparkyFitnessServer/schemas/measurementSchemas.ts
+++ b/SparkyFitnessServer/schemas/measurementSchemas.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+import { isDayString } from '@workspace/shared';
 
 const coerceLegacyNumber = (value: unknown) => {
   if (typeof value !== 'string') {
@@ -227,6 +228,31 @@ export const DateRangeParamSchema = z
   .loose();
 
 export type DateRangeParam = z.infer<typeof DateRangeParamSchema>;
+
+const requiredDayString = (fieldName: string) =>
+  z.preprocess(
+    (value) => (typeof value === 'string' ? value.trim() : value),
+    z
+      .string()
+      .refine(isDayString, `${fieldName} must be a YYYY-MM-DD calendar date`)
+  );
+
+/**
+ * Date-range params that are actually validated as calendar days.
+ *
+ * `DateRangeParamSchema` only asserts a non-empty string, so a malformed date reaches the
+ * repository and surfaces as a database error rather than a 400. Fixing that schema in
+ * place would change the contract of the endpoints already using it, so new routes adopt
+ * this one instead and the older routes are migrated separately.
+ */
+export const StrictDateRangeParamSchema = z
+  .object({
+    startDate: requiredDayString('startDate'),
+    endDate: requiredDayString('endDate'),
+  })
+  .loose();
+
+export type StrictDateRangeParam = z.infer<typeof StrictDateRangeParamSchema>;
 
 export const CustomMeasurementsRangeParamSchema = z
   .object({

--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -493,6 +493,42 @@ async function getWaterIntake(
     throw error;
   }
 }
+interface WaterTotalRow {
+  entry_date: string;
+  total_ml: string | number;
+}
+
+interface WaterIntakeDayTotal {
+  entry_date: string;
+  water_ml: number;
+}
+
+async function getWaterIntakeByDateRange(
+  authenticatedUserId: string,
+  targetUserId: string,
+  startDate: string,
+  endDate: string
+): Promise<WaterIntakeDayTotal[]> {
+  try {
+    const waterTotals = await measurementRepository.getWaterTotalsByDateRange(
+      targetUserId,
+      startDate,
+      endDate
+    );
+    // total_ml is a SUM, so pg hands it back as a string; normalize here so no caller parses.
+    return (waterTotals as WaterTotalRow[]).map((row) => ({
+      entry_date: row.entry_date,
+      water_ml: Number(row.total_ml) || 0,
+    }));
+  } catch (error) {
+    log(
+      'error',
+      `Error fetching water intake range for user ${targetUserId} from ${startDate} to ${endDate} by ${authenticatedUserId}:`,
+      error
+    );
+    throw error;
+  }
+}
 async function upsertWaterIntake(
   authenticatedUserId: string,
   actingUserId: string,
@@ -1739,6 +1775,7 @@ export const getSleepEntriesByUserIdAndDateRange =
 export const deleteSleepEntry = sleepRepository.deleteSleepEntry;
 export { processHealthData };
 export { getWaterIntake };
+export { getWaterIntakeByDateRange };
 export { upsertWaterIntake };
 export { logWaterIntakeAmount };
 export { getWaterIntakeEntryById };
@@ -1866,6 +1903,7 @@ export { updateWaterIntakeLogTime };
 export default {
   processHealthData,
   getWaterIntake,
+  getWaterIntakeByDateRange,
   upsertWaterIntake,
   logWaterIntakeAmount,
   getWaterIntakeEntryById,

--- a/SparkyFitnessServer/tests/measurementRoutes.test.ts
+++ b/SparkyFitnessServer/tests/measurementRoutes.test.ts
@@ -9,6 +9,7 @@ import measurementRoutes from '../routes/measurementRoutes.js';
 vi.mock('../services/measurementService.js', () => ({
   default: {
     processHealthData: vi.fn(),
+    getWaterIntakeByDateRange: vi.fn(),
   },
 }));
 
@@ -200,5 +201,96 @@ describe('Measurement Routes - POST /health-data', () => {
       error:
         'Invalid health data format. All entries must be non-null objects.',
     });
+  });
+});
+
+describe('Measurement Routes - GET /api/measurements/water-intake-range/:startDate/:endDate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the service rows with 200', async () => {
+    const rows = [{ entry_date: '2026-08-30', water_ml: 750 }];
+    vi.mocked(measurementService.getWaterIntakeByDateRange).mockResolvedValue(
+      rows
+    );
+
+    const res = await request(app).get(
+      '/api/measurements/water-intake-range/2026-08-01/2026-08-30'
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(rows);
+  });
+
+  it('forwards the validated window to the service', async () => {
+    vi.mocked(measurementService.getWaterIntakeByDateRange).mockResolvedValue(
+      []
+    );
+
+    await request(app).get(
+      '/api/measurements/water-intake-range/2026-08-01/2026-08-30'
+    );
+
+    expect(measurementService.getWaterIntakeByDateRange).toHaveBeenCalledWith(
+      'test-user-id',
+      'test-user-id',
+      '2026-08-01',
+      '2026-08-30'
+    );
+  });
+
+  it('rejects a malformed date with 400 before reaching the service', async () => {
+    vi.mocked(measurementService.getWaterIntakeByDateRange).mockResolvedValue(
+      []
+    );
+
+    const res = await request(app).get(
+      '/api/measurements/water-intake-range/not-a-date/2026-08-30'
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toContain('startDate');
+    expect(measurementService.getWaterIntakeByDateRange).not.toHaveBeenCalled();
+  });
+
+  it('rejects a well-formed but impossible date with 400', async () => {
+    vi.mocked(measurementService.getWaterIntakeByDateRange).mockResolvedValue(
+      []
+    );
+
+    const res = await request(app).get(
+      '/api/measurements/water-intake-range/2026-02-30/2026-08-30'
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(measurementService.getWaterIntakeByDateRange).not.toHaveBeenCalled();
+  });
+
+  it('maps a Forbidden-prefixed service error to 403', async () => {
+    vi.mocked(measurementService.getWaterIntakeByDateRange).mockRejectedValue(
+      new Error('Forbidden: You do not have permission to view this data.')
+    );
+
+    const res = await request(app).get(
+      '/api/measurements/water-intake-range/2026-08-01/2026-08-30'
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({
+      error: 'Forbidden: You do not have permission to view this data.',
+    });
+  });
+
+  it('passes any other service error to the error handler', async () => {
+    vi.mocked(measurementService.getWaterIntakeByDateRange).mockRejectedValue(
+      new Error('boom')
+    );
+
+    const res = await request(app).get(
+      '/api/measurements/water-intake-range/2026-08-01/2026-08-30'
+    );
+
+    expect(res.statusCode).toBe(500);
   });
 });

--- a/SparkyFitnessServer/tests/measurementService.waterIntake.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.waterIntake.test.ts
@@ -324,6 +324,75 @@ describe('Measurement Service - Water Intake', () => {
       expect(measurementRepository.deleteWaterIntake).not.toHaveBeenCalled();
     });
   });
+  describe('getWaterIntakeByDateRange', () => {
+    const mockUserId = 'test-user-id';
+    const targetUserId = 'target-user-id';
+    const startDate = '2026-08-01';
+    const endDate = '2026-08-30';
+
+    it('maps repository rows to the wire shape with a numeric total', async () => {
+      vi.mocked(
+        measurementRepository.getWaterTotalsByDateRange
+      ).mockResolvedValue([{ entry_date: '2026-08-30', total_ml: '750' }]);
+
+      const result = await measurementService.getWaterIntakeByDateRange(
+        mockUserId,
+        targetUserId,
+        startDate,
+        endDate
+      );
+
+      expect(result).toEqual([{ entry_date: '2026-08-30', water_ml: 750 }]);
+    });
+
+    it('passes the target user and window straight through to the repository', async () => {
+      vi.mocked(
+        measurementRepository.getWaterTotalsByDateRange
+      ).mockResolvedValue([]);
+
+      await measurementService.getWaterIntakeByDateRange(
+        mockUserId,
+        targetUserId,
+        startDate,
+        endDate
+      );
+
+      expect(
+        measurementRepository.getWaterTotalsByDateRange
+      ).toHaveBeenCalledWith(targetUserId, startDate, endDate);
+    });
+
+    it('coerces an unparseable total to 0', async () => {
+      vi.mocked(
+        measurementRepository.getWaterTotalsByDateRange
+      ).mockResolvedValue([{ entry_date: '2026-08-30', total_ml: null }]);
+
+      const result = await measurementService.getWaterIntakeByDateRange(
+        mockUserId,
+        targetUserId,
+        startDate,
+        endDate
+      );
+
+      expect(result).toEqual([{ entry_date: '2026-08-30', water_ml: 0 }]);
+    });
+
+    it('rethrows a repository failure', async () => {
+      const repositoryError = new Error('Database error');
+      vi.mocked(
+        measurementRepository.getWaterTotalsByDateRange
+      ).mockRejectedValue(repositoryError);
+
+      await expect(
+        measurementService.getWaterIntakeByDateRange(
+          mockUserId,
+          targetUserId,
+          startDate,
+          endDate
+        )
+      ).rejects.toThrow(repositoryError);
+    });
+  });
   // ---------------------------------------------------------------------------
   // Integration Tests
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The mobile Health Trends pager had no way to see hydration over time — water intake was only ever visible as today's gauge on the Dashboard.

**How did you implement the solution?**
- Adds `GET /api/measurements/water-intake-range/:startDate/:endDate`, backed by the existing `getWaterTotalsByDateRange` query the reports service already uses. Without it a 90-day window would need 90 calls to the per-day route, and `/reports` returns whole food, exercise and medication payloads a chart has no use for. The `SUM` arrives from pg as a string, so the service normalizes it to a number once rather than leaving every caller to parse.
- The route validates its params with a new `StrictDateRangeParamSchema` built on the shared `isDayString` helper, so a malformed or impossible date is a 400 instead of failing in Postgres as a 500. `DateRangeParamSchema` has the same weakness but is shared with endpoints whose contract this change should not alter, so new routes adopt the strict schema and the older ones migrate separately.
- `useHydrationRange` zero-fills every day in the window: a day with no logged water genuinely means none was drunk, unlike a weigh-in where a missing day is simply unknown.
- Extracts `TrendBarChart` from `StepsBarChart` and builds `HydrationBarChart` on it. The two differ only in title, value, copy and unit, and the repo's rule is to extract on the second duplication rather than let the copies drift. `volumeFromMl` and `formatVolumeForUnit` likewise move out of `HydrationGauge`, now their second consumer.
- Millilitre-to-display-unit conversion happens once, in `HydrationBarChart`, so the bars, the axis labels and the tooltip cannot disagree — mirroring how `DashboardScreen` owns the same boundary for weight.

Linked Issue: Closes #2348  

## How to Test

1. Check out this branch, then start the backend (`cd SparkyFitnessServer && pnpm start`) and the app (`cd SparkyFitnessMobile && pnpm start`).
2. Log water on a few different days so the window has something to plot.
3. On the Dashboard, scroll to **Health Trends** and swipe to the **Hydration** page. Confirm the bars match the logged volumes and switch correctly between 7d / 30d / 90d.
4. Change the water display unit and confirm the bars, the y-axis and the tooltip all move to the new unit together.
5. Open **Settings → Dashboard → Health Trends** and confirm Hydration can be reordered and hidden alongside the existing graphs.
6. Run `cd SparkyFitnessServer && pnpm test` and `cd SparkyFitnessMobile && pnpm exec jest --watchman=false --runInBand`.

## PR Type

- [ ] Issue (bug fix)
- [x] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes. _(N/A — no frontend changes.)_
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. _(N/A — no frontend changes. The mobile `en` catalog is the only translation file touched.)_

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. _(N/A — no schema change; the new route reads `water_intake_entries` through the existing repository query.)_

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### After
<img width="250" alt="Screenshot_1788830568" src="https://github.com/user-attachments/assets/a1561ef8-a341-4f6f-b4b0-92c4fe67e9a6" />
<img width="250" alt="Screenshot_1788831068" src="https://github.com/user-attachments/assets/d228ac2b-c1d1-4046-ac17-1d514dcae3fb" />

</details>

## Notes for Reviewers

- **No schema change.** The endpoint exposes a repository query that already existed; there is no migration, no new table and no RLS change. It requires the `checkin` permission, matching the per-day water route.
- **Range is unbounded.** The new route runs a `SUM ... GROUP BY entry_date` over `water_intake_entries` for whatever range the caller sends. It is indexed the same way the existing per-day query is, but there is no server-side cap beyond what the client requests (the pager only ever asks for 7/30/90 days).
- **Registering another graph is now cheap.** `HealthTrendsPager`'s render map is a total `Record<HealthTrendKey, ...>`, so adding a key to `constants/healthTrends.ts` without rendering it is a compile error. Calories is the obvious next consumer.
- **Pre-existing y-axis rounding is visible here.** `formatChartYLabel` uses `notation: 'compact'` with `maximumFractionDigits: 0`, so everything from 1500–2499 renders as `2K`. That is fine for Steps (8K–12K) but collides on a millilitre axis, which can show two ticks both labelled `2K`. The formatter is unchanged by this PR; happy to fix it here or in a follow-up, whichever reviewers prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hydration as a health trend with daily intake charts and localized tooltips.
  * Added hydration data for selectable date ranges, including zero-intake days.
  * Added water-intake range support with date validation.
  * Added localized volume conversion and formatting for millilitres, ounces, and litres.
  * Added shared trend chart behavior for loading, error, empty, and interactive states.
  * Synchronized hydration units between the dashboard gauge and trend chart.

* **Documentation**
  * Documented the water-intake range API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->