### PR TITLE
fix(demo): block demo password resets that identify the account by token

### DIFF
--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -16,6 +16,7 @@ import { applySignOutCookieCleanup } from './middleware/signOutCookieCleanup.js'
 import {
   isDemoMode,
   isDemoEmail,
+  isDemoPasswordResetToken,
   getDemoEmail,
   demoRestrictionGuard,
 } from './middleware/demoGuardMiddleware.js';
@@ -277,8 +278,13 @@ app.use(async (req, res, next) => {
       );
 
       // Password-recovery endpoints are unauthenticated, so there is no session
-      // to match on — key off the address in the request body instead, or the
-      // demo credential could be reset out from under the sandbox.
+      // to match on — identify the account from the request itself, or the demo
+      // credential could be reset out from under the sandbox.
+      //
+      // The two request endpoints name it by address. `/reset-password` does
+      // not: it carries `{ newPassword, token }`, so the account has to be
+      // resolved from the token, which Better Auth accepts in either the body
+      // or the query string.
       const recoveryPrefixes = [
         '/api/auth/forget-password',
         '/api/auth/request-password-reset',
@@ -287,7 +293,11 @@ app.use(async (req, res, next) => {
       const isRecoveryPath = recoveryPrefixes.some(
         (prefix) => req.path === prefix || req.path.startsWith(prefix + '/')
       );
-      if (isRecoveryPath && isDemoEmail(req.body?.email)) {
+      if (
+        isRecoveryPath &&
+        (isDemoEmail(req.body?.email) ||
+          (await isDemoPasswordResetToken(req.body?.token ?? req.query?.token)))
+      ) {
         log(
           'warn',
           `[DEMO GUARD] Blocked password recovery on ${req.method} ${req.path} for the demo account`

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -296,7 +296,12 @@ app.use(async (req, res, next) => {
       if (
         isRecoveryPath &&
         (isDemoEmail(req.body?.email) ||
-          (await isDemoPasswordResetToken(req.body?.token ?? req.query?.token)))
+          (await isDemoPasswordResetToken(
+            // `||`, not `??`: Better Auth resolves the token as
+            // `ctx.body.token || ctx.query?.token`, so an empty body token still
+            // falls through to the query string there and must here too.
+            req.body?.token || req.query?.token
+          )))
       ) {
         log(
           'warn',

--- a/SparkyFitnessServer/middleware/demoGuardMiddleware.ts
+++ b/SparkyFitnessServer/middleware/demoGuardMiddleware.ts
@@ -45,16 +45,27 @@ export async function isDemoPasswordResetToken(
   if (!isDemoMode()) return false;
   if (typeof token !== 'string' || token.trim() === '') return false;
 
-  const client = await getSystemClient();
+  // Acquired inside the try so a pool that cannot hand out a connection is
+  // caught here rather than rejecting out of the guard.
+  let client: Awaited<ReturnType<typeof getSystemClient>> | null = null;
   try {
+    client = await getSystemClient();
     const result = await client.query(
+      // Deliberately not filtered on `expires_at`. A token that resolves to the
+      // demo account is blocked whether or not it has lapsed -- Better Auth
+      // judges expiry in JS against a `timestamp without time zone` column, and
+      // an SQL `now()` comparison resolves in the database session's timezone
+      // rather than the one the row was written in. Where those differ the two
+      // verdicts diverge, and the direction that lets a live token read as
+      // expired here would hand the reset straight to Better Auth.
       `SELECT u.email
          FROM verification v
          JOIN "user" u ON u.id::text = v.value
         WHERE v.identifier = $1
-          AND v.expires_at > now()
         LIMIT 1`,
-      [`reset-password:${token.trim()}`]
+      // Keyed on the raw token, not a trimmed copy: Better Auth looks up
+      // `reset-password:${token}` verbatim, so the guard has to hit the same row.
+      [`reset-password:${token}`]
     );
     return isDemoEmail(result.rows[0]?.email);
   } catch (error) {
@@ -65,7 +76,7 @@ export async function isDemoPasswordResetToken(
     );
     return true;
   } finally {
-    client.release();
+    client?.release();
   }
 }
 

--- a/SparkyFitnessServer/middleware/demoGuardMiddleware.ts
+++ b/SparkyFitnessServer/middleware/demoGuardMiddleware.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express';
 import { log } from '../config/logging.js';
+import { getSystemClient } from '../db/poolManager.js';
 
 /**
  * Marker written into `profiles.bio` when the demo sandbox is seeded. It is the
@@ -23,6 +24,49 @@ export function getDemoEmail(): string {
 export function isDemoEmail(email?: string | null): boolean {
   if (!isDemoMode() || !email) return false;
   return email.toLowerCase().trim() === getDemoEmail();
+}
+
+/**
+ * True when a Better Auth password-reset token belongs to the demo account.
+ *
+ * The other recovery endpoints name the account in the request body, but
+ * `/api/auth/reset-password` carries only `{ newPassword, token }` -- Better
+ * Auth identifies the account by the token alone. An address-based check
+ * therefore sees nothing there and lets the reset through, so resolve the token
+ * to its owner instead. Better Auth records it as a `verification` row keyed
+ * `reset-password:<token>` whose value is the user id.
+ *
+ * Fails closed: a lookup that cannot be completed must not be read as "not the
+ * demo account". In demo mode that only costs a reset the sandbox can retry.
+ */
+export async function isDemoPasswordResetToken(
+  token: unknown
+): Promise<boolean> {
+  if (!isDemoMode()) return false;
+  if (typeof token !== 'string' || token.trim() === '') return false;
+
+  const client = await getSystemClient();
+  try {
+    const result = await client.query(
+      `SELECT u.email
+         FROM verification v
+         JOIN "user" u ON u.id::text = v.value
+        WHERE v.identifier = $1
+          AND v.expires_at > now()
+        LIMIT 1`,
+      [`reset-password:${token.trim()}`]
+    );
+    return isDemoEmail(result.rows[0]?.email);
+  } catch (error) {
+    log(
+      'error',
+      '[DEMO GUARD] Could not resolve a password reset token; blocking to fail closed:',
+      error
+    );
+    return true;
+  } finally {
+    client.release();
+  }
 }
 
 /**

--- a/SparkyFitnessServer/services/demoSeedService.ts
+++ b/SparkyFitnessServer/services/demoSeedService.ts
@@ -228,6 +228,17 @@ async function cleanDemoUserData(
   // Clean filesystem upload directories for demo user first
   await removeDemoUploadedFiles(client, userId);
 
+  // Any password-reset token still outstanding for the demo account would let
+  // whoever holds it change the shared credential after this reset. They are
+  // Better Auth `verification` rows keyed `reset-password:<token>` whose value
+  // is the user id, so drop them along with the rest of the account's state.
+  await client.query(
+    `DELETE FROM verification
+      WHERE value = $1
+        AND identifier LIKE 'reset-password:%'`,
+    [userId]
+  );
+
   await client.query('DELETE FROM cycle_daily_entries WHERE user_id = $1', [
     userId,
   ]);

--- a/SparkyFitnessServer/tests/demoPasswordResetGuard.test.ts
+++ b/SparkyFitnessServer/tests/demoPasswordResetGuard.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isDemoPasswordResetToken } from '../middleware/demoGuardMiddleware.js';
+import * as poolManager from '../db/poolManager.js';
+
+vi.mock('../db/poolManager.js', () => ({
+  getSystemClient: vi.fn(),
+  getClient: vi.fn(),
+}));
+
+vi.mock('../config/logging.js', () => ({
+  log: vi.fn(),
+}));
+
+/**
+ * `/api/auth/reset-password` is the one recovery endpoint that never names the
+ * account: Better Auth sends `{ newPassword, token }` and identifies the user
+ * from a `verification` row keyed `reset-password:<token>`. The address-based
+ * guard on the sibling endpoints is blind to it, so a reset token issued for
+ * the demo account could change the shared demo credential.
+ */
+describe('demo password reset token guard', () => {
+  const originalEnv = process.env;
+
+  const mockClient = (rows: Array<{ email: string }>) => {
+    const client = {
+      query: vi.fn().mockResolvedValue({ rows }),
+      release: vi.fn(),
+    };
+    vi.mocked(poolManager.getSystemClient).mockResolvedValue(
+      client as unknown as Awaited<
+        ReturnType<typeof poolManager.getSystemClient>
+      >
+    );
+    return client;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    process.env.SPARKY_FITNESS_DEMO_MODE = 'true';
+    delete process.env.SPARKY_FITNESS_DEMO_EMAIL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('recognises a reset token that belongs to the demo account', async () => {
+    const client = mockClient([{ email: 'demo@sparkyfitness.com' }]);
+
+    await expect(isDemoPasswordResetToken('tok_abc')).resolves.toBe(true);
+
+    expect(client.query).toHaveBeenCalledWith(expect.any(String), [
+      'reset-password:tok_abc',
+    ]);
+    expect(client.release).toHaveBeenCalled();
+  });
+
+  it('leaves a real user on the demo instance able to reset their password', async () => {
+    mockClient([{ email: 'someone@example.com' }]);
+
+    await expect(isDemoPasswordResetToken('tok_abc')).resolves.toBe(false);
+  });
+
+  it('does not block an unknown or expired token', async () => {
+    mockClient([]);
+
+    await expect(isDemoPasswordResetToken('tok_expired')).resolves.toBe(false);
+  });
+
+  it('only matches the reset-password identifier, scoped to live rows', async () => {
+    const client = mockClient([]);
+
+    await isDemoPasswordResetToken('tok_abc');
+
+    const [sql, params] = client.query.mock.calls[0] as [string, string[]];
+    // The identifier is parameterised, so the prefix lives in the bound value.
+    expect(params).toEqual(['reset-password:tok_abc']);
+    expect(sql).toContain('expires_at > now()');
+    expect(sql).toContain('verification');
+  });
+
+  it('fails closed when the lookup throws', async () => {
+    const client = {
+      query: vi.fn().mockRejectedValue(new Error('connection refused')),
+      release: vi.fn(),
+    };
+    vi.mocked(poolManager.getSystemClient).mockResolvedValue(
+      client as unknown as Awaited<
+        ReturnType<typeof poolManager.getSystemClient>
+      >
+    );
+
+    // An unreadable row must never be read as "not the demo account".
+    await expect(isDemoPasswordResetToken('tok_abc')).resolves.toBe(true);
+    expect(client.release).toHaveBeenCalled();
+  });
+
+  it('honours a configured demo address', async () => {
+    process.env.SPARKY_FITNESS_DEMO_EMAIL = 'sandbox@example.com';
+    mockClient([{ email: 'Sandbox@Example.com' }]);
+
+    await expect(isDemoPasswordResetToken('tok_abc')).resolves.toBe(true);
+  });
+
+  it('never touches the pool outside demo mode', async () => {
+    process.env.SPARKY_FITNESS_DEMO_MODE = 'false';
+
+    await expect(isDemoPasswordResetToken('tok_abc')).resolves.toBe(false);
+    expect(poolManager.getSystemClient).not.toHaveBeenCalled();
+  });
+
+  it('ignores a missing or non-string token without querying', async () => {
+    for (const token of [undefined, null, '', '   ', 123, ['a']]) {
+      await expect(isDemoPasswordResetToken(token)).resolves.toBe(false);
+    }
+    expect(poolManager.getSystemClient).not.toHaveBeenCalled();
+  });
+});

--- a/SparkyFitnessServer/tests/demoPasswordResetGuard.test.ts
+++ b/SparkyFitnessServer/tests/demoPasswordResetGuard.test.ts
@@ -62,13 +62,26 @@ describe('demo password reset token guard', () => {
     await expect(isDemoPasswordResetToken('tok_abc')).resolves.toBe(false);
   });
 
-  it('does not block an unknown or expired token', async () => {
+  it('does not block a token no verification row matches', async () => {
     mockClient([]);
 
-    await expect(isDemoPasswordResetToken('tok_expired')).resolves.toBe(false);
+    await expect(isDemoPasswordResetToken('tok_unknown')).resolves.toBe(false);
   });
 
-  it('only matches the reset-password identifier, scoped to live rows', async () => {
+  it('blocks a lapsed demo token rather than judging expiry in SQL', async () => {
+    const client = mockClient([{ email: 'demo@sparkyfitness.com' }]);
+
+    await expect(isDemoPasswordResetToken('tok_abc')).resolves.toBe(true);
+
+    // Expiry is Better Auth's call, made in JS. Repeating it as an SQL `now()`
+    // comparison against a `timestamp without time zone` column resolves in the
+    // database session timezone, which need not be the one the row was written
+    // in; a live token reading as expired here would be a bypass.
+    const [sql] = client.query.mock.calls[0] as [string];
+    expect(sql).not.toContain('expires_at');
+  });
+
+  it('looks the token up under the reset-password identifier', async () => {
     const client = mockClient([]);
 
     await isDemoPasswordResetToken('tok_abc');
@@ -76,7 +89,6 @@ describe('demo password reset token guard', () => {
     const [sql, params] = client.query.mock.calls[0] as [string, string[]];
     // The identifier is parameterised, so the prefix lives in the bound value.
     expect(params).toEqual(['reset-password:tok_abc']);
-    expect(sql).toContain('expires_at > now()');
     expect(sql).toContain('verification');
   });
 
@@ -94,6 +106,15 @@ describe('demo password reset token guard', () => {
     // An unreadable row must never be read as "not the demo account".
     await expect(isDemoPasswordResetToken('tok_abc')).resolves.toBe(true);
     expect(client.release).toHaveBeenCalled();
+  });
+
+  it('fails closed when the pool cannot hand out a client', async () => {
+    vi.mocked(poolManager.getSystemClient).mockRejectedValue(
+      new Error('pool exhausted')
+    );
+
+    // Acquisition failure must be caught here, not thrown out of the guard.
+    await expect(isDemoPasswordResetToken('tok_abc')).resolves.toBe(true);
   });
 
   it('honours a configured demo address', async () => {


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The demo-mode guard is meant to stop anyone resetting the shared demo account's password, but it only recognises the two recovery endpoints that carry an email in the body. `/api/auth/reset-password` carries `{ newPassword, token }` instead, so the check saw nothing and let the request through to Better Auth.

**How did you implement the solution?**

- Resolve the reset token to its owner instead of looking for an address. Better Auth records the token as a `verification` row keyed `reset-password:<token>` whose `value` is the user id, so the new `isDemoPasswordResetToken()` joins that row to `public."user"` and compares the email against the demo address.
- Read the token from the query string as well as the body, resolving it the way Better Auth does (`body.token || query.token`, not `??`) so an empty body token still falls through to a valid query token instead of short-circuiting the guard.
- Key the lookup on the raw token, since Better Auth builds the `reset-password:<token>` identifier verbatim.
- Leave expiry to Better Auth rather than repeating it as an SQL `now()` comparison: `verification.expires_at` is `timestamp without time zone`, so the comparison resolves in the database session's timezone rather than the one the row was written in, and a live token reading as expired there would be waved through. A token that resolves to the demo account is blocked either way.
- Fail closed if the lookup cannot be completed, so an unreadable row is never read as "not the demo account".
- Purge outstanding `reset-password:` tokens for the demo user in `cleanDemoUserData`, so a token issued before demo mode was switched on cannot outlive the daily reset.

Real users who register on a demo instance keep their password reset: only tokens that resolve to the demo account are rejected, which is why the endpoint is not simply blocked outright.

Linked Issue: N/A — no issue filed; found while auditing the demo-mode guard.

## How to Test

1. Check out this branch and start the server with demo mode on:
   `SPARKY_FITNESS_DEMO_MODE=true SPARKY_FITNESS_DEMO_EMAIL=demo@sparkyfitness.com pnpm start` (from `SparkyFitnessServer/`).
2. Run the unit tests: `cd SparkyFitnessServer && pnpm exec vitest run tests/demoPasswordResetGuard.test.ts`.
3. Reproduce the original gap against `main`: issue a reset token for the demo user, then
   `curl -X POST localhost:3010/api/auth/reset-password -H 'Content-Type: application/json' -d '{"token":"<token>","newPassword":"whatever"}'`.
   On `main` the password changes; on this branch it returns `403 DEMO_ACTION_RESTRICTED`.
4. Repeat with the token in the query string (`/api/auth/reset-password?token=<token>`) — also blocked.
5. Confirm a non-demo account registered on the same instance can still complete a reset normally.
6. Trigger the demo reset and verify outstanding `reset-password:` rows for the demo user are gone:
   `SELECT * FROM verification WHERE identifier LIKE 'reset-password:%';`
7. Send an empty body token alongside a valid query token (`-d '{"token":"","newPassword":"whatever"}'` with `?token=<token>`) — also blocked, matching how Better Auth itself picks the token.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. — N/A, bug fix.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes. — N/A, no frontend changes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. — N/A, no translation changes.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. — No new tables; the lookup reads Better Auth's existing `verification` and `user` tables through the system client, as the surrounding demo code already does.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. — N/A, headless change.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. — N/A, no mobile changes.

## Screenshots

N/A — backend-only change with no UI surface.

## Notes for Reviewers

- **Severity is low in practice.** Getting a usable token requires the reset-request endpoints, and those were already blocked for the demo address — so this is the second door behind a locked one. The realistic residual risk was a token issued before demo mode or the guard was enabled, which is what the `cleanDemoUserData` purge addresses.
- **Why not just block the endpoint in demo mode:** people can register real accounts on a demo instance, and a blanket block would break their password resets too. That is why the guard resolves ownership rather than matching on path alone.
- **Fail-closed choice:** if the verification lookup throws, the request is blocked. In demo mode that costs at most a retryable reset, and it matches the existing convention in `demoGuardMiddleware.ts`, where the seed marker is documented to fail closed.
- **Test scope:** coverage is unit-level against `isDemoPasswordResetToken` with the pool mocked, covering demo token, non-demo token, unmatched token, lapsed demo token, a thrown lookup, a pool that cannot hand out a client, configured demo address, non-demo mode, and non-string tokens. There is no full HTTP integration test for the middleware — booting `SparkyFitnessServer.ts` pulls in cron and DB startup — so the wiring itself is verified by inspection rather than by test.
- `tests/schemaParity.integration.test.ts` fails on my machine both with and without this change, because my local dev database carries tables from other branches. It is unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved demo-mode password recovery protection by recognizing reset tokens from request bodies and query parameters.
  * Reset tokens are now matched to their associated account, including configured demo accounts.
  * Demo-account reset tokens are blocked consistently, including expired tokens and lookup failures.
  * Outstanding demo-account password reset records are removed during demo data cleanup.
* **Tests**
  * Added coverage for valid, expired, unknown, invalid, and error-handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
