### PR TITLE
fix(auth): forward every Set-Cookie from the demo login response

### DIFF
--- a/SparkyFitnessServer/routes/auth/authCoreRoutes.ts
+++ b/SparkyFitnessServer/routes/auth/authCoreRoutes.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { log } from '../../config/logging.js';
+import { forwardResponseHeaders } from '../../utils/forwardResponseHeaders.js';
 import globalSettingsRepository from '../../models/globalSettingsRepository.js';
 import oidcProviderRepository from '../../models/oidcProviderRepository.js';
 import userRepository from '../../models/userRepository.js';
@@ -222,9 +223,7 @@ router.post('/demo-login', demoLoginRateLimit, async (req, res) => {
       });
     }
 
-    response.headers.forEach((value, key) => {
-      res.setHeader(key, value);
-    });
+    forwardResponseHeaders(response.headers, res);
 
     const body = await response.json();
     return res.status(response.status).json(body);

--- a/SparkyFitnessServer/tests/forwardResponseHeaders.test.ts
+++ b/SparkyFitnessServer/tests/forwardResponseHeaders.test.ts
@@ -11,10 +11,12 @@ const mockRes = () => {
 };
 
 /**
- * Better Auth returns a Fetch `Response` and sets more than one cookie on
- * sign-in. Forwarding those through `Headers.forEach` + `res.setHeader` keeps
- * only the last one, because forEach yields each set-cookie separately and
- * setHeader replaces rather than appends.
+ * Better Auth returns a Fetch `Response`. Forwarding its headers through
+ * `Headers.forEach` + `res.setHeader` keeps only the last set-cookie, because
+ * forEach yields each one separately and setHeader replaces rather than
+ * appends. Sign-in emits a single cookie under the current config, so these
+ * cover the multi-cookie response as a supported shape rather than as today's
+ * behaviour.
  */
 describe('forwardResponseHeaders', () => {
   it('forwards every Set-Cookie value, not just the last one', () => {

--- a/SparkyFitnessServer/tests/forwardResponseHeaders.test.ts
+++ b/SparkyFitnessServer/tests/forwardResponseHeaders.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Response as ExpressResponse } from 'express';
+import { forwardResponseHeaders } from '../utils/forwardResponseHeaders.js';
+
+const mockRes = () => {
+  const setHeader = vi.fn();
+  return {
+    res: { setHeader } as unknown as ExpressResponse,
+    setHeader,
+  };
+};
+
+/**
+ * Better Auth returns a Fetch `Response` and sets more than one cookie on
+ * sign-in. Forwarding those through `Headers.forEach` + `res.setHeader` keeps
+ * only the last one, because forEach yields each set-cookie separately and
+ * setHeader replaces rather than appends.
+ */
+describe('forwardResponseHeaders', () => {
+  it('forwards every Set-Cookie value, not just the last one', () => {
+    const headers = new Headers();
+    headers.append('set-cookie', 'session_token=abc; Path=/; HttpOnly');
+    headers.append('set-cookie', 'session_data=xyz; Path=/; HttpOnly');
+    const { res, setHeader } = mockRes();
+
+    forwardResponseHeaders(headers, res);
+
+    expect(setHeader).toHaveBeenCalledWith('set-cookie', [
+      'session_token=abc; Path=/; HttpOnly',
+      'session_data=xyz; Path=/; HttpOnly',
+    ]);
+  });
+
+  it('sets Set-Cookie exactly once so no earlier value is replaced', () => {
+    const headers = new Headers();
+    headers.append('set-cookie', 'a=1');
+    headers.append('set-cookie', 'b=2');
+    headers.append('set-cookie', 'c=3');
+    const { res, setHeader } = mockRes();
+
+    forwardResponseHeaders(headers, res);
+
+    const cookieCalls = setHeader.mock.calls.filter(
+      ([key]) => String(key).toLowerCase() === 'set-cookie'
+    );
+    expect(cookieCalls).toHaveLength(1);
+    expect(cookieCalls[0]?.[1]).toEqual(['a=1', 'b=2', 'c=3']);
+  });
+
+  it('still forwards ordinary headers', () => {
+    const headers = new Headers();
+    headers.append('content-type', 'application/json');
+    headers.append('x-request-id', 'req-1');
+    const { res, setHeader } = mockRes();
+
+    forwardResponseHeaders(headers, res);
+
+    expect(setHeader).toHaveBeenCalledWith('content-type', 'application/json');
+    expect(setHeader).toHaveBeenCalledWith('x-request-id', 'req-1');
+  });
+
+  it('carries a single cookie through unchanged', () => {
+    const headers = new Headers();
+    headers.append('set-cookie', 'only=1; Path=/');
+    const { res, setHeader } = mockRes();
+
+    forwardResponseHeaders(headers, res);
+
+    expect(setHeader).toHaveBeenCalledWith('set-cookie', ['only=1; Path=/']);
+  });
+
+  it('does not set Set-Cookie when the response carries none', () => {
+    const headers = new Headers({ 'content-type': 'application/json' });
+    const { res, setHeader } = mockRes();
+
+    forwardResponseHeaders(headers, res);
+
+    expect(
+      setHeader.mock.calls.some(
+        ([key]) => String(key).toLowerCase() === 'set-cookie'
+      )
+    ).toBe(false);
+  });
+});

--- a/SparkyFitnessServer/utils/forwardResponseHeaders.ts
+++ b/SparkyFitnessServer/utils/forwardResponseHeaders.ts
@@ -1,0 +1,29 @@
+import type { Response as ExpressResponse } from 'express';
+
+/**
+ * Copies a Fetch `Response`'s headers onto an Express response.
+ *
+ * `Set-Cookie` needs its own path. `Headers.forEach` yields each set-cookie
+ * value as a separate entry rather than folding them, and `res.setHeader`
+ * replaces the header on every call — so forwarding them through the loop keeps
+ * only the last cookie and silently drops the rest. Better Auth sets more than
+ * one cookie on sign-in, which would leave the session incomplete.
+ *
+ * Express accepts an array for `set-cookie` and emits one header line per
+ * entry, so collect them and set them once.
+ */
+export function forwardResponseHeaders(
+  source: Headers,
+  res: ExpressResponse
+): void {
+  const setCookies = source.getSetCookie();
+
+  source.forEach((value, key) => {
+    if (key.toLowerCase() === 'set-cookie') return;
+    res.setHeader(key, value);
+  });
+
+  if (setCookies.length > 0) {
+    res.setHeader('set-cookie', setCookies);
+  }
+}

--- a/SparkyFitnessServer/utils/forwardResponseHeaders.ts
+++ b/SparkyFitnessServer/utils/forwardResponseHeaders.ts
@@ -6,8 +6,13 @@ import type { Response as ExpressResponse } from 'express';
  * `Set-Cookie` needs its own path. `Headers.forEach` yields each set-cookie
  * value as a separate entry rather than folding them, and `res.setHeader`
  * replaces the header on every call — so forwarding them through the loop keeps
- * only the last cookie and silently drops the rest. Better Auth sets more than
- * one cookie on sign-in, which would leave the session incomplete.
+ * only the last cookie and silently drops the rest.
+ *
+ * A multi-cookie sign-in response is a supported case, not today's behaviour:
+ * the current config disables `session.cookieCache`, so Better Auth emits the
+ * session token alone. Turning that cache back on, a `rememberMe: false`
+ * sign-in, or any plugin that sets its own cookie would each add a second one,
+ * and the loop would drop it silently and leave the session incomplete.
  *
  * Express accepts an array for `set-cookie` and emits one header line per
  * entry, so collect them and set them once.


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
`/api/auth/demo-login` forwards Better Auth's sign-in response by copying its Fetch headers onto the Express response, which silently drops all but the last `Set-Cookie` value.

**How did you implement the solution?**

- `Headers.forEach` yields each `set-cookie` value as its own entry rather than folding them, and `res.setHeader` *replaces* the header on every call — so the loop kept only the last cookie.
- Collect them with `Headers.getSetCookie()` and pass the array to `res.setHeader` once; Express emits one header line per entry. Other headers still go through the loop, with `set-cookie` skipped.
- Extracted to `utils/forwardResponseHeaders.ts` so the behaviour is unit tested rather than buried in the route.

**Impact is latent, not active.** `session.cookieCache` is disabled (`auth.ts`), so Better Auth sets a single cookie on sign-in today and nothing is currently lost. This is a correctness fix: enabling the cookie cache, or a Better Auth version that sets a second cookie, would break demo login in a way that reads as a session bug rather than a header bug. It is not a security issue — the failure mode is losing a cookie, never gaining one.

Linked Issue: N/A — no issue filed; found while reading the demo-login response path.

## How to Test

1. `cd SparkyFitnessServer && pnpm exec vitest run tests/forwardResponseHeaders.test.ts`
2. To see the original behaviour, temporarily enable `session.cookieCache` in `auth.ts`, start the server with `SPARKY_FITNESS_DEMO_MODE=true`, and sign in through the demo button.
3. On `main`, the response carries one `Set-Cookie` line; on this branch it carries one per cookie Better Auth set. Confirm the demo session still works normally in both single- and multi-cookie configurations.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. — N/A, bug fix.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes. — N/A, no frontend changes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. — N/A, no translation changes.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. — N/A, no schema or table changes.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. — N/A, headless change.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. — N/A, no mobile changes.

## Screenshots

N/A — backend-only change with no UI surface.

## Notes for Reviewers

- Raised in review on #2379 as "Forward `Set-Cookie` values separately". The finding was correct that the endpoint is broken, but attributed it to `forEach` folding multiple values. It does not fold them — verified on Node 24, appending two `set-cookie` values and iterating yields two separate entries. The actual cause is `res.setHeader` replacing rather than appending. Same outcome, different mechanism, and it matters because the fix is `getSetCookie()` rather than a join.
- `demo-login` is the only place in the server that forwards a Fetch `Response`'s headers this way, so there is no other call site to migrate.
- Longer term this whole code path is avoidable: the demo credentials are public, so the frontend could call the normal sign-in endpoint directly and let Better Auth set its own cookies, removing the proxy, the 401 re-seed retry, and this forwarding entirely. Out of scope here.
- `tests/schemaParity.integration.test.ts` fails on my machine both with and without this change, because my local dev database carries tables from other branches. Unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Demo login now preserves and forwards multiple session cookies correctly, preventing later cookies from replacing earlier ones.
  - Other response headers continue to be forwarded as expected.
  - Existing response status, body, retry, and error behavior remain unchanged.

- **Tests**
  - Added coverage for multiple cookies, single cookies, standard headers, and responses without cookies.
  - Verified that cookie values remain intact when multiple cookies are returned together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
