### PR TITLE
Fix/measured bmr override

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -779,7 +779,9 @@
     "saveSuccessDesc": "Calculation settings saved successfully!",
     "selectBmrAlgorithm": "Select BMR Algorithm",
     "selectBodyFatAlgorithm": "Select Body Fat Algorithm",
-    "selectEnergyUnitPlaceholder": "Select energy unit"
+    "selectEnergyUnitPlaceholder": "Select energy unit",
+    "useExternalBmr": "Use measured/synced BMR when available",
+    "useExternalBmrHint": "When enabled, a BMR entered on a check-in or synced from a smart scale or health provider can override the calculated formula for that day. Off by default -- your calculated BMR is always used until you opt in."
   },
   "aboutDialog": {
     "title": "About SparkyFitness",

--- a/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
@@ -111,6 +111,11 @@ interface PreferencesContextType {
   bmrAlgorithm: BmrAlgorithm;
   bodyFatAlgorithm: BodyFatAlgorithm;
   includeBmrInNetCalories: boolean;
+  // Whether a measured/synced BMR (smart scale, check-in entry, health-provider
+  // sync) is allowed to override the formula-calculated BMR at all. Off by
+  // default, matching the DB column -- the formula estimate is used until a
+  // user opts in.
+  useExternalBmr: boolean;
   showNetCarbs: boolean;
   aiAssistedConversions: boolean;
   fatBreakdownAlgorithm: FatBreakdownAlgorithm;
@@ -162,6 +167,7 @@ interface PreferencesContextType {
   setBmrAlgorithm: (algorithm: BmrAlgorithm) => void;
   setBodyFatAlgorithm: (algorithm: BodyFatAlgorithm) => void;
   setIncludeBmrInNetCalories: (include: boolean) => void;
+  setUseExternalBmr: (use: boolean) => void;
   setShowNetCarbs: (show: boolean) => void;
   setAiAssistedConversions: (enabled: boolean) => void;
   setFatBreakdownAlgorithm: (algorithm: FatBreakdownAlgorithm) => void;
@@ -233,6 +239,7 @@ export interface DefaultPreferences {
   bmr_algorithm: BmrAlgorithm;
   body_fat_algorithm: BodyFatAlgorithm;
   include_bmr_in_net_calories: boolean;
+  use_external_bmr: boolean;
   show_net_carbs: boolean;
   ai_assisted_conversions: boolean;
   fat_breakdown_algorithm: FatBreakdownAlgorithm;
@@ -324,6 +331,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
     useState<BodyFatAlgorithm>(BodyFatAlgorithm.US_NAVY);
   const [includeBmrInNetCalories, setIncludeBmrInNetCaloriesState] =
     useState<boolean>(false);
+  const [useExternalBmr, setUseExternalBmrState] = useState<boolean>(false);
   const [showNetCarbs, setShowNetCarbsState] = useState<boolean>(false);
   const [addExerciseWaterToGoal, setAddExerciseWaterToGoalState] =
     useState<boolean>(false);
@@ -727,6 +735,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         setIncludeBmrInNetCaloriesState(
           data.include_bmr_in_net_calories ?? false
         );
+        setUseExternalBmrState(data.use_external_bmr ?? false);
         setShowNetCarbsState(data.show_net_carbs ?? false);
         setAddExerciseWaterToGoalState(
           data.add_exercise_water_to_goal ?? false
@@ -918,6 +927,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         body_fat_algorithm: newPrefs?.bodyFatAlgorithm ?? bodyFatAlgorithm,
         include_bmr_in_net_calories:
           newPrefs?.includeBmrInNetCalories ?? includeBmrInNetCalories,
+        use_external_bmr: newPrefs?.useExternalBmr ?? useExternalBmr,
         show_net_carbs: newPrefs?.showNetCarbs ?? showNetCarbs,
         add_exercise_water_to_goal:
           newPrefs?.addExerciseWaterToGoal ?? addExerciseWaterToGoal,
@@ -992,6 +1002,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       bmrAlgorithm,
       bodyFatAlgorithm,
       includeBmrInNetCalories,
+      useExternalBmr,
       showNetCarbs,
       aiAssistedConversions,
       fatBreakdownAlgorithm,
@@ -1251,6 +1262,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       bmrAlgorithm,
       bodyFatAlgorithm,
       includeBmrInNetCalories,
+      useExternalBmr,
       showNetCarbs,
       aiAssistedConversions,
       fatBreakdownAlgorithm,
@@ -1299,6 +1311,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       setBmrAlgorithm: setBmrAlgorithmState,
       setBodyFatAlgorithm: setBodyFatAlgorithmState,
       setIncludeBmrInNetCalories: setIncludeBmrInNetCaloriesState,
+      setUseExternalBmr: setUseExternalBmrState,
       setShowNetCarbs: setShowNetCarbsState,
       setAiAssistedConversions: setAiAssistedConversionsState,
       setFatBreakdownAlgorithm: setFatBreakdownAlgorithmState,
@@ -1349,6 +1362,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       bmrAlgorithm,
       bodyFatAlgorithm,
       includeBmrInNetCalories,
+      useExternalBmr,
       showNetCarbs,
       aiAssistedConversions,
       fatBreakdownAlgorithm,

--- a/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
+++ b/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
@@ -165,7 +165,8 @@ export const useMostRecentBmrQuery = (enabled = true) => {
 
 export const useCalculatedBMR = () => {
   const { user } = useAuth();
-  const { bmrAlgorithm, includeBmrInNetCalories, timezone } = usePreferences();
+  const { bmrAlgorithm, includeBmrInNetCalories, useExternalBmr, timezone } =
+    usePreferences();
 
   const { data: userProfile } = useQuery({
     queryKey: userKeys.profile(user?.id ?? ''),
@@ -206,11 +207,12 @@ export const useCalculatedBMR = () => {
     }
   }
 
-  // A measured/synced BMR only overrides the formula when it is plausible for
-  // this person -- otherwise a bad reading (unit mismatch, a stale
-  // partial-day sync value, ...) silently tanks the displayed BMR and every
-  // TDEE/calorie-goal calculation that reads it.
-  if (isPlausibleMeasuredBmr(rawMeasured, formulaBmr)) {
+  // A measured/synced BMR only overrides the formula when the user has opted
+  // in (useExternalBmr) AND it is plausible for this person -- otherwise a
+  // bad reading (unit mismatch, a stale partial-day sync value, ...) silently
+  // tanks the displayed BMR and every TDEE/calorie-goal calculation that
+  // reads it.
+  if (useExternalBmr && isPlausibleMeasuredBmr(rawMeasured, formulaBmr)) {
     return {
       bmr: rawMeasured,
       measuredBmr: rawMeasured,

--- a/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
+++ b/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
 import { usePreferences } from '@/contexts/PreferencesContext';
-import { calculateAge } from '@workspace/shared';
+import { calculateAge, isPlausibleMeasuredBmr } from '@workspace/shared';
 import { dailyProgressKeys } from '@/api/keys/diary';
 import { userManagementService } from '@/api/Admin/userManagementService';
 import {
@@ -179,11 +179,38 @@ export const useCalculatedBMR = () => {
   const { data: bmrData } = useMostRecentBmrQuery();
 
   const rawMeasured = bmrData?.bmr ? Number(bmrData.bmr) : null;
-  const isMeasured = Boolean(
-    rawMeasured && rawMeasured >= 300 && rawMeasured <= 10000
+
+  const hasProfileForFormula = Boolean(
+    userProfile &&
+    weightData?.weight &&
+    heightData?.height &&
+    userProfile.gender
   );
 
-  if (isMeasured && rawMeasured !== null) {
+  let formulaBmr: number | null = null;
+  if (hasProfileForFormula) {
+    const age = userProfile!.date_of_birth
+      ? calculateAge(userProfile!.date_of_birth, timezone)
+      : 0;
+    try {
+      formulaBmr = calculateBmr(
+        bmrAlgorithm as BmrAlgorithm,
+        weightData!.weight,
+        heightData!.height,
+        age,
+        userProfile!.gender as 'male' | 'female',
+        bodyFatData?.body_fat_percentage
+      );
+    } catch (err) {
+      formulaBmr = null;
+    }
+  }
+
+  // A measured/synced BMR only overrides the formula when it is plausible for
+  // this person -- otherwise a bad reading (unit mismatch, a stale
+  // partial-day sync value, ...) silently tanks the displayed BMR and every
+  // TDEE/calorie-goal calculation that reads it.
+  if (isPlausibleMeasuredBmr(rawMeasured, formulaBmr)) {
     return {
       bmr: rawMeasured,
       measuredBmr: rawMeasured,
@@ -193,37 +220,15 @@ export const useCalculatedBMR = () => {
     };
   }
 
-  if (
-    !userProfile ||
-    !weightData?.weight ||
-    !heightData?.height ||
-    !userProfile.gender
-  ) {
+  if (!hasProfileForFormula || formulaBmr === null) {
     return { bmr: 0, includeInNet: false };
   }
 
-  const age = userProfile.date_of_birth
-    ? calculateAge(userProfile.date_of_birth, timezone)
-    : 0;
-
-  try {
-    const bmr = calculateBmr(
-      bmrAlgorithm as BmrAlgorithm,
-      weightData.weight,
-      heightData.height,
-      age,
-      userProfile.gender as 'male' | 'female',
-      bodyFatData?.body_fat_percentage
-    );
-
-    return {
-      bmr,
-      measuredBmr: null,
-      includeInNet: includeBmrInNetCalories || false,
-      weight: weightData.weight,
-      height: heightData.height,
-    };
-  } catch (err) {
-    return { bmr: 0, includeInNet: false, weight: 0, height: 0 };
-  }
+  return {
+    bmr: formulaBmr,
+    measuredBmr: null,
+    includeInNet: includeBmrInNetCalories || false,
+    weight: weightData!.weight,
+    height: heightData!.height,
+  };
 };

--- a/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
@@ -113,6 +113,7 @@ const CalculationSettings = () => {
     bmrAlgorithm: contextBmrAlgorithm,
     bodyFatAlgorithm: contextBodyFatAlgorithm,
     includeBmrInNetCalories: contextIncludeBmrInNetCalories,
+    useExternalBmr: contextUseExternalBmr,
     showNetCarbs: contextShowNetCarbs,
     fatBreakdownAlgorithm: contextFatBreakdownAlgorithm,
     mineralCalculationAlgorithm: contextMineralCalculationAlgorithm,
@@ -193,6 +194,9 @@ const CalculationSettings = () => {
   const [includeBmrInNetCalories, setIncludeBmrInNetCalories] = useState(
     contextIncludeBmrInNetCalories || false
   );
+  const [useExternalBmr, setUseExternalBmr] = useState(
+    contextUseExternalBmr || false
+  );
   const [showNetCarbs, setShowNetCarbs] = useState(
     contextShowNetCarbs || false
   );
@@ -232,6 +236,9 @@ const CalculationSettings = () => {
     }
     if (contextIncludeBmrInNetCalories !== undefined) {
       setIncludeBmrInNetCalories(contextIncludeBmrInNetCalories);
+    }
+    if (contextUseExternalBmr !== undefined) {
+      setUseExternalBmr(contextUseExternalBmr);
     }
     if (contextShowNetCarbs !== undefined) {
       setShowNetCarbs(contextShowNetCarbs);
@@ -296,6 +303,7 @@ const CalculationSettings = () => {
     contextBmrAlgorithm,
     contextBodyFatAlgorithm,
     contextIncludeBmrInNetCalories,
+    contextUseExternalBmr,
     contextShowNetCarbs,
     contextFatBreakdownAlgorithm,
     contextMineralCalculationAlgorithm,
@@ -322,6 +330,7 @@ const CalculationSettings = () => {
         bmrAlgorithm,
         bodyFatAlgorithm,
         includeBmrInNetCalories,
+        useExternalBmr,
         showNetCarbs,
         energyUnit, // Ensure energyUnit is included in saving
         fatBreakdownAlgorithm: fatBreakdownAlgorithm,
@@ -755,6 +764,31 @@ const CalculationSettings = () => {
             {t(
               'calculationSettings.includeBmrInNetCaloriesHint',
               'When enabled, your BMR will be subtracted from your daily net calorie total.'
+            )}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="use-external-bmr"
+          checked={useExternalBmr}
+          onCheckedChange={(checked) => setUseExternalBmr(Boolean(checked))}
+        />
+        <div className="grid gap-1.5 leading-none">
+          <Label
+            htmlFor="use-external-bmr"
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+          >
+            {t(
+              'calculationSettings.useExternalBmr',
+              'Use measured/synced BMR when available'
+            )}
+          </Label>
+          <p className="text-sm text-muted-foreground">
+            {t(
+              'calculationSettings.useExternalBmrHint',
+              'When enabled, a BMR entered on a check-in or synced from a smart scale or health provider can override the calculated formula for that day. Off by default -- your calculated BMR is always used until you opt in.'
             )}
           </p>
         </div>

--- a/SparkyFitnessFrontend/src/tests/hooks/useCalculatedBMR.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useCalculatedBMR.test.tsx
@@ -27,6 +27,7 @@ describe('useCalculatedBMR', () => {
     mockUsePreferences.mockReturnValue({
       bmrAlgorithm: 'Mifflin-St Jeor',
       includeBmrInNetCalories: false,
+      useExternalBmr: true,
       timezone: 'UTC',
     });
     mockQueryData = {};
@@ -52,6 +53,35 @@ describe('useCalculatedBMR', () => {
     expect(result.current.bmr).toBe(1750);
     expect(result.current.measuredBmr).toBe(1750);
     expect(result.current.includeInNet).toBe(false);
+  });
+
+  it('ignores measured BMR when useExternalBmr is off (issue #2395)', () => {
+    mockUsePreferences.mockReturnValue({
+      bmrAlgorithm: 'Mifflin-St Jeor',
+      includeBmrInNetCalories: false,
+      useExternalBmr: false,
+      timezone: 'UTC',
+    });
+    mockQueryData[JSON.stringify(['users', 'profile', 'user-1'])] = {
+      gender: 'male',
+      date_of_birth: '1990-01-01',
+    };
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'weight'])
+    ] = { weight: 75 };
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'height'])
+    ] = { height: 180 };
+    // Plausible relative to this person's formula estimate, but not opted in.
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'bmr'])
+    ] = { bmr: 1750 };
+
+    const { result } = renderHook(() => useCalculatedBMR());
+
+    expect(result.current.measuredBmr).toBeNull();
+    expect(result.current.bmr).toBeGreaterThan(1000);
+    expect(result.current.bmr).not.toBe(1750);
   });
 
   it('falls back to formula BMR when no valid measured BMR is present', () => {

--- a/SparkyFitnessFrontend/src/tests/utils/calorieCalculations.test.ts
+++ b/SparkyFitnessFrontend/src/tests/utils/calorieCalculations.test.ts
@@ -10,6 +10,8 @@ import {
   normalizeCalorieGoalAdjustmentMode,
   shouldShowCalorieSafetyWarning,
   isAdaptiveTdeeMature,
+  isPlausibleMeasuredBmr,
+  calculateMinimumMetabolism,
   ADAPTIVE_TDEE_GOAL_MIN_DAYS,
   convertEnergyValue,
 } from '@workspace/shared';
@@ -761,6 +763,136 @@ describe('isAdaptiveTdeeMature', () => {
     expect(immature.baselineTdee).toBe(1920);
     expect(mature.insufficientHistory).toBe(false);
     expect(mature.baselineTdee).toBe(1420);
+  });
+});
+
+describe('isPlausibleMeasuredBmr', () => {
+  // GitHub issue #2395: a stale/carried-forward measured BMR of ~350 replaced
+  // a real ~1800 kcal formula estimate, collapsing the calorie target once
+  // Adaptive TDEE + a goal-mode deficit were both in play.
+  it('rejects a value far below the formula estimate even though it clears the absolute range', () => {
+    expect(isPlausibleMeasuredBmr(350, 1800)).toBe(false);
+  });
+
+  it('rejects a value far above the formula estimate', () => {
+    expect(isPlausibleMeasuredBmr(4500, 1800)).toBe(false);
+  });
+
+  it('accepts a measured value within a plausible band of the formula estimate', () => {
+    expect(isPlausibleMeasuredBmr(1650, 1800)).toBe(true);
+    expect(isPlausibleMeasuredBmr(1080, 1800)).toBe(true); // 0.6x boundary
+    expect(isPlausibleMeasuredBmr(2880, 1800)).toBe(true); // 1.6x boundary
+  });
+
+  it('rejects a value just outside the plausible band', () => {
+    expect(isPlausibleMeasuredBmr(1079, 1800)).toBe(false);
+    expect(isPlausibleMeasuredBmr(2881, 1800)).toBe(false);
+  });
+
+  it('rejects a value outside the absolute physiological range regardless of the formula estimate', () => {
+    expect(isPlausibleMeasuredBmr(299, 1800)).toBe(false);
+    expect(isPlausibleMeasuredBmr(10001, 1800)).toBe(false);
+  });
+
+  it('rejects nullish or non-finite input', () => {
+    expect(isPlausibleMeasuredBmr(null, 1800)).toBe(false);
+    expect(isPlausibleMeasuredBmr(undefined, 1800)).toBe(false);
+    expect(isPlausibleMeasuredBmr(NaN, 1800)).toBe(false);
+  });
+
+  it('falls back to the absolute range alone when there is no formula estimate to compare against', () => {
+    expect(isPlausibleMeasuredBmr(350, null)).toBe(true);
+    expect(isPlausibleMeasuredBmr(350, 0)).toBe(true);
+    expect(isPlausibleMeasuredBmr(350, undefined)).toBe(true);
+  });
+});
+
+describe('calculateMinimumMetabolism', () => {
+  const person = {
+    weightKg: 80,
+    heightCm: 180,
+    age: 30,
+    gender: 'male' as const,
+  };
+
+  it('ignores an implausible measured BMR and uses the formula estimate', () => {
+    const withoutMeasured = calculateMinimumMetabolism(
+      person.weightKg,
+      person.heightCm,
+      person.age,
+      person.gender
+    );
+
+    const withImplausibleMeasured = calculateMinimumMetabolism(
+      person.weightKg,
+      person.heightCm,
+      person.age,
+      person.gender,
+      undefined,
+      'Mifflin-St Jeor',
+      undefined,
+      350
+    );
+
+    expect(withImplausibleMeasured).toBe(withoutMeasured);
+    expect(withImplausibleMeasured).toBeGreaterThan(1500);
+  });
+
+  it('uses a plausible measured BMR over the formula estimate', () => {
+    const result = calculateMinimumMetabolism(
+      person.weightKg,
+      person.heightCm,
+      person.age,
+      person.gender,
+      undefined,
+      'Mifflin-St Jeor',
+      undefined,
+      1650
+    );
+
+    expect(result).toBe(1650);
+  });
+});
+
+describe('computeCalorieTarget ignores an implausible measured BMR (issue #2395)', () => {
+  // Body Recomposition (10% deficit) baselined on the formula-calculated TDEE
+  // (2200) rather than being wrecked by a stray ~350 kcal measured reading.
+  it('does not collapse the target when the measured BMR is wildly off', () => {
+    const withoutMeasured = computeCalorieTarget({
+      goalMode: 'recomp',
+      calculationMethod: 'manual',
+      customPercentage: 0,
+      bmr: 1800,
+      activityLevelMultiplier: 1.2,
+      adaptiveTdee: null,
+      adaptiveTdeeFallback: true,
+      adaptiveTdeeDaysOfData: 0,
+      weightKg: 80,
+      heightCm: 180,
+      age: 30,
+      gender: 'male',
+      currentGoalCalories: 2160,
+    });
+
+    const withImplausibleMeasured = computeCalorieTarget({
+      goalMode: 'recomp',
+      calculationMethod: 'manual',
+      customPercentage: 0,
+      bmr: 1800,
+      activityLevelMultiplier: 1.2,
+      adaptiveTdee: null,
+      adaptiveTdeeFallback: true,
+      adaptiveTdeeDaysOfData: 0,
+      weightKg: 80,
+      heightCm: 180,
+      age: 30,
+      gender: 'male',
+      currentGoalCalories: 2160,
+      measuredBmr: 350,
+    });
+
+    expect(withImplausibleMeasured.rmr).toBe(withoutMeasured.rmr);
+    expect(withImplausibleMeasured.finalTarget).toBeGreaterThan(1000);
   });
 });
 

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -22,6 +22,7 @@ interface UserProfile {
 interface UserPreferences {
   bmr_algorithm?: string | null;
   activity_level?: string | null;
+  use_external_bmr?: boolean | null;
 }
 
 interface LatestMeasurement {
@@ -123,13 +124,16 @@ function computeAdaptiveTdeeFromData(
         : undefined
     ) ||
     10 * weightKg + 6.25 * heightCm - 5 * age + (gender === 'male' ? 5 : -161);
-  // A measured/synced BMR only overrides the formula when it is plausible for
-  // this person; otherwise a bad reading (unit mismatch, a partial-day sample
-  // carried forward from an old sync, ...) would silently tank every TDEE and
+  // A measured/synced BMR only overrides the formula when the user has
+  // opted in (use_external_bmr) AND it is plausible for this person;
+  // otherwise a bad reading (unit mismatch, a partial-day sample carried
+  // forward from an old sync, ...) would silently tank every TDEE and
   // calorie-goal calculation that reads it. See isPlausibleMeasuredBmr.
-  const baseBmr = isPlausibleMeasuredBmr(measuredBmr, formulaBmr)
-    ? measuredBmr
-    : formulaBmr;
+  const baseBmr =
+    preferences?.use_external_bmr &&
+    isPlausibleMeasuredBmr(measuredBmr, formulaBmr)
+      ? measuredBmr
+      : formulaBmr;
 
   const fallbackTdee = baseBmr * multiplier;
 

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -11,6 +11,7 @@ import {
   todayInZone,
   dayToPickerDate,
   ENERGY_DENSITY_KCAL_PER_KG,
+  isPlausibleMeasuredBmr,
 } from '@workspace/shared';
 const tdeeCache = new NodeCache({ stdTTL: 3600 }); // 1 hour cache
 interface UserProfile {
@@ -110,23 +111,25 @@ function computeAdaptiveTdeeFromData(
   const measuredBmr = latestMeasurement?.bmr
     ? parseFloat(String(latestMeasurement.bmr))
     : null;
-  const baseBmr =
-    measuredBmr && measuredBmr >= 300 && measuredBmr <= 10000
-      ? measuredBmr
-      : bmrService.calculateBmr(
-          bmrAlgorithm,
-          weightKg,
-          heightCm,
-          age,
-          gender as 'male' | 'female',
-          latestMeasurement?.body_fat_percentage
-            ? parseFloat(String(latestMeasurement.body_fat_percentage))
-            : undefined
-        ) ||
-        10 * weightKg +
-          6.25 * heightCm -
-          5 * age +
-          (gender === 'male' ? 5 : -161);
+  const formulaBmr =
+    bmrService.calculateBmr(
+      bmrAlgorithm,
+      weightKg,
+      heightCm,
+      age,
+      gender as 'male' | 'female',
+      latestMeasurement?.body_fat_percentage
+        ? parseFloat(String(latestMeasurement.body_fat_percentage))
+        : undefined
+    ) ||
+    10 * weightKg + 6.25 * heightCm - 5 * age + (gender === 'male' ? 5 : -161);
+  // A measured/synced BMR only overrides the formula when it is plausible for
+  // this person; otherwise a bad reading (unit mismatch, a partial-day sample
+  // carried forward from an old sync, ...) would silently tank every TDEE and
+  // calorie-goal calculation that reads it. See isPlausibleMeasuredBmr.
+  const baseBmr = isPlausibleMeasuredBmr(measuredBmr, formulaBmr)
+    ? measuredBmr
+    : formulaBmr;
 
   const fallbackTdee = baseBmr * multiplier;
 

--- a/SparkyFitnessServer/services/calorieBalanceService.ts
+++ b/SparkyFitnessServer/services/calorieBalanceService.ts
@@ -280,15 +280,19 @@ export function computeCalorieBalance({
 
   // 1b. Measured BMR override — when a measured BMR is recorded on the day
   // (from a smart scale, health provider sync, or manual check-in entry),
-  // prefer it over the formula, but only when it is plausible for this person
-  // (see isPlausibleMeasuredBmr) — otherwise a bad reading silently tanks the
+  // prefer it over the formula, but only when the user has opted in
+  // (use_external_bmr) AND it is plausible for this person (see
+  // isPlausibleMeasuredBmr) — otherwise a bad reading silently tanks the
   // day's calorie balance.
   let bmrSource: 'formula' | 'measured' = 'formula';
   const checkInBmr = measurements?.bmr
     ? parseFloat(String(measurements.bmr))
     : null;
 
-  if (isPlausibleMeasuredBmr(checkInBmr, bmr)) {
+  if (
+    userPreferences?.use_external_bmr &&
+    isPlausibleMeasuredBmr(checkInBmr, bmr)
+  ) {
     bmr = checkInBmr;
     bmrSource = 'measured';
   }

--- a/SparkyFitnessServer/services/calorieBalanceService.ts
+++ b/SparkyFitnessServer/services/calorieBalanceService.ts
@@ -16,6 +16,7 @@ import {
   computeCalorieProgress,
   getGoalModeAdjustment,
   getRecommendedCalorieSafetyFloor,
+  isPlausibleMeasuredBmr,
   MAX_HEALTH_TOTAL_CALORIES_PER_DAY,
   MIN_CALORIE_SAFETY_FLOOR,
   resolveCalorieSafetyFloor,
@@ -279,21 +280,16 @@ export function computeCalorieBalance({
 
   // 1b. Measured BMR override — when a measured BMR is recorded on the day
   // (from a smart scale, health provider sync, or manual check-in entry),
-  // prefer it over the formula. Sanity-bounded between 300 and 10000 kcal.
+  // prefer it over the formula, but only when it is plausible for this person
+  // (see isPlausibleMeasuredBmr) — otherwise a bad reading silently tanks the
+  // day's calorie balance.
   let bmrSource: 'formula' | 'measured' = 'formula';
   const checkInBmr = measurements?.bmr
     ? parseFloat(String(measurements.bmr))
     : null;
-  const validCheckInBmr =
-    checkInBmr !== null &&
-    Number.isFinite(checkInBmr) &&
-    checkInBmr >= 300 &&
-    checkInBmr <= 10000
-      ? checkInBmr
-      : null;
 
-  if (validCheckInBmr !== null) {
-    bmr = validCheckInBmr;
+  if (isPlausibleMeasuredBmr(checkInBmr, bmr)) {
+    bmr = checkInBmr;
     bmrSource = 'measured';
   }
 

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -17,6 +17,7 @@ import {
   CALORIE_CALCULATION_CONSTANTS,
   computeCalorieTarget,
   isAdaptiveTdeeMature,
+  isPlausibleMeasuredBmr,
   resolveCalorieSafetyFloor,
   DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
   ACTIVITY_MULTIPLIERS,
@@ -223,13 +224,11 @@ async function getUserGoalsForRange(
       const measuredBmr = getMeasurementFieldForDate(dateStr, 'bmr');
 
       let bmr = 0;
-      if (measuredBmr && measuredBmr >= 300 && measuredBmr <= 10000) {
-        bmr = measuredBmr;
-      } else if (userProfile && userPreferences) {
+      if (userProfile && userPreferences) {
         const tz = userPreferences.timezone || 'UTC';
         const age = userAge(userProfile.date_of_birth ?? '', tz) ?? 30;
         try {
-          bmr = bmrService.calculateBmr(
+          const formulaBmr = bmrService.calculateBmr(
             bmrAlgorithm,
             weightKg,
             heightCm,
@@ -237,12 +236,21 @@ async function getUserGoalsForRange(
             gender,
             bodyFat
           );
+          // A measured/carried-forward BMR only overrides the formula when it
+          // is plausible for this person -- otherwise a bad reading (unit
+          // mismatch, a stale partial-day sync value, ...) silently tanks
+          // every downstream TDEE and calorie-goal calculation.
+          bmr = isPlausibleMeasuredBmr(measuredBmr, formulaBmr)
+            ? measuredBmr
+            : formulaBmr;
         } catch (err) {
           log(
             'warn',
             `goalService: BMR calc failed for ${userId} on ${dateStr}: ${(err as Error).message}`
           );
         }
+      } else if (isPlausibleMeasuredBmr(measuredBmr)) {
+        bmr = measuredBmr;
       }
 
       // Mirror DashboardService exactly: use user's actual activity multiplier, not hardcoded
@@ -339,10 +347,9 @@ async function getUserGoalsForRange(
           calorieSafetyFloorValue:
             userPreferences?.calorie_safety_floor_value ||
             DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
-          measuredBmr:
-            measuredBmr && measuredBmr >= 300 && measuredBmr <= 10000
-              ? measuredBmr
-              : undefined,
+          // computeCalorieTarget validates this against its own formula
+          // estimate (isPlausibleMeasuredBmr) before trusting it.
+          measuredBmr,
         });
         goalCalories = targetResult.finalTarget;
       }

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -236,20 +236,26 @@ async function getUserGoalsForRange(
             gender,
             bodyFat
           );
-          // A measured/carried-forward BMR only overrides the formula when it
-          // is plausible for this person -- otherwise a bad reading (unit
-          // mismatch, a stale partial-day sync value, ...) silently tanks
-          // every downstream TDEE and calorie-goal calculation.
-          bmr = isPlausibleMeasuredBmr(measuredBmr, formulaBmr)
-            ? measuredBmr
-            : formulaBmr;
+          // A measured/carried-forward BMR only overrides the formula when
+          // the user has opted in (use_external_bmr) AND it is plausible for
+          // this person -- otherwise a bad reading (unit mismatch, a stale
+          // partial-day sync value, ...) silently tanks every downstream
+          // TDEE and calorie-goal calculation.
+          bmr =
+            userPreferences.use_external_bmr &&
+            isPlausibleMeasuredBmr(measuredBmr, formulaBmr)
+              ? measuredBmr
+              : formulaBmr;
         } catch (err) {
           log(
             'warn',
             `goalService: BMR calc failed for ${userId} on ${dateStr}: ${(err as Error).message}`
           );
         }
-      } else if (isPlausibleMeasuredBmr(measuredBmr)) {
+      } else if (
+        userPreferences?.use_external_bmr &&
+        isPlausibleMeasuredBmr(measuredBmr)
+      ) {
         bmr = measuredBmr;
       }
 
@@ -348,8 +354,12 @@ async function getUserGoalsForRange(
             userPreferences?.calorie_safety_floor_value ||
             DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
           // computeCalorieTarget validates this against its own formula
-          // estimate (isPlausibleMeasuredBmr) before trusting it.
-          measuredBmr,
+          // estimate (isPlausibleMeasuredBmr) before trusting it; also
+          // respect the same opt-in as the bmr resolution above so the
+          // safety floor doesn't silently use a source the user disabled.
+          measuredBmr: userPreferences?.use_external_bmr
+            ? measuredBmr
+            : undefined,
         });
         goalCalories = targetResult.finalTarget;
       }

--- a/SparkyFitnessServer/services/reportService.ts
+++ b/SparkyFitnessServer/services/reportService.ts
@@ -312,6 +312,7 @@ async function getReportsData(
           latestMeasurement?.bmr !== undefined
             ? Number(latestMeasurement.bmr)
             : undefined;
+        const useExternalBmr = Boolean(userPreferences?.use_external_bmr);
         if (weight && height && age && gender && bmrAlgorithm) {
           try {
             const formulaBmr = bmrService.calculateBmr(
@@ -323,10 +324,12 @@ async function getReportsData(
               bodyFat
             );
             // A measured/carried-forward BMR only overrides the formula when
-            // it is plausible for this person -- see isPlausibleMeasuredBmr.
-            day.bmr = isPlausibleMeasuredBmr(measuredBmr, formulaBmr)
-              ? measuredBmr
-              : formulaBmr;
+            // the user has opted in (use_external_bmr) AND it is plausible
+            // for this person -- see isPlausibleMeasuredBmr.
+            day.bmr =
+              useExternalBmr && isPlausibleMeasuredBmr(measuredBmr, formulaBmr)
+                ? measuredBmr
+                : formulaBmr;
           } catch (error) {
             log(
               'warn',
@@ -335,7 +338,7 @@ async function getReportsData(
             );
             day.bmr = null;
           }
-        } else if (isPlausibleMeasuredBmr(measuredBmr)) {
+        } else if (useExternalBmr && isPlausibleMeasuredBmr(measuredBmr)) {
           day.bmr = measuredBmr;
         } else {
           day.bmr = null;

--- a/SparkyFitnessServer/services/reportService.ts
+++ b/SparkyFitnessServer/services/reportService.ts
@@ -16,6 +16,7 @@ import {
   addDays,
   compareDays,
   FOOD_VARIANT_NUTRIENT_FIELDS,
+  isPlausibleMeasuredBmr,
   todayInZone,
 } from '@workspace/shared';
 import { userAge } from '../utils/dateHelpers.js';
@@ -311,11 +312,9 @@ async function getReportsData(
           latestMeasurement?.bmr !== undefined
             ? Number(latestMeasurement.bmr)
             : undefined;
-        if (measuredBmr && measuredBmr >= 300 && measuredBmr <= 10000) {
-          day.bmr = measuredBmr;
-        } else if (weight && height && age && gender && bmrAlgorithm) {
+        if (weight && height && age && gender && bmrAlgorithm) {
           try {
-            day.bmr = bmrService.calculateBmr(
+            const formulaBmr = bmrService.calculateBmr(
               bmrAlgorithm,
               weight,
               height,
@@ -323,6 +322,11 @@ async function getReportsData(
               gender,
               bodyFat
             );
+            // A measured/carried-forward BMR only overrides the formula when
+            // it is plausible for this person -- see isPlausibleMeasuredBmr.
+            day.bmr = isPlausibleMeasuredBmr(measuredBmr, formulaBmr)
+              ? measuredBmr
+              : formulaBmr;
           } catch (error) {
             log(
               'warn',
@@ -331,6 +335,8 @@ async function getReportsData(
             );
             day.bmr = null;
           }
+        } else if (isPlausibleMeasuredBmr(measuredBmr)) {
+          day.bmr = measuredBmr;
         } else {
           day.bmr = null;
         }

--- a/SparkyFitnessServer/tests/adaptiveTdeeService.test.ts
+++ b/SparkyFitnessServer/tests/adaptiveTdeeService.test.ts
@@ -427,4 +427,34 @@ describe('AdaptiveTdeeService', () => {
     // 2000 kcal intake + (~0.88 kg smoothed weight loss * 6000) / 28 = ~2190 kcal
     expect(result.tdee).toBe(2190);
   });
+
+  test('ignores an implausible measured BMR carried on the latest measurement (issue #2395)', () => {
+    // @ts-expect-error
+    bmrService.calculateBmr.mockReturnValue(1800);
+    bmrService.ActivityMultiplier = { moderate: 1.55 };
+
+    const data = {
+      profile: { date_of_birth: '1990-01-01', gender: 'male' },
+      preferences: {
+        bmr_algorithm: 'Mifflin-St Jeor',
+        activity_level: 'moderate',
+      },
+      // A stray/carried-forward measured BMR of 350 kcal (e.g. a corrupted
+      // sync value) must not replace the ~1800 kcal formula estimate just
+      // because it clears the absolute 300-10000 sanity bound.
+      latestMeasurement: { weight: 80, height: 180, bmr: 350 },
+      // A single weight entry is not enough history, so this takes the
+      // fallback path and returns fallbackTdee = baseBmr * activityMultiplier
+      // directly -- the clearest place to see which BMR won.
+      checkInMeasurements: [{ entry_date: calculationDateStr, weight: 80 }],
+      nutritionData: [],
+    };
+
+    const result = computeAdaptiveTdeeFromData(data, calculationDateStr);
+
+    expect(result.isFallback).toBe(true);
+    // 1800 * 1.55 = 2790, nowhere near the 350 * 1.55 = 542.5 a blindly
+    // trusted measured BMR would have produced.
+    expect(result.tdee).toBe(2790);
+  });
 });

--- a/SparkyFitnessServer/tests/adaptiveTdeeService.test.ts
+++ b/SparkyFitnessServer/tests/adaptiveTdeeService.test.ts
@@ -438,6 +438,9 @@ describe('AdaptiveTdeeService', () => {
       preferences: {
         bmr_algorithm: 'Mifflin-St Jeor',
         activity_level: 'moderate',
+        // Opted in -- this test exercises the plausibility guard itself,
+        // not the opt-in gate (see the dedicated opt-in test below).
+        use_external_bmr: true,
       },
       // A stray/carried-forward measured BMR of 350 kcal (e.g. a corrupted
       // sync value) must not replace the ~1800 kcal formula estimate just
@@ -455,6 +458,31 @@ describe('AdaptiveTdeeService', () => {
     expect(result.isFallback).toBe(true);
     // 1800 * 1.55 = 2790, nowhere near the 350 * 1.55 = 542.5 a blindly
     // trusted measured BMR would have produced.
+    expect(result.tdee).toBe(2790);
+  });
+
+  test('ignores an otherwise-plausible measured BMR when use_external_bmr is off', () => {
+    // @ts-expect-error
+    bmrService.calculateBmr.mockReturnValue(1800);
+    bmrService.ActivityMultiplier = { moderate: 1.55 };
+
+    const data = {
+      profile: { date_of_birth: '1990-01-01', gender: 'male' },
+      preferences: {
+        bmr_algorithm: 'Mifflin-St Jeor',
+        activity_level: 'moderate',
+        use_external_bmr: false,
+      },
+      // Plausible relative to the 1800 formula estimate, but not opted in.
+      latestMeasurement: { weight: 80, height: 180, bmr: 1750 },
+      checkInMeasurements: [{ entry_date: calculationDateStr, weight: 80 }],
+      nutritionData: [],
+    };
+
+    const result = computeAdaptiveTdeeFromData(data, calculationDateStr);
+
+    expect(result.isFallback).toBe(true);
+    // Same as the formula-only case: 1800 * 1.55 = 2790.
     expect(result.tdee).toBe(2790);
   });
 });

--- a/SparkyFitnessServer/tests/calorieBalanceService.test.ts
+++ b/SparkyFitnessServer/tests/calorieBalanceService.test.ts
@@ -546,17 +546,40 @@ describe('measured BMR override', () => {
     }
   );
 
-  test.each([300, 10000])('accepts the boundary value %s', (value) => {
-    const balance = computeCalorieBalance(
-      inputs({
-        measurements: { weight: 80, height: 180, bmr: value },
-        userPreferences: prefs,
-      })
-    );
+  test.each([300, 10000])(
+    'rejects an absolute-range-legal but implausible value like %s',
+    (value) => {
+      // Formula BMR is mocked to 2000, so 300/10000 sit far outside the
+      // plausible 1200-3200 band around it -- a bad reading (unit mismatch, a
+      // stale partial-day sync value, ...) must not silently override a
+      // sane formula estimate just because it clears the absolute 300-10000
+      // sanity bound.
+      const balance = computeCalorieBalance(
+        inputs({
+          measurements: { weight: 80, height: 180, bmr: value },
+          userPreferences: prefs,
+        })
+      );
 
-    expect(balance.bmr).toBe(value);
-    expect(balance.bmrSource).toBe('measured');
-  });
+      expect(balance.bmr).toBe(BMR);
+      expect(balance.bmrSource).toBe('formula');
+    }
+  );
+
+  test.each([1200, 3200])(
+    'accepts a measured value at the plausible boundary %s',
+    (value) => {
+      const balance = computeCalorieBalance(
+        inputs({
+          measurements: { weight: 80, height: 180, bmr: value },
+          userPreferences: prefs,
+        })
+      );
+
+      expect(balance.bmr).toBe(value);
+      expect(balance.bmrSource).toBe('measured');
+    }
+  );
 
   test('falls back to formula BMR when check-in BMR is absent', () => {
     const balance = computeCalorieBalance(

--- a/SparkyFitnessServer/tests/calorieBalanceService.test.ts
+++ b/SparkyFitnessServer/tests/calorieBalanceService.test.ts
@@ -515,7 +515,20 @@ describe('measured BMR override', () => {
     activity_level: 'not_much',
     calorie_goal_adjustment_mode: 'dynamic' as const,
     include_bmr_in_net_calories: true,
+    use_external_bmr: true,
   };
+
+  test('ignores a plausible check-in BMR when use_external_bmr is off (issue #2395)', () => {
+    const balance = computeCalorieBalance(
+      inputs({
+        measurements: { weight: 80, height: 180, bmr: 1850 },
+        userPreferences: { ...prefs, use_external_bmr: false },
+      })
+    );
+
+    expect(balance.bmr).toBe(BMR);
+    expect(balance.bmrSource).toBe('formula');
+  });
 
   test('prefers a check-in measured BMR over the formula calculation', () => {
     const balance = computeCalorieBalance(

--- a/SparkyFitnessServer/tests/dailySummaryService.test.ts
+++ b/SparkyFitnessServer/tests/dailySummaryService.test.ts
@@ -397,6 +397,16 @@ describe('dailySummaryService', () => {
   describe('external BMR override', () => {
     // Use dynamic mode so calorieBalance.bmr reflects the resolved BMR directly
     test('overrides formula BMR with the check-in measured value', async () => {
+      vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+        bmr_algorithm: 'Mifflin-St Jeor',
+        activity_level: 'not_much',
+        calorie_goal_adjustment_mode: 'tdee',
+        exercise_calorie_percentage: 100,
+        include_bmr_in_net_calories: false,
+        tdee_allow_negative_adjustment: false,
+        timezone: 'UTC',
+        use_external_bmr: true,
+      });
       vi.mocked(
         measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
       ).mockResolvedValue({ weight: 80, height: 180, bmr: 1500 } as never);

--- a/SparkyFitnessServer/tests/dashboardService.test.ts
+++ b/SparkyFitnessServer/tests/dashboardService.test.ts
@@ -155,6 +155,10 @@ describe('getDashboardStats includeCheckin gate', () => {
   });
 
   test('includeCheckin=true applies check-in measured BMR when present', async () => {
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      ...basePreferences,
+      use_external_bmr: true,
+    });
     vi.mocked(
       measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
     ).mockResolvedValue({ weight: 80, height: 180, bmr: 1950 } as never);

--- a/SparkyFitnessServer/tests/goalServiceMeasuredBmrPlausibility.test.ts
+++ b/SparkyFitnessServer/tests/goalServiceMeasuredBmrPlausibility.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import goalService from '../services/goalService.js';
+import goalRepository from '../models/goalRepository.js';
+import weeklyGoalPlanRepository from '../models/weeklyGoalPlanRepository.js';
+import preferenceRepository from '../models/preferenceRepository.js';
+import userRepository from '../models/userRepository.js';
+import measurementRepository from '../models/measurementRepository.js';
+import bmrService from '../services/bmrService.js';
+import adaptiveTdeeService from '../services/AdaptiveTdeeService.js';
+
+vi.mock('../models/goalRepository.js');
+vi.mock('../models/weeklyGoalPlanRepository.js');
+vi.mock('../models/goalPresetRepository.js');
+vi.mock('../models/userRepository.js');
+vi.mock('../models/preferenceRepository.js');
+vi.mock('../models/measurementRepository.js');
+vi.mock('../models/exerciseEntry.js');
+vi.mock('../services/bmrService.js');
+vi.mock('../services/AdaptiveTdeeService.js');
+
+const userId = 'user-1';
+const date = '2026-08-21';
+
+// Formula BMR the mocked bmrService always hands back for this person.
+const FORMULA_BMR = 1800;
+// A stray/carried-forward measured BMR (unit mismatch, a partial-day sync
+// value, ...) that clears the absolute 300-10000 sanity bound but is
+// nowhere near this person's own formula estimate. GitHub issue #2395:
+// enabling Adaptive TDEE + Body Recomposition on top of a value like this
+// collapsed the daily calorie target from ~1800 to ~350.
+const IMPLAUSIBLE_MEASURED_BMR = 350;
+
+/**
+ * Reproduces GitHub issue #2395: a measured BMR carried on the check-in
+ * history must not silently replace a sane formula estimate just because it
+ * clears the absolute range, especially once a goal-mode deficit (here,
+ * Body Recomposition's 10%) is layered on top of it.
+ */
+describe('goalService ignores an implausible measured BMR (issue #2395)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(
+      weeklyGoalPlanRepository.getActiveWeeklyGoalPlan
+    ).mockResolvedValue(null);
+    vi.mocked(goalRepository.getGoalsInRange).mockResolvedValue([]);
+    vi.mocked(goalRepository.getMostRecentGoalBeforeDate).mockResolvedValue({
+      calories: 2000,
+      protein_percentage: null,
+      carbs_percentage: null,
+      fat_percentage: null,
+    });
+    vi.mocked(userRepository.getUserProfile).mockResolvedValue({
+      date_of_birth: '1990-01-01',
+      gender: 'male',
+    });
+    vi.mocked(
+      measurementRepository.getCheckInMeasurementsByDateRange
+    ).mockResolvedValue([]);
+    vi.mocked(bmrService.calculateBmr).mockReturnValue(FORMULA_BMR);
+    // No adaptive TDEE history yet -- computeCalorieTarget falls back to
+    // bmr * activityMultiplier as the baseline, which is exactly the path
+    // that used to be corrupted by an implausible measured BMR.
+    vi.mocked(adaptiveTdeeService.calculateAdaptiveTdeeRange).mockResolvedValue(
+      {}
+    );
+    vi.mocked(adaptiveTdeeService.calculateAdaptiveTdee).mockRejectedValue(
+      new Error('insufficient history')
+    );
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      calorie_goal_adjustment_mode: 'dynamic',
+      goal_mode: 'recomp',
+      goal_mode_calculation_method: 'adaptive',
+      goal_mode_custom_percentage: 0,
+      activity_level: 'not_much',
+      bmr_algorithm: 'Mifflin-St Jeor',
+      calorie_safety_floor_mode: 'standard',
+      calorie_safety_floor_value: 1200,
+      timezone: 'Europe/Berlin',
+    });
+  });
+
+  const caloriesForDate = async () => {
+    const result = await goalService.getUserGoalsForRange(
+      userId,
+      date,
+      date,
+      true
+    );
+    return (result[date] as { calories: number }).calories;
+  };
+
+  it('bases Body Recomposition on the formula BMR when the measured value is implausible', async () => {
+    vi.mocked(
+      measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
+    ).mockResolvedValue({
+      entry_date: date,
+      weight: 80,
+      height: 180,
+      bmr: IMPLAUSIBLE_MEASURED_BMR,
+    });
+
+    // 1800 * 1.2 (not_much) = 2160 baseline TDEE, recomp = -10% = 1944.
+    expect(await caloriesForDate()).toBe(1944);
+  });
+
+  it('uses a plausible measured BMR over the formula estimate', async () => {
+    vi.mocked(
+      measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
+    ).mockResolvedValue({
+      entry_date: date,
+      weight: 80,
+      height: 180,
+      bmr: 1700, // within the plausible band around the 1800 formula estimate
+    });
+
+    // 1700 * 1.2 = 2040 baseline TDEE, recomp = -10% = 1836.
+    expect(await caloriesForDate()).toBe(1836);
+  });
+});

--- a/SparkyFitnessServer/tests/goalServiceMeasuredBmrPlausibility.test.ts
+++ b/SparkyFitnessServer/tests/goalServiceMeasuredBmrPlausibility.test.ts
@@ -34,7 +34,9 @@ const IMPLAUSIBLE_MEASURED_BMR = 350;
  * Reproduces GitHub issue #2395: a measured BMR carried on the check-in
  * history must not silently replace a sane formula estimate just because it
  * clears the absolute range, especially once a goal-mode deficit (here,
- * Body Recomposition's 10%) is layered on top of it.
+ * Body Recomposition's 10%) is layered on top of it. Two independent guards
+ * cover this: the user must opt in via use_external_bmr, and even then the
+ * value must be plausible for their own formula estimate.
  */
 describe('goalService ignores an implausible measured BMR (issue #2395)', () => {
   beforeEach(() => {
@@ -76,6 +78,9 @@ describe('goalService ignores an implausible measured BMR (issue #2395)', () => 
       calorie_safety_floor_mode: 'standard',
       calorie_safety_floor_value: 1200,
       timezone: 'Europe/Berlin',
+      // Opted in: these tests exercise the plausibility guard itself, not
+      // the opt-in gate (see the dedicated opt-in test below).
+      use_external_bmr: true,
     });
   });
 
@@ -115,5 +120,31 @@ describe('goalService ignores an implausible measured BMR (issue #2395)', () => 
 
     // 1700 * 1.2 = 2040 baseline TDEE, recomp = -10% = 1836.
     expect(await caloriesForDate()).toBe(1836);
+  });
+
+  it('ignores an otherwise-plausible measured BMR when use_external_bmr is off', async () => {
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      calorie_goal_adjustment_mode: 'dynamic',
+      goal_mode: 'recomp',
+      goal_mode_calculation_method: 'adaptive',
+      goal_mode_custom_percentage: 0,
+      activity_level: 'not_much',
+      bmr_algorithm: 'Mifflin-St Jeor',
+      calorie_safety_floor_mode: 'standard',
+      calorie_safety_floor_value: 1200,
+      timezone: 'Europe/Berlin',
+      use_external_bmr: false,
+    });
+    vi.mocked(
+      measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
+    ).mockResolvedValue({
+      entry_date: date,
+      weight: 80,
+      height: 180,
+      bmr: 1700, // plausible, but the user has not opted in to using it
+    });
+
+    // Same as the formula-only case: 1800 * 1.2 = 2160, recomp = -10% = 1944.
+    expect(await caloriesForDate()).toBe(1944);
   });
 });

--- a/shared/src/constants/calorieConstants.ts
+++ b/shared/src/constants/calorieConstants.ts
@@ -77,6 +77,26 @@ export const DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR = 1200;
  */
 export const MAX_HEALTH_TOTAL_CALORIES_PER_DAY = 20_000;
 
+/**
+ * Absolute plausibility bounds for a measured/synced BMR value (smart scale,
+ * wearable, or a value carried forward from a previous sync). Matches the
+ * `check_in_measurements.bmr` column's CHECK constraint.
+ */
+export const MIN_MEASURED_BMR_KCAL = 300;
+export const MAX_MEASURED_BMR_KCAL = 10000;
+
+/**
+ * How far a measured BMR may diverge from the formula-calculated estimate for
+ * the same person before it is treated as implausible and the formula is used
+ * instead. Real measured BMR (and real metabolic adaptation) can differ
+ * meaningfully from a population formula, but a reading this far off a
+ * person's own estimate is far more likely to be a unit mismatch, a
+ * partial-day accumulator value mistaken for a full-day total, or otherwise
+ * corrupted data than an actual BMR.
+ */
+export const MEASURED_BMR_MIN_RATIO_OF_FORMULA = 0.6;
+export const MEASURED_BMR_MAX_RATIO_OF_FORMULA = 1.6;
+
 export const ACTIVITY_MULTIPLIERS: Record<string, number> = {
   none: 1.0,
   not_much: 1.2,

--- a/shared/src/utils/calorieCalculations.ts
+++ b/shared/src/utils/calorieCalculations.ts
@@ -5,7 +5,11 @@ import {
   DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
   ENERGY_DENSITY_KCAL_PER_KG,
   MAX_CALORIE_SAFETY_FLOOR,
+  MAX_MEASURED_BMR_KCAL,
+  MEASURED_BMR_MAX_RATIO_OF_FORMULA,
+  MEASURED_BMR_MIN_RATIO_OF_FORMULA,
   MIN_CALORIE_SAFETY_FLOOR,
+  MIN_MEASURED_BMR_KCAL,
   type CalorieSafetyFloorMode,
 } from "../constants/calorieConstants.ts";
 
@@ -475,6 +479,47 @@ export function calculateBmr(
   return 10 * weightKg + 6.25 * heightCm - 5 * age + genderOffset;
 }
 
+/**
+ * Whether a measured/synced BMR (smart scale, wearable sync, or a value
+ * carried forward from check-in history) is trustworthy enough to override a
+ * formula-calculated estimate.
+ *
+ * Checks the absolute physiological range first, then -- when a calculated
+ * estimate for the same person is available -- requires the measurement to
+ * sit within `MEASURED_BMR_MIN_RATIO_OF_FORMULA`..`MEASURED_BMR_MAX_RATIO_OF_FORMULA`
+ * of it. The absolute range alone is far too wide to catch bad data: a
+ * partial-day resting-energy accumulator sample, a unit mismatch, or a value
+ * synced for an unrelated metric can easily land inside 300-10000 while being
+ * wildly wrong for a specific person (e.g. a real ~1800 kcal BMR reported as
+ * ~350). Comparing against that person's own formula estimate catches this
+ * without narrowing what a deliberately-entered, genuinely unusual BMR can be.
+ *
+ * When no calculated estimate is available to compare against (missing
+ * profile data), falls back to the absolute range alone -- the same behavior
+ * every caller had before this check existed.
+ */
+export function isPlausibleMeasuredBmr(
+  measuredBmr: number | null | undefined,
+  calculatedBmr?: number | null,
+): measuredBmr is number {
+  if (
+    measuredBmr === null ||
+    measuredBmr === undefined ||
+    !Number.isFinite(measuredBmr) ||
+    measuredBmr < MIN_MEASURED_BMR_KCAL ||
+    measuredBmr > MAX_MEASURED_BMR_KCAL
+  ) {
+    return false;
+  }
+  if (!calculatedBmr || !Number.isFinite(calculatedBmr) || calculatedBmr <= 0) {
+    return true;
+  }
+  return (
+    measuredBmr >= calculatedBmr * MEASURED_BMR_MIN_RATIO_OF_FORMULA &&
+    measuredBmr <= calculatedBmr * MEASURED_BMR_MAX_RATIO_OF_FORMULA
+  );
+}
+
 export function calculateMinimumMetabolism(
   weightKg: number,
   heightCm: number,
@@ -485,27 +530,26 @@ export function calculateMinimumMetabolism(
   calculateBmrFn?: BmrCalculatorFn,
   measuredBmr?: number | null,
 ): number {
-  if (measuredBmr && measuredBmr >= 300 && measuredBmr <= 10000) {
-    return measuredBmr;
-  }
   const activeBmrFn = calculateBmrFn || calculateBmr;
-  if (
+  const formulaBmr =
     (bmrAlgorithm === "Katch-McArdle" || bmrAlgorithm === "Cunningham") &&
     bodyFatPercentage &&
     bodyFatPercentage > 0
-  ) {
-    const lbm = weightKg * (1 - bodyFatPercentage / 100);
-    return bmrAlgorithm === "Cunningham" ? 500 + 22 * lbm : 370 + 21.6 * lbm;
-  }
+      ? bmrAlgorithm === "Cunningham"
+        ? 500 + 22 * weightKg * (1 - bodyFatPercentage / 100)
+        : 370 + 21.6 * weightKg * (1 - bodyFatPercentage / 100)
+      : activeBmrFn(
+          bmrAlgorithm,
+          weightKg,
+          heightCm,
+          age,
+          gender,
+          bodyFatPercentage,
+        );
 
-  return activeBmrFn(
-    bmrAlgorithm,
-    weightKg,
-    heightCm,
-    age,
-    gender,
-    bodyFatPercentage,
-  );
+  return isPlausibleMeasuredBmr(measuredBmr, formulaBmr)
+    ? measuredBmr
+    : formulaBmr;
 }
 
 export interface CalorieTargetResult {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**

On v1.6.5 a measured / synced `check_in_measurements.bmr` unconditionally overrides the formula BMR everywhere TDEE and calorie goals are computed. The only guard is a 300–10000 kcal range, which is wide enough that a stale sync, a unit mismatch, or a partial-day sample (e.g. 350 kcal/day) is treated as authoritative. That is what collapsed the reporter's target in #2395, and it is also what pushed other users' goals ~300–500 kcal the other way.

The existing `use_external_bmr` preference is fully wired through the DB, Zod schemas, and repository, but nothing reads it — so there is no way to opt out.

**How did you implement the solution?**

Two independent layers, in that order:

1. **Plausibility.** `isPlausibleMeasuredBmr(measuredBmr, calculatedBmr)` in `@workspace/shared` keeps the absolute 300–10000 range, and also requires the measured value to sit within 60%–160% of that person's own formula estimate. `calculateMinimumMetabolism` and every previous flat range check (goalService, AdaptiveTdeeService, calorieBalanceService, reportService, `useCalculatedBMR`) now go through it. An implausible value falls back to the formula instead of rewriting the target.

2. **Opt-in.** Gate the measured-BMR override behind `use_external_bmr` at every server call site, and on the web hook. Add a Settings → Calculation Settings toggle (`Use measured/synced BMR when available`). Default is off, matching the column's `DEFAULT false`, so nothing changes until a user explicitly opts in.

Linked Issue: Fixes #2395

## How to Test

1. Server: `cd SparkyFitnessServer && pnpm exec vitest run tests/goalServiceMeasuredBmrPlausibility.test.ts tests/adaptiveTdeeService.test.ts tests/calorieBalanceService.test.ts`
2. Frontend: `cd SparkyFitnessFrontend && pnpm exec jest --runInBand src/tests/utils/calorieCalculations.test.ts src/tests/hooks/useCalculatedBMR.test.tsx`
3. With `use_external_bmr` off (the default): a check-in BMR of 350 or 2600 against a ~1800 formula BMR must **not** change the Diary calorie target or Adaptive TDEE clamp band.
4. Opt in via Settings → Calculation Settings → "Use measured/synced BMR when available". A measured value inside 60%–160% of the formula estimate should now be used and tagged as measured; a value outside that band should still fall back to the formula.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots
Before:
<img width="1235" height="750" alt="before 1" src="https://github.com/user-attachments/assets/7c2d705d-ebc4-4d46-9ce1-c4161f747664" />

After:
<img width="1247" height="762" alt="after" src="https://github.com/user-attachments/assets/bcc00f27-d59c-458f-a61b-20d4c690260d" />

<details>
<summary>Click to expand</summary>

No visual change to Diary / check-in. The only new UI is a Calculation Settings toggle, default off. Happy to add a screenshot of that row if useful.

</details>

## Notes for Reviewers

The Adaptive TDEE formula itself never touches BMR, but `fallbackTdee = baseBmr * multiplier` is the +/-500 clamp band. A bad measured BMR therefore moves Adaptive TDEE even when the raw log-derived estimate is unchanged — that is the "goal jumped 300 kcal with identical intake" case.

No schema change, no new table, `rls_policies.sql` untouched. The `use_external_bmr` column already exists.

Related context: #2210 (the preference was already documented as unused), #2279 (the measured-BMR work this tightens).

<!-- restored-checklist -->
---
## ✅ Required Checklist (restored automatically)

> The mandatory checklist from our PR template is missing from this description, so it
> has been added back below. **Please tick each box and do not delete this section** —
> these checked boxes are how we record your agreement. Edit the description in place;
> no new commit is needed.

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a calculation setting to optionally use BMR values entered during check-ins or synced from smart scales and health providers.
  - The preference is saved across sessions and applies to daily calorie, TDEE, goal, balance, and report calculations.

- **Bug Fixes**
  - External BMR values are now used only when explicitly enabled and within a plausible range.
  - Implausible or unavailable values safely fall back to formula-based calculations, preventing distorted calorie targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->