### PR TITLE
fix(bmr): scope measured BMR to its own day and tighten plausibility

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2213,7 +2213,8 @@
       "unsafeLossText": "Losing more than 1.5% of body weight per week is considered excessive. This rate dramatically increases risks of severe muscle loss, lethargy, hormonal imbalances, and nutritional deficiencies. Please choose a less aggressive goal mode.",
       "calibrationDescription": "Sparky's Adaptive TDEE engine requires at least {{required}} days of consistent tracking to calculate your metabolism accurately (currently using fallback estimates). To speed up calibration:",
       "calibrationWeightTip": "Log weight at least 3-4 times per week.",
-      "calibrationFoodTip": "Log food intake daily (>200 kcal/day)."
+      "calibrationFoodTip": "Log food intake daily (>200 kcal/day).",
+      "livePreviewSavedNote": "BMR and body fat update as you change settings. Expenditure is calculated on the server from your saved settings, so it and the final target only change after you save."
     },
     "mfa": {
       "confirmPassword": "Confirm Password to Continue",
@@ -2788,7 +2789,7 @@
     "calculateExplanation": {
       "bmrMeasured": "Measured",
       "bmrMeasuredDesc": "Using a measured BMR of {{value}} {{unit}} recorded for this day, from a smart scale or health app sync. Your {{algorithm}} formula is not applied.",
-      "bmrMeasuredScope": "A measured value only counts on the day it was recorded. Days without one fall back to the formula. To stop using measured values, disable BMR sync for your connected device or health app.",
+      "bmrMeasuredScope": "A measured value only counts on the day it was recorded. Days without one fall back to the formula. To stop using measured values, turn off “Use measured BMR from check-ins and synced devices” in Calculation Settings.",
       "dialogDescription": "Step-by-step breakdown of how your daily energy target is calculated.",
       "todayTarget": "How today's target is calculated",
       "bmrTitle": "1. Basal Metabolic Rate (BMR)",
@@ -2855,11 +2856,19 @@
       "adaptiveTdeeExpenditure": "Adaptive TDEE (Expenditure)",
       "adaptiveManualGoal": "Adaptive Manual Calorie Goal",
       "targetSafeRange": "✓ Target is in safe range above metabolic safety floor.",
-      "weightTrendTerm": "Weight trend: {{start}} → {{end}} kg ({{change}} kg across all {{days}} days of the window) = {{daily}} kg/day",
-      "weightTrendCalories": "Energy from that trend: {{daily}} kg/day × {{kcalPerKg}} kcal/kg = {{value}}",
+      "weightTrendTerm": "Weight trend: {{start}} → {{end}} kg ({{change}} kg across all {{days}} days of the window) = {{daily}} kg/day — 7-day averages of your logged weights, not the readings themselves, with missing days filled in between the ones either side",
+      "weightTrendCalories": "Energy from that trend: {{daily}} kg/day × {{kcalPerKg}} kcal/kg ≈ {{value}}",
       "tdeeSum": "({{intake}} {{sign}} {{delta}})",
       "adaptiveClamped": "Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±{{band}} {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}}).",
-      "intakeWindow": "(mean of {{logged}} logged days between {{start}} and {{end}}; days under 200 kcal are excluded, not counted as zero)"
+      "intakeWindow": "(mean of {{logged}} logged days between {{start}} and {{end}}; days under 200 kcal are excluded, not counted as zero)",
+      "adaptivePlausibilityBand": "Plausibility limits from your activity level (×{{multiplier}}): {{min}}–{{max}} {{unit}}. The estimate is inside this range, so it is used as calculated.",
+      "adjustmentMode": "Daily calorie goal adjustment: {{mode}}",
+      "deviceProjectionCaveat": "In this mode your Diary target comes from your device’s total calories projected to midnight, which is not known here. The figures below are the stored-goal derivation and will differ from what the Diary shows.",
+      "modeAdaptive": "Adaptive Goal",
+      "modeDynamic": "Dynamic Goal",
+      "modeFixed": "Fixed Goal",
+      "modePercentage": "Percentage Earn-Back",
+      "modeDevice": "Device Projection"
     },
     "copyAllError": "Failed to copy entire day.",
     "copyAllFromYesterday": "Copy all from yesterday",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2072,7 +2072,7 @@
       "activityModerate": "Moderately active (×1.55)",
       "activityNone": "None (×1.0)",
       "activityNotMuch": "Sedentary (×1.2)",
-      "adaptiveActivityHint": "In Adaptive mode, this setting acts as a fallback until you have enough tracking data.",
+      "adaptiveActivityHint": "In Adaptive mode this is the fallback estimate until you have enough tracking data — and it keeps setting the plausibility limits afterwards. Your measured TDEE is capped to within ±500 kcal of BMR × this multiplier, so a level set too low can hold a genuinely higher expenditure down.",
       "adaptiveGoal": "Adaptive Goal",
       "adaptiveGoalDescription": "Your calorie goal is derived from your measured expenditure, by comparing your logged intake against your weight trend over the last 28 days. This is the most accurate option once you have a few weeks of consistent weight and food logging.",
       "allowNegativeAdjustment": "Allow the fallback projection to lower the target",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2786,7 +2786,7 @@
     "calculateExplanation": {
       "bmrMeasured": "Measured",
       "bmrMeasuredDesc": "Using a measured BMR of {{value}} {{unit}} recorded for this day, from a smart scale or health app sync. Your {{algorithm}} formula is not applied.",
-      "bmrMeasuredScope": "A measured value only counts on the day it was recorded. Days without one fall back to the formula. To stop using measured values, turn off BMR sync in your health app settings.",
+      "bmrMeasuredScope": "A measured value only counts on the day it was recorded. Days without one fall back to the formula. To stop using measured values, disable BMR sync for your connected device or health app.",
       "dialogDescription": "Step-by-step breakdown of how your daily energy target is calculated.",
       "todayTarget": "How today's target is calculated",
       "bmrTitle": "1. Basal Metabolic Rate (BMR)",
@@ -2852,7 +2852,11 @@
       "fallbackBaselineDetail": "BMR ({{bmr}}) × Activity Multiplier ({{multiplier}}) = {{result}} {{unit}} (Fallback used: not enough history [<{{required}} days]; raw calculation of {{raw}} {{unit}} bypassed)",
       "adaptiveTdeeExpenditure": "Adaptive TDEE (Expenditure)",
       "adaptiveManualGoal": "Adaptive Manual Calorie Goal",
-      "targetSafeRange": "✓ Target is in safe range above metabolic safety floor."
+      "targetSafeRange": "✓ Target is in safe range above metabolic safety floor.",
+      "weightTrendTerm": "Weight trend: {{start}} → {{end}} kg ({{change}} kg over {{days}} days) = {{daily}} kg/day",
+      "weightTrendCalories": "Energy from that trend: {{daily}} kg/day × 6000 kcal/kg = {{value}} {{unit}}",
+      "tdeeSum": "({{intake}} {{sign}} {{delta}})",
+      "adaptiveClamped": "Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±500 {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}})."
     },
     "copyAllError": "Failed to copy entire day.",
     "copyAllFromYesterday": "Copy all from yesterday",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2259,8 +2259,8 @@
       "goalMaintain": "Maintain (0% change)",
       "surplus": "Surplus",
       "deficit": "Deficit",
-      "adaptiveFormula": "Formula: Average Daily Calories − (Daily Weight Change in kg × {{energyPerKg}} {{unit}}/kg)",
-      "adaptiveFormulaExplainer": "{{energyPerKg}} {{unit}}/kg is how much energy a kilogram of body weight represents, so your weight trend can be converted into energy. Body weight lost or gained is a mix of fat (~{{fatPerKg}} {{unit}}/kg) and lean tissue and water (~{{leanPerKg}} {{unit}}/kg), and {{energyPerKg}} reflects a typical blend.",
+      "adaptiveFormula": "Formula: Average Daily Calories − (Daily Weight Change in kg × {{kcalPerKg}} kcal/kg)",
+      "adaptiveFormulaExplainer": "{{kcalPerKg}} kcal/kg is how much energy a kilogram of body weight represents, so your weight trend can be converted into calories. Body weight lost or gained is a mix of fat (~{{fatPerKg}} kcal/kg) and lean tissue and water (~{{leanPerKg}} kcal/kg), and {{kcalPerKg}} reflects a typical blend.",
       "adjustment": "Adjustment",
       "goalAdjustmentLabel": "Goal Adjustment:"
     },
@@ -2854,7 +2854,7 @@
       "adaptiveManualGoal": "Adaptive Manual Calorie Goal",
       "targetSafeRange": "✓ Target is in safe range above metabolic safety floor.",
       "weightTrendTerm": "Weight trend: {{start}} → {{end}} kg ({{change}} kg across all {{days}} days of the window) = {{daily}} kg/day",
-      "weightTrendCalories": "Energy from that trend: {{daily}} kg/day × {{density}} {{unit}}/kg = {{value}} {{unit}}",
+      "weightTrendCalories": "Energy from that trend: {{daily}} kg/day × {{kcalPerKg}} kcal/kg = {{value}}",
       "tdeeSum": "({{intake}} {{sign}} {{delta}})",
       "adaptiveClamped": "Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±500 {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}}).",
       "intakeWindow": "(mean of {{logged}} logged days between {{start}} and {{end}}; days under 200 kcal are excluded, not counted as zero)"

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2856,7 +2856,7 @@
       "weightTrendTerm": "Weight trend: {{start}} → {{end}} kg ({{change}} kg across all {{days}} days of the window) = {{daily}} kg/day",
       "weightTrendCalories": "Energy from that trend: {{daily}} kg/day × {{kcalPerKg}} kcal/kg = {{value}}",
       "tdeeSum": "({{intake}} {{sign}} {{delta}})",
-      "adaptiveClamped": "Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±500 {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}}).",
+      "adaptiveClamped": "Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±{{band}} {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}}).",
       "intakeWindow": "(mean of {{logged}} logged days between {{start}} and {{end}}; days under 200 kcal are excluded, not counted as zero)"
     },
     "copyAllError": "Failed to copy entire day.",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2857,7 +2857,7 @@
       "adaptiveManualGoal": "Adaptive Manual Calorie Goal",
       "targetSafeRange": "✓ Target is in safe range above metabolic safety floor.",
       "weightTrendTerm": "Weight trend: {{start}} → {{end}} kg ({{change}} kg across all {{days}} days of the window) = {{daily}} kg/day — 7-day averages of your logged weights, not the readings themselves, with missing days filled in between the ones either side",
-      "weightTrendCalories": "Energy from that trend: {{daily}} kg/day × {{kcalPerKg}} kcal/kg ≈ {{value}}",
+      "weightTrendCalories": "Energy from that trend: −({{daily}} kg/day × {{kcalPerKg}} kcal/kg) ≈ {{value}}",
       "tdeeSum": "({{intake}} {{sign}} {{delta}})",
       "adaptiveClamped": "Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±{{band}} {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}}).",
       "intakeWindow": "(mean of {{logged}} logged days between {{start}} and {{end}}; days under 200 kcal are excluded, not counted as zero)",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2259,8 +2259,8 @@
       "goalMaintain": "Maintain (0% change)",
       "surplus": "Surplus",
       "deficit": "Deficit",
-      "adaptiveFormula": "Formula: Average Daily Calories − (Daily Weight Change in kg × {{kcalPerKg}} kcal/kg)",
-      "adaptiveFormulaExplainer": "{{kcalPerKg}} kcal/kg is how much energy a kilogram of body weight represents, so your weight trend can be converted into calories. Body weight lost or gained is a mix of fat (~9,441 kcal/kg) and lean tissue and water (~1,816 kcal/kg), and {{kcalPerKg}} reflects a typical blend.",
+      "adaptiveFormula": "Formula: Average Daily Calories − (Daily Weight Change in kg × {{energyPerKg}} {{unit}}/kg)",
+      "adaptiveFormulaExplainer": "{{energyPerKg}} {{unit}}/kg is how much energy a kilogram of body weight represents, so your weight trend can be converted into energy. Body weight lost or gained is a mix of fat (~{{fatPerKg}} {{unit}}/kg) and lean tissue and water (~{{leanPerKg}} {{unit}}/kg), and {{energyPerKg}} reflects a typical blend.",
       "adjustment": "Adjustment",
       "goalAdjustmentLabel": "Goal Adjustment:"
     },
@@ -2854,7 +2854,7 @@
       "adaptiveManualGoal": "Adaptive Manual Calorie Goal",
       "targetSafeRange": "✓ Target is in safe range above metabolic safety floor.",
       "weightTrendTerm": "Weight trend: {{start}} → {{end}} kg ({{change}} kg across all {{days}} days of the window) = {{daily}} kg/day",
-      "weightTrendCalories": "Energy from that trend: {{daily}} kg/day × 6000 kcal/kg = {{value}} {{unit}}",
+      "weightTrendCalories": "Energy from that trend: {{daily}} kg/day × {{density}} {{unit}}/kg = {{value}} {{unit}}",
       "tdeeSum": "({{intake}} {{sign}} {{delta}})",
       "adaptiveClamped": "Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±500 {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}}).",
       "intakeWindow": "(mean of {{logged}} logged days between {{start}} and {{end}}; days under 200 kcal are excluded, not counted as zero)"

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -779,7 +779,9 @@
     "saveSuccessDesc": "Calculation settings saved successfully!",
     "selectBmrAlgorithm": "Select BMR Algorithm",
     "selectBodyFatAlgorithm": "Select Body Fat Algorithm",
-    "selectEnergyUnitPlaceholder": "Select energy unit"
+    "selectEnergyUnitPlaceholder": "Select energy unit",
+    "useExternalBmr": "Use measured BMR from check-ins and synced devices",
+    "useExternalBmrHint": "Off by default — your chosen formula is always used until you turn this on. When enabled, a BMR recorded on a check-in or synced from a smart scale or health provider replaces the formula for that day, provided it is physiologically plausible for you. Some devices report BMR as a running daily total rather than a rate, which is why this is opt-in."
   },
   "aboutDialog": {
     "title": "About SparkyFitness",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2853,10 +2853,11 @@
       "adaptiveTdeeExpenditure": "Adaptive TDEE (Expenditure)",
       "adaptiveManualGoal": "Adaptive Manual Calorie Goal",
       "targetSafeRange": "✓ Target is in safe range above metabolic safety floor.",
-      "weightTrendTerm": "Weight trend: {{start}} → {{end}} kg ({{change}} kg over {{days}} days) = {{daily}} kg/day",
+      "weightTrendTerm": "Weight trend: {{start}} → {{end}} kg ({{change}} kg across all {{days}} days of the window) = {{daily}} kg/day",
       "weightTrendCalories": "Energy from that trend: {{daily}} kg/day × 6000 kcal/kg = {{value}} {{unit}}",
       "tdeeSum": "({{intake}} {{sign}} {{delta}})",
-      "adaptiveClamped": "Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±500 {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}})."
+      "adaptiveClamped": "Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±500 {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}}).",
+      "intakeWindow": "(mean of {{logged}} logged days between {{start}} and {{end}}; days under 200 kcal are excluded, not counted as zero)"
     },
     "copyAllError": "Failed to copy entire day.",
     "copyAllFromYesterday": "Copy all from yesterday",

--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -2785,7 +2785,8 @@
     "addSuccess": "Food added successfully.",
     "calculateExplanation": {
       "bmrMeasured": "Measured",
-      "bmrMeasuredDesc": "Using your measured BMR. No formula applied.",
+      "bmrMeasuredDesc": "Using a measured BMR of {{value}} {{unit}} recorded for this day, from a smart scale or health app sync. Your {{algorithm}} formula is not applied.",
+      "bmrMeasuredScope": "A measured value only counts on the day it was recorded. Days without one fall back to the formula. To stop using measured values, turn off BMR sync in your health app settings.",
       "dialogDescription": "Step-by-step breakdown of how your daily energy target is calculated.",
       "todayTarget": "How today's target is calculated",
       "bmrTitle": "1. Basal Metabolic Rate (BMR)",

--- a/SparkyFitnessFrontend/src/api/CheckIn/checkInService.ts
+++ b/SparkyFitnessFrontend/src/api/CheckIn/checkInService.ts
@@ -133,10 +133,15 @@ export const saveCustomMeasurement = async (
 };
 
 export const getMostRecentMeasurement = async (
-  measurementType: string
+  measurementType: string,
+  onDate?: string
 ): Promise<RecentCheckInMeasurementsResponse | null> => {
+  // `onDate` pins the lookup to a single day instead of the newest value ever
+  // recorded. Used for measured BMR, which only applies on the day it was taken.
   const response = await apiCall(
-    `/measurements/most-recent/${measurementType}`
+    `/measurements/most-recent/${measurementType}${
+      onDate ? `?date=${encodeURIComponent(onDate)}` : ''
+    }`
   );
 
   // if there are no entries the backend returns an empty object

--- a/SparkyFitnessFrontend/src/api/keys/diary.ts
+++ b/SparkyFitnessFrontend/src/api/keys/diary.ts
@@ -8,8 +8,14 @@ export const dailyProgressKeys = {
   all: ['dailyProgress'] as const,
   steps: (date: string) => [...dailyProgressKeys.all, 'steps', date] as const,
   measurements: {
-    mostRecent: (type: string) =>
-      [...dailyProgressKeys.all, 'measurements', 'recent', type] as const,
+    mostRecent: (type: string, onDate?: string) =>
+      [
+        ...dailyProgressKeys.all,
+        'measurements',
+        'recent',
+        type,
+        ...(onDate ? [onDate] : []),
+      ] as const,
   },
   adaptiveTdee: (date: string) =>
     [...dailyProgressKeys.all, 'adaptiveTdee', date] as const,

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -157,11 +157,6 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
   // the sum again in kJ — 2100 + 100 kcal renders as 8786 + 418 = 9204 kJ beside a
   // total of 9205. So the delta is derived from the two displayed numbers rather
   // than converted on its own, and the arithmetic holds in either unit.
-  // Energy density in the unit on screen, so the stated formula matches the
-  // numbers beside it in kJ as well as kcal.
-  const displayEnergyPerKg = Math.round(
-    convertEnergy(ENERGY_DENSITY_KCAL_PER_KG, 'kcal', energyUnit)
-  );
   const displayAdaptiveIntake = Math.round(
     convertEnergy(adaptiveTdeeData?.avgIntake || 0, 'kcal', energyUnit)
   );
@@ -172,6 +167,20 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
   // longer equals intake plus trend, and the trend row still has to state the real
   // trend rather than be bent to match a capped total.
   const displayAdaptiveDelta = displayAdaptiveRawTdee - displayAdaptiveIntake;
+  // In kcal the equation stands alone; in any other unit the kcal result is shown
+  // first (so the multiplication checks out) with the converted value beside it.
+  const adaptiveDeltaKcal =
+    Math.round(adaptiveTdeeData?.rawTdee || 0) -
+    Math.round(adaptiveTdeeData?.avgIntake || 0);
+  const signedKcal = `${adaptiveDeltaKcal >= 0 ? '+' : '−'}${Math.abs(
+    adaptiveDeltaKcal
+  )} kcal`;
+  const adaptiveDeltaText =
+    energyUnit === 'kcal'
+      ? signedKcal
+      : `${signedKcal} (${
+          displayAdaptiveDelta >= 0 ? '+' : '−'
+        }${Math.abs(displayAdaptiveDelta)} ${getEnergyUnitString(energyUnit)})`;
 
   // Inputs are printed at the precision the formula actually evaluates at. Rounding
   // weight to one decimal made the panel unable to reproduce its own answer: a stored
@@ -567,26 +576,18 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
             <div className="font-semibold text-foreground">
               {t(
                 'settings.breakdown.adaptiveFormula',
-                'Formula: Average Daily Calories − (Daily Weight Change in kg × {{energyPerKg}} {{unit}}/kg)',
-                {
-                  energyPerKg: displayEnergyPerKg,
-                  unit: getEnergyUnitString(energyUnit),
-                }
+                'Formula: Average Daily Calories − (Daily Weight Change in kg × {{kcalPerKg}} kcal/kg)',
+                { kcalPerKg: ENERGY_DENSITY_KCAL_PER_KG }
               )}
             </div>
             <p className="text-muted-foreground">
               {t(
                 'settings.breakdown.adaptiveFormulaExplainer',
-                '{{energyPerKg}} {{unit}}/kg is how much energy a kilogram of body weight represents, so your weight trend can be converted into energy. Body weight lost or gained is a mix of fat (~{{fatPerKg}} {{unit}}/kg) and lean tissue and water (~{{leanPerKg}} {{unit}}/kg), and {{energyPerKg}} reflects a typical blend.',
+                '{{kcalPerKg}} kcal/kg is how much energy a kilogram of body weight represents, so your weight trend can be converted into calories. Body weight lost or gained is a mix of fat (~{{fatPerKg}} kcal/kg) and lean tissue and water (~{{leanPerKg}} kcal/kg), and {{kcalPerKg}} reflects a typical blend.',
                 {
-                  energyPerKg: displayEnergyPerKg,
-                  fatPerKg: Math.round(
-                    convertEnergy(FAT_KCAL_PER_KG, 'kcal', energyUnit)
-                  ),
-                  leanPerKg: Math.round(
-                    convertEnergy(LEAN_TISSUE_KCAL_PER_KG, 'kcal', energyUnit)
-                  ),
-                  unit: getEnergyUnitString(energyUnit),
+                  kcalPerKg: ENERGY_DENSITY_KCAL_PER_KG,
+                  fatPerKg: FAT_KCAL_PER_KG.toLocaleString(),
+                  leanPerKg: LEAN_TISSUE_KCAL_PER_KG.toLocaleString(),
                 }
               )}
             </p>
@@ -819,25 +820,19 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                     <li>
                       {t(
                         'diary.calculateExplanation.weightTrendCalories',
-                        'Energy from that trend: {{daily}} kg/day × {{density}} {{unit}}/kg = {{value}} {{unit}}',
+                        'Energy from that trend: {{daily}} kg/day × {{kcalPerKg}} kcal/kg = {{value}}',
                         {
-                          // Energy density in the unit on screen. Labelling it
-                          // kcal/kg while printing a kJ result stated an equation
-                          // that does not compute.
-                          density: Math.round(
-                            convertEnergy(
-                              ENERGY_DENSITY_KCAL_PER_KG,
-                              'kcal',
-                              energyUnit
-                            )
-                          ),
                           daily: (
                             adaptiveTdeeData.dailyWeightChangeKg ?? 0
                           ).toFixed(4),
-                          value: `${
-                            displayAdaptiveDelta >= 0 ? '+' : '−'
-                          }${Math.abs(displayAdaptiveDelta)}`,
-                          unit: getEnergyUnitString(energyUnit),
+                          kcalPerKg: ENERGY_DENSITY_KCAL_PER_KG,
+                          // Evaluated against the kcal constant so the equation
+                          // reproduces, with the converted figure appended when the
+                          // viewer reads another unit. The energy densities are
+                          // reference values from the literature — restating them as
+                          // 25,104 kJ/kg would make the sum work and the citation
+                          // unrecognisable.
+                          value: adaptiveDeltaText,
                         }
                       )}
                     </li>

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -36,6 +36,8 @@ interface AdaptiveTdeeData {
   endWeightTrend?: number;
   weightChangeKg?: number;
   daysInWindow?: number;
+  windowStartDate?: string;
+  windowEndDate?: string;
   dailyWeightChangeKg?: number;
   weightChangeCalories?: number;
   rawTdee?: number;
@@ -742,13 +744,32 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                       )
                     )}{' '}
                     {getEnergyUnitString(energyUnit)}
+                    {adaptiveTdeeData?.windowStartDate &&
+                      adaptiveTdeeData?.windowEndDate && (
+                        // The average covers only days that were actually logged,
+                        // not every day in the window — days under 200 kcal are
+                        // skipped rather than counted as zero. Saying so is what
+                        // makes the "under-logging reads high" caveat make sense.
+                        <span className="text-muted-foreground">
+                          {' '}
+                          {t(
+                            'diary.calculateExplanation.intakeWindow',
+                            '(mean of {{logged}} logged days between {{start}} and {{end}}; days under 200 kcal are excluded, not counted as zero)',
+                            {
+                              logged: adaptiveTdeeData?.daysOfData ?? 0,
+                              start: adaptiveTdeeData.windowStartDate,
+                              end: adaptiveTdeeData.windowEndDate,
+                            }
+                          )}
+                        </span>
+                      )}
                   </li>
                   {typeof adaptiveTdeeData?.weightChangeCalories ===
                     'number' && (
                     <li>
                       {t(
                         'diary.calculateExplanation.weightTrendTerm',
-                        'Weight trend: {{start}} → {{end}} kg ({{change}} kg over {{days}} days) = {{daily}} kg/day',
+                        'Weight trend: {{start}} → {{end}} kg ({{change}} kg across all {{days}} days of the window) = {{daily}} kg/day',
                         {
                           start: adaptiveTdeeData.startWeightTrend ?? 0,
                           end: adaptiveTdeeData.endWeightTrend ?? 0,

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -158,6 +158,19 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
   // the sum again in kJ — 2100 + 100 kcal renders as 8786 + 418 = 9204 kJ beside a
   // total of 9205. So the delta is derived from the two displayed numbers rather
   // than converted on its own, and the arithmetic holds in either unit.
+  const adjustmentModeLabel =
+    {
+      adaptive: t('diary.calculateExplanation.modeAdaptive', 'Adaptive Goal'),
+      dynamic: t('diary.calculateExplanation.modeDynamic', 'Dynamic Goal'),
+      fixed: t('diary.calculateExplanation.modeFixed', 'Fixed Goal'),
+      percentage: t(
+        'diary.calculateExplanation.modePercentage',
+        'Percentage Earn-Back'
+      ),
+      tdee: t('diary.calculateExplanation.modeDevice', 'Device Projection'),
+      smart: t('diary.calculateExplanation.modeDevice', 'Device Projection'),
+    }[calorieGoalAdjustmentMode] ?? calorieGoalAdjustmentMode;
+
   const displayAdaptiveIntake = Math.round(
     convertEnergy(adaptiveTdeeData?.avgIntake || 0, 'kcal', energyUnit)
   );
@@ -478,7 +491,7 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
             <div>
               {t(
                 'diary.calculateExplanation.bmrMeasuredScope',
-                'A measured value only counts on the day it was recorded. Days without one fall back to the formula. To stop using measured values, turn off BMR sync in your health app settings.'
+                'A measured value only counts on the day it was recorded. Days without one fall back to the formula. To stop using measured values, turn off “Use measured BMR from check-ins and synced devices” in Calculation Settings.'
               )}
             </div>
           </div>
@@ -552,6 +565,26 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                   { algorithm: bmrAlgorithmLabel }
                 )}
         </p>
+      </div>
+
+      {/* Which Daily Calorie Goal Adjustment mode produced this. Without it the
+          panel reads as the only possible derivation, and under Device Projection
+          it is not even the one the Diary will use. */}
+      <div className="text-xs text-muted-foreground">
+        {t(
+          'diary.calculateExplanation.adjustmentMode',
+          'Daily calorie goal adjustment: {{mode}}',
+          { mode: adjustmentModeLabel }
+        )}
+        {calorieGoalAdjustmentMode === 'tdee' && (
+          <span className="text-amber-600 dark:text-amber-500">
+            {' '}
+            {t(
+              'diary.calculateExplanation.deviceProjectionCaveat',
+              'In this mode your Diary target comes from your device’s total calories projected to midnight, which is not known here. The figures below are the stored-goal derivation and will differ from what the Diary shows.'
+            )}
+          </span>
+        )}
       </div>
 
       {/* Step 3: Adaptive TDEE (Expenditure) */}
@@ -801,7 +834,7 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                     <li>
                       {t(
                         'diary.calculateExplanation.weightTrendTerm',
-                        'Weight trend: {{start}} → {{end}} kg ({{change}} kg across all {{days}} days of the window) = {{daily}} kg/day',
+                        'Weight trend: {{start}} → {{end}} kg ({{change}} kg across all {{days}} days of the window) = {{daily}} kg/day — 7-day averages of your logged weights, not the readings themselves, with missing days filled in between the ones either side',
                         {
                           start: adaptiveTdeeData.startWeightTrend ?? 0,
                           end: adaptiveTdeeData.endWeightTrend ?? 0,
@@ -821,12 +854,18 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                     <li>
                       {t(
                         'diary.calculateExplanation.weightTrendCalories',
-                        'Energy from that trend: {{daily}} kg/day × {{kcalPerKg}} kcal/kg = {{value}}',
+                        'Energy from that trend: {{daily}} kg/day × {{kcalPerKg}} kcal/kg ≈ {{value}}',
                         {
                           daily: (
                             adaptiveTdeeData.dailyWeightChangeKg ?? 0
                           ).toFixed(4),
                           kcalPerKg: ENERGY_DENSITY_KCAL_PER_KG,
+                          // Approximate, deliberately. The intake and the total
+                          // are each rounded on their own, so the difference
+                          // between them can sit a kcal away from what the
+                          // rounded daily rate multiplies out to. The sum line
+                          // below is the one that has to reconcile exactly, and
+                          // it does; claiming '=' here would be the false half.
                           // Evaluated against the kcal constant so the equation
                           // reproduces, with the converted figure appended when the
                           // viewer reads another unit. The energy densities are
@@ -869,6 +908,38 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                       )}
                   </li>
                 </ul>
+                {typeof adaptiveTdeeData?.clampMin === 'number' &&
+                  typeof adaptiveTdeeData?.clampMax === 'number' &&
+                  !adaptiveTdeeData?.wasClamped && (
+                    // Stated even when it does not bite: the band is set by the
+                    // activity level, and a user whose expenditure is being held
+                    // down has no way to discover that unless the limits are
+                    // visible before they start clipping.
+                    <p className="text-xs text-muted-foreground">
+                      {t(
+                        'diary.calculateExplanation.adaptivePlausibilityBand',
+                        'Plausibility limits from your activity level (×{{multiplier}}): {{min}}–{{max}} {{unit}}. The estimate is inside this range, so it is used as calculated.',
+                        {
+                          multiplier: activityMultiplier.toFixed(3),
+                          min: Math.round(
+                            convertEnergy(
+                              adaptiveTdeeData.clampMin,
+                              'kcal',
+                              energyUnit
+                            )
+                          ),
+                          max: Math.round(
+                            convertEnergy(
+                              adaptiveTdeeData.clampMax,
+                              'kcal',
+                              energyUnit
+                            )
+                          ),
+                          unit: getEnergyUnitString(energyUnit),
+                        }
+                      )}
+                    </p>
+                  )}
                 {adaptiveTdeeData?.wasClamped && (
                   // Without this the arithmetic above simply would not add up to
                   // the number shown, which is exactly the "my TDEE moved and I

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -854,12 +854,18 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                     <li>
                       {t(
                         'diary.calculateExplanation.weightTrendCalories',
-                        'Energy from that trend: {{daily}} kg/day × {{kcalPerKg}} kcal/kg ≈ {{value}}',
+                        'Energy from that trend: −({{daily}} kg/day × {{kcalPerKg}} kcal/kg) ≈ {{value}}',
                         {
                           daily: (
                             adaptiveTdeeData.dailyWeightChangeKg ?? 0
                           ).toFixed(4),
                           kcalPerKg: ENERGY_DENSITY_KCAL_PER_KG,
+                          // Negated on purpose. The server computes
+                          // rawTdee = avgIntake − dailyWeightChange × 6000, so the
+                          // term added to intake is minus the product of the two
+                          // factors printed here. Without the sign the line reads
+                          // '−0.0185 × 6000 = +111', which is the wrong number in
+                          // the one panel built for checking the arithmetic.
                           // Approximate, deliberately. The intake and the total
                           // are each rounded on their own, so the difference
                           // between them can sit a kcal away from what the

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -31,6 +31,17 @@ interface AdaptiveTdeeData {
   avgIntake?: number;
   weightTrend?: number | null;
   confidence?: 'HIGH' | 'MEDIUM' | 'LOW';
+  // Derivation terms for the Active branch (see AdaptiveTdeeService).
+  startWeightTrend?: number;
+  endWeightTrend?: number;
+  weightChangeKg?: number;
+  daysInWindow?: number;
+  dailyWeightChangeKg?: number;
+  weightChangeCalories?: number;
+  rawTdee?: number;
+  wasClamped?: boolean;
+  clampMin?: number;
+  clampMax?: number;
 }
 
 interface CalorieTargetBreakdownProps {
@@ -732,6 +743,54 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                     )}{' '}
                     {getEnergyUnitString(energyUnit)}
                   </li>
+                  {typeof adaptiveTdeeData?.weightChangeCalories ===
+                    'number' && (
+                    <li>
+                      {t(
+                        'diary.calculateExplanation.weightTrendTerm',
+                        'Weight trend: {{start}} → {{end}} kg ({{change}} kg over {{days}} days) = {{daily}} kg/day',
+                        {
+                          start: adaptiveTdeeData.startWeightTrend ?? 0,
+                          end: adaptiveTdeeData.endWeightTrend ?? 0,
+                          change: (
+                            adaptiveTdeeData.weightChangeKg ?? 0
+                          ).toFixed(2),
+                          days: adaptiveTdeeData.daysInWindow ?? 0,
+                          daily: (
+                            adaptiveTdeeData.dailyWeightChangeKg ?? 0
+                          ).toFixed(3),
+                        }
+                      )}
+                    </li>
+                  )}
+                  {typeof adaptiveTdeeData?.weightChangeCalories ===
+                    'number' && (
+                    <li>
+                      {t(
+                        'diary.calculateExplanation.weightTrendCalories',
+                        'Energy from that trend: {{daily}} kg/day × 6000 kcal/kg = {{value}} {{unit}}',
+                        {
+                          daily: (
+                            adaptiveTdeeData.dailyWeightChangeKg ?? 0
+                          ).toFixed(3),
+                          value: `${
+                            adaptiveTdeeData.weightChangeCalories >= 0
+                              ? '+'
+                              : '−'
+                          }${Math.abs(
+                            Math.round(
+                              convertEnergy(
+                                adaptiveTdeeData.weightChangeCalories,
+                                'kcal',
+                                energyUnit
+                              )
+                            )
+                          )}`,
+                          unit: getEnergyUnitString(energyUnit),
+                        }
+                      )}
+                    </li>
+                  )}
                   <li>
                     {t(
                       'diary.calculateExplanation.calculatedExpenditure',
@@ -745,8 +804,83 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                       )
                     )}{' '}
                     {getEnergyUnitString(energyUnit)}
+                    {typeof adaptiveTdeeData?.weightChangeCalories ===
+                      'number' &&
+                      !adaptiveTdeeData?.wasClamped && (
+                        <span className="text-muted-foreground">
+                          {' '}
+                          {t(
+                            'diary.calculateExplanation.tdeeSum',
+                            '({{intake}} {{sign}} {{delta}})',
+                            {
+                              intake: Math.round(
+                                convertEnergy(
+                                  adaptiveTdeeData?.avgIntake || 0,
+                                  'kcal',
+                                  energyUnit
+                                )
+                              ),
+                              sign:
+                                adaptiveTdeeData.weightChangeCalories < 0
+                                  ? '−'
+                                  : '+',
+                              delta: Math.abs(
+                                Math.round(
+                                  convertEnergy(
+                                    adaptiveTdeeData.weightChangeCalories,
+                                    'kcal',
+                                    energyUnit
+                                  )
+                                )
+                              ),
+                            }
+                          )}
+                        </span>
+                      )}
                   </li>
                 </ul>
+                {adaptiveTdeeData?.wasClamped && (
+                  // Without this the arithmetic above simply would not add up to
+                  // the number shown, which is exactly the "my TDEE moved and I
+                  // cannot see why" confusion this panel exists to prevent.
+                  <p className="text-xs text-amber-600 dark:text-amber-500">
+                    {t(
+                      'diary.calculateExplanation.adaptiveClamped',
+                      'Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±500 {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}}).',
+                      {
+                        raw: Math.round(
+                          convertEnergy(
+                            adaptiveTdeeData?.rawTdee || 0,
+                            'kcal',
+                            energyUnit
+                          )
+                        ),
+                        capped: Math.round(
+                          convertEnergy(
+                            adaptiveTdeeData?.tdee || 0,
+                            'kcal',
+                            energyUnit
+                          )
+                        ),
+                        min: Math.round(
+                          convertEnergy(
+                            adaptiveTdeeData?.clampMin || 0,
+                            'kcal',
+                            energyUnit
+                          )
+                        ),
+                        max: Math.round(
+                          convertEnergy(
+                            adaptiveTdeeData?.clampMax || 0,
+                            'kcal',
+                            energyUnit
+                          )
+                        ),
+                        unit: getEnergyUnitString(energyUnit),
+                      }
+                    )}
+                  </p>
+                )}
               </div>
             )}
           </div>

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -23,6 +23,10 @@ import {
   type CalorieTargetResult,
 } from '@workspace/shared';
 
+/** Energy density of the tissue the blended ENERGY_DENSITY_KCAL_PER_KG averages. */
+const FAT_KCAL_PER_KG = 9441;
+const LEAN_TISSUE_KCAL_PER_KG = 1816;
+
 interface AdaptiveTdeeData {
   tdee?: number;
   isFallback?: boolean;
@@ -153,6 +157,11 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
   // the sum again in kJ — 2100 + 100 kcal renders as 8786 + 418 = 9204 kJ beside a
   // total of 9205. So the delta is derived from the two displayed numbers rather
   // than converted on its own, and the arithmetic holds in either unit.
+  // Energy density in the unit on screen, so the stated formula matches the
+  // numbers beside it in kJ as well as kcal.
+  const displayEnergyPerKg = Math.round(
+    convertEnergy(ENERGY_DENSITY_KCAL_PER_KG, 'kcal', energyUnit)
+  );
   const displayAdaptiveIntake = Math.round(
     convertEnergy(adaptiveTdeeData?.avgIntake || 0, 'kcal', energyUnit)
   );
@@ -558,15 +567,27 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
             <div className="font-semibold text-foreground">
               {t(
                 'settings.breakdown.adaptiveFormula',
-                'Formula: Average Daily Calories − (Daily Weight Change in kg × {{kcalPerKg}} kcal/kg)',
-                { kcalPerKg: ENERGY_DENSITY_KCAL_PER_KG }
+                'Formula: Average Daily Calories − (Daily Weight Change in kg × {{energyPerKg}} {{unit}}/kg)',
+                {
+                  energyPerKg: displayEnergyPerKg,
+                  unit: getEnergyUnitString(energyUnit),
+                }
               )}
             </div>
             <p className="text-muted-foreground">
               {t(
                 'settings.breakdown.adaptiveFormulaExplainer',
-                '{{kcalPerKg}} kcal/kg is how much energy a kilogram of body weight represents, so your weight trend can be converted into calories. Body weight lost or gained is a mix of fat (~9,441 kcal/kg) and lean tissue and water (~1,816 kcal/kg), and {{kcalPerKg}} reflects a typical blend.',
-                { kcalPerKg: ENERGY_DENSITY_KCAL_PER_KG }
+                '{{energyPerKg}} {{unit}}/kg is how much energy a kilogram of body weight represents, so your weight trend can be converted into energy. Body weight lost or gained is a mix of fat (~{{fatPerKg}} {{unit}}/kg) and lean tissue and water (~{{leanPerKg}} {{unit}}/kg), and {{energyPerKg}} reflects a typical blend.',
+                {
+                  energyPerKg: displayEnergyPerKg,
+                  fatPerKg: Math.round(
+                    convertEnergy(FAT_KCAL_PER_KG, 'kcal', energyUnit)
+                  ),
+                  leanPerKg: Math.round(
+                    convertEnergy(LEAN_TISSUE_KCAL_PER_KG, 'kcal', energyUnit)
+                  ),
+                  unit: getEnergyUnitString(energyUnit),
+                }
               )}
             </p>
             {previewResult.insufficientHistory ? (
@@ -798,11 +819,21 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                     <li>
                       {t(
                         'diary.calculateExplanation.weightTrendCalories',
-                        'Energy from that trend: {{daily}} kg/day × 6000 kcal/kg = {{value}} {{unit}}',
+                        'Energy from that trend: {{daily}} kg/day × {{density}} {{unit}}/kg = {{value}} {{unit}}',
                         {
+                          // Energy density in the unit on screen. Labelling it
+                          // kcal/kg while printing a kJ result stated an equation
+                          // that does not compute.
+                          density: Math.round(
+                            convertEnergy(
+                              ENERGY_DENSITY_KCAL_PER_KG,
+                              'kcal',
+                              energyUnit
+                            )
+                          ),
                           daily: (
                             adaptiveTdeeData.dailyWeightChangeKg ?? 0
-                          ).toFixed(3),
+                          ).toFixed(4),
                           value: `${
                             displayAdaptiveDelta >= 0 ? '+' : '−'
                           }${Math.abs(displayAdaptiveDelta)}`,

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -20,6 +20,7 @@ import {
   ADAPTIVE_TDEE_GOAL_MIN_DAYS,
   getGoalModeAdjustment,
   ENERGY_DENSITY_KCAL_PER_KG,
+  ADAPTIVE_TDEE_CLAMP_KCAL,
   type CalorieTargetResult,
 } from '@workspace/shared';
 
@@ -810,7 +811,7 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                           days: adaptiveTdeeData.daysInWindow ?? 0,
                           daily: (
                             adaptiveTdeeData.dailyWeightChangeKg ?? 0
-                          ).toFixed(3),
+                          ).toFixed(4),
                         }
                       )}
                     </li>
@@ -875,8 +876,18 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                   <p className="text-xs text-amber-600 dark:text-amber-500">
                     {t(
                       'diary.calculateExplanation.adaptiveClamped',
-                      'Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±500 {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}}).',
+                      'Raw estimate of {{raw}} {{unit}} was capped to {{capped}} {{unit}}, the plausibility limit of ±{{band}} {{unit}} around your BMR-based estimate ({{min}}–{{max}} {{unit}}).',
                       {
+                        // The band is defined in kcal; printing a bare 500 beside
+                        // converted bounds claimed a range 4x narrower than the one
+                        // shown next to it.
+                        band: Math.round(
+                          convertEnergy(
+                            ADAPTIVE_TDEE_CLAMP_KCAL,
+                            'kcal',
+                            energyUnit
+                          )
+                        ),
                         raw: Math.round(
                           convertEnergy(
                             adaptiveTdeeData?.rawTdee || 0,

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -20,13 +20,11 @@ import {
   ADAPTIVE_TDEE_GOAL_MIN_DAYS,
   getGoalModeAdjustment,
   ENERGY_DENSITY_KCAL_PER_KG,
+  FAT_KCAL_PER_KG,
+  LEAN_TISSUE_KCAL_PER_KG,
   ADAPTIVE_TDEE_CLAMP_KCAL,
   type CalorieTargetResult,
 } from '@workspace/shared';
-
-/** Energy density of the tissue the blended ENERGY_DENSITY_KCAL_PER_KG averages. */
-const FAT_KCAL_PER_KG = 9441;
-const LEAN_TISSUE_KCAL_PER_KG = 1816;
 
 interface AdaptiveTdeeData {
   tdee?: number;

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -417,30 +417,39 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
           </span>
         </div>
         {isMeasuredBmr ? (
-          <div className="text-muted-foreground text-sm bg-muted/40 p-1.5 rounded border border-border/60">
-            {t(
-              'diary.calculateExplanation.bmrMeasuredDesc',
-              'Using your measured BMR. No formula applied.'
-            )}
+          <div className="text-muted-foreground text-sm bg-muted/40 p-1.5 rounded border border-border/60 space-y-1">
+            <div>
+              {t('diary.calculateExplanation.bmrMeasuredDesc', {
+                defaultValue:
+                  'Using a measured BMR of {{value}} {{unit}} recorded for this day, from a smart scale or health app sync. Your {{algorithm}} formula is not applied.',
+                value: displayBmrVal,
+                unit: getEnergyUnitString(energyUnit),
+                algorithm: bmrAlgorithmLabel,
+              })}
+            </div>
+            <div>
+              {t(
+                'diary.calculateExplanation.bmrMeasuredScope',
+                'A measured value only counts on the day it was recorded. Days without one fall back to the formula. To stop using measured values, turn off BMR sync in your health app settings.'
+              )}
+            </div>
           </div>
         ) : (
           <pre className="text-muted-foreground font-sans whitespace-pre-line text-sm bg-muted/40 p-1.5 rounded border border-border/60">
             {bmrMathText()}
           </pre>
         )}
-        {!isMeasuredBmr && (
-          <div className="flex justify-between items-center bg-muted/50 dark:bg-muted/40 p-1.5 rounded mt-1">
-            <span>
-              {t(
-                'diary.calculateExplanation.restingMetabolism',
-                'Resting Metabolism (RMR/BMR):'
-              )}
-            </span>
-            <span className="font-semibold text-foreground">
-              {displayBmrVal} {getEnergyUnitString(energyUnit)}
-            </span>
-          </div>
-        )}
+        <div className="flex justify-between items-center bg-muted/50 dark:bg-muted/40 p-1.5 rounded mt-1">
+          <span>
+            {t(
+              'diary.calculateExplanation.restingMetabolism',
+              'Resting Metabolism (RMR/BMR):'
+            )}
+          </span>
+          <span className="font-semibold text-foreground">
+            {displayBmrVal} {getEnergyUnitString(energyUnit)}
+          </span>
+        </div>
       </div>
 
       {/* Step 2: Body Fat Percentage */}

--- a/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
+++ b/SparkyFitnessFrontend/src/components/CalorieTargetBreakdown.tsx
@@ -148,6 +148,22 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
     convertEnergy(previewResult.rmr, 'kcal', energyUnit)
   );
 
+  // Adaptive TDEE derivation, in the units actually shown. The server reconciles
+  // its figures in kcal, but converting and rounding each one independently breaks
+  // the sum again in kJ — 2100 + 100 kcal renders as 8786 + 418 = 9204 kJ beside a
+  // total of 9205. So the delta is derived from the two displayed numbers rather
+  // than converted on its own, and the arithmetic holds in either unit.
+  const displayAdaptiveIntake = Math.round(
+    convertEnergy(adaptiveTdeeData?.avgIntake || 0, 'kcal', energyUnit)
+  );
+  const displayAdaptiveRawTdee = Math.round(
+    convertEnergy(adaptiveTdeeData?.rawTdee || 0, 'kcal', energyUnit)
+  );
+  // Against the raw estimate, not the capped one: when the cap binds the total no
+  // longer equals intake plus trend, and the trend row still has to state the real
+  // trend rather than be bent to match a capped total.
+  const displayAdaptiveDelta = displayAdaptiveRawTdee - displayAdaptiveIntake;
+
   // Inputs are printed at the precision the formula actually evaluates at. Rounding
   // weight to one decimal made the panel unable to reproduce its own answer: a stored
   // 73.45 kg printed as "73.5" recomputes to 1597 kcal against a stated 1596.
@@ -736,14 +752,7 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                       'diary.calculateExplanation.averageDailyIntake',
                       'Average daily calorie intake:'
                     )}{' '}
-                    {Math.round(
-                      convertEnergy(
-                        adaptiveTdeeData?.avgIntake || 0,
-                        'kcal',
-                        energyUnit
-                      )
-                    )}{' '}
-                    {getEnergyUnitString(energyUnit)}
+                    {displayAdaptiveIntake} {getEnergyUnitString(energyUnit)}
                     {adaptiveTdeeData?.windowStartDate &&
                       adaptiveTdeeData?.windowEndDate && (
                         // The average covers only days that were actually logged,
@@ -795,18 +804,8 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                             adaptiveTdeeData.dailyWeightChangeKg ?? 0
                           ).toFixed(3),
                           value: `${
-                            adaptiveTdeeData.weightChangeCalories >= 0
-                              ? '+'
-                              : '−'
-                          }${Math.abs(
-                            Math.round(
-                              convertEnergy(
-                                adaptiveTdeeData.weightChangeCalories,
-                                'kcal',
-                                energyUnit
-                              )
-                            )
-                          )}`,
+                            displayAdaptiveDelta >= 0 ? '+' : '−'
+                          }${Math.abs(displayAdaptiveDelta)}`,
                           unit: getEnergyUnitString(energyUnit),
                         }
                       )}
@@ -834,26 +833,9 @@ export const CalorieTargetBreakdown: React.FC<CalorieTargetBreakdownProps> = ({
                             'diary.calculateExplanation.tdeeSum',
                             '({{intake}} {{sign}} {{delta}})',
                             {
-                              intake: Math.round(
-                                convertEnergy(
-                                  adaptiveTdeeData?.avgIntake || 0,
-                                  'kcal',
-                                  energyUnit
-                                )
-                              ),
-                              sign:
-                                adaptiveTdeeData.weightChangeCalories < 0
-                                  ? '−'
-                                  : '+',
-                              delta: Math.abs(
-                                Math.round(
-                                  convertEnergy(
-                                    adaptiveTdeeData.weightChangeCalories,
-                                    'kcal',
-                                    energyUnit
-                                  )
-                                )
-                              ),
+                              intake: displayAdaptiveIntake,
+                              sign: displayAdaptiveDelta < 0 ? '−' : '+',
+                              delta: Math.abs(displayAdaptiveDelta),
                             }
                           )}
                         </span>

--- a/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
+++ b/SparkyFitnessFrontend/src/contexts/PreferencesContext.tsx
@@ -111,6 +111,8 @@ interface PreferencesContextType {
   bmrAlgorithm: BmrAlgorithm;
   bodyFatAlgorithm: BodyFatAlgorithm;
   includeBmrInNetCalories: boolean;
+  /** Whether a synced/measured BMR may replace the chosen formula. Off by default. */
+  useExternalBmr: boolean;
   showNetCarbs: boolean;
   aiAssistedConversions: boolean;
   fatBreakdownAlgorithm: FatBreakdownAlgorithm;
@@ -162,6 +164,7 @@ interface PreferencesContextType {
   setBmrAlgorithm: (algorithm: BmrAlgorithm) => void;
   setBodyFatAlgorithm: (algorithm: BodyFatAlgorithm) => void;
   setIncludeBmrInNetCalories: (include: boolean) => void;
+  setUseExternalBmr: (use: boolean) => void;
   setShowNetCarbs: (show: boolean) => void;
   setAiAssistedConversions: (enabled: boolean) => void;
   setFatBreakdownAlgorithm: (algorithm: FatBreakdownAlgorithm) => void;
@@ -233,6 +236,7 @@ export interface DefaultPreferences {
   bmr_algorithm: BmrAlgorithm;
   body_fat_algorithm: BodyFatAlgorithm;
   include_bmr_in_net_calories: boolean;
+  use_external_bmr: boolean;
   show_net_carbs: boolean;
   ai_assisted_conversions: boolean;
   fat_breakdown_algorithm: FatBreakdownAlgorithm;
@@ -324,6 +328,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
     useState<BodyFatAlgorithm>(BodyFatAlgorithm.US_NAVY);
   const [includeBmrInNetCalories, setIncludeBmrInNetCaloriesState] =
     useState<boolean>(false);
+  const [useExternalBmr, setUseExternalBmrState] = useState<boolean>(false);
   const [showNetCarbs, setShowNetCarbsState] = useState<boolean>(false);
   const [addExerciseWaterToGoal, setAddExerciseWaterToGoalState] =
     useState<boolean>(false);
@@ -727,6 +732,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         setIncludeBmrInNetCaloriesState(
           data.include_bmr_in_net_calories ?? false
         );
+        setUseExternalBmrState(data.use_external_bmr ?? false);
         setShowNetCarbsState(data.show_net_carbs ?? false);
         setAddExerciseWaterToGoalState(
           data.add_exercise_water_to_goal ?? false
@@ -918,6 +924,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
         body_fat_algorithm: newPrefs?.bodyFatAlgorithm ?? bodyFatAlgorithm,
         include_bmr_in_net_calories:
           newPrefs?.includeBmrInNetCalories ?? includeBmrInNetCalories,
+        use_external_bmr: newPrefs?.useExternalBmr ?? useExternalBmr,
         show_net_carbs: newPrefs?.showNetCarbs ?? showNetCarbs,
         add_exercise_water_to_goal:
           newPrefs?.addExerciseWaterToGoal ?? addExerciseWaterToGoal,
@@ -992,6 +999,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       bmrAlgorithm,
       bodyFatAlgorithm,
       includeBmrInNetCalories,
+      useExternalBmr,
       showNetCarbs,
       aiAssistedConversions,
       fatBreakdownAlgorithm,
@@ -1251,6 +1259,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       bmrAlgorithm,
       bodyFatAlgorithm,
       includeBmrInNetCalories,
+      useExternalBmr,
       showNetCarbs,
       aiAssistedConversions,
       fatBreakdownAlgorithm,
@@ -1299,6 +1308,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       setBmrAlgorithm: setBmrAlgorithmState,
       setBodyFatAlgorithm: setBodyFatAlgorithmState,
       setIncludeBmrInNetCalories: setIncludeBmrInNetCaloriesState,
+      setUseExternalBmr: setUseExternalBmrState,
       setShowNetCarbs: setShowNetCarbsState,
       setAiAssistedConversions: setAiAssistedConversionsState,
       setFatBreakdownAlgorithm: setFatBreakdownAlgorithmState,
@@ -1349,6 +1359,7 @@ export const PreferencesProvider: React.FC<{ children: React.ReactNode }> = ({
       bmrAlgorithm,
       bodyFatAlgorithm,
       includeBmrInNetCalories,
+      useExternalBmr,
       showNetCarbs,
       aiAssistedConversions,
       fatBreakdownAlgorithm,

--- a/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
+++ b/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
@@ -209,7 +209,7 @@ export const useCalculatedBMR = () => {
       ? calculateAge(userProfile!.date_of_birth, timezone)
       : 0;
     try {
-      formulaBmr = calculateBmr(
+      const computed = calculateBmr(
         bmrAlgorithm as BmrAlgorithm,
         weightData!.weight,
         heightData!.height,
@@ -217,6 +217,10 @@ export const useCalculatedBMR = () => {
         userProfile!.gender as 'male' | 'female',
         bodyFatData?.body_fat_percentage
       );
+      // `calculateBmr` does not throw on incomplete input — it warns and returns 0
+      // (e.g. Katch-McArdle with no body-fat reading). A zero is "no estimate", not
+      // an estimate of zero, so it must not reach the ratio check or the caller.
+      formulaBmr = computed > 0 ? computed : null;
     } catch {
       formulaBmr = null;
     }
@@ -232,10 +236,17 @@ export const useCalculatedBMR = () => {
     };
   }
 
+  // One shape for every outcome, so consumers never have to branch on which keys
+  // are present. With no usable BMR there is nothing to subtract, so net calories
+  // must exclude it regardless of the user's preference.
   if (formulaBmr === null) {
-    return canComputeFormula
-      ? { bmr: 0, includeInNet: false, weight: 0, height: 0 }
-      : { bmr: 0, includeInNet: false };
+    return {
+      bmr: 0,
+      measuredBmr: null,
+      includeInNet: false,
+      weight: weightData?.weight || 0,
+      height: heightData?.height || 0,
+    };
   }
 
   return {

--- a/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
+++ b/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
@@ -175,10 +175,24 @@ export const useMostRecentBmrQuery = (onDate: string, enabled = true) => {
   });
 };
 
-export const useCalculatedBMR = () => {
+/**
+ * @param overrides Unsaved values to preview against. The Settings page holds its
+ * pending edits in local state, so without these the live preview would keep
+ * showing the last *saved* preference and only catch up after a save and reload.
+ */
+export const useCalculatedBMR = (overrides?: {
+  bmrAlgorithm?: string;
+  useExternalBmr?: boolean;
+}) => {
   const { user } = useAuth();
-  const { bmrAlgorithm, includeBmrInNetCalories, useExternalBmr, timezone } =
-    usePreferences();
+  const {
+    bmrAlgorithm: savedBmrAlgorithm,
+    includeBmrInNetCalories,
+    useExternalBmr: savedUseExternalBmr,
+    timezone,
+  } = usePreferences();
+  const bmrAlgorithm = overrides?.bmrAlgorithm ?? savedBmrAlgorithm;
+  const useExternalBmr = overrides?.useExternalBmr ?? savedUseExternalBmr;
 
   const { data: userProfile } = useQuery({
     queryKey: userKeys.profile(user?.id ?? ''),

--- a/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
+++ b/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
@@ -177,7 +177,8 @@ export const useMostRecentBmrQuery = (onDate: string, enabled = true) => {
 
 export const useCalculatedBMR = () => {
   const { user } = useAuth();
-  const { bmrAlgorithm, includeBmrInNetCalories, timezone } = usePreferences();
+  const { bmrAlgorithm, includeBmrInNetCalories, useExternalBmr, timezone } =
+    usePreferences();
 
   const { data: userProfile } = useQuery({
     queryKey: userKeys.profile(user?.id ?? ''),
@@ -226,7 +227,13 @@ export const useCalculatedBMR = () => {
     }
   }
 
-  if (isUsableMeasuredBmr(rawMeasured, formulaBmr) && rawMeasured !== null) {
+  // Same opt-in gate as the server: without it the Diary would show a measured
+  // BMR the goal calculation had already discarded.
+  if (
+    useExternalBmr &&
+    isUsableMeasuredBmr(rawMeasured, formulaBmr) &&
+    rawMeasured !== null
+  ) {
     return {
       bmr: rawMeasured,
       measuredBmr: rawMeasured,

--- a/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
+++ b/SparkyFitnessFrontend/src/hooks/Diary/useDailyProgress.ts
@@ -2,7 +2,11 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
 import { usePreferences } from '@/contexts/PreferencesContext';
-import { calculateAge } from '@workspace/shared';
+import {
+  calculateAge,
+  isUsableMeasuredBmr,
+  todayInZone,
+} from '@workspace/shared';
 import { dailyProgressKeys } from '@/api/keys/diary';
 import { userManagementService } from '@/api/Admin/userManagementService';
 import {
@@ -147,13 +151,21 @@ export const useMostRecentBodyFatQuery = (enabled = true) => {
   });
 };
 
-export const useMostRecentBmrQuery = (enabled = true) => {
+/**
+ * Measured BMR for a single day.
+ *
+ * Unlike weight or height this is never carried forward: a measured BMR describes
+ * the day it was recorded, so on a day without a reading the caller falls back to
+ * the user's chosen formula. Carrying it forward kept a stale reading driving the
+ * calorie target long after syncing stopped (issue #2395).
+ */
+export const useMostRecentBmrQuery = (onDate: string, enabled = true) => {
   const { t } = useTranslation();
 
   return useQuery({
-    queryKey: dailyProgressKeys.measurements.mostRecent('bmr'),
-    queryFn: () => getMostRecentMeasurement('bmr'),
-    enabled,
+    queryKey: dailyProgressKeys.measurements.mostRecent('bmr', onDate),
+    queryFn: () => getMostRecentMeasurement('bmr', onDate),
+    enabled: enabled && Boolean(onDate),
     meta: {
       errorMessage: t(
         'measurements.errorLoadingBmr',
@@ -176,14 +188,41 @@ export const useCalculatedBMR = () => {
   const { data: weightData } = useMostRecentWeightQuery();
   const { data: heightData } = useMostRecentHeightQuery();
   const { data: bodyFatData } = useMostRecentBodyFatQuery();
-  const { data: bmrData } = useMostRecentBmrQuery();
+  const { data: bmrData } = useMostRecentBmrQuery(todayInZone(timezone));
 
   const rawMeasured = bmrData?.bmr ? Number(bmrData.bmr) : null;
-  const isMeasured = Boolean(
-    rawMeasured && rawMeasured >= 300 && rawMeasured <= 10000
+
+  // The formula estimate is computed first, because a measured reading is only
+  // trusted once it has been checked against this person's own estimate. It stays
+  // null when the profile is too incomplete to compute one, in which case the
+  // absolute bounds decide alone. Mirrors the server (calorieBalanceService).
+  const canComputeFormula = Boolean(
+    userProfile &&
+    weightData?.weight &&
+    heightData?.height &&
+    userProfile.gender
   );
 
-  if (isMeasured && rawMeasured !== null) {
+  let formulaBmr: number | null = null;
+  if (canComputeFormula) {
+    const age = userProfile!.date_of_birth
+      ? calculateAge(userProfile!.date_of_birth, timezone)
+      : 0;
+    try {
+      formulaBmr = calculateBmr(
+        bmrAlgorithm as BmrAlgorithm,
+        weightData!.weight,
+        heightData!.height,
+        age,
+        userProfile!.gender as 'male' | 'female',
+        bodyFatData?.body_fat_percentage
+      );
+    } catch {
+      formulaBmr = null;
+    }
+  }
+
+  if (isUsableMeasuredBmr(rawMeasured, formulaBmr) && rawMeasured !== null) {
     return {
       bmr: rawMeasured,
       measuredBmr: rawMeasured,
@@ -193,37 +232,17 @@ export const useCalculatedBMR = () => {
     };
   }
 
-  if (
-    !userProfile ||
-    !weightData?.weight ||
-    !heightData?.height ||
-    !userProfile.gender
-  ) {
-    return { bmr: 0, includeInNet: false };
+  if (formulaBmr === null) {
+    return canComputeFormula
+      ? { bmr: 0, includeInNet: false, weight: 0, height: 0 }
+      : { bmr: 0, includeInNet: false };
   }
 
-  const age = userProfile.date_of_birth
-    ? calculateAge(userProfile.date_of_birth, timezone)
-    : 0;
-
-  try {
-    const bmr = calculateBmr(
-      bmrAlgorithm as BmrAlgorithm,
-      weightData.weight,
-      heightData.height,
-      age,
-      userProfile.gender as 'male' | 'female',
-      bodyFatData?.body_fat_percentage
-    );
-
-    return {
-      bmr,
-      measuredBmr: null,
-      includeInNet: includeBmrInNetCalories || false,
-      weight: weightData.weight,
-      height: heightData.height,
-    };
-  } catch (err) {
-    return { bmr: 0, includeInNet: false, weight: 0, height: 0 };
-  }
+  return {
+    bmr: formulaBmr,
+    measuredBmr: null,
+    includeInNet: includeBmrInNetCalories || false,
+    weight: weightData!.weight,
+    height: heightData!.height,
+  };
 };

--- a/SparkyFitnessFrontend/src/pages/CheckIn/CheckInForm.tsx
+++ b/SparkyFitnessFrontend/src/pages/CheckIn/CheckInForm.tsx
@@ -12,7 +12,11 @@ import { Switch } from '@/components/ui/switch';
 import { usePreferences } from '@/contexts/PreferencesContext';
 import { useTranslation } from 'react-i18next';
 import { UnitInput } from '@/components/ui/UnitInput';
-import { CustomCategoriesResponse } from '@workspace/shared';
+import {
+  CustomCategoriesResponse,
+  MIN_MEASURED_BMR_KCAL,
+  MAX_MEASURED_BMR_KCAL,
+} from '@workspace/shared';
 import { CheckInPlaceholders } from '@/types/checkin';
 import { History } from 'lucide-react';
 import {
@@ -368,8 +372,8 @@ export const CheckInForm: React.FC<CheckInFormProps> = ({
               <Input
                 id="bmr"
                 type="number"
-                min="300"
-                max="10000"
+                min={MIN_MEASURED_BMR_KCAL}
+                max={MAX_MEASURED_BMR_KCAL}
                 step="1"
                 value={bmr}
                 onChange={(e) => setBmr(e.target.value)}

--- a/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
@@ -1003,7 +1003,7 @@ const CalculationSettings = () => {
                   💡{' '}
                   {t(
                     'settings.calorieGoalAdjustment.adaptiveActivityHint',
-                    'In Adaptive mode, this setting acts as a fallback until you have enough tracking data.'
+                    'In Adaptive mode this is the fallback estimate until you have enough tracking data — and it keeps setting the plausibility limits afterwards. Your measured TDEE is capped to within ±500 kcal of BMR × this multiplier, so a level set too low can hold a genuinely higher expenditure down.'
                   )}
                 </p>
               )}

--- a/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
@@ -235,6 +235,9 @@ const CalculationSettings = () => {
     if (contextIncludeBmrInNetCalories !== undefined) {
       setIncludeBmrInNetCalories(contextIncludeBmrInNetCalories);
     }
+    if (contextUseExternalBmr !== undefined) {
+      setUseExternalBmr(contextUseExternalBmr);
+    }
     if (contextShowNetCarbs !== undefined) {
       setShowNetCarbs(contextShowNetCarbs);
     }
@@ -298,6 +301,7 @@ const CalculationSettings = () => {
     contextBmrAlgorithm,
     contextBodyFatAlgorithm,
     contextIncludeBmrInNetCalories,
+    contextUseExternalBmr,
     contextShowNetCarbs,
     contextFatBreakdownAlgorithm,
     contextMineralCalculationAlgorithm,
@@ -395,7 +399,7 @@ const CalculationSettings = () => {
     measuredBmr,
     weight: weightKg,
     height: heightCm,
-  } = useCalculatedBMR();
+  } = useCalculatedBMR({ bmrAlgorithm, useExternalBmr });
   const todayStr = todayInZone(timezone || 'UTC');
   const { data: adaptiveTdeeData } = useAdaptiveTdee(todayStr);
   const { data: goalsData } = useDiaryGoals(todayStr, false);
@@ -1491,6 +1495,16 @@ const CalculationSettings = () => {
           <div className="p-4 bg-muted/50 dark:bg-muted/30 border border-border rounded-xl space-y-2">
             <p className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
               {t('settings.goalMode.livePreview', 'Live Preview Calculation')}
+            </p>
+            {/* Adaptive TDEE is computed on the server from the *saved*
+                preferences, so an unsaved edit cannot move it or anything derived
+                from it. BMR and body fat are worked out here and do update as you
+                type, which makes the split invisible without saying so. */}
+            <p className="text-xs text-muted-foreground italic">
+              {t(
+                'settings.goalMode.livePreviewSavedNote',
+                'BMR and body fat update as you change settings. Expenditure is calculated on the server from your saved settings, so it and the final target only change after you save.'
+              )}
             </p>
             <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 text-sm">
               <div>

--- a/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
+++ b/SparkyFitnessFrontend/src/pages/Settings/CalculationSettings.tsx
@@ -113,6 +113,7 @@ const CalculationSettings = () => {
     bmrAlgorithm: contextBmrAlgorithm,
     bodyFatAlgorithm: contextBodyFatAlgorithm,
     includeBmrInNetCalories: contextIncludeBmrInNetCalories,
+    useExternalBmr: contextUseExternalBmr,
     showNetCarbs: contextShowNetCarbs,
     fatBreakdownAlgorithm: contextFatBreakdownAlgorithm,
     mineralCalculationAlgorithm: contextMineralCalculationAlgorithm,
@@ -193,6 +194,7 @@ const CalculationSettings = () => {
   const [includeBmrInNetCalories, setIncludeBmrInNetCalories] = useState(
     contextIncludeBmrInNetCalories || false
   );
+  const [useExternalBmr, setUseExternalBmr] = useState(contextUseExternalBmr);
   const [showNetCarbs, setShowNetCarbs] = useState(
     contextShowNetCarbs || false
   );
@@ -322,6 +324,7 @@ const CalculationSettings = () => {
         bmrAlgorithm,
         bodyFatAlgorithm,
         includeBmrInNetCalories,
+        useExternalBmr,
         showNetCarbs,
         energyUnit, // Ensure energyUnit is included in saving
         fatBreakdownAlgorithm: fatBreakdownAlgorithm,
@@ -755,6 +758,31 @@ const CalculationSettings = () => {
             {t(
               'calculationSettings.includeBmrInNetCaloriesHint',
               'When enabled, your BMR will be subtracted from your daily net calorie total.'
+            )}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="use-external-bmr"
+          checked={useExternalBmr}
+          onCheckedChange={(checked) => setUseExternalBmr(Boolean(checked))}
+        />
+        <div className="grid gap-1.5 leading-none">
+          <Label
+            htmlFor="use-external-bmr"
+            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+          >
+            {t(
+              'calculationSettings.useExternalBmr',
+              'Use measured BMR from check-ins and synced devices'
+            )}
+          </Label>
+          <p className="text-sm text-muted-foreground">
+            {t(
+              'calculationSettings.useExternalBmrHint',
+              'Off by default — your chosen formula is always used until you turn this on. When enabled, a BMR recorded on a check-in or synced from a smart scale or health provider replaces the formula for that day, provided it is physiologically plausible for you. Some devices report BMR as a running daily total rather than a rate, which is why this is opt-in.'
             )}
           </p>
         </div>

--- a/SparkyFitnessFrontend/src/tests/hooks/useCalculatedBMR.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useCalculatedBMR.test.tsx
@@ -1,5 +1,11 @@
 import { renderHook } from '@testing-library/react';
+import { todayInZone } from '@workspace/shared';
 import { useCalculatedBMR } from '@/hooks/Diary/useDailyProgress';
+
+// Measured BMR is looked up for a single day, so its query key carries that date.
+// The other metrics carry forward and stay date-less.
+const bmrKey = (date: string = todayInZone('UTC')) =>
+  JSON.stringify(['dailyProgress', 'measurements', 'recent', 'bmr', date]);
 
 const mockUseAuth = jest.fn();
 const mockUsePreferences = jest.fn();
@@ -43,9 +49,7 @@ describe('useCalculatedBMR', () => {
     mockQueryData[
       JSON.stringify(['dailyProgress', 'measurements', 'recent', 'height'])
     ] = null; // Missing height
-    mockQueryData[
-      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'bmr'])
-    ] = { bmr: 1750 };
+    mockQueryData[bmrKey()] = { bmr: 1750 };
 
     const { result } = renderHook(() => useCalculatedBMR());
 
@@ -65,9 +69,7 @@ describe('useCalculatedBMR', () => {
     mockQueryData[
       JSON.stringify(['dailyProgress', 'measurements', 'recent', 'height'])
     ] = { height: 175 };
-    mockQueryData[
-      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'bmr'])
-    ] = null;
+    mockQueryData[bmrKey()] = null;
 
     const { result } = renderHook(() => useCalculatedBMR());
 
@@ -80,5 +82,46 @@ describe('useCalculatedBMR', () => {
 
     expect(result.current.bmr).toBe(0);
     expect(result.current.includeInNet).toBe(false);
+  });
+
+  it('ignores a measured BMR recorded on a different day', () => {
+    mockQueryData[JSON.stringify(['users', 'profile', 'user-1'])] = {
+      gender: 'male',
+      date_of_birth: '1990-01-01',
+    };
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'weight'])
+    ] = { weight: 70 };
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'height'])
+    ] = { height: 175 };
+    // Recorded on some other date, so today's lookup misses it entirely.
+    mockQueryData[bmrKey('2020-01-01')] = { bmr: 2600 };
+
+    const { result } = renderHook(() => useCalculatedBMR());
+
+    expect(result.current.measuredBmr).toBeNull();
+    expect(result.current.bmr).toBeGreaterThan(1000);
+    expect(result.current.bmr).not.toBe(2600);
+  });
+
+  it('rejects a measured BMR outside the plausible range', () => {
+    mockQueryData[JSON.stringify(['users', 'profile', 'user-1'])] = {
+      gender: 'male',
+      date_of_birth: '1990-01-01',
+    };
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'weight'])
+    ] = { weight: 70 };
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'height'])
+    ] = { height: 175 };
+    // The reading from issue #2395 — inside the old 300-10000 range, outside 600-6000.
+    mockQueryData[bmrKey()] = { bmr: 350 };
+
+    const { result } = renderHook(() => useCalculatedBMR());
+
+    expect(result.current.measuredBmr).toBeNull();
+    expect(result.current.bmr).toBeGreaterThan(1000);
   });
 });

--- a/SparkyFitnessFrontend/src/tests/hooks/useCalculatedBMR.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useCalculatedBMR.test.tsx
@@ -33,6 +33,8 @@ describe('useCalculatedBMR', () => {
     mockUsePreferences.mockReturnValue({
       bmrAlgorithm: 'Mifflin-St Jeor',
       includeBmrInNetCalories: false,
+      // The measured-BMR path is opt-in; these cases exercise it turned on.
+      useExternalBmr: true,
       timezone: 'UTC',
     });
     mockQueryData = {};
@@ -123,5 +125,31 @@ describe('useCalculatedBMR', () => {
 
     expect(result.current.measuredBmr).toBeNull();
     expect(result.current.bmr).toBeGreaterThan(1000);
+  });
+  it('ignores a measured BMR when the opt-in is off', () => {
+    mockUsePreferences.mockReturnValue({
+      bmrAlgorithm: 'Mifflin-St Jeor',
+      includeBmrInNetCalories: false,
+      useExternalBmr: false,
+      timezone: 'UTC',
+    });
+    mockQueryData[JSON.stringify(['users', 'profile', 'user-1'])] = {
+      gender: 'male',
+      date_of_birth: '1990-01-01',
+    };
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'weight'])
+    ] = { weight: 80 };
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'height'])
+    ] = { height: 180 };
+    // Well inside the plausible band, so only the preference can reject it.
+    mockQueryData[bmrKey()] = { bmr: 1900 };
+
+    const { result } = renderHook(() => useCalculatedBMR());
+
+    expect(result.current.measuredBmr).toBeNull();
+    expect(result.current.bmr).toBeGreaterThan(1000);
+    expect(result.current.bmr).not.toBe(1900);
   });
 });

--- a/SparkyFitnessFrontend/src/tests/hooks/useCalculatedBMR.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useCalculatedBMR.test.tsx
@@ -152,4 +152,31 @@ describe('useCalculatedBMR', () => {
     expect(result.current.bmr).toBeGreaterThan(1000);
     expect(result.current.bmr).not.toBe(1900);
   });
+  it('honours an unsaved override so the settings preview reacts before saving', () => {
+    // Saved preference is off; the Settings page passes its pending edit instead.
+    mockUsePreferences.mockReturnValue({
+      bmrAlgorithm: 'Mifflin-St Jeor',
+      includeBmrInNetCalories: false,
+      useExternalBmr: false,
+      timezone: 'UTC',
+    });
+    mockQueryData[JSON.stringify(['users', 'profile', 'user-1'])] = {
+      gender: 'male',
+      date_of_birth: '1990-01-01',
+    };
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'weight'])
+    ] = { weight: 80 };
+    mockQueryData[
+      JSON.stringify(['dailyProgress', 'measurements', 'recent', 'height'])
+    ] = { height: 180 };
+    mockQueryData[bmrKey()] = { bmr: 1900 };
+
+    const { result } = renderHook(() =>
+      useCalculatedBMR({ useExternalBmr: true })
+    );
+
+    expect(result.current.measuredBmr).toBe(1900);
+    expect(result.current.bmr).toBe(1900);
+  });
 });

--- a/SparkyFitnessMobile/__tests__/screens/CalorieSettingsScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/CalorieSettingsScreen.test.tsx
@@ -122,6 +122,21 @@ describe('CalorieSettingsScreen', () => {
     expect(mockMutate).toHaveBeenCalledWith({ goal_mode: 'recomp' });
   });
 
+  it('saves the measured-BMR opt-in against the shared preference', () => {
+    // Same `use_external_bmr` column the web Calculation Settings writes, so the
+    // two clients stay in step without any sync of their own.
+    const { getByLabelText } = render(
+      <CalorieSettingsScreen navigation={navigation} route={route} />
+    );
+
+    const toggle = getByLabelText(
+      'Use measured BMR from check-ins and synced devices'
+    );
+    fireEvent(toggle, 'valueChange', true);
+
+    expect(mockMutate).toHaveBeenCalledWith({ use_external_bmr: true });
+  });
+
   it('saves a bounded custom Goal Mode percentage', () => {
     mockPreferences.goal_mode = 'manual';
     mockPreferences.goal_mode_custom_percentage = -10;

--- a/SparkyFitnessMobile/app.json
+++ b/SparkyFitnessMobile/app.json
@@ -51,18 +51,14 @@
           }
         }
       ],
-      [
-        "expo-notifications"
-      ],
+      ["expo-notifications"],
       [
         "expo-navigation-bar",
         {
           "enforceContrast": false
         }
       ],
-      [
-        "@bacons/apple-targets"
-      ]
+      ["@bacons/apple-targets"]
     ],
     "experiments": {
       "reactCompiler": true,

--- a/SparkyFitnessMobile/src/localization/locales/en/translation.json
+++ b/SparkyFitnessMobile/src/localization/locales/en/translation.json
@@ -874,7 +874,10 @@
       "standardDescription": "Uses the higher of your estimated RMR and the clinical minimum.",
       "customDescription": "Replaces the standard floor with your chosen minimum. Health recommendations remain visible.",
       "disabledDescription": "Stops automatic target clamping. Health warnings remain visible."
-    }
+    },
+    "useExternalBmr": "Use measured BMR from check-ins and synced devices",
+    "useExternalBmrHint": "Off by default — your chosen formula is always used until you turn this on. When enabled, a BMR recorded on a check-in or synced from a smart scale or health provider replaces the formula for that day, provided it is physiologically plausible for you.",
+    "useExternalBmrIosNote": "Apple Health’s Resting Energy already includes light daily activity, so consider setting Activity Level to None (×1.0) to avoid counting it twice."
   },
   "dashboardSettings": {
     "updateFailed": "Failed to update setting.",

--- a/SparkyFitnessMobile/src/localization/locales/en/translation.json
+++ b/SparkyFitnessMobile/src/localization/locales/en/translation.json
@@ -2012,7 +2012,7 @@
       "feetInchesNumber": "Enter a number for feet and inches.",
       "bodyFatRange": "Body fat % must be between 0 and 100.",
       "bodyWaterRange": "Body water % must be between 0 and 100.",
-      "bmrRange": "BMR must be between 300 and 10000 kcal."
+      "bmrRange": "BMR must be between 600 and 6000 kcal."
     },
     "nothingToSave": "Nothing to save",
     "enterValue": "Enter or clear at least one value.",

--- a/SparkyFitnessMobile/src/localization/locales/en/translation.json
+++ b/SparkyFitnessMobile/src/localization/locales/en/translation.json
@@ -804,7 +804,7 @@
     "exerciseCaloriesDescription": "How much of your exercise calories are added back to your daily goal.",
     "activityLevel": "Activity Level",
     "activityBaseline": "Used as a baseline for TDEE.",
-    "adaptiveFallback": "Acts as a fallback until you have enough tracking data.",
+    "adaptiveFallback": "The fallback estimate until you have enough tracking data — and it keeps setting the plausibility limits afterwards. Your measured TDEE is capped to within ±500 kcal of BMR × this multiplier.",
     "allowNegative": "Allow Lower Fallback Projection",
     "negativeDescription": "When a device total is unavailable, let the BMR + active calories fallback lower your target.",
     "includeResting": "Include Resting Calories",

--- a/SparkyFitnessMobile/src/screens/CalorieSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/CalorieSettingsScreen.tsx
@@ -582,7 +582,7 @@ const CalorieSettingsScreen: React.FC<CalorieSettingsScreenProps> = () => {
                 <Text className="text-text-secondary text-sm mt-3">
                   {t('calorieSettings.adaptiveFallback', {
                     defaultValue:
-                      'Acts as a fallback until you have enough tracking data.',
+                      'The fallback estimate until you have enough tracking data — and it keeps setting the plausibility limits afterwards. Your measured TDEE is capped to within ±500 kcal of BMR × this multiplier.',
                   })}
                 </Text>
               )}

--- a/SparkyFitnessMobile/src/screens/CalorieSettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/CalorieSettingsScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { View, Text, ScrollView } from 'react-native';
+import { View, Text, ScrollView, Platform } from 'react-native';
 import Animated, { LinearTransition } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useCSSVariable } from 'uniwind';
@@ -38,6 +38,7 @@ function normalizePreferences(prefs: UserPreferences | undefined) {
     activityLevel: prefs?.activity_level ?? 'not_much',
     exerciseCaloriePercentage: prefs?.exercise_calorie_percentage ?? 100,
     includeBmrInNetCalories: prefs?.include_bmr_in_net_calories ?? false,
+    useExternalBmr: prefs?.use_external_bmr ?? false,
     tdeeAllowNegativeAdjustment: prefs?.tdee_allow_negative_adjustment ?? false,
     goalMode: prefs?.goal_mode ?? 'maintain',
     goalModeCustomPercentage: prefs?.goal_mode_custom_percentage ?? 0,
@@ -291,6 +292,13 @@ const CalorieSettingsScreen: React.FC<CalorieSettingsScreenProps> = () => {
   const handleBmrToggle = useCallback(
     (value: boolean) => {
       mutation.mutate({ include_bmr_in_net_calories: value });
+    },
+    [mutation]
+  );
+
+  const handleExternalBmrToggle = useCallback(
+    (value: boolean) => {
+      mutation.mutate({ use_external_bmr: value });
     },
     [mutation]
   );
@@ -833,6 +841,43 @@ const CalorieSettingsScreen: React.FC<CalorieSettingsScreenProps> = () => {
             )}
           </Animated.View>
         </Animated.View>
+
+        {/* Measured BMR — same `use_external_bmr` preference as the web
+            Calculation Settings, so a change here shows up there and vice versa.
+            Deliberately worded identically: one setting under two different names
+            across clients is worse than a slightly less platform-native label. */}
+        <View className="bg-surface rounded-xl p-4 mb-4 shadow-sm">
+          <View className="flex-row justify-between items-center">
+            <Text className="text-base font-semibold text-text-primary flex-1 mr-3">
+              {t('calorieSettings.useExternalBmr', {
+                defaultValue:
+                  'Use measured BMR from check-ins and synced devices',
+              })}
+            </Text>
+            <Switch
+              onValueChange={handleExternalBmrToggle}
+              value={normalized.useExternalBmr}
+              accessibilityLabel={t('calorieSettings.useExternalBmr', {
+                defaultValue:
+                  'Use measured BMR from check-ins and synced devices',
+              })}
+            />
+          </View>
+          <Text className="text-text-secondary text-sm mt-3">
+            {t('calorieSettings.useExternalBmrHint', {
+              defaultValue:
+                'Off by default — your chosen formula is always used until you turn this on. When enabled, a BMR recorded on a check-in or synced from a smart scale or health provider replaces the formula for that day, provided it is physiologically plausible for you.',
+            })}
+          </Text>
+          {normalized.useExternalBmr && Platform.OS === 'ios' && (
+            <Text className="text-text-secondary text-xs mt-3 italic">
+              {t('calorieSettings.useExternalBmrIosNote', {
+                defaultValue:
+                  'Apple Health’s Resting Energy already includes light daily activity, so consider setting Activity Level to None (×1.0) to avoid counting it twice.',
+              })}
+            </Text>
+          )}
+        </View>
       </ScrollView>
     </View>
   );

--- a/SparkyFitnessMobile/src/screens/MeasurementsAddScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MeasurementsAddScreen.tsx
@@ -43,6 +43,10 @@ import {
 } from '../utils/unitConversions';
 import { parseDecimalInput } from '../utils/numericInput';
 import {
+  MIN_MEASURED_BMR_KCAL,
+  MAX_MEASURED_BMR_KCAL,
+} from '@workspace/shared';
+import {
   syncCustomForm,
   buildCustomOps,
   isManualSource,
@@ -831,13 +835,13 @@ const MeasurementsAddScreen: React.FC<Props> = ({ navigation, route }) => {
       !apply(
         'bmr',
         evaluateField('bmr', fieldLabel('bmr', 'BMR'), {
-          min: 300,
-          max: 10000,
+          min: MIN_MEASURED_BMR_KCAL,
+          max: MAX_MEASURED_BMR_KCAL,
           minMessage: t('measurements.validation.bmrRange', {
-            defaultValue: 'BMR must be between 300 and 10000 kcal.',
+            defaultValue: 'BMR must be between 600 and 6000 kcal.',
           }),
           maxMessage: t('measurements.validation.bmrRange', {
-            defaultValue: 'BMR must be between 300 and 10000 kcal.',
+            defaultValue: 'BMR must be between 600 and 6000 kcal.',
           }),
         }),
         (v) => v

--- a/SparkyFitnessServer/ai/tools/schemas/checkin.ts
+++ b/SparkyFitnessServer/ai/tools/schemas/checkin.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
 import {
+  MIN_MEASURED_BMR_KCAL,
+  MAX_MEASURED_BMR_KCAL,
+} from '@workspace/shared';
+import {
   dateSchema,
   optionalDateSchema,
   weightUnitEnum,
@@ -55,8 +59,8 @@ const logBiometricsSchema = z
       .describe('Body water percentage'),
     bmr: z.coerce
       .number()
-      .min(300)
-      .max(10000)
+      .min(MIN_MEASURED_BMR_KCAL)
+      .max(MAX_MEASURED_BMR_KCAL)
       .optional()
       .describe('Basal Metabolic Rate (BMR) in kcal'),
   })

--- a/SparkyFitnessServer/db/migrations/20260908120000_narrow_check_in_bmr_bounds.sql
+++ b/SparkyFitnessServer/db/migrations/20260908120000_narrow_check_in_bmr_bounds.sql
@@ -1,0 +1,24 @@
+-- Narrow the plausibility bounds on check_in_measurements.bmr from 300-10000 to 600-6000.
+--
+-- The 300-10000 range introduced with the measured-BMR feature is wide enough to accept
+-- readings no adult can produce. A 350 kcal value passed validation, replaced the user's
+-- chosen formula, and — because getRecommendedCalorieSafetyFloor() uses RMR verbatim —
+-- became the safety floor under their calorie goal (issue #2395).
+--
+-- 600-6000 is still generous: Mifflin-St Jeor gives roughly 1030 kcal for a 40 kg, 150 cm
+-- woman and 3070 kcal for a 200 kg, 190 cm man. It rejects impossible readings without
+-- second-guessing an unusual body. These are the bounds that shipped in v1.6.3/v1.6.4.
+--
+-- Only values the new constraint would reject are cleared; every plausible reading,
+-- including those backfilled from the legacy basal_metabolic_rate custom category, is
+-- preserved. Affected days fall back to the user's configured BMR formula.
+UPDATE check_in_measurements
+SET bmr = NULL
+WHERE bmr IS NOT NULL
+  AND (bmr < 600 OR bmr > 6000);
+
+ALTER TABLE check_in_measurements
+DROP CONSTRAINT IF EXISTS check_in_measurements_bmr_check,
+ADD CONSTRAINT check_in_measurements_bmr_check CHECK (bmr IS NULL OR (bmr >= 600 AND bmr <= 6000));
+
+COMMENT ON COLUMN check_in_measurements.bmr IS 'Basal Metabolic Rate (BMR) in kcal, measured from smart weight scale or synced from health provider. Applies only to its own entry_date; days without a reading fall back to the user''s BMR formula.';

--- a/SparkyFitnessServer/models/measurementRepository.ts
+++ b/SparkyFitnessServer/models/measurementRepository.ts
@@ -603,7 +603,9 @@ async function getLatestCheckInMeasurementsOnOrBeforeDate(
          (SELECT muscle_mass_kg FROM check_in_measurements WHERE user_id = $1 AND entry_date <= $2 AND muscle_mass_kg IS NOT NULL AND muscle_mass_kg > 0 ORDER BY entry_date DESC LIMIT 1) as muscle_mass_kg,
          (SELECT bone_mass_kg FROM check_in_measurements WHERE user_id = $1 AND entry_date <= $2 AND bone_mass_kg IS NOT NULL AND bone_mass_kg > 0 ORDER BY entry_date DESC LIMIT 1) as bone_mass_kg,
          (SELECT body_water_percentage FROM check_in_measurements WHERE user_id = $1 AND entry_date <= $2 AND body_water_percentage IS NOT NULL AND body_water_percentage > 0 ORDER BY entry_date DESC LIMIT 1) as body_water_percentage,
-         (SELECT bmr FROM check_in_measurements WHERE user_id = $1 AND entry_date <= $2 AND bmr IS NOT NULL AND bmr > 0 ORDER BY entry_date DESC LIMIT 1) as bmr,
+         -- Exact date, like steps: a measured BMR applies to the day it was taken
+         -- and no other, so days without a reading fall back to the user's formula.
+         (SELECT bmr FROM check_in_measurements WHERE user_id = $1 AND entry_date = $2 AND bmr IS NOT NULL AND bmr > 0 LIMIT 1) as bmr,
          le.created_at,
          le.updated_at,
          le.created_by_user_id,
@@ -1475,6 +1477,20 @@ async function getExternalBmrByDateRange(
     client.release();
   }
 }
+/**
+ * Most recent check-in values for a user, one column at a time, unbounded by date.
+ *
+ * Body metrics (weight, height, circumferences, composition) carry forward because
+ * there is no alternative source for a day without a reading — you weigh something
+ * today whether or not you stepped on the scale.
+ *
+ * `bmr` is deliberately NOT one of those and must not be read from here for a
+ * per-date calculation. A measured BMR has a fallback the others lack — the user's
+ * chosen formula, which tracks their current weight — so a stale reading is strictly
+ * worse than recomputing. Read it from the check-in row for the date being computed
+ * instead (see AdaptiveTdeeService). Reading it from here applied a value recorded
+ * today to dates weeks earlier (issue #2395).
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getLatestMeasurement(userId: any) {
   const client = await getClient(userId); // User-specific operation
@@ -1494,7 +1510,6 @@ async function getLatestMeasurement(userId: any) {
          (SELECT muscle_mass_kg FROM check_in_measurements WHERE user_id = $1 AND muscle_mass_kg IS NOT NULL ORDER BY entry_date DESC LIMIT 1) as muscle_mass_kg,
          (SELECT bone_mass_kg FROM check_in_measurements WHERE user_id = $1 AND bone_mass_kg IS NOT NULL ORDER BY entry_date DESC LIMIT 1) as bone_mass_kg,
          (SELECT body_water_percentage FROM check_in_measurements WHERE user_id = $1 AND body_water_percentage IS NOT NULL ORDER BY entry_date DESC LIMIT 1) as body_water_percentage,
-         (SELECT bmr FROM check_in_measurements WHERE user_id = $1 AND bmr IS NOT NULL ORDER BY entry_date DESC LIMIT 1) as bmr,
          (SELECT created_at FROM check_in_measurements WHERE user_id = $1 ORDER BY entry_date DESC LIMIT 1) as created_at,
          (SELECT updated_at FROM check_in_measurements WHERE user_id = $1 ORDER BY entry_date DESC LIMIT 1) as updated_at`,
       [userId]
@@ -1521,20 +1536,29 @@ async function getCustomMeasurementOwnerId(id: any, userId: any) {
     client.release();
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getMostRecentMeasurement(userId: any, measurementType: any) {
+async function getMostRecentMeasurement(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  userId: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  measurementType: any,
+  onDate?: string
+) {
   // SECURITY: Whitelist allowed measurement columns to prevent SQL injection via dynamic column names
   if (!ALLOWED_CHECK_IN_COLUMNS.includes(measurementType)) {
     throw new Error(`Invalid measurement type requested: ${measurementType}`);
   }
   const client = await getClient(userId); // User-specific operation
   try {
+    // `onDate` pins the lookup to a single day rather than "most recent ever".
+    // Callers use it for measured BMR, which only applies on the day it was taken.
+    const dayFilter = onDate ? 'AND entry_date = $2' : '';
+    const params = onDate ? [userId, onDate] : [userId];
     const result = await client.query(
       `SELECT ${measurementType} FROM check_in_measurements
-       WHERE user_id = $1 AND ${measurementType} IS NOT NULL
+       WHERE user_id = $1 ${dayFilter} AND ${measurementType} IS NOT NULL
        ORDER BY entry_date DESC, updated_at DESC
        LIMIT 1`,
-      [userId]
+      params
     );
     return result.rows[0];
   } finally {

--- a/SparkyFitnessServer/routes/measurementRoutes.ts
+++ b/SparkyFitnessServer/routes/measurementRoutes.ts
@@ -18,6 +18,7 @@ import {
   CustomMeasurementsRangeParamSchema,
   ImportHealthDataBodySchema,
 } from '../schemas/measurementSchemas.js';
+import { isDayString } from '@workspace/shared';
 import { canAccessUserData } from '../utils/permissionUtils.js';
 import { clearUserTdeeCache } from '../services/AdaptiveTdeeService.js';
 const router = express.Router();
@@ -1679,10 +1680,18 @@ router.get(
   checkPermissionMiddleware('checkin'),
   async (req, res, next) => {
     const { measurementType } = req.params;
+    // Optional `?date=YYYY-MM-DD` pins the lookup to that single day instead of
+    // returning the newest value ever recorded. The Diary uses it for BMR, which
+    // is only meaningful on the day it was measured.
+    const onDate =
+      typeof req.query.date === 'string' && isDayString(req.query.date)
+        ? req.query.date
+        : undefined;
     try {
       const measurement = await measurementService.getMostRecentMeasurement(
         req.userId,
-        measurementType
+        measurementType,
+        onDate
       );
       res.status(200).json(measurement);
     } catch (error) {

--- a/SparkyFitnessServer/routes/measurementRoutes.ts
+++ b/SparkyFitnessServer/routes/measurementRoutes.ts
@@ -1670,9 +1670,21 @@ router.get(
  *         schema:
  *           type: string
  *         description: weight, steps, body_fat_percentage, etc.
+ *       - in: query
+ *         name: date
+ *         required: false
+ *         schema:
+ *           type: string
+ *           format: date
+ *         description: >-
+ *           Restrict the lookup to this single day (YYYY-MM-DD) instead of
+ *           returning the newest value ever recorded. Used for measured BMR,
+ *           which only applies on the day it was taken.
  *     responses:
  *       200:
  *         description: The most recent measurement.
+ *       400:
+ *         description: The date query parameter was present but not a valid YYYY-MM-DD day.
  */
 router.get(
   '/most-recent/:measurementType',
@@ -1683,10 +1695,19 @@ router.get(
     // Optional `?date=YYYY-MM-DD` pins the lookup to that single day instead of
     // returning the newest value ever recorded. The Diary uses it for BMR, which
     // is only meaningful on the day it was measured.
-    const onDate =
-      typeof req.query.date === 'string' && isDayString(req.query.date)
-        ? req.query.date
-        : undefined;
+    //
+    // A malformed date is rejected rather than ignored: silently dropping it would
+    // fall back to "newest ever", which for BMR is exactly the carry-forward this
+    // change removes — and the caller would get it with a 200 and no signal.
+    const rawDate = req.query.date;
+    if (rawDate !== undefined) {
+      if (typeof rawDate !== 'string' || !isDayString(rawDate)) {
+        return res
+          .status(400)
+          .json({ error: 'date must be a valid YYYY-MM-DD day string.' });
+      }
+    }
+    const onDate = typeof rawDate === 'string' ? rawDate : undefined;
     try {
       const measurement = await measurementService.getMostRecentMeasurement(
         req.userId,

--- a/SparkyFitnessServer/schemas/measurementSchemas.ts
+++ b/SparkyFitnessServer/schemas/measurementSchemas.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod/v4';
-import { isDayString } from '@workspace/shared';
+import {
+  isDayString,
+  MIN_MEASURED_BMR_KCAL,
+  MAX_MEASURED_BMR_KCAL,
+} from '@workspace/shared';
 
 const coerceLegacyNumber = (value: unknown) => {
   if (typeof value !== 'string') {
@@ -92,8 +96,12 @@ const boundedNullableOptionalLegacyNumber = (min: number, max: number) =>
 // numeric(5,2) columns, so 999.99 is the largest storable mass.
 const smartScaleMassKg = boundedNullableOptionalLegacyNumber(0, 999.99);
 const percentage = boundedNullableOptionalLegacyNumber(0, 100);
-// numeric(6,1) column for BMR kcal (300 to 10000 kcal).
-const smartScaleBmrKcal = boundedNullableOptionalLegacyNumber(300, 10000);
+// numeric(6,1) column for BMR kcal. Bounds are shared with every consumer that
+// decides whether a measured BMR may replace the formula estimate.
+const smartScaleBmrKcal = boundedNullableOptionalLegacyNumber(
+  MIN_MEASURED_BMR_KCAL,
+  MAX_MEASURED_BMR_KCAL
+);
 
 export const UpsertWaterIntakeBodySchema = z
   .object({

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -63,6 +63,23 @@ interface AdaptiveTdeeResult {
   avgIntake?: number;
   daysOfData: number;
   lastCalculated: string;
+  /**
+   * Derivation terms for the Active branch, so the UI can show how the estimate
+   * was reached rather than only its inputs and result. Absent on the fallback
+   * branch, which has its own (BMR x multiplier) explanation.
+   */
+  startWeightTrend?: number;
+  endWeightTrend?: number;
+  weightChangeKg?: number;
+  daysInWindow?: number;
+  dailyWeightChangeKg?: number;
+  /** The weight-trend term in kcal — the gap between average intake and TDEE. */
+  weightChangeCalories?: number;
+  /** Estimate before the +/-500 plausibility cap. */
+  rawTdee?: number;
+  wasClamped?: boolean;
+  clampMin?: number;
+  clampMax?: number;
 }
 
 function computeAdaptiveTdeeFromData(
@@ -290,13 +307,18 @@ function computeAdaptiveTdeeFromData(
   // TDEE = (Avg_Daily_Intake) - (Avg_Daily_Weight_Change_kg * kcal_per_kg)
   // Losing weight on a given intake means expenditure exceeded it, so a negative
   // dailyWeightChange raises the estimate above intake.
-  let adaptiveTdee =
+  const rawAdaptiveTdee =
     avgDailyIntake - dailyWeightChange * ENERGY_DENSITY_KCAL_PER_KG;
   // Plausibility capping: +/- 500 kcal from the BMR-based estimate. Clinical
   // calorie floors are a goal policy and are applied later, not to TDEE itself.
   const maxTdee = fallbackTdee + 500;
   const minTdee = Math.max(0, fallbackTdee - 500);
-  adaptiveTdee = Math.min(Math.max(adaptiveTdee, minTdee), maxTdee);
+  const adaptiveTdee = Math.min(Math.max(rawAdaptiveTdee, minTdee), maxTdee);
+  // Whether the clamp actually moved the number. When it did, the displayed TDEE
+  // is not `intake + weight term` and the arithmetic on screen would not
+  // reconcile, so the UI has to say the cap bound rather than leave the reader to
+  // work out why the figures do not add up.
+  const wasClamped = Math.round(adaptiveTdee) !== Math.round(rawAdaptiveTdee);
 
   // Find tracking age of weight logging (weightEntries is sorted by date ascending)
   let trackingAgeWeeks = 0;
@@ -346,6 +368,20 @@ function computeAdaptiveTdeeFromData(
     avgIntake: Math.round(avgDailyIntake),
     daysOfData: filteredCalories.length,
     lastCalculated: new Date().toISOString(),
+    // Derivation terms, so the UI can show how the number was reached instead of
+    // only its inputs and result.
+    startWeightTrend: Math.round(startWeightTrend * 10) / 10,
+    endWeightTrend: Math.round(endWeightTrend * 10) / 10,
+    weightChangeKg: Math.round(weightChange * 100) / 100,
+    daysInWindow,
+    dailyWeightChangeKg: Math.round(dailyWeightChange * 1000) / 1000,
+    weightChangeCalories: Math.round(
+      -dailyWeightChange * ENERGY_DENSITY_KCAL_PER_KG
+    ),
+    rawTdee: Math.round(rawAdaptiveTdee),
+    wasClamped,
+    clampMin: Math.round(minTdee),
+    clampMax: Math.round(maxTdee),
   };
 }
 

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -23,6 +23,7 @@ interface UserProfile {
 interface UserPreferences {
   bmr_algorithm?: string | null;
   activity_level?: string | null;
+  use_external_bmr?: boolean | null;
 }
 
 interface LatestMeasurement {
@@ -155,9 +156,11 @@ function computeAdaptiveTdeeFromData(
         : undefined
     ) ||
     10 * weightKg + 6.25 * heightCm - 5 * age + (gender === 'male' ? 5 : -161);
-  const baseBmr = isUsableMeasuredBmr(measuredBmr, formulaBmr)
-    ? parseFloat(String(measuredBmr))
-    : formulaBmr;
+  const baseBmr =
+    preferences?.use_external_bmr &&
+    isUsableMeasuredBmr(measuredBmr, formulaBmr)
+      ? parseFloat(String(measuredBmr))
+      : formulaBmr;
 
   const fallbackTdee = baseBmr * multiplier;
 

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -11,6 +11,7 @@ import {
   todayInZone,
   dayToPickerDate,
   ENERGY_DENSITY_KCAL_PER_KG,
+  ADAPTIVE_TDEE_CLAMP_KCAL,
   isUsableMeasuredBmr,
 } from '@workspace/shared';
 const tdeeCache = new NodeCache({ stdTTL: 3600 }); // 1 hour cache
@@ -315,8 +316,8 @@ function computeAdaptiveTdeeFromData(
     avgDailyIntake - dailyWeightChange * ENERGY_DENSITY_KCAL_PER_KG;
   // Plausibility capping: +/- 500 kcal from the BMR-based estimate. Clinical
   // calorie floors are a goal policy and are applied later, not to TDEE itself.
-  const maxTdee = fallbackTdee + 500;
-  const minTdee = Math.max(0, fallbackTdee - 500);
+  const maxTdee = fallbackTdee + ADAPTIVE_TDEE_CLAMP_KCAL;
+  const minTdee = Math.max(0, fallbackTdee - ADAPTIVE_TDEE_CLAMP_KCAL);
   const adaptiveTdee = Math.min(Math.max(rawAdaptiveTdee, minTdee), maxTdee);
   // Whether the clamp actually moved the number. When it did, the displayed TDEE
   // is not `intake + weight term` and the arithmetic on screen would not

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -387,7 +387,10 @@ function computeAdaptiveTdeeFromData(
     endWeightTrend: Math.round(endWeightTrend * 10) / 10,
     weightChangeKg: Math.round(weightChange * 100) / 100,
     daysInWindow,
-    dailyWeightChangeKg: Math.round(dailyWeightChange * 1000) / 1000,
+    // Four decimals, not three: the UI multiplies this by the energy density to
+    // show its working, and at 3dp a -0.0185 kg/day trend prints as -0.018 and
+    // reproduces 108 kcal against a stated 111.
+    dailyWeightChangeKg: Math.round(dailyWeightChange * 10000) / 10000,
     // Derived from the two rounded figures the UI actually prints, not rounded
     // independently: otherwise "2026 + 110" renders next to a total of 2137 and
     // the explanation undermines itself.

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -11,6 +11,7 @@ import {
   todayInZone,
   dayToPickerDate,
   ENERGY_DENSITY_KCAL_PER_KG,
+  isUsableMeasuredBmr,
 } from '@workspace/shared';
 const tdeeCache = new NodeCache({ stdTTL: 3600 }); // 1 hour cache
 interface UserProfile {
@@ -27,12 +28,16 @@ interface LatestMeasurement {
   weight?: string | number | null;
   height?: string | number | null;
   body_fat_percentage?: string | number | null;
-  bmr?: string | number | null;
+  // No `bmr` here on purpose: this snapshot is fetched once and reused across a
+  // whole date range, so a BMR read from it would apply a reading taken today to
+  // every earlier date. Measured BMR comes from the per-date check-in row instead.
 }
 
 interface CheckInMeasurement {
   entry_date: string | Date;
   weight: string | number | null;
+  /** Measured BMR for this exact day, when one was recorded. */
+  bmr?: string | number | null;
 }
 
 interface NutritionDataEntry {
@@ -107,26 +112,30 @@ function computeAdaptiveTdeeFromData(
   }
 
   const gender = profile?.gender || 'male';
-  const measuredBmr = latestMeasurement?.bmr
-    ? parseFloat(String(latestMeasurement.bmr))
-    : null;
-  const baseBmr =
-    measuredBmr && measuredBmr >= 300 && measuredBmr <= 10000
-      ? measuredBmr
-      : bmrService.calculateBmr(
-          bmrAlgorithm,
-          weightKg,
-          heightCm,
-          age,
-          gender as 'male' | 'female',
-          latestMeasurement?.body_fat_percentage
-            ? parseFloat(String(latestMeasurement.body_fat_percentage))
-            : undefined
-        ) ||
-        10 * weightKg +
-          6.25 * heightCm -
-          5 * age +
-          (gender === 'male' ? 5 : -161);
+  // A measured BMR counts only on the day it was recorded, so read it from this
+  // date's check-in row rather than from `latestMeasurement`. The latter is fetched
+  // once and reused across a whole range, which let a reading taken today set the
+  // fallback TDEE — and therefore the +/-500 plausibility clamp — for dates weeks
+  // earlier (issue #2395).
+  const measuredBmr =
+    checkInMeasurements.find(
+      (m) => String(m.entry_date).slice(0, 10) === calculationDateStr
+    )?.bmr ?? null;
+  const formulaBmr =
+    bmrService.calculateBmr(
+      bmrAlgorithm,
+      weightKg,
+      heightCm,
+      age,
+      gender as 'male' | 'female',
+      latestMeasurement?.body_fat_percentage
+        ? parseFloat(String(latestMeasurement.body_fat_percentage))
+        : undefined
+    ) ||
+    10 * weightKg + 6.25 * heightCm - 5 * age + (gender === 'male' ? 5 : -161);
+  const baseBmr = isUsableMeasuredBmr(measuredBmr, formulaBmr)
+    ? parseFloat(String(measuredBmr))
+    : formulaBmr;
 
   const fallbackTdee = baseBmr * multiplier;
 

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -375,9 +375,11 @@ function computeAdaptiveTdeeFromData(
     weightChangeKg: Math.round(weightChange * 100) / 100,
     daysInWindow,
     dailyWeightChangeKg: Math.round(dailyWeightChange * 1000) / 1000,
-    weightChangeCalories: Math.round(
-      -dailyWeightChange * ENERGY_DENSITY_KCAL_PER_KG
-    ),
+    // Derived from the two rounded figures the UI actually prints, not rounded
+    // independently: otherwise "2026 + 110" renders next to a total of 2137 and
+    // the explanation undermines itself.
+    weightChangeCalories:
+      Math.round(rawAdaptiveTdee) - Math.round(avgDailyIntake),
     rawTdee: Math.round(rawAdaptiveTdee),
     wasClamped,
     clampMin: Math.round(minTdee),

--- a/SparkyFitnessServer/services/AdaptiveTdeeService.ts
+++ b/SparkyFitnessServer/services/AdaptiveTdeeService.ts
@@ -71,7 +71,11 @@ interface AdaptiveTdeeResult {
   startWeightTrend?: number;
   endWeightTrend?: number;
   weightChangeKg?: number;
+  /** Length of the TDEE window in days (28), which the weight trend spans. */
   daysInWindow?: number;
+  /** First and last day of that window, as YYYY-MM-DD. */
+  windowStartDate?: string;
+  windowEndDate?: string;
   dailyWeightChangeKg?: number;
   /** The weight-trend term in kcal — the gap between average intake and TDEE. */
   weightChangeCalories?: number;
@@ -370,6 +374,15 @@ function computeAdaptiveTdeeFromData(
     lastCalculated: new Date().toISOString(),
     // Derivation terms, so the UI can show how the number was reached instead of
     // only its inputs and result.
+    windowStartDate: calculationWindow[0]
+      ? format(calculationWindow[0].date, 'yyyy-MM-dd')
+      : undefined,
+    windowEndDate: calculationWindow[calculationWindow.length - 1]
+      ? format(
+          calculationWindow[calculationWindow.length - 1]!.date,
+          'yyyy-MM-dd'
+        )
+      : undefined,
     startWeightTrend: Math.round(startWeightTrend * 10) / 10,
     endWeightTrend: Math.round(endWeightTrend * 10) / 10,
     weightChangeKg: Math.round(weightChange * 100) / 100,

--- a/SparkyFitnessServer/services/calorieBalanceService.ts
+++ b/SparkyFitnessServer/services/calorieBalanceService.ts
@@ -16,6 +16,7 @@ import {
   computeCalorieProgress,
   getGoalModeAdjustment,
   getRecommendedCalorieSafetyFloor,
+  isUsableMeasuredBmr,
   MAX_HEALTH_TOTAL_CALORIES_PER_DAY,
   MIN_CALORIE_SAFETY_FLOOR,
   resolveCalorieSafetyFloor,
@@ -43,7 +44,6 @@ export interface CalorieBalanceUserPreferences {
   activity_level?: string | null;
   bmr_algorithm?: string | null;
   include_bmr_in_net_calories?: boolean | null;
-  use_external_bmr?: boolean | null;
   calorie_goal_adjustment_mode?: CalorieGoalAdjustmentMode | string | null;
   exercise_calorie_percentage?: number | null;
   tdee_allow_negative_adjustment?: boolean | null;
@@ -277,23 +277,15 @@ export function computeCalorieBalance({
     }
   }
 
-  // 1b. Measured BMR override — when a measured BMR is recorded on the day
-  // (from a smart scale, health provider sync, or manual check-in entry),
-  // prefer it over the formula. Sanity-bounded between 300 and 10000 kcal.
+  // 1b. Measured BMR override — when a measured BMR was recorded on this day
+  // (smart scale, health provider sync, or manual check-in entry), prefer it over
+  // the formula. `measurements.bmr` is resolved for this exact date, never carried
+  // forward, so "measured" always means a reading actually taken on the day shown.
+  // `bmr` still holds the formula estimate here, which is what the measured value
+  // is sanity-checked against.
   let bmrSource: 'formula' | 'measured' = 'formula';
-  const checkInBmr = measurements?.bmr
-    ? parseFloat(String(measurements.bmr))
-    : null;
-  const validCheckInBmr =
-    checkInBmr !== null &&
-    Number.isFinite(checkInBmr) &&
-    checkInBmr >= 300 &&
-    checkInBmr <= 10000
-      ? checkInBmr
-      : null;
-
-  if (validCheckInBmr !== null) {
-    bmr = validCheckInBmr;
+  if (isUsableMeasuredBmr(measurements?.bmr, bmr)) {
+    bmr = parseFloat(String(measurements!.bmr));
     bmrSource = 'measured';
   }
 

--- a/SparkyFitnessServer/services/calorieBalanceService.ts
+++ b/SparkyFitnessServer/services/calorieBalanceService.ts
@@ -44,6 +44,8 @@ export interface CalorieBalanceUserPreferences {
   activity_level?: string | null;
   bmr_algorithm?: string | null;
   include_bmr_in_net_calories?: boolean | null;
+  /** Opt-in for letting a synced/measured BMR replace the chosen formula. */
+  use_external_bmr?: boolean | null;
   calorie_goal_adjustment_mode?: CalorieGoalAdjustmentMode | string | null;
   exercise_calorie_percentage?: number | null;
   tdee_allow_negative_adjustment?: boolean | null;
@@ -284,7 +286,10 @@ export function computeCalorieBalance({
   // `bmr` still holds the formula estimate here, which is what the measured value
   // is sanity-checked against.
   let bmrSource: 'formula' | 'measured' = 'formula';
-  if (isUsableMeasuredBmr(measurements?.bmr, bmr)) {
+  if (
+    userPreferences?.use_external_bmr &&
+    isUsableMeasuredBmr(measurements?.bmr, bmr)
+  ) {
     bmr = parseFloat(String(measurements!.bmr));
     bmrSource = 'measured';
   }

--- a/SparkyFitnessServer/services/dailySummaryRangeService.ts
+++ b/SparkyFitnessServer/services/dailySummaryRangeService.ts
@@ -209,10 +209,13 @@ export async function getDailySummaryRange({
   };
 
   // Exact-date lookup for the one field that is not carried forward.
-  const bmrByDate = new Map<string, unknown>();
+  const bmrByDate = new Map<string, string | number | null>();
   for (const row of measurementsAsc) {
     if (row.bmr !== null && row.bmr !== undefined && Number(row.bmr) > 0) {
-      bmrByDate.set(String(row.entry_date).slice(0, 10), row.bmr);
+      bmrByDate.set(
+        String(row.entry_date).slice(0, 10),
+        row.bmr as string | number
+      );
     }
   }
 
@@ -272,7 +275,7 @@ export async function getDailySummaryRange({
         adjustedGoalCalories: Number(dayGoals?.calories) || 2000,
         userProfile,
         userPreferences,
-        measurements: { ...carried, bmr: bmrByDate.get(date) as never },
+        measurements: { ...carried, bmr: bmrByDate.get(date) ?? null },
         ...deviceProjectionSnapshot,
       }),
     });

--- a/SparkyFitnessServer/services/dailySummaryRangeService.ts
+++ b/SparkyFitnessServer/services/dailySummaryRangeService.ts
@@ -59,12 +59,16 @@ interface CheckInRow {
 /**
  * Body-composition fields the BMR formula reads. Each is carried forward on its own,
  * mirroring the per-field subselects in `getLatestCheckInMeasurementsOnOrBeforeDate`.
+ *
+ * `bmr` is deliberately absent: a measured BMR describes the day it was recorded, so
+ * it is resolved per date below rather than carried. Leaving it here reported a
+ * single Sept 1 reading as `measured` for Sept 2 and 3 as well, which put this
+ * endpoint (Reports) and the Diary in disagreement about the same day.
  */
 const MEASUREMENT_FIELDS = [
   'weight',
   'height',
   'body_fat_percentage',
-  'bmr',
 ] as const satisfies readonly (keyof CalorieBalanceMeasurements)[];
 
 /**
@@ -202,8 +206,15 @@ export async function getDailySummaryRange({
     height: (seedMeasurement as CalorieBalanceMeasurements | null)?.height,
     body_fat_percentage: (seedMeasurement as CalorieBalanceMeasurements | null)
       ?.body_fat_percentage,
-    bmr: (seedMeasurement as CalorieBalanceMeasurements | null)?.bmr,
   };
+
+  // Exact-date lookup for the one field that is not carried forward.
+  const bmrByDate = new Map<string, unknown>();
+  for (const row of measurementsAsc) {
+    if (row.bmr !== null && row.bmr !== undefined && Number(row.bmr) > 0) {
+      bmrByDate.set(String(row.entry_date).slice(0, 10), row.bmr);
+    }
+  }
 
   const days: DailyCalorieBalanceRow[] = [];
 
@@ -261,7 +272,7 @@ export async function getDailySummaryRange({
         adjustedGoalCalories: Number(dayGoals?.calories) || 2000,
         userProfile,
         userPreferences,
-        measurements: carried,
+        measurements: { ...carried, bmr: bmrByDate.get(date) as never },
         ...deviceProjectionSnapshot,
       }),
     });

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -20,6 +20,7 @@ import {
   resolveCalorieSafetyFloor,
   DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
   ACTIVITY_MULTIPLIERS,
+  isUsableMeasuredBmr,
 } from '@workspace/shared';
 import customNutrientService from './customNutrientService.js';
 import { DEFAULT_GOALS } from '../constants/goals.js';
@@ -178,6 +179,26 @@ async function getUserGoalsForRange(
     return found ? parseFloat(String(found[field])) : null;
   };
 
+  // Same lookup, without carry-forward. Used for measured BMR, which is only valid
+  // on the day it was recorded — carrying it forward would keep a stale reading
+  // driving the goal long after syncing stopped (issue #2395).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const getMeasurementFieldOnDate = (dateStr: string, field: string) => {
+    const found = allMeasurements.find((m: any) => {
+      const mDateStr =
+        m.entry_date instanceof Date
+          ? localDateToDay(m.entry_date)
+          : String(m.entry_date).slice(0, 10);
+      return (
+        mDateStr === dateStr &&
+        m[field] !== null &&
+        m[field] !== undefined &&
+        m[field] !== ''
+      );
+    });
+    return found ? parseFloat(String(found[field])) : null;
+  };
+
   while (!isAfter(cursor, end)) {
     const dateStr = format(cursor, 'yyyy-MM-dd');
     let goals = explicitByDate[dateStr] ?? null;
@@ -220,16 +241,15 @@ async function getUserGoalsForRange(
         CALORIE_CALCULATION_CONSTANTS.DEFAULT_HEIGHT_CM;
       const bodyFat =
         getMeasurementFieldForDate(dateStr, 'body_fat_percentage') || undefined;
-      const measuredBmr = getMeasurementFieldForDate(dateStr, 'bmr');
+      // Exact date, not carry-forward: a measured BMR only counts on its own day.
+      const measuredBmr = getMeasurementFieldOnDate(dateStr, 'bmr');
 
-      let bmr = 0;
-      if (measuredBmr && measuredBmr >= 300 && measuredBmr <= 10000) {
-        bmr = measuredBmr;
-      } else if (userProfile && userPreferences) {
+      let formulaBmr = 0;
+      if (userProfile && userPreferences) {
         const tz = userPreferences.timezone || 'UTC';
         const age = userAge(userProfile.date_of_birth ?? '', tz) ?? 30;
         try {
-          bmr = bmrService.calculateBmr(
+          formulaBmr = bmrService.calculateBmr(
             bmrAlgorithm,
             weightKg,
             heightCm,
@@ -244,6 +264,12 @@ async function getUserGoalsForRange(
           );
         }
       }
+      // The measured value is checked against the formula estimate when one could
+      // be computed, and on the absolute bounds alone when it could not — a failed
+      // or impossible formula must not discard an otherwise good reading.
+      const bmr = isUsableMeasuredBmr(measuredBmr, formulaBmr || null)
+        ? (measuredBmr as number)
+        : formulaBmr;
 
       // Mirror DashboardService exactly: use user's actual activity multiplier, not hardcoded
       const activityMultiplier = ACTIVITY_MULTIPLIERS[activityLevel] || 1.2;
@@ -339,10 +365,11 @@ async function getUserGoalsForRange(
           calorieSafetyFloorValue:
             userPreferences?.calorie_safety_floor_value ||
             DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
-          measuredBmr:
-            measuredBmr && measuredBmr >= 300 && measuredBmr <= 10000
-              ? measuredBmr
-              : undefined,
+          // computeCalorieTarget re-validates this against its own formula estimate
+          // before letting it become the RMR safety floor.
+          measuredBmr: isUsableMeasuredBmr(measuredBmr, formulaBmr || null)
+            ? measuredBmr
+            : undefined,
         });
         goalCalories = targetResult.finalTarget;
       }

--- a/SparkyFitnessServer/services/goalService.ts
+++ b/SparkyFitnessServer/services/goalService.ts
@@ -267,9 +267,11 @@ async function getUserGoalsForRange(
       // The measured value is checked against the formula estimate when one could
       // be computed, and on the absolute bounds alone when it could not — a failed
       // or impossible formula must not discard an otherwise good reading.
-      const bmr = isUsableMeasuredBmr(measuredBmr, formulaBmr || null)
-        ? (measuredBmr as number)
-        : formulaBmr;
+      const bmr =
+        userPreferences?.use_external_bmr &&
+        isUsableMeasuredBmr(measuredBmr, formulaBmr || null)
+          ? (measuredBmr as number)
+          : formulaBmr;
 
       // Mirror DashboardService exactly: use user's actual activity multiplier, not hardcoded
       const activityMultiplier = ACTIVITY_MULTIPLIERS[activityLevel] || 1.2;
@@ -367,9 +369,11 @@ async function getUserGoalsForRange(
             DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR,
           // computeCalorieTarget re-validates this against its own formula estimate
           // before letting it become the RMR safety floor.
-          measuredBmr: isUsableMeasuredBmr(measuredBmr, formulaBmr || null)
-            ? measuredBmr
-            : undefined,
+          measuredBmr:
+            userPreferences?.use_external_bmr &&
+            isUsableMeasuredBmr(measuredBmr, formulaBmr || null)
+              ? measuredBmr
+              : undefined,
         });
         goalCalories = targetResult.finalTarget;
       }

--- a/SparkyFitnessServer/services/healthDataHandlers.ts
+++ b/SparkyFitnessServer/services/healthDataHandlers.ts
@@ -676,6 +676,12 @@ function prepareCheckInMeasurement(
 // all valid records go through one bulkUpsertCheckInMeasurements call (one
 // client + one transaction), with same-date records merged server-side
 // (later record wins per column, matching the old sequential upserts).
+/**
+ * Sources whose BMR is a running daily total rather than a rate, so a value read
+ * before the day ends is only part of it.
+ */
+const ACCUMULATING_BMR_SOURCES = new Set(['garmin']);
+
 const checkInHandleBatch: HandleBatchFn = async (entries, ctx) => {
   const outcomes: HandlerOutcome[] = new Array(entries.length);
   const writes: Array<{
@@ -684,17 +690,26 @@ const checkInHandleBatch: HandleBatchFn = async (entries, ctx) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     measurements: Record<string, any>;
   }> = [];
-  // BMR only: providers that report it as a daily *accumulation* rather than a
-  // rate — Garmin's `bmrKilocalories` sits in the daily summary beside
-  // `totalKilocalories` — hand back a partial total when the day is still
-  // running. A 4am sync reported 716 kcal against a ~1800 kcal formula estimate
-  // (issue #2395), and a late-afternoon one is worse because it looks plausible.
-  // HealthKit already keeps only fully-elapsed days; this is the equivalent for
-  // every other source. Resolved once per batch, and only when a BMR is present.
-  const hasBmrWrite = entries.some(
-    (e) => e.entry?.type === 'bmr' || e.entry?.type === 'basal_metabolic_rate'
+  // Garmin reports BMR as a daily *accumulation*, not a rate: `bmrKilocalories`
+  // sits in the daily summary beside `totalKilocalories`, so a sync while the day
+  // is still running hands back part of it. A 4am sync reported 716 kcal against a
+  // ~1800 kcal formula estimate (issue #2395), and a late-afternoon one is worse
+  // because it looks plausible enough to clear the ratio band.
+  //
+  // Scoped to those sources deliberately. HealthKit already keeps only fully
+  // elapsed days and stamps each one with D+1 — the day it applies to — so a
+  // blanket "refuse today" rejected precisely the value it is designed to send and
+  // stopped iOS storing any BMR at all. Health Connect's BasalMetabolicRate is an
+  // instantaneous rate and is fine on the current day too.
+  const isAccumulatingBmrSource = (entry: { source?: unknown }) =>
+    typeof entry?.source === 'string' &&
+    ACCUMULATING_BMR_SOURCES.has(entry.source.toLowerCase());
+  const hasGuardedBmrWrite = entries.some(
+    (e) =>
+      (e.entry?.type === 'bmr' || e.entry?.type === 'basal_metabolic_rate') &&
+      isAccumulatingBmrSource(e.entry)
   );
-  const todayForUser = hasBmrWrite
+  const todayForUser = hasGuardedBmrWrite
     ? todayInZone(await loadUserTimezone(ctx.userId))
     : null;
   for (let i = 0; i < entries.length; i++) {
@@ -706,12 +721,13 @@ const checkInHandleBatch: HandleBatchFn = async (entries, ctx) => {
     if (
       prepared.measurements.bmr !== undefined &&
       todayForUser !== null &&
+      isAccumulatingBmrSource(entries[i].entry) &&
       entries[i].parsedDate >= todayForUser
     ) {
       delete prepared.measurements.bmr;
       log(
         'info',
-        `healthDataHandlers: ignoring BMR for ${entries[i].parsedDate} — the day is not complete in the user's timezone, so the value may be a partial daily total.`
+        `healthDataHandlers: ignoring BMR for ${entries[i].parsedDate} from ${entries[i].entry?.source} — that source reports BMR as a daily total and the day is not complete in the user's timezone.`
       );
       if (Object.keys(prepared.measurements).length === 0) {
         outcomes[i] = {

--- a/SparkyFitnessServer/services/healthDataHandlers.ts
+++ b/SparkyFitnessServer/services/healthDataHandlers.ts
@@ -21,6 +21,7 @@ import {
   type TelemetryGpsPoint,
 } from './workoutTelemetryDerivation.js';
 import { upsertSamplesByDay } from './healthMetricSampleWriter.js';
+import { loadUserTimezone } from '../utils/timezoneLoader.js';
 import * as genericHealthRepository from '../models/genericHealthRepository.js';
 import {
   BUILT_IN_MOODS,
@@ -28,6 +29,7 @@ import {
   MAX_HEALTH_TOTAL_CALORIES_PER_DAY,
   MIN_MEASURED_BMR_KCAL,
   MAX_MEASURED_BMR_KCAL,
+  todayInZone,
 } from '@workspace/shared';
 
 /**
@@ -682,11 +684,43 @@ const checkInHandleBatch: HandleBatchFn = async (entries, ctx) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     measurements: Record<string, any>;
   }> = [];
+  // BMR only: providers that report it as a daily *accumulation* rather than a
+  // rate — Garmin's `bmrKilocalories` sits in the daily summary beside
+  // `totalKilocalories` — hand back a partial total when the day is still
+  // running. A 4am sync reported 716 kcal against a ~1800 kcal formula estimate
+  // (issue #2395), and a late-afternoon one is worse because it looks plausible.
+  // HealthKit already keeps only fully-elapsed days; this is the equivalent for
+  // every other source. Resolved once per batch, and only when a BMR is present.
+  const hasBmrWrite = entries.some(
+    (e) => e.entry?.type === 'bmr' || e.entry?.type === 'basal_metabolic_rate'
+  );
+  const todayForUser = hasBmrWrite
+    ? todayInZone(await loadUserTimezone(ctx.userId))
+    : null;
   for (let i = 0; i < entries.length; i++) {
     const prepared = prepareCheckInMeasurement(entries[i].entry);
     if ('error' in prepared) {
       outcomes[i] = { status: 'error', error: prepared.error };
       continue;
+    }
+    if (
+      prepared.measurements.bmr !== undefined &&
+      todayForUser !== null &&
+      entries[i].parsedDate >= todayForUser
+    ) {
+      delete prepared.measurements.bmr;
+      log(
+        'info',
+        `healthDataHandlers: ignoring BMR for ${entries[i].parsedDate} — the day is not complete in the user's timezone, so the value may be a partial daily total.`
+      );
+      if (Object.keys(prepared.measurements).length === 0) {
+        outcomes[i] = {
+          status: 'skipped',
+          reason:
+            'BMR is only accepted for a completed day, since some providers report it as a running daily total.',
+        };
+        continue;
+      }
     }
     writes.push({
       index: i,

--- a/SparkyFitnessServer/services/healthDataHandlers.ts
+++ b/SparkyFitnessServer/services/healthDataHandlers.ts
@@ -26,6 +26,8 @@ import {
   BUILT_IN_MOODS,
   instantToDay,
   MAX_HEALTH_TOTAL_CALORIES_PER_DAY,
+  MIN_MEASURED_BMR_KCAL,
+  MAX_MEASURED_BMR_KCAL,
 } from '@workspace/shared';
 
 /**
@@ -644,11 +646,11 @@ function prepareCheckInMeasurement(
       if (
         trimmed === '' ||
         !Number.isFinite(numericValue) ||
-        numericValue < 300 ||
-        numericValue > 10000
+        numericValue < MIN_MEASURED_BMR_KCAL ||
+        numericValue > MAX_MEASURED_BMR_KCAL
       ) {
         return {
-          error: `Invalid value for ${entry.type}. Must be between 300 and 10000 kcal.`,
+          error: `Invalid value for ${entry.type}. Must be between ${MIN_MEASURED_BMR_KCAL} and ${MAX_MEASURED_BMR_KCAL} kcal.`,
         };
       }
       return { measurements: { [canonical]: numericValue } };

--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -1754,11 +1754,16 @@ async function deleteCustomMeasurementEntry(authenticatedUserId: any, id: any) {
   }
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getMostRecentMeasurement(userId: any, measurementType: any) {
+async function getMostRecentMeasurement(
+  userId: any,
+  measurementType: any,
+  onDate?: string
+) {
   try {
     const measurement = await measurementRepository.getMostRecentMeasurement(
       userId,
-      measurementType
+      measurementType,
+      onDate
     );
     return measurement;
   } catch (error) {

--- a/SparkyFitnessServer/services/reportService.ts
+++ b/SparkyFitnessServer/services/reportService.ts
@@ -17,6 +17,7 @@ import {
   compareDays,
   FOOD_VARIANT_NUTRIENT_FIELDS,
   todayInZone,
+  isUsableMeasuredBmr,
 } from '@workspace/shared';
 import { userAge } from '../utils/dateHelpers.js';
 import { loadUserTimezone } from '../utils/timezoneLoader.js';
@@ -306,16 +307,19 @@ async function getReportsData(
           latestMeasurement?.body_fat_percentage !== undefined
             ? Number(latestMeasurement.body_fat_percentage)
             : undefined;
-        const measuredBmr =
-          latestMeasurement?.bmr !== null &&
-          latestMeasurement?.bmr !== undefined
-            ? Number(latestMeasurement.bmr)
-            : undefined;
-        if (measuredBmr && measuredBmr >= 300 && measuredBmr <= 10000) {
-          day.bmr = measuredBmr;
-        } else if (weight && height && age && gender && bmrAlgorithm) {
+        // Exact date, unlike the body metrics above: a measured BMR describes the
+        // day it was taken, so it is never carried forward onto later days.
+        const measuredBmr = (measurementData as MeasurementEntry[]).find(
+          (m: MeasurementEntry) =>
+            String(m.entry_date).slice(0, 10) ===
+              String(day.date).slice(0, 10) &&
+            m.bmr !== null &&
+            m.bmr !== undefined
+        )?.bmr;
+        let formulaBmr: number | null = null;
+        if (weight && height && age && gender && bmrAlgorithm) {
           try {
-            day.bmr = bmrService.calculateBmr(
+            formulaBmr = bmrService.calculateBmr(
               bmrAlgorithm,
               weight,
               height,
@@ -329,11 +333,15 @@ async function getReportsData(
               // @ts-expect-error TS(2571): Object is of type 'unknown'.
               `Could not calculate BMR for user ${targetUserId} on date ${day.date}: ${error.message}`
             );
-            day.bmr = null;
+            formulaBmr = null;
           }
-        } else {
-          day.bmr = null;
         }
+        // The measured reading wins only if it is plausible against this person's
+        // own formula estimate; with no estimate to compare, the absolute bounds
+        // decide on their own.
+        day.bmr = isUsableMeasuredBmr(measuredBmr, formulaBmr)
+          ? Number(measuredBmr)
+          : formulaBmr;
         day.include_bmr_in_net_calories =
           userPreferences.include_bmr_in_net_calories;
       });

--- a/SparkyFitnessServer/services/reportService.ts
+++ b/SparkyFitnessServer/services/reportService.ts
@@ -339,9 +339,11 @@ async function getReportsData(
         // The measured reading wins only if it is plausible against this person's
         // own formula estimate; with no estimate to compare, the absolute bounds
         // decide on their own.
-        day.bmr = isUsableMeasuredBmr(measuredBmr, formulaBmr)
-          ? Number(measuredBmr)
-          : formulaBmr;
+        day.bmr =
+          userPreferences?.use_external_bmr &&
+          isUsableMeasuredBmr(measuredBmr, formulaBmr)
+            ? Number(measuredBmr)
+            : formulaBmr;
         day.include_bmr_in_net_calories =
           userPreferences.include_bmr_in_net_calories;
       });

--- a/SparkyFitnessServer/tests/adaptiveTdeeService.test.ts
+++ b/SparkyFitnessServer/tests/adaptiveTdeeService.test.ts
@@ -427,4 +427,96 @@ describe('AdaptiveTdeeService', () => {
     // 2000 kcal intake + (~0.88 kg smoothed weight loss * 6000) / 28 = ~2190 kcal
     expect(result.tdee).toBe(2190);
   });
+
+  describe('measured BMR is scoped to its own day', () => {
+    // Regression cover for issue #2395. `latestMeasurement` is fetched once and
+    // reused across a whole date range, so reading BMR from it let a value recorded
+    // today set the fallback TDEE — and therefore the +/-500 plausibility clamp —
+    // for dates weeks earlier. BMR must come from the row for the date being computed.
+    const buildData = (
+      checkInMeasurements: Array<{
+        entry_date: string;
+        weight: number;
+        bmr?: number;
+      }>,
+      latestMeasurement: { weight: number; height: number } = {
+        weight: 80,
+        height: 180,
+      }
+    ) => ({
+      profile: { date_of_birth: '1990-01-01', gender: 'male' },
+      preferences: {
+        bmr_algorithm: 'Mifflin-St Jeor',
+        activity_level: 'moderate',
+      },
+      latestMeasurement,
+      checkInMeasurements,
+      // Only two weight entries and no calorie history, so the result is the
+      // BMR-derived fallback and the effect of BMR is directly observable.
+      nutritionData: [],
+    });
+
+    const weights = [
+      {
+        entry_date: format(subDays(calculationDate, 47), 'yyyy-MM-dd'),
+        weight: 80,
+      },
+      { entry_date: format(calculationDate, 'yyyy-MM-dd'), weight: 79 },
+    ];
+
+    beforeEach(() => {
+      // @ts-expect-error mocked module
+      bmrService.calculateBmr.mockReturnValue(1800);
+      bmrService.ActivityMultiplier = { moderate: 1.55 };
+    });
+
+    test('uses a measured BMR recorded on the calculation date', () => {
+      const data = buildData(
+        weights.map((w) =>
+          w.entry_date === calculationDateStr ? { ...w, bmr: 2200 } : w
+        )
+      );
+
+      const result = computeAdaptiveTdeeFromData(data, calculationDateStr);
+
+      expect(result.tdee).toBe(Math.round(2200 * 1.55));
+    });
+
+    test('ignores a measured BMR recorded on a different day', () => {
+      const data = buildData(
+        weights.map((w) =>
+          w.entry_date === calculationDateStr ? w : { ...w, bmr: 2200 }
+        )
+      );
+
+      const result = computeAdaptiveTdeeFromData(data, calculationDateStr);
+
+      expect(result.tdee).toBe(Math.round(1800 * 1.55));
+    });
+
+    test('ignores a measured BMR carried on latestMeasurement', () => {
+      // `LatestMeasurement` no longer declares `bmr` at all, so this asserts the
+      // snapshot cannot smuggle one in even when the row carries the column.
+      const data = {
+        ...buildData(weights),
+        latestMeasurement: { weight: 80, height: 180, bmr: 2200 },
+      };
+
+      const result = computeAdaptiveTdeeFromData(data, calculationDateStr);
+
+      expect(result.tdee).toBe(Math.round(1800 * 1.55));
+    });
+
+    test('ignores an out-of-bounds measured BMR on the calculation date', () => {
+      const data = buildData(
+        weights.map((w) =>
+          w.entry_date === calculationDateStr ? { ...w, bmr: 350 } : w
+        )
+      );
+
+      const result = computeAdaptiveTdeeFromData(data, calculationDateStr);
+
+      expect(result.tdee).toBe(Math.round(1800 * 1.55));
+    });
+  });
 });

--- a/SparkyFitnessServer/tests/adaptiveTdeeService.test.ts
+++ b/SparkyFitnessServer/tests/adaptiveTdeeService.test.ts
@@ -38,6 +38,7 @@ describe('AdaptiveTdeeService', () => {
     preferenceRepository.getUserPreferences.mockResolvedValue({
       bmr_algorithm: 'Mifflin-St Jeor',
       activity_level: 'moderate',
+      use_external_bmr: true,
     });
     // Mock weight entries spanning 90 days
     const weightEntries = [];
@@ -110,6 +111,7 @@ describe('AdaptiveTdeeService', () => {
       preferences: {
         bmr_algorithm: 'Mifflin-St Jeor',
         activity_level: 'moderate',
+        use_external_bmr: true,
       },
       latestMeasurement: { weight: 80, height: 180 },
       checkInMeasurements: [
@@ -144,6 +146,7 @@ describe('AdaptiveTdeeService', () => {
     preferenceRepository.getUserPreferences.mockResolvedValue({
       bmr_algorithm: 'Mifflin-St Jeor',
       activity_level: 'moderate',
+      use_external_bmr: true,
     });
     // Mock weight entries spanning 90 days
     const weightEntries = [];
@@ -203,6 +206,7 @@ describe('AdaptiveTdeeService', () => {
       preferences: {
         bmr_algorithm: 'Mifflin-St Jeor',
         activity_level: 'moderate',
+        use_external_bmr: true,
       },
       latestMeasurement: { weight: 80, height: 180 },
       checkInMeasurements: [
@@ -287,6 +291,7 @@ describe('AdaptiveTdeeService', () => {
       preferences: {
         bmr_algorithm: 'Mifflin-St Jeor',
         activity_level: 'moderate',
+        use_external_bmr: true,
       },
       latestMeasurement: { weight: 80, height: 180 },
       checkInMeasurements: Array.from({ length: 28 }, (_, i) => ({
@@ -336,6 +341,7 @@ describe('AdaptiveTdeeService', () => {
       preferences: {
         bmr_algorithm: 'Mifflin-St Jeor',
         activity_level: 'moderate',
+        use_external_bmr: true,
       },
       latestMeasurement: { weight: 80, height: 180 },
       checkInMeasurements,
@@ -365,6 +371,7 @@ describe('AdaptiveTdeeService', () => {
       preferences: {
         bmr_algorithm: 'Mifflin-St Jeor',
         activity_level: 'moderate',
+        use_external_bmr: true,
       },
       latestMeasurement: { weight: 80, height: 180 },
       checkInMeasurements: Array.from({ length: 70 }, (_, i) => ({
@@ -414,6 +421,7 @@ describe('AdaptiveTdeeService', () => {
       preferences: {
         bmr_algorithm: 'Mifflin-St Jeor',
         activity_level: 'moderate',
+        use_external_bmr: true,
       },
       latestMeasurement: { weight: 80, height: 180 },
       checkInMeasurements,
@@ -448,6 +456,7 @@ describe('AdaptiveTdeeService', () => {
       preferences: {
         bmr_algorithm: 'Mifflin-St Jeor',
         activity_level: 'moderate',
+        use_external_bmr: true,
       },
       latestMeasurement,
       checkInMeasurements,

--- a/SparkyFitnessServer/tests/calorieBalanceService.test.ts
+++ b/SparkyFitnessServer/tests/calorieBalanceService.test.ts
@@ -530,8 +530,10 @@ describe('measured BMR override', () => {
     expect(balance.burned).toBe(1850);
   });
 
-  // A bad sample must not be able to zero out the day's target.
-  test.each([299, 10001, 0, -50])(
+  // A bad sample must not be able to zero out the day's target, nor become the RMR
+  // safety floor. 350 is the reading from issue #2395 that the old 300-10000 range
+  // let through and 600-6000 rejects.
+  test.each([599, 6001, 350, 0, -50])(
     'keeps the formula BMR when the check-in value %s is out of bounds',
     (value) => {
       const balance = computeCalorieBalance(
@@ -546,7 +548,27 @@ describe('measured BMR override', () => {
     }
   );
 
-  test.each([300, 10000])('accepts the boundary value %s', (value) => {
+  // Relative band: a reading can sit inside the absolute bounds and still be
+  // implausible for a particular body. BMR here is the formula estimate.
+  test.each([
+    [Math.round(BMR * 0.5), 'far below the formula estimate'],
+    [Math.round(BMR * 1.9), 'far above the formula estimate'],
+  ])('keeps the formula BMR when the measured value %s is %s', (value) => {
+    const balance = computeCalorieBalance(
+      inputs({
+        measurements: { weight: 80, height: 180, bmr: value },
+        userPreferences: prefs,
+      })
+    );
+
+    expect(balance.bmr).toBe(BMR);
+    expect(balance.bmrSource).toBe('formula');
+  });
+
+  test.each([
+    [Math.round(BMR * 0.7), 'below but within the band'],
+    [Math.round(BMR * 1.5), 'above but within the band'],
+  ])('accepts a measured value %s that is %s', (value) => {
     const balance = computeCalorieBalance(
       inputs({
         measurements: { weight: 80, height: 180, bmr: value },
@@ -557,6 +579,44 @@ describe('measured BMR override', () => {
     expect(balance.bmr).toBe(value);
     expect(balance.bmrSource).toBe('measured');
   });
+
+  test.each([BMR * 0.6, BMR * 1.6])(
+    'accepts the ratio boundary value %s',
+    (value) => {
+      const balance = computeCalorieBalance(
+        inputs({
+          measurements: { weight: 80, height: 180, bmr: value },
+          userPreferences: prefs,
+        })
+      );
+
+      expect(balance.bmr).toBe(value);
+      expect(balance.bmrSource).toBe('measured');
+    }
+  );
+
+  // With no profile there is no formula estimate to compare against, so only the
+  // absolute bounds apply. They must stay meaningful on their own: this is the
+  // path where the old 300-10000 range let issue #2395's 350 kcal reading through.
+  test.each([
+    [600, 'measured'],
+    [6000, 'measured'],
+    [350, 'formula'],
+    [9000, 'formula'],
+  ])(
+    'falls back to the absolute bounds without a formula estimate: %s',
+    (value, expectedSource) => {
+      const balance = computeCalorieBalance(
+        inputs({
+          measurements: { weight: 80, height: 180, bmr: value },
+          userPreferences: prefs,
+          userProfile: null,
+        })
+      );
+
+      expect(balance.bmrSource).toBe(expectedSource);
+    }
+  );
 
   test('falls back to formula BMR when check-in BMR is absent', () => {
     const balance = computeCalorieBalance(

--- a/SparkyFitnessServer/tests/calorieBalanceService.test.ts
+++ b/SparkyFitnessServer/tests/calorieBalanceService.test.ts
@@ -515,6 +515,8 @@ describe('measured BMR override', () => {
     activity_level: 'not_much',
     calorie_goal_adjustment_mode: 'dynamic' as const,
     include_bmr_in_net_calories: true,
+    // The override is opt-in; this block exercises it turned on.
+    use_external_bmr: true,
   };
 
   test('prefers a check-in measured BMR over the formula calculation', () => {

--- a/SparkyFitnessServer/tests/dailySummaryRangeService.test.ts
+++ b/SparkyFitnessServer/tests/dailySummaryRangeService.test.ts
@@ -200,6 +200,43 @@ const runRange = () =>
     includeCheckin: true,
   });
 
+describe('measured BMR is scoped to its own day', () => {
+  /**
+   * Reports read this endpoint while the Diary reads the per-date path. Carrying a
+   * measured BMR forward here made the two disagree about the same day: one
+   * reading on Aug 9 reported `measured` for Aug 10 and 11 as well.
+   */
+  test('applies a measured BMR only on the date it was recorded', async () => {
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      ...PREFERENCES,
+      use_external_bmr: true,
+    });
+    vi.mocked(
+      measurementRepository.getCheckInMeasurementsByDateRange
+    ).mockResolvedValue(
+      DATES.map((date) => ({
+        entry_date: date,
+        steps: FIXTURE[date].steps,
+        ...MEASUREMENT,
+        // A single reading, well inside the plausibility band against the 2000
+        // kcal formula estimate the bmrService mock returns.
+        bmr: date === '2026-08-09' ? 2200 : null,
+      })) as never
+    );
+
+    const { days } = await runRange();
+    const byDate = new Map(days.map((d) => [d.date, d]));
+
+    expect(byDate.get('2026-08-09')?.bmr).toBe(2200);
+    expect(byDate.get('2026-08-09')?.bmrSource).toBe('measured');
+
+    for (const date of ['2026-08-10', '2026-08-11'] as const) {
+      expect(byDate.get(date)?.bmrSource).toBe('formula');
+      expect(byDate.get(date)?.bmr).not.toBe(2200);
+    }
+  });
+});
+
 describe('parity with the per-date Diary path', () => {
   /**
    * The structural guard for issue #2094.

--- a/SparkyFitnessServer/tests/dailySummaryService.test.ts
+++ b/SparkyFitnessServer/tests/dailySummaryService.test.ts
@@ -396,6 +396,46 @@ describe('dailySummaryService', () => {
 
   describe('external BMR override', () => {
     // Use dynamic mode so calorieBalance.bmr reflects the resolved BMR directly
+    beforeEach(() => {
+      // The override is opt-in, so these cases enable it explicitly.
+      vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+        bmr_algorithm: 'Mifflin-St Jeor',
+        activity_level: 'not_much',
+        calorie_goal_adjustment_mode: 'tdee',
+        exercise_calorie_percentage: 100,
+        include_bmr_in_net_calories: false,
+        tdee_allow_negative_adjustment: false,
+        use_external_bmr: true,
+        timezone: 'UTC',
+      });
+    });
+
+    test('ignores the measured value when the opt-in is off', async () => {
+      vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+        bmr_algorithm: 'Mifflin-St Jeor',
+        activity_level: 'not_much',
+        calorie_goal_adjustment_mode: 'tdee',
+        exercise_calorie_percentage: 100,
+        include_bmr_in_net_calories: false,
+        tdee_allow_negative_adjustment: false,
+        use_external_bmr: false,
+        timezone: 'UTC',
+      });
+      vi.mocked(
+        measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
+      ).mockResolvedValue({ weight: 80, height: 180, bmr: 1500 } as never);
+
+      const result = await getDailySummary({
+        actorUserId,
+        targetUserId,
+        date,
+        includeCheckin: true,
+      });
+
+      expect(result.calorieBalance.bmr).toBe(1800);
+      expect(result.calorieBalance.bmrSource).toBe('formula');
+    });
+
     test('overrides formula BMR with the check-in measured value', async () => {
       vi.mocked(
         measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate

--- a/SparkyFitnessServer/tests/dashboardService.test.ts
+++ b/SparkyFitnessServer/tests/dashboardService.test.ts
@@ -155,6 +155,10 @@ describe('getDashboardStats includeCheckin gate', () => {
   });
 
   test('includeCheckin=true applies check-in measured BMR when present', async () => {
+    vi.mocked(preferenceRepository.getUserPreferences).mockResolvedValue({
+      ...basePreferences,
+      use_external_bmr: true,
+    } as never);
     vi.mocked(
       measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
     ).mockResolvedValue({ weight: 80, height: 180, bmr: 1950 } as never);

--- a/SparkyFitnessServer/tests/healthDataHandlers.test.ts
+++ b/SparkyFitnessServer/tests/healthDataHandlers.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { todayInZone } from '@workspace/shared';
 import {
   resolveHandler,
   customMeasurementHandler,
@@ -322,6 +323,29 @@ describe('bmrHandler.handleBatch', () => {
     );
 
     expect(outcomes[0].status).toBe('success');
+  });
+
+  it('refuses an in-progress day only for sources that accumulate', async () => {
+    // Garmin's bmrKilocalories is a running daily total, so a value read before
+    // the day ends is only part of it. HealthKit stamps each fully-elapsed day
+    // with D+1 and Health Connect sends an instantaneous rate, so both are valid
+    // on the current date — refusing today wholesale stopped iOS storing any BMR.
+    const today = todayInZone('UTC');
+    const outcomes = await bmrHandler.handleBatch!(
+      [
+        prepared({ type: 'bmr', value: '1650', source: 'garmin' }, today),
+        prepared(
+          { type: 'bmr', value: '1650', source: 'garmin' },
+          '2026-08-03'
+        ),
+        prepared({ type: 'bmr', value: '1650', source: 'HealthKit' }, today),
+      ],
+      ctx
+    );
+
+    expect(outcomes[0].status).toBe('skipped');
+    expect(outcomes[1].status).toBe('success');
+    expect(outcomes[2].status).toBe('success');
   });
 
   it('rejects values with non-numeric suffixes or out of bounds', async () => {

--- a/SparkyFitnessServer/tests/healthDataHandlers.test.ts
+++ b/SparkyFitnessServer/tests/healthDataHandlers.test.ts
@@ -329,9 +329,12 @@ describe('bmrHandler.handleBatch', () => {
       [
         prepared({ type: 'bmr', value: '1650kcal' }),
         prepared({ type: 'bmr', value: '300xyz' }),
-        prepared({ type: 'bmr', value: '299' }),
-        prepared({ type: 'bmr', value: '10001' }),
+        prepared({ type: 'bmr', value: '599' }),
+        prepared({ type: 'bmr', value: '6001' }),
         prepared({ type: 'bmr', value: '' }),
+        // The reading from issue #2395: physiologically impossible for an adult,
+        // but inside the old 300-10000 range that shipped in v1.6.5.
+        prepared({ type: 'bmr', value: '350' }),
       ],
       ctx
     );
@@ -341,5 +344,19 @@ describe('bmrHandler.handleBatch', () => {
     expect(outcomes[2].status).toBe('error');
     expect(outcomes[3].status).toBe('error');
     expect(outcomes[4].status).toBe('error');
+    expect(outcomes[5].status).toBe('error');
+  });
+
+  it('accepts the 600 and 6000 boundary values', async () => {
+    const outcomes = await bmrHandler.handleBatch!(
+      [
+        prepared({ type: 'bmr', value: '600' }),
+        prepared({ type: 'bmr', value: '6000' }),
+      ],
+      ctx
+    );
+
+    expect(outcomes[0].status).not.toBe('error');
+    expect(outcomes[1].status).not.toBe('error');
   });
 });

--- a/SparkyFitnessServer/tests/measurementRepository.test.ts
+++ b/SparkyFitnessServer/tests/measurementRepository.test.ts
@@ -41,6 +41,33 @@ describe('measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate', () 
     expect(mockClient.release).toHaveBeenCalledTimes(1);
   });
 
+  it('selects bmr for the exact date while other fields carry forward', async () => {
+    // The one-line fix for issue #2395. Reverting `entry_date = $2` back to `<= $2`
+    // for bmr passed the whole suite before this, so the query text is asserted
+    // directly: a measured BMR describes the day it was taken, and nothing else.
+    mockClient.query.mockResolvedValue({ rows: [{ id: 'm1' }] });
+
+    await measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate(
+      'user-1',
+      '2026-06-12'
+    );
+
+    const sql: string = mockClient.query.mock.calls[0][0];
+    const bmrSubselect = sql
+      .split('\n')
+      .find((line: string) => line.includes(') as bmr'));
+
+    expect(bmrSubselect).toBeDefined();
+    expect(bmrSubselect).toContain('entry_date = $2');
+    expect(bmrSubselect).not.toContain('entry_date <= $2');
+
+    // Body composition is still carried forward — only bmr changed.
+    const weightSubselect = sql
+      .split('\n')
+      .find((line: string) => line.includes(') as weight'));
+    expect(weightSubselect).toContain('entry_date <= $2');
+  });
+
   it('returns null when no data exists', async () => {
     mockClient.query.mockResolvedValue({ rows: [{ id: null }] });
 

--- a/SparkyFitnessServer/tests/measurementSchemas.checkIn.test.ts
+++ b/SparkyFitnessServer/tests/measurementSchemas.checkIn.test.ts
@@ -92,8 +92,9 @@ describe('check-in body schemas cover smart-scale composition', () => {
     ['muscle_mass_kg', 1000],
     ['bone_mass_kg', 1000],
     ['body_water_percentage', 101],
-    ['bmr', 299],
-    ['bmr', 10001],
+    ['bmr', 599],
+    ['bmr', 6001],
+    ['bmr', 350],
   ] as const)('rejects an out-of-range %s of %s', (field, value) => {
     expect(
       UpsertCheckInBodySchema.safeParse({
@@ -112,7 +113,7 @@ describe('check-in body schemas cover smart-scale composition', () => {
       muscle_mass_kg: 999.99,
       bone_mass_kg: 0,
       body_water_percentage: 100,
-      bmr: 300,
+      bmr: 600,
     });
 
     expect(result.success).toBe(true);

--- a/agent-docs/file-and-domain-reference.md
+++ b/agent-docs/file-and-domain-reference.md
@@ -146,7 +146,18 @@ that query is unbounded by date and is fetched once and reused across a whole
 range, so a reading taken today would set the fallback TDEE, and therefore the
 ±500 Adaptive TDEE clamp, for dates weeks earlier.
 
-**Two-layer plausibility, always both.** `isUsableMeasuredBmr(value, formulaBmr)`
+**Opt-in first.** Every consumer is gated on the `use_external_bmr` preference,
+which defaults to `false`. Check it *before* `isUsableMeasuredBmr`. The mobile
+per-metric sync toggle is not a substitute: Garmin has no per-metric control, so
+`bmr_calories` arrives with no user opt-out of its own.
+
+**Completed days only.** `checkInHandleBatch` in `healthDataHandlers.ts` drops a
+`bmr` write whose `entry_date` is not yet finished in the user's timezone. Garmin
+reports `bmrKilocalories` in its daily summary beside `totalKilocalories` — a
+running accumulation, not a rate — so a mid-day sync sends part of the day. The
+ratio band catches an early-morning value but not a late-afternoon one.
+
+**Two-layer plausibility.** `isUsableMeasuredBmr(value, formulaBmr)`
 in `shared/src/utils/calorieCalculations.ts` applies absolute bounds
 (`MIN/MAX_MEASURED_BMR_KCAL`, 600–6000) *and* a ratio band against the user's own
 formula estimate (0.6–1.6). Compute the formula estimate first and pass it. When

--- a/agent-docs/file-and-domain-reference.md
+++ b/agent-docs/file-and-domain-reference.md
@@ -127,6 +127,55 @@ Paths are relative to each package root. `—` means that layer does not exist f
 
 ---
 
+## Measured BMR — Rules That Are Easy To Break
+
+`check_in_measurements.bmr` holds a BMR measured by a smart scale or synced from a
+health provider. It is not treated like the other body metrics, and every rule
+below exists because breaking it caused issue #2395.
+
+**Exact date, never carried forward.** Weight, height, circumferences and body
+composition all carry forward — there is no other source for a day without a
+reading, so the last known value is reused. BMR is the exception: a formula
+fallback exists that already tracks the user's current weight, so a stale reading
+is strictly worse than recomputing. It applies only on its own `entry_date`, and
+days without one use the formula. This is also what makes "turn the sync off"
+actually restore the formula the next day.
+
+Do **not** read `bmr` from `getLatestMeasurement()` for a per-date calculation —
+that query is unbounded by date and is fetched once and reused across a whole
+range, so a reading taken today would set the fallback TDEE, and therefore the
+±500 Adaptive TDEE clamp, for dates weeks earlier.
+
+**Two-layer plausibility, always both.** `isUsableMeasuredBmr(value, formulaBmr)`
+in `shared/src/utils/calorieCalculations.ts` applies absolute bounds
+(`MIN/MAX_MEASURED_BMR_KCAL`, 600–6000) *and* a ratio band against the user's own
+formula estimate (0.6–1.6). Compute the formula estimate first and pass it. When
+no estimate can be computed the absolute bounds decide alone, so they must stay
+meaningful on their own — the wider 300–10000 pair is what let a 350 kcal reading
+through.
+
+**Five consumers, one rule.** A measured BMR feeds the daily burn
+(`calorieBalanceService`), the goal (`goalService`), the Adaptive TDEE fallback
+(`AdaptiveTdeeService`), the RMR safety floor (`calculateMinimumMetabolism` in
+shared) and reports (`reportService`). The safety-floor path is the one people
+miss: `getRecommendedCalorieSafetyFloor()` uses RMR verbatim, so a bad value does
+not merely shift the goal, it becomes the floor underneath it.
+
+**Provider quirks.** iOS maps `BasalMetabolicRate` to HealthKit's
+`BasalEnergyBurned`, keeps only fully-elapsed days, and stamps each day D with
+D+1 so an exact-date lookup picks up yesterday's complete resting energy. Android
+reads Health Connect's `BasalMetabolicRate` at the record's own timestamp, with no
+such shift — so the same underlying data lands a day apart on the two platforms.
+Garmin sends `bmrKilocalories` from the daily summary, which accumulates through
+the day and has no per-metric opt-out.
+
+**Activity level still matters after Adaptive goes live.** It does not feed the
+adaptive estimate, but `fallbackTdee = BMR × multiplier` sets the ±500 band the
+estimate is capped to. A level set too low silently holds a genuinely higher
+measured expenditure down.
+
+---
+
 ## How AI Tools Use This
 
 Grep the feature name in this doc to narrow to the right package folders, then grep the same name inside those folders to open the actual files. The naming is intentionally **not** uniform, so confirm against the filesystem rather than assuming a `<feature>Service.ts` / `<feature>Repository.ts` file exists.

--- a/docs/content/2.features/7.settings/calculation-settings.md
+++ b/docs/content/2.features/7.settings/calculation-settings.md
@@ -20,26 +20,37 @@ _Note: Weight (`W`) is in kg, Height (`H`) is in cm, and Age (`A`) is in years._
 
 ### Measured BMR
 
-If a smart scale or a connected health app reports a BMR, SparkyFitness uses that
+If a smart scale or a connected health app reports a BMR, SparkyFitness can use that
 measured value for that day instead of the formula above, and the calculation
 breakdown on the Diary labels it **Measured**.
+
+This is **off by default**. Turn on **Use measured BMR from check-ins and synced
+devices** in Calculation Settings to enable it; until you do, your chosen formula
+is always used.
 
 - **It counts only on the day it was recorded.** A measured BMR is never carried
   forward. Days without a reading fall back to your chosen formula, so turning the
   sync off restores the formula the next day — you do not have to delete anything.
-- **Implausible readings are ignored.** A value is used only if it falls between
-  600 and 6,000 kcal *and* lands within 60–160% of your own formula estimate. A
+- **Implausible readings are ignored.** A value must fall between 600 and 6,000
+  kcal. When your profile is complete enough to produce a formula estimate, it must
+  *also* land within 60–160% of that estimate; if it is not — for example when
+  height or date of birth is missing — the absolute bounds decide on their own. A
   partial-day figure or a mis-mapped metric is discarded and the formula is used
   instead. The second check matters because a value can look reasonable on its own
   and still be impossible for your body.
+- **Readings for a day that has not finished are refused.** Some providers report
+  BMR as a running daily total rather than a rate, so a sync partway through the
+  day hands back part of the day's figure. Only completed days are accepted.
 - **It also sets your safety floor.** The Standard Adaptive Safety Floor uses the
   higher of your RMR and the clinical minimum, and your measured BMR *is* that RMR
   when one is available. So a measured value that differs from the formula moves
   the floor under your calorie goal, not just the estimate above it.
 
-To stop using measured values, disable BMR sync for the connected device or health
-app. On Apple Health and Health Connect this is a per-metric setting, so you can
-keep syncing weight and body fat while dropping BMR.
+To stop using measured values, turn the setting off in Calculation Settings. That
+covers every source at once. You can also disable BMR sync at the provider — on
+Apple Health and Health Connect that is a per-metric setting, so you can keep
+syncing weight and body fat while dropping BMR. Garmin has no per-metric control,
+which is why the Calculation Settings toggle exists.
 
 ---
 

--- a/docs/content/2.features/7.settings/calculation-settings.md
+++ b/docs/content/2.features/7.settings/calculation-settings.md
@@ -18,6 +18,29 @@ Your Basal Metabolic Rate (BMR) represents the energy your body requires to perf
 
 _Note: Weight (`W`) is in kg, Height (`H`) is in cm, and Age (`A`) is in years._
 
+### Measured BMR
+
+If a smart scale or a connected health app reports a BMR, SparkyFitness uses that
+measured value for that day instead of the formula above, and the calculation
+breakdown on the Diary labels it **Measured**.
+
+- **It counts only on the day it was recorded.** A measured BMR is never carried
+  forward. Days without a reading fall back to your chosen formula, so turning the
+  sync off restores the formula the next day — you do not have to delete anything.
+- **Implausible readings are ignored.** A value is used only if it falls between
+  600 and 6,000 kcal *and* lands within 60–160% of your own formula estimate. A
+  partial-day figure or a mis-mapped metric is discarded and the formula is used
+  instead. The second check matters because a value can look reasonable on its own
+  and still be impossible for your body.
+- **It also sets your safety floor.** The Standard Adaptive Safety Floor uses the
+  higher of your RMR and the clinical minimum, and your measured BMR *is* that RMR
+  when one is available. So a measured value that differs from the formula moves
+  the floor under your calorie goal, not just the estimate above it.
+
+To stop using measured values, disable BMR sync for the connected device or health
+app. On Apple Health and Health Connect this is a per-metric setting, so you can
+keep syncing weight and body fat while dropping BMR.
+
 ---
 
 ## 2. Body Fat Algorithms
@@ -48,7 +71,8 @@ This setting determines **how physical activity changes your calorie budget** th
 - **Adaptive TDEE:** Dynamically computes your metabolic expenditure by correlating your actual weight changes with your historical calorie intake over the last 28 days. _(Best for high-precision tracking)._
   - **Expenditure (Adaptive TDEE):** On the Diary page, "Expenditure" represents your calculated Total Daily Energy Expenditure (TDEE). This is the baseline number from which your deficit/surplus is subtracted.
   - **Fallback Behavior:** If you have insufficient history (less than 14 days of weight and calorie data, or fewer than 7 days of calorie entries ≥ 200 kcal), the system will use a fallback estimate based on the standard `BMR × Activity Multiplier` formula until enough data is collected.
-  - **The formula:** `TDEE = Average Daily Calories - (Daily Weight Change in kg × 6,000 kcal/kg)`.
+  - **The formula:** `TDEE = Average Daily Calories - (Daily Weight Change in kg × 6,000 kcal/kg)`. The average covers only days with at least 200 kcal logged — unlogged days are skipped, not counted as zero — while the weight change spans the whole 28-day window.
+  - **Plausibility cap:** the result is capped to within ±500 kcal of `BMR × Activity Multiplier`. Your **Activity Level** therefore keeps mattering after Adaptive goes live: it does not feed the estimate, but it sets the window the estimate is allowed to land in. A level set well below your real activity can hold a genuinely higher measured expenditure down, and the Diary's calculation breakdown says so when the cap binds.
 
     The `6,000 kcal/kg` term is an energy density — how many calories a kilogram of body weight represents — which is what lets a weight trend be converted into calories. If you ate 2,000 kcal/day and lost 0.5 kg over 14 days, that lost weight represents about 3,000 kcal your body burned beyond what you ate, or ~214 kcal/day, so your true expenditure was ~2,214 kcal/day.
 
@@ -116,7 +140,7 @@ Under the Adaptive method the floor applies whenever the calculated target falls
 > [!TIP]
 > If a goal mode appears to have no effect, the Standard floor is binding. That is usually about your **activity level**, not your body size. With the fallback estimate (TDEE = RMR × activity multiplier) and RMR as the binding half, the floor bites once your deficit exceeds roughly `1 - 1/activityMultiplier` — about 17% at **Sedentary** (×1.2), and 0% at **None** (×1.0), where every deficit mode returns the same target. Once Adaptive has enough history it uses your _measured_ TDEE, so the real limit is how far your expenditure sits above your RMR. A sedentary man and a sedentary woman of very different sizes hit the same ceiling.
 >
-> If you are still on the fallback estimate, check your **Activity Level** and profile data first, since they set the ceiling there and are the most common things to have understated. Once Adaptive is using measured TDEE the setting no longer feeds the calculation, and the ceiling reflects your real expenditure instead. If your target has been agreed with a qualified clinician and still falls below the Standard floor, choose a **Custom minimum** or **Disabled**. Very small adults may find the clinical minimum sits above their own maintenance, in which case those two options are the only way to set a deficit at all. Very low calorie targets can carry health risks and may require medical supervision.
+> If you are still on the fallback estimate, check your **Activity Level** and profile data first, since they set the ceiling there and are the most common things to have understated. Once Adaptive is using measured TDEE the setting no longer feeds the estimate itself, and the ceiling reflects your real expenditure — but it still sets the ±500 kcal plausibility cap around `BMR × Activity Multiplier`, so an understated level can still hold your measured TDEE down. If your target has been agreed with a qualified clinician and still falls below the Standard floor, choose a **Custom minimum** or **Disabled**. Very small adults may find the clinical minimum sits above their own maintenance, in which case those two options are the only way to set a deficit at all. Very low calorie targets can carry health risks and may require medical supervision.
 
 ---
 

--- a/shared/src/constants/calorieConstants.ts
+++ b/shared/src/constants/calorieConstants.ts
@@ -77,6 +77,35 @@ export const DEFAULT_CUSTOM_CALORIE_SAFETY_FLOOR = 1200;
  */
 export const MAX_HEALTH_TOTAL_CALORIES_PER_DAY = 20_000;
 
+/**
+ * Absolute plausibility bounds for a measured BMR, in kcal/day.
+ *
+ * Deliberately wide — Mifflin-St Jeor gives roughly 1030 kcal for a 40 kg, 150 cm
+ * woman and 3070 kcal for a 200 kg, 190 cm man — so it rejects impossible readings
+ * without second-guessing an unusual body. These are the bounds that shipped in
+ * v1.6.3/v1.6.4; the wider 300-10000 pair used in v1.6.5 let a 350 kcal reading
+ * through, which then became the RMR safety floor (issue #2395).
+ */
+export const MIN_MEASURED_BMR_KCAL = 600;
+export const MAX_MEASURED_BMR_KCAL = 6000;
+
+/**
+ * How far a measured BMR may sit from the formula estimate for the SAME person
+ * before it is treated as implausible.
+ *
+ * The absolute bounds above cannot catch a reading that is wrong only relative to
+ * a particular body: 2400 kcal is unremarkable in isolation but implausible for
+ * someone whose formula estimate is 1200. Comparing against the person's own
+ * estimate catches unit mismatches and mis-mapped metrics that land inside the
+ * absolute range, without narrowing what a genuinely unusual measured BMR can be.
+ *
+ * A real measured BMR does diverge from a population formula — that is the point
+ * of measuring — so the band is loose enough to let real metabolic variation and
+ * adaptation through.
+ */
+export const MEASURED_BMR_MIN_RATIO_OF_FORMULA = 0.6;
+export const MEASURED_BMR_MAX_RATIO_OF_FORMULA = 1.6;
+
 export const ACTIVITY_MULTIPLIERS: Record<string, number> = {
   none: 1.0,
   not_much: 1.2,

--- a/shared/src/constants/calorieConstants.ts
+++ b/shared/src/constants/calorieConstants.ts
@@ -47,6 +47,15 @@ export const CALORIE_CALCULATION_CONSTANTS = {
 export const ENERGY_DENSITY_KCAL_PER_KG = 6000;
 
 /**
+ * Half-width of the Adaptive TDEE plausibility band, in kcal.
+ *
+ * The log-derived estimate is capped to within this much of `BMR x activity
+ * multiplier`. Defined in kcal because the estimate is: any display in another
+ * unit must convert it, or the stated band contradicts the bounds beside it.
+ */
+export const ADAPTIVE_TDEE_CLAMP_KCAL = 500;
+
+/**
  * Qualifying calorie-log days before a measured adaptive TDEE may drive a goal.
  *
  * `AdaptiveTdeeService` releases a raw estimate at 7 days, which is enough to

--- a/shared/src/constants/calorieConstants.ts
+++ b/shared/src/constants/calorieConstants.ts
@@ -112,6 +112,13 @@ export const MAX_MEASURED_BMR_KCAL = 6000;
  * of measuring — so the band is loose enough to let real metabolic variation and
  * adaptation through.
  */
+/**
+ * The two tissue densities that ENERGY_DENSITY_KCAL_PER_KG blends. Kept beside it
+ * so the blend and its components cannot drift apart.
+ */
+export const FAT_KCAL_PER_KG = 9441;
+export const LEAN_TISSUE_KCAL_PER_KG = 1816;
+
 export const MEASURED_BMR_MIN_RATIO_OF_FORMULA = 0.6;
 export const MEASURED_BMR_MAX_RATIO_OF_FORMULA = 1.6;
 

--- a/shared/src/utils/calorieCalculations.ts
+++ b/shared/src/utils/calorieCalculations.ts
@@ -6,6 +6,10 @@ import {
   ENERGY_DENSITY_KCAL_PER_KG,
   MAX_CALORIE_SAFETY_FLOOR,
   MIN_CALORIE_SAFETY_FLOOR,
+  MIN_MEASURED_BMR_KCAL,
+  MAX_MEASURED_BMR_KCAL,
+  MEASURED_BMR_MIN_RATIO_OF_FORMULA,
+  MEASURED_BMR_MAX_RATIO_OF_FORMULA,
   type CalorieSafetyFloorMode,
 } from "../constants/calorieConstants.ts";
 
@@ -361,6 +365,50 @@ export type GoalModeCalculationMethod = "adaptive" | "manual";
 export const MAX_GOAL_MODE_PERCENTAGE = 40;
 
 /**
+ * Whether a measured BMR may be used in place of a formula estimate.
+ *
+ * Two layers. The absolute bounds reject readings no adult can produce. The ratio
+ * band then rejects readings that are only wrong *for this person* — 2400 kcal is
+ * unremarkable on its own but implausible against a 1200 kcal formula estimate —
+ * which is what catches unit mismatches and mis-mapped metrics that sit inside the
+ * absolute range.
+ *
+ * When no formula estimate is available (incomplete profile) the absolute bounds
+ * alone decide. That is why they must stay meaningful on their own rather than
+ * relying on the ratio to do the work.
+ *
+ * Accepts the loose shapes these values arrive in (numeric strings from the
+ * database driver, null/undefined when absent) so callers do not each re-implement
+ * the parse.
+ */
+export function isUsableMeasuredBmr(
+  value: number | string | null | undefined,
+  formulaBmr?: number | null,
+): boolean {
+  if (value === null || value === undefined || value === "") return false;
+  const parsed = typeof value === "number" ? value : parseFloat(String(value));
+  if (
+    !Number.isFinite(parsed) ||
+    parsed < MIN_MEASURED_BMR_KCAL ||
+    parsed > MAX_MEASURED_BMR_KCAL
+  ) {
+    return false;
+  }
+  if (
+    formulaBmr === null ||
+    formulaBmr === undefined ||
+    !Number.isFinite(formulaBmr) ||
+    formulaBmr <= 0
+  ) {
+    return true;
+  }
+  return (
+    parsed >= formulaBmr * MEASURED_BMR_MIN_RATIO_OF_FORMULA &&
+    parsed <= formulaBmr * MEASURED_BMR_MAX_RATIO_OF_FORMULA
+  );
+}
+
+/**
  * Signed adjustment applied to the baseline TDEE, as a fraction.
  *
  * **Return value: positive means a deficit, negative means a surplus.** That is
@@ -485,27 +533,31 @@ export function calculateMinimumMetabolism(
   calculateBmrFn?: BmrCalculatorFn,
   measuredBmr?: number | null,
 ): number {
-  if (measuredBmr && measuredBmr >= 300 && measuredBmr <= 10000) {
-    return measuredBmr;
-  }
   const activeBmrFn = calculateBmrFn || calculateBmr;
+  // The formula is computed unconditionally, because a measured value is only
+  // trusted once it has been checked against it.
+  let formulaBmr: number;
   if (
     (bmrAlgorithm === "Katch-McArdle" || bmrAlgorithm === "Cunningham") &&
     bodyFatPercentage &&
     bodyFatPercentage > 0
   ) {
     const lbm = weightKg * (1 - bodyFatPercentage / 100);
-    return bmrAlgorithm === "Cunningham" ? 500 + 22 * lbm : 370 + 21.6 * lbm;
+    formulaBmr = bmrAlgorithm === "Cunningham" ? 500 + 22 * lbm : 370 + 21.6 * lbm;
+  } else {
+    formulaBmr = activeBmrFn(
+      bmrAlgorithm,
+      weightKg,
+      heightCm,
+      age,
+      gender,
+      bodyFatPercentage,
+    );
   }
 
-  return activeBmrFn(
-    bmrAlgorithm,
-    weightKg,
-    heightCm,
-    age,
-    gender,
-    bodyFatPercentage,
-  );
+  return isUsableMeasuredBmr(measuredBmr, formulaBmr)
+    ? (measuredBmr as number)
+    : formulaBmr;
 }
 
 export interface CalorieTargetResult {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!

## Description

**What problem does this PR solve?**

A measured BMR (smart scale, health-provider sync, manual check-in) unconditionally replaced the user's chosen formula and was then carried forward indefinitely. Since `getRecommendedCalorieSafetyFloor()` uses RMR verbatim, a bad reading did not just shift the calorie goal, it became the floor underneath it — which is how a 350 kcal value collapsed one user's target while a high reading pushed another's up ~500 kcal.

**How did you implement the solution?**

- **Scope a measured BMR to its own `entry_date`.** It was carried forward per column, and `getLatestMeasurement` had *no date bound at all* — so a reading taken today set the fallback TDEE, and therefore the ±500 Adaptive TDEE clamp band, for dates weeks earlier. Days with no reading now use the formula, so turning sync off restores it the next day instead of never.
- **Narrow the plausibility bounds from 300–10000 to 600–6000** (the v1.6.3/v1.6.4 values) across the five resolution sites, the health-data ingest, the check-in schemas, and both clients. Mifflin-St Jeor gives ~1030 kcal for a 40 kg/150 cm woman and ~3070 for a 200 kg/190 cm man, so this stays generous while rejecting impossible readings.
- **Add a relative plausibility band** — a measured value must also sit within 60–160% of that person's own formula estimate. This catches readings that are wrong only for a particular body (2400 kcal is unremarkable alone, implausible against a 1200 kcal estimate). Falls back to the absolute bounds when the profile is too incomplete to compute an estimate, which is why those bounds still have to be meaningful on their own.
- **Explain the switch in the Diary breakdown**: which value was used, that it came from a scale or health sync, and that it applies only to the day it was recorded. Several reports were about the number changing silently on upgrade rather than the number itself being wrong.
- **Made the override opt-in (`use_external_bmr`, default off) with a Settings toggle.** Garmin has no per-metric sync control, so before this there was no way for an affected user to turn it off. Every consumer is gated, so the formula is used until a user opts in.
- **Refused a BMR for a day that has not finished** in the user's timezone. Garmin reports `bmrKilocalories` in its daily summary beside `totalKilocalories` — a running accumulation, not a rate — so a sync partway through the day hands back a partial total. HealthKit already keeps only fully-elapsed days; this is the equivalent for every other source. The relative band catches an early-morning value (716 against a ~1800 estimate is a ratio of 0.40) but a late-afternoon one looks plausible and would otherwise pass.
- **Migration clears only values the new constraint rejects.** Every plausible reading is preserved, including history backfilled from the legacy `basal_metabolic_rate` custom category.

Linked Issue: Closes #2395

## How to Test

1. `cd SparkyFitnessServer && pnpm test && pnpm validate`
2. `cd SparkyFitnessFrontend && pnpm test && pnpm validate`
3. Restart the server to apply `20260908120000_narrow_check_in_bmr_bounds.sql`.
4. With a `check_in_measurements.bmr` of 350 for today: the Diary must show the formula BMR and the pre-1.6.5 goal, with no `(Measured)` tag.
5. Set a plausible value (e.g. 1850) for today: it is used and tagged as measured. Tomorrow, with no reading, the goal falls back to the formula.
6. Set 1850 dated today, then open a date three weeks back — that date must be unchanged, and its Adaptive TDEE must match what it showed before.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. — N/A, bug fix.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. — N/A, no new table; this only narrows a CHECK constraint on an existing column.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. — described below; images to follow.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. — Mobile change is validation bounds only (600–6000 in the check-in form); goals and BMR come from the server, so mobile picks up the fix with no client change.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

The Adaptive TDEE panel showed only inputs and result — average intake and calculated expenditure — with no way to see where the difference between them came from. The BMR panel showed a bare `Measured` tag and "Using your measured BMR. No formula applied." with no value, source or date.

### After
<img width="1479" height="1246" alt="image" src="https://github.com/user-attachments/assets/fe1e8a56-ff15-424d-8ef9-3eeeb10974e0" />

BMR names the value, its source and that it applies to that day only. Adaptive TDEE now shows the weight-trend term and its kcal conversion, and says explicitly when the ±500 plausibility cap bound the result.

</details>

## Notes for Reviewers

**Credit to @Professorvennie.** The relative plausibility band in this PR is their idea, taken from #2400 — a flat range cannot catch a reading that is wrong only relative to a particular person, and comparing against that person's own formula estimate does. Their root-cause analysis on #2395 also correctly identified the safety-floor path and the Adaptive TDEE clamp-band effect. @Professorvennie — would you review this?

**On `use_external_bmr`:** this PR **gates every consumer on it, and it defaults off.** An earlier revision of this PR argued the opposite — that the mobile per-metric sync toggle (`syncBasalMetabolicRateEnabled`) was already the opt-in and a server preference merely duplicated it. That reasoning was wrong, for one concrete reason: **Garmin has no per-metric toggle.** `bmr_calories` flows through `garminMeasurementMapping.ts` with no user control, so a Garmin user's only "off" was disconnecting Garmin entirely. Garmin is also where most of the reports come from — the reporter on #2395 posted a check-in showing `Source: Garmin`, `BMR 716`, `Total Calories 372`, captured at a 4am sync.

One server-side switch covers every source uniformly — mobile, Garmin, Withings, manual entry — which per-provider toggles structurally cannot. Defaulting it off restores v1.6.4 behaviour for everyone with no user action, which is what resolves the open reports.

Credit to @Professorvennie for arguing this in #2400; that call was right and this PR follows it.

The reason a toggle felt necessary is that turning the sync off did not actually revert, because the value carried forward. That is fixed here.

**Known gaps, both out of scope:**
- Garmin has no per-metric toggle — `bmr_calories` flows through `garminMeasurementMapping.ts` with no user control, so "just turn it off" does not apply there yet.
- On iOS, `BasalMetabolicRate` maps to `HKQuantityTypeIdentifierBasalEnergyBurned` and is stamped D+1 (yesterday's complete resting energy applies to today) so exact-date lookups work. Android uses the record's own timestamp. The calculation is right on both, but the BMR chart is a day off on iOS, and the two platforms disagree for identical data.
- `tests/schemaParity.integration.test.ts` fails on this branch and on a clean checkout alike — unrelated caffeine/alcohol/water columns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Measured BMR readings now apply only to the day they were recorded; other days use the calculated value.
- BMR values are validated against 600–6,000 kcal and the personal formula estimate.
- Calorie breakdowns now explain measured BMR details and show adaptive TDEE calculation components.
- Adaptive TDEE displays its calculation window, intake averaging rules, weight-trend impact, energy units, and plausibility-limit notices.

## Bug Fixes

- Prevented implausible or outdated readings from affecting calorie targets, reports, and adaptive calculations.
- Invalid date filters now return clear validation errors.
- Updated mobile validation messages and server-side handling.

## Documentation

- Added guidance explaining measured BMR usage and adaptive TDEE calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

