### PR TITLE
fix(sleep): use primary stage cluster for duration envelope

### DIFF
--- a/SparkyFitnessServer/services/measurementService.ts
+++ b/SparkyFitnessServer/services/measurementService.ts
@@ -10,6 +10,11 @@ import {
   isDayString,
 } from '@workspace/shared';
 import { userAge } from '../utils/dateHelpers.js';
+import {
+  getPrimarySleepStageCluster,
+  recomputeSleepAggregatesFromStages,
+  sumAsleepSeconds,
+} from '../utils/sleepStageAggregates.js';
 import userRepository from '../models/userRepository.js';
 import sleepRepository from '../models/sleepRepository.js';
 import exerciseEntryDb from '../models/exerciseEntry.js';
@@ -1316,25 +1321,6 @@ async function calculateSleepScore(
   // Ensure score is within 0-100 range
   return Math.round(Math.max(0, Math.min(score, maxScore)));
 }
-// "Time asleep" is the sum of the genuinely-asleep stages only: deep + light + rem.
-// It excludes 'awake', and also 'in_bed' and 'unknown' — the in-bed envelope still
-// counts toward `duration` (so efficiency = time_asleep / duration stays meaningful)
-// but must not inflate asleep time. Overlap across sources is resolved on the mobile
-// client before upload, so a plain sum over the stored stages does not double-count.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function sumAsleepSeconds(stages: any[]): number {
-  if (!Array.isArray(stages)) return 0;
-  return stages.reduce((sum, stage) => {
-    if (
-      stage.stage_type === 'deep' ||
-      stage.stage_type === 'light' ||
-      stage.stage_type === 'rem'
-    ) {
-      return sum + (Math.round(Number(stage.duration_in_seconds)) || 0);
-    }
-    return sum;
-  }, 0);
-}
 async function processSleepEntry(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   userId: any,
@@ -1481,13 +1467,14 @@ async function processSleepEntry(
         `[processSleepEntry] Preserving ${mergedStages.length} existing stage events for entry ${newSleepEntry.id} because the payload had no authoritative stage data.`
       );
     }
+    const primaryStages = getPrimarySleepStageCluster(mergedStages);
     const recomputed = recomputeSleepAggregatesFromStages(mergedStages);
     const recomputedSleepScore = await calculateSleepScore(
       {
         duration_in_seconds: recomputed.duration_in_seconds,
         time_asleep_in_seconds: recomputed.time_asleep_in_seconds,
       },
-      mergedStages,
+      primaryStages,
       age,
       // @ts-expect-error TS(2554): Expected 2-3 arguments, but got 4.
       gender
@@ -1512,68 +1499,6 @@ async function processSleepEntry(
   }
 }
 
-// Pure aggregate derivation from a stage list. The stored stages are already a
-// non-overlapping timeline (mobile resolves cross-source overlap before upload), so the
-// per-stage buckets and `duration` are plain min/max/sum. `time_asleep` counts only the
-// asleep stages (deep/light/rem) via sumAsleepSeconds; `duration` still spans the full
-// in-bed envelope so efficiency = time_asleep / duration stays meaningful.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function recomputeSleepAggregatesFromStages(stages: any[]) {
-  if (!stages || stages.length === 0) {
-    return {
-      bedtime: null,
-      wake_time: null,
-      duration_in_seconds: 0,
-      time_asleep_in_seconds: 0,
-      deep_sleep_seconds: 0,
-      light_sleep_seconds: 0,
-      rem_sleep_seconds: 0,
-      awake_sleep_seconds: 0,
-    };
-  }
-  let minStart = new Date(stages[0].start_time).getTime();
-  let maxEnd = new Date(stages[0].end_time).getTime();
-  let deep = 0;
-  let light = 0;
-  let rem = 0;
-  let awake = 0;
-  for (const s of stages) {
-    const startMs = new Date(s.start_time).getTime();
-    const endMs = new Date(s.end_time).getTime();
-    if (startMs < minStart) minStart = startMs;
-    if (endMs > maxEnd) maxEnd = endMs;
-    const duration = Math.round(Number(s.duration_in_seconds)) || 0;
-    switch (s.stage_type) {
-      case 'deep':
-        deep += duration;
-        break;
-      case 'light':
-        light += duration;
-        break;
-      case 'rem':
-        rem += duration;
-        break;
-      case 'awake':
-        awake += duration;
-        break;
-      default:
-        // in_bed / unknown: bounds the envelope (min/max above) but is NOT asleep time.
-        break;
-    }
-  }
-  const durationInSeconds = Math.max(0, Math.round((maxEnd - minStart) / 1000));
-  const timeAsleep = sumAsleepSeconds(stages);
-  return {
-    bedtime: new Date(minStart),
-    wake_time: new Date(maxEnd),
-    duration_in_seconds: durationInSeconds,
-    time_asleep_in_seconds: timeAsleep,
-    deep_sleep_seconds: deep,
-    light_sleep_seconds: light,
-    rem_sleep_seconds: rem,
-    awake_sleep_seconds: awake,
-  };
-}
 async function updateSleepEntry(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   userId: any,
@@ -1802,6 +1727,12 @@ export { processSleepEntry };
 export { updateSleepEntry };
 export { getOrCreateCustomCategory };
 export { resolveHealthEntryDate };
+export {
+  clusterSleepStagesByGap,
+  getPrimarySleepStageCluster,
+  recomputeSleepAggregatesFromStages,
+  sumAsleepSeconds,
+} from '../utils/sleepStageAggregates.js';
 
 // ── Water Intake Entries service functions ───────────────────────────────
 

--- a/SparkyFitnessServer/tests/measurementService.sleepPrimaryCluster.test.ts
+++ b/SparkyFitnessServer/tests/measurementService.sleepPrimaryCluster.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clusterSleepStagesByGap,
+  getPrimarySleepStageCluster,
+  recomputeSleepAggregatesFromStages,
+} from '../utils/sleepStageAggregates.js';
+
+/**
+ * Regression for #1954 / Health Connect same-day merge: when stages from the
+ * main night and a disconnected evening fragment (next night / nap) land on
+ * one entry_date, duration must follow the primary cluster — not min→max
+ * across a ~24h envelope.
+ */
+describe('recomputeSleepAggregatesFromStages primary cluster (#1954)', () => {
+  const mainNight = [
+    {
+      stage_type: 'light',
+      start_time: '2026-09-05T23:28:00-03:00',
+      end_time: '2026-09-05T23:41:00-03:00',
+      duration_in_seconds: 13 * 60,
+    },
+    {
+      stage_type: 'deep',
+      start_time: '2026-09-05T23:42:00-03:00',
+      end_time: '2026-09-06T00:16:00-03:00',
+      duration_in_seconds: 34 * 60,
+    },
+    {
+      stage_type: 'light',
+      start_time: '2026-09-06T00:17:00-03:00',
+      end_time: '2026-09-06T06:06:00-03:00',
+      duration_in_seconds: 349 * 60,
+    },
+  ];
+
+  const eveningFragment = [
+    {
+      stage_type: 'light',
+      start_time: '2026-09-06T22:12:00-03:00',
+      end_time: '2026-09-06T22:23:00-03:00',
+      duration_in_seconds: 11 * 60,
+    },
+    {
+      stage_type: 'deep',
+      start_time: '2026-09-06T22:24:00-03:00',
+      end_time: '2026-09-06T23:56:59.999-03:00',
+      duration_in_seconds: 93 * 60,
+    },
+  ];
+
+  it('splits disconnected blocks when gap exceeds 4 hours', () => {
+    const clusters = clusterSleepStagesByGap([
+      ...mainNight,
+      ...eveningFragment,
+    ]);
+    expect(clusters).toHaveLength(2);
+  });
+
+  it('picks the longer asleep block as primary', () => {
+    const primary = getPrimarySleepStageCluster([
+      ...eveningFragment,
+      ...mainNight,
+    ]);
+    expect(new Date(primary[0].start_time).toISOString()).toBe(
+      new Date('2026-09-05T23:28:00-03:00').toISOString()
+    );
+  });
+
+  it('does not stretch wake_time to the evening fragment', () => {
+    const agg = recomputeSleepAggregatesFromStages([
+      ...mainNight,
+      ...eveningFragment,
+    ]);
+    expect(agg.wake_time?.toISOString()).toBe(
+      new Date('2026-09-06T06:06:00-03:00').toISOString()
+    );
+    expect(agg.bedtime?.toISOString()).toBe(
+      new Date('2026-09-05T23:28:00-03:00').toISOString()
+    );
+    // ~6.6h in bed, not ~24.5h
+    expect(agg.duration_in_seconds).toBeGreaterThan(6 * 3600);
+    expect(agg.duration_in_seconds).toBeLessThan(8 * 3600);
+    expect(agg.time_asleep_in_seconds).toBe((13 + 34 + 349) * 60);
+  });
+
+  it('keeps a single contiguous night as one envelope (issue #1180 path)', () => {
+    const withSmallGap = [
+      ...mainNight.slice(0, 2),
+      {
+        stage_type: 'light',
+        // 45 min gap after deep — still same night
+        start_time: '2026-09-06T01:01:00-03:00',
+        end_time: '2026-09-06T06:06:00-03:00',
+        duration_in_seconds: 305 * 60,
+      },
+    ];
+    expect(clusterSleepStagesByGap(withSmallGap)).toHaveLength(1);
+    const agg = recomputeSleepAggregatesFromStages(withSmallGap);
+    expect(agg.duration_in_seconds).toBe(
+      Math.round(
+        (new Date('2026-09-06T06:06:00-03:00').getTime() -
+          new Date('2026-09-05T23:28:00-03:00').getTime()) /
+          1000
+      )
+    );
+  });
+});

--- a/SparkyFitnessServer/utils/sleepStageAggregates.ts
+++ b/SparkyFitnessServer/utils/sleepStageAggregates.ts
@@ -1,0 +1,155 @@
+// Sleep stage clustering + aggregate helpers.
+//
+// Health Connect / HealthKit sync merges stages onto one entry_date. When a
+// disconnected block (next-night evening fragment or daytime nap) lands on the
+// same row, min(start)→max(end) produces a ~24h History envelope (#1954).
+// Cluster by gap (same 4h threshold as the HealthKit mobile aggregator) and
+// take the primary (longest asleep) cluster for bedtime/wake/duration.
+
+export const SLEEP_STAGE_CLUSTER_GAP_MS = 4 * 60 * 60 * 1000;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function sumAsleepSeconds(stages: any[]): number {
+  if (!Array.isArray(stages)) return 0;
+  return stages.reduce((sum, stage) => {
+    if (
+      stage.stage_type === 'deep' ||
+      stage.stage_type === 'light' ||
+      stage.stage_type === 'rem'
+    ) {
+      return sum + (Math.round(Number(stage.duration_in_seconds)) || 0);
+    }
+    return sum;
+  }, 0);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function clusterSleepStagesByGap(
+  stages: any[],
+  gapMs = SLEEP_STAGE_CLUSTER_GAP_MS
+) {
+  if (!Array.isArray(stages) || stages.length === 0) return [];
+  const sorted = [...stages].sort(
+    (a, b) =>
+      new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+  );
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const clusters: any[][] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let current: any[] = [sorted[0]];
+  let clusterEnd = new Date(sorted[0].end_time).getTime();
+  for (let i = 1; i < sorted.length; i++) {
+    const stage = sorted[i];
+    const startMs = new Date(stage.start_time).getTime();
+    const endMs = new Date(stage.end_time).getTime();
+    if (startMs - clusterEnd > gapMs) {
+      clusters.push(current);
+      current = [stage];
+      clusterEnd = endMs;
+    } else {
+      current.push(stage);
+      if (endMs > clusterEnd) clusterEnd = endMs;
+    }
+  }
+  clusters.push(current);
+  return clusters;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function sleepStageEnvelopeSeconds(stages: any[]) {
+  if (!stages || stages.length === 0) return 0;
+  let minStart = new Date(stages[0].start_time).getTime();
+  let maxEnd = new Date(stages[0].end_time).getTime();
+  for (const s of stages) {
+    const startMs = new Date(s.start_time).getTime();
+    const endMs = new Date(s.end_time).getTime();
+    if (startMs < minStart) minStart = startMs;
+    if (endMs > maxEnd) maxEnd = endMs;
+  }
+  return Math.max(0, Math.round((maxEnd - minStart) / 1000));
+}
+
+// Prefer the longest asleep block; tie-break on envelope duration.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getPrimarySleepStageCluster(stages: any[]) {
+  const clusters = clusterSleepStagesByGap(stages);
+  if (clusters.length === 0) return [];
+  if (clusters.length === 1) return clusters[0];
+  let best = clusters[0];
+  let bestAsleep = sumAsleepSeconds(best);
+  let bestEnvelope = sleepStageEnvelopeSeconds(best);
+  for (let i = 1; i < clusters.length; i++) {
+    const candidate = clusters[i];
+    const asleep = sumAsleepSeconds(candidate);
+    const envelope = sleepStageEnvelopeSeconds(candidate);
+    if (
+      asleep > bestAsleep ||
+      (asleep === bestAsleep && envelope > bestEnvelope)
+    ) {
+      best = candidate;
+      bestAsleep = asleep;
+      bestEnvelope = envelope;
+    }
+  }
+  return best;
+}
+
+// Aggregates from the primary cluster only. Within one night, partial re-sync
+// gaps stay under the 4h threshold so #1180 union behavior is preserved.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function recomputeSleepAggregatesFromStages(stages: any[]) {
+  const primary = getPrimarySleepStageCluster(stages);
+  if (!primary || primary.length === 0) {
+    return {
+      bedtime: null,
+      wake_time: null,
+      duration_in_seconds: 0,
+      time_asleep_in_seconds: 0,
+      deep_sleep_seconds: 0,
+      light_sleep_seconds: 0,
+      rem_sleep_seconds: 0,
+      awake_sleep_seconds: 0,
+    };
+  }
+  let minStart = new Date(primary[0].start_time).getTime();
+  let maxEnd = new Date(primary[0].end_time).getTime();
+  let deep = 0;
+  let light = 0;
+  let rem = 0;
+  let awake = 0;
+  for (const s of primary) {
+    const startMs = new Date(s.start_time).getTime();
+    const endMs = new Date(s.end_time).getTime();
+    if (startMs < minStart) minStart = startMs;
+    if (endMs > maxEnd) maxEnd = endMs;
+    const duration = Math.round(Number(s.duration_in_seconds)) || 0;
+    switch (s.stage_type) {
+      case 'deep':
+        deep += duration;
+        break;
+      case 'light':
+        light += duration;
+        break;
+      case 'rem':
+        rem += duration;
+        break;
+      case 'awake':
+        awake += duration;
+        break;
+      default:
+        break;
+    }
+  }
+  const durationInSeconds = Math.max(0, Math.round((maxEnd - minStart) / 1000));
+  const timeAsleep = sumAsleepSeconds(primary);
+  return {
+    bedtime: new Date(minStart),
+    wake_time: new Date(maxEnd),
+    duration_in_seconds: durationInSeconds,
+    time_asleep_in_seconds: timeAsleep,
+    deep_sleep_seconds: deep,
+    light_sleep_seconds: light,
+    rem_sleep_seconds: rem,
+    awake_sleep_seconds: awake,
+  };
+}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
When Health Connect (and similar) merges multiple disconnected sleep blocks onto one `entry_date`, History bedtime/wake/duration could stretch to ~24h because aggregates used `min(start)→max(end)` across all stages.

**How did you implement the solution?**
Cluster stages with a **4h gap** (same threshold as the HealthKit mobile session aggregator), pick the **primary** cluster (longest asleep time), and derive bedtime / wake / duration / stage buckets from that cluster only. Same-night partial re-sync gaps stay under 4h, so issue #1180 union behavior is preserved. Separating naps into distinct entries remains an enhancement tracked by #1954.

Linked Issue: #1954

## How to Test

1. Unit: `cd SparkyFitnessServer && pnpm test tests/measurementService.sleepPrimaryCluster.test.ts`
2. Manual: sync HC sleep that includes a main overnight session and a later evening fragment / nap on the same wake day; History duration should match the main night (~6–8h), not ~24h.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

N/A — backend-only change (no UI).

</details>

## Notes for Reviewers

No new tables/endpoints. RLS checkbox marked because no schema change was required. Unit coverage is in `tests/measurementService.sleepPrimaryCluster.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sleep metrics by focusing calculations on the primary sleep period.
  * Excluded disconnected sleep fragments from bedtime, wake time, duration, and sleep-stage totals.
  * Preserved contiguous overnight sleep periods when gaps are within the supported threshold.

* **Tests**
  * Added coverage for sleep-period clustering, primary-period selection, aggregate calculations, and empty or fragmented sleep data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->