### PR TITLE
fix(strava): replace synced details and clean historical duplicates

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -57,6 +57,7 @@ jobs:
               - 'SparkyFitnessServer/utils/applyRlsPolicies.ts'
               - 'SparkyFitnessServer/tests/migrate.script.ts'
               - 'SparkyFitnessServer/tests/rlsPermissionMatrix.integration.test.ts'
+              - 'SparkyFitnessServer/tests/stravaActivityDetailCleanup.integration.test.ts'
               - 'SparkyFitnessServer/package.json'
               - '.github/workflows/ci-tests.yml'
 
@@ -252,8 +253,8 @@ jobs:
       # The schema + RLS policies are now applied and the non-superuser app role
       # exists, so the permission matrix can verify every table's real RLS
       # behaviour as the app role (superuser DB user seeds, app role is enforced).
-      - name: Verify RLS permission matrix
-        run: pnpm exec vitest run tests/rlsPermissionMatrix.integration.test.ts
+      - name: Verify RLS permission matrix and Strava cleanup
+        run: pnpm exec vitest run tests/rlsPermissionMatrix.integration.test.ts tests/stravaActivityDetailCleanup.integration.test.ts
         env:
           # Default-on (SKIP_RLS_MATRIX unset) — runs against the Postgres this
           # job provisions, with policies already applied by the steps above.

--- a/SparkyFitnessServer/db/migrations/20260909203000_deduplicate_strava_activity_details.sql
+++ b/SparkyFitnessServer/db/migrations/20260909203000_deduplicate_strava_activity_details.sql
@@ -1,0 +1,38 @@
+-- Remove recognized duplicate Strava snapshots left by repeated imports.
+-- Keep complete detail ahead of summaries, then the latest acquired snapshot.
+-- Preserve creator boundaries and leave an entire group untouched if any
+-- snapshot has an unknown shape, activity identity, resource state or creator.
+BEGIN;
+
+-- Match the runtime writer's parent-before-detail lock order. Reads continue;
+-- parent updates and detail writes wait until survivor selection commits.
+LOCK TABLE public.exercise_entries IN SHARE MODE;
+LOCK TABLE public.exercise_entry_activity_details IN SHARE ROW EXCLUSIVE MODE;
+
+WITH ranked AS (
+  SELECT d.id,
+         BOOL_AND(COALESCE(
+           d.created_by_user_id IS NOT NULL
+           AND jsonb_typeof(d.detail_data) = 'object'
+           AND d.detail_data->>'id' ~ '^[1-9][0-9]*$'
+           AND d.detail_data->>'id' = e.source_id
+           AND d.detail_data->'resource_state' IN ('2'::jsonb, '3'::jsonb),
+           false
+         )) OVER source_group AS recognized_group,
+         ROW_NUMBER() OVER (
+           source_group ORDER BY (d.detail_data->'resource_state' = '3'::jsonb) DESC,
+                                 d.created_at DESC NULLS LAST, d.id DESC
+         ) AS position
+  FROM public.exercise_entry_activity_details d
+  JOIN public.exercise_entries e ON e.id = d.exercise_entry_id
+  WHERE d.provider_name = 'Strava'
+    AND d.detail_type = 'full_activity_data'
+    AND d.exercise_preset_entry_id IS NULL
+    AND e.source = 'Strava'
+  WINDOW source_group AS (PARTITION BY d.exercise_entry_id, d.created_by_user_id)
+)
+DELETE FROM public.exercise_entry_activity_details d
+USING ranked r
+WHERE d.id = r.id AND r.recognized_group AND r.position > 1;
+
+COMMIT;

--- a/SparkyFitnessServer/integrations/strava/stravaDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/strava/stravaDataProcessor.ts
@@ -1,7 +1,6 @@
 import { log } from '../../config/logging.js';
 import exerciseRepository from '../../models/exercise.js';
 import exerciseEntryRepository from '../../models/exerciseEntry.js';
-import activityDetailsRepository from '../../models/activityDetailsRepository.js';
 import measurementRepository from '../../models/measurementRepository.js';
 import * as workoutTelemetryRepo from '../../models/workoutTelemetryRepository.js';
 import { todayInZone, instantToDay } from '@workspace/shared';
@@ -181,21 +180,22 @@ async function processStravaActivities(
         userId,
         entryData,
         createdByUserId,
-        'Strava'
+        'Strava',
+        null,
+        {
+          // A failed detail fetch must not replace a previously complete dump.
+          activityDetail: detailedActivity
+            ? {
+                provider_name: 'Strava',
+                detail_type: 'full_activity_data',
+                detail_data: detailedActivity,
+                created_by_user_id: String(createdByUserId),
+                updated_by_user_id: String(createdByUserId),
+              }
+            : undefined,
+        }
       );
-      // Store detailed activity data (GPS, laps, splits, segments) if available
       if (newEntry && newEntry.id) {
-        const detailedActivity = detailedActivities[activity.id] as
-          StravaActivity | undefined;
-        const detailData = detailedActivity || activity;
-        await activityDetailsRepository.createActivityDetail(userId, {
-          exercise_entry_id: newEntry.id,
-          provider_name: 'Strava',
-          detail_type: 'full_activity_data',
-          detail_data: detailData,
-          created_by_user_id: createdByUserId,
-        });
-
         // Only the DetailedActivity response (fetched per-activity) carries laps and
         // the fuller telemetry summary; a bare SummaryActivity has neither.
         if (detailedActivity) {

--- a/SparkyFitnessServer/tests/stravaActivityDetailCleanup.integration.test.ts
+++ b/SparkyFitnessServer/tests/stravaActivityDetailCleanup.integration.test.ts
@@ -1,0 +1,421 @@
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  afterEach,
+  vi,
+} from 'vitest';
+import { getClient, getSystemClient, endPool } from '../db/poolManager.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const MIGRATION_SQL = readFileSync(
+  path.join(
+    here,
+    '../db/migrations/20260909203000_deduplicate_strava_activity_details.sql'
+  ),
+  'utf8'
+);
+
+async function dbReachable(): Promise<boolean> {
+  if (process.env.SKIP_RLS_MATRIX === '1') return false;
+  if (
+    !process.env.SPARKY_FITNESS_DB_HOST ||
+    !process.env.SPARKY_FITNESS_APP_DB_USER
+  )
+    return false;
+  // The migration is unscoped, so fixture IDs alone cannot protect a normal DB.
+  if (!/(^|[_-])test([_-]|$)/i.test(process.env.SPARKY_FITNESS_DB_NAME ?? ''))
+    return false;
+  const probe = new pg.Client({
+    host: process.env.SPARKY_FITNESS_DB_HOST,
+    port: Number(process.env.SPARKY_FITNESS_DB_PORT) || 5432,
+    database: process.env.SPARKY_FITNESS_DB_NAME,
+    user: process.env.SPARKY_FITNESS_APP_DB_USER,
+    password: process.env.SPARKY_FITNESS_APP_DB_PASSWORD,
+    connectionTimeoutMillis: 2000,
+  });
+  try {
+    await probe.connect();
+    await probe.query(
+      'SELECT id FROM public.exercise_entry_activity_details LIMIT 0'
+    );
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await probe.end().catch(() => {});
+  }
+}
+
+const RUN = await dbReachable();
+const OWNER = '00000000-0000-4000-b200-000000000001';
+const OTHER = '00000000-0000-4000-b200-000000000002';
+const EXERCISE = '00000000-0000-4000-b200-000000000003';
+const ENTRY = '00000000-0000-4000-b200-000000000004';
+const FOREIGN = '00000000-0000-4000-b200-000000000005';
+const MANUAL = '00000000-0000-4000-b200-000000000006';
+const PRESET = '00000000-0000-4000-b200-000000000007';
+const LOW = '00000000-0000-4000-b200-000000000011';
+const HIGH = '00000000-0000-4000-b200-000000000012';
+const ENTRY_IDS = [ENTRY, FOREIGN, MANUAL];
+const ACTIVITY = { id: 123456789, resource_state: 3, calories: 300 };
+
+type Detail = {
+  id: string;
+  exercise_entry_id: string | null;
+  exercise_preset_entry_id: string | null;
+  provider_name: string;
+  detail_type: string;
+  detail_data: unknown;
+  created_by_user_id: string | null;
+  created_at: string | null;
+  updated_at: string;
+};
+
+const SURVIVOR_CASES: [string, Partial<Detail>, Partial<Detail>, 0 | 1][] = [
+  [
+    'complete detail over a newer summary',
+    {},
+    { detail_data: { ...ACTIVITY, resource_state: 2 } },
+    0,
+  ],
+  [
+    'latest detail despite metadata edits',
+    { updated_at: '2026-09-09' },
+    { detail_data: { ...ACTIVITY, calories: 325 } },
+    1,
+  ],
+  [
+    'latest summary',
+    { detail_data: { ...ACTIVITY, resource_state: 2 } },
+    { detail_data: { ...ACTIVITY, resource_state: 2 } },
+    1,
+  ],
+  [
+    'UUID tie-break',
+    { created_at: '2026-09-02', updated_at: '2026-09-09' },
+    {},
+    1,
+  ],
+  ['dated detail over an undated snapshot', { created_at: null }, {}, 1],
+  [
+    'UUID tie-break with no timestamps',
+    { created_at: null },
+    { created_at: null, detail_data: { ...ACTIVITY, id: String(ACTIVITY.id) } },
+    1,
+  ],
+];
+
+describe.runIf(RUN)('Strava activity detail cleanup migration', () => {
+  let sys: pg.PoolClient;
+
+  async function clearFixtures() {
+    await sys.query(
+      'DELETE FROM public.exercise_entries WHERE id = ANY($1::uuid[])',
+      [ENTRY_IDS]
+    );
+    await sys.query(
+      'DELETE FROM public.exercise_preset_entries WHERE id = $1',
+      [PRESET]
+    );
+    await sys.query('DELETE FROM public.exercises WHERE id = $1', [EXERCISE]);
+    await sys.query('DELETE FROM public."user" WHERE id = ANY($1::uuid[])', [
+      [OWNER, OTHER],
+    ]);
+  }
+
+  beforeAll(async () => {
+    sys = await getSystemClient();
+    await clearFixtures();
+    for (const id of [OWNER, OTHER]) {
+      await sys.query(
+        'INSERT INTO public."user" (id, email, email_verified) VALUES ($1, $2, true)',
+        [id, `strava-cleanup-${id}@example.test`]
+      );
+    }
+    await sys.query(
+      "INSERT INTO public.exercises (id, name, source, user_id, is_custom) VALUES ($1, 'Cleanup fixture', 'test', $2, true)",
+      [EXERCISE, OWNER]
+    );
+    for (const [id, user, source] of [
+      [ENTRY, OWNER, 'Strava'],
+      [FOREIGN, OTHER, 'Strava'],
+      [MANUAL, OWNER, 'manual'],
+    ]) {
+      await sys.query(
+        `INSERT INTO public.exercise_entries
+        (id, user_id, exercise_id, duration_minutes, calories_burned, source, source_id, entry_date)
+        VALUES ($1, $2, $3, 30, 300, $4, '123456789', '2026-09-01')`,
+        [id, user, EXERCISE, source]
+      );
+    }
+    await sys.query(
+      "INSERT INTO public.exercise_preset_entries (id, user_id, name, entry_date) VALUES ($1, $2, 'Cleanup fixture', '2026-09-01')",
+      [PRESET, OWNER]
+    );
+    await sys.query(
+      'INSERT INTO public.exercise_entry_sets (exercise_entry_id, set_number, duration) VALUES ($1, 1, 1800)',
+      [ENTRY]
+    );
+    await sys.query(
+      `INSERT INTO public.exercise_entry_laps (user_id, exercise_entry_id, entry_date, lap_index, start_time, end_time, duration_seconds, calories)
+      VALUES ($1, $2, '2026-09-01', 1, '2026-09-01T01:00:00Z', '2026-09-01T01:30:00Z', 1800, 300)`,
+      [OWNER, ENTRY]
+    );
+    await sys.query(
+      `INSERT INTO public.exercise_entry_gps_points (user_id, exercise_entry_id, entry_date, points)
+      VALUES ($1, $2, '2026-09-01', '[{"lat":1,"lng":2}]')`,
+      [OWNER, ENTRY]
+    );
+  });
+
+  afterEach(async () => {
+    await sys.query('ROLLBACK');
+    await sys.query(
+      'DELETE FROM public.exercise_entry_activity_details WHERE exercise_entry_id = ANY($1::uuid[]) OR exercise_preset_entry_id = $2',
+      [ENTRY_IDS, PRESET]
+    );
+  });
+  afterAll(async () => {
+    try {
+      await clearFixtures();
+    } finally {
+      sys.release();
+      await endPool();
+    }
+  });
+
+  async function insertDetails(overrides: Partial<Detail>[], client = sys) {
+    const ids: string[] = [];
+    for (const override of overrides) {
+      const row: Detail = {
+        id: randomUUID(),
+        exercise_entry_id: ENTRY,
+        exercise_preset_entry_id: null,
+        provider_name: 'Strava',
+        detail_type: 'full_activity_data',
+        detail_data: ACTIVITY,
+        created_by_user_id: OWNER,
+        created_at: '2026-09-01',
+        updated_at: '2026-09-01',
+        ...override,
+      };
+      await client.query(
+        `INSERT INTO public.exercise_entry_activity_details
+        (id, exercise_entry_id, exercise_preset_entry_id, provider_name, detail_type, detail_data, created_by_user_id, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9)`,
+        [
+          row.id,
+          row.exercise_entry_id,
+          row.exercise_preset_entry_id,
+          row.provider_name,
+          row.detail_type,
+          JSON.stringify(row.detail_data),
+          row.created_by_user_id,
+          row.created_at,
+          row.updated_at,
+        ]
+      );
+      ids.push(row.id);
+    }
+    return ids;
+  }
+
+  async function readRows(client = sys) {
+    return (
+      await client.query<{ id: string; row: Record<string, unknown> }>(
+        'SELECT id, to_jsonb(d) AS row FROM public.exercise_entry_activity_details d WHERE exercise_entry_id = ANY($1::uuid[]) OR exercise_preset_entry_id = $2 ORDER BY id',
+        [ENTRY_IDS, PRESET]
+      )
+    ).rows;
+  }
+
+  it.each(SURVIVOR_CASES)(
+    'keeps %s and is idempotent',
+    async (_name, first, second, keep) => {
+      const ids = await insertDetails([
+        { id: LOW, ...first },
+        { id: HIGH, created_at: '2026-09-02', ...second },
+      ]);
+      const expected = (await readRows()).filter((row) => row.id === ids[keep]);
+      await sys.query(MIGRATION_SQL);
+      expect(await readRows()).toEqual(expected);
+      await sys.query(MIGRATION_SQL);
+      expect(await readRows()).toEqual(expected);
+    }
+  );
+
+  it.each([
+    ['wrapped JSON', JSON.stringify(ACTIVITY)],
+    ['null', null],
+    ['array', []],
+    ['scalar', 42],
+    ['missing ID', { resource_state: 3 }],
+    ['zero ID', { ...ACTIVITY, id: 0 }],
+    ['unknown ID', { ...ACTIVITY, id: 'unknown' }],
+    ['mismatched ID', { ...ACTIVITY, id: 987654321 }],
+    ['missing state', { id: ACTIVITY.id }],
+    ['null state', { ...ACTIVITY, resource_state: null }],
+    ['unknown state', { ...ACTIVITY, resource_state: 1 }],
+    ['string state', { ...ACTIVITY, resource_state: '3' }],
+  ])('preserves the whole group for %s', async (_name, detail_data) => {
+    await insertDetails([{}, {}, { detail_data }]);
+    const before = await readRows();
+    await sys.query(MIGRATION_SQL);
+    expect(await readRows()).toEqual(before);
+  });
+
+  it('preserves creator boundaries, other attachments, workout data and account visibility', async () => {
+    const survivors: string[] = [];
+    for (const [row, keep] of [
+      [{}, 1],
+      [{ created_by_user_id: OTHER }, 1],
+      [{ exercise_entry_id: FOREIGN, created_by_user_id: OTHER }, 1],
+      [{ created_by_user_id: null }, 2],
+      [{ provider_name: 'Other' }, 2],
+      [{ detail_type: 'other_detail' }, 2],
+      [{ exercise_entry_id: MANUAL }, 2],
+      [{ exercise_entry_id: null, exercise_preset_entry_id: PRESET }, 2],
+    ] as const) {
+      const ids = await insertDetails([
+        row,
+        { ...row, created_at: '2026-09-02' },
+      ]);
+      survivors.push(...ids.slice(-keep));
+    }
+    const before = await readRows();
+    async function readWorkouts() {
+      const result = [];
+      for (const table of [
+        'exercise_entries',
+        'exercise_entry_sets',
+        'exercise_entry_laps',
+        'exercise_entry_gps_points',
+      ] as const) {
+        const key = table === 'exercise_entries' ? 'id' : 'exercise_entry_id';
+        result.push(
+          (
+            await sys.query(
+              `SELECT to_jsonb(r) FROM public.${table} r WHERE ${key} = ANY($1::uuid[]) ORDER BY id`,
+              [ENTRY_IDS]
+            )
+          ).rows
+        );
+      }
+      return result;
+    }
+    const workouts = await readWorkouts();
+    const clients: pg.PoolClient[] = await Promise.all([
+      getClient(OWNER),
+      getClient(OTHER),
+    ]);
+    try {
+      const visible = await Promise.all(
+        clients.map((client) => readRows(client))
+      );
+      expect(
+        visible[0].some((row) => row.row.exercise_entry_id === FOREIGN)
+      ).toBe(false);
+      await sys.query(MIGRATION_SQL);
+      expect(await readRows()).toEqual(
+        before.filter((row) => survivors.includes(row.id))
+      );
+      expect(await readWorkouts()).toEqual(workouts);
+      for (const [index, client] of clients.entries()) {
+        expect(await readRows(client)).toEqual(
+          visible[index].filter((row) => survivors.includes(row.id))
+        );
+      }
+    } finally {
+      clients.forEach((client) => client.release());
+    }
+  });
+
+  it('rolls back all deletions if the migration fails', async () => {
+    await insertDetails([{}, {}]);
+    const before = await readRows();
+    const name = `strava_cleanup_${randomUUID().replaceAll('-', '')}`;
+    await sys.query(
+      `CREATE FUNCTION public.${name}() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'synthetic cleanup rejection'; END $$`
+    );
+    try {
+      await sys.query(
+        `CREATE TRIGGER ${name} AFTER DELETE ON public.exercise_entry_activity_details FOR EACH ROW WHEN (OLD.exercise_entry_id = '${ENTRY}'::uuid) EXECUTE FUNCTION public.${name}()`
+      );
+      await expect(sys.query(MIGRATION_SQL)).rejects.toThrow(
+        'synthetic cleanup rejection'
+      );
+      await sys.query('ROLLBACK');
+      expect(await readRows()).toEqual(before);
+    } finally {
+      await sys.query('ROLLBACK');
+      await sys.query(
+        `DROP TRIGGER IF EXISTS ${name} ON public.exercise_entry_activity_details`
+      );
+      await sys.query(`DROP FUNCTION public.${name}()`);
+    }
+  });
+
+  it('waits for an in-flight import and serializes cleanup without blocking readers', async () => {
+    await insertDetails([{}, {}]);
+    const writer: pg.PoolClient = await getSystemClient();
+    const cleaners: pg.PoolClient[] = await Promise.all([
+      getSystemClient(),
+      getSystemClient(),
+    ]);
+    const pending: Promise<pg.QueryResult>[] = [];
+    try {
+      for (const client of [writer, ...cleaners])
+        await client.query("SET statement_timeout = '10s'");
+      const backends = await Promise.all(
+        cleaners.map((client) =>
+          client.query<{ pid: number }>('SELECT pg_backend_pid() AS pid')
+        )
+      );
+      const pids = backends.map((result) => result.rows[0].pid);
+      await writer.query('BEGIN');
+      await writer.query(
+        'UPDATE public.exercise_entries SET notes = $1 WHERE id = $2',
+        ['Concurrent import', ENTRY]
+      );
+      const newest = await insertDetails(
+        [{ created_at: '2026-09-03' }],
+        writer
+      );
+      pending.push(...cleaners.map((client) => client.query(MIGRATION_SQL)));
+      // Handle query rejections even if the lock assertion fails first.
+      const finished = Promise.allSettled(pending);
+      await vi.waitFor(
+        async () => {
+          const result = await sys.query(
+            'SELECT pid FROM pg_stat_activity WHERE pid = ANY($1::int[]) AND wait_event_type = $2',
+            [pids, 'Lock']
+          );
+          expect(result.rowCount).toBe(2);
+        },
+        { timeout: 3000, interval: 20 }
+      );
+      expect(await readRows()).toHaveLength(2);
+      await writer.query('COMMIT');
+      expect(
+        (await finished).every((result) => result.status === 'fulfilled')
+      ).toBe(true);
+      expect((await readRows()).map((row) => row.id)).toEqual(newest);
+    } finally {
+      await writer.query('ROLLBACK');
+      await Promise.allSettled(pending);
+      for (const client of [writer, ...cleaners]) {
+        await client.query('ROLLBACK');
+        await client.query('RESET statement_timeout');
+        client.release();
+      }
+    }
+  });
+});

--- a/SparkyFitnessServer/tests/stravaDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/stravaDataProcessor.test.ts
@@ -1,6 +1,7 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
 import exerciseRepository from '../models/exercise.js';
 import exerciseEntryRepository from '../models/exerciseEntry.js';
+import activityDetailsRepository from '../models/activityDetailsRepository.js';
 import { processStravaActivities } from '../integrations/strava/stravaDataProcessor.js';
 
 type StravaActivity = NonNullable<
@@ -18,6 +19,7 @@ vi.mock('../models/exercise.js', () => ({
 vi.mock('../models/exerciseEntry.js', () => ({
   default: {
     createExerciseEntry: vi.fn(),
+    updateExerciseEntryTelemetryOnly: vi.fn(),
   },
 }));
 vi.mock('../models/activityDetailsRepository.js', () => ({
@@ -27,7 +29,7 @@ vi.mock('../models/activityDetailsRepository.js', () => ({
 const UID = 1;
 const CID = 1;
 
-describe('processStravaActivities duration units', () => {
+describe('processStravaActivities', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(exerciseRepository.findExerciseByNameAndUserId).mockResolvedValue(
@@ -59,7 +61,63 @@ describe('processStravaActivities duration units', () => {
         sets: [expect.objectContaining({ duration: 1800 })],
       }),
       CID,
-      'Strava'
+      'Strava',
+      null,
+      { activityDetail: undefined }
     );
+  });
+
+  it('passes repeated complete snapshots through the entry transaction', async () => {
+    const activity = { id: 987, name: 'Morning Run' };
+    const detail = { ...activity, resource_state: 3, calories: 300 };
+
+    for (let i = 0; i < 2; i++) {
+      await processStravaActivities(UID, CID, [activity], { 987: detail });
+    }
+
+    expect(exerciseEntryRepository.createExerciseEntry).toHaveBeenCalledTimes(
+      2
+    );
+    expect(exerciseEntryRepository.createExerciseEntry).toHaveBeenCalledWith(
+      UID,
+      expect.objectContaining({ source_id: '987', calories_burned: 300 }),
+      CID,
+      'Strava',
+      null,
+      {
+        activityDetail: {
+          provider_name: 'Strava',
+          detail_type: 'full_activity_data',
+          detail_data: detail,
+          created_by_user_id: String(CID),
+          updated_by_user_id: String(CID),
+        },
+      }
+    );
+    expect(
+      activityDetailsRepository.createActivityDetail
+    ).not.toHaveBeenCalled();
+  });
+
+  it('does not replace a complete snapshot when the next detail fetch is missing', async () => {
+    const activity = { id: 987, name: 'Morning Run' };
+    await processStravaActivities(UID, CID, [activity], {
+      987: { ...activity, resource_state: 3, calories: 300 },
+    });
+    await processStravaActivities(UID, CID, [activity]);
+
+    expect(
+      exerciseEntryRepository.createExerciseEntry
+    ).toHaveBeenLastCalledWith(
+      UID,
+      expect.objectContaining({ source_id: '987' }),
+      CID,
+      'Strava',
+      null,
+      { activityDetail: undefined }
+    );
+    expect(
+      activityDetailsRepository.createActivityDetail
+    ).not.toHaveBeenCalled();
   });
 });

--- a/SparkyFitnessServer/tests/stravaDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/stravaDataProcessor.test.ts
@@ -78,22 +78,27 @@ describe('processStravaActivities', () => {
     expect(exerciseEntryRepository.createExerciseEntry).toHaveBeenCalledTimes(
       2
     );
-    expect(exerciseEntryRepository.createExerciseEntry).toHaveBeenCalledWith(
-      UID,
-      expect.objectContaining({ source_id: '987', calories_burned: 300 }),
-      CID,
-      'Strava',
-      null,
-      {
-        activityDetail: {
-          provider_name: 'Strava',
-          detail_type: 'full_activity_data',
-          detail_data: detail,
-          created_by_user_id: String(CID),
-          updated_by_user_id: String(CID),
-        },
-      }
-    );
+    for (const call of [1, 2]) {
+      expect(
+        exerciseEntryRepository.createExerciseEntry
+      ).toHaveBeenNthCalledWith(
+        call,
+        UID,
+        expect.objectContaining({ source_id: '987', calories_burned: 300 }),
+        CID,
+        'Strava',
+        null,
+        {
+          activityDetail: {
+            provider_name: 'Strava',
+            detail_type: 'full_activity_data',
+            detail_data: detail,
+            created_by_user_id: String(CID),
+            updated_by_user_id: String(CID),
+          },
+        }
+      );
+    }
     expect(
       activityDetailsRepository.createActivityDetail
     ).not.toHaveBeenCalled();
@@ -101,14 +106,24 @@ describe('processStravaActivities', () => {
 
   it('does not replace a complete snapshot when the next detail fetch is missing', async () => {
     const activity = { id: 987, name: 'Morning Run' };
-    await processStravaActivities(UID, CID, [activity], {
-      987: { ...activity, resource_state: 3, calories: 300 },
-    });
+    const detail = { ...activity, resource_state: 3, calories: 300 };
+    await processStravaActivities(UID, CID, [activity], { 987: detail });
     await processStravaActivities(UID, CID, [activity]);
 
-    expect(
-      exerciseEntryRepository.createExerciseEntry
-    ).toHaveBeenLastCalledWith(
+    expect(exerciseEntryRepository.createExerciseEntry).toHaveBeenCalledTimes(
+      2
+    );
+    expect(exerciseEntryRepository.createExerciseEntry).toHaveBeenNthCalledWith(
+      1,
+      UID,
+      expect.objectContaining({ source_id: '987', calories_burned: 300 }),
+      CID,
+      'Strava',
+      null,
+      { activityDetail: expect.objectContaining({ detail_data: detail }) }
+    );
+    expect(exerciseEntryRepository.createExerciseEntry).toHaveBeenNthCalledWith(
+      2,
       UID,
       expect.objectContaining({ source_id: '987' }),
       CID,


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Repeated Strava imports append raw activity snapshots to an existing workout. Historical duplicates remain after the hourly sync moves on to the next day.

**How did you implement the solution?**
Pass complete snapshots through the existing workout transaction so repeat imports replace their matching detail record. Add a startup migration that consolidates recognized historical snapshots per workout and creator, preferring complete detail over summaries, then acquisition time. Leave the whole creator group untouched when any snapshot has an uncertain shape, identity, or resource state.

Linked Issue: None.

## How to Test

1. In `SparkyFitnessServer`, run `pnpm run test:ci && pnpm validate`.
2. Against a disposable PostgreSQL database named `sparky_test` with the documented database variables set, run `pnpm run test:migrations`, then `pnpm exec vitest run tests/stravaActivityDetailCleanup.integration.test.ts tests/rlsPermissionMatrix.integration.test.ts`.
3. Import the same Strava activity repeatedly and concurrently. Confirm one workout and one Strava `full_activity_data` record. Repeat with a missing detail response and confirm the saved complete snapshot remains.

Validation: `test:ci` passed with coverage (4,149 passed, 270 database-dependent tests skipped in that job). Typecheck, lint, and formatting passed. The native cleanup, RLS matrix, processor, and transaction suites passed all 234 tests on PostgreSQL 18.6. Fresh-install migrations and restart simulation passed.

Normal `pnpm start` upgraded the stock schema with 50,000 synthetic snapshots: 1,000 remained, preserving all 1,000 workouts and their calorie values. Account visibility stayed intact. Readers continued during cleanup, a waiting writer resumed afterward, and rerunning the migration changed nothing. The unblocked 50,000-row cleanup took 734 ms in this fixture; production timing depends on data and active transactions.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. No new tables or policy changes.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS and Android.

## Screenshots

Not applicable: backend persistence only.

## Notes for Reviewers

The migration deletes superseded recognized snapshots. It preserves null-creator groups, uncertain payload groups, presets, other providers/types, and non-Strava workouts. It locks parent and detail writes until cleanup commits; ordinary reads continue. Old-version importers can append records after that lock releases, so the rollout must retire them.

A summary-only first import still creates the workout, with the raw attachment added when complete detail becomes available. The existing calorie reset after a failed detail fetch remains a separate defect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strava activity imports now preserve complete activity details when available.
  - Duplicate Strava activity-detail records are cleaned up while retaining the most complete and recent data.
  - Separate activity details remain preserved across users and unrelated attachments.
  - Ambiguous or malformed records are left unchanged.
  - Cleanup operations now protect against partial changes if an error occurs and coordinate safely with in-progress imports.

- **Tests**
  - Expanded automated coverage for Strava imports, duplicate cleanup, rollback behavior, and concurrent activity processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->