### PR TITLE
fix(docker): build the frontend bundle natively instead of under QEMU

### DIFF
--- a/docker/Dockerfile.frontend
+++ b/docker/Dockerfile.frontend
@@ -1,5 +1,7 @@
+# syntax=docker/dockerfile:1.4
+
 # Stage 1: Build the React application
-FROM node:24-alpine AS builder
+FROM --platform=$BUILDPLATFORM node:24-alpine AS builder
 WORKDIR /app
 
 # Install pnpm


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
The Docker publish workflow takes 50+ minutes, almost entirely spent building the frontend bundle for `linux/arm64` under QEMU emulation. This makes every release and every `dev` tag push painfully slow.

**How did you implement the solution?**
- `docker/Dockerfile.frontend` stage 1 was a bare `FROM node:24-alpine`, so Buildx emulated it for each non-native target platform. pnpm install, Vite, Rollup and tsc all ran through `qemu-aarch64`, which is where the ~40 minutes goes.
- Pinned the builder stage to the native build host with `FROM --platform=$BUILDPLATFORM node:24-alpine AS builder` — the same pattern `backend_builder` already uses in `docker/Dockerfile.backend`, which is why the server image builds in a few minutes.
- Added the `# syntax=docker/dockerfile:1.4` directive so both Dockerfiles match.

Why this is safe for ARM users:
- The runtime stage (`FROM nginx:alpine3.22`) is deliberately left alone, so it still resolves to `$TARGETPLATFORM`. ARM64 pulls still get native ARM64 nginx; amd64 still gets amd64. The published manifest list is unchanged: `linux/amd64, linux/arm64`.
- The builder stage's only output is `SparkyFitnessFrontend/dist` — static HTML/CSS/JS/images executed by the browser, byte-identical regardless of which CPU bundled them.
- Neither workspace pulls in arch-specific native modules (the only crypto dep is `bcryptjs`, pure JS), so no host-architecture binary can leak across the `COPY --from=builder` boundary.

As a bonus, the builder stage is now identical for both targets, so Buildx builds it once and shares the result instead of running the whole install-and-bundle twice.

Linked Issue: Closes # <!-- N/A - no tracking issue -->

## How to Test

1. Check out this branch and trigger **Manually Publish Docker Images** against it (`service: frontend`, `tag: dev`).
2. Watch the `Build and push frontend` step. The `pnpm --filter sparkyfitnessfrontend run build` layer should complete in about a minute instead of ~38, and the log should no longer show a separate bundle build per architecture.
   - Note: the first run is a cold cache — `--platform=$BUILDPLATFORM` changes the stage hash, so the existing `type=gha` entries will not be reused. Expect one slower run before the fast steady state.
3. Confirm the manifest still advertises both architectures:
   ```bash
   docker buildx imagetools inspect codewithcj/sparkyfitness:dev
   ```
   Both `linux/amd64` and `linux/arm64` must be listed.
4. Pull and run the image on an ARM64 host (Raspberry Pi 5, Apple Silicon, or ARM VPS) and load the app to verify nginx starts and serves the bundle:
   ```bash
   docker run --rm -p 8080:80 codewithcj/sparkyfitness:dev
   ```
5. Repeat step 4 on an x86_64 host to confirm no regression there.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. <!-- N/A - not a new feature -->

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes. <!-- N/A - no files under SparkyFitnessFrontend/ are touched; this is a build-infra change only -->
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. <!-- N/A - no translation files touched -->

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests. <!-- N/A - no server code touched -->
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. <!-- N/A - no schema change -->

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. <!-- N/A - no UI change; output bundle is unchanged -->

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. <!-- N/A - mobile app untouched -->

## Screenshots

<details>
<summary>Click to expand</summary>

N/A — build-infrastructure change only. The emitted `dist` bundle is byte-identical, so there is no visual change to capture.

</details>

## Notes for Reviewers

- **The single line that matters** is the `--platform=$BUILDPLATFORM` on the builder stage. Please confirm the runtime stage was *not* given the same flag — that would be the one way to actually break ARM support, by shipping amd64 nginx to ARM devices.
- **Not verified with a local build.** No Docker daemon was available on the machine this was prepared on, so the change has not been build-tested locally; it is a two-line change mirroring the working `Dockerfile.backend` pattern, but the real verification is the CI run in "How to Test" above.
- The `# syntax=docker/dockerfile:1.4` directive is not strictly required — `--platform=$BUILDPLATFORM` works on any modern BuildKit. It is included only to match `Dockerfile.backend`. Happy to drop it if you'd rather keep the diff to one line.
- `docker/Dockerfile.backend` and the Garmin image are unchanged; only the frontend build path is affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend build configuration to improve cross-platform container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->