### PR TITLE
fix(strava): preserve calories when activity details are missing

### DIFF
--- a/SparkyFitnessServer/integrations/strava/stravaDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/strava/stravaDataProcessor.ts
@@ -143,13 +143,11 @@ async function processStravaActivities(
           : 0;
       const durationMinutes = Math.round(durationSeconds / 60);
       // Strava SummaryActivity often lacks calories, but DetailedActivity (if available) has it.
-      // Default to 0 to satisfy the NOT NULL constraint in the database.
+      // Missing calories preserve existing values; new entries default to 0.
       const detailedActivity = detailedActivities[activity.id] as
         StravaActivity | undefined;
       const caloriesAuto =
-        (detailedActivity && detailedActivity.calories) ||
-        activity.calories ||
-        0;
+        detailedActivity?.calories ?? activity.calories ?? undefined;
       const entryData = {
         exercise_id: exercise.id,
         entry_date: entryDate,

--- a/SparkyFitnessServer/tests/stravaDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/stravaDataProcessor.test.ts
@@ -1,4 +1,5 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
+import { log } from '../config/logging.js';
 import exerciseRepository from '../models/exercise.js';
 import exerciseEntryRepository from '../models/exerciseEntry.js';
 import activityDetailsRepository from '../models/activityDetailsRepository.js';
@@ -135,4 +136,54 @@ describe('processStravaActivities', () => {
       activityDetailsRepository.createActivityDetail
     ).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ['missing detail', undefined, undefined, undefined],
+    ['detail without calories', {}, undefined, undefined],
+    ['null detail calories', { calories: null }, undefined, undefined],
+    ['summary calories', undefined, 300, 300],
+    ['zero summary calories', undefined, 0, 0],
+    ['detail calories', { calories: 325 }, 300, 325],
+    ['zero detail calories', { calories: 0 }, 300, 0],
+    ['summary fallback', { calories: null }, 300, 300],
+  ] as const)(
+    'passes %s to the entry transaction',
+    async (_case, detail, summaryCalories, expected) => {
+      const activity = {
+        id: 987,
+        name: 'Morning Run',
+        calories: summaryCalories,
+      };
+      await processStravaActivities(UID, CID, [activity], {
+        987: { ...activity, calories: 325 },
+      });
+      await processStravaActivities(
+        UID,
+        CID,
+        [activity],
+        detail ? { 987: detail } : {}
+      );
+
+      for (const [index, calories] of [325, expected].entries()) {
+        expect(
+          exerciseEntryRepository.createExerciseEntry
+        ).toHaveBeenNthCalledWith(
+          index + 1,
+          UID,
+          expect.objectContaining({
+            source_id: '987',
+            calories_burned: calories,
+          }),
+          CID,
+          'Strava',
+          null,
+          expect.any(Object)
+        );
+      }
+      expect(exerciseEntryRepository.createExerciseEntry).toHaveBeenCalledTimes(
+        2
+      );
+      expect(log).not.toHaveBeenCalledWith('error', expect.any(String));
+    }
+  );
 });


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
After a Strava detail fetch fails, importing the activity again resets the existing workout's calories to zero. An explicit zero in the detail response can also be ignored in favor of summary calories.

**How did you implement the solution?**
Keep missing calories undefined so the existing entry transaction preserves stored values on updates and defaults new entries to zero. Use nullish fallback so an explicit zero remains a supplied value.

Linked Issue: None.

## How to Test

1. In `SparkyFitnessServer`, run `pnpm exec vitest run tests/stravaDataProcessor.test.ts`, `pnpm run test:ci`, and `pnpm run validate`.
2. Import an activity with 325 calories, then import its summary without a detail response or calories. Confirm the workout retains 325 calories. Repeat with a detail response containing zero and confirm it updates to zero.
3. Import a new summary without calories. Confirm it starts at zero and accepts calories from a later complete response.

Validation: all 4,176 server tests passed, with 270 database-dependent tests skipped in the CI test command. Typecheck, lint, and formatting passed. Four of the eleven focused tests fail against current main and all eleven pass with this change.

A separate PostgreSQL 18.6 fixture at `845834ef`, before the merge of #2407, used the stock migrations and application role and reproduced the 325-to-zero reset before the fix. Afterward, all ten scenarios passed across stored workouts, diary totals, reports, tool totals, and daily calorie splits, including concurrent complete and missing imports. Workout identity and account visibility were preserved.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. No new tables or policy changes.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

Not applicable: backend import behavior only.

## Notes for Reviewers

This change preserves calories during future imports. It does not restore values already overwritten or change activity-detail cleanup in #2407.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected calorie handling for Strava activities.
  * Explicit calorie values of zero are now preserved.
  * Missing calorie values no longer overwrite previously stored values and use the database default for new entries.

* **Tests**
  * Added coverage for calorie selection across missing, null, zero, summary, and detail values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->