### PR TITLE
fix(db): keep the server running after idle connection errors

### DIFF
--- a/SparkyFitnessServer/db/poolManager.ts
+++ b/SparkyFitnessServer/db/poolManager.ts
@@ -32,7 +32,6 @@ function createOwnerPoolInstance() {
   });
   newPool.on('error', (err) => {
     log('error', 'Unexpected error on idle owner client', err);
-    process.exit(-1);
   });
   return newPool;
 }
@@ -50,7 +49,6 @@ function createAppPoolInstance() {
   });
   newPool.on('error', (err) => {
     log('error', 'Unexpected error on idle app client', err);
-    process.exit(-1);
   });
   return newPool;
 }

--- a/SparkyFitnessServer/tests/poolIdleErrors.test.ts
+++ b/SparkyFitnessServer/tests/poolIdleErrors.test.ts
@@ -1,0 +1,43 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resetPool } from '../db/poolManager.js';
+import { log } from '../config/logging.js';
+
+vi.mock('pg', async (importOriginal) => {
+  const original = await importOriginal<typeof import('pg')>();
+  return {
+    default: {
+      ...original.default,
+      Pool: class extends EventEmitter {
+        end = vi.fn();
+      },
+    },
+  };
+});
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('idle database errors', () => {
+  it.each(['owner', 'app'] as const)(
+    'logs an idle %s error without exiting the process',
+    async (role) => {
+      const pools = await resetPool();
+      const pool = pools[`${role}PoolInstance`];
+      const error = new Error('Connection terminated unexpectedly');
+      const exit = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('Process exited');
+      });
+
+      expect(() => pool.emit('error', error)).not.toThrow();
+      expect(log).toHaveBeenCalledWith(
+        'error',
+        `Unexpected error on idle ${role} client`,
+        error
+      );
+      expect(exit).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/SparkyFitnessServer/tests/rlsPermissionMatrix.integration.test.ts
+++ b/SparkyFitnessServer/tests/rlsPermissionMatrix.integration.test.ts
@@ -36,9 +36,8 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { getClient, getSystemClient, endPool } from '../db/poolManager.js';
 
 // Probe the app role RLS actually needs, with a short timeout, using a
-// standalone client (NOT the shared pools, whose error handler calls
-// process.exit). Returns false on any failure so the suite skips rather than
-// erroring when no DB is reachable.
+// standalone client. Returns false on any failure so the suite skips rather
+// than erroring when no DB is reachable.
 async function rlsTestDbReachable(): Promise<boolean> {
   if (process.env.SKIP_RLS_MATRIX === '1') return false;
   if (


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
An error on an idle PostgreSQL connection exits the server, even though the pool has already removed that connection.

**How did you implement the solution?**
Keep logging idle errors in both pools and let the driver replace failed connections as needed.

Linked Issue: None.

## How to Test

1. In `SparkyFitnessServer`, run `pnpm exec vitest run tests/poolIdleErrors.test.ts`.
2. Run `pnpm run validate` and `TZ=UTC NODE_ENV=test SKIP_RLS_MATRIX=1 pnpm run test:ci`.

Both regression cases fail on unchanged main and pass with the patch. Typecheck, lint and formatting pass; the full UTC coverage run passes 4,347 tests with 270 database-dependent tests skipped.

In a disposable PostgreSQL 18.3 fixture, both migration passes and all 226 RLS/Strava integration cases pass. Terminating an idle backend in each pool leaves the process running, and the next checkout completes a query on a new connection. The app connection has the requested user and actor context.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. <!-- N/A: bug fix -->

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes. <!-- N/A: server only -->
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. <!-- N/A -->

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. <!-- N/A: no new tables -->

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. <!-- N/A: no UI changes -->

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. <!-- N/A -->

## Screenshots

N/A: server connection handling only.

## Notes for Reviewers

In-flight queries are not replayed.

On unchanged main and this patch, the hydration range Date-object test fails in `America/Los_Angeles`; the UTC run above passes. The first local patch run also hit the authentication suite's 10-second setup timeout, which did not recur in the complete passing UTC run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Database connection pool errors are now logged without terminating the server process.
  - The application can continue running and recover from unexpected idle-client database errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->