### PR TITLE
fix(workouts): resolve missing userId in workout plan template retrieval

### DIFF
--- a/SparkyFitnessServer/services/workoutPlanTemplateService.ts
+++ b/SparkyFitnessServer/services/workoutPlanTemplateService.ts
@@ -87,6 +87,9 @@ async function getWorkoutPlanTemplatesByUserId(userId: any) {
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getWorkoutPlanTemplateById(userId: any, templateId: any) {
+  // RLS already gates read access (owner or family-shared via
+  // can_view_exercise_library). If the row comes back, the caller is allowed to
+  // see it; an extra owner check here would wrongly 403 shared templates.
   const template =
     await workoutPlanTemplateRepository.getWorkoutPlanTemplateById(
       templateId,
@@ -94,16 +97,6 @@ async function getWorkoutPlanTemplateById(userId: any, templateId: any) {
     );
   if (!template) {
     throw new Error('Workout plan template not found.');
-  }
-  const ownerId =
-    // @ts-expect-error TS(2554): Expected 2 arguments, but got 1.
-    await workoutPlanTemplateRepository.getWorkoutPlanTemplateOwnerId(
-      templateId
-    );
-  if (ownerId !== userId) {
-    throw new Error(
-      'Forbidden: You do not have access to this workout plan template.'
-    );
   }
   return template;
 }

--- a/SparkyFitnessServer/services/workoutPlanTemplateService.ts
+++ b/SparkyFitnessServer/services/workoutPlanTemplateService.ts
@@ -3,8 +3,51 @@ import workoutPresetRepository from '../models/workoutPresetRepository.js';
 import exerciseRepository from '../models/exerciseRepository.js';
 import { log } from '../config/logging.js';
 import { resolveTemplateStartDay } from '../utils/timezoneLoader.js';
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function createWorkoutPlanTemplate(userId: any, planData: any) {
+
+export interface WorkoutPlanAssignmentSetInput {
+  id?: number | string | null;
+  set_number: number;
+  set_type?: string | null;
+  reps?: number | null;
+  weight?: number | null;
+  duration?: number | null;
+  rest_time?: number | null;
+  notes?: string | null;
+}
+
+export interface WorkoutPlanAssignmentInput {
+  id?: number | string | null;
+  day_of_week: number;
+  workout_preset_id?: number | string | null;
+  exercise_id?: string | null;
+  sort_order?: number | null;
+  sets?: WorkoutPlanAssignmentSetInput[] | null;
+}
+
+export interface CreateWorkoutPlanTemplateInput {
+  plan_name: string;
+  description?: string | null;
+  start_date?: string | Date | null;
+  end_date?: string | Date | null;
+  is_active?: boolean | null;
+  assignments?: WorkoutPlanAssignmentInput[] | null;
+  currentClientDate?: string | null;
+}
+
+export interface UpdateWorkoutPlanTemplateInput {
+  plan_name?: string;
+  description?: string | null;
+  start_date?: string | Date | null;
+  end_date?: string | Date | null;
+  is_active?: boolean | null;
+  assignments?: WorkoutPlanAssignmentInput[] | null;
+  currentClientDate?: string | null;
+}
+
+async function createWorkoutPlanTemplate(
+  userId: string,
+  planData: CreateWorkoutPlanTemplateInput
+) {
   log(
     'info',
     'createWorkoutPlanTemplate service - received planData:',
@@ -70,10 +113,10 @@ async function createWorkoutPlanTemplate(userId: any, planData: any) {
     }
     return newPlan;
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     log(
       'error',
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      `Error creating workout plan template for user ${userId}: ${error.message}`,
+      `Error creating workout plan template for user ${userId}: ${message}`,
       error
     );
     throw new Error('Failed to create workout plan template.', {
@@ -81,12 +124,15 @@ async function createWorkoutPlanTemplate(userId: any, planData: any) {
     });
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getWorkoutPlanTemplatesByUserId(userId: any) {
+
+async function getWorkoutPlanTemplatesByUserId(userId: string) {
   return workoutPlanTemplateRepository.getWorkoutPlanTemplatesByUserId(userId);
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getWorkoutPlanTemplateById(userId: any, templateId: any) {
+
+async function getWorkoutPlanTemplateById(
+  userId: string,
+  templateId: string | number
+) {
   // RLS already gates read access (owner or family-shared via
   // can_view_exercise_library). If the row comes back, the caller is allowed to
   // see it; an extra owner check here would wrongly 403 shared templates.
@@ -102,12 +148,9 @@ async function getWorkoutPlanTemplateById(userId: any, templateId: any) {
 }
 
 async function updateWorkoutPlanTemplate(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  templateId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  updateData: any
+  userId: string,
+  templateId: string | number,
+  updateData: UpdateWorkoutPlanTemplateInput
 ) {
   log(
     'info',
@@ -195,10 +238,10 @@ async function updateWorkoutPlanTemplate(
     }
     return updatedPlan;
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     log(
       'error',
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      `Error updating workout plan template ${templateId} for user ${userId}: ${error.message}`,
+      `Error updating workout plan template ${templateId} for user ${userId}: ${message}`,
       error
     );
     throw new Error('Failed to update workout plan template.', {
@@ -206,8 +249,11 @@ async function updateWorkoutPlanTemplate(
     });
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function deleteWorkoutPlanTemplate(userId: any, templateId: any) {
+
+async function deleteWorkoutPlanTemplate(
+  userId: string,
+  templateId: string | number
+) {
   log(
     'info',
     `deleteWorkoutPlanTemplate service - received templateId: ${templateId} for user: ${userId}`
@@ -250,10 +296,10 @@ async function deleteWorkoutPlanTemplate(userId: any, templateId: any) {
     log('info', `Workout plan template ${templateId} deleted successfully.`);
     return { message: 'Workout plan template deleted successfully.' };
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
     log(
       'error',
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      `Error deleting workout plan template ${templateId} for user ${userId}: ${error.message}`,
+      `Error deleting workout plan template ${templateId} for user ${userId}: ${message}`,
       error
     );
     throw new Error('Failed to delete workout plan template.', {
@@ -261,13 +307,14 @@ async function deleteWorkoutPlanTemplate(userId: any, templateId: any) {
     });
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getActiveWorkoutPlanForDate(userId: any, date: any) {
+
+async function getActiveWorkoutPlanForDate(userId: string, date: string) {
   return workoutPlanTemplateRepository.getActiveWorkoutPlanForDate(
     userId,
     date
   );
 }
+
 export { createWorkoutPlanTemplate };
 export { getWorkoutPlanTemplatesByUserId };
 export { getWorkoutPlanTemplateById };

--- a/SparkyFitnessServer/services/workoutPlanTemplateService.ts
+++ b/SparkyFitnessServer/services/workoutPlanTemplateService.ts
@@ -27,8 +27,8 @@ export interface WorkoutPlanAssignmentInput {
 export interface CreateWorkoutPlanTemplateInput {
   plan_name: string;
   description?: string | null;
-  start_date?: string | Date | null;
-  end_date?: string | Date | null;
+  start_date?: string | null;
+  end_date?: string | null;
   is_active?: boolean | null;
   assignments?: WorkoutPlanAssignmentInput[] | null;
   currentClientDate?: string | null;
@@ -37,8 +37,8 @@ export interface CreateWorkoutPlanTemplateInput {
 export interface UpdateWorkoutPlanTemplateInput {
   plan_name?: string;
   description?: string | null;
-  start_date?: string | Date | null;
-  end_date?: string | Date | null;
+  start_date?: string | null;
+  end_date?: string | null;
   is_active?: boolean | null;
   assignments?: WorkoutPlanAssignmentInput[] | null;
   currentClientDate?: string | null;

--- a/SparkyFitnessServer/tests/workoutPlanTemplateService.test.ts
+++ b/SparkyFitnessServer/tests/workoutPlanTemplateService.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import workoutPlanTemplateService from '../services/workoutPlanTemplateService.js';
+import workoutPlanTemplateRepository from '../models/workoutPlanTemplateRepository.js';
+import exerciseRepository from '../models/exerciseRepository.js';
+
+vi.mock('../models/workoutPlanTemplateRepository.js', () => ({
+  default: {
+    createWorkoutPlanTemplate: vi.fn(),
+    getWorkoutPlanTemplatesByUserId: vi.fn(),
+    getWorkoutPlanTemplateById: vi.fn(),
+    updateWorkoutPlanTemplate: vi.fn(),
+    deleteWorkoutPlanTemplate: vi.fn(),
+    getWorkoutPlanTemplateOwnerId: vi.fn(),
+    getActiveWorkoutPlanForDate: vi.fn(),
+  },
+}));
+
+vi.mock('../models/workoutPresetRepository.js', () => ({
+  default: {
+    getWorkoutPresetById: vi.fn(),
+  },
+}));
+
+vi.mock('../models/exerciseRepository.js', () => ({
+  default: {
+    getExerciseById: vi.fn(),
+    createExerciseEntriesFromTemplate: vi.fn(),
+    deleteExerciseEntriesByTemplateId: vi.fn(),
+  },
+}));
+
+vi.mock('../config/logging.js', () => ({
+  log: vi.fn(),
+}));
+
+vi.mock('../utils/timezoneLoader.js', () => ({
+  resolveTemplateStartDay: vi.fn(async () => '2026-09-10'),
+}));
+
+const USER_ID = 'user-uuid-1234';
+const OTHER_USER_ID = 'other-user-uuid-5678';
+const TEMPLATE_ID = 'template-uuid-9999';
+
+describe('workoutPlanTemplateService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getWorkoutPlanTemplateById', () => {
+    it('returns the template when found for the user', async () => {
+      const mockTemplate = {
+        id: TEMPLATE_ID,
+        user_id: USER_ID,
+        plan_name: 'Hypertrophy Block A',
+        is_active: true,
+        assignments: [],
+      };
+      vi.mocked(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplateById
+      ).mockResolvedValue(mockTemplate);
+
+      const result =
+        await workoutPlanTemplateService.getWorkoutPlanTemplateById(
+          USER_ID,
+          TEMPLATE_ID
+        );
+
+      expect(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplateById
+      ).toHaveBeenCalledWith(TEMPLATE_ID, USER_ID);
+      expect(result).toEqual(mockTemplate);
+    });
+
+    it('throws "Workout plan template not found." when repository returns null', async () => {
+      vi.mocked(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplateById
+      ).mockResolvedValue(null);
+
+      await expect(
+        workoutPlanTemplateService.getWorkoutPlanTemplateById(
+          USER_ID,
+          TEMPLATE_ID
+        )
+      ).rejects.toThrow('Workout plan template not found.');
+    });
+  });
+
+  describe('getWorkoutPlanTemplatesByUserId', () => {
+    it('delegates to repository getWorkoutPlanTemplatesByUserId', async () => {
+      const mockTemplates = [
+        { id: 't1', plan_name: 'Plan 1' },
+        { id: 't2', plan_name: 'Plan 2' },
+      ];
+      vi.mocked(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplatesByUserId
+      ).mockResolvedValue(mockTemplates);
+
+      const result =
+        await workoutPlanTemplateService.getWorkoutPlanTemplatesByUserId(
+          USER_ID
+        );
+
+      expect(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplatesByUserId
+      ).toHaveBeenCalledWith(USER_ID);
+      expect(result).toEqual(mockTemplates);
+    });
+  });
+
+  describe('updateWorkoutPlanTemplate', () => {
+    it('throws Forbidden when user does not own the template', async () => {
+      vi.mocked(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplateOwnerId
+      ).mockResolvedValue(OTHER_USER_ID);
+
+      await expect(
+        workoutPlanTemplateService.updateWorkoutPlanTemplate(
+          USER_ID,
+          TEMPLATE_ID,
+          { plan_name: 'Updated Name' }
+        )
+      ).rejects.toThrow(
+        'Forbidden: You do not have permission to update this workout plan template.'
+      );
+    });
+
+    it('updates template when user is owner', async () => {
+      vi.mocked(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplateOwnerId
+      ).mockResolvedValue(USER_ID);
+      vi.mocked(
+        workoutPlanTemplateRepository.updateWorkoutPlanTemplate
+      ).mockResolvedValue({
+        id: TEMPLATE_ID,
+        plan_name: 'Updated Name',
+        is_active: false,
+      });
+
+      const result = await workoutPlanTemplateService.updateWorkoutPlanTemplate(
+        USER_ID,
+        TEMPLATE_ID,
+        { plan_name: 'Updated Name' }
+      );
+
+      expect(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplateOwnerId
+      ).toHaveBeenCalledWith(TEMPLATE_ID, USER_ID);
+      expect(
+        workoutPlanTemplateRepository.updateWorkoutPlanTemplate
+      ).toHaveBeenCalledWith(TEMPLATE_ID, USER_ID, {
+        plan_name: 'Updated Name',
+      });
+      expect(result.plan_name).toBe('Updated Name');
+    });
+  });
+
+  describe('deleteWorkoutPlanTemplate', () => {
+    it('throws not found when owner ID is not found', async () => {
+      vi.mocked(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplateOwnerId
+      ).mockResolvedValue(null);
+
+      await expect(
+        workoutPlanTemplateService.deleteWorkoutPlanTemplate(
+          USER_ID,
+          TEMPLATE_ID
+        )
+      ).rejects.toThrow('Workout plan template not found.');
+    });
+
+    it('throws Forbidden when user does not own the template', async () => {
+      vi.mocked(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplateOwnerId
+      ).mockResolvedValue(OTHER_USER_ID);
+
+      await expect(
+        workoutPlanTemplateService.deleteWorkoutPlanTemplate(
+          USER_ID,
+          TEMPLATE_ID
+        )
+      ).rejects.toThrow(
+        'Forbidden: You do not have permission to delete this workout plan template.'
+      );
+    });
+
+    it('deletes template and cleans up entries when user is owner', async () => {
+      vi.mocked(
+        workoutPlanTemplateRepository.getWorkoutPlanTemplateOwnerId
+      ).mockResolvedValue(USER_ID);
+      vi.mocked(
+        workoutPlanTemplateRepository.deleteWorkoutPlanTemplate
+      ).mockResolvedValue({ id: TEMPLATE_ID });
+
+      const result = await workoutPlanTemplateService.deleteWorkoutPlanTemplate(
+        USER_ID,
+        TEMPLATE_ID
+      );
+
+      expect(
+        exerciseRepository.deleteExerciseEntriesByTemplateId
+      ).toHaveBeenCalledWith(TEMPLATE_ID, USER_ID, '2026-09-10');
+      expect(
+        workoutPlanTemplateRepository.deleteWorkoutPlanTemplate
+      ).toHaveBeenCalledWith(TEMPLATE_ID, USER_ID);
+      expect(result).toEqual({
+        message: 'Workout plan template deleted successfully.',
+      });
+    });
+  });
+});


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Retrieving a workout plan template by ID failed with `userId is required for getClient to ensure RLS is applied` when called by Sparky AI or direct lookups due to a redundant `getWorkoutPlanTemplateOwnerId` call with a missing `userId` parameter.

**How did you implement the solution?**
Removed the redundant `getWorkoutPlanTemplateOwnerId` call in `getWorkoutPlanTemplateById` and rely directly on RLS database-level gating. Added unit tests for `workoutPlanTemplateService`.

Linked Issue: Closes #2390

## How to Test

1. In `SparkyFitnessServer`, run `pnpm exec vitest run tests/workoutPlanTemplateService.test.ts tests/chatbotToolsWorkoutPlans.test.ts`.
2. Run `pnpm run validate` and `pnpm test`.
3. In Sparky AI, ask to inspect details of a saved workout plan template.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

N/A

### After

N/A

</details>

## Notes for Reviewers

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Workout plan template retrieval now relies on the platform’s data-level security controls.
  - Explicit ownership validation is no longer performed during template retrieval.

- **Reliability**
  - Added automated coverage for retrieving, updating, and deleting workout plan templates, including not-found and unauthorized access scenarios.
  - Improved error handling to provide consistent messages when unexpected failures occur.

- **Validation**
  - Workout plan template dates now accept string values or null, providing clearer input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->