### PR TITLE
fix(db): release clients when context initialization fails

### DIFF
--- a/SparkyFitnessServer/db/poolManager.ts
+++ b/SparkyFitnessServer/db/poolManager.ts
@@ -78,11 +78,16 @@ async function getClient(
   const store = dbContextStorage.getStore();
   const actualAuthUserId =
     authenticatedUserId || store?.authenticatedUserId || userId;
-  await client.query('SELECT public.set_app_context($1, $2)', [
-    userId,
-    actualAuthUserId,
-  ]);
-  return client;
+  try {
+    await client.query('SELECT public.set_app_context($1, $2)', [
+      userId,
+      actualAuthUserId,
+    ]);
+    return client;
+  } catch (error) {
+    client.release(true);
+    throw error;
+  }
 }
 async function getSystemClient() {
   const client = await _getRawOwnerPool().connect();

--- a/SparkyFitnessServer/db/poolManager.ts
+++ b/SparkyFitnessServer/db/poolManager.ts
@@ -64,6 +64,10 @@ function _getRawAppPool() {
   }
   return appPoolInstance;
 }
+/**
+ * Borrows a client with RLS context set for the target user and authenticated actor.
+ * The caller must release it in a finally block; failed context setup discards it.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function getClient(
   userId: any,

--- a/SparkyFitnessServer/tests/poolContext.test.ts
+++ b/SparkyFitnessServer/tests/poolContext.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dbContextStorage, getClient } from '../db/poolManager.js';
+
+const { client, connect } = vi.hoisted(() => {
+  const client = { query: vi.fn(), release: vi.fn() };
+  return { client, connect: vi.fn().mockResolvedValue(client) };
+});
+vi.mock('pg', async (importOriginal) => {
+  const original = await importOriginal<typeof import('pg')>();
+  return {
+    default: {
+      ...original.default,
+      Pool: class {
+        connect = connect;
+        on = vi.fn();
+      },
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  client.query.mockResolvedValue({ rows: [] });
+});
+afterEach(() => {
+  dbContextStorage.disable();
+});
+
+describe('getClient', () => {
+  it('discards the borrowed client and preserves a context query error', async () => {
+    const error = new Error('Context initialization failed');
+    client.query.mockRejectedValueOnce(error);
+
+    await expect(getClient('owner')).rejects.toBe(error);
+
+    expect(client.release).toHaveBeenCalledExactlyOnceWith(true);
+  });
+
+  it.each([
+    [null, undefined, 'owner'],
+    [null, 'delegate', 'delegate'],
+    ['explicit', 'delegate', 'explicit'],
+  ])(
+    'initializes context with actor %s / %s',
+    async (explicit, inherited, actor) => {
+      const result = inherited
+        ? await dbContextStorage.run({ authenticatedUserId: inherited }, () =>
+            getClient('owner', explicit)
+          )
+        : await getClient('owner', explicit);
+
+      expect(result).toBe(client);
+      expect(client.query).toHaveBeenCalledExactlyOnceWith(
+        'SELECT public.set_app_context($1, $2)',
+        ['owner', actor]
+      );
+      expect(client.release).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not borrow a client without a user ID', async () => {
+    await expect(getClient(null)).rejects.toThrow('userId is required');
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it('preserves a connection failure without releasing an unborrowed client', async () => {
+    const error = new Error('Connection refused');
+    connect.mockRejectedValueOnce(error);
+
+    await expect(getClient('owner')).rejects.toBe(error);
+    expect(client.release).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
When `set_app_context` fails, `getClient` rejects without releasing its borrowed client. Ten failures exhaust the default app pool and subsequent requests time out.

**How did you implement the solution?**
Discard the client on initialization failure and rethrow the original error. Successful checkouts still belong to the caller.

Linked Issue: None.

## How to Test

1. In `SparkyFitnessServer`, run `pnpm exec vitest run tests/poolContext.test.ts`.
2. Run `pnpm run validate` and `TZ=UTC NODE_ENV=test SKIP_RLS_MATRIX=1 pnpm run test:ci`.

The new regression fails on unchanged main because the client is never released. All six cases pass with the fix. On PostgreSQL 18.3, ten failed context queries exhaust the original pool; the patch handles twelve failures and then returns a usable client with the requested owner and actor.

Formatting and server validation pass. The final coverage run passes 4,361 tests, with 270 database-dependent tests skipped. The separate RLS and Strava database suites pass all 226 cases after applying migrations twice.

During earlier validation at `739adc9c`, one coverage run hit a 10-second setup timeout in `garminNutritionSync.integration.test.ts`. The same command then passed on that unchanged base (4,345 tests) and with the patch; the timeout's cause is unverified.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. <!-- N/A: bug fix -->

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes. <!-- N/A: server only -->
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. <!-- N/A -->

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. <!-- N/A: no new tables -->

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. <!-- N/A: no UI changes -->

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. <!-- N/A -->

## Screenshots

N/A: server connection handling only.

## Notes for Reviewers

The failed client is destroyed rather than returned with uncertain context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling when application context initialization fails by safely discarding the affected connection and preserving the original error.
  * Prevented unnecessary connection borrowing when required user information is missing.
  * Ensured connection and context errors are reported consistently, including failures during connection setup.

* **Tests**
  * Added coverage for context resolution, connection failures, missing user information, and connection cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->