### PR TITLE
fix(usda): restrict food search to non-branded datasets by default

### DIFF
--- a/SparkyFitnessServer/integrations/usda/usdaService.ts
+++ b/SparkyFitnessServer/integrations/usda/usdaService.ts
@@ -19,12 +19,8 @@ function scaleProviderNutrients(
 // Using native fetch (standard in Node 22+)
 const USDA_API_BASE_URL = 'https://api.nal.usda.gov/fdc/v1';
 
-// USDA's default search mixes Branded (manufacturer SKU) results in with
-// Foundation/SR Legacy/Survey (FNDDS) generic entries. A plain query like
-// "chicken breast" with no dataType filter returns only Branded noise (Giant
-// Eagle, Tyson, Jennie-O, ...) and no generic match at all; restricting to
-// the non-branded datasets by default is what surfaces the clean generic
-// entry for an ordinary staple-food search.
+// Excludes Branded (manufacturer SKU noise) by default so a plain query like
+// "chicken breast" reaches the generic entry instead of retail duplicates.
 const DEFAULT_USDA_SEARCH_DATA_TYPES = 'Foundation,SR Legacy,Survey (FNDDS)';
 
 const STANDARD_UNITS = new Set([

--- a/SparkyFitnessServer/integrations/usda/usdaService.ts
+++ b/SparkyFitnessServer/integrations/usda/usdaService.ts
@@ -19,6 +19,14 @@ function scaleProviderNutrients(
 // Using native fetch (standard in Node 22+)
 const USDA_API_BASE_URL = 'https://api.nal.usda.gov/fdc/v1';
 
+// USDA's default search mixes Branded (manufacturer SKU) results in with
+// Foundation/SR Legacy/Survey (FNDDS) generic entries. A plain query like
+// "chicken breast" with no dataType filter returns only Branded noise (Giant
+// Eagle, Tyson, Jennie-O, ...) and no generic match at all; restricting to
+// the non-branded datasets by default is what surfaces the clean generic
+// entry for an ordinary staple-food search.
+const DEFAULT_USDA_SEARCH_DATA_TYPES = 'Foundation,SR Legacy,Survey (FNDDS)';
+
 const STANDARD_UNITS = new Set([
   'g',
   'ml',
@@ -94,7 +102,8 @@ async function searchUsdaFoods(
   query: string,
   apiKey: string | undefined,
   page = 1,
-  pageSize = 50
+  pageSize = 50,
+  dataType: string = DEFAULT_USDA_SEARCH_DATA_TYPES
 ): Promise<
   UsdaSearchResponse & {
     pagination: {
@@ -106,7 +115,14 @@ async function searchUsdaFoods(
   }
 > {
   try {
-    const searchUrl = `${USDA_API_BASE_URL}/foods/search?query=${encodeURIComponent(query)}&pageNumber=${page}&pageSize=${pageSize}&api_key=${apiKey || ''}`;
+    const searchParams = new URLSearchParams({
+      query,
+      pageNumber: String(page),
+      pageSize: String(pageSize),
+      api_key: apiKey || '',
+      dataType,
+    });
+    const searchUrl = `${USDA_API_BASE_URL}/foods/search?${searchParams.toString()}`;
     const response = await fetch(searchUrl, { method: 'GET' });
     log('debug', 'USDA API Search Response Status:', response.status);
     if (!response.ok) {

--- a/SparkyFitnessServer/tests/usdaService.test.ts
+++ b/SparkyFitnessServer/tests/usdaService.test.ts
@@ -23,11 +23,6 @@ describe('searchUsdaFoods', () => {
     );
   }
 
-  // With no dataType filter, USDA's default search mixes in Branded (manufacturer
-  // SKU) results and can bury or fully hide the clean Foundation/SR Legacy/Survey
-  // generic entries behind branded noise (e.g. "chicken breast" returned 8 Branded
-  // products and zero generic matches). Restricting to the non-branded datasets by
-  // default is what surfaces the generic entry for a plain staple-food search.
   it('requests the non-branded datasets by default, correctly URL-encoded', async () => {
     const fetchMock = vi.fn().mockResolvedValue(searchResponse());
     globalThis.fetch = fetchMock;
@@ -41,11 +36,8 @@ describe('searchUsdaFoods', () => {
     expect(searchParams.get('dataType')).toBe(
       'Foundation,SR Legacy,Survey (FNDDS)'
     );
-    // Belt-and-suspenders: the decoded assertion above would also pass a
-    // hand-rolled template string that left the value's raw space and
-    // parentheses on the wire (the WHATWG URL parser tolerates those in a
-    // query component), so also assert the query string itself carries no
-    // literal, unencoded space or parenthesis character.
+    // Catches an unencoded space/paren surviving on the wire even though
+    // the decoded assertion above would still pass.
     const rawQuery = requestedUrl.split('?')[1];
     expect(rawQuery).not.toMatch(/[ ()]/);
   });

--- a/SparkyFitnessServer/tests/usdaService.test.ts
+++ b/SparkyFitnessServer/tests/usdaService.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+import { searchUsdaFoods } from '../integrations/usda/usdaService.js';
+
+describe('searchUsdaFoods', () => {
+  const realFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function searchResponse() {
+    return new Response(
+      JSON.stringify({
+        foods: [],
+        currentPage: 1,
+        totalPages: 1,
+        totalHits: 0,
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+  }
+
+  // With no dataType filter, USDA's default search mixes in Branded (manufacturer
+  // SKU) results and can bury or fully hide the clean Foundation/SR Legacy/Survey
+  // generic entries behind branded noise (e.g. "chicken breast" returned 8 Branded
+  // products and zero generic matches). Restricting to the non-branded datasets by
+  // default is what surfaces the generic entry for a plain staple-food search.
+  it('requests the non-branded datasets by default, correctly URL-encoded', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(searchResponse());
+    globalThis.fetch = fetchMock;
+
+    await searchUsdaFoods('chicken breast', 'test-api-key');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const requestedUrl = fetchMock.mock.calls[0][0] as string;
+    const { searchParams } = new URL(requestedUrl);
+
+    expect(searchParams.get('dataType')).toBe(
+      'Foundation,SR Legacy,Survey (FNDDS)'
+    );
+    // Belt-and-suspenders: the decoded assertion above would also pass a
+    // hand-rolled template string that left the value's raw space and
+    // parentheses on the wire (the WHATWG URL parser tolerates those in a
+    // query component), so also assert the query string itself carries no
+    // literal, unencoded space or parenthesis character.
+    const rawQuery = requestedUrl.split('?')[1];
+    expect(rawQuery).not.toMatch(/[ ()]/);
+  });
+
+  it('still sends the query, paging, and api key params', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(searchResponse());
+    globalThis.fetch = fetchMock;
+
+    await searchUsdaFoods('chicken breast', 'test-api-key', 2, 25);
+
+    const requestedUrl = fetchMock.mock.calls[0][0] as string;
+    const { searchParams } = new URL(requestedUrl);
+
+    expect(searchParams.get('query')).toBe('chicken breast');
+    expect(searchParams.get('pageNumber')).toBe('2');
+    expect(searchParams.get('pageSize')).toBe('25');
+    expect(searchParams.get('api_key')).toBe('test-api-key');
+  });
+});


### PR DESCRIPTION
Fixes #2417.

**What problem does this PR solve?**
`searchUsdaFoods` requested no `dataType` filter, so a plain query like "chicken breast" returned only Branded SKUs (Giant Eagle, Tyson, Jennie-O, etc.) with zero generic entries, even though USDA has a clean "Chicken, breast, boneless, skinless, raw" entry in its Foundation/SR Legacy data.

**How did you implement the solution?**
Added a `dataType` parameter (default `'Foundation,SR Legacy,Survey (FNDDS)'`) to the search request, built with `URLSearchParams` instead of a hand-rolled template string — matching the existing convention in `integrations/fatsecret/fatsecretService.ts` — so the space/comma/parentheses in the dataType values are correctly encoded. Both existing call sites pass only 4 args today, so this is backward-compatible.

**How to test:**
See the new `SparkyFitnessServer/tests/usdaService.test.ts` — asserts the outgoing request URL carries the correct, correctly-encoded `dataType` param.

## PR Type
- [x] Issue (bug fix)

## Checklist

**All PRs:**
- [ ] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the License terms.

**Backend changes (`SparkyFitnessServer/`):**
- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.

Draft PR — code and tests are ready and passing (typecheck/lint/98 related tests all green), opened as draft for easier review than a raw diff. Checkboxes left unchecked pending review.