### PR TITLE
Rank manual/mobile food search results the same way the chatbot already does

### DIFF
--- a/SparkyFitnessServer/services/externalFoodSearchService.ts
+++ b/SparkyFitnessServer/services/externalFoodSearchService.ts
@@ -24,6 +24,10 @@ import {
   searchTandoorFoods,
   searchNorishFoods,
 } from './foodIntegrationService.js';
+import {
+  rankProviderMatches,
+  type ProviderFoodItem,
+} from '../utils/foodRanking.js';
 
 import type { ProviderType } from '../constants/foodProviders.js';
 import type { OpenFoodFactsCredentialScope } from '../integrations/openfoodfacts/openFoodFactsAuth.js';
@@ -442,5 +446,15 @@ export async function searchProviderFoods(
     }
   }
 
-  return { foods, pagination };
+  // All VALID_PROVIDER_TYPES are food providers (see constants/foodProviders.ts),
+  // so every case above lands here and gets ranked once, in one place, rather
+  // than duplicating the sort per-case. Without this, providers that list
+  // branded/processed items ahead of the plain whole food a user actually
+  // searched for (e.g. OpenFoodFacts for "chicken breast") passed that raw
+  // order straight through to the manual search UI and the mobile app — only
+  // the chatbot/photo-import path (via foodProviderLookupService.ts) ranked
+  // its results.
+  const ranked = rankProviderMatches(foods as ProviderFoodItem[], query);
+
+  return { foods: ranked, pagination };
 }

--- a/SparkyFitnessServer/services/externalFoodSearchService.ts
+++ b/SparkyFitnessServer/services/externalFoodSearchService.ts
@@ -446,14 +446,7 @@ export async function searchProviderFoods(
     }
   }
 
-  // All VALID_PROVIDER_TYPES are food providers (see constants/foodProviders.ts),
-  // so every case above lands here and gets ranked once, in one place, rather
-  // than duplicating the sort per-case. Without this, providers that list
-  // branded/processed items ahead of the plain whole food a user actually
-  // searched for (e.g. OpenFoodFacts for "chicken breast") passed that raw
-  // order straight through to the manual search UI and the mobile app — only
-  // the chatbot/photo-import path (via foodProviderLookupService.ts) ranked
-  // its results.
+  // All VALID_PROVIDER_TYPES are food providers, so this covers every case above.
   const ranked = rankProviderMatches(foods as ProviderFoodItem[], query);
 
   return { foods: ranked, pagination };

--- a/SparkyFitnessServer/services/foodProviderLookupService.ts
+++ b/SparkyFitnessServer/services/foodProviderLookupService.ts
@@ -6,6 +6,11 @@ import {
   type ProviderType,
 } from './externalFoodSearchService.js';
 import { VALID_PROVIDER_TYPES } from '../constants/foodProviders.js';
+import {
+  rankProviderMatches,
+  type ProviderFoodItem,
+  type ProviderFoodVariant,
+} from '../utils/foodRanking.js';
 
 /**
  * The external half of the food-lookup cascade: the user's configured food
@@ -88,76 +93,8 @@ export async function resolveFoodProviderOrder(
   return targets;
 }
 
-export interface ProviderFoodVariant {
-  id?: string;
-  serving_size?: number | string | null;
-  serving_unit?: string | null;
-  calories?: number | string | null;
-  energy?: number | string | null;
-  protein?: number | string | null;
-  carbs?: number | string | null;
-  fat?: number | string | null;
-  saturated_fat?: number | string | null;
-  polyunsaturated_fat?: number | string | null;
-  monounsaturated_fat?: number | string | null;
-  trans_fat?: number | string | null;
-  cholesterol?: number | string | null;
-  sodium?: number | string | null;
-  potassium?: number | string | null;
-  dietary_fiber?: number | string | null;
-  fiber?: number | string | null;
-  sugars?: number | string | null;
-  sugar?: number | string | null;
-  vitamin_a?: number | string | null;
-  vitamin_c?: number | string | null;
-  calcium?: number | string | null;
-  iron?: number | string | null;
-  glycemic_index?: string | null;
-  is_default?: boolean | null;
-  [key: string]: unknown;
-}
-
-export interface ProviderFoodItem {
-  id?: string;
-  name: string;
-  brand?: string | null;
-  images?: unknown[];
-  provider_type?: string | null;
-  provider_external_id?: string | null;
-  variants?: ProviderFoodVariant[];
-  default_variant?: ProviderFoodVariant | null;
-  [key: string]: unknown;
-}
-
-/**
- * Ranks provider results so plain whole foods beat branded products.
- *
- * Providers return branded items ("EGG (SNICKERS)", "BANANA (BETTER'N PEANUT
- * BUTTER)") ahead of the plain whole food a user almost always means, and small
- * models just take the first result. Stable within each tier, so the provider's
- * own relevance order is otherwise preserved.
- */
-export function rankProviderMatches<T extends ProviderFoodItem>(
-  foods: T[],
-  query: string
-): T[] {
-  const q = query.trim().toLowerCase();
-  const qStem = q.replace(/s$/, '');
-  const score = (f: T): number => {
-    const name = String(f?.name ?? '').toLowerCase();
-    const branded = Boolean(f?.brand && String(f.brand).trim());
-    const firstSegment = name.split(',')[0].trim();
-    let s = branded ? 0 : 100; // whole foods first
-    if (firstSegment === q || firstSegment === qStem) s += 20;
-    else if (firstSegment.startsWith(qStem)) s += 10;
-    else if (name.includes(q)) s += 5;
-    return s;
-  };
-  return foods
-    .map((f, i) => ({ f, i, s: score(f) }))
-    .sort((a, b) => b.s - a.s || a.i - b.i)
-    .map((x) => x.f);
-}
+export type { ProviderFoodVariant, ProviderFoodItem };
+export { rankProviderMatches };
 
 /**
  * Sub-gram units a provider sometimes reports as the serving. Quoting a food

--- a/SparkyFitnessServer/tests/externalFoodSearchService.openFoodFacts.test.ts
+++ b/SparkyFitnessServer/tests/externalFoodSearchService.openFoodFacts.test.ts
@@ -42,7 +42,10 @@ vi.mock('../integrations/swissfood/swissFoodService.js', () => ({
 
 import externalProviderService from '../services/externalProviderService.js';
 import preferenceService from '../services/preferenceService.js';
-import { searchOpenFoodFacts } from '../integrations/openfoodfacts/openFoodFactsService.js';
+import {
+  searchOpenFoodFacts,
+  mapOpenFoodFactsProduct,
+} from '../integrations/openfoodfacts/openFoodFactsService.js';
 import {
   resolveOpenFoodFactsProviderId,
   searchProviderFoods,
@@ -168,5 +171,52 @@ describe('searchProviderFoods OpenFoodFacts pagination', () => {
       7,
       'global'
     );
+  });
+});
+
+describe('searchProviderFoods ranking', () => {
+  it('ranks a plain whole food ahead of a branded product for the same query', async () => {
+    vi.mocked(preferenceService.getUserPreferences).mockResolvedValue({
+      language: 'en',
+    });
+    // OpenFoodFacts itself returns the branded item first -- this is the raw,
+    // unranked provider order that reaches the UI today.
+    vi.mocked(searchOpenFoodFacts).mockResolvedValue({
+      products: [
+        {
+          code: '1',
+          product_name: 'Chicken Breast (Value Pack)',
+          brands: 'Acme Foods',
+          nutriments: {},
+        },
+        {
+          code: '2',
+          product_name: 'Chicken Breast',
+          brands: '',
+          nutriments: {},
+        },
+      ],
+      pagination: { page: 1, pageSize: 20, totalCount: 2, hasMore: false },
+    });
+    vi.mocked(mapOpenFoodFactsProduct).mockImplementation(
+      // @ts-expect-error test double only needs the fields the code under test reads
+      (p: { product_name?: string; brands?: string }) => ({
+        name: p.product_name ?? '',
+        brand: p.brands || '',
+        provider_type: 'openfoodfacts',
+      })
+    );
+
+    const result = await searchProviderFoods(
+      USER_ID,
+      'openfoodfacts',
+      'chicken breast',
+      {}
+    );
+
+    expect(result.foods.map((f) => (f as { name: string }).name)).toEqual([
+      'Chicken Breast',
+      'Chicken Breast (Value Pack)',
+    ]);
   });
 });

--- a/SparkyFitnessServer/utils/foodRanking.ts
+++ b/SparkyFitnessServer/utils/foodRanking.ts
@@ -1,0 +1,84 @@
+// Shared ranking logic for external-provider food search results.
+//
+// Extracted out of `services/foodProviderLookupService.ts` so
+// `services/externalFoodSearchService.ts` can rank its own results without
+// creating a circular import: `foodProviderLookupService.ts` already imports
+// `searchProviderFoods` FROM `externalFoodSearchService.ts` for its own
+// provider-lookup loop, so `externalFoodSearchService.ts` cannot import
+// anything back from `foodProviderLookupService.ts`. This module sits below
+// both and depends on neither.
+
+export interface ProviderFoodVariant {
+  id?: string;
+  serving_size?: number | string | null;
+  serving_unit?: string | null;
+  calories?: number | string | null;
+  energy?: number | string | null;
+  protein?: number | string | null;
+  carbs?: number | string | null;
+  fat?: number | string | null;
+  saturated_fat?: number | string | null;
+  polyunsaturated_fat?: number | string | null;
+  monounsaturated_fat?: number | string | null;
+  trans_fat?: number | string | null;
+  cholesterol?: number | string | null;
+  sodium?: number | string | null;
+  potassium?: number | string | null;
+  dietary_fiber?: number | string | null;
+  fiber?: number | string | null;
+  sugars?: number | string | null;
+  sugar?: number | string | null;
+  vitamin_a?: number | string | null;
+  vitamin_c?: number | string | null;
+  calcium?: number | string | null;
+  iron?: number | string | null;
+  glycemic_index?: string | null;
+  is_default?: boolean | null;
+  [key: string]: unknown;
+}
+
+export interface ProviderFoodItem {
+  id?: string;
+  name: string;
+  brand?: string | null;
+  images?: unknown[];
+  provider_type?: string | null;
+  provider_external_id?: string | null;
+  variants?: ProviderFoodVariant[];
+  default_variant?: ProviderFoodVariant | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Ranks provider results so plain whole foods beat branded products.
+ *
+ * Providers return branded items ("EGG (SNICKERS)", "BANANA (BETTER'N PEANUT
+ * BUTTER)") ahead of the plain whole food a user almost always means, and small
+ * models just take the first result. Stable within each tier, so the provider's
+ * own relevance order is otherwise preserved.
+ */
+export function rankProviderMatches<T extends ProviderFoodItem>(
+  foods: T[],
+  query: string
+): T[] {
+  const q = query.trim().toLowerCase();
+  const qStem = q.replace(/s$/, '');
+  const score = (f: T): number => {
+    const name = String(f?.name ?? '').toLowerCase();
+    const branded = Boolean(f?.brand && String(f.brand).trim());
+    const firstSegment = name.split(',')[0].trim();
+    let s = branded ? 0 : 100; // whole foods first
+    if (firstSegment === q || firstSegment === qStem) s += 20;
+    else if (firstSegment.startsWith(qStem)) s += 10;
+    else if (name.includes(q)) s += 5;
+    return s;
+  };
+  return foods
+    .map((f, i) => ({ f, i, s: score(f) }))
+    .sort((a, b) => b.s - a.s || a.i - b.i)
+    .map((x) => x.f);
+}
+
+export default {
+  rankProviderMatches,
+};

--- a/SparkyFitnessServer/utils/foodRanking.ts
+++ b/SparkyFitnessServer/utils/foodRanking.ts
@@ -1,12 +1,6 @@
-// Shared ranking logic for external-provider food search results.
-//
-// Extracted out of `services/foodProviderLookupService.ts` so
-// `services/externalFoodSearchService.ts` can rank its own results without
-// creating a circular import: `foodProviderLookupService.ts` already imports
-// `searchProviderFoods` FROM `externalFoodSearchService.ts` for its own
-// provider-lookup loop, so `externalFoodSearchService.ts` cannot import
-// anything back from `foodProviderLookupService.ts`. This module sits below
-// both and depends on neither.
+// Extracted out of foodProviderLookupService.ts so externalFoodSearchService.ts
+// can use it too, without the circular import that would create (the former
+// already imports the latter). Depends on neither.
 
 export interface ProviderFoodVariant {
   id?: string;


### PR DESCRIPTION
Fixes #2418.

**What problem does this PR solve?**
`rankProviderMatches()` in `foodProviderLookupService.ts` already demotes branded items behind plain whole foods, but it was wired only into the chatbot/photo-import lookup path. The manual search endpoint (`searchProviderFoods()`, used by the web UI and the mobile app's per-provider search/"Top Matches") returned each provider's raw, unranked order — so the search screen users actually type into never benefited from ranking logic that already existed in the codebase.

**How did you implement the solution?**
Extracted `rankProviderMatches()` and its `ProviderFoodItem`/`ProviderFoodVariant` types into a new lower-level shared module, `utils/foodRanking.ts`, since `foodProviderLookupService.ts` already imports `searchProviderFoods` from `externalFoodSearchService.ts` — importing the ranking function back the other way would have created a circular dependency. Both services now import from the new module (`foodProviderLookupService.ts` re-exports for its existing consumers, so nothing downstream needed to change), and `searchProviderFoods()` applies ranking once, after building `foods`, before returning.

**How to test:**
See the new `describe('searchProviderFoods ranking', ...)` block in `SparkyFitnessServer/tests/externalFoodSearchService.openFoodFacts.test.ts`. Also ran the full suite (`pnpm test`) to check for regressions given this touches a shared module — 331 files / 4148 tests, all passing, including the chatbot/photo-import path's own tests unchanged.

## PR Type
- [x] Issue (bug fix)

## Checklist

**All PRs:**
- [ ] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the License terms.

**Backend changes (`SparkyFitnessServer/`):**
- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.

Draft PR — code and tests are ready and passing (typecheck/lint/full 4148-test suite all green), opened as draft for easier review than a raw diff. Checkboxes left unchecked pending review.