### PR TITLE
fix(calories): use dated measurements for historical steps

### DIFF
--- a/SparkyFitnessServer/models/measurementRepository.ts
+++ b/SparkyFitnessServer/models/measurementRepository.ts
@@ -1367,30 +1367,28 @@ async function deleteCustomMeasurement(id: any, userId: any) {
     client.release();
   }
 }
-/**
- * Weight and height for step-calorie estimation.
- *
- * Deliberately whole-table latest rather than latest-on-or-before the target day. The
- * Diary has always read it this way, and the acceptance criterion for #2094 is that
- * Reports agrees with the Diary -- date-scoping it here would make the two disagree again
- * for every day after a weight change. Note that BMR in the same balance *does* use
- * on-or-before, so the two are inconsistent with each other. Tracked separately; do not
- * "fix" one without the other.
- */
+/** Prefer prior measurements, falling back independently to the earliest later value. */
 async function getLatestWeightHeight(
-  userId: string
+  userId: string,
+  date: string
 ): Promise<{ weightKg: number | null; heightCm: number | null }> {
   const client = await getClient(userId);
   try {
     const result = await client.query(
       `SELECT
-         (SELECT weight FROM check_in_measurements
-           WHERE user_id = $1 AND weight IS NOT NULL AND weight > 0
-           ORDER BY entry_date DESC, updated_at DESC LIMIT 1) AS weight,
-         (SELECT height FROM check_in_measurements
-           WHERE user_id = $1 AND height IS NOT NULL AND height > 0
-           ORDER BY entry_date DESC, updated_at DESC LIMIT 1) AS height`,
-      [userId]
+         COALESCE((SELECT weight FROM check_in_measurements
+           WHERE user_id = $1 AND entry_date <= $2 AND weight IS NOT NULL AND weight > 0
+           ORDER BY entry_date DESC, updated_at DESC LIMIT 1),
+           (SELECT weight FROM check_in_measurements
+           WHERE user_id = $1 AND entry_date > $2 AND weight IS NOT NULL AND weight > 0
+           ORDER BY entry_date ASC, updated_at DESC LIMIT 1)) AS weight,
+         COALESCE((SELECT height FROM check_in_measurements
+           WHERE user_id = $1 AND entry_date <= $2 AND height IS NOT NULL AND height > 0
+           ORDER BY entry_date DESC, updated_at DESC LIMIT 1),
+           (SELECT height FROM check_in_measurements
+           WHERE user_id = $1 AND entry_date > $2 AND height IS NOT NULL AND height > 0
+           ORDER BY entry_date ASC, updated_at DESC LIMIT 1)) AS height`,
+      [userId, date]
     );
     const weight = parseFloat(result.rows[0]?.weight);
     const height = parseFloat(result.rows[0]?.height);
@@ -1420,7 +1418,7 @@ async function getStepCaloriesForDate(
   activitySteps: number
 ): Promise<number> {
   const [{ weightKg, heightCm }, totalSteps] = await Promise.all([
-    getLatestWeightHeight(userId),
+    getLatestWeightHeight(userId, date),
     getCheckInStepsForDate(userId, date),
   ]);
 

--- a/SparkyFitnessServer/services/DashboardService.ts
+++ b/SparkyFitnessServer/services/DashboardService.ts
@@ -71,7 +71,7 @@ async function getDashboardStats(
         ? measurementRepository.getCheckInMeasurementsByDate(userId, date)
         : null,
       includeCheckin
-        ? measurementRepository.getLatestWeightHeight(userId)
+        ? measurementRepository.getLatestWeightHeight(userId, date)
         : { weightKg: null, heightCm: null },
       includeCheckin
         ? genericHealthRepository

--- a/SparkyFitnessServer/services/dailySummaryRangeService.ts
+++ b/SparkyFitnessServer/services/dailySummaryRangeService.ts
@@ -135,7 +135,7 @@ export async function getDailySummaryRange({
       : null,
     includeCheckin
       ? measurementRepository
-          .getLatestWeightHeight(targetUserId)
+          .getLatestWeightHeight(targetUserId, startDate)
           .catch(() => ({ weightKg: null, heightCm: null }))
       : { weightKg: null, heightCm: null },
     userRepository.getUserProfile(targetUserId),
@@ -249,8 +249,8 @@ export async function getDailySummaryRange({
       ? resolveBackgroundStepCalories({
           totalSteps,
           activitySteps: exercise.activitySteps,
-          weightKg: latestWeightHeight.weightKg,
-          heightCm: latestWeightHeight.heightCm,
+          weightKg: Number(carried.weight ?? latestWeightHeight.weightKg),
+          heightCm: Number(carried.height ?? latestWeightHeight.heightCm),
         })
       : 0;
 

--- a/SparkyFitnessServer/services/dailySummaryRangeService.ts
+++ b/SparkyFitnessServer/services/dailySummaryRangeService.ts
@@ -87,6 +87,11 @@ function enumerateDays(startDate: string, endDate: string): string[] {
   return days;
 }
 
+/**
+ * Returns a balance for every day in the inclusive range without per-day queries.
+ * Step estimates can use the earliest later weight or height when no prior value
+ * exists; body-composition inputs for BMR remain prior-only.
+ */
 export async function getDailySummaryRange({
   actorUserId,
   targetUserId,

--- a/SparkyFitnessServer/services/exerciseCalorieRangeService.ts
+++ b/SparkyFitnessServer/services/exerciseCalorieRangeService.ts
@@ -37,6 +37,8 @@ export interface ResolvedExerciseCalorieDay {
 interface CheckInStepsRow {
   entry_date: string;
   steps?: number | string | null;
+  weight?: number | string | null;
+  height?: number | string | null;
 }
 
 export async function getResolvedExerciseCaloriesRange(
@@ -61,14 +63,13 @@ export async function getResolvedExerciseCaloriesRange(
         return [];
       }),
     measurementRepository
-      .getLatestWeightHeight(userId)
+      .getLatestWeightHeight(userId, startDate)
       .catch(() => ({ weightKg: null, heightCm: null })),
   ]);
 
-  const stepsByDate = new Map<string, number>();
-  for (const row of checkInRows as CheckInStepsRow[]) {
-    stepsByDate.set(row.entry_date, Number(row.steps) || 0);
-  }
+  const checkInByDate = new Map(
+    (checkInRows as CheckInStepsRow[]).map((row) => [row.entry_date, row])
+  );
 
   const splitByDate = new Map(splits.map((split) => [split.entry_date, split]));
 
@@ -77,20 +78,24 @@ export async function getResolvedExerciseCaloriesRange(
   // produces no row at all -- and that day's step calories would vanish from the totals
   // the health-summary and 30-day tools report. That shape is common: it is exactly the
   // steps-only day from issue #2094.
-  const dates = new Set([...splitByDate.keys(), ...stepsByDate.keys()]);
+  const dates = new Set([...splitByDate.keys(), ...checkInByDate.keys()]);
 
   const byDate = new Map<string, ResolvedExerciseCalorieDay>();
+  let { weightKg, heightCm } = latestWeightHeight;
   for (const date of [...dates].sort()) {
+    const checkIn = checkInByDate.get(date);
+    if (Number(checkIn?.weight) > 0) weightKg = Number(checkIn?.weight);
+    if (Number(checkIn?.height) > 0) heightCm = Number(checkIn?.height);
     const split = splitByDate.get(date);
     const activeCalories = Number(split?.active_calories) || 0;
     const loggedCalories = Number(split?.other_calories) || 0;
     const activitySteps = Number(split?.activity_steps) || 0;
 
     const stepCalories = resolveBackgroundStepCalories({
-      totalSteps: stepsByDate.get(date) ?? 0,
+      totalSteps: Number(checkIn?.steps) || 0,
       activitySteps,
-      weightKg: latestWeightHeight.weightKg,
-      heightCm: latestWeightHeight.heightCm,
+      weightKg,
+      heightCm,
     });
 
     const resolved = resolveExerciseCalories(

--- a/SparkyFitnessServer/services/exerciseCalorieRangeService.ts
+++ b/SparkyFitnessServer/services/exerciseCalorieRangeService.ts
@@ -41,6 +41,11 @@ interface CheckInStepsRow {
   height?: number | string | null;
 }
 
+/**
+ * Returns resolved calories for days with exercise or check-ins in the inclusive range.
+ * Weight and height carry forward independently, seeded from the latest prior value
+ * or the earliest later value when no prior measurement exists.
+ */
 export async function getResolvedExerciseCaloriesRange(
   userId: string,
   startDate: string,

--- a/SparkyFitnessServer/tests/dailySummaryRangeService.test.ts
+++ b/SparkyFitnessServer/tests/dailySummaryRangeService.test.ts
@@ -464,3 +464,71 @@ describe('range mechanics', () => {
     }
   });
 });
+
+test('step calories use independently carried measurements for each report date', async () => {
+  vi.mocked(measurementRepository.getLatestWeightHeight).mockResolvedValue({
+    weightKg: 120,
+    heightCm: 200,
+  });
+  vi.mocked(
+    measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
+  ).mockResolvedValue({ weight: '80', height: '180' });
+  vi.mocked(
+    measurementRepository.getCheckInMeasurementsByDateRange
+  ).mockResolvedValue([
+    { entry_date: '2026-08-11', steps: 10000, weight: 0, height: -1 },
+    { entry_date: '2026-08-09', steps: 10000, weight: '100', height: null },
+    { entry_date: '2026-08-08', steps: 10000 },
+    { entry_date: '2026-08-10', steps: 10000, height: '200' },
+  ]);
+  vi.mocked(
+    exerciseEntryRepository.getDailyExerciseCalorieSplitRange
+  ).mockResolvedValue([]);
+
+  const { days } = await getDailySummaryRange({
+    actorUserId: USER,
+    targetUserId: USER,
+    startDate: '2026-08-08',
+    endDate: '2026-08-11',
+    includeCheckin: true,
+  });
+
+  expect(days.map((day) => [day.date, day.stepCalories])).toEqual([
+    ['2026-08-08', 316],
+    ['2026-08-09', 395],
+    ['2026-08-10', 439],
+    ['2026-08-11', 439],
+  ]);
+});
+
+test('uses the earliest later height until dated measurements are available', async () => {
+  vi.mocked(measurementRepository.getLatestWeightHeight).mockResolvedValue({
+    weightKg: 80,
+    heightCm: 200,
+  });
+  vi.mocked(
+    measurementRepository.getLatestCheckInMeasurementsOnOrBeforeDate
+  ).mockResolvedValue({ weight: '80', height: null });
+  vi.mocked(
+    measurementRepository.getCheckInMeasurementsByDateRange
+  ).mockResolvedValue([
+    { entry_date: '2026-08-08', steps: 10000 },
+    { entry_date: '2026-08-09', steps: 10000, height: '200' },
+    { entry_date: '2026-08-10', steps: 10000, weight: '100' },
+  ]);
+  vi.mocked(
+    exerciseEntryRepository.getDailyExerciseCalorieSplitRange
+  ).mockResolvedValue([]);
+
+  const { days } = await runRange();
+
+  expect(days.map((day) => [day.date, day.stepCalories])).toEqual([
+    ['2026-08-08', 351],
+    ['2026-08-09', 351],
+    ['2026-08-10', 439],
+    ['2026-08-11', 0],
+  ]);
+  expect(
+    measurementRepository.getLatestWeightHeight
+  ).toHaveBeenCalledExactlyOnceWith(USER, '2026-08-08');
+});

--- a/SparkyFitnessServer/tests/dashboardService.test.ts
+++ b/SparkyFitnessServer/tests/dashboardService.test.ts
@@ -292,3 +292,23 @@ describe('getDashboardStats calorie arithmetic', () => {
     expect(result.progress).toBe(150);
   });
 });
+
+test('dashboard step calories use weight and height known on the requested date', async () => {
+  vi.mocked(measurementRepository.getLatestWeightHeight).mockImplementation(
+    async (_user, date) =>
+      date === '2026-06-13'
+        ? { weightKg: 80, heightCm: 180 }
+        : { weightKg: 120, heightCm: 200 }
+  );
+  vi.mocked(
+    measurementRepository.getCheckInMeasurementsByDate
+  ).mockResolvedValue({ steps: 10000 });
+
+  const result = await getDashboardStats('user1', '2026-06-13', true);
+
+  expect(result.stepCalories).toBe(316);
+  expect(measurementRepository.getLatestWeightHeight).toHaveBeenCalledWith(
+    'user1',
+    '2026-06-13'
+  );
+});

--- a/SparkyFitnessServer/tests/exerciseCalorieRangeService.test.ts
+++ b/SparkyFitnessServer/tests/exerciseCalorieRangeService.test.ts
@@ -197,3 +197,81 @@ describe('getResolvedExerciseCaloriesTotal', () => {
     expect(total).toBe(1287);
   });
 });
+
+describe('historical step measurements', () => {
+  test('uses the range seed and carries weight and height forward independently', async () => {
+    vi.mocked(
+      exerciseEntryRepository.getDailyExerciseCalorieSplitRange
+    ).mockResolvedValue([]);
+    vi.mocked(measurementRepository.getLatestWeightHeight).mockImplementation(
+      async (_user, date) =>
+        date === '2026-08-08'
+          ? { weightKg: 80, heightCm: 180 }
+          : { weightKg: 120, heightCm: 200 }
+    );
+    vi.mocked(
+      measurementRepository.getCheckInMeasurementsByDateRange
+    ).mockResolvedValue([
+      { entry_date: '2026-08-11', steps: 10000, weight: 0, height: -1 },
+      { entry_date: '2026-08-09', steps: 10000, weight: '100', height: null },
+      { entry_date: '2026-08-08', steps: 10000, weight: null, height: null },
+      { entry_date: '2026-08-10', steps: 10000, height: '200' },
+    ]);
+
+    const days = await getResolvedExerciseCaloriesRange(
+      USER,
+      '2026-08-08',
+      '2026-08-11'
+    );
+
+    expect(
+      [...days.values()].map((day) => [
+        day.date,
+        day.stepCalories,
+        day.calories,
+      ])
+    ).toEqual([
+      ['2026-08-08', 316, 316],
+      ['2026-08-09', 395, 395],
+      ['2026-08-10', 439, 439],
+      ['2026-08-11', 439, 439],
+    ]);
+    expect(
+      measurementRepository.getLatestWeightHeight
+    ).toHaveBeenCalledExactlyOnceWith(USER, '2026-08-08');
+    expect(
+      measurementRepository.getCheckInMeasurementsByDateRange
+    ).toHaveBeenCalledOnce();
+  });
+
+  test('uses the default weight when only height has been recorded', async () => {
+    vi.mocked(
+      exerciseEntryRepository.getDailyExerciseCalorieSplitRange
+    ).mockResolvedValue([]);
+    vi.mocked(measurementRepository.getLatestWeightHeight).mockResolvedValue({
+      weightKg: null,
+      heightCm: 180,
+    });
+    vi.mocked(
+      measurementRepository.getCheckInMeasurementsByDateRange
+    ).mockResolvedValue([
+      { entry_date: '2026-08-08', steps: 10000 },
+      { entry_date: '2026-08-09', height: 200 },
+      { entry_date: '2026-08-10', steps: 10000 },
+    ]);
+
+    const days = await getResolvedExerciseCaloriesRange(
+      USER,
+      '2026-08-08',
+      '2026-08-10'
+    );
+
+    expect(
+      [...days.values()].map((day) => [day.date, day.stepCalories])
+    ).toEqual([
+      ['2026-08-08', 276],
+      ['2026-08-09', 0],
+      ['2026-08-10', 307],
+    ]);
+  });
+});

--- a/SparkyFitnessServer/tests/measurementRepository.test.ts
+++ b/SparkyFitnessServer/tests/measurementRepository.test.ts
@@ -153,3 +153,36 @@ describe('measurementRepository.upsertStepData', () => {
     expect(insert.values).toEqual(['user-1', '2026-07-07', 4252, 'acting-1']);
   });
 });
+
+describe('measurementRepository.getLatestWeightHeight', () => {
+  it('prefers prior measurements and falls back to the earliest later value for each field', async () => {
+    const client = {
+      query: vi
+        .fn()
+        .mockResolvedValue({ rows: [{ weight: '80', height: '180' }] }),
+      release: vi.fn(),
+    };
+    vi.mocked(getClient).mockResolvedValue(client);
+
+    const result = await measurementRepository.getLatestWeightHeight(
+      'user-1',
+      '2026-08-08'
+    );
+
+    expect(result).toEqual({ weightKg: 80, heightCm: 180 });
+    const [sql, params] = client.query.mock.calls[0];
+    expect(params).toEqual(['user-1', '2026-08-08']);
+    for (const field of ['weight', 'height']) {
+      expect(sql).toContain(
+        `WHERE user_id = $1 AND entry_date <= $2 AND ${field} IS NOT NULL AND ${field} > 0`
+      );
+      expect(sql).toContain(
+        `WHERE user_id = $1 AND entry_date > $2 AND ${field} IS NOT NULL AND ${field} > 0`
+      );
+    }
+    expect(sql).toContain('COALESCE((SELECT weight');
+    expect(sql).toContain('COALESCE((SELECT height');
+    expect(sql).toContain('ORDER BY entry_date ASC, updated_at DESC LIMIT 1');
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Historical step-calorie estimates use the latest weight and height, so a new measurement changes older Diary, report, dashboard and tool totals.

**How did you implement the solution?**
Resolve each field from its latest positive measurement on or before the day, falling back to its earliest later measurement when history starts afterwards. Range calculations carry measurements forward independently; existing defaults apply only when that field has no valid measurement.

Linked Issue: None.

## How to Test

1. In `SparkyFitnessServer`, run `pnpm exec vitest run tests/measurementRepository.test.ts tests/exerciseCalorieRangeService.test.ts tests/dailySummaryRangeService.test.ts tests/dashboardService.test.ts`.
2. Run `pnpm run validate` and `pnpm run test:ci`.

The six new regression cases fail against the original code; all 40 focused cases pass with the patch. Full server validation and 4,361 tests pass, with 270 database-dependent cases skipped in the coverage run. A disposable PostgreSQL 18.3 fixture verified all four calculation paths, including later measurements outside the report range, backdated corrections, missing measurements and account isolation. Both migration passes and all 226 RLS/Strava integration cases pass.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. <!-- N/A: bug fix -->

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes. <!-- N/A: server only -->
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. <!-- N/A -->

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. <!-- N/A: no new tables -->

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. <!-- N/A: no UI changes -->

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. <!-- N/A -->

## Screenshots

N/A: server calculation changes only.

## Notes for Reviewers

Historical estimates update when read; no data migration is needed. Adding or correcting historical measurements can change the affected estimates. The fallback applies only to step calories; BMR measurement handling, the active-versus-logged calorie rule and per-date step counts are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved step-calorie calculations for dashboards and date-range summaries by using the weight and height applicable to each requested date.
  - Weight and height measurements are now carried forward independently across historical dates.
  - When measurements are unavailable, calculations use the nearest valid value for each measurement, including later entries when necessary.
  - Exercise calorie estimates now account for measurement changes throughout a date range instead of relying on a single current measurement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->