### PR TITLE
fix: prevent duplicate active calories with family sharing

### DIFF
--- a/SparkyFitnessServer/db/migrations/20260910180000_deduplicate_shared_active_calories.sql
+++ b/SparkyFitnessServer/db/migrations/20260910180000_deduplicate_shared_active_calories.sql
@@ -1,0 +1,55 @@
+-- Daily active calories are cumulative totals, not additive workouts.
+-- Retain the most recently written import, including downward corrections.
+BEGIN;
+
+-- Prevent edits and cascading child inserts while selecting complete groups.
+LOCK TABLE public.exercise_entries IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE public.exercise_entry_activity_details,
+           public.exercise_entry_sets,
+           public.exercise_entry_laps,
+           public.exercise_entry_gps_points,
+           public.exercise_entry_hr_zones IN SHARE MODE;
+
+WITH ranked AS (
+  SELECT e.id,
+         BOOL_OR(x.user_id <> e.user_id) OVER source_group AS shared_group,
+         BOOL_AND(COALESCE(
+           e.created_by_user_id = e.user_id
+           AND (e.updated_by_user_id IS NULL OR e.updated_by_user_id = e.user_id)
+           AND e.entry_date IS NOT NULL
+           AND e.duration_minutes = 0
+           AND e.calories_burned >= 0 AND e.calories_burned < 'Infinity'::numeric
+           AND e.notes IN (
+             'Active calories logged from ' || CASE WHEN e.source = 'HealthKit' THEN 'Apple Health' ELSE e.source END || '.',
+             'Active calories logged from ' || CASE WHEN e.source = 'HealthKit' THEN 'Apple Health' ELSE e.source END || ' (updated).'
+           )
+           -- Extra snapshot fields distinguish edited entries from bare imports.
+           AND jsonb_strip_nulls(to_jsonb(e) - ARRAY[
+             'id', 'user_id', 'exercise_id', 'entry_date', 'duration_minutes',
+             'calories_burned', 'notes', 'created_by_user_id', 'updated_by_user_id',
+             'exercise_name', 'source', 'created_at', 'updated_at', 'sort_order'
+           ]) = '{}'::jsonb
+           AND COALESCE(e.sort_order, 0) = 0
+           AND NOT EXISTS (SELECT 1 FROM public.exercise_entry_activity_details d WHERE d.exercise_entry_id = e.id)
+           AND NOT EXISTS (SELECT 1 FROM public.exercise_entry_sets s WHERE s.exercise_entry_id = e.id)
+           AND NOT EXISTS (SELECT 1 FROM public.exercise_entry_laps l WHERE l.exercise_entry_id = e.id)
+           AND NOT EXISTS (SELECT 1 FROM public.exercise_entry_gps_points g WHERE g.exercise_entry_id = e.id)
+           AND NOT EXISTS (SELECT 1 FROM public.exercise_entry_hr_zones h WHERE h.exercise_entry_id = e.id),
+           false
+         )) OVER source_group AS recognized_group,
+         ROW_NUMBER() OVER (
+           source_group ORDER BY e.updated_at DESC, e.calories_burned DESC,
+                                 (x.user_id = e.user_id) DESC,
+                                 e.created_at, e.id
+         ) AS position
+  FROM public.exercise_entries e
+  JOIN public.exercises x ON x.id = e.exercise_id
+  WHERE e.exercise_name = 'Active Calories'
+    AND e.source IS NOT NULL AND e.source <> ''
+  WINDOW source_group AS (PARTITION BY e.user_id, e.entry_date, e.source)
+)
+DELETE FROM public.exercise_entries e
+USING ranked r
+WHERE e.id = r.id AND r.shared_group AND r.recognized_group AND r.position > 1;
+
+COMMIT;

--- a/SparkyFitnessServer/models/exercise.ts
+++ b/SparkyFitnessServer/models/exercise.ts
@@ -53,9 +53,9 @@ async function getExerciseOwnerId(id: any, userId: any) {
     client.release();
   }
 }
+/** Reuses the user's own active-calorie exercise, independently of library sharing. */
 async function getOrCreateActiveCaloriesExercise(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
+  userId: string,
   source = 'Health Data'
 ) {
   const exerciseName = 'Active Calories';
@@ -63,8 +63,8 @@ async function getOrCreateActiveCaloriesExercise(
   let exercise;
   try {
     const result = await client.query(
-      'SELECT id FROM exercises WHERE name = $1',
-      [exerciseName]
+      'SELECT id FROM exercises WHERE name = $1 AND user_id = $2 ORDER BY created_at, id LIMIT 1',
+      [exerciseName, userId]
     );
     exercise = result.rows[0];
   } catch (error) {

--- a/SparkyFitnessServer/models/exerciseEntry.ts
+++ b/SparkyFitnessServer/models/exerciseEntry.ts
@@ -6,17 +6,16 @@ import format from 'pg-format';
 import { log } from '../config/logging.js';
 import exerciseRepository from './exercise.js';
 import activityDetailsRepository from './activityDetailsRepository.js';
+/**
+ * Updates a daily calorie import, retaining entries created against shared exercises.
+ * A matching exercise takes precedence; legacy matches require the same source.
+ */
 async function upsertExerciseEntryData(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  createdByUserId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  exerciseId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  caloriesBurned: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  date: any,
+  userId: string,
+  createdByUserId: string,
+  exerciseId: string,
+  caloriesBurned: number,
+  date: string,
   source = 'Health Data'
 ) {
   log('info', 'upsertExerciseEntryData received date parameter:', date);
@@ -48,8 +47,15 @@ async function upsertExerciseEntryData(
       );
     }
     const result = await client.query(
-      'SELECT id, calories_burned FROM exercise_entries WHERE user_id = $1 AND exercise_id = $2 AND entry_date = $3',
-      [userId, exerciseId, date]
+      `SELECT id, calories_burned FROM exercise_entries
+       WHERE user_id = $1 AND entry_date = $3
+         AND (exercise_id = $2 OR (
+           $4 = 'Active Calories' AND exercise_name = $4 AND source = $5
+           AND duration_minutes = 0 AND exercise_preset_entry_id IS NULL
+           AND source_id IS NULL
+         ))
+       ORDER BY (exercise_id = $2) DESC, created_at, id LIMIT 1`,
+      [userId, exerciseId, date, exerciseName, sourceValue]
     );
     existingEntry = result.rows[0];
   } catch (error) {
@@ -75,7 +81,7 @@ async function upsertExerciseEntryData(
     const updateClient = await getClient(userId);
     try {
       const updateResult = await updateClient.query(
-        'UPDATE exercise_entries SET calories_burned = $1, notes = $2, updated_by_user_id = $3, exercise_name = $4, source = $5, updated_at = now() WHERE id = $6 RETURNING *',
+        'UPDATE exercise_entries SET calories_burned = $1, notes = $2, updated_by_user_id = $3, exercise_name = $4, source = $5, exercise_id = $7, updated_at = now() WHERE id = $6 RETURNING *',
         [
           caloriesBurned,
           `Active calories logged from ${sourceLabel} (updated).`,
@@ -83,6 +89,7 @@ async function upsertExerciseEntryData(
           exerciseName,
           sourceValue,
           existingEntry.id,
+          exerciseId,
         ]
       );
       result = updateResult.rows[0];

--- a/SparkyFitnessServer/tests/exerciseActiveCalories.test.ts
+++ b/SparkyFitnessServer/tests/exerciseActiveCalories.test.ts
@@ -1,0 +1,60 @@
+import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import exerciseDb from '../models/exercise.js';
+import { getClient } from '../db/poolManager.js';
+import {
+  createMockDbClient,
+  type MockDbClient,
+} from './helpers/mockDbClient.js';
+
+vi.mock('../db/poolManager.js', () => ({
+  getClient: vi.fn(),
+  getSystemClient: vi.fn(),
+}));
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+describe('getOrCreateActiveCaloriesExercise', () => {
+  let client: MockDbClient;
+
+  beforeEach(() => {
+    client = createMockDbClient();
+    vi.mocked(getClient).mockResolvedValue(client);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('selects a stable exercise owned by the importing user', async () => {
+    client.query.mockResolvedValueOnce({ rows: [{ id: 'owned-exercise' }] });
+    expect(
+      await exerciseDb.getOrCreateActiveCaloriesExercise('user-1', 'HealthKit')
+    ).toBe('owned-exercise');
+    const [sql, params] = client.query.mock.calls[0];
+    expect(sql).toContain('name = $1 AND user_id = $2');
+    expect(sql).toContain('ORDER BY created_at, id LIMIT 1');
+    expect(params).toEqual(['Active Calories', 'user-1']);
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(client.release).toHaveBeenCalledOnce();
+  });
+
+  it('creates a private exercise when the user has no copy', async () => {
+    client.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 'new-exercise' }] });
+    expect(
+      await exerciseDb.getOrCreateActiveCaloriesExercise('user-1', 'HealthKit')
+    ).toBe('new-exercise');
+    const [sql, params] = client.query.mock.calls[1];
+    expect(sql).toContain('INSERT INTO exercises');
+    expect(params).toEqual([
+      'user-1',
+      'Active Calories',
+      'Cardio',
+      600,
+      expect.any(String),
+      true,
+      false,
+      'HealthKit',
+      'duration_distance',
+    ]);
+    expect(client.release).toHaveBeenCalledTimes(2);
+  });
+});

--- a/SparkyFitnessServer/tests/rlsPermissionMatrix.integration.test.ts
+++ b/SparkyFitnessServer/tests/rlsPermissionMatrix.integration.test.ts
@@ -32,7 +32,11 @@
  * a database is up.
  */
 import pg from 'pg';
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import exerciseDb from '../models/exercise.js';
+import exerciseEntryDb from '../models/exerciseEntry.js';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
 import { getClient, getSystemClient, endPool } from '../db/poolManager.js';
 
 // Probe the app role RLS actually needs, with a short timeout, using a
@@ -831,6 +835,418 @@ describe.runIf(RUN)('RLS permission matrix', () => {
         touchColumn: 'serving_size',
         rowId: () => variantId,
       });
+    });
+  });
+});
+
+describe.runIf(RUN)('Active calorie imports with shared exercises', () => {
+  const users = [
+    '00000000-0000-4000-b300-000000000001',
+    '00000000-0000-4000-b300-000000000002',
+  ];
+  let sys: pg.PoolClient;
+
+  beforeAll(async () => {
+    sys = await getSystemClient();
+    for (const id of users) {
+      await sys.query(
+        'INSERT INTO public."user" (id, email, email_verified) VALUES ($1, $2, true)',
+        [id, `active-calories-${id}@example.test`]
+      );
+    }
+  });
+
+  beforeEach(async () => {
+    await sys.query(
+      'DELETE FROM exercise_entries WHERE user_id = ANY($1::uuid[])',
+      [users]
+    );
+    await sys.query(
+      'DELETE FROM exercise_preset_entries WHERE user_id = ANY($1::uuid[])',
+      [users]
+    );
+    await sys.query('DELETE FROM exercises WHERE user_id = ANY($1::uuid[])', [
+      users,
+    ]);
+    await sys.query('DELETE FROM family_access WHERE owner_user_id = $1', [
+      users[0],
+    ]);
+  });
+
+  afterAll(async () => {
+    try {
+      await sys.query(
+        'DELETE FROM exercise_entries WHERE user_id = ANY($1::uuid[])',
+        [users]
+      );
+      await sys.query('DELETE FROM exercises WHERE user_id = ANY($1::uuid[])', [
+        users,
+      ]);
+      await sys.query('DELETE FROM public."user" WHERE id = ANY($1::uuid[])', [
+        users,
+      ]);
+    } finally {
+      sys.release();
+      await endPool();
+    }
+  });
+
+  /** Imports the same daily HealthKit total through the production repositories. */
+  async function sync(calories: number) {
+    const exerciseId = await exerciseDb.getOrCreateActiveCaloriesExercise(
+      users[1],
+      'HealthKit'
+    );
+    return exerciseEntryDb.upsertExerciseEntryData(
+      users[1],
+      users[1],
+      exerciseId,
+      calories,
+      '2026-09-10',
+      'HealthKit'
+    );
+  }
+
+  it.each(['family', 'public'])(
+    'keeps one owned entry when %s sharing changes',
+    async (sharing) => {
+      await sys.query('DELETE FROM exercises WHERE user_id = ANY($1::uuid[])', [
+        users,
+      ]);
+      const sharedId = await exerciseDb.getOrCreateActiveCaloriesExercise(
+        users[0],
+        'HealthKit'
+      );
+      if (sharing === 'public') {
+        await sys.query(
+          'UPDATE exercises SET shared_with_public = true WHERE id = $1',
+          [sharedId]
+        );
+      } else {
+        await sys.query(
+          `INSERT INTO family_access (owner_user_id, family_user_id, family_email, access_permissions, is_active, status)
+         VALUES ($1, $2, $3, '{"can_view_exercise_library":true}', true, 'active')`,
+          [users[0], users[1], `active-calories-${users[1]}@example.test`]
+        );
+      }
+      expect((await exerciseDb.getExerciseById(sharedId, users[1])).id).toBe(
+        sharedId
+      );
+      const first = await sync(300);
+      const firstExercise = await exerciseDb.getExerciseById(
+        first.exercise_id,
+        users[1]
+      );
+      await sys.query(
+        'UPDATE family_access SET is_active = false WHERE owner_user_id = $1',
+        [users[0]]
+      );
+      await sys.query(
+        'UPDATE exercises SET shared_with_public = false WHERE id = $1',
+        [sharedId]
+      );
+      const second = await sync(350);
+      const rows = await sys.query(
+        `SELECT ee.id, ee.calories_burned, e.user_id AS exercise_owner
+       FROM exercise_entries ee JOIN exercises e ON e.id = ee.exercise_id
+       WHERE ee.user_id = $1`,
+        [users[1]]
+      );
+      expect(second.id).toBe(first.id);
+      expect(firstExercise.user_id).toBe(users[1]);
+      expect(rows.rows).toEqual([
+        { id: first.id, calories_burned: 350, exercise_owner: users[1] },
+      ]);
+    }
+  );
+
+  it('reuses an old import after its shared exercise becomes inaccessible', async () => {
+    const sharedId = await exerciseDb.getOrCreateActiveCaloriesExercise(
+      users[0],
+      'HealthKit'
+    );
+    const oldId = randomUUID();
+    await sys.query(
+      `INSERT INTO exercise_entries (id, user_id, exercise_id, entry_date, calories_burned, duration_minutes, exercise_name, source)
+       VALUES ($1, $2, $3, '2026-09-10', 300, 0, 'Active Calories', 'HealthKit')`,
+      [oldId, users[1], sharedId]
+    );
+    expect(
+      await exerciseDb.getExerciseById(sharedId, users[1])
+    ).toBeUndefined();
+    const updated = await sync(350);
+    const repeated = await sync(400);
+    expect(updated.id).toBe(oldId);
+    expect(repeated.id).toBe(oldId);
+    expect(repeated.exercise_id).not.toBe(sharedId);
+    expect(repeated.calories_burned).toBe(400);
+    expect(repeated.updated_by_user_id).toBe(users[1]);
+    expect(repeated.notes).toBe(
+      'Active calories logged from Apple Health (updated).'
+    );
+    const rows = await sys.query(
+      'SELECT id FROM exercise_entries WHERE user_id = $1',
+      [users[1]]
+    );
+    expect(rows.rows).toEqual([{ id: oldId }]);
+  });
+
+  it('updates the exact exercise match without altering an existing legacy duplicate', async () => {
+    const sharedId = await exerciseDb.getOrCreateActiveCaloriesExercise(
+      users[0],
+      'HealthKit'
+    );
+    const ownedId = await exerciseDb.getOrCreateActiveCaloriesExercise(
+      users[1],
+      'HealthKit'
+    );
+    const legacyId = randomUUID();
+    const exactId = randomUUID();
+    await sys.query(
+      `INSERT INTO exercise_entries (id, user_id, exercise_id, entry_date, calories_burned, duration_minutes, exercise_name, source, created_at)
+       VALUES ($1, $3, $4, '2026-09-10', 100, 0, 'Active Calories', 'HealthKit', '2026-09-09'),
+              ($2, $3, $5, '2026-09-10', 200, 0, 'Active Calories', 'HealthKit', '2026-09-10')`,
+      [legacyId, exactId, users[1], sharedId, ownedId]
+    );
+    const before = await sys.query(
+      'SELECT * FROM exercise_entries WHERE id = $1',
+      [legacyId]
+    );
+    const updated = await sync(350);
+    expect(updated.id).toBe(exactId);
+    expect(updated.calories_burned).toBe(350);
+    const after = await sys.query(
+      'SELECT * FROM exercise_entries WHERE id = $1',
+      [legacyId]
+    );
+    expect(after.rows).toEqual(before.rows);
+  });
+
+  it.each([
+    ['another user', { otherUser: true }],
+    ['another source', { source: 'Health Connect' }],
+    ['another date', { date: '2026-09-09' }],
+    ['a workout', { duration: 30 }],
+    ['a preset exercise', { preset: true }],
+    ['a provider activity', { sourceId: 'activity-1' }],
+    ['another exercise name', { name: 'Running' }],
+  ])('preserves %s when finding a legacy import', async (_label, change) => {
+    const sharedId = await exerciseDb.getOrCreateActiveCaloriesExercise(
+      users[0],
+      'HealthKit'
+    );
+    const untouchedId = randomUUID();
+    const values = {
+      otherUser: false,
+      preset: false,
+      source: 'HealthKit',
+      date: '2026-09-10',
+      duration: 0,
+      sourceId: null,
+      name: 'Active Calories',
+      ...change,
+    };
+    const presetId = values.preset ? randomUUID() : null;
+    if (presetId) {
+      await sys.query(
+        "INSERT INTO exercise_preset_entries (id, user_id, name, entry_date) VALUES ($1, $2, 'Active calorie fixture', '2026-09-10')",
+        [presetId, users[1]]
+      );
+    }
+    await sys.query(
+      `INSERT INTO exercise_entries (id, user_id, exercise_id, entry_date, calories_burned, duration_minutes, exercise_name, source, source_id, exercise_preset_entry_id)
+       VALUES ($1, $2, $3, $4, 123, $5, $6, $7, $8, $9)`,
+      [
+        untouchedId,
+        values.otherUser ? users[0] : users[1],
+        sharedId,
+        values.date,
+        values.duration,
+        values.name,
+        values.source,
+        values.sourceId,
+        presetId,
+      ]
+    );
+    const before = await sys.query(
+      'SELECT * FROM exercise_entries WHERE id = $1',
+      [untouchedId]
+    );
+    const imported = await sync(350);
+    expect(imported.id).not.toBe(untouchedId);
+    const after = await sys.query(
+      'SELECT * FROM exercise_entries WHERE id = $1',
+      [untouchedId]
+    );
+    expect(after.rows).toEqual(before.rows);
+  });
+
+  // This migration is unscoped; namespaced fixture IDs alone cannot protect a normal DB.
+  describe.runIf(
+    /(^|[_-])test([_-]|$)/i.test(process.env.SPARKY_FITNESS_DB_NAME ?? '')
+  )('historical cleanup', () => {
+    const migration = readFileSync(
+      new URL(
+        '../db/migrations/20260910180000_deduplicate_shared_active_calories.sql',
+        import.meta.url
+      ),
+      'utf8'
+    );
+    let legacyId: string;
+    let ownedId: string;
+
+    beforeEach(async () => {
+      const sharedExercise = await exerciseDb.getOrCreateActiveCaloriesExercise(
+        users[0],
+        'HealthKit'
+      );
+      const owned = await sync(300);
+      ownedId = owned.id;
+      legacyId = randomUUID();
+      await sys.query(
+        `INSERT INTO exercise_entries (id, user_id, exercise_id, entry_date, calories_burned, duration_minutes, notes, created_by_user_id, exercise_name, source)
+         VALUES ($1, $2, $3, '2026-09-10', 350, 0, 'Active calories logged from Apple Health.', $2, 'Active Calories', 'HealthKit')`,
+        [legacyId, users[1], sharedExercise]
+      );
+    });
+
+    /** Reads complete fixture rows so preservation checks include all metadata. */
+    async function entries() {
+      return (
+        await sys.query(
+          'SELECT * FROM exercise_entries WHERE user_id = ANY($1::uuid[]) ORDER BY id',
+          [users]
+        )
+      ).rows;
+    }
+
+    it.each([
+      ['a newer shared import', 400, '2026-09-09', '2026-09-10', false],
+      ['a newer lower owned import', 250, '2026-09-11', '2026-09-10', true],
+      [
+        'the higher total on tied timestamps',
+        300,
+        '2026-09-10',
+        '2026-09-10',
+        false,
+      ],
+      [
+        'the owned exercise on tied timestamps and totals',
+        350,
+        '2026-09-10',
+        '2026-09-10',
+        true,
+      ],
+    ] as const)(
+      'keeps %s',
+      async (_label, calories, ownedUpdated, legacyUpdated, keepOwned) => {
+        await sys.query(
+          'UPDATE exercise_entries SET calories_burned = $1, updated_at = $2 WHERE id = $3',
+          [calories, ownedUpdated, ownedId]
+        );
+        await sys.query(
+          'UPDATE exercise_entries SET updated_at = $1 WHERE id = $2',
+          [legacyUpdated, legacyId]
+        );
+        const before = await entries();
+        const survivor = before.find(
+          (row) => row.id === (keepOwned ? ownedId : legacyId)
+        );
+        await sys.query(migration);
+        expect(await entries()).toEqual([survivor]);
+        await sys.query(migration);
+        expect(await entries()).toEqual([survivor]);
+        const corrected = await sync(200);
+        expect(corrected.id).toBe(survivor.id);
+        expect(corrected.calories_burned).toBe(200);
+        expect((await entries()).map((row) => row.id)).toEqual([survivor.id]);
+      }
+    );
+
+    it.each([
+      ['manual notes', "notes = 'Evening walk'"],
+      ['missing creator', 'created_by_user_id = NULL'],
+      ['different creator', 'created_by_user_id = $2'],
+      ['different editor', 'updated_by_user_id = $2'],
+      ['workout duration', 'duration_minutes = 30'],
+      ['provider identity', "source_id = 'activity-1'"],
+      ['entry time', "entry_time = '12:00'"],
+      ['snapshot metadata', "image_url = 'https://example.test/workout.png'"],
+      ['telemetry', 'steps = 100'],
+      ['sort order', 'sort_order = 2'],
+      ['negative calories', 'calories_burned = -1'],
+      ['nonfinite calories', "calories_burned = 'NaN'::numeric"],
+      ['infinite calories', "calories_burned = 'Infinity'::numeric"],
+      ['another date', "entry_date = '2026-09-09'"],
+      [
+        'another source',
+        "source = 'Health Connect', notes = 'Active calories logged from Health Connect.'",
+      ],
+      ['another user', 'user_id = $2, created_by_user_id = $2'],
+    ])('preserves groups containing %s', async (_label, change) => {
+      await sys.query(
+        `UPDATE exercise_entries SET ${change} WHERE id = $1`,
+        change.includes('$2') ? [legacyId, users[0]] : [legacyId]
+      );
+      const before = await entries();
+      await sys.query(migration);
+      expect(await entries()).toEqual(before);
+    });
+
+    it.each([
+      [
+        'activity_details',
+        "INSERT INTO exercise_entry_activity_details (exercise_entry_id, provider_name, detail_type, detail_data) VALUES ($1, 'HealthKit', 'workout', '{}')",
+      ],
+      [
+        'sets',
+        'INSERT INTO exercise_entry_sets (exercise_entry_id, set_number) VALUES ($1, 1)',
+      ],
+      [
+        'laps',
+        "INSERT INTO exercise_entry_laps (exercise_entry_id, user_id, entry_date, lap_index, start_time, end_time, duration_seconds) VALUES ($1, $2, '2026-09-10', 1, now(), now(), 0)",
+      ],
+      [
+        'gps_points',
+        "INSERT INTO exercise_entry_gps_points (exercise_entry_id, user_id, entry_date) VALUES ($1, $2, '2026-09-10')",
+      ],
+      [
+        'hr_zones',
+        "INSERT INTO exercise_entry_hr_zones (exercise_entry_id, user_id, entry_date, zone_index, seconds_in_zone) VALUES ($1, $2, '2026-09-10', 1, 60)",
+      ],
+    ])(
+      'preserves attached %s even when its owner differs',
+      async (table, insert) => {
+        await sys.query(
+          insert,
+          insert.includes('$2') ? [ownedId, users[0]] : [ownedId]
+        );
+        const before = await entries();
+        const children = await sys.query(
+          `SELECT * FROM exercise_entry_${table} WHERE exercise_entry_id = $1`,
+          [ownedId]
+        );
+        await sys.query(migration);
+        expect(await entries()).toEqual(before);
+        expect(
+          (
+            await sys.query(
+              `SELECT * FROM exercise_entry_${table} WHERE exercise_entry_id = $1`,
+              [ownedId]
+            )
+          ).rows
+        ).toEqual(children.rows);
+      }
+    );
+
+    it('preserves duplicates without evidence of a shared exercise', async () => {
+      await sys.query(
+        'UPDATE exercise_entries SET exercise_id = (SELECT exercise_id FROM exercise_entries WHERE id = $1) WHERE id = $2',
+        [ownedId, legacyId]
+      );
+      const before = await entries();
+      await sys.query(migration);
+      expect(await entries()).toEqual(before);
     });
   });
 });


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
With exercise-library access enabled through Family & Friends Sharing, an Apple Health import can select a family member's Active Calories exercise instead of the importing user's own exercise. If a later sync selects a different exercise ID for the same day, the existing-entry lookup misses the previous import and inserts another row. Both rows belong to the importing user, but their cumulative totals are added together, inflating the day's active calories.

**How did you implement the solution?**
Keep the daily import tied to the importing user's own exercise regardless of family-library visibility, and reuse same-day, same-source legacy imports linked to another exercise. A migration removes recognized duplicate daily imports caused by shared definitions, retaining the most recently updated import. It leaves groups with manual edits, unknown metadata or attached workout data unchanged.

Linked Issue: None.

## How to Test

1. Run the server validation and test suite. The existing migration checks also run the new cases in `rlsPermissionMatrix.integration.test.ts` against PostgreSQL.
2. In Family & Friends Sharing, grant a second user View Exercise Library access to a user with an Active Calories exercise. Import 300 HealthKit calories for the second user, revoke that access, and import 350 for the same day. Verify one entry remains with 350 calories and an exercise owned by the second user. Native tests also cover public exercise sharing, which exposes the same lookup defect.
3. Seed bare autogenerated HealthKit entries for the same person and day: 300 calories using an owned exercise and a newer 350-calorie import using a shared exercise. Apply the migration and verify only the 350-calorie row remains, with its original ID and metadata. Repeat the migration to verify idempotence.
4. Sync a corrected total of 250 for that day. Verify the remaining row is updated to 250. Also verify a newer 250-calorie duplicate takes precedence over an older 350-calorie duplicate during migration. Native tests also check user/date/source boundaries and preservation of manual metadata and all five attached-data tables.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

Not applicable.

## Notes for Reviewers

The survivor uses `updated_at`, which records the last write to Sparky, not source measurement time. Equal timestamps prefer the higher cumulative total, then an owned exercise and stable creation time/ID. A later sync can still correct the retained value downward. Cleanup requires a foreign-owned exercise definition in the group and recognized autogenerated entries throughout; unknown groups remain unchanged. No new tables or RLS policy changes. Source selection for an existing exact-exercise match is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Active Calories imports now consistently reuse the importing user’s own exercise, improving data isolation and privacy.
  * Syncing correctly updates the intended exercise entry while preserving relevant historical records and metadata.
  * Fixed handling of legacy Active Calories entries and scenarios where shared exercises become inaccessible.
  * Removed duplicate shared Active Calories entries while retaining the most relevant record and associated details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->