### PR TITLE
fix(polar): anchor hypnogram stages in the recording zone and stop them at wake time

### DIFF
--- a/SparkyFitnessServer/integrations/polar/polarDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/polar/polarDataProcessor.ts
@@ -531,7 +531,10 @@ async function processPolarSleep(
           else if (stageCode === 4) stageType = 'deep';
           else if (stageCode === 6) stageType = 'awake'; // 6 is short interruption
           // Note: Stage 5 (Unknown) falls through to "light" sleep per review suggestion
-          const stageStartMs = current.startMs;
+          // Keys carry minute precision while bedtime carries seconds, so the
+          // first stage may read a few seconds early; the session starts at
+          // bedtime.
+          const stageStartMs = Math.max(current.startMs, bedtimeMs);
           const nextStartMs =
             i < sortedStages.length - 1 ? sortedStages[i + 1].startMs : wakeMs;
           const stageEndMs = Number.isFinite(wakeMs)

--- a/SparkyFitnessServer/integrations/polar/polarDataProcessor.ts
+++ b/SparkyFitnessServer/integrations/polar/polarDataProcessor.ts
@@ -41,6 +41,33 @@ const parsePolarToUTC = (timeStr: any) => {
   return new Date(timeStr).toISOString();
 };
 /**
+ * Resolve a hypnogram wall-clock key ("HH:MM", recording zone) to a UTC instant.
+ *
+ * The key is placed on the calendar day of `anchorMs` (the bedtime) as seen in
+ * the recording zone; when that lands before the anchor (minute granularity,
+ * the first key equals the sleep-start minute while bedtime carries seconds)
+ * the stage belongs to the next day. Nothing here consults the process zone.
+ */
+export const hypnogramStageStartMs = (
+  hhmm: string,
+  anchorMs: number,
+  utcOffsetMinutes: number
+): number => {
+  const [hours, minutes] = hhmm.split(':').map(Number);
+  const offsetMs = utcOffsetMinutes * 60_000;
+  const shifted = new Date(anchorMs + offsetMs);
+  const dayStartUtc = Date.UTC(
+    shifted.getUTCFullYear(),
+    shifted.getUTCMonth(),
+    shifted.getUTCDate()
+  );
+  let stageMs = dayStartUtc + (hours * 60 + minutes) * 60_000 - offsetMs;
+  const anchorMinuteMs = anchorMs - (anchorMs % 60_000);
+  if (stageMs < anchorMinuteMs) stageMs += 24 * 60 * 60_000;
+  return stageMs;
+};
+
+/**
  * Maps Polar exercise types/names to SparkyFitness exercise entries.
  */
 
@@ -469,53 +496,58 @@ async function processPolarSleep(
         const stagesArray = Array.isArray(hypnogram)
           ? hypnogram
           : Object.entries(hypnogram).map(([time, value]) => ({ time, value }));
-        const sortedStages = stagesArray.sort((a, b) =>
-          a.time.localeCompare(b.time)
-        );
+        // Hypnogram keys are wall-clock HH:MM in the recording zone (the
+        // ±HH:MM suffix of sleep-start-time). Resolve each key against the
+        // bedtime in that zone (a key that reads earlier than bedtime belongs
+        // to the next day) and order the stages by the resolved instant: a
+        // string sort put the post-midnight stages before the evening ones,
+        // and reading the anchor with getHours()/setHours() tied the result to
+        // the process time zone. Both stretched "awake" far past the night
+        // (issue #2431). The last stage ends at the recorded wake time, and no
+        // stage runs past it.
+        const bedtimeMs = new Date(
+          parsePolarToUTC(startTime) as string
+        ).getTime();
+        const wakeMs = endTime
+          ? new Date(parsePolarToUTC(endTime) as string).getTime()
+          : Number.NaN;
+        const offsetMinutes = recordUtcOffsetMinutes ?? 0;
+        const sortedStages = stagesArray
+          .map((stage) => ({
+            value: stage.value,
+            startMs: hypnogramStageStartMs(
+              stage.time,
+              bedtimeMs,
+              offsetMinutes
+            ),
+          }))
+          .sort((a, b) => a.startMs - b.startMs);
         for (let i = 0; i < sortedStages.length; i++) {
           const current = sortedStages[i];
           const stageCode = current.value;
-          const timeStr = current.time;
           let stageType = 'light';
           if (stageCode === 0) stageType = 'awake';
           else if (stageCode === 1) stageType = 'rem';
           else if (stageCode === 4) stageType = 'deep';
           else if (stageCode === 6) stageType = 'awake'; // 6 is short interruption
           // Note: Stage 5 (Unknown) falls through to "light" sleep per review suggestion
-          // Construct start time for this stage
-          // @ts-expect-error TS(2769): No overload matches this call.
-          const stageStartTimeUTC = new Date(parsePolarToUTC(startTime));
-          const [hours, minutes] = timeStr.split(':').map(Number);
-          const startHours = stageStartTimeUTC.getHours();
-          if (hours < startHours) {
-            stageStartTimeUTC.setDate(stageStartTimeUTC.getDate() + 1);
-          }
-          stageStartTimeUTC.setHours(hours, minutes, 0, 0);
-          let durationSec = 0;
-          if (i < sortedStages.length - 1) {
-            const nextTimeStr = sortedStages[i + 1].time;
-            const nextDate = new Date(stageStartTimeUTC);
-            const [nH, nM] = nextTimeStr.split(':').map(Number);
-            if (nH < hours) nextDate.setDate(nextDate.getDate() + 1);
-            nextDate.setHours(nH, nM, 0, 0);
-            // @ts-expect-error TS(2362): The left-hand side of an arithmetic operation must... Remove this comment to see the full error message
-            durationSec = Math.round((nextDate - stageStartTimeUTC) / 1000);
-          } else {
-            // @ts-expect-error TS(2769): No overload matches this call.
-            const endDateUTC = new Date(parsePolarToUTC(endTime));
-            // @ts-expect-error TS(2362): The left-hand side of an arithmetic operation must... Remove this comment to see the full error message
-            durationSec = Math.round((endDateUTC - stageStartTimeUTC) / 1000);
-          }
+          const stageStartMs = current.startMs;
+          const nextStartMs =
+            i < sortedStages.length - 1 ? sortedStages[i + 1].startMs : wakeMs;
+          const stageEndMs = Number.isFinite(wakeMs)
+            ? Math.min(nextStartMs, wakeMs)
+            : nextStartMs;
+          const durationSec = Number.isFinite(stageEndMs)
+            ? Math.round((stageEndMs - stageStartMs) / 1000)
+            : 0;
           if (durationSec > 0) {
             await sleepRepository.upsertSleepStageEvent(
               userId,
               entry.id,
               {
                 stage_type: stageType,
-                start_time: stageStartTimeUTC.toISOString(),
-                end_time: new Date(
-                  stageStartTimeUTC.getTime() + durationSec * 1000
-                ).toISOString(),
+                start_time: new Date(stageStartMs).toISOString(),
+                end_time: new Date(stageEndMs).toISOString(),
                 duration_in_seconds: durationSec,
               },
               createdByUserId

--- a/SparkyFitnessServer/tests/polarDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/polarDataProcessor.test.ts
@@ -146,9 +146,9 @@ describe('processPolarSleep hypnogram stages (issue #2431)', () => {
     expect(stageCalls()).toEqual([
       {
         stage_type: 'awake',
-        start_time: '2026-07-14T20:39:00.000Z',
+        start_time: '2026-07-14T20:39:07.000Z',
         end_time: '2026-07-14T20:50:00.000Z',
-        duration_in_seconds: 660,
+        duration_in_seconds: 653,
       },
       {
         stage_type: 'deep',
@@ -177,7 +177,7 @@ describe('processPolarSleep hypnogram stages (issue #2431)', () => {
     const total = stages.reduce((sum, s) => sum + s.duration_in_seconds, 0);
     const nightSeconds =
       (Date.parse('2026-07-15T07:00:00+03:00') -
-        Date.parse('2026-07-14T23:39:00+03:00')) /
+        Date.parse('2026-07-14T23:39:07+03:00')) /
       1000;
     expect(total).toBe(nightSeconds);
     expect(stages.at(-1)?.end_time).toBe('2026-07-15T04:00:00.000Z');
@@ -206,7 +206,7 @@ describe('processPolarSleep hypnogram stages (issue #2431)', () => {
       } as never,
     ]);
     expect(stageCalls().map((s) => [s.stage_type, s.start_time])).toEqual([
-      ['awake', '2026-07-14T20:39:00.000Z'],
+      ['awake', '2026-07-14T20:39:07.000Z'],
       ['deep', '2026-07-14T20:50:00.000Z'],
       ['rem', '2026-07-14T23:10:00.000Z'],
       ['awake', '2026-07-15T03:40:00.000Z'],

--- a/SparkyFitnessServer/tests/polarDataProcessor.test.ts
+++ b/SparkyFitnessServer/tests/polarDataProcessor.test.ts
@@ -3,6 +3,7 @@ import exerciseRepository from '../models/exercise.js';
 import exerciseEntryRepository from '../models/exerciseEntry.js';
 import sleepRepository from '../models/sleepRepository.js';
 import {
+  hypnogramStageStartMs,
   processPolarExercises,
   processPolarSleep,
 } from '../integrations/polar/polarDataProcessor.js';
@@ -103,5 +104,143 @@ describe('processPolarSleep recording-zone stamp (issue #2033)', () => {
     await processPolarSleep(UID, CID, [night('2026-07-14T23:39:07')]);
     const entry = vi.mocked(sleepRepository.upsertSleepEntry).mock.calls[0][2];
     expect(entry.record_utc_offset_minutes).toBeUndefined();
+  });
+});
+
+describe('processPolarSleep hypnogram stages (issue #2431)', () => {
+  // A night recorded at UTC+03:00: bedtime 23:39:07, wake 07:00 local, with the
+  // hypnogram keyed by wall-clock HH:MM in that zone. Expected instants are in
+  // UTC and must not depend on the zone this test process runs in.
+  const night = {
+    date: '2026-07-15',
+    'sleep-start-time': '2026-07-14T23:39:07+03:00',
+    'sleep-end-time': '2026-07-15T07:00:00+03:00',
+    'light-sleep': 15000,
+    'deep-sleep': 6000,
+    'rem-sleep': 6000,
+    'total-interruption-duration': 1800,
+    'sleep-score': 80,
+    hypnogram: { '23:39': 0, '23:50': 4, '02:10': 1, '06:40': 0 },
+  } as never;
+
+  const stageCalls = () =>
+    vi.mocked(sleepRepository.upsertSleepStageEvent).mock.calls.map(
+      (call) =>
+        call[2] as {
+          stage_type: string;
+          start_time: string;
+          end_time: string;
+          duration_in_seconds: number;
+        }
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(sleepRepository.upsertSleepEntry).mockResolvedValue({
+      id: 'sleep-1',
+    });
+  });
+
+  it('anchors every stage in the recording zone and ends the last one at wake time', async () => {
+    await processPolarSleep(UID, CID, [night]);
+    expect(stageCalls()).toEqual([
+      {
+        stage_type: 'awake',
+        start_time: '2026-07-14T20:39:00.000Z',
+        end_time: '2026-07-14T20:50:00.000Z',
+        duration_in_seconds: 660,
+      },
+      {
+        stage_type: 'deep',
+        start_time: '2026-07-14T20:50:00.000Z',
+        end_time: '2026-07-14T23:10:00.000Z',
+        duration_in_seconds: 8400,
+      },
+      {
+        stage_type: 'rem',
+        start_time: '2026-07-14T23:10:00.000Z',
+        end_time: '2026-07-15T03:40:00.000Z',
+        duration_in_seconds: 16200,
+      },
+      {
+        stage_type: 'awake',
+        start_time: '2026-07-15T03:40:00.000Z',
+        end_time: '2026-07-15T04:00:00.000Z',
+        duration_in_seconds: 1200,
+      },
+    ]);
+  });
+
+  it('keeps the stage total inside the recorded night', async () => {
+    await processPolarSleep(UID, CID, [night]);
+    const stages = stageCalls();
+    const total = stages.reduce((sum, s) => sum + s.duration_in_seconds, 0);
+    const nightSeconds =
+      (Date.parse('2026-07-15T07:00:00+03:00') -
+        Date.parse('2026-07-14T23:39:00+03:00')) /
+      1000;
+    expect(total).toBe(nightSeconds);
+    expect(stages.at(-1)?.end_time).toBe('2026-07-15T04:00:00.000Z');
+  });
+
+  it('clamps stages to the wake time and drops one that starts after it', async () => {
+    await processPolarSleep(UID, CID, [
+      { ...(night as object), hypnogram: { '23:39': 4, '07:30': 0 } } as never,
+    ]);
+    const stages = stageCalls();
+    expect(stages.map((s) => s.stage_type)).toEqual(['deep']);
+    expect(stages[0].end_time).toBe('2026-07-15T04:00:00.000Z');
+  });
+
+  it('orders stages by instant, not by clock string, across midnight', async () => {
+    // Keys handed over in a scrambled order: the night is 23:39 → 23:50 → 02:10 → 06:40.
+    await processPolarSleep(UID, CID, [
+      {
+        ...(night as object),
+        hypnogram: [
+          { time: '06:40', value: 0 },
+          { time: '23:50', value: 4 },
+          { time: '02:10', value: 1 },
+          { time: '23:39', value: 0 },
+        ],
+      } as never,
+    ]);
+    expect(stageCalls().map((s) => [s.stage_type, s.start_time])).toEqual([
+      ['awake', '2026-07-14T20:39:00.000Z'],
+      ['deep', '2026-07-14T20:50:00.000Z'],
+      ['rem', '2026-07-14T23:10:00.000Z'],
+      ['awake', '2026-07-15T03:40:00.000Z'],
+    ]);
+  });
+});
+
+describe('hypnogramStageStartMs', () => {
+  const bedtime = Date.parse('2026-07-14T23:39:07+03:00');
+
+  it('places a key on the anchor day in the recording zone', () => {
+    expect(hypnogramStageStartMs('23:39', bedtime, 180)).toBe(
+      Date.parse('2026-07-14T23:39:00+03:00')
+    );
+  });
+
+  it('rolls a key that reads earlier than the anchor onto the next day', () => {
+    expect(hypnogramStageStartMs('00:05', bedtime, 180)).toBe(
+      Date.parse('2026-07-15T00:05:00+03:00')
+    );
+    expect(hypnogramStageStartMs('06:40', bedtime, 180)).toBe(
+      Date.parse('2026-07-15T06:40:00+03:00')
+    );
+  });
+
+  it('works for a negative offset and for a naive (UTC) record', () => {
+    const west = Date.parse('2026-07-14T22:30:00-05:00');
+    expect(hypnogramStageStartMs('22:30', west, -300)).toBe(west);
+    expect(hypnogramStageStartMs('06:10', west, -300)).toBe(
+      Date.parse('2026-07-15T06:10:00-05:00')
+    );
+    const naive = Date.parse('2026-07-14T21:00:00Z');
+    expect(hypnogramStageStartMs('03:15', naive, 0)).toBe(
+      Date.parse('2026-07-15T03:15:00Z')
+    );
   });
 });


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
Polar sleep imports produced hypnograms with 16 to 33 hours of "Awake" after the night and stage totals far above the session length (#2431).

**How did you implement the solution?**
Polar hypnogram keys are wall-clock `HH:MM` in the recording zone. The processor sorted them as strings, which put the post-midnight stages before the evening ones, and turned each key into an instant with `getHours()`/`setHours()` on the bedtime, which ties the result to the server's time zone. Stages landed hours or a whole day off, and the final awake segment stretched to the wrong day. The processor now resolves every key against the bedtime in the recording zone (the `±HH:MM` suffix that #2033 already extracts; an earlier clock reading belongs to the next day), orders stages by the resolved instant, ends the last stage at the recorded wake time, and never lets a stage run past it. The small resolver `hypnogramStageStartMs` is exported for the unit tests. No schema or frontend change.

Linked Issue: Closes #2431

## How to Test

1. Check out this branch and run `pnpm test -- tests/polarDataProcessor.test.ts` in `SparkyFitnessServer/` (10 tests, 4 of them new: full-night stage layout in UTC+03:00, stage total equals the night length, clamping to wake time, scrambled key order across midnight; plus resolver tests for positive, negative and naive offsets).
2. Connect Polar Flow, sync a night that crosses midnight, and open Reports → Sleep Analytics → Nightly Details.
3. Verify that the hypnogram ends at the recorded wake time, that the last Awake block is a few minutes long rather than many hours, and that Awake + REM + Light + Deep add up to the session duration.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. (No new tables.)

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: N/A (bug fix)

Backend checks run locally in `SparkyFitnessServer/`: `pnpm test` for the Polar file, `pnpm run typecheck`, `eslint --max-warnings 0` and `prettier --check` on the two changed files: all clean.

<!-- restored-checklist -->
---
## ✅ Required Checklist (restored automatically)

> The mandatory checklist from our PR template is missing from this description, so it
> has been added back below. **Please tick each box and do not delete this section** —
> these checked boxes are how we record your agreement. Edit the description in place;
> no new commit is needed.

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Polar sleep-stage timelines when recordings cross midnight or use non-UTC time zones.
  - Sleep stages are now ordered by their actual recorded time rather than clock labels alone.
  - The first stage now starts at the recorded bedtime, avoiding minute-rounding discrepancies.
  - Stage durations are prevented from extending beyond the recorded wake time.
  - The final sleep stage now ends precisely at the recorded wake time, improving hypnogram accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
