### PR TITLE
fix(mobile): respect 24-hour time format in time pickers and displays

### DIFF
--- a/SparkyFitnessMobile/__tests__/components/CaffeineCard.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/CaffeineCard.test.tsx
@@ -51,6 +51,12 @@ jest.mock('victory-native', () => {
   };
 });
 
+let mockPreferences = { time_format: 'HH:mm' };
+
+jest.mock('../../src/hooks/usePreferences', () => ({
+  usePreferences: () => ({ preferences: mockPreferences }),
+}));
+
 const NOW = new Date('2026-09-05T14:00:00.000Z').getTime();
 
 const baseKinetics: CaffeineActiveResponse = {
@@ -76,6 +82,10 @@ const baseKinetics: CaffeineActiveResponse = {
 };
 
 describe('CaffeineCard (mobile)', () => {
+  beforeEach(() => {
+    mockPreferences = { time_format: 'HH:mm' };
+  });
+
   it('renders the curve and the threshold as separate series', () => {
     render(
       <CaffeineCard kinetics={baseKinetics} nowMs={NOW} isLoading={false} />
@@ -86,11 +96,22 @@ describe('CaffeineCard (mobile)', () => {
     expect(screen.getByLabelText('threshold')).toBeTruthy();
   });
 
-  it('shows the cutoff time when one is still ahead', () => {
+  it('shows the cutoff time when one is still ahead in 24h format', () => {
+    mockPreferences = { time_format: 'HH:mm' };
     render(
       <CaffeineCard kinetics={baseKinetics} nowMs={NOW} isLoading={false} />
     );
     expect(screen.getByText('17:45')).toBeTruthy();
+    expect(screen.getByText('At 22:30')).toBeTruthy();
+  });
+
+  it('shows the cutoff time when one is still ahead in 12h format', () => {
+    mockPreferences = { time_format: 'h:mm A' };
+    render(
+      <CaffeineCard kinetics={baseKinetics} nowMs={NOW} isLoading={false} />
+    );
+    expect(screen.getByText('5:45 PM')).toBeTruthy();
+    expect(screen.getByText('At 10:30 PM')).toBeTruthy();
   });
 
   // The web card and this one read the same cutoff_state, so "already over"

--- a/SparkyFitnessMobile/__tests__/components/MedicationsCard.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/MedicationsCard.test.tsx
@@ -18,6 +18,10 @@ jest.mock('../../src/hooks/useMedications', () => ({
   useLogDose: jest.fn(),
 }));
 
+jest.mock('../../src/hooks/usePreferences', () => ({
+  usePreferences: () => ({ preferences: { time_format: 'h:mm A' } }),
+}));
+
 jest.mock('../../src/stores/diaryDateStore', () => ({
   useDiaryDateStore: (selector: (s: { selectedDate: string }) => unknown) =>
     selector({ selectedDate: '2026-07-29' }),

--- a/SparkyFitnessMobile/__tests__/components/TimeSheet.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/TimeSheet.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, act, fireEvent } from '@testing-library/react-native';
+import TimeSheet, { type TimeSheetRef } from '../../src/components/TimeSheet';
+import { usePreferences } from '../../src/hooks/usePreferences';
+
+jest.mock('@gorhom/bottom-sheet', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    BottomSheetModal: React.forwardRef((props: any, ref: any) => {
+      React.useImperativeHandle(ref, () => ({
+        present: jest.fn(),
+        dismiss: jest.fn(),
+      }));
+      return <View testID="bottom-sheet-modal">{props.children}</View>;
+    }),
+    BottomSheetView: ({ children }: any) => <View>{children}</View>,
+  };
+});
+
+jest.mock('../../src/hooks/usePreferences');
+
+function pickerProps(queries: { getByTestId: (id: string) => any }) {
+  return queries.getByTestId('date-picker').props;
+}
+
+describe('TimeSheet', () => {
+  const mockedUsePreferences = usePreferences as jest.MockedFunction<
+    typeof usePreferences
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('uses 24-hour presentation (use12Hours=false) when preferences set time_format to HH:mm', () => {
+    mockedUsePreferences.mockReturnValue({
+      preferences: { time_format: 'HH:mm' },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    const queries = render(
+      <TimeSheet value="13:30" onSelectTime={jest.fn()} />
+    );
+    const picker = pickerProps(queries);
+    expect(picker.use12Hours).toBe(false);
+  });
+
+  it('uses 12-hour presentation (use12Hours=true) when preferences set time_format to h:mm A', () => {
+    mockedUsePreferences.mockReturnValue({
+      preferences: { time_format: 'h:mm A' },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    const queries = render(
+      <TimeSheet value="13:30" onSelectTime={jest.fn()} />
+    );
+    const picker = pickerProps(queries);
+    expect(picker.use12Hours).toBe(true);
+  });
+
+  it('explicit timeFormat prop overrides preferences', () => {
+    mockedUsePreferences.mockReturnValue({
+      preferences: { time_format: 'h:mm A' },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    const queries = render(
+      <TimeSheet value="13:30" onSelectTime={jest.fn()} timeFormat="HH:mm" />
+    );
+    const picker = pickerProps(queries);
+    expect(picker.use12Hours).toBe(false);
+  });
+
+  it('calls onSelectTime when time changes and Done is clicked', () => {
+    mockedUsePreferences.mockReturnValue({
+      preferences: { time_format: 'HH:mm' },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    const onSelectTime = jest.fn();
+    const ref = React.createRef<TimeSheetRef>();
+    const queries = render(
+      <TimeSheet ref={ref} value="13:30" onSelectTime={onSelectTime} />
+    );
+
+    act(() => {
+      ref.current?.present();
+    });
+
+    act(() => {
+      pickerProps(queries).onChange({
+        date: new Date(2026, 0, 1, 14, 45, 0),
+      });
+    });
+
+    expect(onSelectTime).toHaveBeenCalledWith('14:45');
+
+    const doneButton = queries.getByText('Done');
+    fireEvent.press(doneButton);
+
+    expect(onSelectTime).toHaveBeenLastCalledWith('14:45');
+  });
+});

--- a/SparkyFitnessMobile/__tests__/screens/MedicationDetailScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/MedicationDetailScreen.test.tsx
@@ -33,6 +33,10 @@ jest.mock('../../src/hooks/useMedications', () => ({
   useLogDose: jest.fn(),
 }));
 
+jest.mock('../../src/hooks/usePreferences', () => ({
+  usePreferences: () => ({ preferences: {} }),
+}));
+
 jest.mock('../../src/stores/diaryDateStore', () => ({
   useDiaryDateStore: (selector: (s: { selectedDate: string }) => unknown) =>
     selector({ selectedDate: '2026-07-29' }),

--- a/SparkyFitnessMobile/__tests__/screens/MedicationScheduleFormScreen.test.tsx
+++ b/SparkyFitnessMobile/__tests__/screens/MedicationScheduleFormScreen.test.tsx
@@ -26,6 +26,10 @@ jest.mock('../../src/hooks/useMedications', () => ({
   useDeleteMedicationSchedule: jest.fn(),
 }));
 
+jest.mock('../../src/hooks/usePreferences', () => ({
+  usePreferences: () => ({ preferences: {} }),
+}));
+
 jest.mock('../../src/components/Icon', () => {
   const { View } = require('react-native');
   return {

--- a/SparkyFitnessMobile/__tests__/utils/dateUtils.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/dateUtils.test.ts
@@ -183,5 +183,15 @@ describe('with a pinned clock', () => {
       expect(older).not.toMatch(/^Yesterday/);
       expect(older).toContain(' at ');
     });
+
+    test('formats time according to timeFormat parameter (12h vs 24h)', () => {
+      const yesterdayDate = minutesAgo(30 * 60); // 30 hours ago -> Yesterday at 16:30 / 4:30 PM
+      expect(
+        formatRelativeTime(yesterdayDate, englishTranslator, 'en-US', 'HH:mm')
+      ).toMatch(/Yesterday at \d{2}:\d{2}$/);
+      expect(
+        formatRelativeTime(yesterdayDate, englishTranslator, 'en-US', 'h:mm A')
+      ).toMatch(/Yesterday at \d{1,2}:\d{2} (AM|PM)$/);
+    });
   });
 });

--- a/SparkyFitnessMobile/__tests__/utils/entryTimeDisplay.test.ts
+++ b/SparkyFitnessMobile/__tests__/utils/entryTimeDisplay.test.ts
@@ -1,5 +1,8 @@
 import { initializeI18n } from '../../src/localization/i18n';
-import { formatTimeLabel } from '../../src/utils/entryTimeDisplay';
+import {
+  formatTimeLabel,
+  is12HourTimeFormat,
+} from '../../src/utils/entryTimeDisplay';
 
 describe('entry time display respects account time_format', () => {
   beforeAll(async () => {
@@ -25,5 +28,13 @@ describe('entry time display respects account time_format', () => {
     expect(formatTimeLabel(null, 'HH:mm')).toBeNull();
     expect(formatTimeLabel('', 'HH:mm')).toBeNull();
     expect(formatTimeLabel('not-a-time', 'HH:mm')).toBeNull();
+  });
+
+  test('is12HourTimeFormat resolves 12h vs 24h correctly', () => {
+    expect(is12HourTimeFormat('HH:mm')).toBe(false);
+    expect(is12HourTimeFormat('h:mm A')).toBe(true);
+    expect(is12HourTimeFormat('h:mm a')).toBe(true);
+    // In English locale default, should be 12-hour
+    expect(is12HourTimeFormat()).toBe(true);
   });
 });

--- a/SparkyFitnessMobile/src/components/CaffeineCard.tsx
+++ b/SparkyFitnessMobile/src/components/CaffeineCard.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { CartesianChart, Line } from 'victory-native';
 import { DashPathEffect } from '@shopify/react-native-skia';
 import { useCSSVariable } from 'uniwind';
-import { getAppLocale } from '../localization/i18n';
 import {
   activeCaffeineAt,
   caffeineCurve,
@@ -13,15 +12,13 @@ import {
 import type { CaffeineActiveResponse } from '@workspace/shared';
 import { makeChartFont, CHART_LABEL_FONT_SIZE } from './charts/chartFormatting';
 import LineSeriesMark from './charts/LineSeriesMark';
+import { usePreferences } from '../hooks/usePreferences';
+import {
+  formatDateToTimeLabel,
+  formatTimeLabel,
+} from '../utils/entryTimeDisplay';
 
 const font = makeChartFont(CHART_LABEL_FONT_SIZE);
-
-/** Local HH:MM for an instant, in the app's locale rather than the device's. */
-const clockLabel = (instant: string | number) =>
-  new Date(instant).toLocaleTimeString(getAppLocale(), {
-    hour: '2-digit',
-    minute: '2-digit',
-  });
 
 type CaffeineCardProps = {
   kinetics: CaffeineActiveResponse | undefined;
@@ -41,11 +38,17 @@ const CaffeineCard: React.FC<CaffeineCardProps> = ({
   isLoading,
 }) => {
   const { t } = useTranslation();
+  const { preferences } = usePreferences();
   const [accentColor, dangerColor, textMuted] = useCSSVariable([
     '--color-accent-primary',
     '--color-icon-danger',
     '--color-text-muted',
   ]) as [string, string, string];
+
+  const clockLabel = (value: number | string | Date) => {
+    const d = value instanceof Date ? value : new Date(value);
+    return formatDateToTimeLabel(d, preferences?.time_format);
+  };
 
   const bedtimeMs = kinetics ? new Date(kinetics.bedtime_at).getTime() : 0;
 
@@ -119,7 +122,10 @@ const CaffeineCard: React.FC<CaffeineCardProps> = ({
 
   const cutoffText =
     kinetics.cutoff_state === 'by' && kinetics.latest_safe_dose_time
-      ? kinetics.latest_safe_dose_time
+      ? formatTimeLabel(
+          kinetics.latest_safe_dose_time,
+          preferences?.time_format
+        )
       : kinetics.cutoff_state === 'passed'
         ? t('caffeine.cutoffPassed', { defaultValue: 'Too late' })
         : kinetics.cutoff_state === 'over'
@@ -149,7 +155,10 @@ const CaffeineCard: React.FC<CaffeineCardProps> = ({
           <Text className="text-text-muted text-xs">
             {t('caffeine.atBedtime', { defaultValue: 'At {{time}}' }).replace(
               '{{time}}',
-              kinetics.target_bedtime
+              formatTimeLabel(
+                kinetics.target_bedtime,
+                preferences?.time_format
+              ) ?? kinetics.target_bedtime
             )}
           </Text>
           <Text className="text-text-primary text-2xl font-bold">

--- a/SparkyFitnessMobile/src/components/EndFastSheet.tsx
+++ b/SparkyFitnessMobile/src/components/EndFastSheet.tsx
@@ -22,7 +22,9 @@ import Toast from 'react-native-toast-message';
 import Icon from './Icon';
 import { sheetContainer, useSheetBackdrop } from './ui/sheetChrome';
 import { useEndFast } from '../hooks/useFasting';
+import { usePreferences } from '../hooks/usePreferences';
 import { formatHoursMinutes, formatDateTime } from '../utils/fasting';
+import { is12HourTimeFormat } from '../utils/entryTimeDisplay';
 import { dateTypeToDate } from './TimeSheet';
 import { addLog } from '../services/LogService';
 import type { FastingLog } from '../types/fasting';
@@ -40,7 +42,10 @@ interface EndFastSheetProps {
 const EndFastSheet = forwardRef<EndFastSheetRef, EndFastSheetProps>(
   ({ onEnded }, ref) => {
     const { t } = useTranslation();
+    const { preferences } = usePreferences();
     const bottomSheetRef = useRef<BottomSheetModal>(null);
+
+    const use12Hours = is12HourTimeFormat(preferences?.time_format);
 
     const [surfaceBg, textMuted, accentPrimary, textPrimary, textSecondary] =
       useCSSVariable([
@@ -216,6 +221,7 @@ const EndFastSheet = forwardRef<EndFastSheetRef, EndFastSheetProps>(
             timePicker
             initialView="time"
             hideHeader
+            use12Hours={use12Hours}
             onChange={onChange}
             styles={pickerStyles}
           />
@@ -255,7 +261,7 @@ const EndFastSheet = forwardRef<EndFastSheetRef, EndFastSheetProps>(
 
           {renderRow(
             t('fastingEdit.started', { defaultValue: 'Started' }),
-            formatDateTime(startDate),
+            formatDateTime(startDate, preferences?.time_format),
             'start'
           )}
           {openPicker === 'start' &&
@@ -263,7 +269,7 @@ const EndFastSheet = forwardRef<EndFastSheetRef, EndFastSheetProps>(
 
           {renderRow(
             t('fastingEdit.ended', { defaultValue: 'Ended' }),
-            formatDateTime(endDate),
+            formatDateTime(endDate, preferences?.time_format),
             'end'
           )}
           {openPicker === 'end' && renderInlinePicker(endDate, handleEndChange)}

--- a/SparkyFitnessMobile/src/components/FastingEditSheet.tsx
+++ b/SparkyFitnessMobile/src/components/FastingEditSheet.tsx
@@ -23,7 +23,9 @@ import Toast from 'react-native-toast-message';
 import Icon from './Icon';
 import { sheetContainer, useSheetBackdrop } from './ui/sheetChrome';
 import { useUpdateFast, useDeleteFast } from '../hooks/useFasting';
+import { usePreferences } from '../hooks/usePreferences';
 import { formatHoursMinutes, formatDateTime } from '../utils/fasting';
+import { is12HourTimeFormat } from '../utils/entryTimeDisplay';
 import { dateTypeToDate } from './TimeSheet';
 import { addLog } from '../services/LogService';
 import type { FastingLog } from '../types/fasting';
@@ -41,7 +43,10 @@ interface FastingEditSheetProps {
 const FastingEditSheet = forwardRef<FastingEditSheetRef, FastingEditSheetProps>(
   ({ onSaved }, ref) => {
     const { t } = useTranslation();
+    const { preferences } = usePreferences();
     const bottomSheetRef = useRef<BottomSheetModal>(null);
+
+    const use12Hours = is12HourTimeFormat(preferences?.time_format);
 
     const [
       surfaceBg,
@@ -276,6 +281,7 @@ const FastingEditSheet = forwardRef<FastingEditSheetRef, FastingEditSheetProps>(
             timePicker
             initialView="time"
             hideHeader
+            use12Hours={use12Hours}
             onChange={onChange}
             styles={pickerStyles}
           />
@@ -311,7 +317,7 @@ const FastingEditSheet = forwardRef<FastingEditSheetRef, FastingEditSheetProps>(
 
           {renderRow(
             t('fastingEdit.started', { defaultValue: 'Started' }),
-            formatDateTime(startDate),
+            formatDateTime(startDate, preferences?.time_format),
             'start'
           )}
           {openPicker === 'start' &&
@@ -319,7 +325,7 @@ const FastingEditSheet = forwardRef<FastingEditSheetRef, FastingEditSheetProps>(
 
           {renderRow(
             t('fastingEdit.ended', { defaultValue: 'Ended' }),
-            formatDateTime(endDate),
+            formatDateTime(endDate, preferences?.time_format),
             'end'
           )}
           {openPicker === 'end' && renderInlinePicker(endDate, handleEndChange)}

--- a/SparkyFitnessMobile/src/components/FastingHistorySheet.tsx
+++ b/SparkyFitnessMobile/src/components/FastingHistorySheet.tsx
@@ -24,6 +24,7 @@ import { sheetContainer, useSheetBackdrop } from './ui/sheetChrome';
 import FastingEditSheet, { type FastingEditSheetRef } from './FastingEditSheet';
 import { FastingProtocolBadge } from './FastingSharedComponents';
 import { useFastingHistory, useDeleteFast } from '../hooks/useFasting';
+import { usePreferences } from '../hooks/usePreferences';
 import {
   formatHoursMinutes,
   relativeDayLabel,
@@ -52,6 +53,7 @@ const FastingHistoryRow: React.FC<FastingHistoryRowProps> = ({
   textMuted,
   t,
 }) => {
+  const { preferences } = usePreferences();
   const dayLabel = relativeDayLabel(
     toLocalDateString(fast.end_time ?? fast.start_time),
     t
@@ -61,8 +63,8 @@ const FastingHistoryRow: React.FC<FastingHistoryRowProps> = ({
       ? formatHoursMinutes(fast.duration_minutes * 60000, t)
       : '—';
   const timeRangeLabel = fast.end_time
-    ? `${formatTime(fast.start_time)} → ${formatTime(fast.end_time)}`
-    : formatTime(fast.start_time);
+    ? `${formatTime(fast.start_time, preferences?.time_format)} → ${formatTime(fast.end_time, preferences?.time_format)}`
+    : formatTime(fast.start_time, preferences?.time_format);
 
   const renderRightActions = () => (
     <DeleteRowAction onPress={() => onDelete(fast)} className="ml-4" />

--- a/SparkyFitnessMobile/src/components/FastingProtocolSheet.tsx
+++ b/SparkyFitnessMobile/src/components/FastingProtocolSheet.tsx
@@ -24,6 +24,8 @@ import { sheetContainer, useSheetBackdrop } from './ui/sheetChrome';
 import Icon from './Icon';
 import StepperInput from './StepperInput';
 import { useStartFast } from '../hooks/useFasting';
+import { usePreferences } from '../hooks/usePreferences';
+import { is12HourTimeFormat } from '../utils/entryTimeDisplay';
 import {
   FASTING_PRESETS,
   DEFAULT_PRESET_ID,
@@ -98,7 +100,10 @@ const FastingProtocolSheet = forwardRef<FastingProtocolSheetRef>(
   (_props, ref) => {
     const { t } = useTranslation();
     const appLocale = useAppLocale();
+    const { preferences } = usePreferences();
     const bottomSheetRef = useRef<BottomSheetModal>(null);
+
+    const use12Hours = is12HourTimeFormat(preferences?.time_format);
 
     const [surfaceBg, textMuted, accentPrimary, textPrimary, textSecondary] =
       useCSSVariable([
@@ -175,8 +180,9 @@ const FastingProtocolSheet = forwardRef<FastingProtocolSheetRef>(
           weekday: 'short',
           hour: 'numeric',
           minute: '2-digit',
+          hour12: use12Hours,
         }),
-      [appLocale, startDate]
+      [appLocale, startDate, use12Hours]
     );
 
     const handleStart = () => {
@@ -358,6 +364,7 @@ const FastingProtocolSheet = forwardRef<FastingProtocolSheetRef>(
               mode="single"
               date={startDate}
               timePicker
+              use12Hours={use12Hours}
               onChange={handleStartChange}
               components={{
                 IconPrev: (

--- a/SparkyFitnessMobile/src/components/MedicationsCard.tsx
+++ b/SparkyFitnessMobile/src/components/MedicationsCard.tsx
@@ -13,11 +13,13 @@ import {
   useMedicationEntries,
   useLogDose,
 } from '../hooks/useMedications';
+import { usePreferences } from '../hooks/usePreferences';
 import { useDiaryDateStore } from '../stores/diaryDateStore';
 import { getDueDosesForDate, formatDose } from '@workspace/shared';
 import { getDeviceTimezone } from '../utils/dateUtils';
 import type { RootStackParamList, TabParamList } from '../types/navigation';
 import { formatLocalizedTimeOfDay } from '../utils/medicationScheduleLocalization';
+
 import { medicationTypeLabel } from '../utils/medicationLocalization';
 import { doseSlotStatus } from '../utils/medications';
 
@@ -37,6 +39,7 @@ const typeLabelFor = (
 
 const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
   const { t } = useTranslation();
+  const { preferences } = usePreferences();
   const selectedDate = useDiaryDateStore((s) => s.selectedDate);
 
   const { data: medications, isLoading: isLoadingMeds } = useMedications({
@@ -130,7 +133,11 @@ const MedicationsCard: React.FC<MedicationsCardProps> = ({ navigation }) => {
             title={med.name}
             time={
               due.schedule.time_of_day
-                ? formatLocalizedTimeOfDay(due.schedule.time_of_day)
+                ? formatLocalizedTimeOfDay(
+                    due.schedule.time_of_day,
+                    undefined,
+                    preferences?.time_format
+                  )
                 : undefined
             }
             subtitle={subtitle}

--- a/SparkyFitnessMobile/src/components/TimeSheet.tsx
+++ b/SparkyFitnessMobile/src/components/TimeSheet.tsx
@@ -13,6 +13,11 @@ import { useCSSVariable } from 'uniwind';
 import DateTimePicker, { type DateType } from 'react-native-ui-datepicker';
 import Button from './ui/Button';
 import { sheetContainer, useSheetBackdrop } from './ui/sheetChrome';
+import { usePreferences } from '../hooks/usePreferences';
+import {
+  is12HourTimeFormat,
+  type EntryTimeFormat,
+} from '../utils/entryTimeDisplay';
 
 /** Normalizes the picker's 6-way `DateType` into a JS `Date`. */
 export function dateTypeToDate(date: DateType): Date | null {
@@ -48,12 +53,18 @@ export interface TimeSheetRef {
 interface TimeSheetProps {
   value: string; // '' or 'HH:MM'
   onSelectTime: (time: string) => void;
+  timeFormat?: EntryTimeFormat | null;
 }
 
 const TimeSheet = forwardRef<TimeSheetRef, TimeSheetProps>(
-  ({ value, onSelectTime }, ref) => {
+  ({ value, onSelectTime, timeFormat }, ref) => {
     const { t } = useTranslation();
+    const { preferences } = usePreferences();
     const bottomSheetRef = useRef<BottomSheetModal>(null);
+
+    const use12Hours = is12HourTimeFormat(
+      timeFormat !== undefined ? timeFormat : preferences?.time_format
+    );
 
     const [surfaceBg, textMuted, accentPrimary, textPrimary, borderSubtle] =
       useCSSVariable([
@@ -131,7 +142,7 @@ const TimeSheet = forwardRef<TimeSheetRef, TimeSheetProps>(
             timePicker
             initialView="time"
             hideHeader
-            use12Hours
+            use12Hours={use12Hours}
             onChange={handleChange}
             styles={pickerStyles}
             // The wheels render 5 rows of 44px; the default 300px container

--- a/SparkyFitnessMobile/src/screens/FastingDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/FastingDetailScreen.tsx
@@ -14,6 +14,7 @@ import FastingProtocolSheet, {
 import EndFastSheet, { type EndFastSheetRef } from '../components/EndFastSheet';
 import { useActiveWorkoutBarPadding } from '../components/ActiveWorkoutBar';
 import { useCurrentFast, useFastingStats } from '../hooks/useFasting';
+import { usePreferences } from '../hooks/usePreferences';
 import { useFastingTimer } from '../hooks/useFastingTimer';
 import { useHeaderActionColors } from '../hooks/useHeaderActionColors';
 import { formatFastingStats, formatTime } from '../utils/fasting';
@@ -53,6 +54,7 @@ const FastingDetailScreen: React.FC<Props> = ({ navigation }) => {
   const dateLocale = translationI18n.language.startsWith('pl')
     ? 'pl-PL'
     : 'en-US';
+  const { preferences } = usePreferences();
   const insets = useSafeAreaInsets();
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
   const protocolSheetRef = useRef<FastingProtocolSheetRef>(null);
@@ -296,7 +298,8 @@ const FastingDetailScreen: React.FC<Props> = ({ navigation }) => {
               <DetailRow
                 label={t('fastingDetail.started', { defaultValue: 'Started' })}
                 value={`${formatDateLabel(toLocalDateString(currentFast.start_time), t, dateLocale)}, ${formatTime(
-                  currentFast.start_time
+                  currentFast.start_time,
+                  preferences?.time_format
                 )}`}
               />
               {currentFast.target_end_time && (
@@ -304,7 +307,10 @@ const FastingDetailScreen: React.FC<Props> = ({ navigation }) => {
                   label={t('fastingDetail.goalReached', {
                     defaultValue: 'Goal reached',
                   })}
-                  value={formatTime(currentFast.target_end_time)}
+                  value={formatTime(
+                    currentFast.target_end_time,
+                    preferences?.time_format
+                  )}
                 />
               )}
 

--- a/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationDetailScreen.tsx
@@ -12,6 +12,7 @@ import {
   useDeleteMedicationEntry,
   useLogDose,
 } from '../hooks/useMedications';
+import { usePreferences } from '../hooks/usePreferences';
 import { useDiaryDateStore } from '../stores/diaryDateStore';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 import { useScreenHeader } from '../hooks/useScreenHeader';
@@ -26,7 +27,7 @@ import {
   localizedDescribeSchedule,
   formatLocalizedTimeOfDay,
 } from '../utils/medicationScheduleLocalization';
-import { getAppLocale } from '../localization';
+import { formatDateToTimeLabel } from '../utils/entryTimeDisplay';
 import { getDeviceTimezone, formatDateLabel } from '../utils/dateUtils';
 import type { RootStackScreenProps } from '../types/navigation';
 import {
@@ -48,6 +49,7 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({
     ? 'pl-PL'
     : 'en-US';
   const { medicationId } = route.params;
+  const { preferences } = usePreferences();
   const insets = useSafeAreaInsets();
   const usesNativeHeader = useNativeIOSHeadersActive();
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
@@ -142,10 +144,10 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({
         t('medications.detail.removeDoseMessage', {
           defaultValue: 'Remove this logged dose from {{time}}?',
           time: entry.taken_at
-            ? new Date(entry.taken_at).toLocaleTimeString(getAppLocale(), {
-                hour: 'numeric',
-                minute: '2-digit',
-              })
+            ? formatDateToTimeLabel(
+                new Date(entry.taken_at),
+                preferences?.time_format
+              )
             : t('medications.detail.today', { defaultValue: 'today' }),
         }),
         [
@@ -174,7 +176,7 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({
         ]
       );
     },
-    [deleteEntryMutation, t]
+    [deleteEntryMutation, preferences?.time_format, t]
   );
 
   const header = useScreenHeader({
@@ -262,8 +264,16 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({
                   onSkip={() => logDose(due, 'skipped')}
                   title={
                     due.schedule.time_of_day
-                      ? formatLocalizedTimeOfDay(due.schedule.time_of_day)
-                      : localizedDescribeSchedule(t, due.schedule)
+                      ? formatLocalizedTimeOfDay(
+                          due.schedule.time_of_day,
+                          undefined,
+                          preferences?.time_format
+                        )
+                      : localizedDescribeSchedule(
+                          t,
+                          due.schedule,
+                          preferences?.time_format
+                        )
                   }
                   subtitle={
                     formatDose(due.medication, due.schedule) ?? undefined
@@ -296,9 +306,9 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({
                       <View className="flex-1">
                         <Text className="text-base text-text-primary">
                           {dose.taken_at
-                            ? new Date(dose.taken_at).toLocaleTimeString(
-                                getAppLocale(),
-                                { hour: 'numeric', minute: '2-digit' }
+                            ? formatDateToTimeLabel(
+                                new Date(dose.taken_at),
+                                preferences?.time_format
                               )
                             : t('medications.detail.logged', {
                                 defaultValue: 'Logged',
@@ -354,9 +364,12 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({
                 </Text>
               </TouchableOpacity>
             </View>
-            {(med.schedules ?? []).map((sched, index) => {
+            {med.schedules?.map((sched, index) => {
               const parts: string[] = [];
-              if (sched.dose_amount != null) {
+              if (
+                sched.dose_amount != null &&
+                sched.dose_amount !== med.dose_amount
+              ) {
                 const scheduleDose = formatDose(med, sched);
                 if (scheduleDose != null) parts.push(scheduleDose);
               }
@@ -383,7 +396,11 @@ const MedicationDetailScreen: React.FC<MedicationDetailScreenProps> = ({
                   >
                     <View className="flex-1">
                       <Text className="text-base text-text-primary">
-                        {localizedDescribeSchedule(t, sched)}
+                        {localizedDescribeSchedule(
+                          t,
+                          sched,
+                          preferences?.time_format
+                        )}
                       </Text>
                       {subtitle !== '' && (
                         <Text className="text-sm text-text-muted mt-0.5">

--- a/SparkyFitnessMobile/src/screens/MedicationScheduleFormScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/MedicationScheduleFormScreen.tsx
@@ -19,6 +19,7 @@ import {
   useUpdateMedicationSchedule,
   useDeleteMedicationSchedule,
 } from '../hooks/useMedications';
+import { usePreferences } from '../hooks/usePreferences';
 import { useNativeIOSHeadersActive } from '../services/nativeTabBarPreference';
 import { useScreenHeader } from '../hooks/useScreenHeader';
 import FormInput from '../components/FormInput';
@@ -171,6 +172,7 @@ const MedicationScheduleFormScreen: React.FC<
     : 'en-US';
   const { medicationId, scheduleId } = route.params;
   const isEditing = !!scheduleId;
+  const { preferences } = usePreferences();
   const insets = useSafeAreaInsets();
   const usesNativeHeader = useNativeIOSHeadersActive();
   const activeWorkoutBarPadding = useActiveWorkoutBarPadding('stack');
@@ -626,7 +628,11 @@ const MedicationScheduleFormScreen: React.FC<
                   )}
                   <Text className="text-base text-text-secondary">
                     {form.timeOfDay
-                      ? formatLocalizedTimeOfDay(form.timeOfDay)
+                      ? formatLocalizedTimeOfDay(
+                          form.timeOfDay,
+                          undefined,
+                          preferences?.time_format
+                        )
                       : t('medications.schedule.none', {
                           defaultValue: 'None',
                         })}
@@ -968,6 +974,7 @@ const MedicationScheduleFormScreen: React.FC<
       <TimeSheet
         ref={timeSheetRef}
         value={form.timeOfDay}
+        timeFormat={preferences?.time_format}
         onSelectTime={(time) => updateField('timeOfDay', time)}
       />
       <CalendarSheet

--- a/SparkyFitnessMobile/src/screens/SettingsScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SettingsScreen.tsx
@@ -74,7 +74,12 @@ const SettingsScreen: React.FC<SettingsScreenProps> = ({ navigation }) => {
   const syncSubtitle = lastSyncedTime
     ? t('settings.lastSynced', {
         defaultValue: 'Last synced {{time}}',
-        time: formatRelativeTime(new Date(lastSyncedTime), t, dateLocale),
+        time: formatRelativeTime(
+          new Date(lastSyncedTime),
+          t,
+          dateLocale,
+          userPreferences?.time_format
+        ),
       })
     : t('date.neverSynced', { defaultValue: 'Never synced' });
 

--- a/SparkyFitnessMobile/src/screens/SyncScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/SyncScreen.tsx
@@ -90,7 +90,7 @@ import type {
   HealthMetricStates,
   HealthDataDisplayState,
 } from '../types/healthRecords';
-import { useSyncHealthData } from '../hooks';
+import { useSyncHealthData, usePreferences } from '../hooks';
 import type { RootStackScreenProps } from '../types/navigation';
 import { fetchHealthDisplayData } from '../services/healthDataDisplay';
 import { shareHealthDiagnosticReport } from '../services/healthDiagnosticService';
@@ -104,6 +104,7 @@ interface TimeRangeOption {
 
 const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
   const { t } = useTranslation();
+  const { preferences } = usePreferences();
   const appLocale = useAppLocale();
   const dateLocale = appLocale;
   const timeRangeOptions = useMemo<TimeRangeOption[]>(
@@ -832,10 +833,20 @@ const SyncScreen: React.FC<SyncScreenProps> = ({ navigation }) => {
                       defaultValue: 'Last synced:',
                     })}
                   </Text>{' '}
-                  {formatRelativeTime(new Date(lastSyncedTime), t, dateLocale)}
+                  {formatRelativeTime(
+                    new Date(lastSyncedTime),
+                    t,
+                    dateLocale,
+                    preferences?.time_format
+                  )}
                 </>
               ) : (
-                formatRelativeTime(null, t, dateLocale)
+                formatRelativeTime(
+                  null,
+                  t,
+                  dateLocale,
+                  preferences?.time_format
+                )
               )
             ) : (
               ' '

--- a/SparkyFitnessMobile/src/screens/WorkoutCompleteScreen.tsx
+++ b/SparkyFitnessMobile/src/screens/WorkoutCompleteScreen.tsx
@@ -42,7 +42,8 @@ import { getActiveServerConfig } from '../services/storage';
 import { fireSuccessHaptic } from '../services/haptics';
 import { withAlpha } from '../utils/colors';
 import { distanceFromKm, weightFromKg } from '../utils/unitConversions';
-import { formatLocalizedNumber, getAppLocale } from '../localization';
+import { formatLocalizedNumber } from '../localization';
+import { formatDateToTimeLabel } from '../utils/entryTimeDisplay';
 import { setsDurationMinutes } from '@workspace/shared';
 import {
   buildPresetUpdateExercises,
@@ -573,12 +574,9 @@ function WorkoutCompleteScreen({ navigation, route }: Props) {
     summary.averageRpe != null ? getRpeTone(summary.averageRpe) : null;
   const rpeToneColor = String(useCSSVariable(RPE_TONE_VARS[rpeTone ?? 'easy']));
 
-  const finishedTimeText = new Date(finishedAt).toLocaleTimeString(
-    getAppLocale(),
-    {
-      hour: 'numeric',
-      minute: '2-digit',
-    }
+  const finishedTimeText = formatDateToTimeLabel(
+    new Date(finishedAt),
+    preferences?.time_format
   );
 
   const sessionForDetail = refreshedSession ?? session;

--- a/SparkyFitnessMobile/src/utils/dateUtils.ts
+++ b/SparkyFitnessMobile/src/utils/dateUtils.ts
@@ -93,7 +93,7 @@ export const formatRelativeTime = (
   const diffMinutes = Math.floor(diffSeconds / 60);
   const diffHours = Math.floor(diffMinutes / 60);
   const diffDays = Math.floor(diffHours / 24);
-  const time = formatDateToTimeLabel(timestamp, timeFormat);
+  const time = formatDateToTimeLabel(timestamp, timeFormat, locale);
 
   if (diffSeconds < 60)
     return translate('date.justNow', { defaultValue: 'Just now' });

--- a/SparkyFitnessMobile/src/utils/dateUtils.ts
+++ b/SparkyFitnessMobile/src/utils/dateUtils.ts
@@ -1,5 +1,7 @@
 import { localDateToDay } from '@workspace/shared';
 import type { TFunction } from 'i18next';
+import type { EntryTimeFormat } from './entryTimeDisplay';
+import { formatDateToTimeLabel } from './entryTimeDisplay';
 
 /**
  * Converts a timestamp to a local date string (YYYY-MM-DD).
@@ -80,7 +82,8 @@ export interface RelativeTimeTranslator {
 export const formatRelativeTime = (
   timestamp: Date | null,
   translate: RelativeTimeTranslator,
-  locale: string
+  locale: string,
+  timeFormat?: EntryTimeFormat | null
 ): string => {
   if (!timestamp)
     return translate('date.neverSynced', { defaultValue: 'Never synced' });
@@ -90,10 +93,7 @@ export const formatRelativeTime = (
   const diffMinutes = Math.floor(diffSeconds / 60);
   const diffHours = Math.floor(diffMinutes / 60);
   const diffDays = Math.floor(diffHours / 24);
-  const time = timestamp.toLocaleTimeString(locale, {
-    hour: 'numeric',
-    minute: '2-digit',
-  });
+  const time = formatDateToTimeLabel(timestamp, timeFormat);
 
   if (diffSeconds < 60)
     return translate('date.justNow', { defaultValue: 'Just now' });

--- a/SparkyFitnessMobile/src/utils/entryTimeDisplay.ts
+++ b/SparkyFitnessMobile/src/utils/entryTimeDisplay.ts
@@ -22,7 +22,8 @@ export type EntryTimeFormat = 'HH:mm' | 'h:mm A' | 'h:mm a';
  */
 export function formatTimeLabel(
   time: string | null | undefined,
-  timeFormat?: EntryTimeFormat | null
+  timeFormat?: EntryTimeFormat | null,
+  locale: string = getAppLocale()
 ): string | null {
   const hourMinute = toHourMinute(time);
   if (!hourMinute) return null;
@@ -30,23 +31,21 @@ export function formatTimeLabel(
   // 24-hour account preference: the stored value is already 'HH:mm'.
   if (timeFormat === 'HH:mm') return hourMinute;
 
-  // 12-hour account preference: render with AM/PM per the app locale.
+  const [hours, minutes] = hourMinute.split(':').map(Number);
+  const date = new Date();
+  date.setHours(hours, minutes, 0, 0);
+
+  // 12-hour account preference: render with AM/PM per the specified locale.
   if (timeFormat === 'h:mm A' || timeFormat === 'h:mm a') {
-    const [hours, minutes] = hourMinute.split(':').map(Number);
-    const date = new Date();
-    date.setHours(hours, minutes, 0, 0);
-    return date.toLocaleTimeString(getAppLocale(), {
+    return date.toLocaleTimeString(locale, {
       hour: 'numeric',
       minute: '2-digit',
       hour12: true,
     });
   }
 
-  // No preference: fall back to the app locale's default convention.
-  const [hours, minutes] = hourMinute.split(':').map(Number);
-  const date = new Date();
-  date.setHours(hours, minutes, 0, 0);
-  return date.toLocaleTimeString(getAppLocale(), {
+  // No preference: fall back to the locale's default convention.
+  return date.toLocaleTimeString(locale, {
     hour: 'numeric',
     minute: '2-digit',
   });
@@ -62,7 +61,8 @@ export function formatTimeLabel(
  */
 export function formatHourLabel(
   hour24: number,
-  timeFormat?: EntryTimeFormat | null
+  timeFormat?: EntryTimeFormat | null,
+  locale: string = getAppLocale()
 ): string {
   // 24-hour account preference: zero-padded so a column of hours stays aligned.
   if (timeFormat === 'HH:mm') return String(hour24).padStart(2, '0');
@@ -71,7 +71,7 @@ export function formatHourLabel(
   date.setHours(hour24, 0, 0, 0);
 
   const usesMeridiem = timeFormat === 'h:mm A' || timeFormat === 'h:mm a';
-  return date.toLocaleTimeString(getAppLocale(), {
+  return date.toLocaleTimeString(locale, {
     hour: 'numeric',
     ...(usesMeridiem ? { hour12: true } : {}),
   });
@@ -82,15 +82,16 @@ export function formatHourLabel(
  * uses 12-hour (AM/PM) or 24-hour presentation.
  */
 export function is12HourTimeFormat(
-  timeFormat?: EntryTimeFormat | null
+  timeFormat?: EntryTimeFormat | null,
+  locale: string = getAppLocale()
 ): boolean {
   if (timeFormat === 'HH:mm') return false;
   if (timeFormat === 'h:mm A' || timeFormat === 'h:mm a') return true;
 
-  // Fall back to the app locale default
+  // Fall back to the locale default
   try {
     const testDate = new Date(2020, 0, 1, 13, 0, 0);
-    const formatted = testDate.toLocaleTimeString(getAppLocale(), {
+    const formatted = testDate.toLocaleTimeString(locale, {
       hour: 'numeric',
       minute: '2-digit',
     });
@@ -105,8 +106,21 @@ export function is12HourTimeFormat(
  */
 export function formatDateToTimeLabel(
   date: Date,
-  timeFormat?: EntryTimeFormat | null
+  timeFormat?: EntryTimeFormat | null,
+  locale: string = getAppLocale()
 ): string {
-  const hhmm = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
-  return formatTimeLabel(hhmm, timeFormat) ?? hhmm;
+  if (timeFormat === 'HH:mm') {
+    return `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+  }
+  if (timeFormat === 'h:mm A' || timeFormat === 'h:mm a') {
+    return date.toLocaleTimeString(locale, {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  }
+  return date.toLocaleTimeString(locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
 }

--- a/SparkyFitnessMobile/src/utils/entryTimeDisplay.ts
+++ b/SparkyFitnessMobile/src/utils/entryTimeDisplay.ts
@@ -76,3 +76,37 @@ export function formatHourLabel(
     ...(usesMeridiem ? { hour12: true } : {}),
   });
 }
+
+/**
+ * Determines whether the given time format (or the active locale default)
+ * uses 12-hour (AM/PM) or 24-hour presentation.
+ */
+export function is12HourTimeFormat(
+  timeFormat?: EntryTimeFormat | null
+): boolean {
+  if (timeFormat === 'HH:mm') return false;
+  if (timeFormat === 'h:mm A' || timeFormat === 'h:mm a') return true;
+
+  // Fall back to the app locale default
+  try {
+    const testDate = new Date(2020, 0, 1, 13, 0, 0);
+    const formatted = testDate.toLocaleTimeString(getAppLocale(), {
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    return !formatted.includes('13');
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Formats a Date instance as a clock time string respecting the time format preference.
+ */
+export function formatDateToTimeLabel(
+  date: Date,
+  timeFormat?: EntryTimeFormat | null
+): string {
+  const hhmm = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+  return formatTimeLabel(hhmm, timeFormat) ?? hhmm;
+}

--- a/SparkyFitnessMobile/src/utils/fasting.ts
+++ b/SparkyFitnessMobile/src/utils/fasting.ts
@@ -3,22 +3,34 @@ import { getAppLocale, formatLocalizedNumber } from '../localization';
 import { getMetabolicStage, type MetabolicStage } from '../constants/fasting';
 import { toLocalDateString, formatDateLabel, normalizeDate } from './dateUtils';
 import type { FastingLog, FastingStats } from '../types/fasting';
+import {
+  formatDateToTimeLabel,
+  is12HourTimeFormat,
+  type EntryTimeFormat,
+} from './entryTimeDisplay';
 const MS_PER_HOUR = 1000 * 60 * 60;
-/** Formats an ISO timestamp's local time of day, e.g. "6:32 PM". */
-export function formatTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString(getAppLocale(), {
-    hour: 'numeric',
-    minute: '2-digit',
-  });
+/** Formats an ISO timestamp's local time of day, e.g. "6:32 PM" or "18:32". */
+export function formatTime(
+  iso: string,
+  timeFormat?: EntryTimeFormat | null
+): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return formatDateToTimeLabel(d, timeFormat);
 }
-/** Formats a Date as a short weekday + date + time label, e.g. "Mon, Jun 3, 6:32 PM". */
-export function formatDateTime(date: Date): string {
+/** Formats a Date as a short weekday + date + time label, e.g. "Mon, Jun 3, 6:32 PM" or "Mon, Jun 3, 18:32". */
+export function formatDateTime(
+  date: Date,
+  timeFormat?: EntryTimeFormat | null
+): string {
+  const is12H = is12HourTimeFormat(timeFormat);
   return date.toLocaleString(getAppLocale(), {
     weekday: 'short',
     month: 'short',
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
+    hour12: is12H,
   });
 }
 /** Formats an elapsed duration as HH:MM:SS (hours are not capped at 24). */

--- a/SparkyFitnessMobile/src/utils/medicationScheduleLocalization.ts
+++ b/SparkyFitnessMobile/src/utils/medicationScheduleLocalization.ts
@@ -1,6 +1,7 @@
 import type { TFunction } from 'i18next';
 import { getAppLocale } from '../localization';
 import type { SharedScheduleRule } from '@workspace/shared';
+import { formatTimeLabel, type EntryTimeFormat } from './entryTimeDisplay';
 
 type ScheduleFields = Pick<
   SharedScheduleRule,
@@ -115,14 +116,19 @@ function localizedFrequency(t: TFunction, schedule: ScheduleFields): string {
 
 export function localizedDescribeSchedule(
   t: TFunction,
-  schedule: ScheduleFields
+  schedule: ScheduleFields,
+  timeFormat?: EntryTimeFormat | null
 ): string {
   const frequency = localizedFrequency(t, schedule);
   if (schedule.schedule_type_id !== 'prn' && schedule.time_of_day) {
     return t('medications.scheduleSummary.at', {
       defaultValue: '{{frequency}} at {{time}}',
       frequency,
-      time: formatLocalizedTimeOfDay(schedule.time_of_day),
+      time: formatLocalizedTimeOfDay(
+        schedule.time_of_day,
+        undefined,
+        timeFormat
+      ),
     });
   }
   return frequency;
@@ -142,7 +148,8 @@ function scheduleFrequencyIdentity(schedule: ScheduleFields): string {
 
 export function localizedDescribeSchedules(
   t: TFunction,
-  schedules: (ScheduleFields & { active?: boolean | null })[]
+  schedules: (ScheduleFields & { active?: boolean | null })[],
+  timeFormat?: EntryTimeFormat | null
 ): string {
   if (schedules.length === 0) {
     return t('medications.scheduleSummary.asNeeded', {
@@ -172,7 +179,7 @@ export function localizedDescribeSchedules(
         return frequency;
       const formattedTimes = [...new Set(times)]
         .sort()
-        .map((time) => formatLocalizedTimeOfDay(time));
+        .map((time) => formatLocalizedTimeOfDay(time, undefined, timeFormat));
       return t('medications.scheduleSummary.at', {
         defaultValue: '{{frequency}} at {{time}}',
         frequency,
@@ -184,8 +191,13 @@ export function localizedDescribeSchedules(
 
 export function formatLocalizedTimeOfDay(
   timeOfDay: string,
-  locale = getAppLocale()
+  locale = getAppLocale(),
+  timeFormat?: EntryTimeFormat | null
 ): string {
+  if (timeFormat) {
+    const formatted = formatTimeLabel(timeOfDay, timeFormat);
+    if (formatted) return formatted;
+  }
   const [hours, minutes] = timeOfDay.split(':').map(Number);
   if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return timeOfDay;
   return new Date(2000, 0, 1, hours, minutes).toLocaleTimeString(locale, {


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
When the user's account preference is set to 24-hour time format (`HH:mm`), the food intake time picker wheel and several other time pickers / displays in the mobile app still forced a 12-hour AM/PM presentation.

**How did you implement the solution?**
- Added `is12HourTimeFormat` and `formatDateToTimeLabel` helpers in `entryTimeDisplay.ts` to dynamically resolve 12-hour vs 24-hour presentation based on `preferences.time_format` or locale defaults.
- Updated `TimeSheet.tsx`, `FastingEditSheet.tsx`, `EndFastSheet.tsx`, and `FastingProtocolSheet.tsx` to conditionally pass `use12Hours={use12Hours}` to `DateTimePicker`.
- Updated time formatters across `MedicationsCard.tsx`, `MedicationDetailScreen.tsx`, `MedicationScheduleFormScreen.tsx`, `CaffeineCard.tsx`, `WorkoutCompleteScreen.tsx`, `SyncScreen.tsx`, and `SettingsScreen.tsx` to respect user time preferences.
- Added comprehensive unit tests for time format detection, `TimeSheet` 12h/24h picker rendering, caffeine kinetics labels, and relative sync timestamps.

Linked Issue: Closes #2397

## How to Test

1. In the app settings, set **Time Format** to **24 Hour (13:00)** (`HH:mm`).
2. Go to the **Diary** tab, tap a food entry, and open the time picker sheet. Verify the wheel shows 00-23 hours without an AM/PM wheel.
3. Open fasting sheets, medication schedule time pickers, caffeine kinetics card, and sync screen to verify all timestamps render in 24-hour format.
4. Switch **Time Format** back to **12 Hour (1:00 PM)** (`h:mm A`) and verify time pickers and labels revert to 12-hour AM/PM format.
5. Run automated tests: `cd SparkyFitnessMobile && pnpm test && pnpm run validate`.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](https://github.com/user-attachments/assets/b4c483d7-2fa5-4dd6-afc2-bc05d933391b)

### After

Time picker and display screens now render in 24-hour clock format (00–23 without AM/PM wheel) when `time_format: 'HH:mm'` is selected.

</details>

## Notes for Reviewers

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Applied the selected 12-hour or 24-hour time format consistently across fasting, medication, caffeine, workout, workout sync, and settings views.
  * Updated time pickers and schedule descriptions to respect saved time-format preferences, with explicit screen settings taking priority where applicable.
  * Improved medication schedule displays to avoid repeating default dose amounts.

* **Tests**
  * Added coverage for time-format preferences, time pickers, relative timestamps, and medication and fasting displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->