### PR TITLE
fix(uploads): serve sensitive photo subtrees through authenticated routes

### DIFF
--- a/SparkyFitnessFrontend/src/api/Pregnancy/pregnancyService.ts
+++ b/SparkyFitnessFrontend/src/api/Pregnancy/pregnancyService.ts
@@ -112,7 +112,6 @@ export interface BumpPhoto {
   pregnancy_id: string;
   week: number;
   entry_date: string;
-  file_path: string;
   notes: string | null;
 }
 

--- a/SparkyFitnessFrontend/src/pages/Cycle/pregnancy/BumpPhotoJournal.tsx
+++ b/SparkyFitnessFrontend/src/pages/Cycle/pregnancy/BumpPhotoJournal.tsx
@@ -75,7 +75,10 @@ export default function BumpPhotoJournal({
             {photos.map((p) => (
               <div key={p.id} className="group relative">
                 <img
-                  src={`/${p.file_path}`}
+                  // Served through the authenticated, owner-checked route (the
+                  // session cookie travels with the same-origin request), not
+                  // the public /uploads static mount.
+                  src={`/api/v2/pregnancy/photos/file/${p.id}`}
                   alt={t('pregnancy.photos.weekAlt', 'Week {{n}} bump photo', {
                     n: p.week,
                   })}

--- a/SparkyFitnessMobile/.prettierignore
+++ b/SparkyFitnessMobile/.prettierignore
@@ -30,6 +30,12 @@ src/localization/locales/
 targets/widget/Assets.xcassets/
 targets/widget/Info.plist
 targets/widget/generated.entitlements
+targets/watch/Assets.xcassets/
+targets/watch/Info.plist
+targets/watch/generated.entitlements
+targets/watch-widget/Assets.xcassets/
+targets/watch-widget/Info.plist
+targets/watch-widget/generated.entitlements
 
 # The native-header contract test (__tests__/navigation/nativeHeaderContract.test.ts)
 # parses the literal source of these two files — hardcoded indentation for the

--- a/SparkyFitnessMobile/AGENTS.md
+++ b/SparkyFitnessMobile/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-_Last updated: 2026-09-05_
+_Last updated: 2026-09-11_
 
 SparkyFitness Mobile is a React Native 0.85 + Expo SDK 56 app for syncing Apple Health / Health Connect data with the SparkyFitness backend, tracking nutrition, hydration, fasting, measurements, exercise, saved foods, meal templates, custom exercises, workout presets, iOS / Android widgets, the active workout HUD, and the Sparky AI chat.
 
@@ -281,7 +281,7 @@ All endpoints require auth headers, and proxy headers are injected before auth h
 
 - `healthDataApi.ts` - `POST /api/health-data`, identity checks, chunking, timeout, retry, session-expiry handling.
 - `dailySummaryApi.ts`, `goalsApi.ts`, `measurementsApi.ts`, `preferencesApi.ts` - daily summary, goals, check-ins, water, timezone bootstrap, nutrient display preferences.
-- `checkInPhotosApi.ts` - progress photos: the gallery (every photo with that day's weight, in one request), a day's photos, the days that have any, multipart upload and delete. Image bytes come from the authenticated `/file/{id}` route, so `useCheckInPhotoSource` attaches auth and proxy headers and memoizes each source by photo id.
+- `checkInPhotosApi.ts` - progress photos: the gallery (every photo with that day's weight, in one request), a day's photos, the days that have any, multipart upload and delete. Image bytes come from the authenticated `/file/{id}` route, so `useCheckInPhotoSource` attaches auth and proxy headers and memoizes each source by photo id. It is a thin wrapper over `useAuthedImageSource`, the shared hook behind every authenticated image (see also `usePregnancyPhotoSource` for bump photos); that hook also refuses to build a source over plaintext HTTP outside `__DEV__`, so the session token never goes out in clear.
 - `foodEntriesApi.ts`, `foodEntryMealsApi.ts`, `foodsApi.ts`, `mealsApi.ts`, `mealTypesApi.ts`, `mealPlansApi.ts` - diary food entries, grouped logged meals, saved foods/variants/barcodes, saved meals, meal types, and recurring meal plans.
 - `externalFoodSearchApi.ts`, `aiSettingsApi.ts`, `aiConversionApi.ts` - provider-agnostic food search/details/barcode, label/photo estimate, AI availability, unit conversion.
 - `exerciseApi.ts`, `externalExerciseSearchApi.ts`, `workoutPresetsApi.ts` - exercise history, suggested/search/import flows, preset/individual exercise sessions, workout presets.

--- a/SparkyFitnessMobile/__tests__/components/wellness/pregnancy/BumpPhotoJournal.test.tsx
+++ b/SparkyFitnessMobile/__tests__/components/wellness/pregnancy/BumpPhotoJournal.test.tsx
@@ -29,6 +29,19 @@ jest.mock('../../../../src/hooks/usePregnancyPhotos', () => ({
   }),
 }));
 
+// Bump photos are fetched through the authenticated, owner-checked route, so
+// the component builds sources via this hook rather than a public /uploads URL.
+const mockGetPhotoSource = jest.fn((id: string) => ({
+  uri: `https://example.com/api/v2/pregnancy/photos/file/${id}`,
+  headers: { Authorization: 'Bearer test' },
+}));
+jest.mock('../../../../src/hooks/usePregnancyPhotoSource', () => ({
+  usePregnancyPhotoSource: () => ({
+    getPhotoSource: mockGetPhotoSource,
+    isReady: true,
+  }),
+}));
+
 jest.mock('../../../../src/hooks/useServerConfigs', () => ({
   useServerConfigs: () => ({
     activeConfig: { id: 'cfg-1', url: 'https://example.com' },
@@ -58,7 +71,6 @@ describe('BumpPhotoJournal', () => {
           pregnancy_id: 'p1',
           week: 12,
           entry_date: '2026-01-01',
-          file_path: 'uploads/pregnancy/u1/p1/w12-1.jpg',
           notes: null,
         },
       ],

--- a/SparkyFitnessMobile/__tests__/hooks/usePregnancyPhotoSource.test.ts
+++ b/SparkyFitnessMobile/__tests__/hooks/usePregnancyPhotoSource.test.ts
@@ -1,0 +1,116 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { usePregnancyPhotoSource } from '../../src/hooks/usePregnancyPhotoSource';
+import {
+  getActiveServerConfig,
+  proxyHeadersToRecord,
+} from '../../src/services/storage';
+
+jest.mock('../../src/services/storage', () => ({
+  getActiveServerConfig: jest.fn(),
+  proxyHeadersToRecord: jest.fn(),
+}));
+
+jest.mock('../../src/services/api/apiClient', () => ({
+  normalizeUrl: (url: string) => url.replace(/\/$/, ''),
+}));
+
+jest.mock('../../src/services/api/authService', () => ({
+  getAuthHeaders: () => ({ Authorization: 'Bearer secret-token' }),
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  useFocusEffect: (cb: () => void) => {
+    const { useEffect } = require('react');
+    useEffect(() => {
+      cb();
+    }, [cb]);
+  },
+}));
+
+const mockGetActiveServerConfig = getActiveServerConfig as jest.MockedFunction<
+  typeof getActiveServerConfig
+>;
+const mockProxyHeadersToRecord = proxyHeadersToRecord as jest.MockedFunction<
+  typeof proxyHeadersToRecord
+>;
+
+const renderWithUrl = async (url: string) => {
+  mockGetActiveServerConfig.mockResolvedValue({
+    id: 'test',
+    url,
+    apiKey: 'key',
+  } as never);
+
+  const { result } = renderHook(() => usePregnancyPhotoSource());
+  await act(async () => {});
+  return result;
+};
+
+/**
+ * Bump photos are owner-only reproductive-health data: they are excluded from the
+ * public /uploads static mount and served only by an authenticated, owner-checked
+ * route, so every source carries the session token. A plaintext base URL would put
+ * that token on the wire, which apiFetch refuses to do for every other request in
+ * the app. This guard lives in the shared useAuthedImageSource hook; these cases
+ * prove the pregnancy wrapper inherits it.
+ */
+describe('usePregnancyPhotoSource', () => {
+  const devGlobal = globalThis as typeof globalThis & { __DEV__: boolean };
+  const originalDev = devGlobal.__DEV__;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockProxyHeadersToRecord.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    devGlobal.__DEV__ = originalDev;
+  });
+
+  it('builds a source with the auth headers over HTTPS', async () => {
+    devGlobal.__DEV__ = false;
+    const result = await renderWithUrl('https://example.com');
+
+    const source = result.current.getPhotoSource('photo-1');
+
+    expect(source?.uri).toBe(
+      'https://example.com/api/v2/pregnancy/photos/file/photo-1'
+    );
+    expect(source?.headers).toMatchObject({
+      Authorization: 'Bearer secret-token',
+    });
+  });
+
+  it('returns null rather than sending the token over HTTP in production', async () => {
+    devGlobal.__DEV__ = false;
+    const result = await renderWithUrl('http://example.com');
+
+    expect(result.current.getPhotoSource('photo-1')).toBeNull();
+  });
+
+  it('refuses HTTP regardless of casing', async () => {
+    devGlobal.__DEV__ = false;
+    const result = await renderWithUrl('HTTP://example.com');
+
+    expect(result.current.getPhotoSource('photo-1')).toBeNull();
+  });
+
+  it('allows HTTP in development, where self-hosted servers are reached by IP', async () => {
+    devGlobal.__DEV__ = true;
+    const result = await renderWithUrl('http://192.168.1.10:3010');
+
+    expect(result.current.getPhotoSource('photo-1')?.uri).toBe(
+      'http://192.168.1.10:3010/api/v2/pregnancy/photos/file/photo-1'
+    );
+  });
+
+  it('returns null before the config resolves', () => {
+    devGlobal.__DEV__ = false;
+    mockGetActiveServerConfig.mockReturnValue(new Promise(() => {}) as never);
+
+    const { result } = renderHook(() => usePregnancyPhotoSource());
+
+    expect(result.current.getPhotoSource('photo-1')).toBeNull();
+    expect(result.current.isReady).toBe(false);
+  });
+});

--- a/SparkyFitnessMobile/src/components/wellness/pregnancy/BumpPhotoJournal.tsx
+++ b/SparkyFitnessMobile/src/components/wellness/pregnancy/BumpPhotoJournal.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import {
   View,
   Text,
-  Image,
   TouchableOpacity,
   ActivityIndicator,
   ScrollView,
@@ -15,12 +14,12 @@ import {
   usePregnancyPhotos,
   usePregnancyPhotoMutations,
 } from '../../../hooks/usePregnancyPhotos';
-import { useServerConfigs } from '../../../hooks/useServerConfigs';
-import { normalizeUrl } from '../../../services/api/apiClient';
+import { usePregnancyPhotoSource } from '../../../hooks/usePregnancyPhotoSource';
 import { getApiErrorMessage } from '../../../services/api/errors';
 import { formatDate } from '../../../utils/dateUtils';
 import ActionSheet, { type ActionSheetRef } from '../../ActionSheet';
 import Icon from '../../Icon';
+import SafeImage from '../../SafeImage';
 import type { BumpPhoto } from '../../../types/womensHealth';
 
 interface BumpPhotoJournalProps {
@@ -39,7 +38,7 @@ const BumpPhotoJournal: React.FC<BumpPhotoJournalProps> = ({
   const { photos, isLoading } = usePregnancyPhotos(pregnancyId);
   const { uploadAsync, isUploading, deleteAsync } =
     usePregnancyPhotoMutations();
-  const { activeConfig } = useServerConfigs();
+  const { getPhotoSource } = usePregnancyPhotoSource();
   const [accentColor, dangerColor] = useCSSVariable([
     '--color-accent-primary',
     '--color-icon-danger',
@@ -48,10 +47,6 @@ const BumpPhotoJournal: React.FC<BumpPhotoJournalProps> = ({
   const actionSheetRef = useRef<ActionSheetRef>(null);
   const pickerLock = useRef(false);
   const [selectedPhoto, setSelectedPhoto] = useState<BumpPhoto | null>(null);
-
-  const baseUrl = activeConfig ? normalizeUrl(activeConfig.url) : null;
-  const photoUri = (filePath: string) =>
-    baseUrl ? `${baseUrl}/${filePath}` : undefined;
 
   const pickAndUpload = async (source: 'camera' | 'library') => {
     if (pickerLock.current) return;
@@ -173,10 +168,15 @@ const BumpPhotoJournal: React.FC<BumpPhotoJournalProps> = ({
                 }
                 className="items-center"
               >
-                <Image
-                  source={{ uri: photoUri(photo.file_path) }}
-                  className="w-24 h-24 rounded-xl bg-raised"
-                  resizeMode="cover"
+                <SafeImage
+                  source={getPhotoSource(photo.id)}
+                  style={{ width: 96, height: 96, borderRadius: 12 }}
+                  contentFit="cover"
+                  fallback={
+                    <View className="w-24 h-24 rounded-xl bg-raised items-center justify-center">
+                      <Icon name="camera" size={20} color={accentColor} />
+                    </View>
+                  }
                 />
                 <Text className="text-text-secondary text-xs mt-1">
                   {t('bumpPhotos.week', {

--- a/SparkyFitnessMobile/src/hooks/useAuthedImageSource.ts
+++ b/SparkyFitnessMobile/src/hooks/useAuthedImageSource.ts
@@ -33,7 +33,20 @@ export function useAuthedImageSource(pathPrefix: string) {
 
   useFocusEffect(
     useCallback(() => {
-      getActiveServerConfig().then(setConfig);
+      // Guard against a config read that rejects (storage failure) or resolves
+      // after the screen has lost focus, which would otherwise leave an
+      // unhandled rejection or apply a stale server's headers.
+      let active = true;
+      void getActiveServerConfig()
+        .then((nextConfig) => {
+          if (active) setConfig(nextConfig);
+        })
+        .catch(() => {
+          if (active) setConfig(null);
+        });
+      return () => {
+        active = false;
+      };
     }, [])
   );
 

--- a/SparkyFitnessMobile/src/hooks/useAuthedImageSource.ts
+++ b/SparkyFitnessMobile/src/hooks/useAuthedImageSource.ts
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import {
+  getActiveServerConfig,
+  proxyHeadersToRecord,
+} from '../services/storage';
+import { getAuthHeaders } from '../services/api/authService';
+import { normalizeUrl } from '../services/api/apiClient';
+import type { ServerConfig } from '../services/storage';
+
+export type AuthedImageSource = {
+  uri: string;
+  headers: Record<string, string>;
+};
+
+/**
+ * Builds `<SafeImage>` sources for images that sit behind authentication.
+ *
+ * Some image bytes are not public uploads — they are served by owner-checked
+ * routes, so a bare URI renders as a broken image and every source has to carry
+ * the auth and proxy headers.
+ *
+ * Each source is memoized by id to keep its object identity stable: a fresh
+ * `{uri, headers}` literal per render reads as a new source to expo-image,
+ * which reloads the picture mid-scroll and restarts the time-lapse.
+ *
+ * @param pathPrefix API path the id is appended to, e.g.
+ *   `/api/measurements/check-in-photos/file/`. Pass a constant — it keys the
+ *   returned callback.
+ */
+export function useAuthedImageSource(pathPrefix: string) {
+  const [config, setConfig] = useState<ServerConfig | null>(null);
+
+  useFocusEffect(
+    useCallback(() => {
+      getActiveServerConfig().then(setConfig);
+    }, [])
+  );
+
+  const cacheRef = useRef<Map<string, AuthedImageSource>>(new Map());
+
+  // Base URL and proxy/auth headers belong to the active server, so drop the
+  // memo when the user switches servers.
+  useEffect(() => {
+    cacheRef.current.clear();
+  }, [config]);
+
+  const getPhotoSource = useCallback(
+    (photoId: string): AuthedImageSource | null => {
+      if (!photoId || !config) return null;
+
+      // Unlike the exercise and food image sources, these carry the session
+      // token, so a plaintext base URL would put it on the wire. Null renders
+      // SafeImage's fallback, which every caller here already handles.
+      const base = normalizeUrl(config.url);
+      if (!__DEV__ && base.toLowerCase().startsWith('http://')) return null;
+
+      const cached = cacheRef.current.get(photoId);
+      if (cached) return cached;
+
+      const source: AuthedImageSource = {
+        uri: `${base}${pathPrefix}${encodeURIComponent(photoId)}`,
+        headers: {
+          ...proxyHeadersToRecord(config.proxyHeaders),
+          ...getAuthHeaders(config),
+        },
+      };
+      cacheRef.current.set(photoId, source);
+      return source;
+    },
+    [config, pathPrefix]
+  );
+
+  return { getPhotoSource, isReady: config !== null };
+}

--- a/SparkyFitnessMobile/src/hooks/useCheckInPhotoSource.ts
+++ b/SparkyFitnessMobile/src/hooks/useCheckInPhotoSource.ts
@@ -1,71 +1,19 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useFocusEffect } from '@react-navigation/native';
 import {
-  getActiveServerConfig,
-  proxyHeadersToRecord,
-} from '../services/storage';
-import { getAuthHeaders } from '../services/api/authService';
-import { normalizeUrl } from '../services/api/apiClient';
-import type { ServerConfig } from '../services/storage';
+  useAuthedImageSource,
+  type AuthedImageSource,
+} from './useAuthedImageSource';
 
-export type CheckInPhotoSource = {
-  uri: string;
-  headers: Record<string, string>;
-};
+export type CheckInPhotoSource = AuthedImageSource;
+
+const CHECK_IN_PHOTO_PATH = '/api/measurements/check-in-photos/file/';
 
 /**
  * Builds `<SafeImage>` sources for progress photos.
  *
- * These bytes are not public uploads: `/check-in-photos/file/:id` sits behind
- * `authenticate` plus the `checkin` permission, so a bare URI renders as a
- * broken image and every source carries the auth and proxy headers.
- *
- * Each source is memoized by photo id to keep its object identity stable: a
- * fresh `{uri, headers}` literal per render reads as a new source to
- * expo-image, which reloads the picture mid-scroll and restarts the time-lapse.
+ * `/check-in-photos/file/:id` sits behind `authenticate` plus the `checkin`
+ * permission, so the bytes need the auth and proxy headers that
+ * {@link useAuthedImageSource} attaches.
  */
 export function useCheckInPhotoSource() {
-  const [config, setConfig] = useState<ServerConfig | null>(null);
-
-  useFocusEffect(
-    useCallback(() => {
-      getActiveServerConfig().then(setConfig);
-    }, [])
-  );
-
-  const cacheRef = useRef<Map<string, CheckInPhotoSource>>(new Map());
-
-  // Base URL and proxy/auth headers belong to the active server, so drop the
-  // memo when the user switches servers.
-  useEffect(() => {
-    cacheRef.current.clear();
-  }, [config]);
-
-  const getPhotoSource = useCallback(
-    (photoId: string): CheckInPhotoSource | null => {
-      if (!photoId || !config) return null;
-
-      // Unlike the exercise and food image sources, these carry the session
-      // token, so a plaintext base URL would put it on the wire. Null renders
-      // SafeImage's fallback, which every caller here already handles.
-      const base = normalizeUrl(config.url);
-      if (!__DEV__ && base.toLowerCase().startsWith('http://')) return null;
-
-      const cached = cacheRef.current.get(photoId);
-      if (cached) return cached;
-
-      const source: CheckInPhotoSource = {
-        uri: `${base}/api/measurements/check-in-photos/file/${encodeURIComponent(photoId)}`,
-        headers: {
-          ...proxyHeadersToRecord(config.proxyHeaders),
-          ...getAuthHeaders(config),
-        },
-      };
-      cacheRef.current.set(photoId, source);
-      return source;
-    },
-    [config]
-  );
-
-  return { getPhotoSource, isReady: config !== null };
+  return useAuthedImageSource(CHECK_IN_PHOTO_PATH);
 }

--- a/SparkyFitnessMobile/src/hooks/usePregnancyPhotoSource.ts
+++ b/SparkyFitnessMobile/src/hooks/usePregnancyPhotoSource.ts
@@ -1,0 +1,20 @@
+import {
+  useAuthedImageSource,
+  type AuthedImageSource,
+} from './useAuthedImageSource';
+
+export type PregnancyPhotoSource = AuthedImageSource;
+
+const PREGNANCY_PHOTO_PATH = '/api/v2/pregnancy/photos/file/';
+
+/**
+ * Builds `<SafeImage>` sources for bump photos.
+ *
+ * Bump photos are owner-only reproductive-health data: they are excluded from
+ * the public `/uploads` static mount and served only by an authenticated,
+ * owner-checked route, so the bytes need the headers that
+ * {@link useAuthedImageSource} attaches.
+ */
+export function usePregnancyPhotoSource() {
+  return useAuthedImageSource(PREGNANCY_PHOTO_PATH);
+}

--- a/SparkyFitnessMobile/src/types/womensHealth.ts
+++ b/SparkyFitnessMobile/src/types/womensHealth.ts
@@ -55,7 +55,6 @@ export interface BumpPhoto {
   pregnancy_id: string;
   week: number;
   entry_date: string;
-  file_path: string;
   notes: string | null;
 }
 

--- a/SparkyFitnessServer/AGENTS.md
+++ b/SparkyFitnessServer/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-_Last updated: 2026-09-08_
+_Last updated: 2026-09-11_
 
 SparkyFitness Server is the backend API package for the SparkyFitness monorepo. Use this file as the primary guide for work inside `SparkyFitnessServer/`.
 
@@ -68,6 +68,7 @@ pnpm exec eslint routes/v2/foodRoutes.ts services/foodCoreService.ts
 - `services/` - business logic and orchestration
 - `models/` - PostgreSQL repositories and persistence helpers
 - `middleware/` - auth, permissions, uploads, and shared Express middleware
+- `utils/uploadsPath.ts` - the uploads root plus the resolver and containment guard for stored `file_path` values; use it instead of re-deriving `SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY`
 - `integrations/` - provider adapters and ingest pipelines
 - `schemas/` - Zod route schemas
 - `types/` - TypeScript declarations, including `Express.Request` augmentation
@@ -160,6 +161,16 @@ When searching, ignore noisy/generated directories unless you explicitly need th
   3. Update the developer-facing documentation in `../docs/content/8.developer/11.database-security-tiers.md` to define its security tier (Tier 1, Tier 2, or Tier 3).
   4. Add or update the matching Zod schema in `../shared/src/schemas/database/`.
 - Startup automatically applies migrations and then reapplies RLS policies; do not create alternate migration mechanisms
+
+### Uploads: Public vs Sensitive
+
+- `SparkyFitnessServer.ts` serves the uploads root publicly at `/uploads` and `/api/uploads`; both are in `publicRoutes`, so `authenticate` never runs on them
+- Sensitive subtrees are **denied on the static mount** and served instead by an authenticated, owner-checked per-id route. Two exist today:
+  - `check-in` -> `GET /api/measurements/check-in-photos/file/:id` (delegatable via the `checkin` permission)
+  - `pregnancy` -> `GET /api/v2/pregnancy/photos/file/:id` (owner-only; deliberately **no** `checkPermissionMiddleware`, because reproductive-health data is never delegated)
+- Adding a sensitive upload subtree means adding its directory name to `SENSITIVE_UPLOAD_SUBTREES` in `SparkyFitnessServer.ts` **and** adding an authenticated file route; the deny rule matches the decoded, normalized path, because a prefix match on the raw URL is bypassable with `..%2f`
+- Responses for these domains omit `file_path`: the on-disk layout is a server detail and clients address photos by id
+- `tests/uploadsStaticMount.test.ts` guards both the deny behavior and the fact that the deny rule is registered before `express.static`
 
 ### Auth and Request Context
 

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -404,12 +404,42 @@ const uploadsStaticOptions = {
   },
   headers: uploadsSecurityHeaders,
 };
-// Check-in progress photos are sensitive. Block direct access via the public
-// static mounts so they can only be reached through the authenticated,
-// ownership-checked route (GET /api/measurements/check-in-photos/file/:id).
+// Check-in progress photos and pregnancy bump photos are sensitive. Block
+// direct access via the public static mounts so they can only be reached
+// through their authenticated, ownership-checked routes:
+//   GET /api/measurements/check-in-photos/file/:id   (check-in)
+//   GET /api/v2/pregnancy/photos/file/:id            (pregnancy)
+// Check-in is delegatable via the 'checkin' permission; pregnancy is
+// owner-only reproductive-health data and is never shared or delegated, so its
+// route deliberately carries no permission middleware.
 // 404 (not 403) so we don't confirm whether a given path exists.
-app.use(['/uploads/check-in', '/api/uploads/check-in'], (_req, res) => {
-  res.status(404).end();
+// This block MUST stay above the express.static mounts below — moving it after
+// them silently re-exposes every file. tests/uploadsStaticMount.test.ts guards
+// both the behavior and the source ordering.
+const SENSITIVE_UPLOAD_SUBTREES = new Set(['check-in', 'pregnancy']);
+app.use(['/uploads', '/api/uploads'], (req, res, next) => {
+  // Match the path the way serve-static resolves it, not the way it was
+  // written: a prefix test against the raw URL would not account for percent-
+  // encoded separators or `..` segments, which serve-static decodes and
+  // normalizes before it looks for a file. So decode once (as it does),
+  // normalize, and test the resulting first segment.
+  let decodedPath: string;
+  try {
+    decodedPath = decodeURIComponent(req.path);
+  } catch {
+    // Malformed percent-encoding never reaches a real file.
+    res.status(400).end();
+    return;
+  }
+  const normalized = path.posix.normalize(decodedPath.replace(/\\/g, '/'));
+  // Lowercased because Express routing and macOS/Windows filesystems are all
+  // case-insensitive, so /uploads/Pregnancy/... reaches the same bytes.
+  const firstSegment = normalized.split('/').filter(Boolean)[0]?.toLowerCase();
+  if (firstSegment && SENSITIVE_UPLOAD_SUBTREES.has(firstSegment)) {
+    res.status(404).end();
+    return;
+  }
+  next();
 });
 app.use('/api/uploads', express.static(UPLOADS_BASE_DIR, uploadsStaticOptions));
 app.use('/uploads', express.static(UPLOADS_BASE_DIR, uploadsStaticOptions));

--- a/SparkyFitnessServer/models/pregnancyRepository.ts
+++ b/SparkyFitnessServer/models/pregnancyRepository.ts
@@ -16,8 +16,13 @@ const KICK_COLS = `id, user_id, pregnancy_id, started_at, ended_at, kick_count, 
 const CONTRACTION_COLS = `id, user_id, pregnancy_id, started_at, ended_at, intensity,
   created_at, updated_at`;
 
+// Response columns only. file_path is deliberately omitted: the on-disk layout
+// is a server detail and bump photos are owner-only reproductive-health data,
+// so clients fetch bytes through GET /api/v2/pregnancy/photos/file/:id rather
+// than the public /uploads static mount. user_id is redundant (always the
+// caller). Internal queries that need file_path select it explicitly.
 const PHOTO_COLS =
-  'id, user_id, pregnancy_id, week, entry_date, file_path, notes, created_at, updated_at';
+  'id, pregnancy_id, week, entry_date, notes, created_at, updated_at';
 
 const CHECKLIST_COLS = `id, user_id, pregnancy_id, template_key, custom_title, week, completed_at,
   dismissed, created_at, updated_at`;
@@ -332,14 +337,41 @@ async function listPhotos(userId: string, pregnancyId: string) {
   }
 }
 
-async function deletePhoto(userId: string, id: string): Promise<boolean> {
+/**
+ * Returns the stored file_path of a photo the caller owns, or null. Scoped both
+ * by the explicit user_id filter (this file's convention) and by RLS through
+ * getClient. Kept free of fs/path work so this module stays pure data access;
+ * pregnancyService resolves and validates the path.
+ */
+async function getPhotoFilePath(
+  userId: string,
+  id: string
+): Promise<string | null> {
   const client = await getClient(userId);
   try {
     const result = await client.query(
-      'DELETE FROM pregnancy_photos WHERE user_id = $1 AND id = $2 RETURNING id',
+      'SELECT file_path FROM pregnancy_photos WHERE user_id = $1 AND id = $2',
       [userId, id]
     );
-    return (result.rowCount ?? 0) > 0;
+    return result.rows[0]?.file_path ?? null;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Deletes the row and returns its file_path so the caller can remove the file
+ * from disk, or null when nothing was deleted. Call through
+ * pregnancyService.deletePhoto so the on-disk file is cleaned up too.
+ */
+async function deletePhoto(userId: string, id: string): Promise<string | null> {
+  const client = await getClient(userId);
+  try {
+    const result = await client.query(
+      'DELETE FROM pregnancy_photos WHERE user_id = $1 AND id = $2 RETURNING file_path',
+      [userId, id]
+    );
+    return result.rows[0]?.file_path ?? null;
   } finally {
     client.release();
   }
@@ -637,6 +669,7 @@ export default {
   listContractions,
   createPhoto,
   listPhotos,
+  getPhotoFilePath,
   deletePhoto,
   listChecklist,
   upsertChecklistItem,

--- a/SparkyFitnessServer/routes/v2/pregnancyRoutes.ts
+++ b/SparkyFitnessServer/routes/v2/pregnancyRoutes.ts
@@ -1,7 +1,6 @@
 import express, { RequestHandler } from 'express';
 import path from 'path';
 import fs from 'fs';
-import { fileURLToPath } from 'url';
 import {
   CreatePregnancyBodySchema,
   UpdatePregnancyBodySchema,
@@ -23,11 +22,7 @@ import checkInPhotoUpload, {
 import { loadUserTimezone } from '../../utils/timezoneLoader.js';
 import { todayInZone, gestationalAge } from '@workspace/shared';
 import { log } from '../../config/logging.js';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const baseUploadsDir = process.env.SPARKY_FITNESS_UPLOADS_DIR
-  ? path.resolve(process.env.SPARKY_FITNESS_UPLOADS_DIR)
-  : path.join(__dirname, '..', '..', 'uploads');
+import { UPLOADS_BASE_DIR } from '../../utils/uploadsPath.js';
 
 const router = express.Router();
 
@@ -257,7 +252,7 @@ const uploadPhoto: RequestHandler = async (req, res, next) => {
     const fileName = `w${week}-${Date.now()}.${ext}`;
     const relPath = path.join(relDir, fileName);
     const absDir = path.join(
-      baseUploadsDir,
+      UPLOADS_BASE_DIR,
       'pregnancy',
       req.userId,
       pregnancyId
@@ -302,12 +297,65 @@ const deletePhoto: RequestHandler = async (req, res, next) => {
       res.status(400).json({ error: 'Invalid photo id' });
       return;
     }
-    const ok = await pregnancyRepository.deletePhoto(req.userId, id);
+    const ok = await pregnancyService.deletePhoto(req.userId, id);
     if (!ok) {
       res.status(404).json({ error: 'Photo not found' });
       return;
     }
     res.status(204).send();
+  } catch (error) {
+    next(error);
+  }
+};
+
+/**
+ * @swagger
+ * /v2/pregnancy/photos/file/{id}:
+ *   get:
+ *     summary: Serve a bump photo image (authenticated, owner only)
+ *     tags: [Women's Health]
+ *     security:
+ *       - cookieAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: The image file.
+ *         content:
+ *           image/*:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       404:
+ *         description: Photo not found or not accessible.
+ */
+const getPhotoFile: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    if (typeof id !== 'string' || !UUID_RE.test(id)) {
+      res.status(400).json({ error: 'Invalid photo id' });
+      return;
+    }
+    const absolutePath = await pregnancyService.getPhotoFile(req.userId, id);
+    if (!absolutePath) {
+      res.status(404).json({ error: 'Photo not found' });
+      return;
+    }
+    // Pin the file to its declared type; matches the check-in file route.
+    // Deliberately no Content-Disposition: attachment, which would stop the
+    // image rendering in <img>.
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.sendFile(absolutePath, (err) => {
+      if (err && !res.headersSent) {
+        log('error', `Failed to send pregnancy photo ${id}`, err);
+        res.status(500).json({ error: 'Failed to serve photo' });
+      }
+    });
   } catch (error) {
     next(error);
   }
@@ -439,6 +487,13 @@ router.get('/contractions', listContractionsHandler);
 
 router.post('/photos', checkInPhotoUpload.single('photo'), uploadPhoto);
 router.get('/photos', listPhotos);
+// No checkPermissionMiddleware here, unlike the check-in equivalent: check-in
+// photos are delegatable via the 'checkin' permission, but pregnancy data is
+// owner-only and is never shared or delegated (db/rls_policies.sql uses
+// create_owner_policy for pregnancy_photos). Adding a permission guard here
+// would grant family members access to bump photos. Owner scoping comes from
+// req.userId + RLS in pregnancyRepository.getPhotoFilePath.
+router.get('/photos/file/:id', getPhotoFile);
 router.delete('/photos/:id', deletePhoto);
 
 router.get('/checklist', getChecklist);

--- a/SparkyFitnessServer/services/checkInPhotoService.ts
+++ b/SparkyFitnessServer/services/checkInPhotoService.ts
@@ -1,38 +1,18 @@
 import { getClient } from '../db/poolManager.js';
 import { log } from '../config/logging.js';
+import {
+  resolveUploadPath,
+  isWithinUploadsRoot,
+} from '../utils/uploadsPath.js';
 import fs from 'fs';
 import path from 'path';
 import { randomUUID } from 'crypto';
-import { fileURLToPath } from 'url';
 import { localDateToDay } from '@workspace/shared';
 import type {
   CheckInPhotoResponse,
   CheckInPhotoWithWeight,
   PhotoType,
 } from '../schemas/checkInPhotoSchemas.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-// Mirror the uploads-root resolution used elsewhere (SparkyFitnessServer.ts,
-// routes/exerciseRoutes.ts, utils/imageDownloader.ts, services/backupService.ts)
-// so a custom uploads location is honored instead of always writing under
-// SparkyFitnessServer/uploads.
-const baseUploadsDir = process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
-  ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY)
-  : path.join(__dirname, '..', 'uploads');
-
-// Stored file_path values are rooted at the logical 'uploads/' directory
-// (e.g. 'uploads/check-in/<user>/<date>/front.jpg') so records stay portable
-// across deployments. Resolve them against the configured uploads root,
-// stripping the leading 'uploads' segment. resolveFilePath('uploads') therefore
-// returns baseUploadsDir, keeping the path-traversal guard in getPhotoFileById
-// correct under a custom uploads directory.
-const resolveFilePath = (relativePath: string) => {
-  const segments = relativePath.split(/[/\\]/).filter(Boolean);
-  if (segments[0] === 'uploads') segments.shift();
-  return path.join(baseUploadsDir, ...segments);
-};
 
 const safeUnlink = async (absolutePath: string) => {
   try {
@@ -176,7 +156,7 @@ export const upsertPhoto = async (
     entryDate,
     fileName
   );
-  const finalPath = resolveFilePath(relativePath);
+  const finalPath = resolveUploadPath(relativePath);
   // Write to a unique temp file first; only promote it to the final name after
   // the DB commit succeeds. This way a failed upsert never leaves an orphan and
   // never clobbers the existing photo when replacing one with the same name.
@@ -228,7 +208,7 @@ export const upsertPhoto = async (
     // Remove the previous file only when the name changed (e.g. a different
     // extension); a same-name replace was already overwritten by the rename.
     if (oldRelativePath && oldRelativePath !== relativePath) {
-      await safeUnlink(resolveFilePath(oldRelativePath));
+      await safeUnlink(resolveUploadPath(oldRelativePath));
     }
 
     const r = result.rows[0];
@@ -276,12 +256,8 @@ export const getPhotoFileById = async (
     if (!filePath) {
       return null;
     }
-    const absolute = resolveFilePath(filePath);
-    const uploadsRoot = resolveFilePath('uploads');
-    if (
-      absolute !== uploadsRoot &&
-      !absolute.startsWith(uploadsRoot + path.sep)
-    ) {
+    const absolute = resolveUploadPath(filePath);
+    if (!isWithinUploadsRoot(absolute)) {
       log(
         'warn',
         `Rejected check-in photo path outside uploads root: ${filePath}`
@@ -315,7 +291,7 @@ export const deletePhoto = async (
     if (result.rows.length === 0) {
       return false;
     }
-    const filePath = resolveFilePath(result.rows[0].file_path);
+    const filePath = resolveUploadPath(result.rows[0].file_path);
     try {
       await fs.promises.unlink(filePath);
       log('debug', `Deleted check-in photo file: ${filePath}`);

--- a/SparkyFitnessServer/services/checkInPhotoService.ts
+++ b/SparkyFitnessServer/services/checkInPhotoService.ts
@@ -2,7 +2,7 @@ import { getClient } from '../db/poolManager.js';
 import { log } from '../config/logging.js';
 import {
   resolveUploadPath,
-  isWithinUploadsRoot,
+  resolveUploadPathWithinRoot,
 } from '../utils/uploadsPath.js';
 import fs from 'fs';
 import path from 'path';
@@ -208,7 +208,17 @@ export const upsertPhoto = async (
     // Remove the previous file only when the name changed (e.g. a different
     // extension); a same-name replace was already overwritten by the rename.
     if (oldRelativePath && oldRelativePath !== relativePath) {
-      await safeUnlink(resolveUploadPath(oldRelativePath));
+      // Guard the stored path before deleting: unlink is destructive, so a
+      // tampered file_path must not be able to reach outside the uploads root.
+      const oldAbsolute = resolveUploadPathWithinRoot(oldRelativePath);
+      if (oldAbsolute) {
+        await safeUnlink(oldAbsolute);
+      } else {
+        log(
+          'warn',
+          `Refused to delete check-in photo path outside uploads root: ${oldRelativePath}`
+        );
+      }
     }
 
     const r = result.rows[0];
@@ -256,8 +266,8 @@ export const getPhotoFileById = async (
     if (!filePath) {
       return null;
     }
-    const absolute = resolveUploadPath(filePath);
-    if (!isWithinUploadsRoot(absolute)) {
+    const absolute = resolveUploadPathWithinRoot(filePath);
+    if (!absolute) {
       log(
         'warn',
         `Rejected check-in photo path outside uploads root: ${filePath}`
@@ -291,7 +301,14 @@ export const deletePhoto = async (
     if (result.rows.length === 0) {
       return false;
     }
-    const filePath = resolveUploadPath(result.rows[0].file_path);
+    const filePath = resolveUploadPathWithinRoot(result.rows[0].file_path);
+    if (!filePath) {
+      log(
+        'warn',
+        `Refused to delete check-in photo path outside uploads root: ${result.rows[0].file_path}`
+      );
+      return true;
+    }
     try {
       await fs.promises.unlink(filePath);
       log('debug', `Deleted check-in photo file: ${filePath}`);

--- a/SparkyFitnessServer/services/pregnancyService.ts
+++ b/SparkyFitnessServer/services/pregnancyService.ts
@@ -1,10 +1,7 @@
 import fs from 'fs';
 import pregnancyRepository from '../models/pregnancyRepository.js';
 import { log } from '../config/logging.js';
-import {
-  resolveUploadPath,
-  isWithinUploadsRoot,
-} from '../utils/uploadsPath.js';
+import { resolveUploadPathWithinRoot } from '../utils/uploadsPath.js';
 import {
   gestationalAge,
   babyWeek,
@@ -237,8 +234,8 @@ async function getPhotoFile(
   if (!filePath) {
     return null;
   }
-  const absolute = resolveUploadPath(filePath);
-  if (!isWithinUploadsRoot(absolute)) {
+  const absolute = resolveUploadPathWithinRoot(filePath);
+  if (!absolute) {
     log(
       'warn',
       `Rejected pregnancy photo path outside uploads root: ${filePath}`
@@ -265,7 +262,16 @@ async function deletePhoto(userId: string, photoId: string): Promise<boolean> {
   if (!filePath) {
     return false;
   }
-  const absolute = resolveUploadPath(filePath);
+  // Guard the stored path before deleting: unlink is destructive, so a
+  // tampered file_path must not be able to reach outside the uploads root.
+  const absolute = resolveUploadPathWithinRoot(filePath);
+  if (!absolute) {
+    log(
+      'warn',
+      `Refused to delete pregnancy photo path outside uploads root: ${filePath}`
+    );
+    return true;
+  }
   try {
     await fs.promises.unlink(absolute);
     log('debug', `Deleted pregnancy photo file: ${absolute}`);

--- a/SparkyFitnessServer/services/pregnancyService.ts
+++ b/SparkyFitnessServer/services/pregnancyService.ts
@@ -1,4 +1,10 @@
+import fs from 'fs';
 import pregnancyRepository from '../models/pregnancyRepository.js';
+import { log } from '../config/logging.js';
+import {
+  resolveUploadPath,
+  isWithinUploadsRoot,
+} from '../utils/uploadsPath.js';
 import {
   gestationalAge,
   babyWeek,
@@ -214,8 +220,74 @@ function normalizeDay(value: string | Date): string {
   return value.slice(0, 10);
 }
 
+/**
+ * Resolves the absolute path of a bump photo the caller owns, or null.
+ *
+ * Bump photos are owner-only reproductive-health data: they are excluded from
+ * the public /uploads static mount, so this is the only way to reach the bytes.
+ * Returns null (never throws) for a missing row, a non-owner, a path that
+ * escapes the uploads root, or a file that is gone from disk, so the route can
+ * answer a uniform 404 without confirming which case it was.
+ */
+async function getPhotoFile(
+  userId: string,
+  photoId: string
+): Promise<string | null> {
+  const filePath = await pregnancyRepository.getPhotoFilePath(userId, photoId);
+  if (!filePath) {
+    return null;
+  }
+  const absolute = resolveUploadPath(filePath);
+  if (!isWithinUploadsRoot(absolute)) {
+    log(
+      'warn',
+      `Rejected pregnancy photo path outside uploads root: ${filePath}`
+    );
+    return null;
+  }
+  // Confirm the file is actually on disk so a missing file yields a clean 404
+  // at the route instead of a 500 from sendFile. Photos uploaded before the
+  // SPARKY_FITNESS_UPLOADS_DIR fix on a custom uploads directory land here.
+  try {
+    await fs.promises.access(absolute);
+  } catch {
+    return null;
+  }
+  return absolute;
+}
+
+/**
+ * Deletes a bump photo row and its file. Returns false when the row did not
+ * exist or the caller does not own it.
+ */
+async function deletePhoto(userId: string, photoId: string): Promise<boolean> {
+  const filePath = await pregnancyRepository.deletePhoto(userId, photoId);
+  if (!filePath) {
+    return false;
+  }
+  const absolute = resolveUploadPath(filePath);
+  try {
+    await fs.promises.unlink(absolute);
+    log('debug', `Deleted pregnancy photo file: ${absolute}`);
+  } catch (err) {
+    // The DB row is already deleted (the source of truth), so don't fail the
+    // request over the file. A missing file is expected; log anything else so
+    // the orphaned file can be cleaned up later.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      log(
+        'error',
+        `Failed to delete pregnancy photo file ${absolute} for photo ${photoId}`,
+        err
+      );
+    }
+  }
+  return true;
+}
+
 export default {
   getOverview,
   getContractionAnalysis,
   resolveDueDate,
+  getPhotoFile,
+  deletePhoto,
 };

--- a/SparkyFitnessServer/tests/pregnancyPhotoService.test.ts
+++ b/SparkyFitnessServer/tests/pregnancyPhotoService.test.ts
@@ -1,4 +1,10 @@
 import { vi, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import {
+  UPLOADS_BASE_DIR,
+  resolveUploadPathWithinRoot,
+} from '../utils/uploadsPath.js';
 import pregnancyRepository from '../models/pregnancyRepository.js';
 import pregnancyService from '../services/pregnancyService.js';
 
@@ -21,7 +27,6 @@ describe('pregnancyService.getPhotoFile', () => {
   it.each([
     'uploads/../../etc/passwd',
     'uploads/pregnancy/../../../../etc/passwd',
-    '/etc/passwd',
   ])('refuses a path escaping the uploads root: %s', async (stored) => {
     vi.mocked(pregnancyRepository.getPhotoFilePath).mockResolvedValue(stored);
     await expect(
@@ -51,6 +56,22 @@ describe('pregnancyService.deletePhoto', () => {
     ).resolves.toBe(false);
   });
 
+  // unlink is destructive, so a tampered file_path must never reach it.
+  it.each([
+    'uploads/../../etc/passwd',
+    'uploads/pregnancy/../../../../etc/passwd',
+  ])('does not unlink a path escaping the uploads root: %s', async (stored) => {
+    const unlinkSpy = vi
+      .spyOn(fs.promises, 'unlink')
+      .mockResolvedValue(undefined);
+    vi.mocked(pregnancyRepository.deletePhoto).mockResolvedValue(stored);
+
+    await pregnancyService.deletePhoto('user-1', PHOTO_ID);
+
+    expect(unlinkSpy).not.toHaveBeenCalled();
+    unlinkSpy.mockRestore();
+  });
+
   // The row is the source of truth: a missing file must not fail the request.
   it('still succeeds when the file is already gone from disk', async () => {
     vi.mocked(pregnancyRepository.deletePhoto).mockResolvedValue(
@@ -59,5 +80,21 @@ describe('pregnancyService.deletePhoto', () => {
     await expect(
       pregnancyService.deletePhoto('user-1', PHOTO_ID)
     ).resolves.toBe(true);
+  });
+});
+
+describe('uploads path resolution', () => {
+  // A leading slash does not escape: the resolver re-roots stored paths under
+  // the uploads directory, so '/etc/passwd' becomes '<uploads>/etc/passwd'.
+  // Only '..' segments can climb out, which is what the containment guard
+  // exists to catch.
+  it('re-roots an absolute-looking stored path inside the uploads root', () => {
+    expect(resolveUploadPathWithinRoot('/etc/passwd')).toBe(
+      path.join(UPLOADS_BASE_DIR, 'etc', 'passwd')
+    );
+  });
+
+  it('rejects a stored path that climbs out with ..', () => {
+    expect(resolveUploadPathWithinRoot('uploads/../../etc/passwd')).toBeNull();
   });
 });

--- a/SparkyFitnessServer/tests/pregnancyPhotoService.test.ts
+++ b/SparkyFitnessServer/tests/pregnancyPhotoService.test.ts
@@ -1,0 +1,63 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import pregnancyRepository from '../models/pregnancyRepository.js';
+import pregnancyService from '../services/pregnancyService.js';
+
+vi.mock('../models/pregnancyRepository.js');
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+const PHOTO_ID = '11111111-1111-4111-8111-111111111111';
+
+describe('pregnancyService.getPhotoFile', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns null when the caller owns no such photo', async () => {
+    vi.mocked(pregnancyRepository.getPhotoFilePath).mockResolvedValue(null);
+    await expect(
+      pregnancyService.getPhotoFile('user-1', PHOTO_ID)
+    ).resolves.toBeNull();
+  });
+
+  // A tampered or corrupted file_path must never escape the uploads root.
+  it.each([
+    'uploads/../../etc/passwd',
+    'uploads/pregnancy/../../../../etc/passwd',
+    '/etc/passwd',
+  ])('refuses a path escaping the uploads root: %s', async (stored) => {
+    vi.mocked(pregnancyRepository.getPhotoFilePath).mockResolvedValue(stored);
+    await expect(
+      pregnancyService.getPhotoFile('user-1', PHOTO_ID)
+    ).resolves.toBeNull();
+  });
+
+  // Photos written before the SPARKY_FITNESS_UPLOADS_DIR fix on a custom
+  // uploads directory resolve to a path that is not on disk.
+  it('returns null when the row points at a file that is gone', async () => {
+    vi.mocked(pregnancyRepository.getPhotoFilePath).mockResolvedValue(
+      'uploads/pregnancy/user-1/preg-1/w12-does-not-exist.jpg'
+    );
+    await expect(
+      pregnancyService.getPhotoFile('user-1', PHOTO_ID)
+    ).resolves.toBeNull();
+  });
+});
+
+describe('pregnancyService.deletePhoto', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reports false when nothing was deleted', async () => {
+    vi.mocked(pregnancyRepository.deletePhoto).mockResolvedValue(null);
+    await expect(
+      pregnancyService.deletePhoto('user-1', PHOTO_ID)
+    ).resolves.toBe(false);
+  });
+
+  // The row is the source of truth: a missing file must not fail the request.
+  it('still succeeds when the file is already gone from disk', async () => {
+    vi.mocked(pregnancyRepository.deletePhoto).mockResolvedValue(
+      'uploads/pregnancy/user-1/preg-1/w12-does-not-exist.jpg'
+    );
+    await expect(
+      pregnancyService.deletePhoto('user-1', PHOTO_ID)
+    ).resolves.toBe(true);
+  });
+});

--- a/SparkyFitnessServer/tests/pregnancyRoutes.test.ts
+++ b/SparkyFitnessServer/tests/pregnancyRoutes.test.ts
@@ -1,4 +1,15 @@
-import { vi, beforeEach, describe, expect, it } from 'vitest';
+import {
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 // @ts-expect-error supertest has no bundled types in this project
 import request from 'supertest';
 import express from 'express';
@@ -15,6 +26,8 @@ vi.mock('../services/pregnancyService.js', async (importOriginal) => {
       ...actual.default,
       getOverview: vi.fn(),
       getContractionAnalysis: vi.fn(),
+      getPhotoFile: vi.fn(),
+      deletePhoto: vi.fn(),
     },
   };
 });
@@ -109,5 +122,78 @@ describe('Pregnancy Routes V2', () => {
       '/api/v2/pregnancy/00000000-0000-0000-0000-000000000000'
     );
     expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('Pregnancy bump photos', () => {
+  const PHOTO_ID = '11111111-1111-4111-8111-111111111111';
+  let tempFile: string;
+
+  beforeAll(async () => {
+    tempFile = path.join(os.tmpdir(), `sparky-bump-${process.pid}.jpg`);
+    await fs.writeFile(tempFile, Buffer.from([0xff, 0xd8, 0xff, 0xdb]));
+  });
+
+  afterAll(async () => {
+    await fs.rm(tempFile, { force: true });
+  });
+
+  beforeEach(() => vi.clearAllMocks());
+
+  // file_path is a server-side storage detail; clients address photos by id.
+  it('omits file_path from the photo list', async () => {
+    vi.mocked(pregnancyRepository.listPhotos).mockResolvedValue([
+      { id: PHOTO_ID, pregnancy_id: 'p1', week: 12, notes: null },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ] as any);
+    const res = await request(app).get(
+      '/api/v2/pregnancy/photos?pregnancy_id=p1'
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.body[0]).not.toHaveProperty('file_path');
+  });
+
+  it('serves an owned photo with nosniff', async () => {
+    vi.mocked(pregnancyService.getPhotoFile).mockResolvedValue(tempFile);
+    const res = await request(app).get(
+      `/api/v2/pregnancy/photos/file/${PHOTO_ID}`
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(pregnancyService.getPhotoFile).toHaveBeenCalledWith(
+      'testUser',
+      PHOTO_ID
+    );
+  });
+
+  // Non-owner, deleted row, and missing-file all collapse to null at the
+  // service so the route cannot confirm which case it was.
+  it('404s when the service resolves nothing', async () => {
+    vi.mocked(pregnancyService.getPhotoFile).mockResolvedValue(null);
+    const res = await request(app).get(
+      `/api/v2/pregnancy/photos/file/${PHOTO_ID}`
+    );
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('rejects a non-UUID id without touching the service', async () => {
+    const res = await request(app).get(
+      '/api/v2/pregnancy/photos/file/not-a-uuid'
+    );
+    expect(res.statusCode).toBe(400);
+    expect(pregnancyService.getPhotoFile).not.toHaveBeenCalled();
+  });
+
+  it('deletes through the service so the file is removed too', async () => {
+    vi.mocked(pregnancyService.deletePhoto).mockResolvedValue(true);
+    const res = await request(app).delete(
+      `/api/v2/pregnancy/photos/${PHOTO_ID}`
+    );
+    expect(res.statusCode).toBe(204);
+    expect(pregnancyService.deletePhoto).toHaveBeenCalledWith(
+      'testUser',
+      PHOTO_ID
+    );
+    expect(pregnancyRepository.deletePhoto).not.toHaveBeenCalled();
   });
 });

--- a/SparkyFitnessServer/tests/uploadsStaticMount.test.ts
+++ b/SparkyFitnessServer/tests/uploadsStaticMount.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+// @ts-expect-error TS(7016): Could not find a declaration file for module 'supertest'
+import request from 'supertest';
+import express from 'express';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Guards the public /uploads static mounts (SparkyFitnessServer.ts).
+ *
+ * Sensitive photo subtrees must never be reachable without authentication:
+ * check-in progress photos and pregnancy bump photos are both served only by
+ * their owner-checked routes. SparkyFitnessServer.ts cannot be imported (it has
+ * no exports and opens a DB connection and a listener at module scope), so the
+ * mount block is reconstructed here, and a separate source-order assertion
+ * below checks the real file still has the deny rule in front of the static
+ * mounts.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+let uploadsRoot: string;
+
+const uploadsSecurityHeaders = {
+  'X-Content-Type-Options': 'nosniff',
+  'Content-Disposition': 'attachment',
+};
+
+const SENSITIVE_UPLOAD_SUBTREES = new Set(['check-in', 'pregnancy']);
+
+function buildApp() {
+  const app = express();
+  app.use(['/uploads', '/api/uploads'], (req, res, next) => {
+    let decodedPath: string;
+    try {
+      decodedPath = decodeURIComponent(req.path);
+    } catch {
+      res.status(400).end();
+      return;
+    }
+    const normalized = path.posix.normalize(decodedPath.replace(/\\/g, '/'));
+    const firstSegment = normalized
+      .split('/')
+      .filter(Boolean)[0]
+      ?.toLowerCase();
+    if (firstSegment && SENSITIVE_UPLOAD_SUBTREES.has(firstSegment)) {
+      res.status(404).end();
+      return;
+    }
+    next();
+  });
+  const options = {
+    etag: false,
+    lastModified: false,
+    maxAge: '7d',
+    immutable: true,
+    setHeaders: (res: express.Response) => {
+      for (const [name, value] of Object.entries(uploadsSecurityHeaders)) {
+        res.setHeader(name, value);
+      }
+    },
+  };
+  app.use('/api/uploads', express.static(uploadsRoot, options));
+  app.use('/uploads', express.static(uploadsRoot, options));
+  return app;
+}
+
+const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+async function seed(relativePath: string) {
+  const absolute = path.join(uploadsRoot, relativePath);
+  await fs.mkdir(path.dirname(absolute), { recursive: true });
+  await fs.writeFile(absolute, PNG);
+}
+
+beforeAll(async () => {
+  uploadsRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'sparky-uploads-'));
+  await seed('pregnancy/user-1/preg-1/w12-1700000000000.png');
+  await seed('check-in/user-1/2026-01-01/front.png');
+  await seed('exercises/ex-1/image.png');
+});
+
+afterAll(async () => {
+  await fs.rm(uploadsRoot, { recursive: true, force: true });
+});
+
+describe('public uploads static mounts', () => {
+  it.each([
+    '/uploads/pregnancy/user-1/preg-1/w12-1700000000000.png',
+    '/api/uploads/pregnancy/user-1/preg-1/w12-1700000000000.png',
+  ])('denies unauthenticated pregnancy bump photos via %s', async (url) => {
+    const res = await request(buildApp()).get(url);
+    expect(res.status).toBe(404);
+  });
+
+  it.each([
+    '/uploads/check-in/user-1/2026-01-01/front.png',
+    '/api/uploads/check-in/user-1/2026-01-01/front.png',
+  ])('denies unauthenticated check-in photos via %s', async (url) => {
+    const res = await request(buildApp()).get(url);
+    expect(res.status).toBe(404);
+  });
+
+  it('denies a case-variant path (Express routing is case-insensitive)', async () => {
+    const res = await request(buildApp()).get(
+      '/uploads/Pregnancy/user-1/preg-1/w12-1700000000000.png'
+    );
+    expect(res.status).toBe(404);
+  });
+
+  // These URLs do not begin with a protected prefix, but serve-static decodes
+  // and normalizes them into one. The guard must therefore test the resolved
+  // path, not the literal URL.
+  it.each([
+    '/uploads/exercises/..%2fpregnancy/user-1/preg-1/w12-1700000000000.png',
+    '/api/uploads/exercises/..%2fpregnancy/user-1/preg-1/w12-1700000000000.png',
+    '/uploads/exercises/..%2fcheck-in/user-1/2026-01-01/front.png',
+    '/api/uploads/exercises/..%2fcheck-in/user-1/2026-01-01/front.png',
+  ])(
+    'denies an encoded traversal into a sensitive subtree via %s',
+    async (url) => {
+      const res = await request(buildApp()).get(url);
+      expect(res.status).toBe(404);
+    }
+  );
+
+  it('still serves genuinely public uploads', async () => {
+    const res = await request(buildApp()).get(
+      '/uploads/exercises/ex-1/image.png'
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+});
+
+describe('SparkyFitnessServer.ts mount ordering', () => {
+  // The deny rule only works because it is registered before express.static.
+  // If this fails after a refactor, FIX THE ORDER (or update the anchors) —
+  // do not delete the assertion: moving the deny rule below the static mounts
+  // silently republishes every sensitive photo.
+  it('registers the sensitive-subtree deny rule before the static mounts', async () => {
+    const source = await fs.readFile(
+      path.join(__dirname, '..', 'SparkyFitnessServer.ts'),
+      'utf8'
+    );
+    const denyIndex = source.indexOf('SENSITIVE_UPLOAD_SUBTREES');
+    const staticIndex = source.indexOf(
+      'express.static(UPLOADS_BASE_DIR, uploadsStaticOptions)'
+    );
+    expect(denyIndex).toBeGreaterThan(-1);
+    expect(staticIndex).toBeGreaterThan(-1);
+    expect(denyIndex).toBeLessThan(staticIndex);
+  });
+});

--- a/SparkyFitnessServer/utils/uploadsPath.ts
+++ b/SparkyFitnessServer/utils/uploadsPath.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * The uploads root. Mirrors the resolution used elsewhere
+ * (SparkyFitnessServer.ts, routes/exerciseRoutes.ts, utils/imageDownloader.ts,
+ * services/backupService.ts) so a custom uploads location is honored instead of
+ * always writing under SparkyFitnessServer/uploads.
+ */
+export const UPLOADS_BASE_DIR = process.env
+  .SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY
+  ? path.resolve(process.env.SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY)
+  : path.join(__dirname, '..', 'uploads');
+
+/**
+ * Stored file_path values are rooted at the logical 'uploads/' directory
+ * (e.g. 'uploads/check-in/<user>/<date>/front.jpg') so records stay portable
+ * across deployments. Resolve them against the configured uploads root,
+ * stripping the leading 'uploads' segment. resolveUploadPath('uploads')
+ * therefore returns UPLOADS_BASE_DIR, which is what keeps isWithinUploadsRoot
+ * correct under a custom uploads directory.
+ */
+export const resolveUploadPath = (relativePath: string): string => {
+  const segments = relativePath.split(/[/\\]/).filter(Boolean);
+  if (segments[0] === 'uploads') segments.shift();
+  return path.join(UPLOADS_BASE_DIR, ...segments);
+};
+
+/**
+ * Path-traversal guard for absolute paths derived from stored file_path values.
+ * A tampered or malformed record (e.g. 'uploads/../../etc/passwd') resolves
+ * outside the uploads root and must never be served.
+ */
+export const isWithinUploadsRoot = (absolutePath: string): boolean => {
+  const root = resolveUploadPath('uploads');
+  return absolutePath === root || absolutePath.startsWith(root + path.sep);
+};

--- a/SparkyFitnessServer/utils/uploadsPath.ts
+++ b/SparkyFitnessServer/utils/uploadsPath.ts
@@ -38,3 +38,18 @@ export const isWithinUploadsRoot = (absolutePath: string): boolean => {
   const root = resolveUploadPath('uploads');
   return absolutePath === root || absolutePath.startsWith(root + path.sep);
 };
+
+/**
+ * Resolves a stored `file_path` and returns it only if it stays inside the
+ * uploads root, otherwise null.
+ *
+ * Prefer this over calling resolveUploadPath directly whenever the path comes
+ * from a database row: it keeps the containment check attached to the
+ * resolution, so a read or an unlink cannot accidentally skip it.
+ */
+export const resolveUploadPathWithinRoot = (
+  relativePath: string
+): string | null => {
+  const absolute = resolveUploadPath(relativePath);
+  return isWithinUploadsRoot(absolute) ? absolute : null;
+};

--- a/agent-docs/file-and-domain-reference.md
+++ b/agent-docs/file-and-domain-reference.md
@@ -70,7 +70,7 @@ Paths are relative to each package root. `—` means that layer does not exist f
 | Feature | Backend | Frontend | Mobile | Shared |
 |---------|---------|----------|--------|--------|
 | **Cycle** | `routes/v2/cycleRoutes.ts`, `schemas/cycleSchemas.ts`, `services/cycleService.ts`, `models/cycleRepository.ts` | `pages/Cycle/` `api/Cycle/` `hooks/useCycle.ts` (flat) | — | tables `cycles`, `cycle_daily_entries`, `cycle_settings` (no `Cycle*.zod.ts`) |
-| **Pregnancy** | `routes/v2/pregnancyRoutes.ts`, `schemas/pregnancySchemas.ts`, `services/pregnancyService.ts`, `models/pregnancyRepository.ts` | `api/Pregnancy/` `hooks/usePregnancy.ts` (no page) | — | (no `Pregnancy*.zod.ts`) |
+| **Pregnancy** | `routes/v2/pregnancyRoutes.ts`, `schemas/pregnancySchemas.ts`, `services/pregnancyService.ts`, `models/pregnancyRepository.ts`, `utils/uploadsPath.ts` (photo bytes) | `api/Pregnancy/` `hooks/usePregnancy.ts`, `pages/Cycle/pregnancy/` | `hooks/usePregnancyPhotoSource.ts`, `components/wellness/pregnancy/` | (no `Pregnancy*.zod.ts`) |
 
 ### Reporting & Analytics
 

--- a/docs/content/2.features/9.family-friends-sharing.md
+++ b/docs/content/2.features/9.family-friends-sharing.md
@@ -43,7 +43,7 @@ Certain tables contain private user data that is **never** accessible to any fam
 * API Keys (`api_key` table)
 * OIDC SSO Connections (`user_oidc_links` table)
 * Personal AI Assistant Chat History (`sparky_chat_history` table)
-* Cycle & Pregnancy hub data (`cycle_settings`, `cycle_daily_entries`, `cycles`, `user_cycle_display_preferences`, `cycle_test_entries`, `pregnancies`, `pregnancy_kick_sessions`, `pregnancy_contractions`, `pregnancy_photos`, `pregnancy_checklist_state`, `health_appointments` tables) — this reproductive-health data is **never** shared or delegated, even with `can_view_reports`. It is strictly owner-only.
+* Cycle & Pregnancy hub data (`cycle_settings`, `cycle_daily_entries`, `cycles`, `user_cycle_display_preferences`, `cycle_test_entries`, `pregnancies`, `pregnancy_kick_sessions`, `pregnancy_contractions`, `pregnancy_photos`, `pregnancy_checklist_state`, `health_appointments` tables) — this reproductive-health data is **never** shared or delegated, even with `can_view_reports`. It is strictly owner-only. Bump photo *files* are owner-only too: they are excluded from the public uploads URLs and can only be fetched through an authenticated request by their owner.
 
 ### 2. Tier 2: Read-Only Profile & Settings Data
 The following data can be **read** by delegates who hold at least one of `can_manage_diary`, `can_manage_checkin`, `can_manage_medications`, or `can_view_reports` — but **only the account owner can modify it**:

--- a/docs/content/8.developer/11.database-security-tiers.md
+++ b/docs/content/8.developer/11.database-security-tiers.md
@@ -47,7 +47,7 @@ These tables contain highly sensitive credentials, API keys, SSO tokens, 2FA rec
 | `pregnancies` | Pregnancy records (due date, status, linked prenatal medication) | Owner-Only | Owner-Only |
 | `pregnancy_kick_sessions` | Fetal kick-counter sessions | Owner-Only | Owner-Only |
 | `pregnancy_contractions` | Contraction timer logs | Owner-Only | Owner-Only |
-| `pregnancy_photos` | Bump photo journal | Owner-Only | Owner-Only |
+| `pregnancy_photos` | Bump photo journal (image bytes served only via the authenticated `GET /api/v2/pregnancy/photos/file/{id}`; excluded from the public `/uploads` static mount) | Owner-Only | Owner-Only |
 | `pregnancy_checklist_state` | Weekly pregnancy checklist completion/custom items | Owner-Only | Owner-Only |
 | `health_appointments` | Prenatal & other health appointments | Owner-Only | Owner-Only |
 | `openfoodfacts_product_read_rate_limit` | Singleton coordination lease and cooldown for Open Food Facts product reads, including manual previews; contains no user data or credentials | System services only | Deny all |
@@ -125,7 +125,7 @@ These tables contain daily diaries, logging entries, and scheduler items. **Care
 | Table Name | Description | Write (insert/update/delete) | Read (select) |
 | :--- | :--- | :--- | :--- |
 | `check_in_measurements` | Weight, body composition, BMR, and circumference measurements | Delegate with `can_manage_checkin` | Delegate with `can_manage_checkin` or `can_view_reports` |
-| `check_in_photos` | Progress photos | Delegate with `can_manage_checkin` | Delegate with `can_manage_checkin` or `can_view_reports` |
+| `check_in_photos` | Progress photos (image bytes served only via the authenticated `GET /api/measurements/check-in-photos/file/{id}`; excluded from the public `/uploads` static mount) | Delegate with `can_manage_checkin` | Delegate with `can_manage_checkin` or `can_view_reports` |
 | `sleep_entries` | Sleep logs (bedtime, wake time) | Delegate with `can_manage_checkin` | Delegate with `can_manage_checkin` or `can_view_reports` |
 | `sleep_entry_stages` | Sleep stage breakdowns (REM, Deep, Light) | Delegate with `can_manage_checkin` | Delegate with `can_manage_checkin` or `can_view_reports` |
 | `sleep_need_calculations` | AI sleep need calculations | Delegate with `can_manage_checkin` | Delegate with `can_manage_checkin` or `can_view_reports` |


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Progress photos and bump photos are both owner-scoped in the database, but only progress photos were served that way: bump photos were delivered from the public `/uploads` static mount, and the mount's deny rule matched the literal URL rather than the path `serve-static` actually resolves. This applies one consistent pattern to both.

**How did you implement the solution?**

- The static-mount guard now resolves the request path the way `serve-static` does (decode once, normalize, test the first segment) and is driven by a `SENSITIVE_UPLOAD_SUBTREES` set, so a raw-URL prefix is no longer what the protection depends on.
- Added `GET /api/v2/pregnancy/photos/file/:id`, owner-scoped via `req.userId` plus RLS. It deliberately carries **no** `checkPermissionMiddleware`, unlike the check-in equivalent — pregnancy data is owner-only and never delegated, so a permission guard there would widen access rather than restrict it. There's a comment on the route saying so.
- Extracted `SparkyFitnessServer/utils/uploadsPath.ts` (uploads root, `file_path` resolver, containment guard) and moved `checkInPhotoService` onto it; the logic existed twice once pregnancy needed it.
- `routes/v2/pregnancyRoutes.ts` now reads `SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY`. It was the only file in the repo reading `SPARKY_FITNESS_UPLOADS_DIR`, which nothing else sets, so on a custom uploads directory bump photos were written outside both the served root and the backup scope.
- Deleting a bump photo now removes the file, not just the row. The delete handler was calling the repository directly and skipping the service layer, so this also routes it through `pregnancyService`.
- `file_path` is no longer returned in bump photo responses; web and mobile address photos by id, matching how check-in photos already work.
- Extracted `useAuthedImageSource` on mobile so the shared plaintext-HTTP guard (which keeps the session token off the wire) backs both check-in and pregnancy image sources instead of being duplicated.

Linked Issue: Closes # N/A

## How to Test

1. Check out this branch, then `cd SparkyFitnessServer && pnpm start` and `cd SparkyFitnessFrontend && pnpm dev`.
2. Open the Cycle → Pregnancy hub and upload a bump photo. Confirm it renders in the journal, and that deleting it removes the file from `SparkyFitnessServer/uploads/pregnancy/...` on disk, not just the entry.
3. Confirm `GET /api/v2/pregnancy/photos` no longer includes `file_path`, and that `GET /api/v2/pregnancy/photos/file/<id>` returns the image for its owner and `404` otherwise.
4. Confirm unrelated public uploads are unaffected — an exercise image still loads.
5. Automated coverage:
   ```
   cd SparkyFitnessServer && pnpm test   # includes tests/uploadsStaticMount.test.ts, tests/pregnancyPhotoService.test.ts
   cd SparkyFitnessFrontend && pnpm test
   cd SparkyFitnessMobile  && pnpm exec jest --watchman=false --runInBand
   ```

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [x] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. — N/A, not a new feature.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. — No translation files were changed.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests. — See the note below on param validation.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. — No new tables; no migration and no RLS change in this PR.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. — The bump photo journal is visually unchanged; only the URL the image is fetched from changed.

**Mobile changes (`SparkyFitnessMobile/`):**

- [x] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. — **Not yet done.** Covered by unit tests only; needs a device/emulator pass on the bump photo journal before merge.

## Screenshots

N/A — no visual change.

## Notes for Reviewers

- **Needs a device check.** The mobile bump photo journal moves from a bare React Native `Image` to `SafeImage` with an authenticated source. Unit tests pass, but the on-device rendering (including the fallback when a photo is missing) has not been verified yet.
- **Client/server must ship together.** Bump photos are no longer reachable at their old public URL, so an older mobile build pointed at an updated server will show blank photos in the journal until the app updates. Web is unaffected.
- **Custom uploads directories.** Because `routes/v2/pregnancyRoutes.ts` previously read an env var nothing else sets, any deployment using `SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY` (e.g. the Nix module) has existing bump photos under `<install>/SparkyFitnessServer/uploads/pregnancy`. They were already unreachable there; after this change the server looks in the configured directory, so recovering them means moving that folder. Docker is unaffected — compose mounts the default path.
- **Param validation uses `UUID_RE`, not Zod.** The new route reuses the regex the rest of `pregnancyRoutes.ts` already uses for ids rather than introducing a Zod param schema for one parameter. Happy to switch it to Zod for consistency with `routes/v2/` conventions if preferred.
- **Caching.** The new route sits under `/api`, so it inherits `Cache-Control: no-store` — same as the existing check-in file route. Photos refetch on scroll rather than caching to disk.
- `tests/uploadsStaticMount.test.ts` reconstructs the mount block because `SparkyFitnessServer.ts` has no exports and opens a DB connection and listener at import. It also asserts the guard is registered before `express.static`, so a future reorder fails CI rather than silently changing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Pregnancy bump photos are served only through authenticated, owner-checked requests.
  - Direct public access to pregnancy and check-in photo paths is blocked, including encoded and case-variant paths.
  - Insecure image connections are rejected outside development environments.

- **User Experience**
  - Bump photo journals load protected images reliably and show a fallback when an image is unavailable.

- **Documentation**
  - Updated privacy and developer documentation to clarify that sensitive photo files are excluded from public uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->