### PR TITLE
refactor(integrations): issue single-use OAuth state nonces for Withings and Polar

### DIFF
--- a/SparkyFitnessServer/AGENTS.md
+++ b/SparkyFitnessServer/AGENTS.md
@@ -69,6 +69,8 @@ pnpm exec eslint routes/v2/foodRoutes.ts services/foodCoreService.ts
 - `models/` - PostgreSQL repositories and persistence helpers
 - `middleware/` - auth, permissions, uploads, and shared Express middleware
 - `utils/uploadsPath.ts` - the uploads root plus the resolver and containment guard for stored `file_path` values; use it instead of re-deriving `SPARKY_FITNESS_CUSTOM_UPLOADS_DIRECTORY`
+- `utils/oauthState.ts` - server-issued single-use OAuth `state` nonces for provider linking (`issueOAuthState`, `persistOAuthState`, `claimOAuthState`); use it instead of hand-rolling a state value
+- `middleware/requireSelfMiddleware.ts` - `requireSelfActor`, which rejects a switched/delegated context outright; attach per-route to account-linking routes
 - `integrations/` - provider adapters and ingest pipelines
 - `schemas/` - Zod route schemas
 - `types/` - TypeScript declarations, including `Express.Request` augmentation
@@ -206,6 +208,7 @@ When searching, ignore noisy/generated directories unless you explicitly need th
 - Current adapters span food/nutrition (OpenFoodFacts, FatSecret, Nutritionix, USDA, Mealie, Tandoor, Norish, SwissFood, Yazio), fitness devices (Garmin Connect sync plus FIT file import via `integrations/garminfit/` + `services/fitImportService.ts`, Withings, Fitbit, Oura, Polar, Strava, Hevy), exercise databases (Wger, FreeExerciseDB), and health-data import (Google Health, generic/mobile health data)
 - Scheduled jobs currently include backups, session cleanup, and hourly sync loops for Withings, Garmin, Fitbit, Oura, Polar, and Strava
 - Integration work often spans route, service, repository, cron, and external-provider settings code; inspect the whole path before calling the work complete
+- **OAuth linking (`/authorize`, `/callback`) is self-only, and `state` is a server-issued single-use nonce.** Never derive a user id from a callback request body, and never gate an authorize route with `checkPermissionMiddleware('diary')` — on GET that resolves to `diary_read`, which would hand a read-only delegate the owner's decrypted OAuth client id. Use `requireSelfActor` plus `utils/oauthState.ts`. Withings and Polar follow this pattern; Oura, Fitbit and Strava are self-only but still send `state = userId` and ignore it on callback (tracked follow-up)
 
 ### AI Services
 

--- a/SparkyFitnessServer/integrations/polar/polarService.ts
+++ b/SparkyFitnessServer/integrations/polar/polarService.ts
@@ -47,7 +47,8 @@ async function getAuthorizationUrl(
 async function exchangeCodeForTokens(
   state: unknown,
   code: string,
-  redirectUri: string
+  redirectUri: string,
+  actorUserId: string
 ) {
   const client = await getSystemClient();
   try {
@@ -66,6 +67,7 @@ async function exchangeCodeForTokens(
     } = await claimOAuthState(client, {
       state,
       providerType: 'polar',
+      actorUserId,
     });
     const clientId = await decrypt(
       encrypted_app_id,

--- a/SparkyFitnessServer/integrations/polar/polarService.ts
+++ b/SparkyFitnessServer/integrations/polar/polarService.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import crypto from 'crypto';
 import { getClient, getSystemClient } from '../../db/poolManager.js';
 import { encrypt, decrypt, ENCRYPTION_KEY } from '../../security/encryption.js';
 import { log } from '../../config/logging.js';
@@ -7,6 +6,7 @@ import polarDataProcessor from './polarDataProcessor.js';
 import { loadUserTimezone } from '../../utils/timezoneLoader.js';
 import { todayInZone, addDays } from '@workspace/shared';
 import { logRawResponse } from '../../utils/diagnosticLogger.js';
+import { claimOAuthState, persistOAuthState } from '../../utils/oauthState.js';
 const POLAR_AUTH_URL = 'https://flow.polar.com/oauth2/authorization';
 const POLAR_TOKEN_URL = 'https://polarremote.com/v2/oauth2/token';
 const POLAR_API_BASE_URL = 'https://www.polaraccesslink.com/v3';
@@ -15,29 +15,20 @@ const POLAR_API_BASE_URL = 'https://www.polaraccesslink.com/v3';
  */
 
 async function getAuthorizationUrl(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  redirectUri: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  providerId: any
+  userId: string,
+  redirectUri: string,
+  providerId?: string | null
 ) {
   const client = await getSystemClient();
   try {
-    const query = providerId
-      ? {
-          text: 'SELECT encrypted_app_id, app_id_iv, app_id_tag FROM external_data_providers WHERE id = $1 AND user_id = $2',
-          values: [providerId, userId],
-        }
-      : {
-          text: "SELECT encrypted_app_id, app_id_iv, app_id_tag FROM external_data_providers WHERE user_id = $1 AND provider_type = 'polar'",
-          values: [userId],
-        };
-    const result = await client.query(query.text, query.values);
-    if (result.rows.length === 0) {
-      throw new Error('Polar client credentials not found for user.');
-    }
-    const { encrypted_app_id, app_id_iv, app_id_tag } = result.rows[0];
+    // One statement issues the nonce and returns the credentials, so the
+    // client_id in this URL always belongs to the row holding the nonce.
+    const { state, encrypted_app_id, app_id_iv, app_id_tag } =
+      await persistOAuthState(client, {
+        userId,
+        providerType: 'polar',
+        providerId,
+      });
     const clientId = await decrypt(
       encrypted_app_id,
       app_id_iv,
@@ -45,18 +36,6 @@ async function getAuthorizationUrl(
       ENCRYPTION_KEY
     );
     const scope = 'accesslink.read_all';
-    const state = crypto.randomBytes(16).toString('hex');
-    // Store state in DB for validation during callback
-    const updateQuery = providerId
-      ? {
-          text: 'UPDATE external_data_providers SET oauth_state = $1 WHERE id = $2 AND user_id = $3',
-          values: [state, providerId, userId],
-        }
-      : {
-          text: "UPDATE external_data_providers SET oauth_state = $1 WHERE user_id = $2 AND provider_type = 'polar'",
-          values: [state, userId],
-        };
-    await client.query(updateQuery.text, updateQuery.values);
     return `${POLAR_AUTH_URL}?response_type=code&client_id=${clientId}&scope=${scope}&state=${state}&redirect_uri=${encodeURIComponent(redirectUri)}`;
   } finally {
     client.release();
@@ -66,57 +45,28 @@ async function getAuthorizationUrl(
  * Exchange authorization code for tokens.
  */
 async function exchangeCodeForTokens(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  code: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  state: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  redirectUri: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  providerId: any
+  state: unknown,
+  code: string,
+  redirectUri: string
 ) {
   const client = await getSystemClient();
   try {
-    const providerQuery = providerId
-      ? {
-          text: `SELECT id, encrypted_app_id, app_id_iv, app_id_tag, encrypted_app_key, app_key_iv, app_key_tag, oauth_state
-                       FROM external_data_providers
-                       WHERE id = $1 AND user_id = $2`,
-          values: [providerId, userId],
-        }
-      : {
-          text: `SELECT id, encrypted_app_id, app_id_iv, app_id_tag, encrypted_app_key, app_key_iv, app_key_tag, oauth_state
-                       FROM external_data_providers
-                       WHERE oauth_state = $1 AND user_id = $2 AND provider_type = 'polar'`,
-          values: [state, userId],
-        };
-    const providerResult = await client.query(
-      providerQuery.text,
-      providerQuery.values
-    );
-    if (providerResult.rows.length === 0) {
-      throw new Error('Polar client credentials not found for user.');
-    }
+    // Replaces the old compare-then-use: the previous providerId branch reached
+    // the credential row by id+user_id with oauth_state absent from the lookup,
+    // and the only thing behind it was a non-atomic equality check.
     const {
       id: finalProviderId,
+      user_id: ownerUserId,
       encrypted_app_id,
       app_id_iv,
       app_id_tag,
       encrypted_app_key,
       app_key_iv,
       app_key_tag,
-      oauth_state: storedState,
-    } = providerResult.rows[0];
-    // Validate state to prevent CSRF
-    if (!storedState || storedState !== state) {
-      log(
-        'warn',
-        `[Polar] State mismatch for user ${userId}. Received: ${state}, Stored: ${storedState}`
-      );
-      throw new Error('Invalid OAuth state. Potential CSRF attack.');
-    }
+    } = await claimOAuthState(client, {
+      state,
+      providerType: 'polar',
+    });
     const clientId = await decrypt(
       encrypted_app_id,
       app_id_iv,
@@ -180,7 +130,7 @@ async function exchangeCodeForTokens(
       });
       log(
         'info',
-        `User ${userId} (Polar ID: ${x_user_id}) is already registered with Polar AccessLink.`
+        `User ${ownerUserId} (Polar ID: ${x_user_id}) is already registered with Polar AccessLink.`
       );
     } catch (getError) {
       // If 404 or 403 (unauthorized might mean not registered yet?), proceed to register
@@ -192,7 +142,7 @@ async function exchangeCodeForTokens(
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
         `User ${x_user_id} lookup status: ${getError.response ? getError.response.status : getError.message}. Proceeding to registration.`
       );
-      const inputBody = `<register><member-id>${userId}</member-id></register>`;
+      const inputBody = `<register><member-id>${ownerUserId}</member-id></register>`;
       try {
         await axios.post(`${POLAR_API_BASE_URL}/users`, inputBody, {
           headers: {
@@ -203,14 +153,14 @@ async function exchangeCodeForTokens(
         });
         log(
           'info',
-          `Successfully registered user ${userId} with Polar AccessLink.`
+          `Successfully registered user ${ownerUserId} with Polar AccessLink.`
         );
       } catch (regError) {
         // @ts-expect-error TS(2571): Object is of type 'unknown'.
         if (regError.response && regError.response.status === 409) {
           log(
             'info',
-            `User ${userId} already registered with Polar AccessLink (Conflict).`
+            `User ${ownerUserId} already registered with Polar AccessLink (Conflict).`
           );
           // @ts-expect-error TS(2571): Object is of type 'unknown'.
         } else if (regError.response && regError.response.status === 401) {
@@ -228,13 +178,13 @@ async function exchangeCodeForTokens(
           log(
             'error',
             // @ts-expect-error TS(2571): Object is of type 'unknown'.
-            `Error registering user ${userId} with Polar AccessLink: ${regError.message} - ${JSON.stringify(regError.response?.data)}`
+            `Error registering user ${ownerUserId} with Polar AccessLink: ${regError.message} - ${JSON.stringify(regError.response?.data)}`
           );
           throw regError;
         }
       }
     }
-    return { success: true, externalUserId: x_user_id };
+    return { success: true, externalUserId: x_user_id, ownerUserId };
   } catch (error) {
     // @ts-expect-error TS(2571): Object is of type 'unknown'.
     log('error', `Error exchanging Polar code for tokens: ${error.message}`);

--- a/SparkyFitnessServer/integrations/withings/withingsService.ts
+++ b/SparkyFitnessServer/integrations/withings/withingsService.ts
@@ -107,7 +107,8 @@ async function getAuthorizationUrl(userId: string) {
 async function exchangeCodeForTokens(
   state: unknown,
   code: string,
-  redirectUri: string
+  redirectUri: string,
+  actorUserId: string
 ) {
   const client = await getSystemClient();
   try {
@@ -123,6 +124,7 @@ async function exchangeCodeForTokens(
     } = await claimOAuthState(client, {
       state,
       providerType: 'withings',
+      actorUserId,
     });
     const clientId = await decrypt(
       encrypted_app_id,

--- a/SparkyFitnessServer/integrations/withings/withingsService.ts
+++ b/SparkyFitnessServer/integrations/withings/withingsService.ts
@@ -4,25 +4,7 @@ import { encrypt, decrypt, ENCRYPTION_KEY } from '../../security/encryption.js';
 import { log } from '../../config/logging.js';
 import withingsDataProcessor from './withingsDataProcessor.js';
 import { logRawResponse } from '../../utils/diagnosticLogger.js';
-// Helper function to interpolate parameters into a SQL query for logging
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function interpolateQuery(sql: any, params: any) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return sql.replace(/\$([0-9]+)/g, (match: any, p1: any) => {
-    const index = parseInt(p1, 10) - 1;
-    if (params[index] === undefined) {
-      return match; // Return original placeholder if param is missing
-    }
-    // Handle different types for proper SQL representation
-    if (typeof params[index] === 'string') {
-      return `'${params[index].replace(/'/g, "''")}'`; // Escape single quotes
-    }
-    if (params[index] instanceof Date) {
-      return `'${params[index].toISOString()}'`;
-    }
-    return params[index];
-  });
-}
+import { claimOAuthState, persistOAuthState } from '../../utils/oauthState.js';
 const WITHINGS_API_BASE_URL = 'https://wbsapi.withings.net';
 const WITHINGS_ACCOUNT_BASE_URL = 'https://account.withings.com';
 interface WithingsTokenBody {
@@ -97,20 +79,16 @@ async function requestWithingsToken(params: Record<string, string>) {
   );
 }
 // Function to construct the Withings authorization URL
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getAuthorizationUrl(userId: any) {
+async function getAuthorizationUrl(userId: string) {
   const client = await getSystemClient();
   try {
-    const result = await client.query(
-      `SELECT encrypted_app_id, app_id_iv, app_id_tag
-             FROM external_data_providers
-             WHERE user_id = $1 AND provider_type = 'withings'`,
-      [userId]
-    );
-    if (result.rows.length === 0) {
-      throw new Error('Withings client credentials not found for user.');
-    }
-    const { encrypted_app_id, app_id_iv, app_id_tag } = result.rows[0];
+    // Issuing the state and reading the client credentials is one statement, so
+    // the client_id in this URL always belongs to the row holding the nonce.
+    const { state, encrypted_app_id, app_id_iv, app_id_tag } =
+      await persistOAuthState(client, {
+        userId,
+        providerType: 'withings',
+      });
     const clientId = await decrypt(
       encrypted_app_id,
       app_id_iv,
@@ -118,37 +96,34 @@ async function getAuthorizationUrl(userId: any) {
       ENCRYPTION_KEY
     );
     const scope = 'user.info,user.metrics,user.activity,user.sleepevents'; // Define required scopes
-    const state = userId; // Use the userId as the state to identify the user on callback
-    // Store state in session or database to validate on callback
     return `${WITHINGS_ACCOUNT_BASE_URL}/oauth2_user/authorize2?response_type=code&client_id=${clientId}&scope=${scope}&redirect_uri=${process.env.SPARKY_FITNESS_FRONTEND_URL}/withings/callback&state=${state}`;
   } finally {
     client.release();
   }
 }
-// Function to exchange authorization code for access and refresh tokens
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function exchangeCodeForTokens(userId: any, code: any, redirectUri: any) {
+// Function to exchange authorization code for access and refresh tokens.
+// `userId` is deliberately absent from this signature: the owner is recovered
+// from the claimed state row, so no caller can name the row that gets written.
+async function exchangeCodeForTokens(
+  state: unknown,
+  code: string,
+  redirectUri: string
+) {
   const client = await getSystemClient();
   try {
-    // Validate state parameter (implementation depends on where state is stored)
-    // For example, retrieve from session and compare
-    const providerResult = await client.query(
-      `SELECT encrypted_app_id, app_id_iv, app_id_tag, encrypted_app_key, app_key_iv, app_key_tag
-             FROM external_data_providers
-             WHERE user_id = $1 AND provider_type = 'withings'`,
-      [userId]
-    );
-    if (providerResult.rows.length === 0) {
-      throw new Error('Withings client credentials not found for user.');
-    }
     const {
+      id: providerRowId,
+      user_id: ownerUserId,
       encrypted_app_id,
       app_id_iv,
       app_id_tag,
       encrypted_app_key,
       app_key_iv,
       app_key_tag,
-    } = providerResult.rows[0];
+    } = await claimOAuthState(client, {
+      state,
+      providerType: 'withings',
+    });
     const clientId = await decrypt(
       encrypted_app_id,
       app_id_iv,
@@ -197,49 +172,32 @@ async function exchangeCodeForTokens(userId: any, code: any, redirectUri: any) {
       scope,
       new Date(Date.now() + validExpiresIn * 1000),
       userid,
-      userId,
+      providerRowId,
     ];
-    log(
-      'info',
-      'Attempting to update database with payload:',
-      JSON.stringify(
-        {
-          encrypted_access_token: encryptedAccessToken.encryptedText,
-          scope: scope,
-          expires_in: expires_in,
-          external_user_id: userid,
-          user_id: userId,
-        },
-        null,
-        2
-      )
-    );
     try {
+      // Keyed on the claimed row's primary key: `provider_type` carries no
+      // uniqueness constraint, so a user_id predicate could fan out across rows.
+      // `oauth_state = NULL` is redundant after the claim, but states the invariant.
       const updateQuery = `UPDATE external_data_providers
                 SET encrypted_access_token = $1, access_token_iv = $2, access_token_tag = $3,
                     encrypted_refresh_token = $4, refresh_token_iv = $5, refresh_token_tag = $6,
-                    scope = $7, token_expires_at = $8, external_user_id = $9, is_active = TRUE, updated_at = NOW()
-                WHERE user_id = $10 AND provider_type = 'withings'`;
-      log('info', `Executing SQL query: ${updateQuery}`);
-      log('info', `With payload: ${JSON.stringify(updatePayload)}`);
-      log(
-        'info',
-        `Interpolated SQL query: ${interpolateQuery(updateQuery, updatePayload)}`
-      );
+                    scope = $7, token_expires_at = $8, external_user_id = $9,
+                    oauth_state = NULL, is_active = TRUE, updated_at = NOW()
+                WHERE id = $10`;
       const dbResult = await client.query(updateQuery, updatePayload);
       log(
         'info',
-        `Database update result for user ${userId}: ${dbResult.rowCount} rows updated.`
+        `Database update result for user ${ownerUserId}: ${dbResult.rowCount} rows updated.`
       );
     } catch (dbError) {
       log(
         'error',
-        `FATAL: Database update failed for user ${userId}:`,
+        `FATAL: Database update failed for user ${ownerUserId}:`,
         dbError
       );
       throw dbError; // Re-throw to ensure the outer catch block handles it
     }
-    return { success: true, userId: userid };
+    return { success: true, userId: userid, ownerUserId };
   } catch (error) {
     // @ts-expect-error TS(2571): Object is of type 'unknown'.
     log('error', `Error exchanging Withings code for tokens: ${error.message}`);

--- a/SparkyFitnessServer/middleware/requireSelfMiddleware.ts
+++ b/SparkyFitnessServer/middleware/requireSelfMiddleware.ts
@@ -1,0 +1,44 @@
+import type { NextFunction, Request, Response } from 'express';
+import { log } from '../config/logging.js';
+
+/**
+ * Rejects requests running in a switched / delegated context.
+ *
+ * `checkPermissionMiddleware` authorizes delegation and `onBehalfOfMiddleware`
+ * establishes it; nothing else in the stack expresses "this route may not be
+ * used on someone else's behalf at all". Account linking needs exactly that: a
+ * family delegate with diary access is authorized to read the owner's diary,
+ * never to bind an external identity to the owner's row or to receive an
+ * authorization URL carrying the owner's decrypted OAuth client id.
+ *
+ * Attach per-route, never with `router.use` — sync, disconnect and status are
+ * legitimately delegatable and must keep working in a switched context.
+ */
+export function requireSelfActor(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  // `||` deliberately mirrors checkPermissionMiddleware.ts so the two agree
+  // exactly on who "the caller" is; diverging here would be a subtle bug.
+  const actorUserId =
+    req.originalUserId || req.authenticatedUserId || req.userId;
+  if (!actorUserId || !req.userId) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  if (req.userId !== actorUserId) {
+    log(
+      'warn',
+      `Forbidden: user ${actorUserId} attempted an account-linking action for ${req.userId}.`
+    );
+    res.status(403).json({
+      error:
+        'Forbidden: account linking is only available for your own account.',
+    });
+    return;
+  }
+  next();
+}
+
+export default requireSelfActor;

--- a/SparkyFitnessServer/routes/fitbitRoutes.ts
+++ b/SparkyFitnessServer/routes/fitbitRoutes.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import fitbitIntegrationService from '../integrations/fitbit/fitbitService.js';
 import fitbitService from '../services/fitbitService.js';
 import { log } from '../config/logging.js';
+import requireSelfActor from '../middleware/requireSelfMiddleware.js';
 import authMiddleware from '../middleware/authMiddleware.js';
 import checkPermissionMiddleware from '../middleware/checkPermissionMiddleware.js';
 const router = express.Router();
@@ -20,7 +21,9 @@ const router = express.Router();
 router.get(
   '/authorize',
   authMiddleware.authenticate,
-  checkPermissionMiddleware('diary'),
+  // Self-only: the diary gate resolves to diary_read on GET, which would expose
+  // the owner's OAuth client id to a read-only delegate.
+  requireSelfActor,
   async (req, res) => {
     try {
       const userId = req.userId;

--- a/SparkyFitnessServer/routes/ouraRoutes.ts
+++ b/SparkyFitnessServer/routes/ouraRoutes.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import ouraIntegrationService from '../integrations/oura/ouraService.js';
 import ouraService from '../services/ouraService.js';
 import { log } from '../config/logging.js';
+import requireSelfActor from '../middleware/requireSelfMiddleware.js';
 import authMiddleware from '../middleware/authMiddleware.js';
 import checkPermissionMiddleware from '../middleware/checkPermissionMiddleware.js';
 import { CallbackBodySchema, SyncBodySchema } from '../schemas/ouraSchemas.js';
@@ -21,7 +22,9 @@ const router = express.Router();
 router.get(
   '/authorize',
   authMiddleware.authenticate,
-  checkPermissionMiddleware('diary'),
+  // Self-only: the diary gate resolves to diary_read on GET, which would expose
+  // the owner's OAuth client id to a read-only delegate.
+  requireSelfActor,
   async (req, res) => {
     try {
       const userId = req.userId;

--- a/SparkyFitnessServer/routes/polarRoutes.ts
+++ b/SparkyFitnessServer/routes/polarRoutes.ts
@@ -117,13 +117,15 @@ router.post('/callback', authMiddleware.authenticate, async (req, res) => {
         .status(400)
         .json({ message: 'Authorization code not received.' });
     }
+    const actorUserId =
+      req.originalUserId || req.authenticatedUserId || req.userId;
     const result = await polarIntegrationService.exchangeCodeForTokens(
       state,
       code,
-      redirectUri
+      redirectUri,
+      actorUserId
     );
-    const actorUserId =
-      req.originalUserId || req.authenticatedUserId || req.userId;
+    // Belt and braces: the claim predicate already guarantees this holds.
     if (result.ownerUserId !== actorUserId) {
       log(
         'warn',

--- a/SparkyFitnessServer/routes/polarRoutes.ts
+++ b/SparkyFitnessServer/routes/polarRoutes.ts
@@ -2,6 +2,8 @@ import express from 'express';
 import polarIntegrationService from '../integrations/polar/polarService.js';
 import polarService from '../services/polarService.js';
 import { log } from '../config/logging.js';
+import requireSelfActor from '../middleware/requireSelfMiddleware.js';
+import { OAuthStateError } from '../utils/oauthState.js';
 import authMiddleware from '../middleware/authMiddleware.js';
 import checkPermissionMiddleware from '../middleware/checkPermissionMiddleware.js';
 const router = express.Router();
@@ -32,11 +34,19 @@ const router = express.Router();
 router.get(
   '/authorize',
   authMiddleware.authenticate,
-  checkPermissionMiddleware('diary'),
+  // Self-only: on GET the diary gate resolves to diary_read, which would hand a
+  // read-only delegate the owner's Polar client id.
+  requireSelfActor,
   async (req, res) => {
     try {
       const userId = req.userId;
-      const { providerId } = req.query; // Optional providerId
+      // Express parses a repeated query key into an array; only accept a
+      // single string, so a non-scalar can never reach the SQL uuid cast.
+      const rawProviderId = req.query.providerId;
+      const providerId =
+        typeof rawProviderId === 'string' && rawProviderId.length > 0
+          ? rawProviderId
+          : null;
       const baseUrl =
         process.env.SPARKY_FITNESS_FRONTEND_URL || 'http://localhost:8080';
       const redirectUri = `${baseUrl}/polar/callback`;
@@ -78,56 +88,73 @@ router.get(
  *               code:
  *                 type: string
  *                 description: The authorization code returned by Polar.
+ *               state:
+ *                 type: string
+ *                 description: The single-use nonce issued by /integrations/polar/authorize and returned by Polar. Required.
  *     responses:
  *       200:
  *         description: Polar account linked successfully.
  *       400:
- *         description: Authorization code not received.
+ *         description: Authorization code not received, or the OAuth state was invalid, expired, or already used.
  *       401:
  *         description: Unauthorized.
+ *       403:
+ *         description: The state is not bound to the authenticated user.
  *       500:
  *         description: Failed to connect Polar account.
  */
-router.post(
-  '/callback',
-  authMiddleware.authenticate,
-  checkPermissionMiddleware('diary'),
-  async (req, res) => {
-    try {
-      const { code, state, providerId } = req.body;
+router.post('/callback', authMiddleware.authenticate, async (req, res) => {
+  try {
+    // providerId is deliberately not read from the body any more: the claimed
+    // state row identifies the provider row.
+    const { code, state } = req.body;
 
-      const userId = req.userId;
-      const baseUrl =
-        process.env.SPARKY_FITNESS_FRONTEND_URL || 'http://localhost:8080';
-      const redirectUri = `${baseUrl}/polar/callback`;
-      if (!code) {
-        return res
-          .status(400)
-          .json({ message: 'Authorization code not received.' });
-      }
-      const result = await polarIntegrationService.exchangeCodeForTokens(
-        userId,
-        code,
-        state,
-        redirectUri,
-        providerId
-      );
-      if (result.success) {
-        res.status(200).json({ message: 'Polar account linked successfully.' });
-      } else {
-        res.status(500).json({ message: 'Failed to connect Polar account.' });
-      }
-    } catch (error) {
-      // @ts-expect-error TS(2571): Object is of type 'unknown'.
-      log('error', `Error handling Polar OAuth callback: ${error.message}`);
-      res.status(500).json({
-        message: 'Error handling Polar OAuth callback',
-        // @ts-expect-error TS(2571): Object is of type 'unknown'.
-        error: error.message,
-      });
+    const baseUrl =
+      process.env.SPARKY_FITNESS_FRONTEND_URL || 'http://localhost:8080';
+    const redirectUri = `${baseUrl}/polar/callback`;
+    if (!code) {
+      return res
+        .status(400)
+        .json({ message: 'Authorization code not received.' });
     }
+    const result = await polarIntegrationService.exchangeCodeForTokens(
+      state,
+      code,
+      redirectUri
+    );
+    const actorUserId =
+      req.originalUserId || req.authenticatedUserId || req.userId;
+    if (result.ownerUserId !== actorUserId) {
+      log(
+        'warn',
+        `Polar callback owner ${result.ownerUserId} did not match actor ${actorUserId}.`
+      );
+      return res
+        .status(403)
+        .json({ message: 'Forbidden: OAuth state is not bound to this user.' });
+    }
+    if (result.success) {
+      res.status(200).json({ message: 'Polar account linked successfully.' });
+    } else {
+      res.status(500).json({ message: 'Failed to connect Polar account.' });
+    }
+  } catch (error) {
+    // One opaque 400 for every state failure; the reason stays server-side.
+    if (error instanceof OAuthStateError) {
+      log('warn', `Polar OAuth state rejected (${error.reason}).`);
+      return res
+        .status(400)
+        .json({ message: 'Invalid or expired authorization state.' });
+    }
+    // @ts-expect-error TS(2571): Object is of type 'unknown'.
+    log('error', `Error handling Polar OAuth callback: ${error.message}`);
+    res.status(500).json({
+      message: 'Error handling Polar OAuth callback',
+      // @ts-expect-error TS(2571): Object is of type 'unknown'.
+      error: error.message,
+    });
   }
-);
+});
 /**
  * @swagger
  * /integrations/polar/sync:

--- a/SparkyFitnessServer/routes/stravaRoutes.ts
+++ b/SparkyFitnessServer/routes/stravaRoutes.ts
@@ -4,6 +4,7 @@ import checkPermissionMiddleware from '../middleware/checkPermissionMiddleware.j
 import stravaIntegrationService from '../integrations/strava/stravaService.js';
 import stravaService from '../services/stravaService.js';
 import { log } from '../config/logging.js';
+import requireSelfActor from '../middleware/requireSelfMiddleware.js';
 const router = express.Router();
 // All Strava routes require authentication, and — when acting in a switched
 // family context — diary access to the active user.
@@ -13,7 +14,9 @@ router.use(checkPermissionMiddleware('diary'));
  * GET /authorize
  * Returns the Strava OAuth authorization URL
  */
-router.get('/authorize', async (req, res) => {
+// Self-only: the router-level diary gate resolves to diary_read on GET, which
+// would expose the owner's OAuth client id to a read-only delegate.
+router.get('/authorize', requireSelfActor, async (req, res) => {
   try {
     const userId = req.userId;
     const redirectUri =

--- a/SparkyFitnessServer/routes/withingsRoutes.ts
+++ b/SparkyFitnessServer/routes/withingsRoutes.ts
@@ -4,6 +4,8 @@ import { log } from '../config/logging.js';
 import authMiddleware from '../middleware/authMiddleware.js';
 import checkPermissionMiddleware from '../middleware/checkPermissionMiddleware.js';
 import withingsServiceCentral from '../services/withingsService.js';
+import requireSelfActor from '../middleware/requireSelfMiddleware.js';
+import { OAuthStateError } from '../utils/oauthState.js';
 const router = express.Router();
 /**
  * @swagger
@@ -26,7 +28,9 @@ const router = express.Router();
 router.get(
   '/authorize',
   authMiddleware.authenticate,
-  checkPermissionMiddleware('diary'),
+  // Self-only, not checkPermissionMiddleware('diary'): on GET that resolves to
+  // diary_read, which would hand a read-only delegate the owner's client id.
+  requireSelfActor,
   async (req, res) => {
     try {
       const userId = req.userId; // Assuming user ID is available from authentication
@@ -58,13 +62,19 @@ router.get(
  *             type: object
  *             properties:
  *               code: { type: 'string' }
- *               state: { type: 'string' }
+ *               state:
+ *                 type: string
+ *                 description: The single-use nonce issued by /withings/authorize and returned by Withings. Never a user id.
  *               error: { type: 'string', nullable: true }
  *     responses:
  *       200:
  *         description: Successfully linked.
+ *       400:
+ *         description: Missing authorization code, or the OAuth state was invalid, expired, or already used.
+ *       403:
+ *         description: The state is not bound to the authenticated user.
  */
-router.post('/callback', async (req, res) => {
+router.post('/callback', authMiddleware.authenticate, async (req, res) => {
   try {
     const { code, state, error } = req.body;
     if (error) {
@@ -76,21 +86,26 @@ router.post('/callback', async (req, res) => {
         .status(400)
         .json({ message: 'Authorization code not received.' });
     }
-    // In a real application, 'state' should be validated against a stored value
-    // associated with the user who initiated the authorization flow.
-    // For now, we'll just log it.
-    log('info', `Withings OAuth callback received. State: ${state}`);
-    // Assuming we can derive userId from the state or a session,
-    // for this example, we'll need to pass a placeholder or retrieve it differently.
-    // In a production app, 'state' would typically contain a user identifier or a session ID.
-    // For simplicity, let's assume a fixed user ID for now, or pass it through state.
-    // containing the userId, which can be decrypted/verified here.
-    const userId = state; // The userId was passed in the state parameter
+    // `state` is never treated as a user id. exchangeCodeForTokens claims it and
+    // recovers the owner from the row that held it.
     const tokenExchangeResult = await withingsService.exchangeCodeForTokens(
-      userId,
+      state,
       code,
       `${process.env.SPARKY_FITNESS_FRONTEND_URL}/withings/callback`
     );
+    // Redundant while linking is self-only, but it turns any future
+    // delegate-authorize path into a 403 instead of a silent cross-user write.
+    const actorUserId =
+      req.originalUserId || req.authenticatedUserId || req.userId;
+    if (tokenExchangeResult.ownerUserId !== actorUserId) {
+      log(
+        'warn',
+        `Withings callback owner ${tokenExchangeResult.ownerUserId} did not match actor ${actorUserId}.`
+      );
+      return res
+        .status(403)
+        .json({ message: 'Forbidden: OAuth state is not bound to this user.' });
+    }
     if (tokenExchangeResult.success) {
       res
         .status(200)
@@ -99,6 +114,14 @@ router.post('/callback', async (req, res) => {
       res.status(500).json({ message: 'Failed to connect Withings account.' });
     }
   } catch (error) {
+    // Every state failure returns one opaque 400 so the response never
+    // reveals which check rejected the value.
+    if (error instanceof OAuthStateError) {
+      log('warn', `Withings OAuth state rejected (${error.reason}).`);
+      return res
+        .status(400)
+        .json({ message: 'Invalid or expired authorization state.' });
+    }
     // @ts-expect-error TS(2571): Object is of type 'unknown'.
     log('error', `Error handling Withings OAuth callback: ${error.message}`);
     res.status(500).json({

--- a/SparkyFitnessServer/routes/withingsRoutes.ts
+++ b/SparkyFitnessServer/routes/withingsRoutes.ts
@@ -86,17 +86,18 @@ router.post('/callback', authMiddleware.authenticate, async (req, res) => {
         .status(400)
         .json({ message: 'Authorization code not received.' });
     }
-    // `state` is never treated as a user id. exchangeCodeForTokens claims it and
-    // recovers the owner from the row that held it.
+    // `state` is never treated as a user id. The claim is scoped to the
+    // authenticated actor, so a state issued to another user matches no row and
+    // fails before any token exchange or provider-row write.
+    const actorUserId =
+      req.originalUserId || req.authenticatedUserId || req.userId;
     const tokenExchangeResult = await withingsService.exchangeCodeForTokens(
       state,
       code,
-      `${process.env.SPARKY_FITNESS_FRONTEND_URL}/withings/callback`
+      `${process.env.SPARKY_FITNESS_FRONTEND_URL}/withings/callback`,
+      actorUserId
     );
-    // Redundant while linking is self-only, but it turns any future
-    // delegate-authorize path into a 403 instead of a silent cross-user write.
-    const actorUserId =
-      req.originalUserId || req.authenticatedUserId || req.userId;
+    // Belt and braces: the claim predicate already guarantees this holds.
     if (tokenExchangeResult.ownerUserId !== actorUserId) {
       log(
         'warn',

--- a/SparkyFitnessServer/tests/integrationRoutesPermissionGating.test.ts
+++ b/SparkyFitnessServer/tests/integrationRoutesPermissionGating.test.ts
@@ -91,3 +91,17 @@ describe('integration routers reject switched-context delegates lacking diary ac
     });
   }
 });
+
+// Account linking is self-only, so it must fail for a delegate even when the
+// diary permission gate would allow the request. This is the property that
+// keeps an owner's OAuth client id out of a read-only delegate's hands.
+describe('integration routers refuse delegated account linking', () => {
+  for (const [mount, router] of cases) {
+    it(`${mount} GET /authorize returns 403 for a switched delegate even when permission is granted`, async () => {
+      permissionState.allow = true;
+      const app = appWith(mount, router);
+      const res = await request(app).get(`${mount}/authorize`);
+      expect(res.statusCode).toBe(403);
+    });
+  }
+});

--- a/SparkyFitnessServer/tests/oauthState.test.ts
+++ b/SparkyFitnessServer/tests/oauthState.test.ts
@@ -162,6 +162,7 @@ describe('claimOAuthState', () => {
     const row = await claimOAuthState(client, {
       state: issueOAuthState(NOW),
       providerType: 'withings',
+      actorUserId: 'owner-1',
       now: NOW,
     });
 
@@ -172,8 +173,10 @@ describe('claimOAuthState', () => {
     expect(sql).toContain('SET oauth_state = NULL');
     expect(sql).toContain('WHERE oauth_state = $1');
     expect(sql).toContain('RETURNING');
-    expect(sql).not.toContain('user_id =');
-    expect(values[1]).toBe('withings');
+    // The actor is part of the predicate, so a state belonging to another user
+    // matches no row rather than being caught after the fact.
+    expect(sql).toContain('user_id = $3');
+    expect(values).toEqual([expect.any(String), 'withings', 'owner-1']);
   });
 
   it.each([
@@ -184,7 +187,12 @@ describe('claimOAuthState', () => {
     async (reason, state) => {
       const client = mockClient();
       await expect(
-        claimOAuthState(client, { state, providerType: 'withings', now: NOW })
+        claimOAuthState(client, {
+          state,
+          providerType: 'withings',
+          actorUserId: 'owner-1',
+          now: NOW,
+        })
       ).rejects.toMatchObject({ reason });
       expect(client.query).not.toHaveBeenCalled();
     }
@@ -196,6 +204,7 @@ describe('claimOAuthState', () => {
       claimOAuthState(client, {
         state: issueOAuthState(NOW),
         providerType: 'withings',
+        actorUserId: 'owner-1',
         now: NOW,
       })
     ).rejects.toMatchObject({ reason: 'unknown' });
@@ -210,6 +219,7 @@ describe('claimOAuthState', () => {
       claimOAuthState(client, {
         state: issueOAuthState(NOW),
         providerType: 'withings',
+        actorUserId: 'owner-1',
         now: NOW,
       })
     ).rejects.toMatchObject({ reason: 'ambiguous' });
@@ -224,6 +234,7 @@ describe('claimOAuthState', () => {
       claimOAuthState(client, {
         state,
         providerType: 'withings',
+        actorUserId: 'owner-1',
         now: NOW + OAUTH_STATE_TTL_MS + 1,
       })
     ).rejects.toMatchObject({ reason: 'expired' });
@@ -233,11 +244,29 @@ describe('claimOAuthState', () => {
     expect(client.query.mock.calls[0][0]).toContain('SET oauth_state = NULL');
   });
 
+  it('does not claim a state that belongs to a different user', async () => {
+    // The predicate matches nothing, so the row is never returned and the real
+    // owner's nonce is left intact for their own flow to complete.
+    const client = mockClient({ rows: [], rowCount: 0 });
+
+    await expect(
+      claimOAuthState(client, {
+        state: issueOAuthState(NOW),
+        providerType: 'withings',
+        actorUserId: 'someone-else',
+        now: NOW,
+      })
+    ).rejects.toMatchObject({ reason: 'unknown' });
+
+    expect(client.query.mock.calls[0][1][2]).toBe('someone-else');
+  });
+
   it('exposes OAuthStateError as a typed error', async () => {
     const client = mockClient({ rows: [], rowCount: 0 });
     const error = await claimOAuthState(client, {
       state: issueOAuthState(NOW),
       providerType: 'polar',
+      actorUserId: 'owner-1',
       now: NOW,
     }).catch((e: unknown) => e);
     expect(error).toBeInstanceOf(OAuthStateError);

--- a/SparkyFitnessServer/tests/oauthState.test.ts
+++ b/SparkyFitnessServer/tests/oauthState.test.ts
@@ -1,0 +1,245 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+import {
+  OAUTH_STATE_TTL_MS,
+  OAuthStateError,
+  claimOAuthState,
+  issueOAuthState,
+  parseOAuthState,
+  persistOAuthState,
+  type OAuthStateQueryClient,
+} from '../utils/oauthState.js';
+
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+
+const NOW = 1_760_000_000_000;
+const CLAIMED_ROW = {
+  id: 'provider-row-1',
+  user_id: 'owner-1',
+  encrypted_app_id: 'a',
+  app_id_iv: 'b',
+  app_id_tag: 'c',
+  encrypted_app_key: 'd',
+  app_key_iv: 'e',
+  app_key_tag: 'f',
+};
+
+function mockClient(
+  result: { rows: unknown[]; rowCount: number | null } = {
+    rows: [CLAIMED_ROW],
+    rowCount: 1,
+  }
+) {
+  return {
+    query: vi.fn().mockResolvedValue(result),
+  } satisfies OAuthStateQueryClient & { query: ReturnType<typeof vi.fn> };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('issueOAuthState', () => {
+  it('produces a 64-hex nonce joined to the issue timestamp', () => {
+    expect(issueOAuthState(NOW)).toMatch(/^[0-9a-f]{64}\.\d+$/);
+    expect(issueOAuthState(NOW).endsWith(`.${NOW}`)).toBe(true);
+  });
+
+  it('never repeats a nonce', () => {
+    const seen = new Set(
+      Array.from({ length: 1000 }, () => issueOAuthState(NOW))
+    );
+    expect(seen.size).toBe(1000);
+  });
+});
+
+describe('parseOAuthState', () => {
+  it('accepts a freshly issued value', () => {
+    const parsed = parseOAuthState(issueOAuthState(NOW), NOW);
+    expect(parsed).toMatchObject({ ok: true, issuedAtMs: NOW });
+  });
+
+  it.each([undefined, null, '', 42, {}, []])(
+    'treats %p as missing',
+    (value) => {
+      expect(parseOAuthState(value, NOW)).toEqual({
+        ok: false,
+        reason: 'missing',
+      });
+    }
+  );
+
+  it.each([
+    ['Polar legacy bare hex', 'a'.repeat(32)],
+    ['a bare SparkyFitness UUID', 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'],
+    ['a nonce with no timestamp', 'a'.repeat(64)],
+    ['a non-numeric timestamp', `${'a'.repeat(64)}.notanumber`],
+    ['a short nonce', `${'a'.repeat(63)}.${NOW}`],
+    ['an uppercase nonce', `${'A'.repeat(64)}.${NOW}`],
+    ['an extra segment', `${'a'.repeat(64)}.${NOW}.1`],
+  ])('rejects %s as malformed', (_label, value) => {
+    expect(parseOAuthState(value, NOW)).toEqual({
+      ok: false,
+      reason: 'malformed',
+    });
+  });
+
+  it('honours the TTL boundary in both directions', () => {
+    const state = issueOAuthState(NOW);
+    expect(parseOAuthState(state, NOW + OAUTH_STATE_TTL_MS).ok).toBe(true);
+    expect(parseOAuthState(state, NOW + OAUTH_STATE_TTL_MS + 1)).toEqual({
+      ok: false,
+      reason: 'expired',
+    });
+  });
+});
+
+describe('persistOAuthState', () => {
+  it('scopes the issue to exactly one row and returns its credentials', async () => {
+    const client = mockClient({
+      rows: [
+        {
+          id: 'provider-row-1',
+          encrypted_app_id: 'a',
+          app_id_iv: 'b',
+          app_id_tag: 'c',
+        },
+      ],
+      rowCount: 1,
+    });
+
+    const issued = await persistOAuthState(client, {
+      userId: 'owner-1',
+      providerType: 'withings',
+      now: NOW,
+    });
+
+    expect(issued.state).toMatch(/^[0-9a-f]{64}\.\d+$/);
+    expect(issued.id).toBe('provider-row-1');
+
+    const [sql, values] = client.query.mock.calls[0];
+    // LIMIT 1 is what stops a duplicate provider_type row from being stamped too.
+    expect(sql).toContain('LIMIT 1');
+    expect(sql).toContain('RETURNING id, encrypted_app_id');
+    expect(values).toEqual([issued.state, 'owner-1', 'withings', null]);
+  });
+
+  it('throws when the user has no provider row', async () => {
+    const client = mockClient({ rows: [], rowCount: 0 });
+    await expect(
+      persistOAuthState(client, {
+        userId: 'owner-1',
+        providerType: 'withings',
+        now: NOW,
+      })
+    ).rejects.toThrow(/client credentials not found/);
+  });
+
+  it('throws when the row exists but has no configured credentials', async () => {
+    const client = mockClient({
+      rows: [
+        {
+          id: 'provider-row-1',
+          encrypted_app_id: null,
+          app_id_iv: null,
+          app_id_tag: null,
+        },
+      ],
+      rowCount: 1,
+    });
+    await expect(
+      persistOAuthState(client, {
+        userId: 'owner-1',
+        providerType: 'withings',
+        now: NOW,
+      })
+    ).rejects.toThrow(/not configured/);
+  });
+});
+
+describe('claimOAuthState', () => {
+  it('consumes a valid state and returns the owning row', async () => {
+    const client = mockClient();
+    const row = await claimOAuthState(client, {
+      state: issueOAuthState(NOW),
+      providerType: 'withings',
+      now: NOW,
+    });
+
+    expect(row).toEqual(CLAIMED_ROW);
+    const [sql, values] = client.query.mock.calls[0];
+    // The claim must stay a single self-clearing UPDATE. A refactor back to a
+    // SELECT would reopen the replay window this function exists to close.
+    expect(sql).toContain('SET oauth_state = NULL');
+    expect(sql).toContain('WHERE oauth_state = $1');
+    expect(sql).toContain('RETURNING');
+    expect(sql).not.toContain('user_id =');
+    expect(values[1]).toBe('withings');
+  });
+
+  it.each([
+    ['missing', undefined],
+    ['malformed', 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'],
+  ])(
+    'rejects a %s state without touching the database',
+    async (reason, state) => {
+      const client = mockClient();
+      await expect(
+        claimOAuthState(client, { state, providerType: 'withings', now: NOW })
+      ).rejects.toMatchObject({ reason });
+      expect(client.query).not.toHaveBeenCalled();
+    }
+  );
+
+  it('reports an unclaimed state as unknown (forged, replayed, or cross-user)', async () => {
+    const client = mockClient({ rows: [], rowCount: 0 });
+    await expect(
+      claimOAuthState(client, {
+        state: issueOAuthState(NOW),
+        providerType: 'withings',
+        now: NOW,
+      })
+    ).rejects.toMatchObject({ reason: 'unknown' });
+  });
+
+  it('refuses to proceed when more than one row matched', async () => {
+    const client = mockClient({
+      rows: [CLAIMED_ROW, { ...CLAIMED_ROW, id: 'provider-row-2' }],
+      rowCount: 2,
+    });
+    await expect(
+      claimOAuthState(client, {
+        state: issueOAuthState(NOW),
+        providerType: 'withings',
+        now: NOW,
+      })
+    ).rejects.toMatchObject({ reason: 'ambiguous' });
+    expect(client.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('burns an expired state rather than leaving it claimable', async () => {
+    const client = mockClient();
+    const state = issueOAuthState(NOW);
+
+    await expect(
+      claimOAuthState(client, {
+        state,
+        providerType: 'withings',
+        now: NOW + OAUTH_STATE_TTL_MS + 1,
+      })
+    ).rejects.toMatchObject({ reason: 'expired' });
+
+    // The clearing UPDATE still ran, so the nonce cannot be retried later.
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(client.query.mock.calls[0][0]).toContain('SET oauth_state = NULL');
+  });
+
+  it('exposes OAuthStateError as a typed error', async () => {
+    const client = mockClient({ rows: [], rowCount: 0 });
+    const error = await claimOAuthState(client, {
+      state: issueOAuthState(NOW),
+      providerType: 'polar',
+      now: NOW,
+    }).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(OAuthStateError);
+  });
+});

--- a/SparkyFitnessServer/tests/polarOauthCallback.test.ts
+++ b/SparkyFitnessServer/tests/polarOauthCallback.test.ts
@@ -91,7 +91,8 @@ describe('Polar callback state binding', () => {
       .send({ code: 'code', state: validState(), providerId: 'other-row' });
 
     const call = polarIntegration.exchangeCodeForTokens.mock.calls[0];
-    expect(call).toHaveLength(3);
+    // state, code, redirectUri, actorUserId — the body's providerId is dropped.
+    expect(call).toHaveLength(4);
     expect(call).not.toContain('other-row');
   });
 

--- a/SparkyFitnessServer/tests/polarOauthCallback.test.ts
+++ b/SparkyFitnessServer/tests/polarOauthCallback.test.ts
@@ -1,0 +1,168 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+// @ts-expect-error TS(7016): supertest ships no types in this workspace.
+import request from 'supertest';
+import express from 'express';
+import { OAuthStateError } from '../utils/oauthState.js';
+
+const OTHER_USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const OWNER_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+const { identity, polarIntegration } = vi.hoisted(() => ({
+  identity: { userId: '', authenticatedUserId: '', originalUserId: '' },
+  polarIntegration: {
+    getAuthorizationUrl: vi.fn(),
+    exchangeCodeForTokens: vi.fn(),
+  },
+}));
+
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+vi.mock('../middleware/authMiddleware.js', () => ({
+  default: {
+    authenticate: (
+      req: express.Request,
+      _res: express.Response,
+      next: express.NextFunction
+    ) => {
+      req.userId = identity.userId;
+      req.authenticatedUserId = identity.authenticatedUserId;
+      req.originalUserId = identity.originalUserId;
+      next();
+    },
+  },
+}));
+vi.mock('../middleware/checkPermissionMiddleware.js', () => ({
+  default:
+    () =>
+    (
+      _req: express.Request,
+      _res: express.Response,
+      next: express.NextFunction
+    ) =>
+      next(),
+}));
+vi.mock('../integrations/polar/polarService.js', () => ({
+  default: polarIntegration,
+}));
+vi.mock('../services/polarService.js', () => ({ default: {} }));
+
+const { default: polarRoutes } = await import('../routes/polarRoutes.js');
+
+function app() {
+  const instance = express();
+  instance.use(express.json());
+  instance.use('/api/integrations/polar', polarRoutes);
+  return instance;
+}
+
+const validState = () => `${'a'.repeat(64)}.${Date.now()}`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  identity.userId = OTHER_USER_ID;
+  identity.authenticatedUserId = OTHER_USER_ID;
+  identity.originalUserId = OTHER_USER_ID;
+  process.env.SPARKY_FITNESS_FRONTEND_URL = 'https://app.test';
+});
+
+describe('Polar callback state binding', () => {
+  it('never passes a request-supplied user id to the exchange', async () => {
+    polarIntegration.exchangeCodeForTokens.mockRejectedValue(
+      new OAuthStateError('malformed', 'malformed')
+    );
+
+    const response = await request(app())
+      .post('/api/integrations/polar/callback')
+      .send({ code: 'code', state: OWNER_ID });
+
+    expect(response.status).toBe(400);
+    const call = polarIntegration.exchangeCodeForTokens.mock.calls[0];
+    expect(call?.[0]).toBe(OWNER_ID); // passed as opaque state, not as an id
+    expect(call?.slice(1)).not.toContain(OWNER_ID);
+  });
+
+  it('ignores a providerId supplied in the request body', async () => {
+    polarIntegration.exchangeCodeForTokens.mockResolvedValue({
+      success: true,
+      ownerUserId: OTHER_USER_ID,
+    });
+
+    await request(app())
+      .post('/api/integrations/polar/callback')
+      .send({ code: 'code', state: validState(), providerId: 'other-row' });
+
+    const call = polarIntegration.exchangeCodeForTokens.mock.calls[0];
+    expect(call).toHaveLength(3);
+    expect(call).not.toContain('other-row');
+  });
+
+  it('returns 403 when the claimed owner is not the actor', async () => {
+    polarIntegration.exchangeCodeForTokens.mockResolvedValue({
+      success: true,
+      ownerUserId: OWNER_ID,
+    });
+
+    const response = await request(app())
+      .post('/api/integrations/polar/callback')
+      .send({ code: 'code', state: validState() });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('returns an opaque 400 for every state failure', async () => {
+    const bodies: string[] = [];
+    for (const reason of ['unknown', 'expired', 'malformed'] as const) {
+      polarIntegration.exchangeCodeForTokens.mockRejectedValue(
+        new OAuthStateError(reason, `detail for ${reason}`)
+      );
+      const response = await request(app())
+        .post('/api/integrations/polar/callback')
+        .send({ code: 'code', state: validState() });
+      expect(response.status).toBe(400);
+      bodies.push(JSON.stringify(response.body));
+    }
+    expect(new Set(bodies).size).toBe(1);
+    expect(bodies[0]).not.toContain('detail for');
+  });
+
+  it('links the account on the happy path', async () => {
+    polarIntegration.exchangeCodeForTokens.mockResolvedValue({
+      success: true,
+      ownerUserId: OTHER_USER_ID,
+    });
+
+    const response = await request(app())
+      .post('/api/integrations/polar/callback')
+      .send({ code: 'code', state: validState() });
+
+    expect(response.status).toBe(200);
+  });
+});
+
+describe('Polar authorize is self-only', () => {
+  it('refuses a delegate acting in a switched context', async () => {
+    identity.userId = OWNER_ID;
+    identity.authenticatedUserId = OTHER_USER_ID;
+    identity.originalUserId = OTHER_USER_ID;
+
+    const response = await request(app()).get(
+      '/api/integrations/polar/authorize'
+    );
+
+    expect(response.status).toBe(403);
+    expect(polarIntegration.getAuthorizationUrl).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-scalar providerId rather than passing it through', async () => {
+    polarIntegration.getAuthorizationUrl.mockResolvedValue('https://polar/x');
+
+    await request(app()).get(
+      '/api/integrations/polar/authorize?providerId=a&providerId=b'
+    );
+
+    expect(polarIntegration.getAuthorizationUrl).toHaveBeenCalledWith(
+      OTHER_USER_ID,
+      expect.any(String),
+      null
+    );
+  });
+});

--- a/SparkyFitnessServer/tests/withingsOauthCallback.test.ts
+++ b/SparkyFitnessServer/tests/withingsOauthCallback.test.ts
@@ -1,0 +1,204 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest';
+// @ts-expect-error TS(7016): supertest ships no types in this workspace.
+import request from 'supertest';
+import express from 'express';
+import { OAuthStateError } from '../utils/oauthState.js';
+
+const OTHER_USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const OWNER_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+// Identity is mutated per test; the router reads it through the mocked auth
+// middleware, matching the switched-context shape authMiddleware produces.
+const { identity, withingsIntegration } = vi.hoisted(() => ({
+  identity: { userId: '', authenticatedUserId: '', originalUserId: '' },
+  withingsIntegration: {
+    getAuthorizationUrl: vi.fn(),
+    exchangeCodeForTokens: vi.fn(),
+  },
+}));
+
+vi.mock('../config/logging.js', () => ({ log: vi.fn() }));
+vi.mock('../middleware/authMiddleware.js', () => ({
+  default: {
+    authenticate: (
+      req: express.Request,
+      _res: express.Response,
+      next: express.NextFunction
+    ) => {
+      req.userId = identity.userId;
+      req.authenticatedUserId = identity.authenticatedUserId;
+      req.originalUserId = identity.originalUserId;
+      next();
+    },
+  },
+}));
+vi.mock('../middleware/checkPermissionMiddleware.js', () => ({
+  default:
+    () =>
+    (
+      _req: express.Request,
+      _res: express.Response,
+      next: express.NextFunction
+    ) =>
+      next(),
+}));
+vi.mock('../integrations/withings/withingsService.js', () => ({
+  default: withingsIntegration,
+}));
+vi.mock('../services/withingsService.js', () => ({ default: {} }));
+
+const { default: withingsRoutes } = await import('../routes/withingsRoutes.js');
+
+function app() {
+  const instance = express();
+  instance.use(express.json());
+  instance.use('/api/withings', withingsRoutes);
+  return instance;
+}
+
+function actingAsSelf(userId: string) {
+  identity.userId = userId;
+  identity.authenticatedUserId = userId;
+  identity.originalUserId = userId;
+}
+
+function actingAsDelegate(owner: string, delegate: string) {
+  identity.userId = owner;
+  identity.authenticatedUserId = delegate;
+  identity.originalUserId = delegate;
+}
+
+const validState = () => `${'a'.repeat(64)}.${Date.now()}`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  actingAsSelf(OTHER_USER_ID);
+  process.env.SPARKY_FITNESS_FRONTEND_URL = 'https://app.test';
+});
+
+describe('Withings callback state binding', () => {
+  it('does not treat a victim user id supplied as state as the target user', async () => {
+    withingsIntegration.exchangeCodeForTokens.mockRejectedValue(
+      new OAuthStateError('malformed', 'malformed')
+    );
+
+    const response = await request(app())
+      .post('/api/withings/callback')
+      .send({ code: 'synthetic-authorization-code', state: OWNER_ID });
+
+    expect(response.status).toBe(400);
+    // The victim id must never have been used as a user identifier.
+    for (const call of withingsIntegration.exchangeCodeForTokens.mock.calls) {
+      expect(call[0]).not.toBe(OTHER_USER_ID);
+      expect(call.slice(1)).not.toContain(OWNER_ID);
+    }
+  });
+
+  it('rejects a bare UUID at the state grammar before any exchange', async () => {
+    const { parseOAuthState } = await import('../utils/oauthState.js');
+    expect(parseOAuthState(OWNER_ID)).toEqual({
+      ok: false,
+      reason: 'malformed',
+    });
+  });
+
+  it.each([
+    ['absent', undefined],
+    ['empty', ''],
+    ['an array', ['a', 'b']],
+    ['numeric', 42],
+  ])('returns 400 when state is %s', async (_label, state) => {
+    withingsIntegration.exchangeCodeForTokens.mockRejectedValue(
+      new OAuthStateError('missing', 'missing')
+    );
+
+    const response = await request(app())
+      .post('/api/withings/callback')
+      .send({ code: 'synthetic-authorization-code', state });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns an identical opaque body for every state failure', async () => {
+    const bodies: string[] = [];
+    for (const reason of ['unknown', 'expired', 'malformed'] as const) {
+      withingsIntegration.exchangeCodeForTokens.mockRejectedValue(
+        new OAuthStateError(reason, `detail for ${reason}`)
+      );
+      const response = await request(app())
+        .post('/api/withings/callback')
+        .send({ code: 'code', state: validState() });
+      expect(response.status).toBe(400);
+      bodies.push(JSON.stringify(response.body));
+    }
+    // One identical body for all three is the opacity guarantee: the caller
+    // cannot tell a forged nonce from a real-but-expired one.
+    expect(new Set(bodies).size).toBe(1);
+    expect(bodies[0]).not.toContain('detail for');
+  });
+
+  it('links the account when the claimed owner is the authenticated actor', async () => {
+    actingAsSelf(OWNER_ID);
+    withingsIntegration.exchangeCodeForTokens.mockResolvedValue({
+      success: true,
+      ownerUserId: OWNER_ID,
+    });
+
+    const response = await request(app())
+      .post('/api/withings/callback')
+      .send({ code: 'code', state: validState() });
+
+    expect(response.status).toBe(200);
+    expect(response.body.message).toBe('Withings account linked successfully.');
+  });
+
+  it('returns 403 when the claimed owner is not the authenticated actor', async () => {
+    actingAsSelf(OTHER_USER_ID);
+    withingsIntegration.exchangeCodeForTokens.mockResolvedValue({
+      success: true,
+      ownerUserId: OWNER_ID,
+    });
+
+    const response = await request(app())
+      .post('/api/withings/callback')
+      .send({ code: 'code', state: validState() });
+
+    expect(response.status).toBe(403);
+  });
+
+  it('still rejects a callback with no authorization code', async () => {
+    const response = await request(app())
+      .post('/api/withings/callback')
+      .send({ state: validState() });
+
+    expect(response.status).toBe(400);
+    expect(withingsIntegration.exchangeCodeForTokens).not.toHaveBeenCalled();
+  });
+});
+
+describe('Withings authorize is self-only', () => {
+  it('refuses a delegate acting in a switched context', async () => {
+    actingAsDelegate(OWNER_ID, OTHER_USER_ID);
+
+    const response = await request(app()).get('/api/withings/authorize');
+
+    expect(response.status).toBe(403);
+    // The owner's client id is never decrypted, so it cannot leak.
+    expect(withingsIntegration.getAuthorizationUrl).not.toHaveBeenCalled();
+  });
+
+  it('allows a user to authorize their own account', async () => {
+    actingAsSelf(OWNER_ID);
+    withingsIntegration.getAuthorizationUrl.mockResolvedValue(
+      'https://account.withings.com/oauth2_user/authorize2?state=x'
+    );
+
+    const response = await request(app()).get('/api/withings/authorize');
+
+    expect(response.status).toBe(200);
+    expect(response.body.authUrl).toContain('withings.com');
+    expect(withingsIntegration.getAuthorizationUrl).toHaveBeenCalledWith(
+      OWNER_ID
+    );
+  });
+});

--- a/SparkyFitnessServer/tests/withingsTokenResponse.test.ts
+++ b/SparkyFitnessServer/tests/withingsTokenResponse.test.ts
@@ -155,7 +155,8 @@ describe('Withings token response validation', () => {
       exchangeCodeForTokens(
         validState(),
         'code',
-        'https://app.test/withings/callback'
+        'https://app.test/withings/callback',
+        USER_ID
       )
     ).rejects.toThrow(/304/);
 
@@ -202,7 +203,8 @@ describe('Withings token response validation', () => {
     await exchangeCodeForTokens(
       validState(),
       'auth-code',
-      'https://app.test/withings/callback'
+      'https://app.test/withings/callback',
+      USER_ID
     );
 
     const [url, body, config] = vi.mocked(axios.post).mock.calls[0];
@@ -243,7 +245,8 @@ describe('Withings OAuth state claim', () => {
     await exchangeCodeForTokens(
       validState(),
       'auth-code',
-      'https://app.test/withings/callback'
+      'https://app.test/withings/callback',
+      USER_ID
     );
 
     const claimSql = client.query.mock.calls[0][0] as string;
@@ -265,7 +268,8 @@ describe('Withings OAuth state claim', () => {
     await exchangeCodeForTokens(
       state,
       'auth-code',
-      'https://app.test/withings/callback'
+      'https://app.test/withings/callback',
+      USER_ID
     );
     expect(axios.post).toHaveBeenCalledTimes(1);
 
@@ -275,7 +279,8 @@ describe('Withings OAuth state claim', () => {
       exchangeCodeForTokens(
         state,
         'auth-code',
-        'https://app.test/withings/callback'
+        'https://app.test/withings/callback',
+        USER_ID
       )
     ).rejects.toMatchObject({ reason: 'unknown' });
 
@@ -295,7 +300,8 @@ describe('Withings OAuth state claim', () => {
     await exchangeCodeForTokens(
       validState(),
       'auth-code',
-      'https://app.test/withings/callback'
+      'https://app.test/withings/callback',
+      USER_ID
     );
 
     const logged = vi

--- a/SparkyFitnessServer/tests/withingsTokenResponse.test.ts
+++ b/SparkyFitnessServer/tests/withingsTokenResponse.test.ts
@@ -26,9 +26,15 @@ vi.mock('../security/encryption.js', () => ({
 
 const USER_ID = 'user-1';
 
+// A well-formed, unexpired state. The claim is mocked at the pg layer, so this
+// only has to satisfy the grammar and TTL check in utils/oauthState.ts.
+const validState = () => `${'a'.repeat(64)}.${Date.now()}`;
+
 // The provider row both flows read before talking to Withings. Values are
 // irrelevant because decrypt is stubbed; only the row's presence matters.
 const PROVIDER_ROW = {
+  id: 'provider-row-1',
+  user_id: USER_ID,
   encrypted_app_id: 'a',
   app_id_iv: 'b',
   app_id_tag: 'c',
@@ -147,7 +153,7 @@ describe('Withings token response validation', () => {
 
     await expect(
       exchangeCodeForTokens(
-        USER_ID,
+        validState(),
         'code',
         'https://app.test/withings/callback'
       )
@@ -194,7 +200,7 @@ describe('Withings token response validation', () => {
     });
 
     await exchangeCodeForTokens(
-      USER_ID,
+      validState(),
       'auth-code',
       'https://app.test/withings/callback'
     );
@@ -213,5 +219,93 @@ describe('Withings token response validation', () => {
     expect(config?.headers?.['Content-Type']).toBe(
       'application/x-www-form-urlencoded'
     );
+  });
+});
+
+describe('Withings OAuth state claim', () => {
+  const okTokenResponse = {
+    data: {
+      status: 0,
+      body: {
+        access_token: 'at',
+        refresh_token: 'rt',
+        expires_in: 3600,
+        scope: 'user.metrics',
+        userid: 'other-withings-user',
+      },
+    },
+  };
+
+  it('derives the write target from the claimed row, not from any argument', async () => {
+    const client = mockClient();
+    vi.mocked(axios.post).mockResolvedValue(okTokenResponse);
+
+    await exchangeCodeForTokens(
+      validState(),
+      'auth-code',
+      'https://app.test/withings/callback'
+    );
+
+    const claimSql = client.query.mock.calls[0][0] as string;
+    expect(claimSql).toContain('SET oauth_state = NULL');
+    expect(client.query.mock.calls[0][1][1]).toBe('withings');
+
+    const [updateSql, updateValues] = client.query.mock.calls[1];
+    // Keyed on the claimed row's primary key, never on a user id.
+    expect(updateSql).toContain('WHERE id = $10');
+    expect(updateSql).not.toContain('user_id = $10');
+    expect(updateValues[9]).toBe('provider-row-1');
+  });
+
+  it('aborts a replayed state before contacting Withings', async () => {
+    const client = mockClient();
+    vi.mocked(axios.post).mockResolvedValue(okTokenResponse);
+    const state = validState();
+
+    await exchangeCodeForTokens(
+      state,
+      'auth-code',
+      'https://app.test/withings/callback'
+    );
+    expect(axios.post).toHaveBeenCalledTimes(1);
+
+    // The second claim finds nothing: the first one already cleared the nonce.
+    client.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await expect(
+      exchangeCodeForTokens(
+        state,
+        'auth-code',
+        'https://app.test/withings/callback'
+      )
+    ).rejects.toMatchObject({ reason: 'unknown' });
+
+    // No second token request was made for the replayed code.
+    expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('never writes token material to the logs', async () => {
+    mockClient();
+    vi.mocked(encrypt).mockResolvedValue({
+      encryptedText: 'ENC-ACCESS-SECRET',
+      iv: 'IV-SECRET',
+      tag: 'TAG-SECRET',
+    });
+    vi.mocked(axios.post).mockResolvedValue(okTokenResponse);
+
+    await exchangeCodeForTokens(
+      validState(),
+      'auth-code',
+      'https://app.test/withings/callback'
+    );
+
+    const logged = vi
+      .mocked(log)
+      .mock.calls.flat()
+      .map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)))
+      .join(' ');
+
+    expect(logged).not.toContain('ENC-ACCESS-SECRET');
+    expect(logged).not.toContain('IV-SECRET');
+    expect(logged).not.toContain('TAG-SECRET');
   });
 });

--- a/SparkyFitnessServer/utils/oauthState.ts
+++ b/SparkyFitnessServer/utils/oauthState.ts
@@ -197,6 +197,12 @@ export async function claimOAuthState(
   params: {
     state: unknown;
     providerType: OAuthStateProviderType;
+    /**
+     * The authenticated caller. Required, and bound into the claim predicate so
+     * a state issued to someone else matches no row at all. This is a session
+     * value, never a request field, so it can only narrow the match.
+     */
+    actorUserId: string;
     now?: number;
   }
 ): Promise<OAuthStateCredentialRow> {
@@ -211,15 +217,21 @@ export async function claimOAuthState(
     );
   }
 
+  // The actor is part of the predicate rather than a check on the returned row:
+  // a state belonging to another user must fail before anything is decrypted,
+  // any token is requested, or any row is written. Failing in the WHERE clause
+  // also leaves the real owner's nonce unconsumed, so a mismatched attempt
+  // cannot destroy an in-flight legitimate flow.
   const result = await client.query(
     `UPDATE external_data_providers
         SET oauth_state = NULL, updated_at = NOW()
       WHERE oauth_state = $1
         AND provider_type = $2
+        AND user_id = $3
       RETURNING id, user_id,
                 encrypted_app_id, app_id_iv, app_id_tag,
                 encrypted_app_key, app_key_iv, app_key_tag`,
-    [params.state, params.providerType]
+    [params.state, params.providerType, params.actorUserId]
   );
 
   // Covers forged state, cross-user substitution, and replay in one branch:
@@ -227,7 +239,7 @@ export async function claimOAuthState(
   if (!result.rowCount) {
     throw new OAuthStateError(
       'unknown',
-      `No ${params.providerType} provider row held the supplied OAuth state.`
+      `No ${params.providerType} provider row held the supplied OAuth state for this user.`
     );
   }
 

--- a/SparkyFitnessServer/utils/oauthState.ts
+++ b/SparkyFitnessServer/utils/oauthState.ts
@@ -1,0 +1,258 @@
+import crypto from 'crypto';
+import { log } from '../config/logging.js';
+
+/**
+ * Server-issued, single-use OAuth `state` nonces for external provider linking.
+ *
+ * The rule this module exists to enforce: a provider callback must never be
+ * allowed to name the user whose row it writes. The owner is recovered from
+ * server-side flow state (the nonce we issued) and from nothing else.
+ *
+ * The value is `"<64 hex chars>.<epochMs>"`. The timestamp is carried inside
+ * the existing `external_data_providers.oauth_state` TEXT column so expiry
+ * needs no new column, and therefore no migration, no RLS change and no schema
+ * backup cycle. Every character is URL-safe unencoded, so it survives a
+ * round-trip through a provider redirect and `URLSearchParams` untouched.
+ */
+
+/** How long an issued state remains claimable. Deliberately not configurable. */
+export const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+const NONCE_BYTES = 32;
+const OAUTH_STATE_PATTERN = /^([0-9a-f]{64})\.([0-9]{1,15})$/;
+
+/** Providers whose linking flow uses a server-issued nonce. */
+export type OAuthStateProviderType = 'withings' | 'polar';
+
+/**
+ * The slice of a `pg` client this module needs. Structural on purpose: it keeps
+ * the helper trivially mockable with the repo's existing `{ query: vi.fn() }`
+ * test stub, without importing `PoolClient` generics into every call site.
+ */
+export interface OAuthStateQueryClient {
+  query(
+    text: string,
+    values?: readonly unknown[]
+  ): Promise<{ rows: unknown[]; rowCount: number | null }>;
+}
+
+/** The provider row that held the nonce, plus its encrypted client credentials. */
+export interface OAuthStateCredentialRow {
+  id: string;
+  user_id: string;
+  encrypted_app_id: string | null;
+  app_id_iv: string | null;
+  app_id_tag: string | null;
+  encrypted_app_key: string | null;
+  app_key_iv: string | null;
+  app_key_tag: string | null;
+}
+
+/** The credential columns returned when a fresh state is issued. */
+export interface IssuedOAuthState {
+  state: string;
+  id: string;
+  encrypted_app_id: string | null;
+  app_id_iv: string | null;
+  app_id_tag: string | null;
+}
+
+export type OAuthStateFailure =
+  /** Absent, empty, or not a string. */
+  | 'missing'
+  /** Present but not `<64 hex>.<digits>` — includes every legacy format. */
+  | 'malformed'
+  /** No row held this state: forged, already consumed, or cross-user. */
+  | 'unknown'
+  /** Claimed, but issued longer ago than the TTL. */
+  | 'expired'
+  /** More than one row matched. Should be unreachable; see claimOAuthState. */
+  | 'ambiguous';
+
+export class OAuthStateError extends Error {
+  readonly reason: OAuthStateFailure;
+
+  constructor(reason: OAuthStateFailure, message: string) {
+    super(message);
+    this.name = 'OAuthStateError';
+    this.reason = reason;
+  }
+}
+
+export type ParsedOAuthState =
+  | { ok: true; nonce: string; issuedAtMs: number }
+  | { ok: false; reason: 'missing' | 'malformed' | 'expired' };
+
+/** Builds a fresh state value. `now` is injectable so tests need no fake timers. */
+export function issueOAuthState(now: number = Date.now()): string {
+  return `${crypto.randomBytes(NONCE_BYTES).toString('hex')}.${now}`;
+}
+
+type ParsedGrammar =
+  | { ok: true; nonce: string; issuedAtMs: number }
+  | { ok: false; reason: 'missing' | 'malformed' };
+
+/**
+ * Grammar only, no TTL. Separate from parseOAuthState because claimOAuthState
+ * must be able to reject a junk value before touching the database while still
+ * letting a merely-expired one reach the claim, so the nonce gets burned.
+ */
+function parseOAuthStateGrammar(value: unknown): ParsedGrammar {
+  if (typeof value !== 'string' || value.length === 0) {
+    return { ok: false, reason: 'missing' };
+  }
+  const match = OAUTH_STATE_PATTERN.exec(value);
+  if (!match) {
+    return { ok: false, reason: 'malformed' };
+  }
+  const issuedAtMs = Number(match[2]);
+  if (!Number.isSafeInteger(issuedAtMs)) {
+    return { ok: false, reason: 'malformed' };
+  }
+  return { ok: true, nonce: match[1], issuedAtMs };
+}
+
+/**
+ * Validates grammar and age. Pure — no I/O.
+ */
+export function parseOAuthState(
+  value: unknown,
+  now: number = Date.now()
+): ParsedOAuthState {
+  const parsed = parseOAuthStateGrammar(value);
+  if (!parsed.ok) {
+    return parsed;
+  }
+  if (now - parsed.issuedAtMs > OAUTH_STATE_TTL_MS) {
+    return { ok: false, reason: 'expired' };
+  }
+  return parsed;
+}
+
+/**
+ * Stamps a fresh state onto exactly one provider row and returns it together
+ * with that row's encrypted client credentials.
+ *
+ * Returning the credentials is a correctness requirement, not an optimisation.
+ * `external_data_providers` is unique on `(user_id, provider_name)`, NOT on
+ * `provider_type`, so a user can hold several rows of the same provider type. A
+ * separate unordered SELECT could pick a different row than the one stamped
+ * here, which would build an authorization URL whose `client_id` does not match
+ * the row the callback later claims. One statement, one row, no divergence.
+ */
+export async function persistOAuthState(
+  client: OAuthStateQueryClient,
+  params: {
+    userId: string;
+    providerType: OAuthStateProviderType;
+    providerId?: string | null;
+    now?: number;
+  }
+): Promise<IssuedOAuthState> {
+  const state = issueOAuthState(params.now);
+  const result = await client.query(
+    `UPDATE external_data_providers
+        SET oauth_state = $1, updated_at = NOW()
+      WHERE id = (
+        SELECT id FROM external_data_providers
+         WHERE user_id = $2
+           AND provider_type = $3
+           AND ($4::uuid IS NULL OR id = $4::uuid)
+         ORDER BY created_at ASC, id ASC
+         LIMIT 1
+      )
+      RETURNING id, encrypted_app_id, app_id_iv, app_id_tag`,
+    [state, params.userId, params.providerType, params.providerId ?? null]
+  );
+
+  const row = result.rows[0] as Omit<IssuedOAuthState, 'state'> | undefined;
+  if (!row) {
+    throw new Error(
+      `${params.providerType} client credentials not found for user.`
+    );
+  }
+  if (!row.encrypted_app_id || !row.app_id_iv || !row.app_id_tag) {
+    throw new Error(
+      `${params.providerType} client credentials are not configured for user.`
+    );
+  }
+  return { ...row, state };
+}
+
+/**
+ * Atomically consumes a state and returns the row that held it.
+ *
+ * There is deliberately no `crypto.timingSafeEqual` here: the comparison IS the
+ * `WHERE oauth_state = $1` predicate inside the UPDATE, so no stored state is
+ * ever read into JS to be compared. Adding a constant-time compare would mean
+ * reintroducing the read-then-compare shape that creates the TOCTOU replay hole
+ * this function exists to close, and a Postgres equality test against a 256-bit
+ * random value is not a practical timing oracle.
+ *
+ * The single UPDATE takes a row-level write lock, so concurrent replays
+ * serialise and exactly one caller sees `rowCount === 1`.
+ */
+export async function claimOAuthState(
+  client: OAuthStateQueryClient,
+  params: {
+    state: unknown;
+    providerType: OAuthStateProviderType;
+    now?: number;
+  }
+): Promise<OAuthStateCredentialRow> {
+  // Grammar only, so a sprayed or malformed value never reaches the database.
+  // Expiry is deliberately NOT checked here: an expired-but-real nonce should
+  // still be consumed below, so it cannot be retried if the clock moves back.
+  const parsed = parseOAuthStateGrammar(params.state);
+  if (!parsed.ok) {
+    throw new OAuthStateError(
+      parsed.reason,
+      `Rejected ${params.providerType} OAuth state: ${parsed.reason}.`
+    );
+  }
+
+  const result = await client.query(
+    `UPDATE external_data_providers
+        SET oauth_state = NULL, updated_at = NOW()
+      WHERE oauth_state = $1
+        AND provider_type = $2
+      RETURNING id, user_id,
+                encrypted_app_id, app_id_iv, app_id_tag,
+                encrypted_app_key, app_key_iv, app_key_tag`,
+    [params.state, params.providerType]
+  );
+
+  // Covers forged state, cross-user substitution, and replay in one branch:
+  // a successful first claim already NULLed the value.
+  if (!result.rowCount) {
+    throw new OAuthStateError(
+      'unknown',
+      `No ${params.providerType} provider row held the supplied OAuth state.`
+    );
+  }
+
+  // Unreachable given the scoped issue query above, but `provider_type` carries
+  // no uniqueness constraint, so this is the seatbelt rather than an assumption.
+  if (result.rowCount > 1) {
+    log(
+      'warn',
+      `[OAuthState] Ambiguous ${params.providerType} state claim matched ${result.rowCount} rows; aborting.`
+    );
+    throw new OAuthStateError(
+      'ambiguous',
+      `Ambiguous ${params.providerType} OAuth state claim.`
+    );
+  }
+
+  // Checked after the claim on purpose: an expired nonce must be burned, not
+  // left live for a later retry.
+  const now = params.now ?? Date.now();
+  if (now - parsed.issuedAtMs > OAUTH_STATE_TTL_MS) {
+    throw new OAuthStateError(
+      'expired',
+      `Expired ${params.providerType} OAuth state.`
+    );
+  }
+
+  return result.rows[0] as OAuthStateCredentialRow;
+}


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Withings used the user id as its OAuth `state` and read that value back off the callback body to decide which provider row to write, and Polar validated its state with a non-atomic compare-then-use that left a state claimable until the next authorize overwrote it. This replaces both with one shared single-use nonce flow.

**How did you implement the solution?**

- Added `SparkyFitnessServer/utils/oauthState.ts`. State is `<32-byte nonce>.<issuedAtMs>` with a 10 minute TTL, stamped onto exactly one provider row at authorize time and consumed by a single atomic self-clearing `UPDATE ... WHERE oauth_state = $1 RETURNING ...`. The timestamp rides inside the existing `oauth_state` column, so there is **no migration and no schema change**.
- Withings and Polar now resolve the provider row from the claimed state. `exchangeCodeForTokens` no longer accepts a user id at all, and the token write is keyed on the claimed row's primary key rather than `user_id + provider_type` — there is no uniqueness constraint on that pair (`unique_user_provider` is on `user_id + provider_name`), so a user can legitimately hold more than one row per provider type.
- The issue step returns the row's encrypted credentials in the same statement, so the `client_id` placed in the authorization URL is guaranteed to come from the same row that holds the nonce.
- Dropped Polar's `providerId` callback-body parameter and its compare-then-use block; the claim makes both redundant.
- Restricted `/authorize` on all five OAuth providers (Withings, Polar, Oura, Fitbit, Strava) to the account owner with a new `requireSelfActor` middleware. Sync, disconnect and status stay delegatable.
- Removed the debug logging that dumped the full token update payload and an interpolated copy of the UPDATE statement, and deleted the now-unused `interpolateQuery` helper.

Linked Issue: Closes # N/A

## How to Test

1. Check out this branch and run `cd SparkyFitnessServer && pnpm run validate && pnpm test`.
2. Configure Withings (or Polar) credentials under Settings → Integrations and click **Connect**.
3. While on the provider's consent screen, confirm the `state` query parameter is 78 characters in the form `<64 hex>.<13 digits>`, and that the same value is stamped on the row:
   ```sql
   SELECT id, provider_name, length(oauth_state), oauth_state
     FROM external_data_providers WHERE provider_type = 'withings';
   ```
4. Complete consent and verify the account links successfully, and that `oauth_state` is back to `NULL` and `external_user_id` is populated.
5. Re-POST the same `code` + `state` to the callback (resend from devtools) and verify it returns `400` and does not issue a second token request to the provider.
6. Leave a consent screen idle for more than 10 minutes, then complete it, and verify it returns `400`.
7. Switch into a family member's context and click **Connect** — verify it returns `403`, while **Sync** and **Disconnect** still work in that context.
8. Confirm an account linked before this change still syncs (manual sync and the hourly cron are untouched).

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [x] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

N/A — backend only, no UI changes.

<details>
<summary>Click to expand</summary>

### Before

N/A

### After

N/A

</details>

## Notes for Reviewers

**No database changes.** `oauth_state` already exists (added in `20260214223000_add_polar_provider_type.sql`) and is already in `ExternalDataProviders.zod.ts`. Encoding the issue time inside the column value avoids a migration entirely, which is why the RLS checklist item is unchecked — no new table, no policy change, no `db_schema_backup.sql` churn.

**No frontend changes.** `WithingsCallback.tsx` and `PolarCallback.tsx` already read `state` from the URL and forward it, so an opaque server nonce round-trips through the existing client. Every character of the nonce is RFC 3986 unreserved, so `encodeURIComponent` is the identity function on it and there is no double-encoding hazard. Server-only, so there is no version-skew window on deploy.

**One behaviour change worth calling out:** a delegate with diary access could previously start account linking on an owner's behalf; that now returns `403`. Linking binds an external identity to the owner's row, so it should be owner-initiated. This may be worth a changelog line — sync, disconnect and status are unaffected and remain delegatable.

**In-flight flows break once, by design.** A user mid-consent at deploy time will present a legacy state, get a `400`, and can simply click Connect again. Legacy Polar values left in the column become permanently unclaimable rather than dangerous, and are overwritten on the next authorize, so no data cleanup is needed.

**`getSystemClient()` is retained deliberately** in both exchange paths. This PR does not change the RLS posture; it makes the privileged call safe by sourcing the row identity from a server-issued secret instead of the request. Switching to `getClient` here would risk silent zero-row updates, since that path resolves the actor from AsyncLocalStorage and the `external_data_providers` update policy keys on `authenticated_user_id()`.

**Scoped deliberately:** Oura, Fitbit and Strava get the owner-only authorize guard but keep their existing callbacks, which take the user from `req.userId` and ignore `state`. Moving those to the nonce flow means changing their callback components to forward `state`, so it belongs in a follow-up rather than here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - OAuth account linking for Fitbit, Oura, Polar, Strava, and Withings is now restricted to the account owner.
  - Added single-use, time-limited OAuth state validation to help prevent replay and unauthorized account linking.
  - OAuth callbacks now verify that the authenticated user matches the account being linked and return safer generic errors for invalid state.
- **Documentation**
  - Updated Polar and Withings API documentation to describe OAuth state requirements and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->