### PR TITLE
fix(reports): escape quotes in custom nutrient names in report queries

### DIFF
--- a/SparkyFitnessServer/models/reportRepository.ts
+++ b/SparkyFitnessServer/models/reportRepository.ts
@@ -7,12 +7,9 @@ import {
   supplementFixedSubquery,
 } from './supplementSql.js';
 async function getNutritionData(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  startDate: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  endDate: any,
+  userId: string,
+  startDate: string,
+  endDate: string,
   customNutrients: Array<{ name: string }> = []
 ) {
   const client = await getClient(userId); // User-specific operation
@@ -129,32 +126,33 @@ async function getNutritionData(
   }
 }
 async function getTabularFoodData(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  startDate: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  endDate: any,
-  customNutrients = []
+  userId: string,
+  startDate: string,
+  endDate: string,
+  customNutrients: Array<{ name: string }> = []
 ) {
   const client = await getClient(userId); // User-specific operation
   try {
     // Generate dynamic SQL parts for custom nutrients
     const customNutrientsSelectCTE = customNutrients
-      .map(
-        (cn) =>
-          // @ts-expect-error TS(2339): Property 'name' does not exist on type 'never'.
-          `(COALESCE(NULLIF(fe.custom_nutrients->>'${cn.name}', '')::numeric, 0) * fe.quantity / fe.serving_size) AS "${cn.name}"`
-      )
+      .map((cn) => {
+        const ident = cn.name.replace(/"/g, '""');
+        const lit = cn.name.replace(/'/g, "''");
+        return `(COALESCE(NULLIF(fe.custom_nutrients->>'${lit}', '')::numeric, 0) * fe.quantity / fe.serving_size) AS "${ident}"`;
+      })
       .join(',\n          ');
     const customNutrientsSelectOuter = customNutrients
-      // @ts-expect-error TS(2339): Property 'name' does not exist on type 'never'.
-      .map((cn) => `cfe."${cn.name}"`)
+      .map((cn) => {
+        const ident = cn.name.replace(/"/g, '""');
+        return `cfe."${ident}"`;
+      })
       .join(',\n        ');
     // Note: cfe_meal values already include scaled quantity, so do NOT multiply by fem.quantity
     const customNutrientsSelectMealAgg = customNutrients
-      // @ts-expect-error TS(2339): Property 'name' does not exist on type 'never'.
-      .map((cn) => `SUM(cfe_meal."${cn.name}") AS "${cn.name}"`)
+      .map((cn) => {
+        const ident = cn.name.replace(/"/g, '""');
+        return `SUM(cfe_meal."${ident}") AS "${ident}"`;
+      })
       .join(',\n        ');
     const result = await client.query(
       `WITH CalculatedFoodEntries AS (
@@ -352,8 +350,11 @@ async function getTabularFoodData(
     client.release();
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getMeasurementData(userId: any, startDate: any, endDate: any) {
+async function getMeasurementData(
+  userId: string,
+  startDate: string,
+  endDate: string
+) {
   const client = await getClient(userId); // User-specific operation
   try {
     const result = await client.query(
@@ -366,14 +367,10 @@ async function getMeasurementData(userId: any, startDate: any, endDate: any) {
   }
 }
 async function getCustomMeasurementsData(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  categoryId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  startDate: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  endDate: any
+  userId: string,
+  categoryId: string,
+  startDate: string,
+  endDate: string
 ) {
   const client = await getClient(userId); // User-specific operation
   try {
@@ -404,13 +401,10 @@ async function getCustomMeasurementsData(
   }
 }
 async function getMiniNutritionTrends(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  startDate: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  endDate: any,
-  customNutrients = []
+  userId: string,
+  startDate: string,
+  endDate: string,
+  customNutrients: Array<{ name: string }> = []
 ) {
   const client = await getClient(userId); // User-specific operation
   try {
@@ -418,23 +412,25 @@ async function getMiniNutritionTrends(
     // Note: Standard nutrients use "total_" prefix in the outer select of the existing query.
     // For custom nutrients, I will use their name directly to match the service mapping.
     const customNutrientsSelectOuter = customNutrients
-      // @ts-expect-error TS(2339): Property 'name' does not exist on type 'never'.
-      .map((cn) => `SUM("${cn.name}") AS "${cn.name}"`)
+      .map((cn) => {
+        const ident = cn.name.replace(/"/g, '""');
+        return `SUM("${ident}") AS "${ident}"`;
+      })
       .join(',\n         ');
     const customNutrientsSelectInner1 = customNutrients
-      .map(
-        (cn) =>
-          // @ts-expect-error TS(2339): Property 'name' does not exist on type 'never'.
-          `(COALESCE(NULLIF(fe.custom_nutrients->>'${cn.name}', '')::numeric, 0) * fe.quantity / fe.serving_size) AS "${cn.name}"`
-      )
+      .map((cn) => {
+        const ident = cn.name.replace(/"/g, '""');
+        const lit = cn.name.replace(/'/g, "''");
+        return `(COALESCE(NULLIF(fe.custom_nutrients->>'${lit}', '')::numeric, 0) * fe.quantity / fe.serving_size) AS "${ident}"`;
+      })
       .join(',\n           ');
     // Note: fe_meal.quantity is already scaled, so do NOT multiply by fem.quantity
     const customNutrientsSelectInner2 = customNutrients
-      .map(
-        (cn) =>
-          // @ts-expect-error TS(2339): Property 'name' does not exist on type 'never'.
-          `SUM(COALESCE(NULLIF(fe_meal.custom_nutrients->>'${cn.name}', '')::numeric, 0) * fe_meal.quantity / fe_meal.serving_size) AS "${cn.name}"`
-      )
+      .map((cn) => {
+        const ident = cn.name.replace(/"/g, '""');
+        const lit = cn.name.replace(/'/g, "''");
+        return `SUM(COALESCE(NULLIF(fe_meal.custom_nutrients->>'${lit}', '')::numeric, 0) * fe_meal.quantity / fe_meal.serving_size) AS "${ident}"`;
+      })
       .join(',\n           ');
     const result = await client.query(
       `SELECT
@@ -533,18 +529,12 @@ async function getMiniNutritionTrends(
   }
 }
 async function getExerciseEntries(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  userId: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  startDate: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  endDate: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  equipment: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  muscle: any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  exercise: any
+  userId: string,
+  startDate: string,
+  endDate: string,
+  equipment?: string | null,
+  muscle?: string | null,
+  exercise?: string | null
 ) {
   const client = await getClient(userId); // User-specific operation
   try {
@@ -580,7 +570,7 @@ async function getExerciseEntries(
          ) AS sets
        FROM exercise_entries ee
        WHERE ee.user_id = $1 AND ee.entry_date BETWEEN $2 AND $3`;
-    const params = [userId, startDate, endDate];
+    const params: (string | number)[] = [userId, startDate, endDate];
     let paramIndex = 4;
     if (equipment) {
       query += ` AND ee.equipment ILIKE $${paramIndex}`;
@@ -604,8 +594,11 @@ async function getExerciseEntries(
     client.release();
   }
 }
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function getExerciseNames(userId: any, muscle: any, equipment: any) {
+async function getExerciseNames(
+  userId: string,
+  muscle?: string | null,
+  equipment?: string | null
+) {
   const client = await getClient(userId); // User-specific operation
   try {
     // Exclude synced device calorie summaries (e.g. Apple Health "Active
@@ -613,7 +606,7 @@ async function getExerciseNames(userId: any, muscle: any, equipment: any) {
     // and the Exercise Reports dashboard filters them out of its aggregates.
     let query =
       "SELECT DISTINCT exercise_id as id, exercise_name as name FROM exercise_entries WHERE user_id = $1 AND exercise_name <> 'Active Calories'";
-    const params = [userId];
+    const params: string[] = [userId];
     let paramIndex = 2;
     if (muscle) {
       query += ` AND primary_muscles ILIKE $${paramIndex}`;

--- a/SparkyFitnessServer/models/reportRepository.ts
+++ b/SparkyFitnessServer/models/reportRepository.ts
@@ -14,6 +14,13 @@ async function getNutritionData(
 ) {
   const client = await getClient(userId); // User-specific operation
   try {
+    const params: (string | number)[] = [userId, startDate, endDate];
+    const customNutrientParamIndexes: number[] = [];
+    customNutrients.forEach((cn) => {
+      params.push(cn.name);
+      customNutrientParamIndexes.push(params.length);
+    });
+
     const standardNutrientsSelectOuter = FOOD_VARIANT_NUTRIENT_FIELDS.map(
       (nutrient) =>
         `SUM(${nutrient}) AS ${nutrient},\n         COALESCE(SUM(${nutrient}) FILTER (WHERE nutrient_source = 'food'), 0) AS food_${nutrient},\n         COALESCE(SUM(${nutrient}) FILTER (WHERE nutrient_source = 'supplement'), 0) AS supplement_${nutrient}`
@@ -30,10 +37,10 @@ async function getNutritionData(
         `(COALESCE(fe.${nutrient}, 0) * fe.quantity / fe.serving_size) AS ${nutrient}`
     ).join(',\n           ');
     const customNutrientsSelectInner1 = customNutrients
-      .map((cn) => {
+      .map((cn, idx) => {
         const ident = cn.name.replace(/"/g, '""');
-        const lit = cn.name.replace(/'/g, "''");
-        return `(COALESCE(NULLIF(fe.custom_nutrients->>'${lit}', '')::numeric, 0) * fe.quantity / fe.serving_size) AS "${ident}"`;
+        const paramIdx = customNutrientParamIndexes[idx];
+        return `(COALESCE(NULLIF(fe.custom_nutrients->>$${paramIdx}, '')::numeric, 0) * fe.quantity / fe.serving_size) AS "${ident}"`;
       })
       .join(',\n           ');
     // Note: fe_meal.quantity is already scaled, so do NOT multiply by fem.quantity
@@ -42,10 +49,10 @@ async function getNutritionData(
         `SUM(COALESCE(fe_meal.${nutrient}, 0) * fe_meal.quantity / fe_meal.serving_size) AS ${nutrient}`
     ).join(',\n           ');
     const customNutrientsSelectInner2 = customNutrients
-      .map((cn) => {
+      .map((cn, idx) => {
         const ident = cn.name.replace(/"/g, '""');
-        const lit = cn.name.replace(/'/g, "''");
-        return `SUM(COALESCE(NULLIF(fe_meal.custom_nutrients->>'${lit}', '')::numeric, 0) * fe_meal.quantity / fe_meal.serving_size) AS "${ident}"`;
+        const paramIdx = customNutrientParamIndexes[idx];
+        return `SUM(COALESCE(NULLIF(fe_meal.custom_nutrients->>$${paramIdx}, '')::numeric, 0) * fe_meal.quantity / fe_meal.serving_size) AS "${ident}"`;
       })
       .join(',\n           ');
     // Each snapshot holds ONE dose's payload; multiply by the dose count taken in this
@@ -62,10 +69,10 @@ async function getNutritionData(
         `(COALESCE(public.sf_try_numeric(me.nutrients_snapshot->>'${nutrient}'), 0) * ${doseScale('me')}) AS ${nutrient}`
     ).join(',\n           ');
     const customNutrientsSelectSupplement = customNutrients
-      .map((cn) => {
+      .map((cn, idx) => {
         const ident = cn.name.replace(/"/g, '""');
-        const lit = cn.name.replace(/'/g, "''");
-        return `(COALESCE(public.sf_try_numeric(me.nutrients_snapshot->'custom_nutrients'->>'${lit}'), 0) * ${doseScale('me')}) AS "${ident}"`;
+        const paramIdx = customNutrientParamIndexes[idx];
+        return `(COALESCE(public.sf_try_numeric(me.nutrients_snapshot->'custom_nutrients'->>$${paramIdx}), 0) * ${doseScale('me')}) AS "${ident}"`;
       })
       .join(',\n           ');
     const result = await client.query(
@@ -118,7 +125,7 @@ async function getNutritionData(
        ) AS combined_nutrition
        GROUP BY entry_date
        ORDER BY entry_date`,
-      [userId, startDate, endDate]
+      params
     );
     return result.rows;
   } finally {
@@ -133,12 +140,14 @@ async function getTabularFoodData(
 ) {
   const client = await getClient(userId); // User-specific operation
   try {
+    const params: (string | number)[] = [userId, startDate, endDate];
     // Generate dynamic SQL parts for custom nutrients
     const customNutrientsSelectCTE = customNutrients
       .map((cn) => {
         const ident = cn.name.replace(/"/g, '""');
-        const lit = cn.name.replace(/'/g, "''");
-        return `(COALESCE(NULLIF(fe.custom_nutrients->>'${lit}', '')::numeric, 0) * fe.quantity / fe.serving_size) AS "${ident}"`;
+        params.push(cn.name);
+        const paramIdx = params.length;
+        return `(COALESCE(NULLIF(fe.custom_nutrients->>$${paramIdx}, '')::numeric, 0) * fe.quantity / fe.serving_size) AS "${ident}"`;
       })
       .join(',\n          ');
     const customNutrientsSelectOuter = customNutrients
@@ -343,7 +352,7 @@ async function getTabularFoodData(
         fem.user_id, 
         fem.quantity
       ORDER BY entry_date, sort_order ASC, food_name ASC`,
-      [userId, startDate, endDate]
+      params
     );
     return result.rows;
   } finally {
@@ -408,6 +417,13 @@ async function getMiniNutritionTrends(
 ) {
   const client = await getClient(userId); // User-specific operation
   try {
+    const params: (string | number)[] = [userId, startDate, endDate];
+    const customNutrientParamIndexes: number[] = [];
+    customNutrients.forEach((cn) => {
+      params.push(cn.name);
+      customNutrientParamIndexes.push(params.length);
+    });
+
     // Generate dynamic SQL parts for custom nutrients
     // Note: Standard nutrients use "total_" prefix in the outer select of the existing query.
     // For custom nutrients, I will use their name directly to match the service mapping.
@@ -418,18 +434,18 @@ async function getMiniNutritionTrends(
       })
       .join(',\n         ');
     const customNutrientsSelectInner1 = customNutrients
-      .map((cn) => {
+      .map((cn, idx) => {
         const ident = cn.name.replace(/"/g, '""');
-        const lit = cn.name.replace(/'/g, "''");
-        return `(COALESCE(NULLIF(fe.custom_nutrients->>'${lit}', '')::numeric, 0) * fe.quantity / fe.serving_size) AS "${ident}"`;
+        const paramIdx = customNutrientParamIndexes[idx];
+        return `(COALESCE(NULLIF(fe.custom_nutrients->>$${paramIdx}, '')::numeric, 0) * fe.quantity / fe.serving_size) AS "${ident}"`;
       })
       .join(',\n           ');
     // Note: fe_meal.quantity is already scaled, so do NOT multiply by fem.quantity
     const customNutrientsSelectInner2 = customNutrients
-      .map((cn) => {
+      .map((cn, idx) => {
         const ident = cn.name.replace(/"/g, '""');
-        const lit = cn.name.replace(/'/g, "''");
-        return `SUM(COALESCE(NULLIF(fe_meal.custom_nutrients->>'${lit}', '')::numeric, 0) * fe_meal.quantity / fe_meal.serving_size) AS "${ident}"`;
+        const paramIdx = customNutrientParamIndexes[idx];
+        return `SUM(COALESCE(NULLIF(fe_meal.custom_nutrients->>$${paramIdx}, '')::numeric, 0) * fe_meal.quantity / fe_meal.serving_size) AS "${ident}"`;
       })
       .join(',\n           ');
     const result = await client.query(
@@ -521,7 +537,7 @@ async function getMiniNutritionTrends(
        ) AS combined_nutrition
        GROUP BY entry_date
        ORDER BY entry_date`,
-      [userId, startDate, endDate]
+      params
     );
     return result.rows;
   } finally {

--- a/SparkyFitnessServer/routes/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/exerciseRoutes.ts
@@ -775,7 +775,15 @@ router.get('/wger-filters', authenticate, async (req, res, next) => {
  *             schema:
  *               type: array
  *               items:
- *                 type: string
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     format: uuid
+ *                     description: Exercise ID.
+ *                   name:
+ *                     type: string
+ *                     description: Exercise name.
  *       500:
  *         description: Server error.
  */

--- a/SparkyFitnessServer/routes/exerciseRoutes.ts
+++ b/SparkyFitnessServer/routes/exerciseRoutes.ts
@@ -781,7 +781,10 @@ router.get('/wger-filters', authenticate, async (req, res, next) => {
  */
 router.get('/names', authenticate, async (req, res, next) => {
   try {
-    const { muscle, equipment } = req.query;
+    const muscle =
+      typeof req.query.muscle === 'string' ? req.query.muscle : undefined;
+    const equipment =
+      typeof req.query.equipment === 'string' ? req.query.equipment : undefined;
     const exerciseNames = await reportRepository.getExerciseNames(
       req.userId,
       muscle,

--- a/SparkyFitnessServer/services/reportService.ts
+++ b/SparkyFitnessServer/services/reportService.ts
@@ -157,7 +157,6 @@ async function getReportsData(
         endDate,
         customNutrients
       ),
-      // @ts-expect-error TS(2554): Expected 6 arguments, but got 3.
       reportRepository.getExerciseEntries(targetUserId, startDate, endDate),
       reportRepository.getMeasurementData(targetUserId, startDate, endDate),
       measurementRepository.getCustomCategories(targetUserId),

--- a/SparkyFitnessServer/tests/reportRepository.customNutrients.test.ts
+++ b/SparkyFitnessServer/tests/reportRepository.customNutrients.test.ts
@@ -1,0 +1,105 @@
+import { vi, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createMockDbClient,
+  type MockDbClient,
+} from './helpers/mockDbClient.js';
+import { v4 as uuidv4 } from 'uuid';
+import { getClient } from '../db/poolManager.js';
+import {
+  getNutritionData,
+  getTabularFoodData,
+  getMiniNutritionTrends,
+} from '../models/reportRepository.js';
+
+vi.mock('../db/poolManager', () => ({
+  getClient: vi.fn(),
+}));
+
+describe('reportRepository — custom nutrient SQL escaping', () => {
+  let mockClient: MockDbClient;
+  const userId = uuidv4();
+
+  beforeEach(() => {
+    mockClient = createMockDbClient([]);
+    vi.mocked(getClient).mockResolvedValue(mockClient);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('getTabularFoodData safely escapes quotes in custom nutrient names', async () => {
+    const customNutrients = [
+      { name: "St. John's Wort" },
+      { name: 'Vitamin "Special" B' },
+    ];
+
+    await getTabularFoodData(
+      userId,
+      '2026-07-01',
+      '2026-07-01',
+      customNutrients
+    );
+
+    expect(mockClient.query).toHaveBeenCalledTimes(1);
+    const sql = String(mockClient.query.mock.calls[0][0]);
+
+    // Check JSON extract escaping for single quotes
+    expect(sql).toContain("fe.custom_nutrients->>'St. John''s Wort'");
+    // Check identifier escaping for double quotes
+    expect(sql).toContain('AS "St. John\'s Wort"');
+    expect(sql).toContain('AS "Vitamin ""Special"" B"');
+    expect(sql).toContain('cfe."St. John\'s Wort"');
+    expect(sql).toContain(
+      'SUM(cfe_meal."St. John\'s Wort") AS "St. John\'s Wort"'
+    );
+  });
+
+  it('getNutritionData safely escapes quotes in custom nutrient names', async () => {
+    const customNutrients = [
+      { name: "St. John's Wort" },
+      { name: 'Vitamin "Special" B' },
+    ];
+
+    await getNutritionData(userId, '2026-07-01', '2026-07-01', customNutrients);
+
+    expect(mockClient.query).toHaveBeenCalledTimes(1);
+    const sql = String(mockClient.query.mock.calls[0][0]);
+
+    // Check JSON extract escaping
+    expect(sql).toContain("fe.custom_nutrients->>'St. John''s Wort'");
+    expect(sql).toContain("fe_meal.custom_nutrients->>'St. John''s Wort'");
+    expect(sql).toContain(
+      "me.nutrients_snapshot->'custom_nutrients'->>'St. John''s Wort'"
+    );
+    // Check identifier escaping
+    expect(sql).toContain('SUM("St. John\'s Wort") AS "St. John\'s Wort"');
+    expect(sql).toContain(
+      'SUM("Vitamin ""Special"" B") AS "Vitamin ""Special"" B"'
+    );
+  });
+
+  it('getMiniNutritionTrends safely escapes quotes in custom nutrient names', async () => {
+    const customNutrients = [
+      { name: "St. John's Wort" },
+      { name: 'Vitamin "Special" B' },
+    ];
+
+    await getMiniNutritionTrends(
+      userId,
+      '2026-07-01',
+      '2026-07-01',
+      customNutrients
+    );
+
+    expect(mockClient.query).toHaveBeenCalledTimes(1);
+    const sql = String(mockClient.query.mock.calls[0][0]);
+
+    // Check JSON extract escaping
+    expect(sql).toContain("fe.custom_nutrients->>'St. John''s Wort'");
+    expect(sql).toContain("fe_meal.custom_nutrients->>'St. John''s Wort'");
+    // Check identifier escaping
+    expect(sql).toContain('SUM("St. John\'s Wort") AS "St. John\'s Wort"');
+    expect(sql).toContain(
+      'SUM("Vitamin ""Special"" B") AS "Vitamin ""Special"" B"'
+    );
+  });
+});

--- a/SparkyFitnessServer/tests/reportRepository.customNutrients.test.ts
+++ b/SparkyFitnessServer/tests/reportRepository.customNutrients.test.ts
@@ -15,7 +15,7 @@ vi.mock('../db/poolManager', () => ({
   getClient: vi.fn(),
 }));
 
-describe('reportRepository — custom nutrient SQL escaping', () => {
+describe('reportRepository — custom nutrient parameterization and SQL escaping', () => {
   let mockClient: MockDbClient;
   const userId = uuidv4();
 
@@ -26,7 +26,7 @@ describe('reportRepository — custom nutrient SQL escaping', () => {
 
   afterEach(() => vi.clearAllMocks());
 
-  it('getTabularFoodData safely escapes quotes in custom nutrient names', async () => {
+  it('getTabularFoodData binds custom nutrient JSON keys as query parameters and escapes identifiers', async () => {
     const customNutrients = [
       { name: "St. John's Wort" },
       { name: 'Vitamin "Special" B' },
@@ -41,9 +41,19 @@ describe('reportRepository — custom nutrient SQL escaping', () => {
 
     expect(mockClient.query).toHaveBeenCalledTimes(1);
     const sql = String(mockClient.query.mock.calls[0][0]);
+    const params = mockClient.query.mock.calls[0][1];
 
-    // Check JSON extract escaping for single quotes
-    expect(sql).toContain("fe.custom_nutrients->>'St. John''s Wort'");
+    // Check JSON extract uses parameter placeholders
+    expect(sql).toContain('fe.custom_nutrients->>$4');
+    expect(sql).toContain('fe.custom_nutrients->>$5');
+    // Check parameters passed to query
+    expect(params).toEqual([
+      userId,
+      '2026-07-01',
+      '2026-07-01',
+      "St. John's Wort",
+      'Vitamin "Special" B',
+    ]);
     // Check identifier escaping for double quotes
     expect(sql).toContain('AS "St. John\'s Wort"');
     expect(sql).toContain('AS "Vitamin ""Special"" B"');
@@ -53,7 +63,7 @@ describe('reportRepository — custom nutrient SQL escaping', () => {
     );
   });
 
-  it('getNutritionData safely escapes quotes in custom nutrient names', async () => {
+  it('getNutritionData binds custom nutrient JSON keys as query parameters and escapes identifiers', async () => {
     const customNutrients = [
       { name: "St. John's Wort" },
       { name: 'Vitamin "Special" B' },
@@ -63,13 +73,23 @@ describe('reportRepository — custom nutrient SQL escaping', () => {
 
     expect(mockClient.query).toHaveBeenCalledTimes(1);
     const sql = String(mockClient.query.mock.calls[0][0]);
+    const params = mockClient.query.mock.calls[0][1];
 
-    // Check JSON extract escaping
-    expect(sql).toContain("fe.custom_nutrients->>'St. John''s Wort'");
-    expect(sql).toContain("fe_meal.custom_nutrients->>'St. John''s Wort'");
-    expect(sql).toContain(
-      "me.nutrients_snapshot->'custom_nutrients'->>'St. John''s Wort'"
-    );
+    // Check JSON extract uses parameter placeholders
+    expect(sql).toContain('fe.custom_nutrients->>$4');
+    expect(sql).toContain('fe_meal.custom_nutrients->>$4');
+    expect(sql).toContain("me.nutrients_snapshot->'custom_nutrients'->>$4");
+    expect(sql).toContain('fe.custom_nutrients->>$5');
+    expect(sql).toContain('fe_meal.custom_nutrients->>$5');
+    expect(sql).toContain("me.nutrients_snapshot->'custom_nutrients'->>$5");
+    // Check parameters passed to query
+    expect(params).toEqual([
+      userId,
+      '2026-07-01',
+      '2026-07-01',
+      "St. John's Wort",
+      'Vitamin "Special" B',
+    ]);
     // Check identifier escaping
     expect(sql).toContain('SUM("St. John\'s Wort") AS "St. John\'s Wort"');
     expect(sql).toContain(
@@ -77,7 +97,7 @@ describe('reportRepository — custom nutrient SQL escaping', () => {
     );
   });
 
-  it('getMiniNutritionTrends safely escapes quotes in custom nutrient names', async () => {
+  it('getMiniNutritionTrends binds custom nutrient JSON keys as query parameters and escapes identifiers', async () => {
     const customNutrients = [
       { name: "St. John's Wort" },
       { name: 'Vitamin "Special" B' },
@@ -92,10 +112,21 @@ describe('reportRepository — custom nutrient SQL escaping', () => {
 
     expect(mockClient.query).toHaveBeenCalledTimes(1);
     const sql = String(mockClient.query.mock.calls[0][0]);
+    const params = mockClient.query.mock.calls[0][1];
 
-    // Check JSON extract escaping
-    expect(sql).toContain("fe.custom_nutrients->>'St. John''s Wort'");
-    expect(sql).toContain("fe_meal.custom_nutrients->>'St. John''s Wort'");
+    // Check JSON extract uses parameter placeholders
+    expect(sql).toContain('fe.custom_nutrients->>$4');
+    expect(sql).toContain('fe_meal.custom_nutrients->>$4');
+    expect(sql).toContain('fe.custom_nutrients->>$5');
+    expect(sql).toContain('fe_meal.custom_nutrients->>$5');
+    // Check parameters passed to query
+    expect(params).toEqual([
+      userId,
+      '2026-07-01',
+      '2026-07-01',
+      "St. John's Wort",
+      'Vitamin "Special" B',
+    ]);
     // Check identifier escaping
     expect(sql).toContain('SUM("St. John\'s Wort") AS "St. John\'s Wort"');
     expect(sql).toContain(

--- a/SparkyFitnessServer/tests/reportSupplementScaling.test.ts
+++ b/SparkyFitnessServer/tests/reportSupplementScaling.test.ts
@@ -40,8 +40,9 @@ describe('getNutritionData — supplement dose scaling', () => {
     );
     // ...and so is the custom-nutrient supplement select.
     expect(sql).toContain(
-      "me.nutrients_snapshot->'custom_nutrients'->>'Boron'), 0) * GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)"
+      "me.nutrients_snapshot->'custom_nutrients'->>$4), 0) * GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)"
     );
+    expect(mockClient.query.mock.calls[0][1]).toContain('Boron');
     // The food arm must NOT be dose-scaled — that multiplier is supplement-only.
     expect(sql).not.toContain('fe.calories, 0) * GREATEST(');
   });

--- a/SparkyFitnessServer/tests/reportSupplementScaling.test.ts
+++ b/SparkyFitnessServer/tests/reportSupplementScaling.test.ts
@@ -42,7 +42,12 @@ describe('getNutritionData — supplement dose scaling', () => {
     expect(sql).toContain(
       "me.nutrients_snapshot->'custom_nutrients'->>$4), 0) * GREATEST(COALESCE(me.dose_amount_snapshot, 1), 0)"
     );
-    expect(mockClient.query.mock.calls[0][1]).toContain('Boron');
+    expect(mockClient.query.mock.calls[0][1]).toEqual([
+      userId,
+      '2026-07-01',
+      '2026-07-01',
+      'Boron',
+    ]);
     // The food arm must NOT be dose-scaled — that multiplier is supplement-only.
     expect(sql).not.toContain('fe.calories, 0) * GREATEST(');
   });


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
Custom nutrient names containing quotes or apostrophes (such as "St. John's Wort") caused PostgreSQL syntax errors in `getTabularFoodData` and `getMiniNutritionTrends`, causing the Reports page to fail loading with "failed to load core reports data".

**How did you implement the solution?**
- Properly escaped single quotes in JSON path extracts (`fe.custom_nutrients->>'...'`) and double quotes in column alias identifiers across `getTabularFoodData` and `getMiniNutritionTrends` in `reportRepository.ts`.
- Applied explicit TypeScript types across `reportRepository.ts` functions and cleaned up obsolete annotations.
- Added comprehensive unit tests in `reportRepository.customNutrients.test.ts` to verify SQL escaping behavior for custom nutrients with special characters.

Linked Issue: Closes #2355

## How to Test

1. Run server unit tests: `cd SparkyFitnessServer && pnpm test tests/reportRepository.customNutrients.test.ts`
2. Run validation: `pnpm run validate`
3. In web UI, add a custom nutrient or supplement with an apostrophe (e.g. `St. John's Wort`), then open Reports and verify that the page loads without PostgreSQL syntax errors.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [ ] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

N/A (Backend query syntax error fix)

### After

N/A (Backend query syntax error fix)

</details>

## Notes for Reviewers

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved report reliability when custom nutrient names contain quotation marks.
  - Strengthened handling of exercise filters and invalid or optional query values.
  - Preserved exclusion of “Active Calories” from exercise-name results.
  - Improved protection for dynamically generated report queries.
  - Improved consistency when retrieving nutrition, measurement, and exercise report data.

- **Documentation**
  - Updated exercise-name API documentation to accurately describe returned identifiers and names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->