### PR TITLE
fix(exercises): paginate workout presets from the server total

### DIFF
--- a/SparkyFitnessFrontend/public/locales/en/translation.json
+++ b/SparkyFitnessFrontend/public/locales/en/translation.json
@@ -1227,7 +1227,6 @@
     "editPresetTooltip": "Edit this preset",
     "deletePresetTooltip": "Delete this preset",
     "loading": "Loading...",
-    "loadMore": "Load More",
     "noExercisesInPreset": "No exercises in this preset",
     "failedToLoadPresets": "Failed to load workout presets.",
     "createSuccess": "Workout preset created successfully.",

--- a/SparkyFitnessFrontend/src/api/keys/exercises.ts
+++ b/SparkyFitnessFrontend/src/api/keys/exercises.ts
@@ -27,8 +27,6 @@ export const presetKeys = {
     [...presetKeys.lists(), { page, limit }] as const,
   details: () => [...presetKeys.all, 'detail'] as const,
   detail: (id: string) => [...presetKeys.details(), id] as const,
-  infinite: (userId?: string, limit: number = 10) =>
-    [...presetKeys.lists(), 'infinite', { userId, limit }] as const,
   search: (searchTerm: string, userId?: string, limit: number = 10) =>
     [...presetKeys.lists(), 'search', { searchTerm, userId, limit }] as const,
 };

--- a/SparkyFitnessFrontend/src/api/keys/exercises.ts
+++ b/SparkyFitnessFrontend/src/api/keys/exercises.ts
@@ -23,8 +23,11 @@ export const exerciseKeys = {
 export const presetKeys = {
   all: ['workoutPresets'] as const,
   lists: () => [...presetKeys.all, 'list'] as const,
-  // Scoped to the signed-in user so a cached page can never be handed back
-  // after the session switches account, matching presetKeys.search below.
+  /**
+   * Key for one page of workout presets. It is scoped to the signed-in user so
+   * a cached page can never be handed back after the session switches account,
+   * matching the shape of `presetKeys.search` below.
+   */
   list: (userId: string | undefined, page: number, limit: number) =>
     [...presetKeys.lists(), { userId, page, limit }] as const,
   /** The user a preset list key belongs to, for placeholder-data guards. */

--- a/SparkyFitnessFrontend/src/api/keys/exercises.ts
+++ b/SparkyFitnessFrontend/src/api/keys/exercises.ts
@@ -23,8 +23,13 @@ export const exerciseKeys = {
 export const presetKeys = {
   all: ['workoutPresets'] as const,
   lists: () => [...presetKeys.all, 'list'] as const,
-  list: (page: number, limit: number) =>
-    [...presetKeys.lists(), { page, limit }] as const,
+  // Scoped to the signed-in user so a cached page can never be handed back
+  // after the session switches account, matching presetKeys.search below.
+  list: (userId: string | undefined, page: number, limit: number) =>
+    [...presetKeys.lists(), { userId, page, limit }] as const,
+  /** The user a preset list key belongs to, for placeholder-data guards. */
+  listUserId: (queryKey: readonly unknown[]): string | undefined =>
+    (queryKey[2] as { userId?: string } | undefined)?.userId,
   details: () => [...presetKeys.all, 'detail'] as const,
   detail: (id: string) => [...presetKeys.details(), id] as const,
   search: (searchTerm: string, userId?: string, limit: number = 10) =>

--- a/SparkyFitnessFrontend/src/api/keys/exercises.ts
+++ b/SparkyFitnessFrontend/src/api/keys/exercises.ts
@@ -30,9 +30,6 @@ export const presetKeys = {
    */
   list: (userId: string | undefined, page: number, limit: number) =>
     [...presetKeys.lists(), { userId, page, limit }] as const,
-  /** The user a preset list key belongs to, for placeholder-data guards. */
-  listUserId: (queryKey: readonly unknown[]): string | undefined =>
-    (queryKey[2] as { userId?: string } | undefined)?.userId,
   details: () => [...presetKeys.all, 'detail'] as const,
   detail: (id: string) => [...presetKeys.details(), id] as const,
   search: (searchTerm: string, userId?: string, limit: number = 10) =>

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPlanAssignments.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPlanAssignments.tsx
@@ -27,10 +27,7 @@ export function useWorkoutPlanAssignments(
   const { loggingLevel } = usePreferences();
 
   const { data: presetData } = useWorkoutPresets(user?.id);
-  const workoutPresets = useMemo(
-    () => presetData?.pages.flatMap((page) => page.presets) ?? [],
-    [presetData]
-  );
+  const workoutPresets = useMemo(() => presetData?.presets ?? [], [presetData]);
 
   const [assignments, setAssignments] = useState<WorkoutPlanAssignment[]>(
     () =>

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPlanAssignments.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPlanAssignments.tsx
@@ -241,6 +241,9 @@ export function useWorkoutPlanAssignments(
             day_of_week: selectedDayForAssignment,
             template_id: '',
             workout_preset_id: preset.id as string,
+            // Carried on the assignment so the copy/paste toasts can name the
+            // preset without searching a page of the preset list.
+            workout_preset_name: preset.name,
             exercise_id: undefined,
             sets: [],
           },
@@ -274,6 +277,16 @@ export function useWorkoutPlanAssignments(
     [selectedDayForAssignment]
   );
 
+  // The preset query only holds one page, so an assignment's own
+  // workout_preset_name (joined by the backend, or carried over when the preset
+  // was added) is the only reliable name for presets beyond the first page.
+  const resolvePresetName = useCallback(
+    (assignment: WorkoutPlanAssignment) =>
+      assignment.workout_preset_name ??
+      workoutPresets.find((p) => p.id === assignment.workout_preset_id)?.name,
+    [workoutPresets]
+  );
+
   const handleCopyAssignment = useCallback(
     (assignment: WorkoutPlanAssignment) => {
       setCopiedAssignment({ ...assignment });
@@ -283,13 +296,12 @@ export function useWorkoutPlanAssignments(
           itemName:
             assignment.exercise_name ||
             `${t('addWorkoutPlanDialog.presetLabel', 'Preset:')} ${
-              workoutPresets.find((p) => p.id === assignment.workout_preset_id)
-                ?.name
+              resolvePresetName(assignment) ?? ''
             }`,
         }),
       });
     },
-    [t, workoutPresets]
+    [t, resolvePresetName]
   );
 
   const handlePasteAssignment = useCallback(
@@ -313,14 +325,12 @@ export function useWorkoutPlanAssignments(
           itemName:
             newAssignment.exercise_name ||
             `${t('addWorkoutPlanDialog.presetLabel', 'Preset:')} ${
-              workoutPresets.find(
-                (p) => p.id === newAssignment.workout_preset_id
-              )?.name
+              resolvePresetName(newAssignment) ?? ''
             }`,
         }),
       });
     },
-    [copiedAssignment, t, workoutPresets]
+    [copiedAssignment, t, resolvePresetName]
   );
 
   const buildAssignmentsForSave = useCallback(

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPlanAssignments.tsx
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPlanAssignments.tsx
@@ -277,9 +277,12 @@ export function useWorkoutPlanAssignments(
     [selectedDayForAssignment]
   );
 
-  // The preset query only holds one page, so an assignment's own
-  // workout_preset_name (joined by the backend, or carried over when the preset
-  // was added) is the only reliable name for presets beyond the first page.
+  /**
+   * Resolves the display name of an assignment. The preset query only holds one
+   * page, so the assignment's own `workout_preset_name` (joined by the backend,
+   * or carried over when the preset was added) is the only reliable name for
+   * presets beyond the first page.
+   */
   const resolvePresetName = useCallback(
     (assignment: WorkoutPlanAssignment) =>
       assignment.workout_preset_name ??

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPresets.ts
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPresets.ts
@@ -1,9 +1,4 @@
-import {
-  useMutation,
-  useQueryClient,
-  keepPreviousData,
-  useQuery,
-} from '@tanstack/react-query';
+import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import {
   getWorkoutPresets,
@@ -17,6 +12,12 @@ import { presetKeys } from '@/api/keys/exercises';
 
 // --- Queries ---
 
+/**
+ * Loads one page of the workout presets visible to the signed-in user. The
+ * query key carries the user id, and the placeholder only reuses a previous
+ * page belonging to the same user, so a page cached for one account is never
+ * rendered for another.
+ */
 export const useWorkoutPresets = (
   userId?: string,
   page: number = 1,
@@ -25,9 +26,15 @@ export const useWorkoutPresets = (
   const { t } = useTranslation();
 
   return useQuery({
-    queryKey: presetKeys.list(page, limit),
+    queryKey: presetKeys.list(userId, page, limit),
     queryFn: () => getWorkoutPresets(page, limit),
-    placeholderData: keepPreviousData,
+    // Keep the table populated while the next page loads, but never across an
+    // account switch: without this guard `keepPreviousData` would briefly show
+    // the previous account's presets.
+    placeholderData: (previousData, previousQuery) =>
+      previousQuery && presetKeys.listUserId(previousQuery.queryKey) === userId
+        ? previousData
+        : undefined,
     enabled: !!userId,
     meta: {
       errorMessage: t(

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPresets.ts
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPresets.ts
@@ -1,7 +1,7 @@
 import {
   useMutation,
   useQueryClient,
-  useInfiniteQuery,
+  keepPreviousData,
   useQuery,
 } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -17,17 +17,17 @@ import { presetKeys } from '@/api/keys/exercises';
 
 // --- Queries ---
 
-export const useWorkoutPresets = (userId?: string, limit: number = 10) => {
+export const useWorkoutPresets = (
+  userId?: string,
+  page: number = 1,
+  limit: number = 10
+) => {
   const { t } = useTranslation();
 
-  return useInfiniteQuery({
-    queryKey: presetKeys.infinite(userId, limit),
-    queryFn: ({ pageParam = 1 }) => getWorkoutPresets(pageParam, limit),
-    initialPageParam: 1,
-    getNextPageParam: (lastPage, allPages) => {
-      const totalLoaded = allPages.length * limit;
-      return lastPage.total > totalLoaded ? allPages.length + 1 : undefined;
-    },
+  return useQuery({
+    queryKey: presetKeys.list(page, limit),
+    queryFn: () => getWorkoutPresets(page, limit),
+    placeholderData: keepPreviousData,
     enabled: !!userId,
     meta: {
       errorMessage: t(

--- a/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPresets.ts
+++ b/SparkyFitnessFrontend/src/hooks/Exercises/useWorkoutPresets.ts
@@ -13,10 +13,12 @@ import { presetKeys } from '@/api/keys/exercises';
 // --- Queries ---
 
 /**
- * Loads one page of the workout presets visible to the signed-in user. The
- * query key carries the user id, and the placeholder only reuses a previous
- * page belonging to the same user, so a page cached for one account is never
- * rendered for another.
+ * Loads one page of the workout presets visible to the signed-in user.
+ *
+ * The query key carries the user id and no previous page is kept as
+ * placeholder data: the endpoint resolves the acting user from the session, so
+ * a page fetched for one account must never be rendered for another. Changing
+ * page therefore shows the table's loading state until the new page arrives.
  */
 export const useWorkoutPresets = (
   userId?: string,
@@ -28,13 +30,6 @@ export const useWorkoutPresets = (
   return useQuery({
     queryKey: presetKeys.list(userId, page, limit),
     queryFn: () => getWorkoutPresets(page, limit),
-    // Keep the table populated while the next page loads, but never across an
-    // account switch: without this guard `keepPreviousData` would briefly show
-    // the previous account's presets.
-    placeholderData: (previousData, previousQuery) =>
-      previousQuery && presetKeys.listUserId(previousQuery.queryKey) === userId
-        ? previousData
-        : undefined,
     enabled: !!userId,
     meta: {
       errorMessage: t(

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetSelector.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetSelector.tsx
@@ -79,10 +79,7 @@ const WorkoutPresetSelector: React.FC<WorkoutPresetSelectorProps> = ({
     isFetching: isSearchFetching,
   } = useSearchWorkoutPresets(debouncedSearchTerm, user?.id);
 
-  const allPresets = useMemo(
-    () => presetData?.pages.flatMap((page) => page.presets) ?? [],
-    [presetData]
-  );
+  const allPresets = useMemo(() => presetData?.presets ?? [], [presetData]);
 
   const [ownershipFilter, setOwnershipFilter] = useState<
     'all' | 'mine' | 'family' | 'public'

--- a/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
+++ b/SparkyFitnessFrontend/src/pages/Exercises/WorkoutPresetsManager.tsx
@@ -15,7 +15,6 @@ import {
   Edit,
   Trash2,
   CalendarPlus,
-  Loader2,
   Layers,
   Dumbbell,
   CheckSquare,
@@ -75,19 +74,32 @@ const WorkoutPresetsManager = () => {
   const [selectedPreset, setSelectedPreset] = useState<WorkoutPreset | null>(
     null
   );
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(10);
 
-  const { data, fetchNextPage, hasNextPage, isLoading, isFetchingNextPage } =
-    useWorkoutPresets(user?.id);
+  const { data, isLoading, isFetching } = useWorkoutPresets(
+    user?.id,
+    currentPage,
+    itemsPerPage
+  );
 
   const { mutateAsync: createPreset } = useCreateWorkoutPresetMutation();
   const { mutateAsync: updatePreset } = useUpdateWorkoutPresetMutation();
   const { mutateAsync: deletePreset } = useDeleteWorkoutPresetMutation();
   const { mutateAsync: logWorkoutPreset } = useLogWorkoutPresetMutation();
 
-  const presets = React.useMemo(
-    () => data?.pages.flatMap((page) => page.presets) ?? [],
-    [data]
-  );
+  const presets = React.useMemo(() => data?.presets ?? [], [data]);
+  const totalPresets = data?.total ?? 0;
+  const totalPages = Math.ceil(totalPresets / itemsPerPage);
+
+  // Deleting every preset on the last page (or shrinking the page size) can
+  // leave the request pointing past the end of the list, which would render an
+  // empty table next to a stale page number. Fall back to the last real page.
+  React.useEffect(() => {
+    if (data && totalPages > 0 && currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [data, totalPages, currentPage]);
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
@@ -485,28 +497,22 @@ const WorkoutPresetsManager = () => {
                 isEditMode ? columns : columns.filter((c) => c.id !== 'select')
               }
               data={presets}
-              isLoading={isLoading}
+              isLoading={isLoading || isFetching}
+              manualPagination
+              pageCount={totalPages}
+              pagination={{
+                pageIndex: currentPage - 1,
+                pageSize: itemsPerPage,
+              }}
+              onPaginationChange={(pageIndex, pageSize) => {
+                if (pageSize !== itemsPerPage) {
+                  setItemsPerPage(pageSize);
+                  setCurrentPage(1);
+                } else {
+                  setCurrentPage(pageIndex + 1);
+                }
+              }}
             />
-          )}
-
-          {hasNextPage && (
-            <div className="flex justify-center pt-4">
-              <Button
-                variant="ghost"
-                onClick={() => {
-                  fetchNextPage();
-                  clearSelection();
-                }}
-                disabled={isFetchingNextPage}
-                className="text-gray-500"
-              >
-                {isFetchingNextPage ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  t('workoutPresetsManager.loadMore', 'Load more')
-                )}
-              </Button>
-            </div>
           )}
         </CardContent>
       </Card>

--- a/SparkyFitnessFrontend/src/tests/components/WorkoutPresetsManager.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/WorkoutPresetsManager.test.tsx
@@ -4,6 +4,7 @@ import WorkoutPresetsManager from '@/pages/Exercises/WorkoutPresetsManager';
 import type { WorkoutPreset } from '@/types/workout';
 
 const mockCreatePreset = jest.fn();
+const mockUseWorkoutPresets = jest.fn();
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -18,6 +19,16 @@ jest.mock('react-i18next', () => ({
         if (key === 'workoutPresetsManager.duplicateNameSuffix') {
           const { name } = defaultOrValues as { name: string };
           return `${name} (Copy)`;
+        }
+        // i18next interpolates the defaultValue when the locale file has no
+        // entry, which is what the DataTable footer relies on.
+        const { defaultValue, ...values } = defaultOrValues as {
+          defaultValue?: unknown;
+        } & Record<string, unknown>;
+        if (typeof defaultValue === 'string') {
+          return defaultValue.replace(/\{\{(\w+)\}\}/g, (_match, name) =>
+            String(values[name] ?? '')
+          );
         }
         return `${key}:${JSON.stringify(defaultOrValues)}`;
       }
@@ -62,13 +73,7 @@ const presetFixture: WorkoutPreset = {
 } as unknown as WorkoutPreset;
 
 jest.mock('@/hooks/Exercises/useWorkoutPresets', () => ({
-  useWorkoutPresets: () => ({
-    data: { pages: [{ presets: [presetFixture], total: 1 }] },
-    fetchNextPage: jest.fn(),
-    hasNextPage: false,
-    isLoading: false,
-    isFetchingNextPage: false,
-  }),
+  useWorkoutPresets: (...args: unknown[]) => mockUseWorkoutPresets(...args),
   useCreateWorkoutPresetMutation: () => ({
     mutateAsync: (...args: unknown[]) => mockCreatePreset(...args),
   }),
@@ -76,9 +81,57 @@ jest.mock('@/hooks/Exercises/useWorkoutPresets', () => ({
   useDeleteWorkoutPresetMutation: () => ({ mutateAsync: jest.fn() }),
 }));
 
+const buildPresets = (count: number, offset = 0): WorkoutPreset[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `preset-${offset + index + 1}`,
+    user_id: 'user-1',
+    name: `Preset ${offset + index + 1}`,
+    description: null,
+    exercises: [],
+  })) as unknown as WorkoutPreset[];
+
+/**
+ * Mocks useWorkoutPresets the way the API behaves: the hook is called with the
+ * requested page and the response carries the server total, so the table must
+ * derive its page count from `total` rather than from the rows it received.
+ */
+const mockPaginatedPresets = (total: number) => {
+  mockUseWorkoutPresets.mockImplementation(
+    (_userId?: string, page = 1, limit = 10) => {
+      const start = (page - 1) * limit;
+      return {
+        data: {
+          presets: buildPresets(
+            Math.max(0, Math.min(limit, total - start)),
+            start
+          ),
+          total,
+          page,
+          limit,
+        },
+        isLoading: false,
+        isFetching: false,
+      };
+    }
+  );
+};
+
 describe('WorkoutPresetsManager duplicate preset', () => {
   beforeEach(() => {
     mockCreatePreset.mockReset();
+    mockUseWorkoutPresets.mockReset();
+    mockUseWorkoutPresets.mockImplementation(
+      (_userId?: string, page = 1, limit = 10) => ({
+        data: {
+          presets: page === 1 ? [presetFixture] : [],
+          total: 1,
+          page,
+          limit,
+        },
+        isLoading: false,
+        isFetching: false,
+      })
+    );
   });
 
   it('creates a private copy with the original exercises/sets and a "(Copy)" name, regardless of the source visibility', async () => {
@@ -133,5 +186,54 @@ describe('WorkoutPresetsManager duplicate preset', () => {
     } finally {
       presetFixture.name = originalName;
     }
+  });
+});
+
+describe('WorkoutPresetsManager pagination', () => {
+  beforeEach(() => {
+    mockCreatePreset.mockReset();
+    mockUseWorkoutPresets.mockReset();
+  });
+
+  it('reports the server page count on the first render instead of one page per loaded batch', () => {
+    mockPaginatedPresets(21);
+
+    render(<WorkoutPresetsManager />);
+
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Preset 10').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Preset 11')).not.toBeInTheDocument();
+  });
+
+  it('fetches the requested page from the server instead of appending rows to the loaded ones', () => {
+    mockPaginatedPresets(21);
+
+    render(<WorkoutPresetsManager />);
+    expect(screen.getByText('Page 1 of 3')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+
+    expect(screen.getByText('Page 2 of 3')).toBeInTheDocument();
+    expect(mockUseWorkoutPresets).toHaveBeenCalledWith('user-1', 2, 10);
+    expect(screen.getAllByText('Preset 11').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Preset 1')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the last available page once the current page no longer exists', () => {
+    mockPaginatedPresets(21);
+
+    render(<WorkoutPresetsManager />);
+    fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }));
+    expect(screen.getByText('Page 3 of 3')).toBeInTheDocument();
+
+    // The presets on the last page were deleted, so the server now reports 11
+    // presets and page 3 is gone. Any re-render should notice and step back.
+    mockPaginatedPresets(11);
+    fireEvent.click(screen.getByRole('button', { name: 'Select' }));
+
+    expect(mockUseWorkoutPresets).toHaveBeenCalledWith('user-1', 2, 10);
+    expect(screen.getByText('Page 2 of 2')).toBeInTheDocument();
   });
 });

--- a/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPlanAssignments.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPlanAssignments.test.tsx
@@ -1,7 +1,8 @@
 import { act, renderHook } from '@testing-library/react';
 import { useWorkoutPlanAssignments } from '@/hooks/Exercises/useWorkoutPlanAssignments';
-import type { WorkoutPlanTemplate } from '@/types/workout';
+import type { WorkoutPlanTemplate, WorkoutPreset } from '@/types/workout';
 import type { Exercise } from '@/types/exercises';
+import { toast } from '@/hooks/use-toast';
 
 jest.mock('@/contexts/PreferencesContext', () => ({
   usePreferences: () => ({
@@ -25,9 +26,26 @@ jest.mock('@/hooks/useAuth', () => ({
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, defaultValue?: string) => defaultValue,
+    t: (key: string, defaultValueOrValues?: unknown) => {
+      if (typeof defaultValueOrValues === 'string') {
+        return defaultValueOrValues;
+      }
+      if (defaultValueOrValues && typeof defaultValueOrValues === 'object') {
+        const values = defaultValueOrValues as Record<string, unknown>;
+        // Mirrors the en/translation.json templates these toasts interpolate.
+        if (key === 'addWorkoutPlanDialog.copiedToastDescription') {
+          return `${values['itemName']} copied to clipboard.`;
+        }
+        if (key === 'addWorkoutPlanDialog.pastedToastDescription') {
+          return `Pasted ${values['itemName']} to the new day.`;
+        }
+      }
+      return key;
+    },
   }),
 }));
+
+const mockedToast = toast as jest.MockedFunction<typeof toast>;
 
 const planWithTimedSet = {
   id: 'plan-1',
@@ -153,6 +171,86 @@ describe('useWorkoutPlanAssignments modality seeding', () => {
     expect(added?.modality).toBe('weight_reps');
     expect(added?.sets[0]).toEqual(
       expect.objectContaining({ reps: 10, weight: null })
+    );
+  });
+});
+
+// The preset query only ever loads one page, so a preset outside it is missing
+// from `workoutPresets`; the assignment's own joined name has to be used.
+const planWithLaterPreset = {
+  id: 'plan-2',
+  user_id: 'user-1',
+  plan_name: 'Split',
+  assignments: [
+    {
+      id: 'assignment-9',
+      template_id: 'plan-2',
+      day_of_week: 1,
+      workout_preset_id: 'preset-42',
+      workout_preset_name: 'Push Day A',
+      sets: [],
+    },
+  ],
+} as unknown as WorkoutPlanTemplate;
+
+describe('useWorkoutPlanAssignments preset naming', () => {
+  beforeEach(() => {
+    mockedToast.mockReset();
+  });
+
+  it('names a preset that is not on the loaded page in the copy toast', () => {
+    const { result } = renderHook(() =>
+      useWorkoutPlanAssignments(planWithLaterPreset)
+    );
+
+    act(() => {
+      result.current.handleCopyAssignment(result.current.assignments[0]!);
+    });
+
+    expect(mockedToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'Preset: Push Day A copied to clipboard.',
+      })
+    );
+  });
+
+  it('names the preset in the paste toast as well', () => {
+    const { result } = renderHook(() =>
+      useWorkoutPlanAssignments(planWithLaterPreset)
+    );
+
+    act(() => {
+      result.current.handleCopyAssignment(result.current.assignments[0]!);
+    });
+    act(() => {
+      result.current.handlePasteAssignment(3);
+    });
+
+    expect(mockedToast).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        description: 'Pasted Preset: Push Day A to the new day.',
+      })
+    );
+  });
+
+  it('carries the preset name onto a preset added from the picker', () => {
+    const { result } = renderHook(() => useWorkoutPlanAssignments(null));
+
+    act(() => {
+      result.current.setSelectedDayForAssignment(2);
+    });
+    act(() => {
+      result.current.handleAddExerciseOrPreset(
+        { id: 'preset-42', name: 'Push Day A' } as unknown as WorkoutPreset,
+        'preset'
+      );
+    });
+
+    expect(result.current.assignments[0]).toEqual(
+      expect.objectContaining({
+        workout_preset_id: 'preset-42',
+        workout_preset_name: 'Push Day A',
+      })
     );
   });
 });

--- a/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPresets.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPresets.test.tsx
@@ -1,0 +1,128 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useWorkoutPresets } from '@/hooks/Exercises/useWorkoutPresets';
+import { getWorkoutPresets } from '@/api/Exercises/workoutPresets';
+import type { PaginatedWorkoutPresets, WorkoutPreset } from '@/types/workout';
+
+jest.mock('@/api/Exercises/workoutPresets', () => ({
+  getWorkoutPresets: jest.fn(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_key: string, fallback: string) => fallback }),
+}));
+
+const mockedGetWorkoutPresets = getWorkoutPresets as jest.MockedFunction<
+  typeof getWorkoutPresets
+>;
+
+const presetFor = (userId: string): WorkoutPreset =>
+  ({
+    id: `preset-${userId}`,
+    user_id: userId,
+    name: `Preset ${userId}`,
+  }) as unknown as WorkoutPreset;
+
+const pageOf = (userId: string, page = 1): PaginatedWorkoutPresets => ({
+  presets: [presetFor(userId)],
+  total: 20,
+  page,
+  limit: 10,
+});
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { Wrapper };
+};
+
+describe('useWorkoutPresets cache isolation', () => {
+  beforeEach(() => {
+    mockedGetWorkoutPresets.mockReset();
+  });
+
+  it('does not serve one account the presets cached for another', async () => {
+    let resolveSecondAccount: (value: PaginatedWorkoutPresets) => void = () =>
+      undefined;
+
+    mockedGetWorkoutPresets
+      .mockResolvedValueOnce(pageOf('user-1'))
+      .mockImplementationOnce(
+        () =>
+          new Promise<PaginatedWorkoutPresets>((resolve) => {
+            resolveSecondAccount = resolve;
+          })
+      );
+
+    const { Wrapper } = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ userId }: { userId: string }) => useWorkoutPresets(userId),
+      { wrapper: Wrapper, initialProps: { userId: 'user-1' } }
+    );
+
+    await waitFor(() =>
+      expect(result.current.data?.presets).toEqual([presetFor('user-1')])
+    );
+
+    // The session switches account. Until the response for the new account
+    // arrives there must be no preset data at all - the cached page of the
+    // previous account must not be reused as placeholder data.
+    rerender({ userId: 'user-2' });
+
+    expect(result.current.data).toBeUndefined();
+
+    await act(async () => {
+      resolveSecondAccount(pageOf('user-2'));
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.presets).toEqual([presetFor('user-2')])
+    );
+  });
+
+  it('keeps the previous page while the next page of the same user loads', async () => {
+    let resolveSecondPage: (value: PaginatedWorkoutPresets) => void = () =>
+      undefined;
+
+    mockedGetWorkoutPresets
+      .mockResolvedValueOnce(pageOf('user-1', 1))
+      .mockImplementationOnce(
+        () =>
+          new Promise<PaginatedWorkoutPresets>((resolve) => {
+            resolveSecondPage = resolve;
+          })
+      );
+
+    const { Wrapper } = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ page }: { page: number }) => useWorkoutPresets('user-1', page),
+      { wrapper: Wrapper, initialProps: { page: 1 } }
+    );
+
+    await waitFor(() =>
+      expect(result.current.data?.presets).toEqual([presetFor('user-1')])
+    );
+
+    rerender({ page: 2 });
+
+    expect(result.current.data?.presets).toEqual([presetFor('user-1')]);
+
+    await act(async () => {
+      resolveSecondPage({
+        presets: [presetFor('user-1-page-2')],
+        total: 20,
+        page: 2,
+        limit: 10,
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.presets).toEqual([presetFor('user-1-page-2')])
+    );
+  });
+});

--- a/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPresets.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useWorkoutPresets.test.tsx
@@ -71,7 +71,7 @@ describe('useWorkoutPresets cache isolation', () => {
 
     // The session switches account. Until the response for the new account
     // arrives there must be no preset data at all - the cached page of the
-    // previous account must not be reused as placeholder data.
+    // previous account must not be served for the new one.
     rerender({ userId: 'user-2' });
 
     expect(result.current.data).toBeUndefined();
@@ -85,7 +85,7 @@ describe('useWorkoutPresets cache isolation', () => {
     );
   });
 
-  it('keeps the previous page while the next page of the same user loads', async () => {
+  it('does not keep one page of presets visible while another user is loading', async () => {
     let resolveSecondPage: (value: PaginatedWorkoutPresets) => void = () =>
       undefined;
 
@@ -108,9 +108,11 @@ describe('useWorkoutPresets cache isolation', () => {
       expect(result.current.data?.presets).toEqual([presetFor('user-1')])
     );
 
+    // Paging is a fresh fetch with no placeholder: the previous page is not
+    // carried over, so a stale row can never be mistaken for the new page.
     rerender({ page: 2 });
 
-    expect(result.current.data?.presets).toEqual([presetFor('user-1')]);
+    expect(result.current.data).toBeUndefined();
 
     await act(async () => {
       resolveSecondPage({


### PR DESCRIPTION
> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
With more than one page of workout presets, the Workout Presets table on the Exercises page reported its page count from the presets the infinite query had already loaded. With 21 presets it showed `Page 1 of 1` next to a separate `Load more` button, and the footer only reached `Page 1 of 3` after every batch had been fetched by hand.

**How did you implement the solution?**
- `useWorkoutPresets` now requests a single server page (`page`/`limit`) instead of an `useInfiniteQuery`, keyed by the signed-in user so a cached page is never rendered for another account. No previous page is kept as placeholder data.
- `WorkoutPresetsManager` owns `currentPage`/`itemsPerPage` and drives the `DataTable` with `manualPagination`, a `pageCount` taken from the server `total`, and a controlled `pagination`/`onPaginationChange` pair — the same model the Exercises table already uses on that screen.
- The table steps back to the last existing page when the current one is emptied by deletions, so an empty table is never paired with a stale page number.
- Removed the `Load more` button, its now-unused `workoutPresetsManager.loadMore` English key, and the unused `presetKeys.infinite` key factory.
- `useWorkoutPresets` takes `(userId, page, limit)` now. The preset selector dialog and `useWorkoutPlanAssignments` read the first page of the same query, which is exactly what they saw before, since the infinite query never advanced past it on its own.

Linked Issue: Closes #2170

## How to Test

1. Have more than 10 workout presets (21 reproduces the report).
2. Run `cd SparkyFitnessFrontend && pnpm dev` and open Exercises → Workout Presets.
3. The footer reads `Page 1 of 3` on first load and there is no `Load more` button.
4. Use the first/previous/next/last controls: each page is fetched from the server and the previous rows are replaced rather than appended.
5. Change "Rows per page": the table returns to page 1 and re-requests with the new size.
6. Automated: `cd SparkyFitnessFrontend && pnpm exec jest --watchman=false --runInBand src/tests/components/WorkoutPresetsManager.test.tsx`.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [ ] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [x] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

Captured in local development against 21 seeded presets, desktop viewport 1512x982.

### Before

![Workout Presets before the fix: footer reads Page 1 of 1 while a Load more button sits below the table](https://raw.githubusercontent.com/Dragonk/SparkyFitness/screenshots/pr-2441-workout-presets-pagination/workout-presets-before.png)

### After

![Workout Presets after the fix: footer reads Page 1 of 3 on first load, with no Load more button](https://raw.githubusercontent.com/Dragonk/SparkyFitness/screenshots/pr-2441-workout-presets-pagination/workout-presets-after.png)

</details>

## Notes for Reviewers

- No server change is needed: `GET /workout-presets` already returns `total`, `page` and `limit`.
- `workout_presets` is ordered by `name ASC` without a tiebreak, so two presets sharing a name could in principle swap places between page requests. That predates this change (the Exercises listing has the same pattern); I left it alone rather than widening the scope, but a deterministic `ORDER BY name, id` would close it if you want it as a follow-up.
- The three new tests cover the server page count on first render, fetching a page from the server instead of appending rows, and the fallback when the current page no longer exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-side pagination for workout presets, allowing users to navigate between pages and adjust the number of items shown.
  * Preset data is now isolated when switching accounts, preventing cached results from appearing under the wrong account.
* **Bug Fixes**
  * Corrected preset loading behavior when changing pages and after deleting items, including fallback to the last available page.
  * Improved workout-plan preset naming and related toast messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->