### PR TITLE
fix(demo,admin): stop the demo request flood and preserve data on user deletes

### DIFF
--- a/SparkyFitnessFrontend/src/api/Auth/auth.ts
+++ b/SparkyFitnessFrontend/src/api/Auth/auth.ts
@@ -22,6 +22,8 @@ export interface IdentityUserResponse {
   fullName: string | null;
   activeUserFullName?: string;
   activeUserEmail: string;
+  /** True when the authenticated account is the demo sandbox. */
+  isDemo?: boolean;
 }
 
 export interface SwitchContextResponse {

--- a/SparkyFitnessFrontend/src/api/api.ts
+++ b/SparkyFitnessFrontend/src/api/api.ts
@@ -37,13 +37,16 @@ export const API_BASE_URL = '/api';
 // Keyed on method *and* path. The demo guard blocks `/api/identity` only for
 // mutating methods, so a path-only key would let a refused PUT answer the GET
 // that the same screen depends on -- turning a read-only demo into a broken one.
-const demoRestrictedEndpoints = new Map<string, string>();
+// Replaced wholesale rather than cleared, so a request that was already in
+// flight when the session changed writes its verdict into the map nobody reads
+// any more instead of seeding the new session with the old account's refusals.
+let demoRestrictedEndpoints = new Map<string, string>();
 
 const demoRestrictionKey = (method: string, endpoint: string): string =>
   `${method.toUpperCase()} ${endpoint}`;
 
 export const clearDemoRestrictions = (): void => {
-  demoRestrictedEndpoints.clear();
+  demoRestrictedEndpoints = new Map<string, string>();
 };
 //export const API_BASE_URL = 'http://192.168.1.111:3010';
 
@@ -119,13 +122,15 @@ export async function apiCall<T = any>(
   let url = isExternal ? endpoint : `${API_BASE_URL}${endpoint}`;
 
   const method = (options?.method || 'GET').toUpperCase();
+  // Captured for the lifetime of this request; see demoRestrictedEndpoints.
+  const restrictionCache = demoRestrictedEndpoints;
 
   // A demo restriction is a standing policy for the whole session, not a
   // transient failure, so asking again can only ever get the same answer.
   // Several blocked endpoints are polled by components that mount on every
   // screen, which turned a permanent "no" into thousands of requests a minute
   // against the server. Answer from here instead of going back to the network.
-  const demoRestriction = demoRestrictedEndpoints.get(
+  const demoRestriction = restrictionCache.get(
     demoRestrictionKey(method, endpoint)
   );
   if (demoRestriction !== undefined) {
@@ -279,7 +284,7 @@ export async function apiCall<T = any>(
           errorCode !== 'DEMO_UPLOAD_RESTRICTED' &&
           !isExternal
         ) {
-          demoRestrictedEndpoints.set(
+          restrictionCache.set(
             demoRestrictionKey(method, endpoint),
             errorMessage
           );

--- a/SparkyFitnessFrontend/src/api/api.ts
+++ b/SparkyFitnessFrontend/src/api/api.ts
@@ -13,9 +13,38 @@ interface ApiCallOptions extends RequestInit {
   responseType?: 'json' | 'text' | 'blob'; // Add responseType option
 }
 
-class HttpApiError extends Error {}
+export class HttpApiError extends Error {
+  // Carries the HTTP status and any server-supplied error code so callers --
+  // notably the React Query retry policy -- can tell a client error that will
+  // never succeed on retry from a transient server error that might.
+  readonly status: number;
+  readonly code?: string;
+
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = 'HttpApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
 
 export const API_BASE_URL = '/api';
+
+// Requests the server has refused for this session with a DEMO_ code, mapped
+// to the message it gave. Module scope, so it resets on reload; cleared on any
+// sign-in or sign-out so a later non-demo session starts from a clean slate.
+//
+// Keyed on method *and* path. The demo guard blocks `/api/identity` only for
+// mutating methods, so a path-only key would let a refused PUT answer the GET
+// that the same screen depends on -- turning a read-only demo into a broken one.
+const demoRestrictedEndpoints = new Map<string, string>();
+
+const demoRestrictionKey = (method: string, endpoint: string): string =>
+  `${method.toUpperCase()} ${endpoint}`;
+
+export const clearDemoRestrictions = (): void => {
+  demoRestrictedEndpoints.clear();
+};
 //export const API_BASE_URL = 'http://192.168.1.111:3010';
 
 // A single-use guard so a reload triggered by gateway interception (see
@@ -88,6 +117,20 @@ export async function apiCall<T = any>(
   const isAbsoluteUrl = /^https?:\/\//.test(endpoint);
   const isExternal = options?.externalApi || isAbsoluteUrl;
   let url = isExternal ? endpoint : `${API_BASE_URL}${endpoint}`;
+
+  const method = (options?.method || 'GET').toUpperCase();
+
+  // A demo restriction is a standing policy for the whole session, not a
+  // transient failure, so asking again can only ever get the same answer.
+  // Several blocked endpoints are polled by components that mount on every
+  // screen, which turned a permanent "no" into thousands of requests a minute
+  // against the server. Answer from here instead of going back to the network.
+  const demoRestriction = demoRestrictedEndpoints.get(
+    demoRestrictionKey(method, endpoint)
+  );
+  if (demoRestriction !== undefined) {
+    throw new HttpApiError(demoRestriction, 403, 'DEMO_ACTION_RESTRICTED');
+  }
 
   if (options?.params) {
     // Filter out undefined values to prevent them from becoming the string "undefined" in URLSearchParams
@@ -224,18 +267,43 @@ export async function apiCall<T = any>(
         );
         return null as unknown as T; // Return null for 404 with suppression
       } else {
-        toast({
-          title: 'API Error',
-          description: errorMessage,
-          variant: 'destructive',
-        });
+        const errorCode = errorData.code ? String(errorData.code) : undefined;
+        const isDemoRestriction = errorCode?.startsWith('DEMO_') ?? false;
+        // DEMO_UPLOAD_RESTRICTED is deliberately not memoized: the guard
+        // decides it from the request's content type, not its route, so the
+        // same method and path can legitimately be allowed with a JSON body.
+        // Uploads are click-driven anyway, so there is no polling flood to
+        // head off here.
+        if (
+          isDemoRestriction &&
+          errorCode !== 'DEMO_UPLOAD_RESTRICTED' &&
+          !isExternal
+        ) {
+          demoRestrictedEndpoints.set(
+            demoRestrictionKey(method, endpoint),
+            errorMessage
+          );
+        }
+        // Demo-account restrictions are a standing policy, not an incident: the
+        // blocked endpoints are polled by components that mount on every page,
+        // so toasting each rejection buries the screen in identical popups and
+        // makes real errors impossible to spot. Only reads are silenced --
+        // a write is something the visitor just clicked, and swallowing that
+        // leaves them staring at a button that appears to do nothing.
+        if (!isDemoRestriction || method !== 'GET') {
+          toast({
+            title: 'API Error',
+            description: errorMessage,
+            variant: 'destructive',
+          });
+        }
         if (
           errorMessage.includes('Authentication: Invalid or expired token.')
         ) {
           localStorage.removeItem('token');
           // window.location.reload(); // Removed aggressive reload, causing loops
         }
-        throw new HttpApiError(errorMessage);
+        throw new HttpApiError(errorMessage, response.status, errorCode);
       }
     }
 

--- a/SparkyFitnessFrontend/src/hooks/AI/useAIServiceSettings.ts
+++ b/SparkyFitnessFrontend/src/hooks/AI/useAIServiceSettings.ts
@@ -15,14 +15,20 @@ import {
   CreateAiServiceSettingsRequest,
   UpdateAiServiceSettingsRequest,
 } from '@workspace/shared';
+import { useAuth } from '@/hooks/useAuth';
 
 // Query hooks for fetching data
 export const useAIServices = () => {
   const { t } = useTranslation();
+  const { user } = useAuth();
 
   return useQuery({
     queryKey: aiServiceKeys.user(),
     queryFn: () => getAIServices(),
+    // Wait until the identity lookup has actually told us which account this
+    // is. Firing on "not yet known" means every page load spends one doomed
+    // 403 against an endpoint the demo sandbox can never use.
+    enabled: user?.isDemo === false,
     meta: {
       errorMessage: t(
         'settings.aiService.userSettings.errorLoading',
@@ -34,11 +40,15 @@ export const useAIServices = () => {
 
 export const useActiveAIService = (enabled: boolean) => {
   const { t } = useTranslation();
+  const { user } = useAuth();
 
   return useQuery({
     queryKey: aiServiceKeys.active(),
     queryFn: () => getActiveAiServiceSetting(),
-    enabled,
+    // The demo sandbox is barred from /api/chat server-side, so asking can only
+    // ever return 403. Skip it rather than firing a request whose answer is
+    // already known.
+    enabled: enabled && user?.isDemo === false,
     meta: {
       errorMessage: t(
         'settings.aiService.userSettings.errorLoading',

--- a/SparkyFitnessFrontend/src/hooks/Settings/useExternalProviderSettings.ts
+++ b/SparkyFitnessFrontend/src/hooks/Settings/useExternalProviderSettings.ts
@@ -1,3 +1,4 @@
+import { useAuth } from '@/hooks/useAuth';
 import { exerciseSearchKeys } from '@/api/keys/exercises';
 import {
   externalProviderKeys,
@@ -78,17 +79,23 @@ export const useCreateExternalProviderMutation = () => {
 };
 
 export const useExternalProviders = (userId?: string) => {
+  const { user } = useAuth();
   return useQuery({
     queryKey: [...externalProviderKeys.lists(), 'enriched'],
     queryFn: getEnrichedProviders,
-    enabled: !!userId,
+    enabled: !!userId && user?.isDemo === false,
   });
 };
 export const useExternalProvidersQuery = () => {
+  const { user } = useAuth();
   return useQuery({
     queryKey: externalProviderKeys.lists(),
     queryFn: getExternalDataProviders,
     staleTime: 1000 * 60 * 60 * 24,
+    // /api/external-providers is blocked for the demo sandbox server-side.
+    // These hooks are consumed by components that mount on most screens, so
+    // firing a request that can only 403 turns a standing policy into a flood.
+    enabled: user?.isDemo === false,
   });
 };
 export const useUpdateExternalProviderMutation = () => {

--- a/SparkyFitnessFrontend/src/hooks/useAuth.tsx
+++ b/SparkyFitnessFrontend/src/hooks/useAuth.tsx
@@ -11,7 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { authClient } from '../lib/auth-client';
 import { fetchIdentityUser, switchUserContext } from '@/api/Auth/auth';
-import { apiCall } from '@/api/api';
+import { apiCall, clearDemoRestrictions } from '@/api/api';
 
 export interface User {
   id: string;
@@ -21,6 +21,12 @@ export interface User {
   role: string;
   twoFactorEnabled: boolean;
   mfaEmailEnabled: boolean;
+  /**
+   * True when the authenticated account is the demo sandbox. Features the demo
+   * guard blocks server-side should check this and skip the request entirely
+   * rather than firing it and handling the 403.
+   */
+  isDemo?: boolean;
 }
 
 interface ExtendedSessionUser {
@@ -60,6 +66,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   const [isSyncing, setIsSyncing] = useState(true); // Track initial hydration
   const navigate = useNavigate();
   const prevSessionRef = React.useRef<typeof session>(null);
+  // Account id the authoritative identity lookup has already been fired for,
+  // so the backstop effect below cannot duplicate the request the sync effect
+  // is already making.
+  const identityLookupRef = React.useRef<string | null>(null);
 
   // Only show global loading during initial hydration (isSyncing).
   // Ignoring sessionLoading avoids unmounting components (like Auth/MFA) during background re-fetches.
@@ -90,6 +100,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         role: extUser.role || 'user',
         twoFactorEnabled: !!extUser.twoFactorEnabled,
         mfaEmailEnabled: !!extUser.mfaEmailEnabled,
+        // Carried over rather than reset: this rebuild is about session fields,
+        // and dropping a resolved isDemo would re-disable the features gated on
+        // it for as long as the lookup below takes.
+        isDemo: user?.id === extUser.id ? user.isDemo : undefined,
       };
 
       //console.log('[Auth Hook] Setting user state from session:', sessionUser.id);
@@ -97,18 +111,21 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
 
       // Fetch Authoritative Data (Active Context)
       // This runs on every session update to ensure we are strictly in sync with the backend.
+      identityLookupRef.current = extUser.id;
       fetchIdentityUser()
         .then((realUserData) => {
           setUser((prev) => {
             if (!prev) return prev;
             if (
               prev.activeUserId === realUserData.activeUserId &&
-              prev.fullName === realUserData.fullName
+              prev.fullName === realUserData.fullName &&
+              prev.isDemo === !!realUserData.isDemo
             ) {
               return prev; // No change
             }
             return {
               ...prev,
+              isDemo: !!realUserData.isDemo,
               activeUserId: realUserData.activeUserId,
               fullName:
                 realUserData.activeUserFullName ||
@@ -118,12 +135,21 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
             };
           });
         })
-        .catch((err) =>
+        .catch((err) => {
           console.error(
             '[Auth Hook] Failed to fetch authoritative user data:',
             err
-          )
-        );
+          );
+          // Fail open on isDemo. Features gate on `isDemo === false`, so
+          // leaving it undefined after a failed lookup would silently disable
+          // them for a perfectly ordinary user. The server-side demo guard is
+          // the real enforcement; this flag only saves a doomed request.
+          setUser((prev) =>
+            prev && prev.isDemo === undefined
+              ? { ...prev, isDemo: false }
+              : prev
+          );
+        });
 
       setIsSyncing(false);
     } else if (session?.user && user && user.id === session.user.id) {
@@ -131,6 +157,39 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       setIsSyncing(false);
     }
   }, [session, user]);
+
+  // 1b. Identity Backstop: the sync effect above only fetches the authoritative
+  // identity when the session's user id or MFA flags actually change. A manual
+  // signIn has already written the same id with both MFA flags false, so for an
+  // account without 2FA the session arrives matching and that fetch never runs,
+  // leaving isDemo unresolved for the whole page life. Features gate on
+  // `isDemo === false`, so they would stay silently disabled for an ordinary
+  // user until the next reload. Resolve it here for any user still missing it.
+  useEffect(() => {
+    if (!user || user.isDemo !== undefined) return;
+    if (identityLookupRef.current === user.id) return;
+    identityLookupRef.current = user.id;
+
+    const userId = user.id;
+    const settle = (isDemo: boolean) =>
+      setUser((prev) =>
+        prev && prev.id === userId && prev.isDemo === undefined
+          ? { ...prev, isDemo }
+          : prev
+      );
+
+    fetchIdentityUser()
+      .then((realUserData) => settle(!!realUserData.isDemo))
+      .catch((err) => {
+        console.error(
+          '[Auth Hook] Failed to resolve demo status; assuming a regular account:',
+          err
+        );
+        // Fail open, for the same reason the sync effect does: the server-side
+        // demo guard is the real enforcement, this flag only saves a request.
+        settle(false);
+      });
+  }, [user]);
 
   // 2. Cleanup Effect: Handles Logout / Session expiry
   useEffect(() => {
@@ -150,6 +209,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
           .then(() => {
             console.log('[Auth Hook] No session found, clearing user state.');
             setUser(null);
+            identityLookupRef.current = null;
             queryClient.clear();
           })
           .catch((err) => {
@@ -185,6 +245,8 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       console.error('[Auth Hook] SignOut unexpected error:', err);
     }
     setUser(null);
+    identityLookupRef.current = null;
+    clearDemoRestrictions();
     queryClient.clear();
     window.location.href = '/';
   }, [queryClient]);
@@ -199,6 +261,12 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       userFullName?: string
     ) => {
       console.log('[Auth Hook] Manual signIn triggered.');
+      // Endpoint restrictions are per-account; the next session may well be
+      // allowed everything this one was refused.
+      clearDemoRestrictions();
+      // Force a fresh identity lookup: this may be a different account than the
+      // one the previous lookup answered for.
+      identityLookupRef.current = null;
       setLastManualSignIn(Date.now());
       setUser({
         id: userId,

--- a/SparkyFitnessFrontend/src/hooks/useAuth.tsx
+++ b/SparkyFitnessFrontend/src/hooks/useAuth.tsx
@@ -107,15 +107,26 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       };
 
       //console.log('[Auth Hook] Setting user state from session:', sessionUser.id);
+      // Endpoint refusals are per-account, and not every sign-in route goes
+      // through this hook's signIn (passkey and OIDC just let the session
+      // appear). Drop them whenever the effective account actually changes, so
+      // a regular user can never inherit the demo sandbox's cached "no".
+      if (user?.id !== extUser.id) {
+        clearDemoRestrictions();
+      }
       setUser(sessionUser);
 
       // Fetch Authoritative Data (Active Context)
       // This runs on every session update to ensure we are strictly in sync with the backend.
-      identityLookupRef.current = extUser.id;
+      // Pinned to the account it was issued for: a lookup can settle after the
+      // session has moved on, and answering for the wrong account is worse than
+      // not answering at all.
+      const identityUserId = extUser.id;
+      identityLookupRef.current = identityUserId;
       fetchIdentityUser()
         .then((realUserData) => {
           setUser((prev) => {
-            if (!prev) return prev;
+            if (!prev || prev.id !== identityUserId) return prev;
             if (
               prev.activeUserId === realUserData.activeUserId &&
               prev.fullName === realUserData.fullName &&
@@ -145,7 +156,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
           // them for a perfectly ordinary user. The server-side demo guard is
           // the real enforcement; this flag only saves a doomed request.
           setUser((prev) =>
-            prev && prev.isDemo === undefined
+            prev && prev.id === identityUserId && prev.isDemo === undefined
               ? { ...prev, isDemo: false }
               : prev
           );
@@ -210,6 +221,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
             console.log('[Auth Hook] No session found, clearing user state.');
             setUser(null);
             identityLookupRef.current = null;
+            clearDemoRestrictions();
             queryClient.clear();
           })
           .catch((err) => {

--- a/SparkyFitnessFrontend/src/hooks/useAuth.tsx
+++ b/SparkyFitnessFrontend/src/hooks/useAuth.tsx
@@ -70,6 +70,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   // so the backstop effect below cannot duplicate the request the sync effect
   // is already making.
   const identityLookupRef = React.useRef<string | null>(null);
+  // The live user and manual-sign-in timestamp, readable from an async callback
+  // that would otherwise close over whatever they were when it started.
+  const currentUserRef = React.useRef<User | null>(null);
+  const lastManualSignInRef = React.useRef(0);
 
   // Only show global loading during initial hydration (isSyncing).
   // Ignoring sessionLoading avoids unmounting components (like Auth/MFA) during background re-fetches.
@@ -202,6 +206,10 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       });
   }, [user]);
 
+  useEffect(() => {
+    currentUserRef.current = user;
+  }, [user]);
+
   // 2. Cleanup Effect: Handles Logout / Session expiry
   useEffect(() => {
     if (!session && !sessionLoading) {
@@ -209,6 +217,11 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       const isSticky = now - lastManualSignIn < 2000;
 
       if (user !== null && !isSticky) {
+        // The account this probe is asking about. A sign-in can complete while
+        // it is still in flight, and logging out the account that just arrived
+        // because the previous one turned out to be gone is worse than leaving
+        // a stale user on screen for one more session tick.
+        const probedUserId = user.id;
         // Better Auth's own session fetch bypasses apiCall, so an upstream
         // auth gateway (e.g. Cloudflare Access) intercepting that request can
         // resolve session to null without SparkyFitness ever seeing it. Before
@@ -218,6 +231,15 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
         // trigger a re-auth reload itself rather than resolving here.
         apiCall('/ping')
           .then(() => {
+            if (
+              currentUserRef.current?.id !== probedUserId ||
+              Date.now() - lastManualSignInRef.current < 2000
+            ) {
+              console.log(
+                '[Auth Hook] Session probe finished after the account changed; leaving the current user alone.'
+              );
+              return;
+            }
             console.log('[Auth Hook] No session found, clearing user state.');
             setUser(null);
             identityLookupRef.current = null;
@@ -279,6 +301,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       // Force a fresh identity lookup: this may be a different account than the
       // one the previous lookup answered for.
       identityLookupRef.current = null;
+      lastManualSignInRef.current = Date.now();
       setLastManualSignIn(Date.now());
       setUser({
         id: userId,

--- a/SparkyFitnessFrontend/src/main.tsx
+++ b/SparkyFitnessFrontend/src/main.tsx
@@ -13,6 +13,7 @@ import i18n from './i18n';
 import { getUserLoggingLevel } from './utils/userPreferences.ts';
 import { toast } from './hooks/use-toast.ts';
 import { error } from '@/utils/logging';
+import { HttpApiError } from './api/api.ts';
 
 declare module '@tanstack/react-query' {
   interface Register {
@@ -100,7 +101,19 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: true,
       refetchOnReconnect: true,
       refetchOnMount: true,
-      retry: 1,
+      // A 4xx is a verdict, not a hiccup: retrying an authorization or
+      // validation failure just doubles the failed requests and the noise.
+      // Only server and network errors are worth a second attempt.
+      retry: (failureCount, err) => {
+        const status =
+          err instanceof HttpApiError
+            ? err.status
+            : (err as { status?: number })?.status;
+        if (typeof status === 'number' && status >= 400 && status < 500) {
+          return false;
+        }
+        return failureCount < 1;
+      },
       retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 30000),
     },
     mutations: {

--- a/SparkyFitnessFrontend/src/pages/Diary/CaffeineCard.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/CaffeineCard.tsx
@@ -403,11 +403,14 @@ export const CaffeineCard = ({ date, userId }: CaffeineCardProps) => {
               {/* A dose whose time was assumed rather than logged is drawn
                   hollow: the payload carries that per dose, and the card used
                   to say so only once, for the whole day. */}
-              {doses.map((dose) => {
+              {doses.map((dose, idx) => {
                 const doseMs = new Date(dose.at).getTime();
                 return (
                   <ReferenceDot
-                    key={`${dose.at}-${dose.mg}`}
+                    // Time plus amount is not unique: the same drink logged
+                    // twice at the same minute collides. Index it, as the dose
+                    // list below already does.
+                    key={`${dose.at}-${idx}`}
                     x={doseMs}
                     y={activeCaffeineAt(doses, doseMs, half_life_hours)}
                     r={4}

--- a/SparkyFitnessFrontend/src/pages/Diary/EditExerciseEntryDialog.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/EditExerciseEntryDialog.tsx
@@ -686,9 +686,13 @@ const EditExerciseEntryDialog = ({
   const handleSave = async () => {
     info(loggingLevel, 'EditExerciseEntryDialog: saving entry:', entry.id);
     try {
-      const exerciseData = await queryClient.fetchQuery(
-        exerciseDetailsOptions(entry.exercise_id)
-      );
+      // An entry whose library exercise has been deleted keeps its snapshot but
+      // has nothing left to look up, so skip the fetch and fall back.
+      const exerciseData = entry.exercise_id
+        ? await queryClient.fetchQuery(
+            exerciseDetailsOptions(entry.exercise_id)
+          )
+        : null;
       const caloriesPerHour =
         (exerciseData as { calories_per_hour?: number })?.calories_per_hour ||
         300;
@@ -1025,8 +1029,11 @@ const EditExerciseEntryDialog = ({
             />
           </div>
 
-          {/* Exercise history */}
-          <ExerciseHistoryDisplay exerciseId={entry.exercise_id} />
+          {/* Exercise history — keyed to the library exercise, so there is
+              nothing to show once that has been deleted. */}
+          {entry.exercise_id && (
+            <ExerciseHistoryDisplay exerciseId={entry.exercise_id} />
+          )}
 
           {/* ── Advanced (collapsible) ── */}
           <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>

--- a/SparkyFitnessFrontend/src/pages/Diary/ExerciseEntryDisplay.tsx
+++ b/SparkyFitnessFrontend/src/pages/Diary/ExerciseEntryDisplay.tsx
@@ -366,6 +366,10 @@ const ExerciseEntryDisplay: React.FC<ExerciseEntryDisplayProps> = ({
             onClick={() => {
               setExerciseToPlay({
                 ...snapshot!,
+                // The snapshot keeps the instructions after the library
+                // exercise is deleted; the modal only uses the id to detect a
+                // change of subject, so the entry's own id identifies it.
+                id: snapshot!.id ?? exerciseEntry.id,
               });
               setIsPlaybackModalOpen(true);
             }}
@@ -378,19 +382,22 @@ const ExerciseEntryDisplay: React.FC<ExerciseEntryDisplayProps> = ({
           onClick={() => handleEdit(exerciseEntry)}
           colorClass="hover:text-indigo-600 hover:bg-indigo-50 dark:hover:bg-indigo-950/50"
         />
-        {snapshot?.user_id === currentUserId && (
-          <ActionButton
-            icon={<Settings className="w-3.5 h-3.5" />}
-            label={t(
-              'exerciseCard.editExerciseInDatabase',
-              'Edit Exercise in Database'
-            )}
-            onClick={() =>
-              handleEditExerciseDatabase(exerciseEntry.exercise_id)
-            }
-            colorClass="hover:text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700"
-          />
-        )}
+        {/* Editing the library exercise needs a library exercise to edit. */}
+        {snapshot?.id &&
+          exerciseEntry.exercise_id &&
+          snapshot.user_id === currentUserId && (
+            <ActionButton
+              icon={<Settings className="w-3.5 h-3.5" />}
+              label={t(
+                'exerciseCard.editExerciseInDatabase',
+                'Edit Exercise in Database'
+              )}
+              onClick={() =>
+                handleEditExerciseDatabase(exerciseEntry.exercise_id!)
+              }
+              colorClass="hover:text-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700"
+            />
+          )}
         <ActionButton
           icon={<Trash2 className="w-3.5 h-3.5" />}
           label={t('exerciseCard.deleteEntry', 'Delete Entry')}

--- a/SparkyFitnessFrontend/src/tests/api/api.test.ts
+++ b/SparkyFitnessFrontend/src/tests/api/api.test.ts
@@ -1,4 +1,8 @@
-import { apiCall, gatewayReloadRuntime } from '@/api/api';
+import {
+  apiCall,
+  clearDemoRestrictions,
+  gatewayReloadRuntime,
+} from '@/api/api';
 import { toast } from '@/hooks/use-toast';
 
 jest.mock('@/hooks/use-toast', () => ({
@@ -122,5 +126,76 @@ describe('apiCall gateway interception handling', () => {
     await flushMicrotasks();
 
     expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('apiCall demo restriction handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    clearDemoRestrictions();
+    global.fetch = jest.fn();
+  });
+
+  const demoResponse = (code = 'DEMO_ACTION_RESTRICTED') =>
+    makeResponse({
+      status: 403,
+      body: JSON.stringify({ error: 'Disabled on the demo account.', code }),
+    });
+
+  it('answers a repeated blocked GET from the memo instead of the network', async () => {
+    jest.mocked(global.fetch).mockResolvedValue(demoResponse());
+
+    await expect(apiCall('/external-providers')).rejects.toThrow(
+      'Disabled on the demo account.'
+    );
+    await expect(apiCall('/external-providers')).rejects.toThrow(
+      'Disabled on the demo account.'
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not let a blocked write answer the read on the same path', async () => {
+    jest
+      .mocked(global.fetch)
+      .mockResolvedValueOnce(demoResponse())
+      .mockResolvedValueOnce(makeResponse({ body: '{"id":"profile-1"}' }));
+
+    await expect(
+      apiCall('/identity/profiles', { method: 'PUT', body: '{}' })
+    ).rejects.toThrow('Disabled on the demo account.');
+    await expect(apiCall('/identity/profiles')).resolves.toEqual({
+      id: 'profile-1',
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('never memoizes an upload rejection, which depends on the content type', async () => {
+    jest
+      .mocked(global.fetch)
+      .mockResolvedValue(demoResponse('DEMO_UPLOAD_RESTRICTED'));
+
+    await expect(
+      apiCall('/identity/profiles/avatar', { method: 'POST', body: '{}' })
+    ).rejects.toThrow('Disabled on the demo account.');
+    await expect(
+      apiCall('/identity/profiles/avatar', { method: 'POST', body: '{}' })
+    ).rejects.toThrow('Disabled on the demo account.');
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('silences the toast for a polled read but not for a write the user clicked', async () => {
+    jest.mocked(global.fetch).mockResolvedValue(demoResponse());
+
+    await expect(apiCall('/chat/ai-service-settings')).rejects.toThrow();
+    expect(mockToast).not.toHaveBeenCalled();
+
+    await expect(
+      apiCall('/identity/mfa/email-toggle', { method: 'POST', body: '{}' })
+    ).rejects.toThrow();
+    expect(mockToast).toHaveBeenCalledTimes(1);
   });
 });

--- a/SparkyFitnessFrontend/src/tests/api/api.test.ts
+++ b/SparkyFitnessFrontend/src/tests/api/api.test.ts
@@ -187,6 +187,26 @@ describe('apiCall demo restriction handling', () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
+  it('does not let a request in flight across a sign-out seed the next session', async () => {
+    let releaseDemoResponse: (() => void) | undefined;
+    jest.mocked(global.fetch).mockImplementation(() =>
+      releaseDemoResponse
+        ? Promise.resolve(makeResponse({ body: '{"ok":true}' }))
+        : new Promise<Response>((resolve) => {
+            releaseDemoResponse = () => resolve(demoResponse());
+          })
+    );
+
+    const blocked = apiCall('/external-providers');
+    // The session ends while that request is still outstanding.
+    clearDemoRestrictions();
+    releaseDemoResponse!();
+    await expect(blocked).rejects.toThrow('Disabled on the demo account.');
+
+    await expect(apiCall('/external-providers')).resolves.toEqual({ ok: true });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
   it('silences the toast for a polled read but not for a write the user clicked', async () => {
     jest.mocked(global.fetch).mockResolvedValue(demoResponse());
 

--- a/SparkyFitnessFrontend/src/tests/components/AIServiceSettings.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/components/AIServiceSettings.test.tsx
@@ -130,7 +130,7 @@ jest.mock('@/hooks/use-toast', () => ({
 }));
 
 // Mock useAuth
-const mockUser = { id: 'user1', email: 'test@example.com' };
+const mockUser = { id: 'user1', email: 'test@example.com', isDemo: false };
 jest.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({ user: mockUser }),
 }));

--- a/SparkyFitnessFrontend/src/tests/hooks/useAuth.isDemo.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useAuth.isDemo.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from '@/hooks/useAuth';
 import { fetchIdentityUser } from '@/api/Auth/auth';
+import { apiCall } from '@/api/api';
 
 let sessionState: { data: unknown; isPending: boolean } = {
   data: null,
@@ -28,6 +29,7 @@ jest.mock('@/api/api', () => ({
 }));
 
 const mockFetchIdentityUser = jest.mocked(fetchIdentityUser);
+const mockApiCall = jest.mocked(apiCall);
 
 const renderProvider = () =>
   renderHook(() => useAuth(), { wrapper: AuthProvider });
@@ -35,6 +37,7 @@ const renderProvider = () =>
 describe('AuthProvider demo status resolution', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockApiCall.mockResolvedValue({});
     sessionState = { data: null, isPending: false };
     mockFetchIdentityUser.mockResolvedValue({
       activeUserId: 'u1',
@@ -116,5 +119,67 @@ describe('AuthProvider demo status resolution', () => {
     });
 
     await waitFor(() => expect(result.current.user?.isDemo).toBe(true));
+  });
+});
+
+describe('AuthProvider session cleanup probe', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    sessionState = { data: null, isPending: false };
+    mockFetchIdentityUser.mockResolvedValue({
+      activeUserId: 'u1',
+      activeUserEmail: 'a@example.com',
+      activeUserFullName: 'A',
+      fullName: 'A',
+      isDemo: false,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // The probe confirms a vanished session is a real logout rather than a
+  // gateway swallowing the session fetch. It can outlive the account it was
+  // asking about, and logging out whoever signed in meanwhile is worse than
+  // leaving a stale user on screen for one more tick.
+  it('does not log out an account that signed in while the probe was in flight', async () => {
+    let finishProbe: (() => void) | undefined;
+    mockApiCall.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishProbe = () => resolve({});
+        })
+    );
+
+    const { result } = renderProvider();
+
+    act(() => {
+      result.current.signIn('a', 'a', 'a@example.com', 'user', false);
+    });
+    expect(result.current.user?.id).toBe('a');
+
+    // Past the manual sign-in grace window, so the cleanup effect runs.
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+    await act(async () => {
+      result.current.signIn('a', 'a', 'a@example.com', 'user', false);
+      jest.advanceTimersByTime(3000);
+    });
+
+    await waitFor(() => expect(finishProbe).toBeDefined());
+
+    // A different account arrives before the probe answers.
+    act(() => {
+      result.current.signIn('b', 'b', 'b@example.com', 'user', false);
+    });
+
+    await act(async () => {
+      finishProbe!();
+    });
+
+    expect(result.current.user?.id).toBe('b');
   });
 });

--- a/SparkyFitnessFrontend/src/tests/hooks/useAuth.isDemo.test.tsx
+++ b/SparkyFitnessFrontend/src/tests/hooks/useAuth.isDemo.test.tsx
@@ -1,0 +1,120 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { AuthProvider, useAuth } from '@/hooks/useAuth';
+import { fetchIdentityUser } from '@/api/Auth/auth';
+
+let sessionState: { data: unknown; isPending: boolean } = {
+  data: null,
+  isPending: false,
+};
+
+jest.mock('@/lib/auth-client', () => ({
+  authClient: {
+    useSession: () => sessionState,
+    signOut: jest.fn(),
+    getSession: jest.fn(),
+  },
+}));
+jest.mock('react-router-dom', () => ({ useNavigate: () => jest.fn() }));
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({ clear: jest.fn() }),
+}));
+jest.mock('@/api/Auth/auth', () => ({
+  fetchIdentityUser: jest.fn(),
+  switchUserContext: jest.fn(),
+}));
+jest.mock('@/api/api', () => ({
+  apiCall: jest.fn().mockResolvedValue({}),
+  clearDemoRestrictions: jest.fn(),
+}));
+
+const mockFetchIdentityUser = jest.mocked(fetchIdentityUser);
+
+const renderProvider = () =>
+  renderHook(() => useAuth(), { wrapper: AuthProvider });
+
+describe('AuthProvider demo status resolution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionState = { data: null, isPending: false };
+    mockFetchIdentityUser.mockResolvedValue({
+      activeUserId: 'u1',
+      activeUserEmail: 'real@example.com',
+      activeUserFullName: 'Real User',
+      fullName: 'Real User',
+      isDemo: false,
+    });
+  });
+
+  // The manual signIn writes the same id with both MFA flags false, so for an
+  // account without 2FA the session that follows matches what is already in
+  // state and the sync effect skips its identity fetch. isDemo has to be
+  // resolved anyway, or every feature gated on it stays dark until a reload.
+  it('resolves isDemo after a manual sign-in the session sync does not re-fetch', async () => {
+    const { result, rerender } = renderProvider();
+
+    act(() => {
+      result.current.signIn(
+        'u1',
+        'u1',
+        'real@example.com',
+        'user',
+        false,
+        'Real User'
+      );
+    });
+
+    sessionState = {
+      data: {
+        user: {
+          id: 'u1',
+          email: 'real@example.com',
+          name: 'Real User',
+          role: 'user',
+          activeUserId: 'u1',
+          twoFactorEnabled: false,
+          mfaEmailEnabled: false,
+        },
+      },
+      isPending: false,
+    };
+    rerender();
+
+    await waitFor(() => expect(result.current.user?.isDemo).toBe(false));
+    expect(mockFetchIdentityUser).toHaveBeenCalled();
+  });
+
+  it('treats a failed identity lookup as a regular account', async () => {
+    mockFetchIdentityUser.mockRejectedValue(new Error('offline'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderProvider();
+    act(() => {
+      result.current.signIn('u1', 'u1', 'real@example.com', 'user', false);
+    });
+
+    await waitFor(() => expect(result.current.user?.isDemo).toBe(false));
+  });
+
+  it('marks the demo sandbox so gated features can skip their requests', async () => {
+    mockFetchIdentityUser.mockResolvedValue({
+      activeUserId: 'demo',
+      activeUserEmail: 'demo@sparkyfitness.com',
+      activeUserFullName: 'Demo',
+      fullName: 'Demo',
+      isDemo: true,
+    });
+
+    const { result } = renderProvider();
+    act(() => {
+      result.current.signIn(
+        'demo',
+        'demo',
+        'demo@sparkyfitness.com',
+        'user',
+        false
+      );
+    });
+
+    await waitFor(() => expect(result.current.user?.isDemo).toBe(true));
+  });
+});

--- a/SparkyFitnessFrontend/src/types/diary.ts
+++ b/SparkyFitnessFrontend/src/types/diary.ts
@@ -2,7 +2,9 @@ import { WorkoutPresetSet } from './workout';
 
 export interface ExerciseEntry {
   id: string;
-  exercise_id: string;
+  // Null once the underlying library exercise is deleted; the entry keeps its
+  // own snapshot (name, calories) and still renders.
+  exercise_id: string | null;
   duration_minutes: number;
   calories_burned: number;
   entry_date: string;

--- a/SparkyFitnessServer/db/migrations/20260912150000_preserve_data_on_user_and_library_deletes.sql
+++ b/SparkyFitnessServer/db/migrations/20260912150000_preserve_data_on_user_and_library_deletes.sql
@@ -1,0 +1,259 @@
+BEGIN;
+
+-- Deleting a user failed outright, deleting a library item quietly destroyed
+-- other people's diary history, and the audit trail was erased along with the
+-- account it described. All three come from delete rules that no longer match
+-- the schema they were written for.
+--
+-- Statement order matters: the entry -> library rules are relaxed first, so that
+-- the cleanup further down can remove a stale food or exercise without taking
+-- somebody's diary entries with it.
+
+-- ---------------------------------------------------------------------------
+-- 1. A diary entry outlives the library item it was logged from.
+--
+-- 20250717190700_add_cascading_deletes.sql made food_entries and exercise_entries
+-- cascade from foods/exercises. That was right at the time: an entry was a bare
+-- pointer, so losing the library row left a diary line that could not say what
+-- was eaten or how many calories it was.
+--
+-- 20251019013200_merged_schema_and_data.sql then added the snapshot columns
+-- (food_name, brand_name, serving_size, the nutrition set, exercise_name,
+-- calories_per_hour, ...) and backfilled them. From that point an entry stood on
+-- its own, but the delete rule was never revisited -- so removing a food still
+-- deleted every entry referencing it, including entries belonging to other users
+-- who logged it through family sharing.
+--
+-- Blank the pointer and keep the entry. The diary read path already LEFT JOINs
+-- foods/food_variants and reads fe.* for name and nutrition.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.food_entries
+  DROP CONSTRAINT IF EXISTS fk_food_entries_food_id,
+  DROP CONSTRAINT IF EXISTS food_entries_food_id_fkey,
+  ADD CONSTRAINT fk_food_entries_food_id
+    FOREIGN KEY (food_id) REFERENCES public.foods(id) ON DELETE SET NULL;
+
+-- exercise_id was NOT NULL because a pointer was mandatory in the pointer era.
+-- It has to allow NULL before an entry can outlive its exercise.
+ALTER TABLE public.exercise_entries
+  ALTER COLUMN exercise_id DROP NOT NULL;
+
+ALTER TABLE public.exercise_entries
+  DROP CONSTRAINT IF EXISTS fk_exercise_entries_exercise_id,
+  DROP CONSTRAINT IF EXISTS exercise_entries_exercise_id_fkey,
+  ADD CONSTRAINT fk_exercise_entries_exercise_id
+    FOREIGN KEY (exercise_id) REFERENCES public.exercises(id) ON DELETE SET NULL;
+
+-- ---------------------------------------------------------------------------
+-- 2. An entry outlives whoever typed it.
+--
+-- created_by_user_id / updated_by_user_id record who entered the row, which under
+-- family sharing is often not the person who owns it. user_id is the owner and
+-- already cascades. Cascading the audit columns as well deletes a surviving
+-- user's entry because the delegate who logged or last edited it was removed --
+-- and on the tables below they had no rule at all, which is what made the
+-- original admin user deletion fail with a foreign key violation.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.food_entries
+  DROP CONSTRAINT IF EXISTS food_entries_created_by_user_id_fkey,
+  ADD CONSTRAINT food_entries_created_by_user_id_fkey
+    FOREIGN KEY (created_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.food_entries
+  DROP CONSTRAINT IF EXISTS food_entries_updated_by_user_id_fkey,
+  ADD CONSTRAINT food_entries_updated_by_user_id_fkey
+    FOREIGN KEY (updated_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.exercise_entries
+  DROP CONSTRAINT IF EXISTS exercise_entries_created_by_user_id_fkey,
+  ADD CONSTRAINT exercise_entries_created_by_user_id_fkey
+    FOREIGN KEY (created_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.exercise_entries
+  DROP CONSTRAINT IF EXISTS exercise_entries_updated_by_user_id_fkey,
+  ADD CONSTRAINT exercise_entries_updated_by_user_id_fkey
+    FOREIGN KEY (updated_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.mood_entries
+  DROP CONSTRAINT IF EXISTS mood_entries_created_by_user_id_fkey,
+  ADD CONSTRAINT mood_entries_created_by_user_id_fkey
+    FOREIGN KEY (created_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.mood_entries
+  DROP CONSTRAINT IF EXISTS mood_entries_updated_by_user_id_fkey,
+  ADD CONSTRAINT mood_entries_updated_by_user_id_fkey
+    FOREIGN KEY (updated_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.sleep_entries
+  DROP CONSTRAINT IF EXISTS sleep_entries_created_by_user_id_fkey,
+  ADD CONSTRAINT sleep_entries_created_by_user_id_fkey
+    FOREIGN KEY (created_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.sleep_entries
+  DROP CONSTRAINT IF EXISTS sleep_entries_updated_by_user_id_fkey,
+  ADD CONSTRAINT sleep_entries_updated_by_user_id_fkey
+    FOREIGN KEY (updated_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.sleep_entry_stages
+  DROP CONSTRAINT IF EXISTS sleep_entry_stages_created_by_user_id_fkey,
+  ADD CONSTRAINT sleep_entry_stages_created_by_user_id_fkey
+    FOREIGN KEY (created_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.sleep_entry_stages
+  DROP CONSTRAINT IF EXISTS sleep_entry_stages_updated_by_user_id_fkey,
+  ADD CONSTRAINT sleep_entry_stages_updated_by_user_id_fkey
+    FOREIGN KEY (updated_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.water_intake_entries
+  DROP CONSTRAINT IF EXISTS water_intake_entries_created_by_user_id_fkey,
+  ADD CONSTRAINT water_intake_entries_created_by_user_id_fkey
+    FOREIGN KEY (created_by_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. A user's own rows go with the user.
+--
+-- 20260125000000_better_auth_migration.sql re-pointed a hand-written list of
+-- tables from auth.users to "user". The tables below were missed, so they ended
+-- up with no foreign key to "user" at all: deleting an account silently left
+-- their rows behind rather than raising an error. That includes secrets --
+-- external_data_providers holds OAuth/refresh tokens, ai_service_settings holds
+-- AI provider API keys.
+--
+-- Existing orphans have to be resolved before a constraint can validate.
+-- ---------------------------------------------------------------------------
+
+DELETE FROM public.ai_service_settings x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.ai_service_settings
+  DROP CONSTRAINT IF EXISTS ai_service_settings_user_id_fkey,
+  ADD CONSTRAINT ai_service_settings_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+DELETE FROM public.check_in_measurements x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.check_in_measurements
+  DROP CONSTRAINT IF EXISTS check_in_measurements_user_id_fkey,
+  ADD CONSTRAINT check_in_measurements_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+DELETE FROM public.custom_categories x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.custom_categories
+  DROP CONSTRAINT IF EXISTS custom_categories_user_id_fkey,
+  ADD CONSTRAINT custom_categories_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+DELETE FROM public.custom_measurements x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.custom_measurements
+  DROP CONSTRAINT IF EXISTS custom_measurements_user_id_fkey,
+  ADD CONSTRAINT custom_measurements_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+DELETE FROM public.exercise_entries x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.exercise_entries
+  DROP CONSTRAINT IF EXISTS exercise_entries_user_id_fkey,
+  ADD CONSTRAINT exercise_entries_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+DELETE FROM public.external_data_providers x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.external_data_providers
+  DROP CONSTRAINT IF EXISTS external_data_providers_user_id_fkey,
+  ADD CONSTRAINT external_data_providers_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+DELETE FROM public.sparky_chat_history x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.sparky_chat_history
+  DROP CONSTRAINT IF EXISTS sparky_chat_history_user_id_fkey,
+  ADD CONSTRAINT sparky_chat_history_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+DELETE FROM public.user_goals x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.user_goals
+  DROP CONSTRAINT IF EXISTS user_goals_user_id_fkey,
+  ADD CONSTRAINT user_goals_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+DELETE FROM public.user_preferences x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.user_preferences
+  DROP CONSTRAINT IF EXISTS user_preferences_user_id_fkey,
+  ADD CONSTRAINT user_preferences_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+DELETE FROM public.water_intake x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.water_intake
+  DROP CONSTRAINT IF EXISTS water_intake_user_id_fkey,
+  ADD CONSTRAINT water_intake_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+-- foods and exercises follow the same rule: the deleted user's library items go
+-- with them. This is only safe because section 1 already stopped that from
+-- reaching anybody's diary.
+
+DELETE FROM public.foods x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.foods
+  DROP CONSTRAINT IF EXISTS foods_user_id_fkey,
+  ADD CONSTRAINT foods_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+DELETE FROM public.exercises x WHERE x.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u.id = x.user_id);
+ALTER TABLE public.exercises
+  DROP CONSTRAINT IF EXISTS exercises_user_id_fkey,
+  ADD CONSTRAINT exercises_user_id_fkey
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 4. Clean up ownerless library rows.
+--
+-- A private library item with user_id IS NULL is reachable by nobody: RLS grants
+-- library access on owner match, shared_with_public, or an active family_access
+-- grant (has_library_access_with_public in rls_policies.sql), and a NULL owner
+-- satisfies none of them. Purge only the rows nothing points at, so a public or
+-- still-referenced item is never touched.
+-- ---------------------------------------------------------------------------
+
+DELETE FROM public.foods f
+WHERE f.user_id IS NULL
+  AND f.shared_with_public IS NOT TRUE
+  AND NOT EXISTS (SELECT 1 FROM public.food_entries fe WHERE fe.food_id = f.id)
+  AND NOT EXISTS (SELECT 1 FROM public.meal_foods mf WHERE mf.food_id = f.id)
+  AND NOT EXISTS (SELECT 1 FROM public.meal_plans mp WHERE mp.food_id = f.id)
+  AND NOT EXISTS (SELECT 1 FROM public.meal_plan_template_assignments mpta WHERE mpta.food_id = f.id)
+  AND NOT EXISTS (SELECT 1 FROM public.food_favorites ff WHERE ff.food_id = f.id)
+  AND NOT EXISTS (SELECT 1 FROM public.user_water_containers uwc WHERE uwc.linked_food_id = f.id);
+
+DELETE FROM public.exercises e
+WHERE e.user_id IS NULL
+  AND e.shared_with_public IS NOT TRUE
+  AND NOT EXISTS (SELECT 1 FROM public.exercise_entries ee WHERE ee.exercise_id = e.id)
+  AND NOT EXISTS (SELECT 1 FROM public.workout_preset_exercises wpe WHERE wpe.exercise_id = e.id)
+  AND NOT EXISTS (SELECT 1 FROM public.workout_plan_template_assignments wpta WHERE wpta.exercise_id = e.id);
+
+-- ---------------------------------------------------------------------------
+-- 5. The audit trail outlives the accounts it describes.
+--
+-- 20251006220500_create_admin_activity_logs_table.sql had target_user_id right
+-- (ON DELETE SET NULL). 20260125000000_better_auth_migration.sql re-pointed both
+-- columns from auth.users to "user" and changed the rule to ON DELETE CASCADE on
+-- the way, so deleting a user erased every log entry about them and deleting an
+-- administrator erased the record of everything they had ever done -- which is
+-- the one question an audit log exists to answer.
+--
+-- Dissociate rather than delete. The acting and target ids are also copied into
+-- `details` by the caller, so an entry stays readable once the accounts are gone.
+-- ---------------------------------------------------------------------------
+
+-- admin_user_id is NOT NULL today, which is what forced CASCADE on it. Allow
+-- NULL so the event can outlive the administrator who performed it.
+ALTER TABLE public.admin_activity_logs
+  ALTER COLUMN admin_user_id DROP NOT NULL;
+
+ALTER TABLE public.admin_activity_logs
+  DROP CONSTRAINT IF EXISTS admin_activity_logs_admin_user_id_fkey,
+  ADD CONSTRAINT admin_activity_logs_admin_user_id_fkey
+    FOREIGN KEY (admin_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+ALTER TABLE public.admin_activity_logs
+  DROP CONSTRAINT IF EXISTS admin_activity_logs_target_user_id_fkey,
+  ADD CONSTRAINT admin_activity_logs_target_user_id_fkey
+    FOREIGN KEY (target_user_id) REFERENCES public."user"(id) ON DELETE SET NULL;
+
+COMMIT;

--- a/SparkyFitnessServer/db/migrations/20260912150000_preserve_data_on_user_and_library_deletes.sql
+++ b/SparkyFitnessServer/db/migrations/20260912150000_preserve_data_on_user_and_library_deletes.sql
@@ -28,6 +28,17 @@ BEGIN;
 -- foods/food_variants and reads fe.* for name and nutrition.
 -- ---------------------------------------------------------------------------
 
+-- chk_food_or_meal_id (20251023221501_add_meal_id_to_food_entries.sql) demands
+-- exactly one of food_id/meal_id. Nulling food_id on a food-logged entry leaves
+-- both null, so the check would reject the delete and the foreign key rule below
+-- would never get to preserve anything. Relax it to what it is actually there to
+-- prevent -- an entry claiming to be both a food and a meal -- and let an entry
+-- whose library row is gone stand on its own snapshot.
+ALTER TABLE public.food_entries
+  DROP CONSTRAINT IF EXISTS chk_food_or_meal_id,
+  ADD CONSTRAINT chk_food_or_meal_id
+    CHECK (food_id IS NULL OR meal_id IS NULL);
+
 ALTER TABLE public.food_entries
   DROP CONSTRAINT IF EXISTS fk_food_entries_food_id,
   DROP CONSTRAINT IF EXISTS food_entries_food_id_fkey,

--- a/SparkyFitnessServer/models/userRepository.ts
+++ b/SparkyFitnessServer/models/userRepository.ts
@@ -426,7 +426,10 @@ async function getAllUsers(
 async function deleteUser(userId: string) {
   const client = await getSystemClient(); // System client for deleting user (admin operation)
   try {
-    // Delete from "user" (this should trigger cascades for session, account, etc.)
+    await client.query('BEGIN'); // Start transaction for atomicity
+    // Everything the user owns goes with them. Diary entries belonging to other
+    // users survive because the library foreign keys null their pointer instead
+    // of cascading; the entry carries its own snapshot of name and nutrition.
     const result = await client.query(
       'DELETE FROM "user" WHERE id = $1 RETURNING id',
       [userId]

--- a/SparkyFitnessServer/routes/adminRoutes.ts
+++ b/SparkyFitnessServer/routes/adminRoutes.ts
@@ -140,8 +140,14 @@ router.delete('/users/:userId', async (req, res, next) => {
     }
     const success = await userRepository.deleteUser(userId);
     if (success) {
-      await logAdminAction(req.userId, userId, 'USER_DELETED', {
+      // target_user_id is deliberately null: the row it would point at no
+      // longer exists, and a foreign key cannot reference a deleted user. The
+      // identity is preserved in details instead, so the entry still says who
+      // was removed. Logging after the delete (not before) keeps a failed
+      // deletion from leaving a log entry claiming it succeeded.
+      await logAdminAction(req.userId, null, 'USER_DELETED', {
         deletedUserId: userId,
+        deletedUserEmail: user.email,
       });
       res.status(200).json({ message: 'User deleted successfully.' });
     } else {

--- a/SparkyFitnessServer/routes/auth/userProfileRoutes.ts
+++ b/SparkyFitnessServer/routes/auth/userProfileRoutes.ts
@@ -61,6 +61,33 @@ const upload = multer({
  *     responses:
  *       200:
  *         description: The user's profile information.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 authenticatedUserId:
+ *                   type: string
+ *                   format: uuid
+ *                 authenticatedUserEmail:
+ *                   type: string
+ *                 role:
+ *                   type: string
+ *                 activeUserId:
+ *                   type: string
+ *                   format: uuid
+ *                 activeUserEmail:
+ *                   type: string
+ *                 activeUserFullName:
+ *                   type: string
+ *                   nullable: true
+ *                 isDemo:
+ *                   type: boolean
+ *                   description: >
+ *                     True when the authenticated account is the demo sandbox.
+ *                     Clients use it to skip calls the demo guard will refuse.
+ *                     Keyed on the authenticated identity, never the active
+ *                     context, so switching context cannot shed it.
  *       404:
  *         description: User not found.
  */

--- a/SparkyFitnessServer/routes/auth/userProfileRoutes.ts
+++ b/SparkyFitnessServer/routes/auth/userProfileRoutes.ts
@@ -1,6 +1,9 @@
 import express from 'express';
 import { authenticate } from '../../middleware/authMiddleware.js';
-import { demoGuard } from '../../middleware/demoGuardMiddleware.js';
+import {
+  demoGuard,
+  isDemoEmail,
+} from '../../middleware/demoGuardMiddleware.js';
 import authService from '../../services/authService.js';
 // @ts-expect-error TS(7016): Could not find a declaration file for module 'mult... Remove this comment to see the full error message
 import multer from 'multer';
@@ -78,6 +81,11 @@ router.get('/user', authenticate, async (req, res, next) => {
       activeUserId: activeUser.id,
       activeUserEmail: activeUser.email,
       activeUserFullName: activeUser.full_name,
+      // Lets the client skip calls to endpoints the demo guard will refuse
+      // anyway. Keyed on the authenticated identity, never the active context,
+      // so switching context cannot shed the restriction -- same rule the
+      // server-side guard follows.
+      isDemo: isDemoEmail(authenticatedUser.email),
     });
   } catch (error) {
     // Use a more specific error check if available from the service layer

--- a/SparkyFitnessServer/services/demoSeedService.ts
+++ b/SparkyFitnessServer/services/demoSeedService.ts
@@ -37,6 +37,26 @@ async function hasDemoMarker(
   return typeof bio === 'string' && bio.includes(DEMO_ACCOUNT_MARKER);
 }
 
+/**
+ * Writes the sandbox marker on its own connection so it commits independently
+ * of the seeding transaction. Only ever called on the path where this process
+ * just created the account, so an account that predates demo mode is never
+ * marked and stays protected by the guard.
+ */
+async function stampDemoMarker(userId: string): Promise<void> {
+  const client = await getSystemClient();
+  try {
+    await client.query(
+      `UPDATE profiles
+         SET bio = $2, updated_at = NOW()
+       WHERE id = $1`,
+      [userId, `${DEMO_ACCOUNT_MARKER} — Daily sandbox resetting at 00:00 UTC`]
+    );
+  } finally {
+    client.release();
+  }
+}
+
 // Generated once per process when no server secret is configured, so the
 // credential stays stable for the lifetime of the server without ever being
 // derivable from the source.
@@ -389,6 +409,13 @@ export async function seedDemoUser(): Promise<string> {
           fullName
         );
         log('info', `[DEMO] Demo user account created with ID: ${userId}`);
+        // Stamp the sandbox marker immediately, outside this transaction.
+        // createUser commits on its own client, so the account survives a
+        // rollback while everything below does not. Without the marker written
+        // just as durably, a seed that fails partway leaves a committed demo
+        // account that the safety guard can never touch again, and demo mode
+        // stays wedged until someone edits the database by hand.
+        await stampDemoMarker(userId);
       } else {
         userId = user.id;
 
@@ -624,9 +651,9 @@ async function populateDemoDataForUser(
        dietary_fiber, sugars, caffeine_mg, quantity, serving_size, serving_unit, entry_date, entry_time, images, created_at
      )
      VALUES
-     (gen_random_uuid(), $1, $2, $3, 'Oatmeal with Blueberries & Almond Butter', 420, 14, 58, 16, 7, 12, 0, 80, 80, 'g', $6, '08:15', '{}', NOW()),
-     (gen_random_uuid(), $1, $4, $5, 'Grilled Chicken Breast with Jasmine Rice & Broccoli', 650, 52, 68, 14, 5, 2, 0, 350, 350, 'g', $6, '12:45', '{}', NOW()),
-     (gen_random_uuid(), $1, $7, $8, 'Double Espresso & Fresh Apple', 100, 1, 25, 0.2, 4, 19, 126, 180, 180, 'g', $6, '15:30', '{}', NOW())`,
+     (gen_random_uuid(), $1, $2, $3, 'Oatmeal with Blueberries & Almond Butter', 420, 14, 58, 16, 7, 12, 0, 80, 80, 'g', $6, '08:15', '[]', NOW()),
+     (gen_random_uuid(), $1, $4, $5, 'Grilled Chicken Breast with Jasmine Rice & Broccoli', 650, 52, 68, 14, 5, 2, 0, 350, 350, 'g', $6, '12:45', '[]', NOW()),
+     (gen_random_uuid(), $1, $7, $8, 'Double Espresso & Fresh Apple', 100, 1, 25, 0.2, 4, 19, 126, 180, 180, 'g', $6, '15:30', '[]', NOW())`,
     [
       userId,
       foodOatmealId,
@@ -672,10 +699,10 @@ async function populateDemoDataForUser(
        dietary_fiber, sugars, caffeine_mg, quantity, serving_size, serving_unit, entry_date, entry_time, images, created_at
      )
      VALUES
-     (gen_random_uuid(), $1, $2, $3, 'Avocado Toast with 2 Poached Eggs', 510, 22, 45, 28, 8, 3, 0, 220, 220, 'g', $10, '08:30', '{}', NOW()),
-     (gen_random_uuid(), $1, $4, $5, 'Fresh Salmon Poke Bowl', 720, 44, 75, 26, 6, 8, 0, 400, 400, 'g', $10, '13:00', '{}', NOW()),
-     (gen_random_uuid(), $1, $6, $7, 'Lean Flank Steak with Roasted Sweet Potatoes', 680, 48, 55, 22, 6, 6, 0, 380, 380, 'g', $10, '19:15', '{}', NOW()),
-     (gen_random_uuid(), $1, $8, $9, 'Greek Yogurt with Raw Honey', 220, 18, 24, 4, 0, 20, 0, 170, 170, 'g', $10, '21:00', '{}', NOW())`,
+     (gen_random_uuid(), $1, $2, $3, 'Avocado Toast with 2 Poached Eggs', 510, 22, 45, 28, 8, 3, 0, 220, 220, 'g', $10, '08:30', '[]', NOW()),
+     (gen_random_uuid(), $1, $4, $5, 'Fresh Salmon Poke Bowl', 720, 44, 75, 26, 6, 8, 0, 400, 400, 'g', $10, '13:00', '[]', NOW()),
+     (gen_random_uuid(), $1, $6, $7, 'Lean Flank Steak with Roasted Sweet Potatoes', 680, 48, 55, 22, 6, 6, 0, 380, 380, 'g', $10, '19:15', '[]', NOW()),
+     (gen_random_uuid(), $1, $8, $9, 'Greek Yogurt with Raw Honey', 220, 18, 24, 4, 0, 20, 0, 170, 170, 'g', $10, '21:00', '[]', NOW())`,
     [
       userId,
       foodAvocadoId,

--- a/SparkyFitnessServer/tests/exerciseEntriesApiSchemas.test.ts
+++ b/SparkyFitnessServer/tests/exerciseEntriesApiSchemas.test.ts
@@ -464,6 +464,34 @@ describe('Exercise entry API schemas', () => {
       });
       expect(withNull.success).toBe(true);
     });
+
+    // Deleting a library exercise nulls the pointer instead of cascading
+    // (20260912150000_preserve_data_on_user_and_library_deletes.sql), so an
+    // entry that outlived its exercise has to survive the response parse --
+    // the routes parse with this schema before replying, and a throw here
+    // would take out the whole diary for everyone who logged that exercise.
+    it('accepts an entry whose library exercise has been deleted', () => {
+      const orphaned = runSchema('exerciseEntryResponseSchema', {
+        ...baseEntryResponse,
+        exercise_id: null,
+        superset_group: null,
+        exercise_snapshot: {
+          id: null,
+          name: 'Deleted Exercise',
+          category: null,
+          images: null,
+          primary_muscles: null,
+          secondary_muscles: null,
+          equipment: null,
+          instructions: null,
+          force: null,
+          level: null,
+          mechanic: null,
+        },
+      });
+      expect(orphaned.success).toBe(true);
+      expect(orphaned.data.exercise_id).toBeNull();
+    });
   });
 
   describe('set duration (integer seconds)', () => {

--- a/shared/src/schemas/api/ExerciseEntries.api.zod.ts
+++ b/shared/src/schemas/api/ExerciseEntries.api.zod.ts
@@ -287,7 +287,10 @@ export const updateExerciseEntryRequestSchema = createExerciseEntryRequestSchema
 export const exerciseEntryResponseSchema = z
   .object({
     id: z.string(),
-    exercise_id: z.string(),
+    // Nulled rather than cascaded when the library exercise is deleted
+    // (20260912150000_preserve_data_on_user_and_library_deletes.sql), so the
+    // entry outlives it. Parsing a preserved entry would throw otherwise.
+    exercise_id: z.string().nullable(),
     duration_minutes: z.number(),
     calories_burned: z.number(),
     entry_date: z.string().nullable(),
@@ -300,7 +303,12 @@ export const exerciseEntryResponseSchema = z
     exercise_preset_entry_id: z.string().nullable().optional(),
     created_at: z.string().nullable().optional(),
     sets: z.array(exerciseEntrySetResponseSchema),
-    exercise_snapshot: exerciseSnapshotResponseSchema.nullable(),
+    // Entry snapshots outlive the library row they were copied from, so their
+    // id can be null. The base schema keeps a required id because it is also
+    // used for live library and search results, where one always exists.
+    exercise_snapshot: exerciseSnapshotResponseSchema
+      .extend({ id: z.string().nullable() })
+      .nullable(),
     activity_details: z.array(activityDetailResponseSchema),
     steps: z.number().nullable().optional(),
     category: z.string().nullable().optional(),

--- a/shared/src/schemas/database/AdminActivityLogs.zod.ts
+++ b/shared/src/schemas/database/AdminActivityLogs.zod.ts
@@ -11,7 +11,7 @@ const userIdSchema = z.any();
 
 export const adminActivityLogsSchema = z.object({
   id: adminActivityLogsIdSchema,
-  admin_user_id: userIdSchema,
+  admin_user_id: userIdSchema.nullable(),
   target_user_id: userIdSchema.nullable(),
   action_type: z.string(),
   details: z.unknown().nullable(),
@@ -20,7 +20,7 @@ export const adminActivityLogsSchema = z.object({
 
 export const adminActivityLogsInitializerSchema = z.object({
   id: adminActivityLogsIdSchema.optional(),
-  admin_user_id: userIdSchema,
+  admin_user_id: userIdSchema.optional().nullable(),
   target_user_id: userIdSchema.optional().nullable(),
   action_type: z.string(),
   details: z.unknown().optional().nullable(),
@@ -29,7 +29,7 @@ export const adminActivityLogsInitializerSchema = z.object({
 
 export const adminActivityLogsMutatorSchema = z.object({
   id: adminActivityLogsIdSchema.optional(),
-  admin_user_id: userIdSchema.optional(),
+  admin_user_id: userIdSchema.optional().nullable(),
   target_user_id: userIdSchema.optional().nullable(),
   action_type: z.string().optional(),
   details: z.unknown().optional().nullable(),

--- a/shared/src/schemas/database/ExerciseEntries.zod.ts
+++ b/shared/src/schemas/database/ExerciseEntries.zod.ts
@@ -5,7 +5,7 @@ export const exerciseEntriesIdSchema = z.string();
 export const exerciseEntriesSchema = z.object({
   id: exerciseEntriesIdSchema,
   user_id: z.string(),
-  exercise_id: z.string(),
+  exercise_id: z.string().nullable(),
   duration_minutes: z.number(),
   calories_burned: z.number(),
   entry_date: z.date().nullable(),
@@ -85,7 +85,7 @@ export const exerciseEntriesSchema = z.object({
 export const exerciseEntriesInitializerSchema = z.object({
   id: exerciseEntriesIdSchema.optional(),
   user_id: z.string(),
-  exercise_id: z.string(),
+  exercise_id: z.string().optional().nullable(),
   duration_minutes: z.number(),
   calories_burned: z.number(),
   entry_date: z.date().optional().nullable(),


### PR DESCRIPTION
## Description

**What problem does this PR solve?**

Signing in to the demo account flooded the server with requests it had already refused and buried the screen in identical error toasts. Separately, deleting a user failed on a foreign key violation, deleting a food or exercise destroyed other people's diary history, and the admin audit trail was erased along with the account it described.

**How did you implement the solution?**

Demo request flood:

- `GET /identity/user` now returns `isDemo`, derived from the authenticated identity rather than the active context, so switching context cannot shed the restriction — the same rule the server-side guard follows.
- The AI-service and external-provider queries are skipped for the demo sandbox instead of firing requests whose answer is already known. These hooks mount on nearly every screen, which is what turned a standing "no" into thousands of requests a minute.
- `apiCall` memoizes a `DEMO_` refusal per **method and path** for the session and answers repeats locally. Keying on the path alone would let a refused `PUT /identity/profiles` answer the `GET` the same screen depends on, since the guard blocks `/api/identity` only for mutating methods. `DEMO_UPLOAD_RESTRICTED` is deliberately not memoized: the guard decides that one from the content type, not the route.
- The API-error toast is silenced only for refused **reads**. A write the visitor just clicked still reports back, rather than leaving them staring at a button that appears to do nothing.
- The shared `QueryClient` no longer retries 4xx. An authorization or validation failure is a verdict, not a hiccup, and retrying it just doubles the failed requests.
- `isDemo` is resolved after a manual sign-in too. `signIn` writes the same id with both MFA flags false, so for an account without 2FA the session that follows matches what is already in state and the sync effect's identity fetch never runs — which would have left every feature gated on `isDemo` dark until the next reload.

Data preservation on deletes (`20260912150000_preserve_data_on_user_and_library_deletes.sql`):

- Diary entries now outlive the library item they were logged from: `food_entries.food_id` and `exercise_entries.exercise_id` are nulled on delete instead of cascading. Entries have carried their own name/nutrition snapshot since those columns landed, and the read path already `LEFT JOIN`s the library, so they render fine without it. `exercise_entries.exercise_id` becomes nullable.
- `created_by_user_id` / `updated_by_user_id` are nulled rather than cascaded. Under family sharing the person who typed a row is often not the person who owns it, so cascading deleted a surviving user's entries when a delegate was removed — and on several tables there was no rule at all, which is what made the admin user deletion fail outright.
- Tables the Better Auth migration missed get a foreign key to `"user"` with `ON DELETE CASCADE`, including `external_data_providers` and `ai_service_settings`, which hold OAuth/refresh tokens and AI provider API keys. Pre-existing orphans are resolved first so the constraints can validate.
- `admin_activity_logs` keeps its rows: both user columns dissociate on delete (`admin_user_id` becomes nullable), and the admin route records the deleted account's id and email in `details` so the entry stays readable once the account is gone.
- `deleteUser` is wrapped in a transaction.

Also in this PR: the demo sandbox marker is stamped outside the seeding transaction, so a seed that fails partway cannot leave a committed demo account the safety guard can never touch again; the demo diary seed writes `images` as a JSON array rather than an empty record; and the caffeine chart's dose markers no longer collide on their React key when the same drink is logged twice in the same minute.

Linked Issue: Closes #

## How to Test

**Demo restrictions** (requires `SPARKY_FITNESS_DEMO_MODE=true`):

1. `cd SparkyFitnessServer && pnpm start`, then `cd SparkyFitnessFrontend && pnpm dev`.
2. Sign in to the demo account and open the Network tab. Navigate between Diary, Reports and Settings.
3. Verify there is no repeating burst of 403s against `/api/chat/*` or `/api/external-providers`, and no wall of "API Error" toasts.
4. Open Settings and try to save a profile change. Verify the refusal **is** toasted (writes still report back) and that the profile itself still loads afterwards — a blocked write must not poison the read on the same path.
5. Sign in as a normal (non-demo) account **without 2FA** and go straight to Settings → AI Service. Verify the service list loads without needing a page reload.

**Deletes:**

1. Restart the server to apply the migration.
2. As an admin, delete a user who shares their diary with someone else. Verify the delete succeeds, the other user's food and exercise entries survive with their name and nutrition intact, and the `USER_DELETED` audit row remains with the deleted account's email in `details`.
3. Delete a custom food that another user has logged. Verify their diary entry survives and still shows its snapshot values.

**Automated:**

```bash
cd SparkyFitnessFrontend && pnpm run validate && pnpm test
cd SparkyFitnessServer && pnpm run validate && pnpm test
```

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord. — N/A, bug fix.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. — N/A, no translation changes.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. — N/A, no new tables; this migration only changes delete rules on existing ones, and the shared Zod schemas for the two nullability changes are updated.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. — N/A, the visible change is the *absence* of a toast storm.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. — N/A, no mobile changes.

## Screenshots

<details>
<summary>Click to expand</summary>

N/A — no visual changes. The user-visible effect is that the demo account no longer produces a stream of identical error toasts.

</details>

## Notes for Reviewers

- **Client gating is an optimization, not enforcement.** `demoRestrictionGuard` remains the only thing that actually blocks the demo account; `isDemo` just saves a request that is guaranteed to be refused. It fails open on a failed identity lookup, so a network blip cannot silently disable AI or provider settings for an ordinary user.
- **The memo key deliberately includes the HTTP method.** A path-only key breaks the read-only demo experience, because `/api/identity` reads are allowed while its writes are not.
- Frontend: `pnpm run validate` clean, 141 suites / 1306 tests pass. Server: `pnpm run validate` clean, 367/370 files pass; the one failure (`openFoodFactsAutomaticSyncMigration.integration.test.ts` → "keeps delayed automatic and interactive product reads at least five seconds apart") reproduces on a clean checkout of this branch point and is unrelated to these changes.
- The migration has been applied and exercised against a dev database. `pnpm run test:migrations` was not run locally because it needs a disposable Postgres; CI's fresh-install migration check covers it.
- `db_schema_backup.sql` is intentionally untouched — CI regenerates it after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Demo accounts are identified automatically and receive clearer handling for restricted features.
  - Restricted background requests fail faster and avoid repeated network calls.
  - AI and external-provider services are no longer requested for demo accounts.

- **Bug Fixes**
  - Diary entries remain available when associated food or exercise records are deleted.
  - Exercise instructions continue working for preserved diary entries.
  - Account deletion preserves relevant shared diary history and audit records.
  - Caffeine chart points remain distinct when doses share the same time and amount.
  - Failed client requests use more appropriate retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->