### PR TITLE
fix(demo): let the sandbox use providers and read its own API keys

### DIFF
--- a/SparkyFitnessFrontend/src/hooks/Settings/useExternalProviderSettings.ts
+++ b/SparkyFitnessFrontend/src/hooks/Settings/useExternalProviderSettings.ts
@@ -1,4 +1,3 @@
-import { useAuth } from '@/hooks/useAuth';
 import { exerciseSearchKeys } from '@/api/keys/exercises';
 import {
   externalProviderKeys,
@@ -79,23 +78,17 @@ export const useCreateExternalProviderMutation = () => {
 };
 
 export const useExternalProviders = (userId?: string) => {
-  const { user } = useAuth();
   return useQuery({
     queryKey: [...externalProviderKeys.lists(), 'enriched'],
     queryFn: getEnrichedProviders,
-    enabled: !!userId && user?.isDemo === false,
+    enabled: !!userId,
   });
 };
 export const useExternalProvidersQuery = () => {
-  const { user } = useAuth();
   return useQuery({
     queryKey: externalProviderKeys.lists(),
     queryFn: getExternalDataProviders,
     staleTime: 1000 * 60 * 60 * 24,
-    // /api/external-providers is blocked for the demo sandbox server-side.
-    // These hooks are consumed by components that mount on most screens, so
-    // firing a request that can only 403 turns a standing policy into a flood.
-    enabled: user?.isDemo === false,
   });
 };
 export const useUpdateExternalProviderMutation = () => {

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -268,7 +268,6 @@ app.use(async (req, res, next) => {
       const restrictedAuthPrefixes = [
         '/api/auth/two-factor',
         '/api/auth/passkey',
-        '/api/auth/api-key', // minting a key would outlive the daily reset
         '/api/auth/change-password',
         '/api/auth/set-password',
         '/api/auth/change-email',
@@ -278,6 +277,16 @@ app.use(async (req, res, next) => {
       const isRestrictedAuthPath = restrictedAuthPrefixes.some(
         (prefix) => req.path === prefix || req.path.startsWith(prefix + '/')
       );
+
+      // API keys are read-only for the sandbox rather than invisible: minting
+      // one would outlive the daily reset, but listing the account's own keys
+      // gives away nothing (Better Auth returns the key itself only at
+      // creation) and blocking the read just makes the settings screen throw.
+      const isApiKeyPath =
+        req.path === '/api/auth/api-key' ||
+        req.path.startsWith('/api/auth/api-key/');
+      const isRestrictedApiKeyPath =
+        isApiKeyPath && req.method.toUpperCase() !== 'GET';
 
       // Password-recovery endpoints are unauthenticated, so there is no session
       // to match on — identify the account from the request itself, or the demo
@@ -316,7 +325,7 @@ app.use(async (req, res, next) => {
         });
       }
 
-      if (isRestrictedAuthPath) {
+      if (isRestrictedAuthPath || isRestrictedApiKeyPath) {
         try {
           const { auth } = authModule;
           const session = await auth.api.getSession({

--- a/SparkyFitnessServer/middleware/demoGuardMiddleware.ts
+++ b/SparkyFitnessServer/middleware/demoGuardMiddleware.ts
@@ -124,15 +124,21 @@ const DEMO_BLOCKED_PREFIXES = [
   '/api/admin', // privileged surface (defense in depth behind the role check)
   '/api/integrations', // Garmin/Fitbit/Oura/Strava/Polar/Hevy/Google OAuth binding
   '/api/withings',
-  '/api/external-providers', // provider config accepts operator-supplied base URLs
 ];
 
 /**
  * Namespaces where reads are fine but writes are not. `/api/identity` is the
  * whole account-management cluster: credentials, MFA, passkeys, API keys,
  * family sharing, and the profile row that carries the demo marker.
+ *
+ * `/api/external-providers` is here rather than in the deny list because the
+ * providers a visitor needs in order to *use* the demo -- the free food and
+ * exercise databases that need no key -- are read through it. Creating or
+ * editing one is what accepts an operator-supplied base URL, and that is a
+ * write. The list endpoints already strip `app_key` from everyone and
+ * `app_id` from non-owners, so a read exposes no credential.
  */
-const DEMO_READONLY_PREFIXES = ['/api/identity'];
+const DEMO_READONLY_PREFIXES = ['/api/identity', '/api/external-providers'];
 
 /**
  * Endpoints that ingest a file, image, or bulk document *without* multipart —

--- a/SparkyFitnessServer/tests/demoSeedService.test.ts
+++ b/SparkyFitnessServer/tests/demoSeedService.test.ts
@@ -426,7 +426,6 @@ describe('Demo Mode Infrastructure', () => {
       '/api/admin/global-settings',
       '/api/integrations/strava/connect',
       '/api/withings/link',
-      '/api/external-providers',
     ])('blocks %s on any method', (path) => {
       const { res, next } = run(path);
       expect(next).not.toHaveBeenCalled();
@@ -444,6 +443,23 @@ describe('Demo Mode Infrastructure', () => {
       const root = run('/', 'POST', {}, '/mcp');
       expect(root.next).not.toHaveBeenCalled();
       expect(root.res.status).toHaveBeenCalledWith(403);
+    });
+
+    // The sandbox has to be usable, not merely non-destructive: the free food
+    // and exercise databases need no key and cost the operator nothing, so a
+    // visitor must be able to read the provider list in order to search at all.
+    // Creating or editing a provider is where an operator-supplied base URL
+    // enters, and that stays blocked.
+    it('blocks mutations under /api/external-providers but allows reads', () => {
+      const read = run('/api/external-providers', 'GET');
+      expect(read.next).toHaveBeenCalled();
+      expect(read.res.status).not.toHaveBeenCalled();
+
+      for (const method of ['POST', 'PUT', 'PATCH', 'DELETE']) {
+        const write = run('/api/external-providers', method);
+        expect(write.next).not.toHaveBeenCalled();
+        expect(write.res.status).toHaveBeenCalledWith(403);
+      }
     });
 
     it('blocks mutations under /api/identity but allows reads', () => {


### PR DESCRIPTION
The demo account is meant to be explorable, not merely non-destructive, and two blanket blocks made it neither.

/api/external-providers was denied on every method, so the demo could not read the provider list -- and without that list there is nothing to search the free food and exercise databases with. Those need no key and cost the operator nothing. The route file already had this right: demoGuard sits on POST, PUT and DELETE only, and the global prefix was overriding it. Move the namespace to the read-only list so creating or editing a provider stays blocked, which is where an operator-supplied base URL enters. Reads leak nothing: the list endpoint strips app_key from everyone and app_id from non-owners.

/api/auth/api-key was blocked on every method for the same reason -- minting a key would outlive the daily reset -- but that also refused the list the settings screen reads on mount, which threw on every visit. Restrict the block to mutating methods; Better Auth returns the key itself only at creation, so listing gives away nothing.

Drops the client-side demo gate on the provider queries, which is no longer needed now that the reads succeed.

> [!TIP]
> **Help us review and merge your PR faster!**
> Please ensure you have completed the **Checklist** below.
> For **Frontend** changes, please run `pnpm run validate` to check for any errors.
> PRs that include tests and clear screenshots are highly preferred!
> Note: AI-generated descriptions must be manually edited for conciseness. Do not paste raw AI summaries.

## Description

**What problem does this PR solve?**
(Keep it concise. 1–2 sentences.)

**How did you implement the solution?**
(Brief technical approach.)

Linked Issue: Closes #

## How to Test

1. Check out this branch and run `...`
2. Navigate to...
3. Verify that...

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [ ] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file.

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [ ] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables.

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below.

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android.

## Screenshots

<details>
<summary>Click to expand</summary>

### Before

![before](url)

### After

![after](url)

</details>

## Notes for Reviewers

> Optional — use this for anything that doesn't fit above: known tradeoffs, areas you'd like specific feedback on, qustions you have or context that helps reviewers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo users can view external food and exercise provider data.
  * Demo users can view their account’s API keys in Settings.
* **Bug Fixes**
  * Read-only access is now available for these settings and provider endpoints, while changes and deletions remain restricted in demo mode.
  * Added coverage to verify that read requests succeed and mutation requests remain blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->