### PR TITLE
fix(auth): prevent false-positive IP bans from auth 4xx

### DIFF
--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -17,3 +17,15 @@ Two rules that override the urge to be helpful:
 - **Never execute an untrusted branch.** Reading a contributor's diff is safe; running it is not. Prefer `gh pr checks` as the test signal, and ask before checking anything out.
 
 Read the surrounding files, not just the diff hunks. Most real findings in this repo are about what the diff *didn't* update: the missing RLS policy, the mobile consumer left behind, the write path that never invalidates the cache.
+
+## Acting on review-bot feedback (CodeRabbit et al.)
+
+When the user asks to *act on* bot feedback — "review the bot comments, fix if legit else reply, and resolve them" or similar — the **Report only** rule above is lifted for that PR: you may fix, reply, and resolve. Default standing workflow, so the user does not have to spell it out each time:
+
+1. **Verify every finding against current source before acting.** Bots are often wrong, stale, or reasoning about a version/config that does not apply here. Trace the claim to the actual code or installed dependency (`node_modules/...`) and confirm it. Never fix or agree on the bot's say-so — and never post a claim you have not verified, because a public walk-back is worse than a slow reply.
+2. **Legit → fix minimally, validate, reply.** Make the smallest correct change, run the affected package's `pnpm run validate` + tests, then reply on the thread stating what changed.
+3. **Not legit, or a deliberate trade-off → reply, don't fix.** Explain the verified reasoning (why it doesn't apply, or why the naive fix is wrong for this deployment). A deployment-specific or heavy-lift item that can't be safely fixed inline: say so and note it as a follow-up.
+4. **Don't invent version-specific workarounds when a real fix is already planned.** If the user is upgrading the dependency (or a proper fix is coming in another PR), defer to that and say so in the reply rather than shipping a band-aid tied to the old version. Confirm with the user before adding any CVE mitigation that the upcoming upgrade would make redundant.
+5. **Resolve every thread you addressed** (fixed or replied) before committing back — GraphQL `resolveReviewThread` with the thread's node id (get ids via the `pullRequest.reviewThreads` query; the inline-comment REST id is not the thread id). Leave a thread open only if you're waiting on the user.
+6. **Keep it clean and unattributed.** Replies and any commits follow the repo's zero-AI-attribution rule (see `pr-submission`). Outside-diff findings have no inline thread — answer them with one top-level PR comment.
+7. **Keep unrelated changes out of the PR.** Fixes for the bot findings go in; tooling/skill edits or drive-by cleanups do not belong in a focused PR — leave those in the working tree for the user.

--- a/SparkyFitnessFrontend/src/hooks/Auth/useAuth.ts
+++ b/SparkyFitnessFrontend/src/hooks/Auth/useAuth.ts
@@ -104,8 +104,11 @@ export const useAuthSettings = () => {
   return useQuery({
     queryKey: authKeys.settings,
     queryFn: getLoginSettings,
-    staleTime: 0,
-    refetchOnMount: 'always',
+    // Login settings change only when the operator edits server config, so a
+    // short stale window is plenty. `staleTime: 0` with `refetchOnMount:
+    // 'always'` handed the Auth page a new object identity on every refetch,
+    // re-running the effect that arms the 800ms OIDC auto-redirect timer.
+    staleTime: 1000 * 60 * 5,
   });
 };
 

--- a/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
+++ b/SparkyFitnessFrontend/src/pages/Auth/Auth.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -135,67 +135,99 @@ const Auth = () => {
   ]);
 
   // Passkey Conditional UI (Autofill)
+  //
+  // `loggingLevel` is deliberately NOT a dependency. It arrives from
+  // PreferencesContext after mount, and including it re-ran this effect and
+  // started a *second* concurrent conditional `navigator.credentials.get()`,
+  // which aborts the first -- the AbortError swallowed below. Read it through a
+  // ref so a preferences load cannot disturb an in-flight request.
+  const loggingLevelRef = useRef(loggingLevel);
+  loggingLevelRef.current = loggingLevel;
+  const passkeyAutofillStartedRef = useRef(false);
+
   useEffect(() => {
+    // Only attempt if not already logged in, and only ever once per mount.
+    if (authUser || authLoading || passkeyAutofillStartedRef.current) {
+      return;
+    }
+
     const initPasskeyAutofill = async () => {
       if (
-        window.PublicKeyCredential &&
-        PublicKeyCredential.isConditionalMediationAvailable
+        !window.PublicKeyCredential ||
+        !PublicKeyCredential.isConditionalMediationAvailable
       ) {
-        const isAvailable =
-          await PublicKeyCredential.isConditionalMediationAvailable();
-        if (isAvailable) {
-          debug(
-            loggingLevel,
-            'Auth: Passkey Conditional UI available. Starting autofill prompt.'
-          );
-          try {
-            await authClient.signIn.passkey({
-              autoFill: true,
-              fetchOptions: {
-                onSuccess() {
-                  info(loggingLevel, 'Auth: Passkey autofill successful.');
-                  navigate('/');
-                },
-                onError(ctx: { error: { message?: string; name?: string } }) {
-                  // Silently ignore "Authentication was not completed" or AbortError
-                  if (
-                    ctx.error.message?.includes(
-                      'Authentication was not completed'
-                    ) ||
-                    ctx.error.name === 'AbortError'
-                  ) {
-                    debug(
-                      loggingLevel,
-                      'Auth: Passkey autofill dismissed or interrupted.'
-                    );
-                    return;
-                  }
-                  error(
-                    loggingLevel,
-                    'Auth: Passkey autofill error:',
-                    ctx.error
-                  );
-                },
-              },
-            });
-          } catch (err: unknown) {
-            if (err instanceof Error && err.name === 'AbortError') {
-              debug(loggingLevel, 'Auth: Passkey autofill aborted.');
-            } else {
-              debug(
-                loggingLevel,
-                'Auth: Passkey autofill silently ignored or failed.'
+        return;
+      }
+      const isAvailable =
+        await PublicKeyCredential.isConditionalMediationAvailable();
+      if (!isAvailable) {
+        return;
+      }
+
+      // Conditional mediation throws if no input advertising `webauthn` as the
+      // last autocomplete token is in the DOM when it is called. The sign-in
+      // form carries one, but it is not mounted on every branch of this page
+      // (the MFA challenge replaces it), so check rather than throw.
+      if (!document.querySelector('input[autocomplete$="webauthn"]')) {
+        debug(
+          loggingLevelRef.current,
+          'Auth: No webauthn autocomplete input mounted; skipping passkey autofill.'
+        );
+        return;
+      }
+
+      debug(
+        loggingLevelRef.current,
+        'Auth: Passkey Conditional UI available. Starting autofill prompt.'
+      );
+      passkeyAutofillStartedRef.current = true;
+      try {
+        await authClient.signIn.passkey({
+          autoFill: true,
+          fetchOptions: {
+            onSuccess() {
+              info(
+                loggingLevelRef.current,
+                'Auth: Passkey autofill successful.'
               );
-            }
-          }
+              navigate('/');
+            },
+            onError(ctx: { error: { message?: string; name?: string } }) {
+              // Silently ignore "Authentication was not completed" or AbortError
+              if (
+                ctx.error.message?.includes(
+                  'Authentication was not completed'
+                ) ||
+                ctx.error.name === 'AbortError'
+              ) {
+                debug(
+                  loggingLevelRef.current,
+                  'Auth: Passkey autofill dismissed or interrupted.'
+                );
+                return;
+              }
+              error(
+                loggingLevelRef.current,
+                'Auth: Passkey autofill error:',
+                ctx.error
+              );
+            },
+          },
+        });
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          debug(loggingLevelRef.current, 'Auth: Passkey autofill aborted.');
+        } else {
+          debug(
+            loggingLevelRef.current,
+            'Auth: Passkey autofill silently ignored or failed.'
+          );
         }
       }
     };
-    // Only attempt if not already logged in
-    if (!authUser && !authLoading) {
-      initPasskeyAutofill();
-    }
-  }, [authUser, authLoading, loggingLevel, navigate]);
+
+    initPasskeyAutofill();
+  }, [authUser, authLoading, navigate]);
 
   const triggerMfaChallenge = useCallback(
     async (

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -262,6 +262,22 @@ app.use(async (req, res, next) => {
       return next();
     }
 
+    // In demo mode the credential backend stays loaded so the one-click demo
+    // login (an in-process auth.api.signInEmail call) keeps working, so the
+    // public password routes have to be closed here instead. The body matches
+    // Better Auth's own EMAIL_PASSWORD_DISABLED response byte for byte, so a
+    // client cannot tell which layer refused it.
+    if (
+      process.env.SPARKY_FITNESS_DISABLE_EMAIL_LOGIN === 'true' &&
+      (req.path.startsWith('/api/auth/sign-in/email') ||
+        req.path.startsWith('/api/auth/sign-up/email'))
+    ) {
+      return res.status(400).json({
+        message: 'Email and password is not enabled',
+        code: 'EMAIL_PASSWORD_DISABLED',
+      });
+    }
+
     if (isDemoMode()) {
       // Prefix matches throughout: exact equality misses trailing-slash and
       // sub-path variants that Better Auth still routes.
@@ -273,6 +289,15 @@ app.use(async (req, res, next) => {
         '/api/auth/change-email',
         '/api/auth/update-user',
         '/api/auth/delete-user',
+        // SSRF stopgap for @better-auth/sso < 1.6.11 (CVE-2026-53513): the
+        // plugin's /sso/register and /sso/update-provider accept
+        // attacker-controlled OIDC endpoint URLs and fetch them server-side,
+        // reachable by any session with no role gate. Anyone can obtain a
+        // session here via the one-click demo login, so block the whole SSO
+        // management surface for the sandbox until better-auth is upgraded.
+        // The register/update writes are the exploit; listing is closed too
+        // since the sandbox never provisions providers anyway.
+        '/api/auth/sso',
       ];
       const isRestrictedAuthPath = restrictedAuthPrefixes.some(
         (prefix) => req.path === prefix || req.path.startsWith(prefix + '/')

--- a/SparkyFitnessServer/SparkyFitnessServer.ts
+++ b/SparkyFitnessServer/SparkyFitnessServer.ts
@@ -289,15 +289,6 @@ app.use(async (req, res, next) => {
         '/api/auth/change-email',
         '/api/auth/update-user',
         '/api/auth/delete-user',
-        // SSRF stopgap for @better-auth/sso < 1.6.11 (CVE-2026-53513): the
-        // plugin's /sso/register and /sso/update-provider accept
-        // attacker-controlled OIDC endpoint URLs and fetch them server-side,
-        // reachable by any session with no role gate. Anyone can obtain a
-        // session here via the one-click demo login, so block the whole SSO
-        // management surface for the sandbox until better-auth is upgraded.
-        // The register/update writes are the exploit; listing is closed too
-        // since the sandbox never provisions providers anyway.
-        '/api/auth/sso',
       ];
       const isRestrictedAuthPath = restrictedAuthPrefixes.some(
         (prefix) => req.path === prefix || req.path.startsWith(prefix + '/')

--- a/SparkyFitnessServer/auth.ts
+++ b/SparkyFitnessServer/auth.ts
@@ -21,6 +21,7 @@ import { sso } from '@better-auth/sso';
 import { expo } from '@better-auth/expo';
 import { expoSsoCookieRelay } from './utils/expoSsoCookieRelay.js';
 import { passkey } from '@better-auth/passkey';
+import { isDemoMode } from './middleware/demoGuardMiddleware.js';
 
 const hashAsync = promisify(bcrypt.hash);
 const compareAsync = promisify(bcrypt.compare);
@@ -115,6 +116,30 @@ async function syncTrustedProviders() {
 }
 // Initial sync on startup - deferred to SparkyFitnessServer.js after migrations
 // syncTrustedProviders().catch(err => console.error('[AUTH] Startup sync failed:', err));
+/**
+ * Window and attempt cap for the credential-checking auth endpoints.
+ *
+ * Two properties of Better Auth's limiter drive these numbers:
+ *  - the counter increments on *every* response, successes included, so this
+ *    caps total sign-in traffic per IP, not just failures; and
+ *  - the window only resets after a full `window` of silence (each counted
+ *    request refreshes `lastRequest`), so a long window lets a client that
+ *    keeps retrying hold itself blocked.
+ *
+ * Both argue for a short window. 60s also keeps sustained failures under the
+ * threshold an upstream IDS watches for (see the `customRules` comment below),
+ * while self-healing after a minute of quiet. Raise these if your instance
+ * sits behind a shared or carrier-NAT address with many users.
+ */
+const SIGN_IN_WINDOW =
+  Number.parseInt(
+    process.env.SPARKY_FITNESS_SIGN_IN_RATELIMIT_WINDOW ?? '',
+    10
+  ) || 60;
+const SIGN_IN_MAX =
+  Number.parseInt(process.env.SPARKY_FITNESS_SIGN_IN_RATELIMIT_MAX ?? '', 10) ||
+  4;
+
 const apiKeyPlugin = apiKey({
   enableSessionForAPIKeys: true, // Required for getSession to work with API Keys
   rateLimit: {
@@ -215,10 +240,39 @@ const auth = betterAuth({
     enabled: true,
     window: 60,
     max: 100,
+    // Credential checks answer 401, which intrusion-detection tooling reads as
+    // a brute-force signal. A common scenario (CrowdSec's generic 401 rule)
+    // burns an IP after six POST 401s arriving faster than one per 10s. Better
+    // Auth's own default for /sign-in is 3 per 10s -- a tight burst but 18/min
+    // sustained, so a user fumbling their password manager can emit six 401s
+    // in ~20s and get the whole IP banned at the edge for hours.
+    //
+    // Capping sustained rate (4/min) rather than burst is what fixes that: the
+    // 5th attempt in a minute gets a local 429, which such rules do not count,
+    // so failures can never accumulate to the ban threshold. This is stricter
+    // than the default for sustained guessing and no looser for bursts.
+    //
+    // Deliberately short: successes count toward the same budget, so this is a
+    // ceiling on all sign-in traffic from one address. Instances behind a
+    // shared or carrier-NAT IP with many users should raise SIGN_IN_MAX.
+    customRules: {
+      '/sign-in/email': { window: SIGN_IN_WINDOW, max: SIGN_IN_MAX },
+      '/two-factor/*': { window: SIGN_IN_WINDOW, max: SIGN_IN_MAX },
+      '/email-otp/verify-email': { window: SIGN_IN_WINDOW, max: SIGN_IN_MAX },
+    },
   },
   // Email/Password authentication
   emailAndPassword: {
-    enabled: process.env.SPARKY_FITNESS_DISABLE_EMAIL_LOGIN !== 'true',
+    // The demo sandbox signs its user in through auth.api.signInEmail(), an
+    // in-process call that this same flag switches off -- so honouring
+    // DISABLE_EMAIL_LOGIN here takes the demo's one-click button down with it
+    // (400 EMAIL_PASSWORD_DISABLED) while the operator only meant to hide the
+    // password form. Keep the credential backend loaded in demo mode and close
+    // the *public* route instead; SparkyFitnessServer.ts refuses
+    // /api/auth/sign-in/email and /sign-up/email with the identical response
+    // Better Auth would have sent, so nothing outside can tell the difference.
+    enabled:
+      isDemoMode() || process.env.SPARKY_FITNESS_DISABLE_EMAIL_LOGIN !== 'true',
     requireEmailVerification: false,
     minPasswordLength: 8,
     sendResetPassword: async ({ user, url }) => {

--- a/SparkyFitnessServer/tests/authRateLimit.test.ts
+++ b/SparkyFitnessServer/tests/authRateLimit.test.ts
@@ -252,3 +252,123 @@ describe('/mfa-factors inline rate limiter', () => {
     expect(results2[0]).toBeNull();
   });
 });
+
+/**
+ * SparkyFitness' own `customRules` (auth.ts). These override Better Auth's
+ * 3-per-10s default on the credential-checking endpoints.
+ *
+ * The default is a tight burst but resets every 10s, so it permits 18 failed
+ * logins a minute indefinitely. Intrusion-detection tooling watching POST 401s
+ * (e.g. CrowdSec's generic 401 rule: a leaky bucket of capacity 5 draining one
+ * per 10s) treats that sustained rate as a brute force and bans the client IP
+ * at the edge — taking a legitimate user who fumbled their password with it.
+ * Capping the sustained rate instead keeps failures permanently under that
+ * threshold.
+ */
+describe('SparkyFitness sign-in customRules', () => {
+  const SIGN_IN_WINDOW = 60;
+  const SIGN_IN_MAX = 4;
+  const CUSTOM_RULES = {
+    '/sign-in/email': { window: SIGN_IN_WINDOW, max: SIGN_IN_MAX },
+    '/two-factor/*': { window: SIGN_IN_WINDOW, max: SIGN_IN_MAX },
+    '/email-otp/verify-email': { window: SIGN_IN_WINDOW, max: SIGN_IN_MAX },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let onRequestRateLimit: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let onResponseRateLimit: any;
+
+  beforeAll(async () => {
+    const mod = await import(
+      path.resolve(
+        __dirname,
+        '../node_modules/better-auth/dist/api/rate-limiter/index.mjs'
+      )
+    );
+    onRequestRateLimit = mod.onRequestRateLimit;
+    onResponseRateLimit = mod.onResponseRateLimit;
+  });
+
+  function makeCustomContext() {
+    const config = {
+      ...RATE_LIMIT_CONFIG,
+      customRules: CUSTOM_RULES,
+    };
+    return {
+      baseURL: BASE_URL,
+      rateLimit: { ...config },
+      options: {
+        rateLimit: { ...config },
+        plugins: [],
+        advanced: { trustProxy: true },
+        trustedOrigins: ['https://example.com'],
+      },
+    };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function send(endpoint: any, count: any, ip: any) {
+    const ctx = makeCustomContext();
+    const results = [];
+    for (let i = 0; i < count; i++) {
+      const req = makeRequest(endpoint, ip);
+      const result = await onRequestRateLimit(req, ctx);
+      results.push(result);
+      if (result === undefined) {
+        await onResponseRateLimit(req, ctx);
+      }
+    }
+    return results;
+  }
+
+  it('allows SIGN_IN_MAX attempts on /sign-in/email', async () => {
+    const results = await send('/sign-in/email', SIGN_IN_MAX, '10.3.0.1');
+    expect(results.filter((r) => r?.status === 429)).toHaveLength(0);
+  });
+
+  it('blocks the attempt after SIGN_IN_MAX, so failures cannot reach the IDS threshold', async () => {
+    const results = await send('/sign-in/email', SIGN_IN_MAX + 1, '10.3.0.2');
+    expect(results.filter((r) => r === undefined)).toHaveLength(SIGN_IN_MAX);
+    expect(results.filter((r) => r?.status === 429)).toHaveLength(1);
+  });
+
+  it('caps sustained rate below Better Auth default: 10 rapid attempts yield at most SIGN_IN_MAX 401s', async () => {
+    const results = await send('/sign-in/email', 10, '10.3.0.3');
+    // Without customRules the default (3 per 10s) would let far more through
+    // over the same span; here everything past the cap is a 429, which the
+    // 401-based IDS rules do not count.
+    expect(results.filter((r) => r === undefined)).toHaveLength(SIGN_IN_MAX);
+  });
+
+  it('applies the same cap to two-factor verification via the wildcard rule', async () => {
+    const results = await send(
+      '/two-factor/verify-totp',
+      SIGN_IN_MAX + 1,
+      '10.3.0.4'
+    );
+    expect(results.filter((r) => r?.status === 429)).toHaveLength(1);
+  });
+
+  it('gives each path its own budget, so one MFA login does not exhaust sign-in', async () => {
+    const ip = '10.3.0.5';
+    const signIn = await send('/sign-in/email', SIGN_IN_MAX, ip);
+    const sendOtp = await send('/two-factor/send-otp', SIGN_IN_MAX, ip);
+    const verifyOtp = await send('/two-factor/verify-otp', SIGN_IN_MAX, ip);
+    for (const r of [signIn, sendOtp, verifyOtp]) {
+      expect(r.filter((x) => x?.status === 429)).toHaveLength(0);
+    }
+  });
+
+  it('tracks budgets per client IP', async () => {
+    await send('/sign-in/email', SIGN_IN_MAX + 1, '10.3.1.1');
+    const other = await send('/sign-in/email', 1, '10.3.1.2');
+    expect(other[0]).toBeUndefined();
+  });
+
+  it('leaves unlisted auth endpoints on the permissive default', async () => {
+    // /api/auth/settings and friends must not inherit the sign-in cap.
+    const results = await send('/get-session', SIGN_IN_MAX + 2, '10.3.2.1');
+    expect(results.filter((r) => r?.status === 429)).toHaveLength(0);
+  });
+});

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -37,7 +37,10 @@ SPARKY_FITNESS_SERVER_PORT=3010
 # --- Frontend Nginx Settings (Optional) ---
 # Host port the frontend is published on. Default: 3004
 #SPARKY_FITNESS_FRONTEND_PORT=3004
-# Rate limit applied to requests by Nginx (e.g. '5r/s'). Default: 5r/s
+# Nginx rate limit for /api/auth/ endpoints (e.g. '5r/s'). Default: 5r/s
+# Note: keyed on the connecting address, which behind a reverse proxy or tunnel is
+# the proxy itself - so this is a shared cap, not per visitor. Per-IP sign-in limits
+# are set by SPARKY_FITNESS_SIGN_IN_RATELIMIT_* below.
 #NGINX_RATE_LIMIT=5r/s
 # Port Nginx listens on inside the container. Defaults to 80 (root) or 8080 (non-root) if not set.
 #NGINX_LISTEN_PORT=
@@ -222,6 +225,17 @@ SPARKY_FITNESS_FORCE_EMAIL_LOGIN=true
 # Defaults to 100 requests per 60-second window if not set.
 #SPARKY_FITNESS_API_KEY_RATELIMIT_WINDOW_MS=60000
 #SPARKY_FITNESS_API_KEY_RATELIMIT_MAX_REQUESTS=100
+
+# --- Sign-in Rate Limiting (Optional) ---
+# Caps sign-in, two-factor and email-OTP verification attempts per client IP.
+# Defaults to 4 attempts per 60-second window. The 5th attempt in a minute gets
+# a 429 instead of another 401, so repeated failures can never accumulate to the
+# threshold an upstream IDS (fail2ban/CrowdSec) bans an IP for.
+# NOTE: successful sign-ins count toward the same budget, so this is a ceiling
+# on ALL sign-in traffic from one address. If your instance sits behind a shared
+# office IP or carrier-grade NAT with many users, raise MAX.
+#SPARKY_FITNESS_SIGN_IN_RATELIMIT_WINDOW=60
+#SPARKY_FITNESS_SIGN_IN_RATELIMIT_MAX=4
 
 # --- Start of Garmin Integration Settings ---
 #Below variables are needed only for Garmin integration. If you don't use Garmin integration, you can remove them in your .env file.

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -23,10 +23,17 @@ mkdir -p /var/run/nginx \
      /var/cache/nginx/scgi \
      /etc/nginx/conf.d 2>/dev/null || true
 
+# nginx.conf references ${NGINX_RATE_LIMIT} directly, and envsubst replaces an
+# unset or empty variable with an empty string -- which would render
+# "rate=;" and make nginx fail to start. Every supported deployment path
+# (Dockerfile ENV, compose, Helm) already supplies a default, so this only
+# guards someone passing the variable through explicitly empty.
+export NGINX_RATE_LIMIT="${NGINX_RATE_LIMIT:-5r/s}"
+
 echo "Starting SparkyFitness Frontend as ${NGINX_PERMISSION_MODE} with environment variables:"
 echo "  SPARKY_FITNESS_SERVER_HOST=${SPARKY_FITNESS_SERVER_HOST}"
 echo "  SPARKY_FITNESS_SERVER_PORT=${SPARKY_FITNESS_SERVER_PORT}"
-echo "  NGINX_RATE_LIMIT=${NGINX_RATE_LIMIT:-5r/s}"
+echo "  NGINX_RATE_LIMIT=${NGINX_RATE_LIMIT}"
 echo "  NGINX_LISTEN_PORT=${NGINX_LISTEN_PORT}"
 echo "  NGINX_ACCESS_LOG=${NGINX_ACCESS_LOG}"
 echo "  NGINX_ERROR_LOG=${NGINX_ERROR_LOG}"

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,4 +1,4 @@
-limit_req_zone $binary_remote_addr zone=login_signup_zone:10m rate=5r/s;
+limit_req_zone $binary_remote_addr zone=login_signup_zone:10m rate=${NGINX_RATE_LIMIT};
 
 server {
   listen ${NGINX_LISTEN_PORT};

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,4 +1,5 @@
 limit_req_zone $binary_remote_addr zone=login_signup_zone:10m rate=${NGINX_RATE_LIMIT};
+limit_req_status 429;
 
 server {
   listen ${NGINX_LISTEN_PORT};

--- a/docs/content/1.install/7.environment-variables.md
+++ b/docs/content/1.install/7.environment-variables.md
@@ -118,6 +118,16 @@ API keys are rate-limited to prevent abuse. These must be passed to `sparkyfitne
 - **`SPARKY_FITNESS_API_KEY_RATELIMIT_WINDOW_MS`**: Time window in milliseconds. Defaults to `60000` (1 minute).
 - **`SPARKY_FITNESS_API_KEY_RATELIMIT_MAX_REQUESTS`**: Maximum number of requests allowed per window. Defaults to `100`.
 
+Sign-in, two-factor and email-OTP verification are rate-limited separately, per client IP.
+
+- **`SPARKY_FITNESS_SIGN_IN_RATELIMIT_WINDOW`**: Time window in **seconds**. Defaults to `60`.
+- **`SPARKY_FITNESS_SIGN_IN_RATELIMIT_MAX`**: Maximum attempts allowed per window. Defaults to `4`.
+
+Successful sign-ins count toward the same budget, so this is a ceiling on all sign-in
+traffic from one address. Raise `..._MAX` if your instance sits behind a shared office IP
+or carrier-grade NAT where many users share one address. See
+[Rate Limiting](/developer/advanced/rate-limiting) for why the defaults are what they are.
+
 ### Outbound Proxy (Server Side)
 
 Most setups do not need these. They route the server's **outbound** requests (food providers, fitness integrations, AI providers, etc.) through a forward proxy. This is **not** how you serve SparkyFitness over HTTPS or behind a reverse proxy — for that (including the HTTPS the mobile app requires), see the [Reverse Proxy guide](/administration/reverse-proxy).

--- a/docs/content/8.developer/8.advanced/3.rate-limiting.md
+++ b/docs/content/8.developer/8.advanced/3.rate-limiting.md
@@ -11,122 +11,50 @@ Rate limiting is crucial for:
 *   **Protecting Password Reset Flows**: Preventing abuse of email-based recovery mechanisms.
 *   **Securing MFA Endpoints**: Limiting attempts to bypass multi-factor authentication.
 
-## Implementation Layer
+## Implementation Layers
 
-Rate limiting is implemented at the **Nginx reverse proxy layer**. This is the most efficient approach as it blocks malicious requests before they reach the backend Node.js application, conserving server resources.
+SparkyFitness rate-limits in two places:
+
+1. **Nginx** (frontend container) — a coarse cap across all `/api/auth/` traffic.
+2. **The application** (Better Auth) — per-IP caps on sign-in and per-key caps on API keys.
+   These are the meaningful controls; see the sections below.
 
 ## Nginx Configuration
 
-The rate limiting is configured in the `nginx.conf` file.
-
-### 1. Client IP Detection
-
-To correctly identify clients behind proxies or CDNs like Cloudflare, the configuration uses a chain of IP detection mechanisms:
+Defined in `docker/nginx.conf`, which is copied into the frontend image as
+`/etc/nginx/templates/default.conf.template` and rendered by `docker-entrypoint.sh`.
 
 ```nginx
-# Trust docker gateway and Cloudflare IPs for real IP detection
-set_real_ip_from 172.16.0.0/12;  # Docker networks
-set_real_ip_from 10.0.0.0/8;      # Private networks
-real_ip_header CF-Connecting-IP;
-real_ip_recursive on;
-
-map $http_cf_connecting_ip $client_ip_from_cf {
-    ""      $binary_remote_addr;
-    default $http_cf_connecting_ip;
-}
-
-map $http_x_real_ip $rate_limit_key {
-    ""      $client_ip_from_cf;
-    default $http_x_real_ip;
-}
+limit_req_zone $binary_remote_addr zone=login_signup_zone:10m rate=${NGINX_RATE_LIMIT};
 ```
 
-The detection priority is:
-1. `CF-Connecting-IP` header (Cloudflare)
-2. `X-Real-IP` header (other proxies)
-3. Direct connection IP (`$binary_remote_addr`)
+The rate is set by `NGINX_RATE_LIMIT` (default `5r/s`), substituted at container start by
+`docker/docker-entrypoint.sh`. Set it to a very high value such as `10000r/s` to effectively
+disable this layer.
 
-### 2. Defining a Rate Limiting Zone
-
-A shared memory zone named `auth_zone` is defined to track request rates based on client IP addresses:
+A single blanket location covers every auth endpoint:
 
 ```nginx
-limit_req_zone $rate_limit_key zone=auth_zone:10m rate=${NGINX_RATE_LIMIT};
-limit_req_status 429;
-```
-
-*   `$rate_limit_key`: Uses the detected client IP address for tracking.
-*   `zone=auth_zone:10m`: Defines a 10-megabyte shared memory zone.
-*   `rate=${NGINX_RATE_LIMIT}`: Configurable rate limit (default: `5r/s`). Set to `10000r/s` to effectively disable rate limiting.
-*   `limit_req_status 429`: Explicitly returns HTTP 429 (Too Many Requests) when rate limited.
-
-### 3. Applying the Rate Limit to Endpoints
-
-The `limit_req` directive is applied to specific authentication endpoints within the `server` block.
-
-**Exact match endpoints:**
-
-```nginx
-# Apply rate limit to login endpoint
-location = /api/auth/login {
-    limit_req zone=auth_zone burst=5 nodelay;
-    proxy_pass http://${SPARKY_FITNESS_SERVER_HOST}:${SPARKY_FITNESS_SERVER_PORT}/auth/login;
-    # ... other proxy settings ...
-}
-
-# Apply rate limit to register endpoint
-location = /api/auth/register {
-    limit_req zone=auth_zone burst=5 nodelay;
-    proxy_pass http://${SPARKY_FITNESS_SERVER_HOST}:${SPARKY_FITNESS_SERVER_PORT}/auth/register;
-    # ... other proxy settings ...
-}
-```
-
-**Regex match for MFA endpoints:**
-
-```nginx
-# Apply rate limit to all MFA endpoints
-location ~ ^/api/auth/mfa(/.*)?$ {
-    limit_req zone=auth_zone burst=5 nodelay;
-    rewrite ^/api/(.*)$ /$1 break;
+location ^~ /api/auth/ {
+    limit_req zone=login_signup_zone burst=10 nodelay;
     proxy_pass http://${SPARKY_FITNESS_SERVER_HOST}:${SPARKY_FITNESS_SERVER_PORT};
-    # ... other proxy settings ...
+    # ... proxy headers ...
 }
 ```
 
-Configuration parameters:
-*   `limit_req zone=auth_zone`: Refers to the defined rate limiting zone.
-*   `burst=5`: Allows a burst of up to 5 requests beyond the defined rate.
-*   `nodelay`: Requests exceeding the burst limit are immediately rejected with a `429 Too Many Requests` error, rather than being delayed.
+*   `burst=10`: allows a burst of 10 requests beyond the configured rate.
+*   `nodelay`: excess requests are rejected immediately with `429` rather than queued.
 
-## Endpoints Protected
+### A caveat worth knowing
 
-The following authentication endpoints are protected by Nginx rate limiting:
-
-| Endpoint | Purpose |
-|----------|---------|
-| `/api/auth/login` | User login |
-| `/api/auth/register` | New user registration |
-| `/api/auth/forgot-password` | Password reset request |
-| `/api/auth/reset-password` | Password reset completion |
-| `/api/auth/request-magic-link` | Magic link request |
-| `/api/auth/magic-link-login` | Magic link authentication |
-| `/api/auth/mfa/*` | All MFA-related endpoints |
-
-## Configuration
-
-The rate limit can be configured via the `NGINX_RATE_LIMIT` environment variable in your Docker Compose configuration:
-
-```yaml
-environment:
-  - NGINX_RATE_LIMIT=5r/s  # Default: 5 requests per second
-```
-
-To effectively disable rate limiting (e.g., for testing), set a very high value:
-```yaml
-environment:
-  - NGINX_RATE_LIMIT=10000r/s
-```
+::warning
+**The zone keys on `$binary_remote_addr`**, which is the address of whatever proxy sits in
+front of the container. If you run behind a reverse proxy, CDN or tunnel (Nginx Proxy
+Manager, Cloudflare Tunnel), that is a single address for *every* visitor — so all users
+share one bucket rather than getting one each. The per-IP protection that actually
+distinguishes clients is the application-layer sign-in limit described below, which reads
+`X-Forwarded-For`.
+::
 
 ## API Key Rate Limiting
 
@@ -158,17 +86,89 @@ When the rate limit is exceeded, the server returns:
 
 This rate limit is per API key, not per IP. Cookie-based browser sessions are not affected.
 
+## Sign-In Rate Limiting
+
+Password sign-in, two-factor verification and email-OTP verification are rate-limited per
+client IP at the application layer, using Better Auth's `customRules`. This **replaces**
+Better Auth's built-in default for those paths.
+
+### Defaults
+
+| Setting | Value |
+|---------|-------|
+| Time window | 60 seconds |
+| Max attempts | 4 per window |
+
+Applied to `/api/auth/sign-in/email`, `/api/auth/two-factor/*` and
+`/api/auth/email-otp/verify-email`. Each path keeps its **own** budget, so one MFA login
+(sign-in, then send-OTP, then verify-OTP) does not exhaust a single counter.
+
+### Why the default is 4 per minute, not a tighter burst
+
+Better Auth's own default for `/sign-in` is **3 requests per 10 seconds**. That is a tight
+burst, but it resets every 10 seconds — so it permits **18 failed logins per minute,
+indefinitely**.
+
+A failed sign-in answers `401`, and intrusion-detection tooling reads sustained `401`s as a
+brute force. CrowdSec's generic 401 scenario, for example, is a leaky bucket of capacity 5
+that drains one event every 10 seconds. At 18/minute that bucket overflows in about twenty
+seconds, and the client IP is banned at the edge — commonly for hours. A legitimate user
+fumbling their password manager can reach that on their own.
+
+Capping the **sustained** rate fixes it. The 5th attempt in a minute receives `429`, which
+those rules do not count, so failures can never accumulate to the ban threshold. This is
+also *stricter* than the default for sustained guessing (4/min versus 18/min) and no looser
+for bursts.
+
+### Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `SPARKY_FITNESS_SIGN_IN_RATELIMIT_WINDOW` | Time window in seconds | `60` |
+| `SPARKY_FITNESS_SIGN_IN_RATELIMIT_MAX` | Max attempts per window | `4` |
+
+### Behavior worth knowing
+
+- **Successful sign-ins count too.** Better Auth increments the counter on every response,
+  not just failures, so this is a ceiling on all sign-in traffic from one address. Instances
+  behind a shared office IP or carrier-grade NAT should raise `..._MAX`.
+- **The window resets only after silence.** Each counted request refreshes the timer, so a
+  client that keeps retrying holds itself blocked until it pauses for a full window. This is
+  why the window is deliberately short — it self-heals after a minute of quiet.
+- **It fails open.** If the client IP cannot be determined (no `X-Forwarded-For`), Better
+  Auth skips rate limiting entirely and logs a warning. A reverse-proxy misconfiguration
+  cannot lock users out.
+- **IPv6 is keyed per exact address**, not per subnet, so a client that rotates addresses
+  within its `/64` gets a fresh budget. Subnet grouping is deliberately not enabled, since
+  it would make a lockout affect every address in the prefix.
+- The demo one-click login (`/api/auth/demo-login`) is a separate Express route with its own
+  limiter (10 per minute per IP) and is **not** affected by these variables.
+
 ## Testing the Rate Limiting
 
-To test the rate limiting, ensure your Docker Compose environment is running with the updated `nginx.conf`. Then, use `curl` to send a high volume of requests to the protected endpoints.
+Send repeated sign-in attempts with a deliberately wrong password and watch the status codes.
+Run them **sequentially**, not in parallel, so you are measuring the application limit rather
+than Nginx's burst:
 
-Example `curl` command (replace with your domain and adjust payload):
 ```bash
-for i in $(seq 1 15); do curl -k -s -o /dev/null -w "%{http_code}\n" -X POST -H "Content-Type: application/json" -d '{"email":"test@example.com", "password":"password"}' https://your-domain.com/api/auth/login & done
+for i in $(seq 1 6); do
+  curl -k -s -o /dev/null -w "%{http_code}\n" \
+    -X POST -H "Content-Type: application/json" \
+    -d '{"email":"test@example.com","password":"wrong-password"}' \
+    https://your-domain.com/api/auth/sign-in/email
+done
 ```
 
-You should observe `429 Too Many Requests` HTTP status codes for requests exceeding the defined rate and burst limits.
+With the defaults you should see four `401`s followed by `429`s. If you see `429` on the
+fourth request instead of the fifth, the custom rules are not being applied and Better Auth's
+3-per-10s default is in force.
+
+::caution
+Do not run this against a production instance that sits behind fail2ban or CrowdSec unless
+your own IP is allow-listed. The `401`s this generates are exactly what those tools ban for,
+and you can lock yourself out at the CDN edge for hours.
+::
 
 ### Note on 503 Errors During Testing
 
-During initial testing, `503 Service Unavailable` errors might be observed instead of `429`s. This indicates that Nginx is indeed applying the rate limit (as confirmed by Nginx error logs showing `limiting requests`), but it's also encountering issues connecting to or receiving timely responses from the backend server. While the rate limiting itself is functional, consistent `503`s suggest an underlying issue with the backend's stability or readiness under load, which is outside the scope of the rate limiting implementation itself.
+When load-testing through Nginx, `503 Service Unavailable` errors might be observed instead of `429`s. This indicates that Nginx is indeed applying the rate limit (as confirmed by Nginx error logs showing `limiting requests`), but it's also encountering issues connecting to or receiving timely responses from the backend server. While the rate limiting itself is functional, consistent `503`s suggest an underlying issue with the backend's stability or readiness under load, which is outside the scope of the rate limiting implementation itself.

--- a/docs/content/8.developer/8.advanced/3.rate-limiting.md
+++ b/docs/content/8.developer/8.advanced/3.rate-limiting.md
@@ -116,9 +116,10 @@ seconds, and the client IP is banned at the edge — commonly for hours. A legit
 fumbling their password manager can reach that on their own.
 
 Capping the **sustained** rate fixes it. The 5th attempt in a minute receives `429`, which
-those rules do not count, so failures can never accumulate to the ban threshold. This is
-also *stricter* than the default for sustained guessing (4/min versus 18/min) and no looser
-for bursts.
+those rules do not count, so failures can never accumulate to the ban threshold. Compared to
+Better Auth's default this is one request looser on the initial burst (4 immediate attempts
+versus 3) but far stricter on sustained guessing (4/minute versus 18/minute) — and the burst
+difference is immaterial next to the sustained cap that actually prevents the ban.
 
 ### Configuration
 
@@ -138,9 +139,11 @@ for bursts.
 - **It fails open.** If the client IP cannot be determined (no `X-Forwarded-For`), Better
   Auth skips rate limiting entirely and logs a warning. A reverse-proxy misconfiguration
   cannot lock users out.
-- **IPv6 is keyed per exact address**, not per subnet, so a client that rotates addresses
-  within its `/64` gets a fresh budget. Subnet grouping is deliberately not enabled, since
-  it would make a lockout affect every address in the prefix.
+- **IPv6 is grouped by `/64` by default.** Better Auth's `normalizeIP` masks IPv6 addresses
+  to a `/64` (its default `ipv6Subnet`) before keying, so an entire `/64` shares one budget
+  and a client rotating addresses within its prefix does **not** get a fresh budget. This is
+  stricter, not looser; the trade-off is that a lockout applies to the whole `/64`. Override
+  with `advanced.ipAddress.ipv6Subnet` in the Better Auth config if you need a different mask.
 - The demo one-click login (`/api/auth/demo-login`) is a separate Express route with its own
   limiter (10 per minute per IP) and is **not** affected by these variables.
 


### PR DESCRIPTION
## Description

**What problem does this PR solve?**
On the public demo, ordinary authentication failures emit 4xx that an upstream IDS (fail2ban/CrowdSec) reads as attacks and IP-bans legitimate visitors; separately, the demo one-click login broke when email/password was disabled, and the documented `NGINX_RATE_LIMIT` variable never actually reached nginx.

**How did you implement the solution?**
- **Sign-in rate limiting** (`auth.ts`): per-IP `customRules` for `/sign-in/email`, `/two-factor/*`, and `/email-otp/verify-email` (default 4 per 60s, env-overridable). Better Auth's 3-per-10s default resets every 10s, allowing 18 failed logins/minute — enough sustained 401s to trip a 401 IDS rule and edge-ban a real user. Capping the sustained rate means the 5th attempt gets a local 429 (which those rules don't count), so failures can't accumulate to a ban.
- **Demo email-login fix** (`auth.ts`, `SparkyFitnessServer.ts`): keep the credential backend loaded in demo mode so the one-click demo login (an in-process `signInEmail` call) keeps working when `SPARKY_FITNESS_DISABLE_EMAIL_LOGIN=true`, and close the public `/sign-in/email` and `/sign-up/email` routes at the interceptor with an identical response.
- **NGINX_RATE_LIMIT wiring + status** (`docker/nginx.conf`, `docker-entrypoint.sh`): reference `${NGINX_RATE_LIMIT}` in the template (it was hardcoded, so the documented variable did nothing), default it before substitution so an empty value can't render `rate=;` and break startup, and return `429` instead of the default `503` for rate-limited requests.
- **Passkey conditional UI** (`Auth.tsx`, `useAuth.ts`): stop a duplicate concurrent conditional WebAuthn request and give `useAuthSettings` a non-zero `staleTime` so the OIDC auto-redirect timer stops re-arming.
- **Docs**: document the new sign-in rate-limit variables and correct the rate-limiting page (nginx config that no longer existed; IPv6 is grouped by /64 by default).

Linked Issue: Closes #

## How to Test

1. Check out this branch and start the server (`cd SparkyFitnessServer && pnpm start`).
2. **Sign-in limit**: `POST /api/auth/sign-in/email` with a wrong password in a loop — expect four `401`s then `429`. A correct password still works from a fresh window.
3. **Demo login**: with `SPARKY_FITNESS_DISABLE_EMAIL_LOGIN=true` and demo mode on, the one-click demo button still returns `200`; direct `POST /api/auth/sign-in/email` returns `400 EMAIL_PASSWORD_DISABLED`.
4. **Nginx var**: build the frontend image and set `NGINX_RATE_LIMIT=10r/s`; the rendered `/etc/nginx/conf.d/default.conf` shows `rate=10r/s` plus `limit_req_status 429;`, and `nginx -t` passes.
5. **Passkey**: load `/login` in Chrome with a registered passkey — autofill appears, no console error, one conditional request.

## PR Type

- [x] Issue (bug fix)
- [ ] New Feature
- [ ] Refactor
- [x] Documentation

## Checklist

**All PRs:**

- [x] **[MANDATORY - ALL] Integrity & License**: I certify this is my own work, free of malicious code, and I agree to the [License terms](https://github.com/CodeWithCJ/SparkyFitness/blob/main/LICENSE).

**New features only:**

- [ ] **[MANDATORY for new feature] Alignment**: I have raised a GitHub issue and it was reviewed/approved by maintainers or it was approved on Discord.

**Frontend changes (`SparkyFitnessFrontend/`):**

- [x] **[MANDATORY for Frontend changes] Quality**: I have run `pnpm run validate` and it passes.
- [x] **[MANDATORY for Frontend changes] Translations**: I have only updated the English (`en`) translation file. (N/A — no translation changes.)

**Backend changes (`SparkyFitnessServer/`):**

- [x] **[MANDATORY for Backend changes] Code Quality**: I have run typecheck, lint, and tests. New files use TypeScript, new endpoints have Zod schemas, and new endpoints include tests.
- [x] **[MANDATORY for Backend changes] Database Security**: I have updated `rls_policies.sql` for any new user-specific tables. (N/A — no schema changes.)

**UI changes (components, screens, pages):**

- [ ] **[MANDATORY for UI changes] Screenshots**: I have attached Before/After screenshots below. (N/A — login-page behavior only, no visual change.)

**Mobile changes (`SparkyFitnessMobile/`):**

- [ ] **[MANDATORY for Mobile changes] Tested on device or emulator**: I have verified the changes work on iOS or Android. (N/A — no mobile changes.)

## Screenshots

N/A — backend and auth-flow changes with no visual difference.

## Notes for Reviewers

- **Config keys**: `SPARKY_FITNESS_SIGN_IN_RATELIMIT_WINDOW` (default 60s) and `SPARKY_FITNESS_SIGN_IN_RATELIMIT_MAX` (default 4). Successful sign-ins count toward the same budget, so instances behind shared/carrier-NAT addresses may want a higher MAX.
- **SSO SSRF (CVE-2026-53513)** flagged by CodeRabbit is intentionally **not** patched here; it is fixed by upgrading `better-auth`/`@better-auth/sso` to the latest release in a dedicated follow-up PR, rather than a version-specific workaround.
- Known follow-up: the nginx limit zone keys on `$binary_remote_addr`, which behind a reverse proxy/tunnel is a single shared bucket; the per-IP sign-in limit is the real per-client control, and the edge IDS on `CF-Connecting-IP` is the brute-force backstop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate passkey authentication attempts and unnecessary authentication redirects.
  - Improved authentication settings stability during page loads and preference updates.

- **Security**
  - Added configurable rate limits for sign-in, two-factor authentication, and email verification.
  - Clarified demo-mode authentication behavior while preserving email/password restrictions on public routes.
  - Prevented invalid Nginx rate-limit configuration from causing startup failures.

- **Documentation**
  - Documented authentication rate-limit settings, defaults, proxy behavior, and testing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->